### PR TITLE
docs: add build badges, MIT license, and CI coverage job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,6 +82,34 @@ jobs:
       - name: Check
         run: make check-daemon
 
+  coverage:
+    name: Code Coverage
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: "1.94"
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: source/daemon
+
+      - name: Install cargo-tarpaulin
+        run: cargo install cargo-tarpaulin
+
+      - name: Generate coverage
+        run: cd source/daemon && cargo tarpaulin --workspace --out xml --output-dir ../../coverage
+
+      - name: Upload to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          files: coverage/cobertura.xml
+          fail_ci_if_error: false
+          token: ${{ secrets.CODECOV_TOKEN }}
+
   build-daemon:
     name: Build Daemon (${{ matrix.target }})
     needs: [build-web, check-daemon]

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Pedro Gomes
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![Rust](https://img.shields.io/badge/rust-1.94-orange.svg)](https://www.rust-lang.org)
 [![dependency status](https://deps.rs/repo/github/pedromvgomes/wardnet/status.svg)](https://deps.rs/repo/github/pedromvgomes/wardnet)
 [![Rust Report Card](https://rust-reportcard.xuri.me/badge/github.com/pedromvgomes/wardnet)](https://rust-reportcard.xuri.me/report/github.com/pedromvgomes/wardnet)
+[![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 
 Wardnet is a self-hosted network privacy gateway that runs on a Raspberry Pi. It sits alongside an existing home or small-office router and acts as the warden of every device's connection to the internet — encrypting traffic, blocking ads and trackers at the DNS level, and giving you per-device control over how each device connects.
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 [![CI](https://github.com/pedromvgomes/wardnet/actions/workflows/ci.yml/badge.svg)](https://github.com/pedromvgomes/wardnet/actions/workflows/ci.yml)
 [![codecov](https://codecov.io/gh/pedromvgomes/wardnet/branch/main/graph/badge.svg)](https://codecov.io/gh/pedromvgomes/wardnet)
 [![Rust](https://img.shields.io/badge/rust-1.94-orange.svg)](https://www.rust-lang.org)
-[![dependency status](https://deps.rs/repo/github/pedromvgomes/wardnet/status.svg)](https://deps.rs/repo/github/pedromvgomes/wardnet)
 [![Rust Report Card](https://rust-reportcard.xuri.me/badge/github.com/pedromvgomes/wardnet)](https://rust-reportcard.xuri.me/report/github.com/pedromvgomes/wardnet)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # Wardnet
 
+[![CI](https://github.com/pedromvgomes/wardnet/actions/workflows/ci.yml/badge.svg)](https://github.com/pedromvgomes/wardnet/actions/workflows/ci.yml)
+[![codecov](https://codecov.io/gh/pedromvgomes/wardnet/branch/main/graph/badge.svg)](https://codecov.io/gh/pedromvgomes/wardnet)
+[![Rust](https://img.shields.io/badge/rust-1.94-orange.svg)](https://www.rust-lang.org)
+[![dependency status](https://deps.rs/repo/github/pedromvgomes/wardnet/status.svg)](https://deps.rs/repo/github/pedromvgomes/wardnet)
+[![Rust Report Card](https://rust-reportcard.xuri.me/badge/github.com/pedromvgomes/wardnet)](https://rust-reportcard.xuri.me/report/github.com/pedromvgomes/wardnet)
+
 Wardnet is a self-hosted network privacy gateway that runs on a Raspberry Pi. It sits alongside an existing home or small-office router and acts as the warden of every device's connection to the internet — encrypting traffic, blocking ads and trackers at the DNS level, and giving you per-device control over how each device connects.
 
 Devices that cannot run VPN software themselves (smart TVs, consoles, IoT) are fully protected at the gateway level.


### PR DESCRIPTION
## Summary

  - Add README badges: CI status, Codecov, Rust version, Rust Report Card, MIT license
  - Add MIT license file
  - Add CI coverage job using cargo-tarpaulin with Codecov upload

  ## Test plan

  - [x] Verify badges render correctly on the README
  - [ ] Verify coverage job runs in CI
  - [ ] Confirm Codecov upload works and badge shows coverage percentage