### PR TITLE
ci: add security audit workflow and Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,22 @@
+version: 2
+updates:
+  - package-ecosystem: "cargo"
+    directory: "/source/daemon"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore(deps):"
+
+  - package-ecosystem: "npm"
+    directory: "/source/web-ui"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore(deps):"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore(ci):"

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,37 @@
+name: Security Audit
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "source/daemon/**/Cargo.toml"
+      - "source/daemon/Cargo.lock"
+  pull_request:
+    branches: [main]
+    paths:
+      - "source/daemon/**/Cargo.toml"
+      - "source/daemon/Cargo.lock"
+  schedule:
+    # Run daily at 06:00 UTC to catch newly disclosed advisories
+    - cron: "0 6 * * *"
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  cargo-audit:
+    name: Cargo Audit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: "1.94"
+
+      - name: Install cargo-audit
+        run: cargo install cargo-audit
+
+      - name: Run cargo-audit
+        run: cd source/daemon && cargo audit

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![codecov](https://codecov.io/gh/pedromvgomes/wardnet/branch/main/graph/badge.svg)](https://codecov.io/gh/pedromvgomes/wardnet)
 [![Rust](https://img.shields.io/badge/rust-1.94-orange.svg)](https://www.rust-lang.org)
 [![Rust Report Card](https://rust-reportcard.xuri.me/badge/github.com/pedromvgomes/wardnet)](https://rust-reportcard.xuri.me/report/github.com/pedromvgomes/wardnet)
+[![Security Audit](https://github.com/pedromvgomes/wardnet/actions/workflows/security.yml/badge.svg)](https://github.com/pedromvgomes/wardnet/actions/workflows/security.yml)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 
 Wardnet is a self-hosted network privacy gateway that runs on a Raspberry Pi. It sits alongside an existing home or small-office router and acts as the warden of every device's connection to the internet — encrypting traffic, blocking ads and trackers at the DNS level, and giving you per-device control over how each device connects.


### PR DESCRIPTION
## Summary

  - Add `cargo-audit` CI workflow that checks Rust dependencies against the RustSec advisory database
    - Triggers on Cargo.toml/Cargo.lock changes and PRs
    - Runs daily at 06:00 UTC to catch newly disclosed advisories
  - Add Dependabot config for automated dependency update PRs:
    - Cargo dependencies (weekly)
    - npm dependencies (weekly)
    - GitHub Actions versions (weekly)
  - Add Security Audit badge to README

  ## Test plan

  - [ ] Verify security audit workflow runs and passes
  - [ ] Verify Dependabot starts opening PRs for outdated dependencies