### PR TITLE
test: boost code coverage from 59% toward 80%

### DIFF
--- a/source/daemon/crates/wardnetd/src/api/mod.rs
+++ b/source/daemon/crates/wardnetd/src/api/mod.rs
@@ -4,6 +4,9 @@ pub mod middleware;
 pub mod system;
 pub mod tunnels;
 
+#[cfg(test)]
+mod tests;
+
 use axum::Router;
 use axum::routing::{delete, get, post, put};
 use tower_http::cors::CorsLayer;

--- a/source/daemon/crates/wardnetd/src/api/tests/auth.rs
+++ b/source/daemon/crates/wardnetd/src/api/tests/auth.rs
@@ -1,0 +1,311 @@
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use axum::Router;
+use axum::body::Body;
+use axum::extract::ConnectInfo;
+use axum::http::{Request, StatusCode};
+use axum::routing::post;
+use tokio::sync::broadcast;
+use tower::ServiceExt;
+use uuid::Uuid;
+use wardnet_types::api::{
+    CreateTunnelRequest, CreateTunnelResponse, DeleteTunnelResponse, DeviceMeResponse,
+    ListTunnelsResponse, SetMyRuleResponse, SystemStatusResponse,
+};
+use wardnet_types::device::{Device, DeviceType};
+use wardnet_types::event::WardnetEvent;
+use wardnet_types::routing::RoutingTarget;
+use wardnet_types::tunnel::Tunnel;
+
+use crate::config::Config;
+use crate::error::AppError;
+use crate::event::EventPublisher;
+use crate::packet_capture::ObservedDevice;
+use crate::service::auth::LoginResult;
+use crate::service::{
+    AuthService, DeviceDiscoveryService, DeviceService, ObservationResult, SystemService,
+    TunnelService,
+};
+use crate::state::AppState;
+
+// ---------------------------------------------------------------------------
+// Stub services (not exercised in these tests)
+// ---------------------------------------------------------------------------
+
+struct StubDeviceService;
+#[async_trait]
+impl DeviceService for StubDeviceService {
+    async fn get_device_for_ip(&self, _ip: &str) -> Result<DeviceMeResponse, AppError> {
+        unimplemented!()
+    }
+    async fn set_rule_for_ip(
+        &self,
+        _ip: &str,
+        _t: RoutingTarget,
+    ) -> Result<SetMyRuleResponse, AppError> {
+        unimplemented!()
+    }
+}
+
+struct StubDiscoveryService;
+#[async_trait]
+impl DeviceDiscoveryService for StubDiscoveryService {
+    async fn restore_devices(&self) -> Result<(), AppError> {
+        unimplemented!()
+    }
+    async fn process_observation(
+        &self,
+        _obs: &ObservedDevice,
+    ) -> Result<ObservationResult, AppError> {
+        unimplemented!()
+    }
+    async fn flush_last_seen(&self) -> Result<u64, AppError> {
+        unimplemented!()
+    }
+    async fn scan_departures(&self, _t: u64) -> Result<Vec<Uuid>, AppError> {
+        unimplemented!()
+    }
+    async fn resolve_hostname(&self, _id: Uuid, _ip: String) -> Result<(), AppError> {
+        unimplemented!()
+    }
+    async fn get_all_devices(&self) -> Result<Vec<Device>, AppError> {
+        unimplemented!()
+    }
+    async fn get_device_by_id(&self, _id: Uuid) -> Result<Device, AppError> {
+        unimplemented!()
+    }
+    async fn update_device(
+        &self,
+        _id: Uuid,
+        _n: Option<&str>,
+        _dt: Option<DeviceType>,
+    ) -> Result<Device, AppError> {
+        unimplemented!()
+    }
+}
+
+struct StubSystemService;
+#[async_trait]
+impl SystemService for StubSystemService {
+    async fn status(&self) -> Result<SystemStatusResponse, AppError> {
+        unimplemented!()
+    }
+}
+
+struct StubTunnelService;
+#[async_trait]
+impl TunnelService for StubTunnelService {
+    async fn import_tunnel(
+        &self,
+        _r: CreateTunnelRequest,
+    ) -> Result<CreateTunnelResponse, AppError> {
+        unimplemented!()
+    }
+    async fn list_tunnels(&self) -> Result<ListTunnelsResponse, AppError> {
+        unimplemented!()
+    }
+    async fn get_tunnel(&self, _id: Uuid) -> Result<Tunnel, AppError> {
+        unimplemented!()
+    }
+    async fn bring_up(&self, _id: Uuid) -> Result<(), AppError> {
+        unimplemented!()
+    }
+    async fn tear_down(&self, _id: Uuid, _r: &str) -> Result<(), AppError> {
+        unimplemented!()
+    }
+    async fn delete_tunnel(&self, _id: Uuid) -> Result<DeleteTunnelResponse, AppError> {
+        unimplemented!()
+    }
+    async fn restore_tunnels(&self) -> Result<(), AppError> {
+        unimplemented!()
+    }
+}
+
+struct StubEventPublisher;
+impl EventPublisher for StubEventPublisher {
+    fn publish(&self, _event: WardnetEvent) {}
+    fn subscribe(&self) -> broadcast::Receiver<WardnetEvent> {
+        let (tx, rx) = broadcast::channel(1);
+        drop(tx);
+        rx
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Mock auth service
+// ---------------------------------------------------------------------------
+
+/// Mock auth service returning a configurable login result or error.
+struct MockAuthService {
+    login_result: Result<LoginResult, AppError>,
+}
+
+#[async_trait]
+impl AuthService for MockAuthService {
+    async fn login(&self, _username: &str, _password: &str) -> Result<LoginResult, AppError> {
+        match &self.login_result {
+            Ok(r) => Ok(LoginResult {
+                token: r.token.clone(),
+                max_age_seconds: r.max_age_seconds,
+            }),
+            Err(_) => Err(AppError::Unauthorized("invalid credentials".to_owned())),
+        }
+    }
+
+    async fn validate_session(&self, _token: &str) -> Result<Option<Uuid>, AppError> {
+        Ok(None)
+    }
+
+    async fn validate_api_key(&self, _key: &str) -> Result<Option<Uuid>, AppError> {
+        Ok(None)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn make_state(auth: impl AuthService + 'static) -> AppState {
+    AppState::new(
+        Arc::new(auth),
+        Arc::new(StubDeviceService),
+        Arc::new(StubDiscoveryService),
+        Arc::new(StubSystemService),
+        Arc::new(StubTunnelService),
+        Arc::new(StubEventPublisher),
+        Config::default(),
+    )
+}
+
+fn login_app(state: AppState) -> Router {
+    Router::new()
+        .route("/api/auth/login", post(crate::api::auth::login))
+        .with_state(state)
+}
+
+fn connect_info_ext() -> ConnectInfo<SocketAddr> {
+    ConnectInfo(SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 1234))
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn login_success_returns_200_and_set_cookie() {
+    let state = make_state(MockAuthService {
+        login_result: Ok(LoginResult {
+            token: "test-session-token".to_owned(),
+            max_age_seconds: 86400,
+        }),
+    });
+
+    let app = login_app(state);
+    let body = serde_json::json!({
+        "username": "admin",
+        "password": "password123"
+    });
+
+    let req = Request::builder()
+        .method("POST")
+        .uri("/api/auth/login")
+        .header("Content-Type", "application/json")
+        .extension(connect_info_ext())
+        .body(Body::from(serde_json::to_vec(&body).unwrap()))
+        .unwrap();
+
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    // Verify Set-Cookie header is present with correct structure.
+    let cookie = resp
+        .headers()
+        .get("set-cookie")
+        .expect("expected Set-Cookie header")
+        .to_str()
+        .unwrap();
+
+    assert!(cookie.contains("wardnet_session=test-session-token"));
+    assert!(cookie.contains("HttpOnly"));
+    assert!(cookie.contains("SameSite=Strict"));
+    assert!(cookie.contains("Max-Age=86400"));
+
+    // Verify JSON body.
+    let resp_body = axum::body::to_bytes(resp.into_body(), 4096).await.unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&resp_body).unwrap();
+    assert_eq!(json["message"], "logged in");
+}
+
+#[tokio::test]
+async fn login_failure_returns_401() {
+    let state = make_state(MockAuthService {
+        login_result: Err(AppError::Unauthorized("invalid credentials".to_owned())),
+    });
+
+    let app = login_app(state);
+    let body = serde_json::json!({
+        "username": "admin",
+        "password": "wrong"
+    });
+
+    let req = Request::builder()
+        .method("POST")
+        .uri("/api/auth/login")
+        .header("Content-Type", "application/json")
+        .extension(connect_info_ext())
+        .body(Body::from(serde_json::to_vec(&body).unwrap()))
+        .unwrap();
+
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn login_missing_body_returns_422_or_400() {
+    let state = make_state(MockAuthService {
+        login_result: Ok(LoginResult {
+            token: "unused".to_owned(),
+            max_age_seconds: 0,
+        }),
+    });
+
+    let app = login_app(state);
+    let req = Request::builder()
+        .method("POST")
+        .uri("/api/auth/login")
+        .header("Content-Type", "application/json")
+        .extension(connect_info_ext())
+        .body(Body::empty())
+        .unwrap();
+
+    let resp = app.oneshot(req).await.unwrap();
+    // axum returns 422 Unprocessable Entity for deserialization failures.
+    assert!(
+        resp.status() == StatusCode::UNPROCESSABLE_ENTITY
+            || resp.status() == StatusCode::BAD_REQUEST
+    );
+}
+
+#[tokio::test]
+async fn login_invalid_json_returns_error() {
+    let state = make_state(MockAuthService {
+        login_result: Ok(LoginResult {
+            token: "unused".to_owned(),
+            max_age_seconds: 0,
+        }),
+    });
+
+    let app = login_app(state);
+    let req = Request::builder()
+        .method("POST")
+        .uri("/api/auth/login")
+        .header("Content-Type", "application/json")
+        .extension(connect_info_ext())
+        .body(Body::from("not json"))
+        .unwrap();
+
+    let resp = app.oneshot(req).await.unwrap();
+    assert!(resp.status().is_client_error());
+}

--- a/source/daemon/crates/wardnetd/src/api/tests/devices.rs
+++ b/source/daemon/crates/wardnetd/src/api/tests/devices.rs
@@ -1,0 +1,642 @@
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use axum::Router;
+use axum::body::Body;
+use axum::extract::ConnectInfo;
+use axum::http::{Request, StatusCode};
+use axum::routing::{get, put};
+use tokio::sync::broadcast;
+use tower::ServiceExt;
+use uuid::Uuid;
+use wardnet_types::api::{
+    CreateTunnelRequest, CreateTunnelResponse, DeleteTunnelResponse, DeviceMeResponse,
+    ListTunnelsResponse, SetMyRuleResponse, SystemStatusResponse,
+};
+use wardnet_types::device::{Device, DeviceType};
+use wardnet_types::event::WardnetEvent;
+use wardnet_types::routing::RoutingTarget;
+use wardnet_types::tunnel::Tunnel;
+
+use crate::config::Config;
+use crate::error::AppError;
+use crate::event::EventPublisher;
+use crate::packet_capture::ObservedDevice;
+use crate::service::auth::LoginResult;
+use crate::service::{
+    AuthService, DeviceDiscoveryService, DeviceService, ObservationResult, SystemService,
+    TunnelService,
+};
+use crate::state::AppState;
+
+// ---------------------------------------------------------------------------
+// Mock services
+// ---------------------------------------------------------------------------
+
+/// Mock `AuthService` that always validates sessions.
+struct MockAuthService;
+
+#[async_trait]
+impl AuthService for MockAuthService {
+    async fn login(&self, _u: &str, _p: &str) -> Result<LoginResult, AppError> {
+        Ok(LoginResult {
+            token: "t".to_owned(),
+            max_age_seconds: 3600,
+        })
+    }
+    async fn validate_session(&self, _token: &str) -> Result<Option<Uuid>, AppError> {
+        Ok(Some(
+            Uuid::parse_str("00000000-0000-0000-0000-000000000099").unwrap(),
+        ))
+    }
+    async fn validate_api_key(&self, _key: &str) -> Result<Option<Uuid>, AppError> {
+        Ok(None)
+    }
+}
+
+/// Mock `DeviceService` returning configurable responses.
+struct MockDeviceService {
+    device: Option<Device>,
+    rule: Option<RoutingTarget>,
+    admin_locked: bool,
+    set_rule_error: Option<String>,
+}
+
+impl MockDeviceService {
+    fn found(device: Device, rule: Option<RoutingTarget>) -> Self {
+        let admin_locked = device.admin_locked;
+        Self {
+            device: Some(device),
+            rule,
+            admin_locked,
+            set_rule_error: None,
+        }
+    }
+
+    fn not_found() -> Self {
+        Self {
+            device: None,
+            rule: None,
+            admin_locked: false,
+            set_rule_error: Some("not_found".to_owned()),
+        }
+    }
+
+    fn forbidden(device: Device) -> Self {
+        Self {
+            device: Some(device),
+            rule: None,
+            admin_locked: true,
+            set_rule_error: Some("forbidden".to_owned()),
+        }
+    }
+}
+
+#[async_trait]
+impl DeviceService for MockDeviceService {
+    async fn get_device_for_ip(&self, _ip: &str) -> Result<DeviceMeResponse, AppError> {
+        Ok(DeviceMeResponse {
+            device: self.device.clone(),
+            current_rule: self.rule.clone(),
+            admin_locked: self.admin_locked,
+        })
+    }
+
+    async fn set_rule_for_ip(
+        &self,
+        _ip: &str,
+        target: RoutingTarget,
+    ) -> Result<SetMyRuleResponse, AppError> {
+        match self.set_rule_error.as_deref() {
+            Some("not_found") => Err(AppError::NotFound(
+                "device not found for this IP".to_owned(),
+            )),
+            Some("forbidden") => Err(AppError::Forbidden("routing is locked by admin".to_owned())),
+            _ => Ok(SetMyRuleResponse {
+                message: "routing rule updated".to_owned(),
+                target,
+            }),
+        }
+    }
+}
+
+/// Mock `DeviceDiscoveryService` for admin device endpoints.
+struct MockDiscoveryService {
+    devices: Vec<Device>,
+}
+
+#[async_trait]
+impl DeviceDiscoveryService for MockDiscoveryService {
+    async fn restore_devices(&self) -> Result<(), AppError> {
+        Ok(())
+    }
+    async fn process_observation(
+        &self,
+        _obs: &ObservedDevice,
+    ) -> Result<ObservationResult, AppError> {
+        unimplemented!()
+    }
+    async fn flush_last_seen(&self) -> Result<u64, AppError> {
+        Ok(0)
+    }
+    async fn scan_departures(&self, _timeout_secs: u64) -> Result<Vec<Uuid>, AppError> {
+        Ok(vec![])
+    }
+    async fn resolve_hostname(&self, _device_id: Uuid, _ip: String) -> Result<(), AppError> {
+        Ok(())
+    }
+    async fn get_all_devices(&self) -> Result<Vec<Device>, AppError> {
+        Ok(self.devices.clone())
+    }
+    async fn get_device_by_id(&self, id: Uuid) -> Result<Device, AppError> {
+        self.devices
+            .iter()
+            .find(|d| d.id == id)
+            .cloned()
+            .ok_or_else(|| AppError::NotFound(format!("device {id} not found")))
+    }
+    async fn update_device(
+        &self,
+        id: Uuid,
+        name: Option<&str>,
+        _device_type: Option<DeviceType>,
+    ) -> Result<Device, AppError> {
+        let mut device = self.get_device_by_id(id).await?;
+        if let Some(n) = name {
+            device.name = Some(n.to_owned());
+        }
+        Ok(device)
+    }
+}
+
+struct StubSystemService;
+#[async_trait]
+impl SystemService for StubSystemService {
+    async fn status(&self) -> Result<SystemStatusResponse, AppError> {
+        Ok(SystemStatusResponse {
+            version: "test".to_owned(),
+            uptime_seconds: 0,
+            device_count: 0,
+            tunnel_count: 0,
+            db_size_bytes: 0,
+        })
+    }
+}
+
+struct StubTunnelService;
+#[async_trait]
+impl TunnelService for StubTunnelService {
+    async fn import_tunnel(
+        &self,
+        _req: CreateTunnelRequest,
+    ) -> Result<CreateTunnelResponse, AppError> {
+        unimplemented!()
+    }
+    async fn list_tunnels(&self) -> Result<ListTunnelsResponse, AppError> {
+        Ok(ListTunnelsResponse { tunnels: vec![] })
+    }
+    async fn get_tunnel(&self, _id: Uuid) -> Result<Tunnel, AppError> {
+        unimplemented!()
+    }
+    async fn bring_up(&self, _id: Uuid) -> Result<(), AppError> {
+        unimplemented!()
+    }
+    async fn tear_down(&self, _id: Uuid, _reason: &str) -> Result<(), AppError> {
+        unimplemented!()
+    }
+    async fn delete_tunnel(&self, _id: Uuid) -> Result<DeleteTunnelResponse, AppError> {
+        unimplemented!()
+    }
+    async fn restore_tunnels(&self) -> Result<(), AppError> {
+        Ok(())
+    }
+}
+
+struct StubEventPublisher;
+impl EventPublisher for StubEventPublisher {
+    fn publish(&self, _event: WardnetEvent) {}
+    fn subscribe(&self) -> broadcast::Receiver<WardnetEvent> {
+        let (tx, rx) = broadcast::channel(1);
+        drop(tx);
+        rx
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn sample_device() -> Device {
+    Device {
+        id: Uuid::parse_str("00000000-0000-0000-0000-000000000001").unwrap(),
+        mac: "AA:BB:CC:DD:EE:01".to_owned(),
+        name: Some("My Phone".to_owned()),
+        hostname: None,
+        manufacturer: Some("Apple".to_owned()),
+        device_type: DeviceType::Phone,
+        first_seen: "2026-03-07T00:00:00Z".parse().unwrap(),
+        last_seen: "2026-03-07T00:00:00Z".parse().unwrap(),
+        last_ip: "192.168.1.10".to_owned(),
+        admin_locked: false,
+    }
+}
+
+fn connect_info() -> ConnectInfo<SocketAddr> {
+    ConnectInfo(SocketAddr::new(
+        IpAddr::V4(Ipv4Addr::new(192, 168, 1, 10)),
+        12345,
+    ))
+}
+
+fn build_state(
+    device_svc: impl DeviceService + 'static,
+    discovery_svc: impl DeviceDiscoveryService + 'static,
+) -> AppState {
+    AppState::new(
+        Arc::new(MockAuthService),
+        Arc::new(device_svc),
+        Arc::new(discovery_svc),
+        Arc::new(StubSystemService),
+        Arc::new(StubTunnelService),
+        Arc::new(StubEventPublisher),
+        Config::default(),
+    )
+}
+
+fn device_router(state: AppState) -> Router {
+    Router::new()
+        .route("/api/devices/me", get(crate::api::devices::get_me))
+        .route(
+            "/api/devices/me/rule",
+            put(crate::api::devices::set_my_rule),
+        )
+        .route("/api/devices", get(crate::api::devices::list_devices))
+        .route(
+            "/api/devices/{id}",
+            get(crate::api::devices::get_device).put(crate::api::devices::update_device),
+        )
+        .with_state(state)
+}
+
+/// Send an authenticated GET request with `ConnectInfo` extension.
+async fn get_json(app: Router, uri: &str) -> (StatusCode, serde_json::Value) {
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .uri(uri)
+                .header("Cookie", "wardnet_session=valid-token")
+                .extension(connect_info())
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    let status = resp.status();
+    let body = axum::body::to_bytes(resp.into_body(), 16384).await.unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap_or(serde_json::Value::Null);
+    (status, json)
+}
+
+/// Send an authenticated PUT request with JSON body and `ConnectInfo` extension.
+async fn put_json(app: Router, uri: &str, json_body: &str) -> (StatusCode, serde_json::Value) {
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("PUT")
+                .uri(uri)
+                .header("Content-Type", "application/json")
+                .header("Cookie", "wardnet_session=valid-token")
+                .extension(connect_info())
+                .body(Body::from(json_body.to_owned()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    let status = resp.status();
+    let body = axum::body::to_bytes(resp.into_body(), 16384).await.unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap_or(serde_json::Value::Null);
+    (status, json)
+}
+
+// ---------------------------------------------------------------------------
+// GET /api/devices/me
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn get_me_returns_device_when_found() {
+    let device = sample_device();
+    let state = build_state(
+        MockDeviceService::found(device, Some(RoutingTarget::Direct)),
+        MockDiscoveryService { devices: vec![] },
+    );
+    let app = device_router(state);
+
+    let (status, json) = get_json(app, "/api/devices/me").await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(json["device"]["mac"], "AA:BB:CC:DD:EE:01");
+    assert_eq!(json["current_rule"]["type"], "direct");
+    assert_eq!(json["admin_locked"], false);
+}
+
+#[tokio::test]
+async fn get_me_returns_null_device_when_unknown_ip() {
+    let state = build_state(
+        MockDeviceService::not_found(),
+        MockDiscoveryService { devices: vec![] },
+    );
+    let app = device_router(state);
+
+    let (status, json) = get_json(app, "/api/devices/me").await;
+    assert_eq!(status, StatusCode::OK);
+    assert!(json["device"].is_null());
+    assert!(json["current_rule"].is_null());
+}
+
+// ---------------------------------------------------------------------------
+// PUT /api/devices/me/rule
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn set_my_rule_success() {
+    let state = build_state(
+        MockDeviceService::found(sample_device(), None),
+        MockDiscoveryService { devices: vec![] },
+    );
+    let app = device_router(state);
+
+    let (status, json) = put_json(
+        app,
+        "/api/devices/me/rule",
+        r#"{"target":{"type":"direct"}}"#,
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(json["target"]["type"], "direct");
+    assert_eq!(json["message"], "routing rule updated");
+}
+
+#[tokio::test]
+async fn set_my_rule_with_tunnel_target() {
+    let tunnel_id = "00000000-0000-0000-0000-000000000010";
+    let state = build_state(
+        MockDeviceService::found(sample_device(), None),
+        MockDiscoveryService { devices: vec![] },
+    );
+    let app = device_router(state);
+
+    let body = format!(r#"{{"target":{{"type":"tunnel","tunnel_id":"{tunnel_id}"}}}}"#);
+    let (status, json) = put_json(app, "/api/devices/me/rule", &body).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(json["target"]["type"], "tunnel");
+    assert_eq!(json["target"]["tunnel_id"], tunnel_id);
+}
+
+#[tokio::test]
+async fn set_my_rule_device_not_found() {
+    let state = build_state(
+        MockDeviceService::not_found(),
+        MockDiscoveryService { devices: vec![] },
+    );
+    let app = device_router(state);
+
+    let (status, json) = put_json(
+        app,
+        "/api/devices/me/rule",
+        r#"{"target":{"type":"direct"}}"#,
+    )
+    .await;
+    assert_eq!(status, StatusCode::NOT_FOUND);
+    assert_eq!(json["error"], "not found");
+}
+
+#[tokio::test]
+async fn set_my_rule_forbidden_when_locked() {
+    let mut device = sample_device();
+    device.admin_locked = true;
+
+    let svc = MockDeviceService::forbidden(device);
+    let state = build_state(svc, MockDiscoveryService { devices: vec![] });
+    let app = device_router(state);
+
+    let (status, json) = put_json(
+        app,
+        "/api/devices/me/rule",
+        r#"{"target":{"type":"direct"}}"#,
+    )
+    .await;
+    assert_eq!(status, StatusCode::FORBIDDEN);
+    assert_eq!(json["error"], "forbidden");
+}
+
+#[tokio::test]
+async fn set_my_rule_bad_json_returns_error() {
+    let state = build_state(
+        MockDeviceService::found(sample_device(), None),
+        MockDiscoveryService { devices: vec![] },
+    );
+    let app = device_router(state);
+
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("PUT")
+                .uri("/api/devices/me/rule")
+                .header("Content-Type", "application/json")
+                .header("Cookie", "wardnet_session=valid-token")
+                .extension(connect_info())
+                .body(Body::from("not json"))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    // Axum returns 400 or 422 for deserialization failures depending on version.
+    let status = resp.status();
+    assert!(
+        status == StatusCode::BAD_REQUEST || status == StatusCode::UNPROCESSABLE_ENTITY,
+        "expected 400 or 422, got {status}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// GET /api/devices (admin, list all)
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn list_devices_returns_all() {
+    let device = sample_device();
+    let state = build_state(
+        MockDeviceService::not_found(),
+        MockDiscoveryService {
+            devices: vec![device],
+        },
+    );
+    let app = device_router(state);
+
+    let (status, json) = get_json(app, "/api/devices").await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(json["devices"].as_array().unwrap().len(), 1);
+    assert_eq!(json["devices"][0]["mac"], "AA:BB:CC:DD:EE:01");
+}
+
+#[tokio::test]
+async fn list_devices_returns_empty() {
+    let state = build_state(
+        MockDeviceService::not_found(),
+        MockDiscoveryService { devices: vec![] },
+    );
+    let app = device_router(state);
+
+    let (status, json) = get_json(app, "/api/devices").await;
+    assert_eq!(status, StatusCode::OK);
+    assert!(json["devices"].as_array().unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn list_devices_unauthorized_without_session() {
+    let state = build_state(
+        MockDeviceService::not_found(),
+        MockDiscoveryService { devices: vec![] },
+    );
+    let app = device_router(state);
+
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .uri("/api/devices")
+                .extension(connect_info())
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+}
+
+// ---------------------------------------------------------------------------
+// GET /api/devices/:id (admin, detail)
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn get_device_by_id_success() {
+    let device = sample_device();
+    let state = build_state(
+        MockDeviceService::found(device.clone(), Some(RoutingTarget::Direct)),
+        MockDiscoveryService {
+            devices: vec![device],
+        },
+    );
+    let app = device_router(state);
+
+    let (status, json) = get_json(app, "/api/devices/00000000-0000-0000-0000-000000000001").await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(json["device"]["mac"], "AA:BB:CC:DD:EE:01");
+    assert_eq!(json["current_rule"]["type"], "direct");
+}
+
+#[tokio::test]
+async fn get_device_by_id_not_found() {
+    let state = build_state(
+        MockDeviceService::not_found(),
+        MockDiscoveryService { devices: vec![] },
+    );
+    let app = device_router(state);
+
+    let (status, json) = get_json(app, "/api/devices/00000000-0000-0000-0000-000000000099").await;
+    assert_eq!(status, StatusCode::NOT_FOUND);
+    assert_eq!(json["error"], "not found");
+}
+
+#[tokio::test]
+async fn get_device_by_id_invalid_uuid() {
+    let state = build_state(
+        MockDeviceService::not_found(),
+        MockDiscoveryService { devices: vec![] },
+    );
+    let app = device_router(state);
+
+    let (status, json) = get_json(app, "/api/devices/not-a-uuid").await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    assert_eq!(json["error"], "bad request");
+}
+
+// ---------------------------------------------------------------------------
+// PUT /api/devices/:id (admin, update)
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn update_device_success() {
+    let device = sample_device();
+    let state = build_state(
+        MockDeviceService::found(device.clone(), None),
+        MockDiscoveryService {
+            devices: vec![device],
+        },
+    );
+    let app = device_router(state);
+
+    let (status, json) = put_json(
+        app,
+        "/api/devices/00000000-0000-0000-0000-000000000001",
+        r#"{"name":"Renamed Device"}"#,
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(json["device"]["name"], "Renamed Device");
+}
+
+#[tokio::test]
+async fn update_device_with_type() {
+    let device = sample_device();
+    let state = build_state(
+        MockDeviceService::found(device.clone(), None),
+        MockDiscoveryService {
+            devices: vec![device],
+        },
+    );
+    let app = device_router(state);
+
+    let (status, json) = put_json(
+        app,
+        "/api/devices/00000000-0000-0000-0000-000000000001",
+        r#"{"device_type":"laptop"}"#,
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert!(json["device"].is_object());
+}
+
+#[tokio::test]
+async fn update_device_invalid_uuid() {
+    let state = build_state(
+        MockDeviceService::not_found(),
+        MockDiscoveryService { devices: vec![] },
+    );
+    let app = device_router(state);
+
+    let (status, json) = put_json(app, "/api/devices/not-a-uuid", r#"{"name":"x"}"#).await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    assert_eq!(json["error"], "bad request");
+}
+
+#[tokio::test]
+async fn update_device_not_found() {
+    let state = build_state(
+        MockDeviceService::not_found(),
+        MockDiscoveryService { devices: vec![] },
+    );
+    let app = device_router(state);
+
+    let (status, json) = put_json(
+        app,
+        "/api/devices/00000000-0000-0000-0000-000000000099",
+        r#"{"name":"x"}"#,
+    )
+    .await;
+    assert_eq!(status, StatusCode::NOT_FOUND);
+    assert_eq!(json["error"], "not found");
+}

--- a/source/daemon/crates/wardnetd/src/api/tests/middleware.rs
+++ b/source/daemon/crates/wardnetd/src/api/tests/middleware.rs
@@ -1,0 +1,422 @@
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use axum::Router;
+use axum::body::Body;
+use axum::extract::ConnectInfo;
+use axum::http::{Request, StatusCode};
+use axum::response::IntoResponse;
+use axum::routing::get;
+use tokio::sync::broadcast;
+use tower::ServiceExt;
+use uuid::Uuid;
+use wardnet_types::api::{
+    CreateTunnelRequest, CreateTunnelResponse, DeleteTunnelResponse, DeviceMeResponse,
+    ListTunnelsResponse, SetMyRuleResponse, SystemStatusResponse,
+};
+use wardnet_types::device::{Device, DeviceType};
+use wardnet_types::event::WardnetEvent;
+use wardnet_types::routing::RoutingTarget;
+use wardnet_types::tunnel::Tunnel;
+
+use crate::config::Config;
+use crate::error::AppError;
+use crate::event::EventPublisher;
+use crate::packet_capture::ObservedDevice;
+use crate::service::auth::LoginResult;
+use crate::service::{
+    AuthService, DeviceDiscoveryService, DeviceService, ObservationResult, SystemService,
+    TunnelService,
+};
+use crate::state::AppState;
+
+// ---------------------------------------------------------------------------
+// Stub services (satisfy AppState::new but are not exercised in these tests)
+// ---------------------------------------------------------------------------
+
+struct StubDeviceService;
+#[async_trait]
+impl DeviceService for StubDeviceService {
+    async fn get_device_for_ip(&self, _ip: &str) -> Result<DeviceMeResponse, AppError> {
+        unimplemented!()
+    }
+    async fn set_rule_for_ip(
+        &self,
+        _ip: &str,
+        _target: RoutingTarget,
+    ) -> Result<SetMyRuleResponse, AppError> {
+        unimplemented!()
+    }
+}
+
+struct StubDiscoveryService;
+#[async_trait]
+impl DeviceDiscoveryService for StubDiscoveryService {
+    async fn restore_devices(&self) -> Result<(), AppError> {
+        unimplemented!()
+    }
+    async fn process_observation(
+        &self,
+        _obs: &ObservedDevice,
+    ) -> Result<ObservationResult, AppError> {
+        unimplemented!()
+    }
+    async fn flush_last_seen(&self) -> Result<u64, AppError> {
+        unimplemented!()
+    }
+    async fn scan_departures(&self, _timeout_secs: u64) -> Result<Vec<Uuid>, AppError> {
+        unimplemented!()
+    }
+    async fn resolve_hostname(&self, _device_id: Uuid, _ip: String) -> Result<(), AppError> {
+        unimplemented!()
+    }
+    async fn get_all_devices(&self) -> Result<Vec<Device>, AppError> {
+        unimplemented!()
+    }
+    async fn get_device_by_id(&self, _id: Uuid) -> Result<Device, AppError> {
+        unimplemented!()
+    }
+    async fn update_device(
+        &self,
+        _id: Uuid,
+        _name: Option<&str>,
+        _device_type: Option<DeviceType>,
+    ) -> Result<Device, AppError> {
+        unimplemented!()
+    }
+}
+
+struct StubSystemService;
+#[async_trait]
+impl SystemService for StubSystemService {
+    async fn status(&self) -> Result<SystemStatusResponse, AppError> {
+        unimplemented!()
+    }
+}
+
+struct StubTunnelService;
+#[async_trait]
+impl TunnelService for StubTunnelService {
+    async fn import_tunnel(
+        &self,
+        _req: CreateTunnelRequest,
+    ) -> Result<CreateTunnelResponse, AppError> {
+        unimplemented!()
+    }
+    async fn list_tunnels(&self) -> Result<ListTunnelsResponse, AppError> {
+        unimplemented!()
+    }
+    async fn get_tunnel(&self, _id: Uuid) -> Result<Tunnel, AppError> {
+        unimplemented!()
+    }
+    async fn bring_up(&self, _id: Uuid) -> Result<(), AppError> {
+        unimplemented!()
+    }
+    async fn tear_down(&self, _id: Uuid, _reason: &str) -> Result<(), AppError> {
+        unimplemented!()
+    }
+    async fn delete_tunnel(&self, _id: Uuid) -> Result<DeleteTunnelResponse, AppError> {
+        unimplemented!()
+    }
+    async fn restore_tunnels(&self) -> Result<(), AppError> {
+        unimplemented!()
+    }
+}
+
+struct StubEventPublisher;
+impl EventPublisher for StubEventPublisher {
+    fn publish(&self, _event: WardnetEvent) {}
+    fn subscribe(&self) -> broadcast::Receiver<WardnetEvent> {
+        let (tx, rx) = broadcast::channel(1);
+        drop(tx);
+        rx
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Configurable mock auth service
+// ---------------------------------------------------------------------------
+
+/// Mock auth service that returns configurable results for session and API key
+/// validation.
+struct MockAuthService {
+    session_result: Option<Uuid>,
+    api_key_result: Option<Uuid>,
+}
+
+#[async_trait]
+impl AuthService for MockAuthService {
+    async fn login(&self, _username: &str, _password: &str) -> Result<LoginResult, AppError> {
+        unimplemented!()
+    }
+
+    async fn validate_session(&self, _token: &str) -> Result<Option<Uuid>, AppError> {
+        Ok(self.session_result)
+    }
+
+    async fn validate_api_key(&self, _key: &str) -> Result<Option<Uuid>, AppError> {
+        Ok(self.api_key_result)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn make_state(auth: impl AuthService + 'static) -> AppState {
+    AppState::new(
+        Arc::new(auth),
+        Arc::new(StubDeviceService),
+        Arc::new(StubDiscoveryService),
+        Arc::new(StubSystemService),
+        Arc::new(StubTunnelService),
+        Arc::new(StubEventPublisher),
+        Config::default(),
+    )
+}
+
+/// Handler that requires `AdminAuth` and returns the admin UUID.
+async fn admin_only(
+    crate::api::middleware::AdminAuth { admin_id }: crate::api::middleware::AdminAuth,
+) -> impl IntoResponse {
+    admin_id.to_string()
+}
+
+/// Handler that requires `ClientIp` and returns the IP.
+async fn ip_handler(
+    crate::api::middleware::ClientIp(ip): crate::api::middleware::ClientIp,
+) -> impl IntoResponse {
+    ip.to_string()
+}
+
+/// Build a router with the admin-only handler.
+fn admin_app(state: AppState) -> Router {
+    Router::new()
+        .route("/test", get(admin_only))
+        .with_state(state)
+}
+
+fn ip_app(state: AppState) -> Router {
+    Router::new()
+        .route("/test", get(ip_handler))
+        .with_state(state)
+}
+
+// ---------------------------------------------------------------------------
+// AdminAuth tests
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn admin_auth_from_session_cookie() {
+    let admin_id = Uuid::new_v4();
+    let state = make_state(MockAuthService {
+        session_result: Some(admin_id),
+        api_key_result: None,
+    });
+
+    let app = admin_app(state);
+    let req = Request::builder()
+        .uri("/test")
+        .header("Cookie", "wardnet_session=some-token-value")
+        .extension(ConnectInfo(SocketAddr::new(
+            IpAddr::V4(Ipv4Addr::LOCALHOST),
+            1234,
+        )))
+        .body(Body::empty())
+        .unwrap();
+
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    let body = axum::body::to_bytes(resp.into_body(), 4096).await.unwrap();
+    assert_eq!(String::from_utf8_lossy(&body), admin_id.to_string());
+}
+
+#[tokio::test]
+async fn admin_auth_from_bearer_api_key() {
+    let admin_id = Uuid::new_v4();
+    let state = make_state(MockAuthService {
+        session_result: None,
+        api_key_result: Some(admin_id),
+    });
+
+    let app = admin_app(state);
+    let req = Request::builder()
+        .uri("/test")
+        .header("Authorization", "Bearer my-api-key")
+        .extension(ConnectInfo(SocketAddr::new(
+            IpAddr::V4(Ipv4Addr::LOCALHOST),
+            1234,
+        )))
+        .body(Body::empty())
+        .unwrap();
+
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    let body = axum::body::to_bytes(resp.into_body(), 4096).await.unwrap();
+    assert_eq!(String::from_utf8_lossy(&body), admin_id.to_string());
+}
+
+#[tokio::test]
+async fn admin_auth_rejected_without_credentials() {
+    let state = make_state(MockAuthService {
+        session_result: None,
+        api_key_result: None,
+    });
+
+    let app = admin_app(state);
+    let req = Request::builder()
+        .uri("/test")
+        .extension(ConnectInfo(SocketAddr::new(
+            IpAddr::V4(Ipv4Addr::LOCALHOST),
+            1234,
+        )))
+        .body(Body::empty())
+        .unwrap();
+
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn admin_auth_session_takes_precedence_over_api_key() {
+    let session_id = Uuid::new_v4();
+    let api_key_id = Uuid::new_v4();
+    let state = make_state(MockAuthService {
+        session_result: Some(session_id),
+        api_key_result: Some(api_key_id),
+    });
+
+    let app = admin_app(state);
+    let req = Request::builder()
+        .uri("/test")
+        .header("Cookie", "wardnet_session=tok")
+        .header("Authorization", "Bearer key")
+        .extension(ConnectInfo(SocketAddr::new(
+            IpAddr::V4(Ipv4Addr::LOCALHOST),
+            1234,
+        )))
+        .body(Body::empty())
+        .unwrap();
+
+    let resp = app.oneshot(req).await.unwrap();
+    let body = axum::body::to_bytes(resp.into_body(), 4096).await.unwrap();
+    // Session cookie should win.
+    assert_eq!(String::from_utf8_lossy(&body), session_id.to_string());
+}
+
+#[tokio::test]
+async fn admin_auth_ignores_empty_session_cookie() {
+    let api_key_id = Uuid::new_v4();
+    let state = make_state(MockAuthService {
+        session_result: None, // won't be called since cookie is empty
+        api_key_result: Some(api_key_id),
+    });
+
+    let app = admin_app(state);
+    let req = Request::builder()
+        .uri("/test")
+        .header("Cookie", "wardnet_session=")
+        .header("Authorization", "Bearer key")
+        .extension(ConnectInfo(SocketAddr::new(
+            IpAddr::V4(Ipv4Addr::LOCALHOST),
+            1234,
+        )))
+        .body(Body::empty())
+        .unwrap();
+
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = axum::body::to_bytes(resp.into_body(), 4096).await.unwrap();
+    assert_eq!(String::from_utf8_lossy(&body), api_key_id.to_string());
+}
+
+#[tokio::test]
+async fn admin_auth_ignores_empty_bearer_token() {
+    let state = make_state(MockAuthService {
+        session_result: None,
+        api_key_result: None,
+    });
+
+    let app = admin_app(state);
+    let req = Request::builder()
+        .uri("/test")
+        .header("Authorization", "Bearer ")
+        .extension(ConnectInfo(SocketAddr::new(
+            IpAddr::V4(Ipv4Addr::LOCALHOST),
+            1234,
+        )))
+        .body(Body::empty())
+        .unwrap();
+
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+}
+
+// ---------------------------------------------------------------------------
+// ClientIp tests
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn client_ip_extracted_from_connect_info() {
+    let state = make_state(MockAuthService {
+        session_result: None,
+        api_key_result: None,
+    });
+
+    let app = ip_app(state);
+    let req = Request::builder()
+        .uri("/test")
+        .extension(ConnectInfo(SocketAddr::new(
+            IpAddr::V4(Ipv4Addr::new(192, 168, 1, 42)),
+            5555,
+        )))
+        .body(Body::empty())
+        .unwrap();
+
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    let body = axum::body::to_bytes(resp.into_body(), 4096).await.unwrap();
+    assert_eq!(String::from_utf8_lossy(&body), "192.168.1.42");
+}
+
+#[tokio::test]
+async fn client_ip_missing_connect_info_returns_500() {
+    let state = make_state(MockAuthService {
+        session_result: None,
+        api_key_result: None,
+    });
+
+    let app = ip_app(state);
+    // No ConnectInfo extension.
+    let req = Request::builder().uri("/test").body(Body::empty()).unwrap();
+
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::INTERNAL_SERVER_ERROR);
+}
+
+#[tokio::test]
+async fn admin_auth_ignores_other_cookies() {
+    let state = make_state(MockAuthService {
+        session_result: None,
+        api_key_result: None,
+    });
+
+    let app = admin_app(state);
+    let req = Request::builder()
+        .uri("/test")
+        .header("Cookie", "other_cookie=value; tracking=abc")
+        .extension(ConnectInfo(SocketAddr::new(
+            IpAddr::V4(Ipv4Addr::LOCALHOST),
+            1234,
+        )))
+        .body(Body::empty())
+        .unwrap();
+
+    let resp = app.oneshot(req).await.unwrap();
+    // No wardnet_session cookie, no bearer, so should be 401.
+    assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+}

--- a/source/daemon/crates/wardnetd/src/api/tests/mod.rs
+++ b/source/daemon/crates/wardnetd/src/api/tests/mod.rs
@@ -1,0 +1,5 @@
+mod auth;
+mod devices;
+mod middleware;
+mod system;
+mod tunnels;

--- a/source/daemon/crates/wardnetd/src/api/tests/system.rs
+++ b/source/daemon/crates/wardnetd/src/api/tests/system.rs
@@ -1,0 +1,327 @@
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use axum::Router;
+use axum::body::Body;
+use axum::extract::ConnectInfo;
+use axum::http::{Request, StatusCode};
+use axum::routing::get;
+use tokio::sync::broadcast;
+use tower::ServiceExt;
+use uuid::Uuid;
+use wardnet_types::api::{
+    CreateTunnelRequest, CreateTunnelResponse, DeleteTunnelResponse, DeviceMeResponse,
+    ListTunnelsResponse, SetMyRuleResponse, SystemStatusResponse,
+};
+use wardnet_types::device::{Device, DeviceType};
+use wardnet_types::event::WardnetEvent;
+use wardnet_types::routing::RoutingTarget;
+use wardnet_types::tunnel::Tunnel;
+
+use crate::config::Config;
+use crate::error::AppError;
+use crate::event::EventPublisher;
+use crate::packet_capture::ObservedDevice;
+use crate::service::auth::LoginResult;
+use crate::service::{
+    AuthService, DeviceDiscoveryService, DeviceService, ObservationResult, SystemService,
+    TunnelService,
+};
+use crate::state::AppState;
+
+// ---------------------------------------------------------------------------
+// Stub services
+// ---------------------------------------------------------------------------
+
+struct StubDeviceService;
+#[async_trait]
+impl DeviceService for StubDeviceService {
+    async fn get_device_for_ip(&self, _ip: &str) -> Result<DeviceMeResponse, AppError> {
+        unimplemented!()
+    }
+    async fn set_rule_for_ip(
+        &self,
+        _ip: &str,
+        _t: RoutingTarget,
+    ) -> Result<SetMyRuleResponse, AppError> {
+        unimplemented!()
+    }
+}
+
+struct StubDiscoveryService;
+#[async_trait]
+impl DeviceDiscoveryService for StubDiscoveryService {
+    async fn restore_devices(&self) -> Result<(), AppError> {
+        unimplemented!()
+    }
+    async fn process_observation(
+        &self,
+        _obs: &ObservedDevice,
+    ) -> Result<ObservationResult, AppError> {
+        unimplemented!()
+    }
+    async fn flush_last_seen(&self) -> Result<u64, AppError> {
+        unimplemented!()
+    }
+    async fn scan_departures(&self, _t: u64) -> Result<Vec<Uuid>, AppError> {
+        unimplemented!()
+    }
+    async fn resolve_hostname(&self, _id: Uuid, _ip: String) -> Result<(), AppError> {
+        unimplemented!()
+    }
+    async fn get_all_devices(&self) -> Result<Vec<Device>, AppError> {
+        unimplemented!()
+    }
+    async fn get_device_by_id(&self, _id: Uuid) -> Result<Device, AppError> {
+        unimplemented!()
+    }
+    async fn update_device(
+        &self,
+        _id: Uuid,
+        _n: Option<&str>,
+        _dt: Option<DeviceType>,
+    ) -> Result<Device, AppError> {
+        unimplemented!()
+    }
+}
+
+struct StubTunnelService;
+#[async_trait]
+impl TunnelService for StubTunnelService {
+    async fn import_tunnel(
+        &self,
+        _r: CreateTunnelRequest,
+    ) -> Result<CreateTunnelResponse, AppError> {
+        unimplemented!()
+    }
+    async fn list_tunnels(&self) -> Result<ListTunnelsResponse, AppError> {
+        unimplemented!()
+    }
+    async fn get_tunnel(&self, _id: Uuid) -> Result<Tunnel, AppError> {
+        unimplemented!()
+    }
+    async fn bring_up(&self, _id: Uuid) -> Result<(), AppError> {
+        unimplemented!()
+    }
+    async fn tear_down(&self, _id: Uuid, _r: &str) -> Result<(), AppError> {
+        unimplemented!()
+    }
+    async fn delete_tunnel(&self, _id: Uuid) -> Result<DeleteTunnelResponse, AppError> {
+        unimplemented!()
+    }
+    async fn restore_tunnels(&self) -> Result<(), AppError> {
+        unimplemented!()
+    }
+}
+
+struct StubEventPublisher;
+impl EventPublisher for StubEventPublisher {
+    fn publish(&self, _event: WardnetEvent) {}
+    fn subscribe(&self) -> broadcast::Receiver<WardnetEvent> {
+        let (tx, rx) = broadcast::channel(1);
+        drop(tx);
+        rx
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Mock services
+// ---------------------------------------------------------------------------
+
+/// Mock auth service that always validates the session (so admin routes pass).
+struct AlwaysAuthService {
+    admin_id: Uuid,
+}
+
+#[async_trait]
+impl AuthService for AlwaysAuthService {
+    async fn login(&self, _u: &str, _p: &str) -> Result<LoginResult, AppError> {
+        unimplemented!()
+    }
+    async fn validate_session(&self, _token: &str) -> Result<Option<Uuid>, AppError> {
+        Ok(Some(self.admin_id))
+    }
+    async fn validate_api_key(&self, _key: &str) -> Result<Option<Uuid>, AppError> {
+        Ok(Some(self.admin_id))
+    }
+}
+
+/// Mock auth service that always rejects.
+struct NeverAuthService;
+#[async_trait]
+impl AuthService for NeverAuthService {
+    async fn login(&self, _u: &str, _p: &str) -> Result<LoginResult, AppError> {
+        unimplemented!()
+    }
+    async fn validate_session(&self, _token: &str) -> Result<Option<Uuid>, AppError> {
+        Ok(None)
+    }
+    async fn validate_api_key(&self, _key: &str) -> Result<Option<Uuid>, AppError> {
+        Ok(None)
+    }
+}
+
+/// Mock system service returning a preconfigured response.
+struct MockSystemService {
+    response: Result<SystemStatusResponse, AppError>,
+}
+
+#[async_trait]
+impl SystemService for MockSystemService {
+    async fn status(&self) -> Result<SystemStatusResponse, AppError> {
+        match &self.response {
+            Ok(r) => Ok(SystemStatusResponse {
+                version: r.version.clone(),
+                uptime_seconds: r.uptime_seconds,
+                device_count: r.device_count,
+                tunnel_count: r.tunnel_count,
+                db_size_bytes: r.db_size_bytes,
+            }),
+            Err(_) => Err(AppError::Internal(anyhow::anyhow!("mock error"))),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn make_state(auth: impl AuthService + 'static, system: impl SystemService + 'static) -> AppState {
+    AppState::new(
+        Arc::new(auth),
+        Arc::new(StubDeviceService),
+        Arc::new(StubDiscoveryService),
+        Arc::new(system),
+        Arc::new(StubTunnelService),
+        Arc::new(StubEventPublisher),
+        Config::default(),
+    )
+}
+
+fn system_app(state: AppState) -> Router {
+    Router::new()
+        .route("/api/system/status", get(crate::api::system::status))
+        .with_state(state)
+}
+
+fn connect_info_ext() -> ConnectInfo<SocketAddr> {
+    ConnectInfo(SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 1234))
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn status_returns_200_with_correct_json() {
+    let admin_id = Uuid::new_v4();
+    let state = make_state(
+        AlwaysAuthService { admin_id },
+        MockSystemService {
+            response: Ok(SystemStatusResponse {
+                version: "1.2.3".to_owned(),
+                uptime_seconds: 3600,
+                device_count: 10,
+                tunnel_count: 3,
+                db_size_bytes: 4096,
+            }),
+        },
+    );
+
+    let app = system_app(state);
+    let req = Request::builder()
+        .uri("/api/system/status")
+        .header("Cookie", "wardnet_session=valid-token")
+        .extension(connect_info_ext())
+        .body(Body::empty())
+        .unwrap();
+
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    let body = axum::body::to_bytes(resp.into_body(), 4096).await.unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+
+    assert_eq!(json["version"], "1.2.3");
+    assert_eq!(json["uptime_seconds"], 3600);
+    assert_eq!(json["device_count"], 10);
+    assert_eq!(json["tunnel_count"], 3);
+    assert_eq!(json["db_size_bytes"], 4096);
+}
+
+#[tokio::test]
+async fn status_requires_authentication() {
+    let state = make_state(
+        NeverAuthService,
+        MockSystemService {
+            response: Ok(SystemStatusResponse {
+                version: "1.0.0".to_owned(),
+                uptime_seconds: 0,
+                device_count: 0,
+                tunnel_count: 0,
+                db_size_bytes: 0,
+            }),
+        },
+    );
+
+    let app = system_app(state);
+    let req = Request::builder()
+        .uri("/api/system/status")
+        .extension(connect_info_ext())
+        .body(Body::empty())
+        .unwrap();
+
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn status_service_error_returns_500() {
+    let admin_id = Uuid::new_v4();
+    let state = make_state(
+        AlwaysAuthService { admin_id },
+        MockSystemService {
+            response: Err(AppError::Internal(anyhow::anyhow!("db down"))),
+        },
+    );
+
+    let app = system_app(state);
+    let req = Request::builder()
+        .uri("/api/system/status")
+        .header("Authorization", "Bearer some-key")
+        .extension(connect_info_ext())
+        .body(Body::empty())
+        .unwrap();
+
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::INTERNAL_SERVER_ERROR);
+}
+
+#[tokio::test]
+async fn status_authenticates_via_bearer_token() {
+    let admin_id = Uuid::new_v4();
+    let state = make_state(
+        AlwaysAuthService { admin_id },
+        MockSystemService {
+            response: Ok(SystemStatusResponse {
+                version: "0.0.1".to_owned(),
+                uptime_seconds: 1,
+                device_count: 0,
+                tunnel_count: 0,
+                db_size_bytes: 0,
+            }),
+        },
+    );
+
+    let app = system_app(state);
+    let req = Request::builder()
+        .uri("/api/system/status")
+        .header("Authorization", "Bearer test-api-key")
+        .extension(connect_info_ext())
+        .body(Body::empty())
+        .unwrap();
+
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+}

--- a/source/daemon/crates/wardnetd/src/api/tests/tunnels.rs
+++ b/source/daemon/crates/wardnetd/src/api/tests/tunnels.rs
@@ -1,0 +1,537 @@
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use axum::Router;
+use axum::body::Body;
+use axum::extract::ConnectInfo;
+use axum::http::{Request, StatusCode};
+use axum::routing::{delete, get};
+use tokio::sync::broadcast;
+use tower::ServiceExt;
+use uuid::Uuid;
+use wardnet_types::api::{
+    CreateTunnelRequest, CreateTunnelResponse, DeleteTunnelResponse, DeviceMeResponse,
+    ListTunnelsResponse, SetMyRuleResponse, SystemStatusResponse,
+};
+use wardnet_types::device::{Device, DeviceType};
+use wardnet_types::event::WardnetEvent;
+use wardnet_types::routing::RoutingTarget;
+use wardnet_types::tunnel::{Tunnel, TunnelStatus};
+
+use crate::config::Config;
+use crate::error::AppError;
+use crate::event::EventPublisher;
+use crate::packet_capture::ObservedDevice;
+use crate::service::auth::LoginResult;
+use crate::service::{
+    AuthService, DeviceDiscoveryService, DeviceService, ObservationResult, SystemService,
+    TunnelService,
+};
+use crate::state::AppState;
+
+// ---------------------------------------------------------------------------
+// Mock / stub services
+// ---------------------------------------------------------------------------
+
+struct MockAuthService;
+#[async_trait]
+impl AuthService for MockAuthService {
+    async fn login(&self, _u: &str, _p: &str) -> Result<LoginResult, AppError> {
+        Ok(LoginResult {
+            token: "t".to_owned(),
+            max_age_seconds: 3600,
+        })
+    }
+    async fn validate_session(&self, _token: &str) -> Result<Option<Uuid>, AppError> {
+        Ok(Some(
+            Uuid::parse_str("00000000-0000-0000-0000-000000000099").unwrap(),
+        ))
+    }
+    async fn validate_api_key(&self, _key: &str) -> Result<Option<Uuid>, AppError> {
+        Ok(None)
+    }
+}
+
+struct StubDeviceService;
+#[async_trait]
+impl DeviceService for StubDeviceService {
+    async fn get_device_for_ip(&self, _ip: &str) -> Result<DeviceMeResponse, AppError> {
+        Ok(DeviceMeResponse {
+            device: None,
+            current_rule: None,
+            admin_locked: false,
+        })
+    }
+    async fn set_rule_for_ip(
+        &self,
+        _ip: &str,
+        target: RoutingTarget,
+    ) -> Result<SetMyRuleResponse, AppError> {
+        Ok(SetMyRuleResponse {
+            message: "ok".to_owned(),
+            target,
+        })
+    }
+}
+
+struct StubDiscoveryService;
+#[async_trait]
+impl DeviceDiscoveryService for StubDiscoveryService {
+    async fn restore_devices(&self) -> Result<(), AppError> {
+        Ok(())
+    }
+    async fn process_observation(
+        &self,
+        _obs: &ObservedDevice,
+    ) -> Result<ObservationResult, AppError> {
+        unimplemented!()
+    }
+    async fn flush_last_seen(&self) -> Result<u64, AppError> {
+        Ok(0)
+    }
+    async fn scan_departures(&self, _timeout_secs: u64) -> Result<Vec<Uuid>, AppError> {
+        Ok(vec![])
+    }
+    async fn resolve_hostname(&self, _id: Uuid, _ip: String) -> Result<(), AppError> {
+        Ok(())
+    }
+    async fn get_all_devices(&self) -> Result<Vec<Device>, AppError> {
+        Ok(vec![])
+    }
+    async fn get_device_by_id(&self, id: Uuid) -> Result<Device, AppError> {
+        Err(AppError::NotFound(format!("device {id} not found")))
+    }
+    async fn update_device(
+        &self,
+        id: Uuid,
+        _name: Option<&str>,
+        _dt: Option<DeviceType>,
+    ) -> Result<Device, AppError> {
+        Err(AppError::NotFound(format!("device {id} not found")))
+    }
+}
+
+struct StubSystemService;
+#[async_trait]
+impl SystemService for StubSystemService {
+    async fn status(&self) -> Result<SystemStatusResponse, AppError> {
+        Ok(SystemStatusResponse {
+            version: "test".to_owned(),
+            uptime_seconds: 0,
+            device_count: 0,
+            tunnel_count: 0,
+            db_size_bytes: 0,
+        })
+    }
+}
+
+struct StubEventPublisher;
+impl EventPublisher for StubEventPublisher {
+    fn publish(&self, _event: WardnetEvent) {}
+    fn subscribe(&self) -> broadcast::Receiver<WardnetEvent> {
+        let (tx, rx) = broadcast::channel(1);
+        drop(tx);
+        rx
+    }
+}
+
+/// Mock `TunnelService` with configurable tunnel list.
+struct MockTunnelService {
+    tunnels: Vec<Tunnel>,
+}
+
+impl MockTunnelService {
+    fn with_tunnels(tunnels: Vec<Tunnel>) -> Self {
+        Self { tunnels }
+    }
+
+    fn empty() -> Self {
+        Self { tunnels: vec![] }
+    }
+}
+
+#[async_trait]
+impl TunnelService for MockTunnelService {
+    async fn import_tunnel(
+        &self,
+        req: CreateTunnelRequest,
+    ) -> Result<CreateTunnelResponse, AppError> {
+        let tunnel = Tunnel {
+            id: Uuid::parse_str("00000000-0000-0000-0000-000000000010").unwrap(),
+            label: req.label,
+            country_code: req.country_code,
+            provider: req.provider,
+            interface_name: "wg_ward0".to_owned(),
+            endpoint: "1.2.3.4:51820".to_owned(),
+            status: TunnelStatus::Down,
+            last_handshake: None,
+            bytes_tx: 0,
+            bytes_rx: 0,
+            created_at: chrono::Utc::now(),
+        };
+        Ok(CreateTunnelResponse {
+            tunnel,
+            message: "tunnel imported successfully".to_owned(),
+        })
+    }
+
+    async fn list_tunnels(&self) -> Result<ListTunnelsResponse, AppError> {
+        Ok(ListTunnelsResponse {
+            tunnels: self.tunnels.clone(),
+        })
+    }
+
+    async fn get_tunnel(&self, id: Uuid) -> Result<Tunnel, AppError> {
+        self.tunnels
+            .iter()
+            .find(|t| t.id == id)
+            .cloned()
+            .ok_or_else(|| AppError::NotFound(format!("tunnel {id} not found")))
+    }
+
+    async fn bring_up(&self, _id: Uuid) -> Result<(), AppError> {
+        Ok(())
+    }
+
+    async fn tear_down(&self, _id: Uuid, _reason: &str) -> Result<(), AppError> {
+        Ok(())
+    }
+
+    async fn delete_tunnel(&self, id: Uuid) -> Result<DeleteTunnelResponse, AppError> {
+        if self.tunnels.iter().any(|t| t.id == id) {
+            Ok(DeleteTunnelResponse {
+                message: "tunnel deleted".to_owned(),
+            })
+        } else {
+            Err(AppError::NotFound(format!("tunnel {id} not found")))
+        }
+    }
+
+    async fn restore_tunnels(&self) -> Result<(), AppError> {
+        Ok(())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn sample_tunnel() -> Tunnel {
+    Tunnel {
+        id: Uuid::parse_str("00000000-0000-0000-0000-000000000010").unwrap(),
+        label: "US West".to_owned(),
+        country_code: "US".to_owned(),
+        provider: Some("Mullvad".to_owned()),
+        interface_name: "wg_ward0".to_owned(),
+        endpoint: "1.2.3.4:51820".to_owned(),
+        status: TunnelStatus::Down,
+        last_handshake: None,
+        bytes_tx: 0,
+        bytes_rx: 0,
+        created_at: "2026-03-07T00:00:00Z".parse().unwrap(),
+    }
+}
+
+fn connect_info() -> ConnectInfo<SocketAddr> {
+    ConnectInfo(SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 12345))
+}
+
+fn build_state(tunnel_svc: impl TunnelService + 'static) -> AppState {
+    AppState::new(
+        Arc::new(MockAuthService),
+        Arc::new(StubDeviceService),
+        Arc::new(StubDiscoveryService),
+        Arc::new(StubSystemService),
+        Arc::new(tunnel_svc),
+        Arc::new(StubEventPublisher),
+        Config::default(),
+    )
+}
+
+fn tunnel_router(state: AppState) -> Router {
+    Router::new()
+        .route(
+            "/api/tunnels",
+            get(crate::api::tunnels::list_tunnels).post(crate::api::tunnels::create_tunnel),
+        )
+        .route(
+            "/api/tunnels/{id}",
+            delete(crate::api::tunnels::delete_tunnel),
+        )
+        .with_state(state)
+}
+
+/// Send an authenticated GET request.
+async fn get_json(app: Router, uri: &str) -> (StatusCode, serde_json::Value) {
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .uri(uri)
+                .header("Cookie", "wardnet_session=valid-token")
+                .extension(connect_info())
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    let status = resp.status();
+    let body = axum::body::to_bytes(resp.into_body(), 16384).await.unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap_or(serde_json::Value::Null);
+    (status, json)
+}
+
+/// Send an authenticated POST request with JSON body.
+async fn post_json(app: Router, uri: &str, json_body: &str) -> (StatusCode, serde_json::Value) {
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(uri)
+                .header("Content-Type", "application/json")
+                .header("Cookie", "wardnet_session=valid-token")
+                .extension(connect_info())
+                .body(Body::from(json_body.to_owned()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    let status = resp.status();
+    let body = axum::body::to_bytes(resp.into_body(), 16384).await.unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap_or(serde_json::Value::Null);
+    (status, json)
+}
+
+/// Send an authenticated DELETE request.
+async fn delete_json(app: Router, uri: &str) -> (StatusCode, serde_json::Value) {
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("DELETE")
+                .uri(uri)
+                .header("Cookie", "wardnet_session=valid-token")
+                .extension(connect_info())
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    let status = resp.status();
+    let body = axum::body::to_bytes(resp.into_body(), 16384).await.unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap_or(serde_json::Value::Null);
+    (status, json)
+}
+
+// ---------------------------------------------------------------------------
+// GET /api/tunnels
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn list_tunnels_returns_all() {
+    let tunnel = sample_tunnel();
+    let state = build_state(MockTunnelService::with_tunnels(vec![tunnel]));
+    let app = tunnel_router(state);
+
+    let (status, json) = get_json(app, "/api/tunnels").await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(json["tunnels"].as_array().unwrap().len(), 1);
+    assert_eq!(json["tunnels"][0]["label"], "US West");
+    assert_eq!(json["tunnels"][0]["country_code"], "US");
+    assert_eq!(json["tunnels"][0]["status"], "down");
+}
+
+#[tokio::test]
+async fn list_tunnels_returns_empty() {
+    let state = build_state(MockTunnelService::empty());
+    let app = tunnel_router(state);
+
+    let (status, json) = get_json(app, "/api/tunnels").await;
+    assert_eq!(status, StatusCode::OK);
+    assert!(json["tunnels"].as_array().unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn list_tunnels_unauthorized_without_session() {
+    let state = build_state(MockTunnelService::empty());
+    let app = tunnel_router(state);
+
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .uri("/api/tunnels")
+                .extension(connect_info())
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+}
+
+// ---------------------------------------------------------------------------
+// POST /api/tunnels
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn create_tunnel_success() {
+    let state = build_state(MockTunnelService::empty());
+    let app = tunnel_router(state);
+
+    let body = serde_json::json!({
+        "label": "US West",
+        "country_code": "US",
+        "provider": "Mullvad",
+        "config": "[Interface]\nPrivateKey = abc\n\n[Peer]\nPublicKey = xyz\nEndpoint = 1.2.3.4:51820\nAllowedIPs = 0.0.0.0/0\n"
+    });
+
+    let (status, json) = post_json(app, "/api/tunnels", &body.to_string()).await;
+    assert_eq!(status, StatusCode::CREATED);
+    assert_eq!(json["tunnel"]["label"], "US West");
+    assert_eq!(json["tunnel"]["country_code"], "US");
+    assert_eq!(json["message"], "tunnel imported successfully");
+}
+
+#[tokio::test]
+async fn create_tunnel_without_provider() {
+    let state = build_state(MockTunnelService::empty());
+    let app = tunnel_router(state);
+
+    let body = serde_json::json!({
+        "label": "DE Berlin",
+        "country_code": "DE",
+        "config": "[Interface]\nPrivateKey = abc\n\n[Peer]\nPublicKey = xyz\nEndpoint = 5.6.7.8:51820\nAllowedIPs = 0.0.0.0/0\n"
+    });
+
+    let (status, json) = post_json(app, "/api/tunnels", &body.to_string()).await;
+    assert_eq!(status, StatusCode::CREATED);
+    assert_eq!(json["tunnel"]["label"], "DE Berlin");
+    assert!(json["tunnel"]["provider"].is_null());
+}
+
+#[tokio::test]
+async fn create_tunnel_bad_json_returns_error() {
+    let state = build_state(MockTunnelService::empty());
+    let app = tunnel_router(state);
+
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/tunnels")
+                .header("Content-Type", "application/json")
+                .header("Cookie", "wardnet_session=valid-token")
+                .extension(connect_info())
+                .body(Body::from("not json"))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    // Axum returns 400 or 422 for deserialization failures depending on version.
+    let status = resp.status();
+    assert!(
+        status == StatusCode::BAD_REQUEST || status == StatusCode::UNPROCESSABLE_ENTITY,
+        "expected 400 or 422, got {status}"
+    );
+}
+
+#[tokio::test]
+async fn create_tunnel_missing_fields_returns_error() {
+    let state = build_state(MockTunnelService::empty());
+    let app = tunnel_router(state);
+
+    // Missing required `config` field.
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/tunnels")
+                .header("Content-Type", "application/json")
+                .header("Cookie", "wardnet_session=valid-token")
+                .extension(connect_info())
+                .body(Body::from(r#"{"label":"x","country_code":"US"}"#))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    let status = resp.status();
+    assert!(
+        status == StatusCode::BAD_REQUEST || status == StatusCode::UNPROCESSABLE_ENTITY,
+        "expected 400 or 422, got {status}"
+    );
+}
+
+#[tokio::test]
+async fn create_tunnel_unauthorized_without_session() {
+    let state = build_state(MockTunnelService::empty());
+    let app = tunnel_router(state);
+
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/tunnels")
+                .header("Content-Type", "application/json")
+                .extension(connect_info())
+                .body(Body::from(
+                    r#"{"label":"x","country_code":"US","config":"y"}"#,
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+}
+
+// ---------------------------------------------------------------------------
+// DELETE /api/tunnels/:id
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn delete_tunnel_success() {
+    let tunnel = sample_tunnel();
+    let state = build_state(MockTunnelService::with_tunnels(vec![tunnel]));
+    let app = tunnel_router(state);
+
+    let (status, json) =
+        delete_json(app, "/api/tunnels/00000000-0000-0000-0000-000000000010").await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(json["message"], "tunnel deleted");
+}
+
+#[tokio::test]
+async fn delete_tunnel_not_found() {
+    let state = build_state(MockTunnelService::empty());
+    let app = tunnel_router(state);
+
+    let (status, json) =
+        delete_json(app, "/api/tunnels/00000000-0000-0000-0000-000000000099").await;
+    assert_eq!(status, StatusCode::NOT_FOUND);
+    assert_eq!(json["error"], "not found");
+}
+
+#[tokio::test]
+async fn delete_tunnel_unauthorized_without_session() {
+    let state = build_state(MockTunnelService::empty());
+    let app = tunnel_router(state);
+
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("DELETE")
+                .uri("/api/tunnels/00000000-0000-0000-0000-000000000010")
+                .extension(connect_info())
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+}

--- a/source/daemon/crates/wardnetd/src/packet_capture_pnet.rs
+++ b/source/daemon/crates/wardnetd/src/packet_capture_pnet.rs
@@ -19,7 +19,7 @@ use crate::packet_capture::{ObservedDevice, PacketCapture, PacketSource};
 pub struct PnetCapture;
 
 /// Find a network interface by name.
-fn find_interface(name: &str) -> anyhow::Result<NetworkInterface> {
+pub(crate) fn find_interface(name: &str) -> anyhow::Result<NetworkInterface> {
     datalink::interfaces()
         .into_iter()
         .find(|iface| iface.name == name)
@@ -27,7 +27,7 @@ fn find_interface(name: &str) -> anyhow::Result<NetworkInterface> {
 }
 
 /// Format a `pnet` `MacAddr` as uppercase colon-separated "AA:BB:CC:DD:EE:FF".
-fn format_mac(mac: MacAddr) -> String {
+pub(crate) fn format_mac(mac: MacAddr) -> String {
     format!(
         "{:02X}:{:02X}:{:02X}:{:02X}:{:02X}:{:02X}",
         mac.0, mac.1, mac.2, mac.3, mac.4, mac.5
@@ -35,7 +35,7 @@ fn format_mac(mac: MacAddr) -> String {
 }
 
 /// Check whether a MAC address should be filtered out.
-fn should_filter_mac(mac: MacAddr, own_mac: MacAddr) -> bool {
+pub(crate) fn should_filter_mac(mac: MacAddr, own_mac: MacAddr) -> bool {
     // Own MAC
     if mac == own_mac {
         return true;
@@ -52,7 +52,7 @@ fn should_filter_mac(mac: MacAddr, own_mac: MacAddr) -> bool {
 }
 
 /// Parse an Ethernet frame into an `ObservedDevice`, if applicable.
-fn parse_frame(data: &[u8], own_mac: MacAddr) -> Option<ObservedDevice> {
+pub(crate) fn parse_frame(data: &[u8], own_mac: MacAddr) -> Option<ObservedDevice> {
     let eth = EthernetPacket::new(data)?;
 
     match eth.get_ethertype() {
@@ -102,7 +102,11 @@ fn parse_frame(data: &[u8], own_mac: MacAddr) -> Option<ObservedDevice> {
 /// Build an ARP request Ethernet frame.
 ///
 /// Returns a `Vec<u8>` containing the complete Ethernet frame.
-fn build_arp_request(src_mac: MacAddr, src_ip: Ipv4Addr, target_ip: Ipv4Addr) -> Option<Vec<u8>> {
+pub(crate) fn build_arp_request(
+    src_mac: MacAddr,
+    src_ip: Ipv4Addr,
+    target_ip: Ipv4Addr,
+) -> Option<Vec<u8>> {
     // Ethernet header (14) + ARP payload (28) = 42 bytes
     let mut buf = vec![0u8; 42];
 
@@ -132,7 +136,7 @@ fn build_arp_request(src_mac: MacAddr, src_ip: Ipv4Addr, target_ip: Ipv4Addr) ->
 /// Compute all host IPs in a subnet given an address and netmask.
 ///
 /// Excludes network and broadcast addresses.
-fn subnet_hosts(ip: Ipv4Addr, mask: Ipv4Addr) -> Vec<Ipv4Addr> {
+pub(crate) fn subnet_hosts(ip: Ipv4Addr, mask: Ipv4Addr) -> Vec<Ipv4Addr> {
     let ip_u32 = u32::from(ip);
     let mask_u32 = u32::from(mask);
     let network = ip_u32 & mask_u32;

--- a/source/daemon/crates/wardnetd/src/tests/error.rs
+++ b/source/daemon/crates/wardnetd/src/tests/error.rs
@@ -1,0 +1,79 @@
+use axum::http::StatusCode;
+use axum::response::IntoResponse;
+
+use crate::error::AppError;
+
+/// Extract status code and JSON body from an `AppError` response.
+async fn error_response(err: AppError) -> (StatusCode, serde_json::Value) {
+    let response = err.into_response();
+    let status = response.status();
+    let body = axum::body::to_bytes(response.into_body(), 4096)
+        .await
+        .unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    (status, json)
+}
+
+#[tokio::test]
+async fn not_found_returns_404_with_detail() {
+    let (status, json) = error_response(AppError::NotFound("thing missing".to_owned())).await;
+
+    assert_eq!(status, StatusCode::NOT_FOUND);
+    assert_eq!(json["error"], "not found");
+    assert_eq!(json["detail"], "thing missing");
+}
+
+#[tokio::test]
+async fn unauthorized_returns_401_with_detail() {
+    let (status, json) = error_response(AppError::Unauthorized("bad credentials".to_owned())).await;
+
+    assert_eq!(status, StatusCode::UNAUTHORIZED);
+    assert_eq!(json["error"], "unauthorized");
+    assert_eq!(json["detail"], "bad credentials");
+}
+
+#[tokio::test]
+async fn forbidden_returns_403_with_detail() {
+    let (status, json) = error_response(AppError::Forbidden("no access".to_owned())).await;
+
+    assert_eq!(status, StatusCode::FORBIDDEN);
+    assert_eq!(json["error"], "forbidden");
+    assert_eq!(json["detail"], "no access");
+}
+
+#[tokio::test]
+async fn bad_request_returns_400_with_detail() {
+    let (status, json) = error_response(AppError::BadRequest("invalid input".to_owned())).await;
+
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    assert_eq!(json["error"], "bad request");
+    assert_eq!(json["detail"], "invalid input");
+}
+
+#[tokio::test]
+async fn internal_returns_500_without_detail() {
+    let (status, json) =
+        error_response(AppError::Internal(anyhow::anyhow!("secret details"))).await;
+
+    assert_eq!(status, StatusCode::INTERNAL_SERVER_ERROR);
+    assert_eq!(json["error"], "internal server error");
+    // Internal errors must not leak detail to the client.
+    assert!(json.get("detail").is_none());
+}
+
+#[tokio::test]
+async fn database_returns_500_without_detail() {
+    let db_err = sqlx::Error::RowNotFound;
+    let (status, json) = error_response(AppError::Database(db_err)).await;
+
+    assert_eq!(status, StatusCode::INTERNAL_SERVER_ERROR);
+    assert_eq!(json["error"], "internal server error");
+    assert!(json.get("detail").is_none());
+}
+
+#[tokio::test]
+async fn anyhow_converts_to_internal() {
+    let err: AppError = anyhow::anyhow!("something broke").into();
+    let (status, _) = error_response(err).await;
+    assert_eq!(status, StatusCode::INTERNAL_SERVER_ERROR);
+}

--- a/source/daemon/crates/wardnetd/src/tests/mod.rs
+++ b/source/daemon/crates/wardnetd/src/tests/mod.rs
@@ -1,5 +1,9 @@
 mod config;
+mod error;
 mod event;
 mod keys;
 mod oui;
+mod packet_capture;
+mod tunnel_idle;
+mod tunnel_monitor;
 mod version;

--- a/source/daemon/crates/wardnetd/src/tests/packet_capture.rs
+++ b/source/daemon/crates/wardnetd/src/tests/packet_capture.rs
@@ -1,0 +1,333 @@
+use std::net::Ipv4Addr;
+
+use pnet::packet::Packet;
+use pnet::packet::arp::{ArpHardwareTypes, ArpOperations, ArpPacket, MutableArpPacket};
+use pnet::packet::ethernet::{EtherTypes, EthernetPacket, MutableEthernetPacket};
+use pnet::packet::ipv4::MutableIpv4Packet;
+use pnet::util::MacAddr;
+
+use crate::packet_capture::PacketSource;
+use crate::packet_capture_pnet::{
+    build_arp_request, find_interface, format_mac, parse_frame, should_filter_mac, subnet_hosts,
+};
+
+// ---------------------------------------------------------------------------
+// format_mac
+// ---------------------------------------------------------------------------
+
+#[test]
+fn format_mac_all_zeros() {
+    assert_eq!(format_mac(MacAddr::zero()), "00:00:00:00:00:00");
+}
+
+#[test]
+fn format_mac_all_ff() {
+    assert_eq!(
+        format_mac(MacAddr::new(0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF)),
+        "FF:FF:FF:FF:FF:FF"
+    );
+}
+
+#[test]
+fn format_mac_typical() {
+    let mac = MacAddr::new(0xAA, 0xBB, 0xCC, 0x01, 0x02, 0x03);
+    assert_eq!(format_mac(mac), "AA:BB:CC:01:02:03");
+}
+
+#[test]
+fn format_mac_lowercase_hex_digits_uppercased() {
+    // Ensure digits a-f come out uppercase.
+    let mac = MacAddr::new(0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f);
+    assert_eq!(format_mac(mac), "0A:0B:0C:0D:0E:0F");
+}
+
+// ---------------------------------------------------------------------------
+// should_filter_mac
+// ---------------------------------------------------------------------------
+
+#[test]
+fn filter_own_mac() {
+    let own = MacAddr::new(0xDE, 0xAD, 0xBE, 0xEF, 0x00, 0x01);
+    assert!(should_filter_mac(own, own));
+}
+
+#[test]
+fn filter_broadcast_mac() {
+    let own = MacAddr::new(0xDE, 0xAD, 0xBE, 0xEF, 0x00, 0x01);
+    assert!(should_filter_mac(MacAddr::broadcast(), own));
+}
+
+#[test]
+fn filter_multicast_mac() {
+    let own = MacAddr::new(0xDE, 0xAD, 0xBE, 0xEF, 0x00, 0x01);
+    // Multicast: bit 0 of first octet is set (0x01, 0x33, etc.)
+    let multicast = MacAddr::new(0x01, 0x00, 0x5E, 0x00, 0x00, 0x01);
+    assert!(should_filter_mac(multicast, own));
+}
+
+#[test]
+fn allow_normal_unicast_mac() {
+    let own = MacAddr::new(0xDE, 0xAD, 0xBE, 0xEF, 0x00, 0x01);
+    let other = MacAddr::new(0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0x00);
+    assert!(!should_filter_mac(other, own));
+}
+
+#[test]
+fn filter_ipv6_multicast_mac() {
+    let own = MacAddr::new(0x02, 0x00, 0x00, 0x00, 0x00, 0x01);
+    // IPv6 multicast prefix 33:33:xx:xx:xx:xx -- first octet 0x33 has bit 0 set
+    let ipv6_mcast = MacAddr::new(0x33, 0x33, 0x00, 0x00, 0x00, 0x01);
+    assert!(should_filter_mac(ipv6_mcast, own));
+}
+
+// ---------------------------------------------------------------------------
+// subnet_hosts
+// ---------------------------------------------------------------------------
+
+#[test]
+fn subnet_hosts_slash_24() {
+    let hosts = subnet_hosts(
+        Ipv4Addr::new(192, 168, 1, 100),
+        Ipv4Addr::new(255, 255, 255, 0),
+    );
+    // /24 has 256 addresses, minus network (.0) and broadcast (.255) = 254 hosts
+    assert_eq!(hosts.len(), 254);
+    assert_eq!(hosts[0], Ipv4Addr::new(192, 168, 1, 1));
+    assert_eq!(hosts[253], Ipv4Addr::new(192, 168, 1, 254));
+}
+
+#[test]
+fn subnet_hosts_slash_30() {
+    // /30 = 4 addresses, minus 2 = 2 hosts
+    let hosts = subnet_hosts(
+        Ipv4Addr::new(10, 0, 0, 1),
+        Ipv4Addr::new(255, 255, 255, 252),
+    );
+    assert_eq!(hosts.len(), 2);
+    assert_eq!(hosts[0], Ipv4Addr::new(10, 0, 0, 1));
+    assert_eq!(hosts[1], Ipv4Addr::new(10, 0, 0, 2));
+}
+
+#[test]
+fn subnet_hosts_slash_31() {
+    // /31 = 2 addresses total, network + broadcast overlap, so no usable hosts
+    // per the implementation: start = network+1, end = broadcast-1, start > end => empty
+    let hosts = subnet_hosts(
+        Ipv4Addr::new(10, 0, 0, 0),
+        Ipv4Addr::new(255, 255, 255, 254),
+    );
+    assert!(hosts.is_empty());
+}
+
+#[test]
+fn subnet_hosts_slash_32() {
+    // /32 = single address, no hosts
+    let hosts = subnet_hosts(Ipv4Addr::new(10, 0, 0, 1), Ipv4Addr::BROADCAST);
+    assert!(hosts.is_empty());
+}
+
+#[test]
+fn subnet_hosts_slash_16() {
+    let hosts = subnet_hosts(Ipv4Addr::new(172, 16, 0, 50), Ipv4Addr::new(255, 255, 0, 0));
+    // /16 = 65536 addresses, minus 2 = 65534 hosts
+    assert_eq!(hosts.len(), 65534);
+    assert_eq!(hosts[0], Ipv4Addr::new(172, 16, 0, 1));
+    assert_eq!(hosts[65533], Ipv4Addr::new(172, 16, 255, 254));
+}
+
+// ---------------------------------------------------------------------------
+// build_arp_request
+// ---------------------------------------------------------------------------
+
+#[test]
+fn build_arp_request_produces_valid_frame() {
+    let src_mac = MacAddr::new(0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF);
+    let src_ip = Ipv4Addr::new(192, 168, 1, 10);
+    let target_ip = Ipv4Addr::new(192, 168, 1, 20);
+
+    let frame = build_arp_request(src_mac, src_ip, target_ip).expect("should build frame");
+    assert_eq!(frame.len(), 42);
+
+    // Verify Ethernet header
+    let eth = EthernetPacket::new(&frame).unwrap();
+    assert_eq!(eth.get_destination(), MacAddr::broadcast());
+    assert_eq!(eth.get_source(), src_mac);
+    assert_eq!(eth.get_ethertype(), EtherTypes::Arp);
+
+    // Verify ARP payload
+    let arp = ArpPacket::new(eth.payload()).unwrap();
+    assert_eq!(arp.get_hardware_type(), ArpHardwareTypes::Ethernet);
+    assert_eq!(arp.get_protocol_type(), EtherTypes::Ipv4);
+    assert_eq!(arp.get_hw_addr_len(), 6);
+    assert_eq!(arp.get_proto_addr_len(), 4);
+    assert_eq!(arp.get_operation(), ArpOperations::Request);
+    assert_eq!(arp.get_sender_hw_addr(), src_mac);
+    assert_eq!(arp.get_sender_proto_addr(), src_ip);
+    assert_eq!(arp.get_target_hw_addr(), MacAddr::zero());
+    assert_eq!(arp.get_target_proto_addr(), target_ip);
+}
+
+// ---------------------------------------------------------------------------
+// parse_frame -- ARP
+// ---------------------------------------------------------------------------
+
+/// Helper: build a raw ARP reply frame for testing `parse_frame`.
+fn make_arp_frame(sender_mac: MacAddr, sender_ip: Ipv4Addr) -> Vec<u8> {
+    let mut buf = vec![0u8; 42];
+    {
+        let mut eth = MutableEthernetPacket::new(&mut buf).unwrap();
+        eth.set_source(sender_mac);
+        eth.set_destination(MacAddr::broadcast());
+        eth.set_ethertype(EtherTypes::Arp);
+    }
+    {
+        let mut arp = MutableArpPacket::new(&mut buf[14..]).unwrap();
+        arp.set_hardware_type(ArpHardwareTypes::Ethernet);
+        arp.set_protocol_type(EtherTypes::Ipv4);
+        arp.set_hw_addr_len(6);
+        arp.set_proto_addr_len(4);
+        arp.set_operation(ArpOperations::Reply);
+        arp.set_sender_hw_addr(sender_mac);
+        arp.set_sender_proto_addr(sender_ip);
+        arp.set_target_hw_addr(MacAddr::zero());
+        arp.set_target_proto_addr(Ipv4Addr::UNSPECIFIED);
+    }
+    buf
+}
+
+/// Helper: build a raw IPv4 Ethernet frame for testing `parse_frame`.
+fn make_ipv4_frame(src_mac: MacAddr, src_ip: Ipv4Addr) -> Vec<u8> {
+    // Ethernet header (14) + IPv4 header (20 minimum) = 34 bytes
+    let mut buf = vec![0u8; 34];
+    {
+        let mut eth = MutableEthernetPacket::new(&mut buf).unwrap();
+        eth.set_source(src_mac);
+        eth.set_destination(MacAddr::new(0xDE, 0xAD, 0x00, 0x00, 0x00, 0x01));
+        eth.set_ethertype(EtherTypes::Ipv4);
+    }
+    {
+        let mut ipv4 = MutableIpv4Packet::new(&mut buf[14..]).unwrap();
+        ipv4.set_version(4);
+        ipv4.set_header_length(5);
+        ipv4.set_total_length(20);
+        ipv4.set_source(src_ip);
+        ipv4.set_destination(Ipv4Addr::new(192, 168, 1, 1));
+    }
+    buf
+}
+
+#[test]
+fn parse_frame_arp_valid() {
+    let own_mac = MacAddr::new(0xDE, 0xAD, 0xBE, 0xEF, 0x00, 0x01);
+    let sender_mac = MacAddr::new(0xAA, 0xBB, 0xCC, 0x11, 0x22, 0x33);
+    let sender_ip = Ipv4Addr::new(192, 168, 1, 50);
+
+    let frame = make_arp_frame(sender_mac, sender_ip);
+    let obs = parse_frame(&frame, own_mac).expect("should parse ARP frame");
+
+    assert_eq!(obs.mac, "AA:BB:CC:11:22:33");
+    assert_eq!(obs.ip, "192.168.1.50");
+    assert_eq!(obs.source, PacketSource::Arp);
+}
+
+#[test]
+fn parse_frame_arp_filtered_own_mac() {
+    let own_mac = MacAddr::new(0xAA, 0xBB, 0xCC, 0x11, 0x22, 0x33);
+    let frame = make_arp_frame(own_mac, Ipv4Addr::new(192, 168, 1, 1));
+    assert!(parse_frame(&frame, own_mac).is_none());
+}
+
+#[test]
+fn parse_frame_arp_filtered_unspecified_ip() {
+    let own_mac = MacAddr::new(0xDE, 0xAD, 0xBE, 0xEF, 0x00, 0x01);
+    let sender_mac = MacAddr::new(0xAA, 0xBB, 0xCC, 0x11, 0x22, 0x33);
+    let frame = make_arp_frame(sender_mac, Ipv4Addr::UNSPECIFIED);
+    assert!(parse_frame(&frame, own_mac).is_none());
+}
+
+#[test]
+fn parse_frame_arp_filtered_broadcast_sender() {
+    let own_mac = MacAddr::new(0xDE, 0xAD, 0xBE, 0xEF, 0x00, 0x01);
+    // ARP with broadcast as sender MAC should be filtered
+    let frame = make_arp_frame(MacAddr::broadcast(), Ipv4Addr::new(10, 0, 0, 1));
+    assert!(parse_frame(&frame, own_mac).is_none());
+}
+
+// ---------------------------------------------------------------------------
+// parse_frame -- IPv4
+// ---------------------------------------------------------------------------
+
+#[test]
+fn parse_frame_ipv4_valid() {
+    let own_mac = MacAddr::new(0xDE, 0xAD, 0xBE, 0xEF, 0x00, 0x01);
+    let src_mac = MacAddr::new(0x00, 0x1A, 0x2B, 0x3C, 0x4D, 0x5E);
+    let src_ip = Ipv4Addr::new(10, 0, 0, 42);
+
+    let frame = make_ipv4_frame(src_mac, src_ip);
+    let obs = parse_frame(&frame, own_mac).expect("should parse IPv4 frame");
+
+    assert_eq!(obs.mac, "00:1A:2B:3C:4D:5E");
+    assert_eq!(obs.ip, "10.0.0.42");
+    assert_eq!(obs.source, PacketSource::Ip);
+}
+
+#[test]
+fn parse_frame_ipv4_filtered_own_mac() {
+    let own_mac = MacAddr::new(0x00, 0x1A, 0x2B, 0x3C, 0x4D, 0x5E);
+    let frame = make_ipv4_frame(own_mac, Ipv4Addr::new(10, 0, 0, 1));
+    assert!(parse_frame(&frame, own_mac).is_none());
+}
+
+#[test]
+fn parse_frame_ipv4_filtered_unspecified_ip() {
+    let own_mac = MacAddr::new(0xDE, 0xAD, 0xBE, 0xEF, 0x00, 0x01);
+    let src_mac = MacAddr::new(0x00, 0x1A, 0x2B, 0x3C, 0x4D, 0x5E);
+    let frame = make_ipv4_frame(src_mac, Ipv4Addr::UNSPECIFIED);
+    assert!(parse_frame(&frame, own_mac).is_none());
+}
+
+// ---------------------------------------------------------------------------
+// parse_frame -- edge cases
+// ---------------------------------------------------------------------------
+
+#[test]
+fn parse_frame_empty_data() {
+    let own_mac = MacAddr::new(0xDE, 0xAD, 0xBE, 0xEF, 0x00, 0x01);
+    assert!(parse_frame(&[], own_mac).is_none());
+}
+
+#[test]
+fn parse_frame_truncated_ethernet_header() {
+    let own_mac = MacAddr::new(0xDE, 0xAD, 0xBE, 0xEF, 0x00, 0x01);
+    // Ethernet header needs at least 14 bytes; provide only 10
+    assert!(parse_frame(&[0u8; 10], own_mac).is_none());
+}
+
+#[test]
+fn parse_frame_unknown_ethertype() {
+    let own_mac = MacAddr::new(0xDE, 0xAD, 0xBE, 0xEF, 0x00, 0x01);
+    // Build a frame with an IPv6 ethertype (0x86DD) -- not handled by parse_frame
+    let mut buf = vec![0u8; 54]; // enough for ethernet + some payload
+    {
+        let mut eth = MutableEthernetPacket::new(&mut buf).unwrap();
+        eth.set_source(MacAddr::new(0xAA, 0xBB, 0xCC, 0x11, 0x22, 0x33));
+        eth.set_destination(own_mac);
+        eth.set_ethertype(EtherTypes::Ipv6);
+    }
+    assert!(parse_frame(&buf, own_mac).is_none());
+}
+
+// ---------------------------------------------------------------------------
+// find_interface
+// ---------------------------------------------------------------------------
+
+#[test]
+fn find_interface_nonexistent() {
+    let result = find_interface("this_interface_does_not_exist_xyz_12345");
+    assert!(result.is_err());
+    let err_msg = result.unwrap_err().to_string();
+    assert!(
+        err_msg.contains("not found"),
+        "expected 'not found' in error: {err_msg}"
+    );
+}

--- a/source/daemon/crates/wardnetd/src/tests/tunnel_idle.rs
+++ b/source/daemon/crates/wardnetd/src/tests/tunnel_idle.rs
@@ -1,0 +1,175 @@
+use std::sync::{Arc, Mutex};
+
+use async_trait::async_trait;
+use chrono::Utc;
+use uuid::Uuid;
+use wardnet_types::api::{
+    CreateTunnelRequest, CreateTunnelResponse, DeleteTunnelResponse, ListTunnelsResponse,
+};
+use wardnet_types::event::WardnetEvent;
+use wardnet_types::tunnel::Tunnel;
+
+use crate::error::AppError;
+use crate::event::{BroadcastEventBus, EventPublisher};
+use crate::service::TunnelService;
+use crate::tunnel_idle::IdleTunnelWatcher;
+
+// -- Mock TunnelService ---------------------------------------------------
+
+/// Tracks calls to `tear_down` for assertion.
+struct MockTunnelService {
+    tear_downs: Mutex<Vec<(Uuid, String)>>,
+}
+
+impl MockTunnelService {
+    fn new() -> Self {
+        Self {
+            tear_downs: Mutex::new(Vec::new()),
+        }
+    }
+}
+
+#[async_trait]
+impl TunnelService for MockTunnelService {
+    async fn import_tunnel(
+        &self,
+        _req: CreateTunnelRequest,
+    ) -> Result<CreateTunnelResponse, AppError> {
+        unimplemented!("not needed for idle watcher tests")
+    }
+
+    async fn list_tunnels(&self) -> Result<ListTunnelsResponse, AppError> {
+        Ok(ListTunnelsResponse {
+            tunnels: Vec::new(),
+        })
+    }
+
+    async fn get_tunnel(&self, _id: Uuid) -> Result<Tunnel, AppError> {
+        Err(AppError::NotFound("not found".to_owned()))
+    }
+
+    async fn bring_up(&self, _id: Uuid) -> Result<(), AppError> {
+        Ok(())
+    }
+
+    async fn tear_down(&self, id: Uuid, reason: &str) -> Result<(), AppError> {
+        self.tear_downs
+            .lock()
+            .unwrap()
+            .push((id, reason.to_owned()));
+        Ok(())
+    }
+
+    async fn delete_tunnel(&self, _id: Uuid) -> Result<DeleteTunnelResponse, AppError> {
+        unimplemented!("not needed for idle watcher tests")
+    }
+
+    async fn restore_tunnels(&self) -> Result<(), AppError> {
+        Ok(())
+    }
+}
+
+// -- Tests ----------------------------------------------------------------
+
+#[tokio::test]
+async fn watcher_receives_events_from_bus() {
+    let bus = Arc::new(BroadcastEventBus::new(16));
+    let tunnel_svc = Arc::new(MockTunnelService::new());
+
+    let parent = tracing::info_span!("test");
+    let watcher = IdleTunnelWatcher::start(bus.clone(), tunnel_svc, 300, &parent);
+
+    // Publish a DeviceGone event.
+    bus.publish(WardnetEvent::DeviceGone {
+        device_id: Uuid::new_v4(),
+        mac: "AA:BB:CC:DD:EE:01".to_owned(),
+        last_ip: "192.168.1.10".to_owned(),
+        timestamp: Utc::now(),
+    });
+
+    // Give the event loop time to process.
+    tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+    watcher.shutdown().await;
+    // The current stub just logs events; if we reach here it processed without panic.
+}
+
+#[tokio::test]
+async fn watcher_handles_multiple_events() {
+    let bus = Arc::new(BroadcastEventBus::new(16));
+    let tunnel_svc = Arc::new(MockTunnelService::new());
+
+    let parent = tracing::info_span!("test");
+    let watcher = IdleTunnelWatcher::start(bus.clone(), tunnel_svc, 300, &parent);
+
+    // Publish several events in sequence.
+    for i in 0..5 {
+        bus.publish(WardnetEvent::DeviceGone {
+            device_id: Uuid::new_v4(),
+            mac: format!("AA:BB:CC:DD:EE:{i:02X}"),
+            last_ip: format!("192.168.1.{}", 10 + i),
+            timestamp: Utc::now(),
+        });
+    }
+
+    tokio::time::sleep(tokio::time::Duration::from_millis(200)).await;
+    watcher.shutdown().await;
+    // All events should be consumed without panic.
+}
+
+#[tokio::test]
+async fn watcher_handles_tunnel_events() {
+    let bus = Arc::new(BroadcastEventBus::new(16));
+    let tunnel_svc = Arc::new(MockTunnelService::new());
+
+    let parent = tracing::info_span!("test");
+    let watcher = IdleTunnelWatcher::start(bus.clone(), tunnel_svc, 300, &parent);
+
+    bus.publish(WardnetEvent::TunnelUp {
+        tunnel_id: Uuid::new_v4(),
+        interface_name: "wg_ward0".to_owned(),
+        endpoint: "198.51.100.1:51820".to_owned(),
+        timestamp: Utc::now(),
+    });
+
+    bus.publish(WardnetEvent::TunnelDown {
+        tunnel_id: Uuid::new_v4(),
+        interface_name: "wg_ward0".to_owned(),
+        reason: "idle".to_owned(),
+        timestamp: Utc::now(),
+    });
+
+    tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+    watcher.shutdown().await;
+}
+
+#[tokio::test]
+async fn watcher_shutdown_without_events() {
+    let bus = Arc::new(BroadcastEventBus::new(16));
+    let tunnel_svc = Arc::new(MockTunnelService::new());
+
+    let parent = tracing::info_span!("test");
+    let watcher = IdleTunnelWatcher::start(bus, tunnel_svc, 300, &parent);
+
+    // Shutdown immediately with no events -- should complete cleanly.
+    watcher.shutdown().await;
+}
+
+#[tokio::test]
+async fn watcher_handles_device_discovered_event() {
+    let bus = Arc::new(BroadcastEventBus::new(16));
+    let tunnel_svc = Arc::new(MockTunnelService::new());
+
+    let parent = tracing::info_span!("test");
+    let watcher = IdleTunnelWatcher::start(bus.clone(), tunnel_svc, 300, &parent);
+
+    bus.publish(WardnetEvent::DeviceDiscovered {
+        device_id: Uuid::new_v4(),
+        mac: "AA:BB:CC:DD:EE:01".to_owned(),
+        ip: "192.168.1.10".to_owned(),
+        hostname: Some("myphone".to_owned()),
+        timestamp: Utc::now(),
+    });
+
+    tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+    watcher.shutdown().await;
+}

--- a/source/daemon/crates/wardnetd/src/tests/tunnel_monitor.rs
+++ b/source/daemon/crates/wardnetd/src/tests/tunnel_monitor.rs
@@ -1,0 +1,435 @@
+use std::sync::{Arc, Mutex};
+
+use async_trait::async_trait;
+use chrono::{DateTime, Utc};
+use tokio::sync::broadcast;
+use uuid::Uuid;
+use wardnet_types::event::WardnetEvent;
+use wardnet_types::tunnel::{Tunnel, TunnelConfig, TunnelStatus};
+
+use crate::event::EventPublisher;
+use crate::repository::TunnelRepository;
+use crate::repository::tunnel::TunnelRow;
+use crate::tunnel_monitor::TunnelMonitor;
+use crate::wireguard::{CreateInterfaceParams, WgInterfaceStats, WireGuardOps};
+
+// -- Mock TunnelRepository ------------------------------------------------
+
+/// Tracks calls to `update_stats` for assertion.
+struct MockTunnelRepo {
+    tunnels: Mutex<Vec<Tunnel>>,
+    stats_updates: Mutex<Vec<StatsUpdate>>,
+    find_all_error: Mutex<bool>,
+}
+
+#[derive(Debug, Clone)]
+struct StatsUpdate {
+    id: String,
+    bytes_tx: i64,
+    bytes_rx: i64,
+    last_handshake: Option<String>,
+}
+
+impl MockTunnelRepo {
+    fn new(tunnels: Vec<Tunnel>) -> Self {
+        Self {
+            tunnels: Mutex::new(tunnels),
+            stats_updates: Mutex::new(Vec::new()),
+            find_all_error: Mutex::new(false),
+        }
+    }
+
+    fn stats_updates(&self) -> Vec<StatsUpdate> {
+        self.stats_updates.lock().unwrap().clone()
+    }
+}
+
+#[async_trait]
+impl TunnelRepository for MockTunnelRepo {
+    async fn find_all(&self) -> anyhow::Result<Vec<Tunnel>> {
+        if *self.find_all_error.lock().unwrap() {
+            anyhow::bail!("simulated find_all error");
+        }
+        Ok(self.tunnels.lock().unwrap().clone())
+    }
+
+    async fn find_by_id(&self, _id: &str) -> anyhow::Result<Option<Tunnel>> {
+        Ok(None)
+    }
+
+    async fn find_config_by_id(&self, _id: &str) -> anyhow::Result<Option<TunnelConfig>> {
+        Ok(None)
+    }
+
+    async fn insert(&self, _row: &TunnelRow) -> anyhow::Result<()> {
+        Ok(())
+    }
+
+    async fn update_status(&self, _id: &str, _status: &str) -> anyhow::Result<()> {
+        Ok(())
+    }
+
+    async fn update_stats(
+        &self,
+        id: &str,
+        bytes_tx: i64,
+        bytes_rx: i64,
+        last_handshake: Option<&str>,
+    ) -> anyhow::Result<()> {
+        self.stats_updates.lock().unwrap().push(StatsUpdate {
+            id: id.to_owned(),
+            bytes_tx,
+            bytes_rx,
+            last_handshake: last_handshake.map(ToOwned::to_owned),
+        });
+        Ok(())
+    }
+
+    async fn delete(&self, _id: &str) -> anyhow::Result<()> {
+        Ok(())
+    }
+
+    async fn next_interface_index(&self) -> anyhow::Result<i64> {
+        Ok(0)
+    }
+
+    async fn count(&self) -> anyhow::Result<i64> {
+        Ok(0)
+    }
+}
+
+// -- Mock WireGuardOps ----------------------------------------------------
+
+/// Returns predetermined stats for `get_stats`.
+struct MockWireGuardOps {
+    stats: Mutex<Option<WgInterfaceStats>>,
+    get_stats_error: Mutex<bool>,
+}
+
+impl MockWireGuardOps {
+    fn with_stats(stats: WgInterfaceStats) -> Self {
+        Self {
+            stats: Mutex::new(Some(stats)),
+            get_stats_error: Mutex::new(false),
+        }
+    }
+
+    fn returning_none() -> Self {
+        Self {
+            stats: Mutex::new(None),
+            get_stats_error: Mutex::new(false),
+        }
+    }
+
+    fn returning_error() -> Self {
+        Self {
+            stats: Mutex::new(None),
+            get_stats_error: Mutex::new(true),
+        }
+    }
+}
+
+#[async_trait]
+impl WireGuardOps for MockWireGuardOps {
+    async fn create_interface(&self, _params: CreateInterfaceParams) -> anyhow::Result<()> {
+        Ok(())
+    }
+
+    async fn bring_up(&self, _interface_name: &str) -> anyhow::Result<()> {
+        Ok(())
+    }
+
+    async fn tear_down(&self, _interface_name: &str) -> anyhow::Result<()> {
+        Ok(())
+    }
+
+    async fn remove_interface(&self, _interface_name: &str) -> anyhow::Result<()> {
+        Ok(())
+    }
+
+    async fn get_stats(&self, _interface_name: &str) -> anyhow::Result<Option<WgInterfaceStats>> {
+        if *self.get_stats_error.lock().unwrap() {
+            anyhow::bail!("simulated get_stats error");
+        }
+        Ok(self.stats.lock().unwrap().clone())
+    }
+
+    async fn list_interfaces(&self) -> anyhow::Result<Vec<String>> {
+        Ok(Vec::new())
+    }
+}
+
+// -- Mock EventPublisher --------------------------------------------------
+
+/// Captures published events for assertion.
+struct MockEventPublisher {
+    events: Mutex<Vec<WardnetEvent>>,
+}
+
+impl MockEventPublisher {
+    fn new() -> Self {
+        Self {
+            events: Mutex::new(Vec::new()),
+        }
+    }
+
+    fn published_events(&self) -> Vec<WardnetEvent> {
+        self.events.lock().unwrap().clone()
+    }
+}
+
+impl EventPublisher for MockEventPublisher {
+    fn publish(&self, event: WardnetEvent) {
+        self.events.lock().unwrap().push(event);
+    }
+
+    fn subscribe(&self) -> broadcast::Receiver<WardnetEvent> {
+        let (_, rx) = broadcast::channel(16);
+        rx
+    }
+}
+
+// -- Helpers --------------------------------------------------------------
+
+fn make_tunnel(id: Uuid, interface_name: &str, status: TunnelStatus) -> Tunnel {
+    Tunnel {
+        id,
+        label: "Test Tunnel".to_owned(),
+        country_code: "SE".to_owned(),
+        provider: Some("TestVPN".to_owned()),
+        interface_name: interface_name.to_owned(),
+        endpoint: "198.51.100.1:51820".to_owned(),
+        status,
+        last_handshake: None,
+        bytes_tx: 0,
+        bytes_rx: 0,
+        created_at: Utc::now(),
+    }
+}
+
+fn make_stats(
+    bytes_tx: u64,
+    bytes_rx: u64,
+    last_handshake: Option<DateTime<Utc>>,
+) -> WgInterfaceStats {
+    WgInterfaceStats {
+        bytes_tx,
+        bytes_rx,
+        last_handshake,
+    }
+}
+
+// -- Tests ----------------------------------------------------------------
+
+#[tokio::test]
+async fn stats_loop_updates_stats_for_up_tunnel() {
+    let tunnel_id = Uuid::new_v4();
+    let tunnel = make_tunnel(tunnel_id, "wg_ward0", TunnelStatus::Up);
+
+    let repo = Arc::new(MockTunnelRepo::new(vec![tunnel]));
+    let wg = Arc::new(MockWireGuardOps::with_stats(make_stats(
+        1000,
+        2000,
+        Some(Utc::now()),
+    )));
+    let events = Arc::new(MockEventPublisher::new());
+
+    let parent = tracing::info_span!("test");
+    let monitor = TunnelMonitor::start(
+        repo.clone(),
+        wg,
+        events.clone(),
+        1, // 1-second stats interval
+        60,
+        &parent,
+    );
+
+    // Allow the stats loop to fire at least once.
+    tokio::time::sleep(tokio::time::Duration::from_millis(1500)).await;
+    monitor.shutdown().await;
+
+    // Verify stats were updated in the repository.
+    let updates = repo.stats_updates();
+    assert!(!updates.is_empty(), "expected at least one stats update");
+    assert_eq!(updates[0].id, tunnel_id.to_string());
+    assert_eq!(updates[0].bytes_tx, 1000);
+    assert_eq!(updates[0].bytes_rx, 2000);
+    assert!(updates[0].last_handshake.is_some());
+
+    // Verify TunnelStatsUpdated event was published.
+    let published = events.published_events();
+    assert!(
+        !published.is_empty(),
+        "expected at least one published event"
+    );
+    assert!(matches!(
+        &published[0],
+        WardnetEvent::TunnelStatsUpdated {
+            tunnel_id: id,
+            bytes_tx: 1000,
+            bytes_rx: 2000,
+            ..
+        } if *id == tunnel_id
+    ));
+}
+
+#[tokio::test]
+async fn stats_loop_skips_down_tunnels() {
+    let tunnel = make_tunnel(Uuid::new_v4(), "wg_ward0", TunnelStatus::Down);
+
+    let repo = Arc::new(MockTunnelRepo::new(vec![tunnel]));
+    let wg = Arc::new(MockWireGuardOps::with_stats(make_stats(100, 200, None)));
+    let events = Arc::new(MockEventPublisher::new());
+
+    let parent = tracing::info_span!("test");
+    let monitor = TunnelMonitor::start(repo.clone(), wg, events.clone(), 1, 60, &parent);
+
+    tokio::time::sleep(tokio::time::Duration::from_millis(1500)).await;
+    monitor.shutdown().await;
+
+    // Down tunnels should not trigger stats updates.
+    let updates = repo.stats_updates();
+    assert!(
+        updates.is_empty(),
+        "down tunnels should not be polled for stats"
+    );
+
+    let published = events.published_events();
+    assert!(
+        published.is_empty(),
+        "no events should be published for down tunnels"
+    );
+}
+
+#[tokio::test]
+async fn stats_loop_handles_get_stats_error_gracefully() {
+    let tunnel = make_tunnel(Uuid::new_v4(), "wg_ward0", TunnelStatus::Up);
+
+    let repo = Arc::new(MockTunnelRepo::new(vec![tunnel]));
+    let wg = Arc::new(MockWireGuardOps::returning_error());
+    let events = Arc::new(MockEventPublisher::new());
+
+    let parent = tracing::info_span!("test");
+    let monitor = TunnelMonitor::start(repo.clone(), wg, events.clone(), 1, 60, &parent);
+
+    tokio::time::sleep(tokio::time::Duration::from_millis(1500)).await;
+    monitor.shutdown().await;
+
+    // Error in get_stats should not crash; no stats updates or events.
+    let updates = repo.stats_updates();
+    assert!(
+        updates.is_empty(),
+        "no stats should be saved when get_stats errors"
+    );
+
+    let published = events.published_events();
+    assert!(published.is_empty(), "no events when get_stats errors");
+}
+
+#[tokio::test]
+async fn stats_loop_handles_none_stats() {
+    let tunnel = make_tunnel(Uuid::new_v4(), "wg_ward0", TunnelStatus::Up);
+
+    let repo = Arc::new(MockTunnelRepo::new(vec![tunnel]));
+    let wg = Arc::new(MockWireGuardOps::returning_none());
+    let events = Arc::new(MockEventPublisher::new());
+
+    let parent = tracing::info_span!("test");
+    let monitor = TunnelMonitor::start(repo.clone(), wg, events.clone(), 1, 60, &parent);
+
+    tokio::time::sleep(tokio::time::Duration::from_millis(1500)).await;
+    monitor.shutdown().await;
+
+    // None stats (interface not found) should be silently skipped.
+    let updates = repo.stats_updates();
+    assert!(updates.is_empty());
+}
+
+#[tokio::test]
+async fn health_loop_runs_without_error_for_healthy_tunnel() {
+    let tunnel = make_tunnel(Uuid::new_v4(), "wg_ward0", TunnelStatus::Up);
+
+    // Recent handshake -- should not generate warnings (just verifying no crash).
+    let repo = Arc::new(MockTunnelRepo::new(vec![tunnel]));
+    let wg = Arc::new(MockWireGuardOps::with_stats(make_stats(
+        0,
+        0,
+        Some(Utc::now()),
+    )));
+    let events = Arc::new(MockEventPublisher::new());
+
+    let parent = tracing::info_span!("test");
+    let monitor = TunnelMonitor::start(repo, wg, events, 60, 1, &parent);
+
+    // Let health loop run at least one tick.
+    tokio::time::sleep(tokio::time::Duration::from_millis(1500)).await;
+    monitor.shutdown().await;
+    // If we reach here without panic, the health loop handled a healthy tunnel correctly.
+}
+
+#[tokio::test]
+async fn health_loop_handles_stale_handshake() {
+    let tunnel = make_tunnel(Uuid::new_v4(), "wg_ward0", TunnelStatus::Up);
+
+    // Handshake from 10 minutes ago -- stale.
+    let stale_time = Utc::now() - chrono::Duration::minutes(10);
+    let repo = Arc::new(MockTunnelRepo::new(vec![tunnel]));
+    let wg = Arc::new(MockWireGuardOps::with_stats(make_stats(
+        0,
+        0,
+        Some(stale_time),
+    )));
+    let events = Arc::new(MockEventPublisher::new());
+
+    let parent = tracing::info_span!("test");
+    let monitor = TunnelMonitor::start(repo, wg, events, 60, 1, &parent);
+
+    tokio::time::sleep(tokio::time::Duration::from_millis(1500)).await;
+    monitor.shutdown().await;
+    // The health loop should log a warning but not crash.
+}
+
+#[tokio::test]
+async fn health_loop_handles_missing_interface() {
+    let tunnel = make_tunnel(Uuid::new_v4(), "wg_ward0", TunnelStatus::Up);
+
+    let repo = Arc::new(MockTunnelRepo::new(vec![tunnel]));
+    let wg = Arc::new(MockWireGuardOps::returning_none());
+    let events = Arc::new(MockEventPublisher::new());
+
+    let parent = tracing::info_span!("test");
+    let monitor = TunnelMonitor::start(repo, wg, events, 60, 1, &parent);
+
+    tokio::time::sleep(tokio::time::Duration::from_millis(1500)).await;
+    monitor.shutdown().await;
+    // Should log an error but not crash.
+}
+
+#[tokio::test]
+async fn health_loop_handles_get_stats_error() {
+    let tunnel = make_tunnel(Uuid::new_v4(), "wg_ward0", TunnelStatus::Up);
+
+    let repo = Arc::new(MockTunnelRepo::new(vec![tunnel]));
+    let wg = Arc::new(MockWireGuardOps::returning_error());
+    let events = Arc::new(MockEventPublisher::new());
+
+    let parent = tracing::info_span!("test");
+    let monitor = TunnelMonitor::start(repo, wg, events, 60, 1, &parent);
+
+    tokio::time::sleep(tokio::time::Duration::from_millis(1500)).await;
+    monitor.shutdown().await;
+    // Should log an error but not crash.
+}
+
+#[tokio::test]
+async fn shutdown_stops_both_loops() {
+    let repo = Arc::new(MockTunnelRepo::new(vec![]));
+    let wg = Arc::new(MockWireGuardOps::returning_none());
+    let events = Arc::new(MockEventPublisher::new());
+
+    let parent = tracing::info_span!("test");
+    let monitor = TunnelMonitor::start(repo, wg, events, 1, 1, &parent);
+
+    // Shutdown immediately -- should complete without hanging.
+    monitor.shutdown().await;
+}


### PR DESCRIPTION
 ## Summary

  Add 92 new tests (108 → 200 total) covering previously untested areas:
  - API layer: middleware auth extractors, login, system status, devices CRUD, tunnels CRUD
  - Error handling: AppError → HTTP status code and JSON body mapping
  - Packet capture: pure helper functions (parse_frame, subnet_hosts, build_arp_request, format_mac)
  - Background tasks: tunnel monitor (stats/health) and idle watcher (DeviceGone events)

  ## Test plan

  - [x] All 200 tests pass locally (cargo test --workspace)
  - [x] cargo fmt and clippy clean
  - [ ] Verify coverage increase via Codecov after merge
