### PR TITLE
feat: support dedicated IP servers via direct hostname resolution

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -336,6 +336,9 @@ cd source/web-ui && yarn format && yarn lint && yarn type-check
 make check
 ```
 
+**Code coverage (MANDATORY for Rust changes):**
+Before starting work, compute the current coverage baseline by running `cargo tarpaulin --workspace` on `main` (or during planning). After implementation, run it again on your branch and verify coverage **does not decrease**. New code must have tests — coverage should stay the same or increase. It must never go down. Config: `source/daemon/tarpaulin.toml`.
+
 ## Boundaries
 
 ### Always do

--- a/source/daemon/crates/wardnet-types/src/api.rs
+++ b/source/daemon/crates/wardnet-types/src/api.rs
@@ -190,6 +190,12 @@ pub struct SetupProviderRequest {
     /// If set, use this specific server ID instead of auto-selecting.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub server_id: Option<String>,
+    /// Direct server hostname for dedicated IP or manual server selection.
+    /// Bypasses server listing -- resolves directly by hostname.
+    /// Accepts short form (`pt131`) or full (`pt131.nordvpn.com`).
+    /// Takes precedence over `server_id` when both are set.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub hostname: Option<String>,
 }
 
 /// Response for POST /api/providers/:id/setup.

--- a/source/daemon/crates/wardnetd/src/service/provider.rs
+++ b/source/daemon/crates/wardnetd/src/service/provider.rs
@@ -129,36 +129,50 @@ impl ProviderService for ProviderServiceImpl {
             ));
         }
 
-        // 2. Fetch servers filtered by country.
-        let filter = ServerFilter {
-            country: Some(request.country.clone()),
-            max_load: None,
-        };
-        let servers = provider
-            .list_servers(&request.credentials, &filter)
-            .await
-            .map_err(AppError::Internal)?;
-
-        if servers.is_empty() {
-            return Err(AppError::NotFound(format!(
-                "no servers found for country '{}'",
-                request.country
-            )));
-        }
-
-        // 3. Select server: specific ID or lowest load.
-        let server = if let Some(ref server_id) = request.server_id {
-            servers
-                .iter()
-                .find(|s| s.id == *server_id)
-                .cloned()
-                .ok_or_else(|| AppError::NotFound(format!("server '{server_id}' not found")))?
+        // 2. Resolve server: hostname path (dedicated IP) or list+select path.
+        let server = if let Some(ref hostname) = request.hostname {
+            // Dedicated IP / direct hostname path.
+            provider
+                .resolve_server(&request.credentials, hostname)
+                .await
+                .map_err(AppError::Internal)?
+                .ok_or_else(|| {
+                    AppError::BadRequest(format!(
+                        "provider '{}' does not support hostname-based server resolution",
+                        info.id
+                    ))
+                })?
         } else {
-            servers
-                .iter()
-                .min_by_key(|s| s.load)
-                .cloned()
-                .expect("servers is non-empty")
+            // Standard flow: list servers filtered by country, then select.
+            let filter = ServerFilter {
+                country: Some(request.country.clone()),
+                max_load: None,
+            };
+            let servers = provider
+                .list_servers(&request.credentials, &filter)
+                .await
+                .map_err(AppError::Internal)?;
+
+            if servers.is_empty() {
+                return Err(AppError::NotFound(format!(
+                    "no servers found for country '{}'",
+                    request.country
+                )));
+            }
+
+            if let Some(ref server_id) = request.server_id {
+                servers
+                    .iter()
+                    .find(|s| s.id == *server_id)
+                    .cloned()
+                    .ok_or_else(|| AppError::NotFound(format!("server '{server_id}' not found")))?
+            } else {
+                servers
+                    .iter()
+                    .min_by_key(|s| s.load)
+                    .cloned()
+                    .expect("servers is non-empty")
+            }
         };
 
         // 4. Generate WireGuard configuration.

--- a/source/daemon/crates/wardnetd/src/service/tests/provider.rs
+++ b/source/daemon/crates/wardnetd/src/service/tests/provider.rs
@@ -26,6 +26,7 @@ struct MockVpnProvider {
     validate_result: Mutex<Result<bool, String>>,
     servers: Mutex<Vec<ServerInfo>>,
     config_result: Mutex<Result<String, String>>,
+    resolve_server_result: Mutex<Option<Result<Option<ServerInfo>, String>>>,
 }
 
 impl MockVpnProvider {
@@ -43,7 +44,17 @@ impl MockVpnProvider {
             validate_result: Mutex::new(Ok(true)),
             servers: Mutex::new(Vec::new()),
             config_result: Mutex::new(Ok(dummy_wg_config())),
+            resolve_server_result: Mutex::new(None),
         }
+    }
+
+    /// Set the result returned by `resolve_server`.
+    fn with_resolve_server_result(
+        self,
+        result: Option<Result<Option<ServerInfo>, String>>,
+    ) -> Self {
+        *self.resolve_server_result.lock().unwrap() = result;
+        self
     }
 
     /// Set the result returned by `validate_credentials`.
@@ -82,6 +93,19 @@ impl VpnProvider for MockVpnProvider {
         _filter: &ServerFilter,
     ) -> anyhow::Result<Vec<ServerInfo>> {
         Ok(self.servers.lock().unwrap().clone())
+    }
+
+    async fn resolve_server(
+        &self,
+        _credentials: &ProviderCredentials,
+        _hostname: &str,
+    ) -> anyhow::Result<Option<ServerInfo>> {
+        let guard = self.resolve_server_result.lock().unwrap();
+        match &*guard {
+            Some(Ok(server)) => Ok(server.clone()),
+            Some(Err(msg)) => Err(anyhow::anyhow!("{msg}")),
+            None => Ok(None),
+        }
     }
 
     async fn generate_config(
@@ -384,6 +408,7 @@ async fn setup_tunnel_happy_path() {
         country: "SE".to_owned(),
         label: None,
         server_id: None,
+        hostname: None,
     };
     let resp = h.svc.setup_tunnel("test", req).await.unwrap();
 
@@ -413,6 +438,7 @@ async fn setup_tunnel_with_specific_server_id() {
         country: "SE".to_owned(),
         label: None,
         server_id: Some("se-3".to_owned()),
+        hostname: None,
     };
     let resp = h.svc.setup_tunnel("test", req).await.unwrap();
 
@@ -432,6 +458,7 @@ async fn setup_tunnel_invalid_credentials() {
         country: "SE".to_owned(),
         label: None,
         server_id: None,
+        hostname: None,
     };
     let result = h.svc.setup_tunnel("test", req).await;
 
@@ -450,6 +477,7 @@ async fn setup_tunnel_no_servers_found() {
         country: "XX".to_owned(),
         label: None,
         server_id: None,
+        hostname: None,
     };
     let result = h.svc.setup_tunnel("test", req).await;
 
@@ -469,6 +497,7 @@ async fn setup_tunnel_server_id_not_found() {
         country: "SE".to_owned(),
         label: None,
         server_id: Some("nonexistent-server".to_owned()),
+        hostname: None,
     };
     let result = h.svc.setup_tunnel("test", req).await;
 
@@ -488,6 +517,7 @@ async fn setup_tunnel_with_custom_label() {
         country: "SE".to_owned(),
         label: Some("My Custom Tunnel".to_owned()),
         server_id: None,
+        hostname: None,
     };
     let resp = h.svc.setup_tunnel("test", req).await.unwrap();
 
@@ -495,4 +525,106 @@ async fn setup_tunnel_with_custom_label() {
 
     let imported = h.tunnel_service.imported.lock().unwrap();
     assert_eq!(imported[0].label, "My Custom Tunnel");
+}
+
+/// Helper to build a single resolved server for hostname tests.
+fn resolved_server() -> ServerInfo {
+    ServerInfo {
+        id: "dedicated-1".to_owned(),
+        name: "Portugal #131".to_owned(),
+        country_code: "PT".to_owned(),
+        city: Some("Lisbon".to_owned()),
+        hostname: "pt131.nordvpn.com".to_owned(),
+        load: 10,
+    }
+}
+
+#[tokio::test]
+async fn setup_tunnel_with_hostname_happy_path() {
+    let provider = MockVpnProvider::new("test", "Test VPN")
+        .with_resolve_server_result(Some(Ok(Some(resolved_server()))));
+    let h = build_harness_with_provider(provider);
+
+    let req = SetupProviderRequest {
+        credentials: sample_credentials(),
+        country: "PT".to_owned(),
+        label: None,
+        server_id: None,
+        hostname: Some("pt131.nordvpn.com".to_owned()),
+    };
+    let resp = h.svc.setup_tunnel("test", req).await.unwrap();
+
+    // Should use the resolved server, not list_servers.
+    assert_eq!(resp.server.hostname, "pt131.nordvpn.com");
+    assert_eq!(resp.server.country_code, "PT");
+    assert_eq!(resp.tunnel.country_code, "PT");
+    assert!(resp.tunnel.label.contains("Portugal #131"));
+
+    // Verify tunnel was imported.
+    let imported = h.tunnel_service.imported.lock().unwrap();
+    assert_eq!(imported.len(), 1);
+    assert_eq!(imported[0].country_code, "PT");
+}
+
+#[tokio::test]
+async fn setup_tunnel_with_hostname_not_found() {
+    let provider = MockVpnProvider::new("test", "Test VPN")
+        .with_resolve_server_result(Some(Err("server not found: bad.nordvpn.com".to_owned())));
+    let h = build_harness_with_provider(provider);
+
+    let req = SetupProviderRequest {
+        credentials: sample_credentials(),
+        country: "XX".to_owned(),
+        label: None,
+        server_id: None,
+        hostname: Some("bad.nordvpn.com".to_owned()),
+    };
+    let result = h.svc.setup_tunnel("test", req).await;
+
+    assert!(result.is_err());
+    assert!(matches!(result.unwrap_err(), AppError::Internal(_)));
+}
+
+#[tokio::test]
+async fn setup_tunnel_with_hostname_unsupported_provider() {
+    // resolve_server returns Ok(None) — provider does not support hostname resolution.
+    let provider =
+        MockVpnProvider::new("test", "Test VPN").with_resolve_server_result(Some(Ok(None)));
+    let h = build_harness_with_provider(provider);
+
+    let req = SetupProviderRequest {
+        credentials: sample_credentials(),
+        country: "SE".to_owned(),
+        label: None,
+        server_id: None,
+        hostname: Some("pt131.nordvpn.com".to_owned()),
+    };
+    let result = h.svc.setup_tunnel("test", req).await;
+
+    assert!(result.is_err());
+    let err = result.unwrap_err();
+    assert!(matches!(err, AppError::BadRequest(_)));
+    assert!(err.to_string().contains("does not support"));
+}
+
+#[tokio::test]
+async fn setup_tunnel_hostname_takes_precedence_over_server_id() {
+    let provider = MockVpnProvider::new("test", "Test VPN")
+        .with_servers(sample_servers())
+        .with_resolve_server_result(Some(Ok(Some(resolved_server()))));
+    let h = build_harness_with_provider(provider);
+
+    // Both hostname and server_id are set; hostname should win.
+    let req = SetupProviderRequest {
+        credentials: sample_credentials(),
+        country: "SE".to_owned(),
+        label: None,
+        server_id: Some("se-1".to_owned()),
+        hostname: Some("pt131.nordvpn.com".to_owned()),
+    };
+    let resp = h.svc.setup_tunnel("test", req).await.unwrap();
+
+    // The resolved server from hostname, not the server_id one.
+    assert_eq!(resp.server.hostname, "pt131.nordvpn.com");
+    assert_eq!(resp.server.country_code, "PT");
 }

--- a/source/daemon/crates/wardnetd/src/tests/vpn_provider_nordvpn.rs
+++ b/source/daemon/crates/wardnetd/src/tests/vpn_provider_nordvpn.rs
@@ -17,7 +17,10 @@ struct MockNordVpnApi {
     validate_result: Mutex<Result<bool, String>>,
     countries: Mutex<Vec<NordCountryInfo>>,
     servers: Mutex<Vec<NordServer>>,
+    server_by_hostname: Mutex<Option<NordServer>>,
     private_key_result: Mutex<Result<String, String>>,
+    /// Records the hostname passed to `get_server_by_hostname`.
+    last_hostname_query: Mutex<Option<String>>,
 }
 
 impl MockNordVpnApi {
@@ -42,7 +45,9 @@ impl MockNordVpnApi {
                 },
             ]),
             servers: Mutex::new(Vec::new()),
+            server_by_hostname: Mutex::new(None),
             private_key_result: Mutex::new(Ok("test-private-key".to_string())),
+            last_hostname_query: Mutex::new(None),
         }
     }
 }
@@ -58,6 +63,14 @@ impl NordVpnApi for MockNordVpnApi {
             Ok(v) => Ok(*v),
             Err(e) => Err(anyhow::anyhow!("{e}")),
         }
+    }
+
+    async fn get_server_by_hostname(&self, hostname: &str) -> anyhow::Result<NordServer> {
+        *self.last_hostname_query.lock().await = Some(hostname.to_string());
+        let guard = self.server_by_hostname.lock().await;
+        guard
+            .clone()
+            .ok_or_else(|| anyhow::anyhow!("server not found: {hostname}"))
     }
 
     async fn list_countries(&self) -> anyhow::Result<Vec<NordCountryInfo>> {
@@ -298,7 +311,7 @@ async fn list_servers_handles_empty() {
 #[tokio::test]
 async fn generate_config_produces_valid_wireguard() {
     let mock = MockNordVpnApi::new();
-    *mock.servers.lock().await = vec![sample_server("se142.nordvpn.com", 25, "SE")];
+    *mock.server_by_hostname.lock().await = Some(sample_server("se142.nordvpn.com", 25, "SE"));
     *mock.private_key_result.lock().await = Ok("YWJjZGVmZ2hpamtsbW5vcHFyc3R1dnd4eXo=".to_string());
     let provider = NordVpnProvider::new(Arc::new(mock));
 
@@ -337,7 +350,7 @@ async fn generate_config_produces_valid_wireguard() {
 #[tokio::test]
 async fn generate_config_no_wireguard_tech() {
     let mock = MockNordVpnApi::new();
-    *mock.servers.lock().await = vec![server_without_wg("nowg.nordvpn.com")];
+    *mock.server_by_hostname.lock().await = Some(server_without_wg("nowg.nordvpn.com"));
     let provider = NordVpnProvider::new(Arc::new(mock));
 
     let server_info = ServerInfo {
@@ -360,7 +373,7 @@ async fn generate_config_no_wireguard_tech() {
 #[tokio::test]
 async fn generate_config_no_public_key() {
     let mock = MockNordVpnApi::new();
-    *mock.servers.lock().await = vec![server_wg_no_key("nokey.nordvpn.com")];
+    *mock.server_by_hostname.lock().await = Some(server_wg_no_key("nokey.nordvpn.com"));
     let provider = NordVpnProvider::new(Arc::new(mock));
 
     let server_info = ServerInfo {
@@ -383,7 +396,7 @@ async fn generate_config_no_public_key() {
 #[tokio::test]
 async fn generate_config_api_key_error() {
     let mock = MockNordVpnApi::new();
-    *mock.servers.lock().await = vec![sample_server("se142.nordvpn.com", 25, "SE")];
+    *mock.server_by_hostname.lock().await = Some(sample_server("se142.nordvpn.com", 25, "SE"));
     *mock.private_key_result.lock().await = Err("API key retrieval failed".to_string());
     let provider = NordVpnProvider::new(Arc::new(mock));
 
@@ -411,8 +424,7 @@ async fn generate_config_api_key_error() {
 #[tokio::test]
 async fn generate_config_server_not_found() {
     let mock = MockNordVpnApi::new();
-    // Servers list does not contain the requested hostname
-    *mock.servers.lock().await = vec![sample_server("other.nordvpn.com", 25, "SE")];
+    // server_by_hostname is None by default, so get_server_by_hostname will error.
     let provider = NordVpnProvider::new(Arc::new(mock));
 
     let server_info = ServerInfo {
@@ -516,7 +528,7 @@ async fn list_servers_with_unknown_country_code_passes_none() {
 #[tokio::test]
 async fn generate_config_rejects_credentials_auth_via_api() {
     let mock = MockNordVpnApi::new();
-    *mock.servers.lock().await = vec![sample_server("se142.nordvpn.com", 25, "SE")];
+    *mock.server_by_hostname.lock().await = Some(sample_server("se142.nordvpn.com", 25, "SE"));
     // Simulate the real API behavior: Credentials auth returns an error for WireGuard key generation.
     *mock.private_key_result.lock().await =
         Err("NordVPN requires token authentication for WireGuard key generation".to_string());
@@ -600,4 +612,106 @@ async fn list_servers_server_without_locations_has_empty_country_code() {
     assert_eq!(servers.len(), 1);
     assert_eq!(servers[0].country_code, "");
     assert!(servers[0].city.is_none());
+}
+
+#[tokio::test]
+async fn get_server_by_hostname_returns_server() {
+    let mock = MockNordVpnApi::new();
+    let nord_server = sample_server_with_city("pt131.nordvpn.com", 15, "PT", Some("Lisbon"));
+    *mock.server_by_hostname.lock().await = Some(nord_server);
+    let mock = Arc::new(mock);
+    let provider = NordVpnProvider::new(mock);
+
+    let result = provider
+        .resolve_server(&token_credentials(), "pt131.nordvpn.com")
+        .await
+        .unwrap();
+
+    let server = result.expect("should return Some");
+    assert_eq!(server.hostname, "pt131.nordvpn.com");
+    assert_eq!(server.country_code, "PT");
+    assert_eq!(server.city.as_deref(), Some("Lisbon"));
+    assert_eq!(server.load, 15);
+}
+
+#[tokio::test]
+async fn resolve_server_normalizes_short_hostname() {
+    let mock = MockNordVpnApi::new();
+    *mock.server_by_hostname.lock().await = Some(sample_server("pt131.nordvpn.com", 15, "PT"));
+    let mock = Arc::new(mock);
+    let provider = NordVpnProvider::new(Arc::clone(&mock) as Arc<dyn NordVpnApi>);
+
+    let _result = provider
+        .resolve_server(&token_credentials(), "pt131")
+        .await
+        .unwrap();
+
+    // Verify the API was queried with the full hostname.
+    let queried = mock.last_hostname_query.lock().await;
+    assert_eq!(queried.as_deref(), Some("pt131.nordvpn.com"));
+}
+
+#[tokio::test]
+async fn resolve_server_full_hostname() {
+    let mock = MockNordVpnApi::new();
+    *mock.server_by_hostname.lock().await = Some(sample_server("pt131.nordvpn.com", 15, "PT"));
+    let mock = Arc::new(mock);
+    let provider = NordVpnProvider::new(Arc::clone(&mock) as Arc<dyn NordVpnApi>);
+
+    let result = provider
+        .resolve_server(&token_credentials(), "pt131.nordvpn.com")
+        .await
+        .unwrap();
+
+    assert!(result.is_some());
+
+    // Verify the API was queried with the exact hostname (no modification).
+    let queried = mock.last_hostname_query.lock().await;
+    assert_eq!(queried.as_deref(), Some("pt131.nordvpn.com"));
+}
+
+#[tokio::test]
+async fn resolve_server_not_found() {
+    let mock = MockNordVpnApi::new();
+    // server_by_hostname is None, so get_server_by_hostname returns an error.
+    let provider = NordVpnProvider::new(Arc::new(mock));
+
+    let result = provider
+        .resolve_server(&token_credentials(), "nonexistent.nordvpn.com")
+        .await;
+
+    assert!(result.is_err());
+    let err = result.unwrap_err().to_string();
+    assert!(err.contains("not found"), "got: {err}");
+}
+
+#[tokio::test]
+async fn generate_config_uses_direct_hostname_lookup() {
+    let mock = MockNordVpnApi::new();
+    *mock.server_by_hostname.lock().await = Some(sample_server("se142.nordvpn.com", 25, "SE"));
+    *mock.private_key_result.lock().await = Ok("YWJjZGVmZ2hpamtsbW5vcHFyc3R1dnd4eXo=".to_string());
+    let mock = Arc::new(mock);
+    let provider = NordVpnProvider::new(Arc::clone(&mock) as Arc<dyn NordVpnApi>);
+
+    let server_info = ServerInfo {
+        id: "1234".to_string(),
+        name: "SE #se142".to_string(),
+        country_code: "SE".to_string(),
+        city: None,
+        hostname: "se142.nordvpn.com".to_string(),
+        load: 25,
+    };
+
+    let config_str = provider
+        .generate_config(&token_credentials(), &server_info)
+        .await
+        .unwrap();
+
+    // Verify the hostname query was made (direct lookup, not list_servers).
+    let queried = mock.last_hostname_query.lock().await;
+    assert_eq!(queried.as_deref(), Some("se142.nordvpn.com"));
+
+    // Verify config is valid.
+    let parsed = wardnet_types::wireguard_config::parse(&config_str).unwrap();
+    assert_eq!(parsed.peers[0].public_key, "dGVzdC1wdWJsaWMta2V5");
 }

--- a/source/daemon/crates/wardnetd/src/vpn_provider.rs
+++ b/source/daemon/crates/wardnetd/src/vpn_provider.rs
@@ -23,6 +23,16 @@ pub trait VpnProvider: Send + Sync {
         filter: &ServerFilter,
     ) -> anyhow::Result<Vec<ServerInfo>>;
 
+    /// Resolve a server by hostname for dedicated IP or manual selection.
+    /// Returns `None` if the provider does not support hostname resolution.
+    async fn resolve_server(
+        &self,
+        _credentials: &ProviderCredentials,
+        _hostname: &str,
+    ) -> anyhow::Result<Option<ServerInfo>> {
+        Ok(None)
+    }
+
     /// Generate a `WireGuard` `.conf` string for connecting to the given server.
     ///
     /// The returned string is a complete `WireGuard` config that can be passed

--- a/source/daemon/crates/wardnetd/src/vpn_provider_nordvpn.rs
+++ b/source/daemon/crates/wardnetd/src/vpn_provider_nordvpn.rs
@@ -24,6 +24,10 @@ pub trait NordVpnApi: Send + Sync {
     /// Fetch recommended servers, optionally filtered by country.
     async fn list_servers(&self, filter: &NordServerFilter) -> anyhow::Result<Vec<NordServer>>;
 
+    /// Fetch a single server by its hostname (e.g. `pt131.nordvpn.com`).
+    /// Used for dedicated IP servers not in recommendations.
+    async fn get_server_by_hostname(&self, hostname: &str) -> anyhow::Result<NordServer>;
+
     /// Get a `WireGuard` private key for the authenticated user.
     async fn get_wireguard_private_key(
         &self,
@@ -198,6 +202,18 @@ impl NordVpnApi for RealNordVpnApi {
         Ok(countries)
     }
 
+    async fn get_server_by_hostname(&self, hostname: &str) -> anyhow::Result<NordServer> {
+        let url = format!(
+            "{}/v1/servers?filters[hostname]={hostname}&limit=1",
+            self.base_url
+        );
+        let servers: Vec<NordServer> = self.client.get(&url).send().await?.json().await?;
+        servers
+            .into_iter()
+            .next()
+            .ok_or_else(|| anyhow::anyhow!("server not found: {hostname}"))
+    }
+
     async fn list_servers(&self, filter: &NordServerFilter) -> anyhow::Result<Vec<NordServer>> {
         let mut url = format!(
             "{}/v1/servers/recommendations?filters[servers_technologies][identifier]=wireguard_udp&limit={}",
@@ -249,6 +265,26 @@ impl NordVpnProvider {
     #[must_use]
     pub fn new(api: Arc<dyn NordVpnApi>) -> Self {
         Self { api }
+    }
+
+    /// Convert a `NordServer` into a [`ServerInfo`].
+    fn to_server_info(s: &NordServer) -> ServerInfo {
+        ServerInfo {
+            id: s.id.to_string(),
+            name: s.name.clone(),
+            country_code: s
+                .locations
+                .first()
+                .map(|l| l.country.code.to_uppercase())
+                .unwrap_or_default(),
+            city: s
+                .locations
+                .first()
+                .and_then(|l| l.country.city.as_ref())
+                .map(|c| c.name.clone()),
+            hostname: s.hostname.clone(),
+            load: s.load,
+        }
     }
 
     /// Extract the `WireGuard` public key from a `NordServer`'s technology metadata.
@@ -316,27 +352,27 @@ impl VpnProvider for NordVpnProvider {
         let servers = self.api.list_servers(&nord_filter).await?;
 
         let results: Vec<ServerInfo> = servers
-            .into_iter()
+            .iter()
             .filter(|s| filter.max_load.is_none_or(|max| s.load <= max))
-            .map(|s| ServerInfo {
-                id: s.id.to_string(),
-                name: s.name.clone(),
-                country_code: s
-                    .locations
-                    .first()
-                    .map(|l| l.country.code.to_uppercase())
-                    .unwrap_or_default(),
-                city: s
-                    .locations
-                    .first()
-                    .and_then(|l| l.country.city.as_ref())
-                    .map(|c| c.name.clone()),
-                hostname: s.hostname.clone(),
-                load: s.load,
-            })
+            .map(Self::to_server_info)
             .collect();
 
         Ok(results)
+    }
+
+    async fn resolve_server(
+        &self,
+        _credentials: &ProviderCredentials,
+        hostname: &str,
+    ) -> anyhow::Result<Option<ServerInfo>> {
+        let full_hostname = if hostname.contains('.') {
+            hostname.to_string()
+        } else {
+            format!("{hostname}.nordvpn.com")
+        };
+
+        let nord_server = self.api.get_server_by_hostname(&full_hostname).await?;
+        Ok(Some(Self::to_server_info(&nord_server)))
     }
 
     async fn generate_config(
@@ -346,33 +382,9 @@ impl VpnProvider for NordVpnProvider {
     ) -> anyhow::Result<String> {
         let private_key = self.api.get_wireguard_private_key(credentials).await?;
 
-        // Resolve country code to numeric ID for the API query.
-        let countries = self.api.list_countries().await?;
-        let country_id = countries
-            .iter()
-            .find(|c| c.code.eq_ignore_ascii_case(&server.country_code))
-            .map(|c| c.id);
-
-        // Re-fetch servers to get the full NordServer with technology metadata.
-        let servers = self
-            .api
-            .list_servers(&NordServerFilter {
-                country_id,
-                limit: 100,
-            })
-            .await?;
-
-        let nord_server = servers
-            .iter()
-            .find(|s| s.hostname == server.hostname)
-            .ok_or_else(|| {
-                anyhow::anyhow!(
-                    "server {} not found in NordVPN server list",
-                    server.hostname
-                )
-            })?;
-
-        let public_key = Self::extract_wg_public_key(nord_server)?;
+        // Fetch full server details directly by hostname.
+        let nord_server = self.api.get_server_by_hostname(&server.hostname).await?;
+        let public_key = Self::extract_wg_public_key(&nord_server)?;
 
         Ok(format!(
             "[Interface]\n\


### PR DESCRIPTION
 ## Summary
  - Add `resolve_server` method to `VpnProvider` trait for dedicated IP and manual server selection
  - Users can specify a hostname (e.g. `pt131` or `pt131.nordvpn.com`) to bypass the server listing flow
  - Refactor `generate_config` to use direct hostname lookup instead of fragile re-fetch-and-search pattern
  - Add code coverage requirement to AGENTS.md pre-push checklist

  ## Problem
  NordVPN dedicated IP servers are not discoverable via the public `/v1/servers/recommendations` API. Users know their assignment from the NordVPN app (e.g. "Portugal 131" → `pt131.nordvpn.com`) but the existing `list_servers → select →
  generate_config` flow cannot find these servers.

  ## Solution
  Add a `hostname` field to `SetupProviderRequest`. When set:
  1. Skip `list_servers` entirely
  2. Call `provider.resolve_server(credentials, hostname)` which queries the NordVPN API directly by hostname
  3. Proceed with `generate_config` as normal

  Short hostnames are normalized: `pt131` → `pt131.nordvpn.com`

  Also refactors `generate_config` to use `get_server_by_hostname` directly instead of re-fetching recommendations with `limit=100` — this was fragile and is now simpler and works for all server types.

  ## Changes
  | File | Change |
  |------|--------|
  | `vpn_provider.rs` | Add `resolve_server` with default `None` return |
  | `vpn_provider_nordvpn.rs` | Add `get_server_by_hostname` to API trait, implement `resolve_server`, refactor `generate_config`, extract `to_server_info` helper |
  | `service/provider.rs` | Add hostname branch in `setup_tunnel` |
  | `wardnet-types/api.rs` | Add `hostname` field to `SetupProviderRequest` |
  | `AGENTS.md` | Add coverage requirement to pre-push checklist |

  ## Test plan
  - [x] `cargo fmt --check` — clean
  - [x] `cargo clippy --all-targets -- -D warnings` — zero warnings
  - [x] `cargo test --workspace` — 366 tests pass (9 new)
  - [x] Coverage: 84.6%
  - [ ] Manual: `POST /api/providers/nordvpn/setup` with `"hostname": "pt131"` creates a dedicated IP tunnel