### PR TITLE
fix: set base path for GitHub Pages and support future custom domain

### DIFF
--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -34,6 +34,8 @@ jobs:
 
       - name: Build
         run: make build-site
+        env:
+          VITE_BASE_PATH: /wardnet/
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v4

--- a/source/site/src/App.tsx
+++ b/source/site/src/App.tsx
@@ -7,7 +7,7 @@ import { Docs } from "@/pages/Docs";
  */
 export default function App() {
   return (
-    <BrowserRouter>
+    <BrowserRouter basename={import.meta.env.BASE_URL}>
       <Routes>
         <Route path="/" element={<Home />} />
         <Route path="/docs" element={<Docs />} />

--- a/source/site/vite.config.ts
+++ b/source/site/vite.config.ts
@@ -6,6 +6,7 @@ import yaml from "@modyfi/vite-plugin-yaml";
 import { fileURLToPath, URL } from "node:url";
 
 export default defineConfig({
+  base: process.env.VITE_BASE_PATH || "/",
   plugins: [react(), tailwindcss(), yaml()],
   resolve: {
     alias: {


### PR DESCRIPTION
### Summary

- Base path configurable via VITE_BASE_PATH env var for GitHub Pages (/wardnet/); defaults to / for custom domain