### PR TITLE
fix(deps): update quinn-proto to 0.11.14 (RUSTSEC-2026-0037)

### DIFF
--- a/source/daemon/Cargo.lock
+++ b/source/daemon/Cargo.lock
@@ -2067,9 +2067,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.13"
+version = "0.11.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
 dependencies = [
  "bytes",
  "getrandom 0.3.4",


### PR DESCRIPTION
## Summary

  - Update `quinn-proto` from 0.11.13 to 0.11.14 to fix a high-severity denial of service vulnerability ([RUSTSEC-2026-0037](https://rustsec.org/advisories/RUSTSEC-2026-0037))
  - Transitive dependency via `reqwest` → `quinn` — only `Cargo.lock` changes needed