### PR TITLE
fix: bump react to 19.2.5 to match react-dom

### DIFF
--- a/source/web-ui/package.json
+++ b/source/web-ui/package.json
@@ -23,7 +23,7 @@
     "lucide-react": "^1.8.0",
     "next-themes": "^0.4.6",
     "radix-ui": "^1.4.3",
-    "react": "^19.2.4",
+    "react": "^19.2.5",
     "react-dom": "^19.2.5",
     "react-router": "^7.13.1",
     "shadcn": "^4.1.0",

--- a/source/web-ui/yarn.lock
+++ b/source/web-ui/yarn.lock
@@ -5695,10 +5695,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react@npm:^19.2.4":
-  version: 19.2.4
-  resolution: "react@npm:19.2.4"
-  checksum: 10c0/cd2c9ff67a720799cc3b38a516009986f7fc4cb8d3e15716c6211cf098d1357ee3e348ab05ad0600042bbb0fd888530ba92e329198c92eafa0994f5213396596
+"react@npm:^19.2.5":
+  version: 19.2.5
+  resolution: "react@npm:19.2.5"
+  checksum: 10c0/4b5f231dbef92886f602533c9ce3bde04d99f0e71dfb5d794c43e02726efaad0421c08688f75fc98a6d6e1dc017372e1af7abbfecdc86a79968f461675931a7a
   languageName: node
   linkType: hard
 
@@ -6653,7 +6653,7 @@ __metadata:
     next-themes: "npm:^0.4.6"
     prettier: "npm:^3.8.1"
     radix-ui: "npm:^1.4.3"
-    react: "npm:^19.2.4"
+    react: "npm:^19.2.5"
     react-dom: "npm:^19.2.5"
     react-router: "npm:^7.13.1"
     shadcn: "npm:^4.1.0"


### PR DESCRIPTION
## Summary
- Bumps `react` from 19.2.4 to 19.2.5 to match `react-dom` version
- Fixes React runtime error #527 (version mismatch) in production web UI

## Test plan
- [ ] Verify web UI loads without errors at http://192.168.100.2:7411

🤖 Generated with [Claude Code](https://claude.com/claude-code)