### PR TITLE
fix: routing flow persistence and DHCP IP conflict on reservation change

### DIFF
--- a/source/daemon/crates/wardnetd-services/src/dhcp/service.rs
+++ b/source/daemon/crates/wardnetd-services/src/dhcp/service.rs
@@ -633,9 +633,7 @@ impl DhcpService for DhcpServiceImpl {
                         .insert_lease_log(&DhcpLeaseLogRow {
                             lease_id: existing.id.to_string(),
                             event_type: "expired".to_owned(),
-                            details: Some(format!(
-                                "superseded by reservation for {reserved_ip}"
-                            )),
+                            details: Some(format!("superseded by reservation for {reserved_ip}")),
                         })
                         .await
                         .map_err(AppError::Internal)?;

--- a/source/daemon/crates/wardnetd-services/src/dhcp/service.rs
+++ b/source/daemon/crates/wardnetd-services/src/dhcp/service.rs
@@ -605,6 +605,44 @@ impl DhcpService for DhcpServiceImpl {
             .await
             .map_err(AppError::Internal)?
         {
+            // If a reservation now points this MAC to a different IP, the device
+            // needs to migrate. Expire the current lease so the old IP is freed
+            // and fall through to assign_lease, which will allocate the reserved IP.
+            // This closes the window where the old IP could be handed to a new
+            // device while the original device still holds it.
+            if let Some(reservation) = self
+                .dhcp
+                .find_reservation_by_mac(mac)
+                .await
+                .map_err(AppError::Internal)?
+            {
+                let reserved_ip: Ipv4Addr = reservation.ip_address;
+
+                if reserved_ip != existing.ip_address {
+                    tracing::info!(
+                        mac,
+                        old_ip = %existing.ip_address,
+                        new_ip = %reserved_ip,
+                        "reservation changed: expiring old lease to migrate device to reserved IP"
+                    );
+                    self.dhcp
+                        .update_lease_status(&existing.id.to_string(), "expired")
+                        .await
+                        .map_err(AppError::Internal)?;
+                    self.dhcp
+                        .insert_lease_log(&DhcpLeaseLogRow {
+                            lease_id: existing.id.to_string(),
+                            event_type: "expired".to_owned(),
+                            details: Some(format!(
+                                "superseded by reservation for {reserved_ip}"
+                            )),
+                        })
+                        .await
+                        .map_err(AppError::Internal)?;
+                    return self.assign_lease(mac, None).await;
+                }
+            }
+
             let config = self.load_config().await?;
             let new_end = chrono::Utc::now()
                 + chrono::Duration::seconds(i64::from(config.lease_duration_secs));

--- a/source/daemon/crates/wardnetd-services/src/dhcp/tests/dhcp.rs
+++ b/source/daemon/crates/wardnetd-services/src/dhcp/tests/dhcp.rs
@@ -813,10 +813,9 @@ async fn renew_lease_migrates_to_reserved_ip_when_reservation_changed() {
     let old_id = seed_active_lease(&dhcp, "aa:bb:cc:dd:ee:30", "192.168.1.105");
     seed_reservation(&dhcp, "aa:bb:cc:dd:ee:30", "192.168.1.106");
 
-    let lease =
-        auth_context::with_context(admin_ctx(), svc.renew_lease("AA:BB:CC:DD:EE:30"))
-            .await
-            .unwrap();
+    let lease = auth_context::with_context(admin_ctx(), svc.renew_lease("AA:BB:CC:DD:EE:30"))
+        .await
+        .unwrap();
 
     // Device should now hold the reserved IP.
     assert_eq!(lease.ip_address, Ipv4Addr::new(192, 168, 1, 106));
@@ -855,10 +854,9 @@ async fn renew_lease_does_not_migrate_when_reservation_matches_current_ip() {
     let existing_id = seed_active_lease(&dhcp, "aa:bb:cc:dd:ee:31", "192.168.1.107");
     seed_reservation(&dhcp, "aa:bb:cc:dd:ee:31", "192.168.1.107");
 
-    let lease =
-        auth_context::with_context(admin_ctx(), svc.renew_lease("AA:BB:CC:DD:EE:31"))
-            .await
-            .unwrap();
+    let lease = auth_context::with_context(admin_ctx(), svc.renew_lease("AA:BB:CC:DD:EE:31"))
+        .await
+        .unwrap();
 
     // Same lease ID — just renewed, not replaced.
     assert_eq!(lease.id.to_string(), existing_id);

--- a/source/daemon/crates/wardnetd-services/src/dhcp/tests/dhcp.rs
+++ b/source/daemon/crates/wardnetd-services/src/dhcp/tests/dhcp.rs
@@ -802,6 +802,73 @@ async fn renew_lease_extends_expiry_into_the_future() {
     );
 }
 
+// Renewal with mismatched reservation: device migrates to reserved IP.
+// Scenario: Device holds .105 (active lease), but a reservation now maps its
+// MAC to .106. On renewal the old lease must be expired and the device must
+// receive .106, closing the window where a new device could be handed .105.
+#[tokio::test]
+async fn renew_lease_migrates_to_reserved_ip_when_reservation_changed() {
+    let (svc, dhcp, _cfg) = build_service_with_deps();
+
+    let old_id = seed_active_lease(&dhcp, "aa:bb:cc:dd:ee:30", "192.168.1.105");
+    seed_reservation(&dhcp, "aa:bb:cc:dd:ee:30", "192.168.1.106");
+
+    let lease =
+        auth_context::with_context(admin_ctx(), svc.renew_lease("AA:BB:CC:DD:EE:30"))
+            .await
+            .unwrap();
+
+    // Device should now hold the reserved IP.
+    assert_eq!(lease.ip_address, Ipv4Addr::new(192, 168, 1, 106));
+    assert_eq!(lease.status, DhcpLeaseStatus::Active);
+
+    // Old lease must be expired so .105 is no longer in the active pool.
+    let old_row = dhcp
+        .leases
+        .lock()
+        .unwrap()
+        .iter()
+        .find(|r| r.id == old_id)
+        .cloned()
+        .unwrap();
+    assert_eq!(old_row.status, "expired", "old lease should be expired");
+
+    // Log should record the migration event followed by the assignment.
+    let logs = dhcp.logs.lock().unwrap();
+    assert!(
+        logs.iter().any(|l| l.event_type == "expired"
+            && l.details.as_deref().unwrap_or("").contains("192.168.1.106")),
+        "expected expiry log mentioning new reserved IP"
+    );
+    assert!(
+        logs.iter().any(|l| l.event_type == "assigned"),
+        "expected assigned log for new lease"
+    );
+}
+
+// Renewal where the reservation matches the current IP: no migration,
+// just a normal extension of the existing lease.
+#[tokio::test]
+async fn renew_lease_does_not_migrate_when_reservation_matches_current_ip() {
+    let (svc, dhcp, _cfg) = build_service_with_deps();
+
+    let existing_id = seed_active_lease(&dhcp, "aa:bb:cc:dd:ee:31", "192.168.1.107");
+    seed_reservation(&dhcp, "aa:bb:cc:dd:ee:31", "192.168.1.107");
+
+    let lease =
+        auth_context::with_context(admin_ctx(), svc.renew_lease("AA:BB:CC:DD:EE:31"))
+            .await
+            .unwrap();
+
+    // Same lease ID — just renewed, not replaced.
+    assert_eq!(lease.id.to_string(), existing_id);
+    assert_eq!(lease.ip_address, Ipv4Addr::new(192, 168, 1, 107));
+
+    let logs = dhcp.logs.lock().unwrap();
+    assert_eq!(logs.len(), 1);
+    assert_eq!(logs[0].event_type, "renewed");
+}
+
 // =========================================================================
 // release_lease tests
 // =========================================================================

--- a/source/daemon/crates/wardnetd-services/src/routing/service.rs
+++ b/source/daemon/crates/wardnetd-services/src/routing/service.rs
@@ -340,7 +340,7 @@ impl RoutingServiceImpl {
     ///
     /// Must be long enough for the device to retransmit at least once and
     /// receive the RST, but short enough to avoid blocking new connections.
-    const TCP_RST_HOLD_DURATION: Duration = Duration::from_millis(500);
+    const TCP_RST_HOLD_DURATION: Duration = Duration::from_millis(1500);
 
     /// Flush stale connections for a device after a routing change.
     ///

--- a/source/daemon/crates/wardnetd/src/policy_router_netlink.rs
+++ b/source/daemon/crates/wardnetd/src/policy_router_netlink.rs
@@ -8,7 +8,7 @@ use rtnetlink::packet_route::route::{RouteAttribute, RouteScope};
 use rtnetlink::packet_route::rule::{RuleAction, RuleAttribute, RuleMessage};
 use rtnetlink::{Handle, RouteMessageBuilder};
 
-use wardnetd_services::command::CommandExecutor;
+use wardnetd_services::command::{CommandExecutor, CommandOutput};
 use wardnetd_services::routing::policy_router::PolicyRouter;
 
 /// Production [`PolicyRouter`] backed by Linux netlink sockets.
@@ -230,36 +230,72 @@ impl PolicyRouter for NetlinkPolicyRouter {
     async fn flush_conntrack(&self, src_ip: &str) -> anyhow::Result<()> {
         // Conntrack flush via CLI — no mature pure-Rust netlink crate for
         // NFNL_SUBSYS_CTNETLINK. Filed as future work.
-        let output = match self.executor.run("conntrack", &["-D", "-s", src_ip]).await {
-            Ok(o) => o,
-            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
-                tracing::warn!(
-                    "`conntrack` command not found; install conntrack to enable \
-                     conntrack flushing on routing changes"
-                );
-                return Ok(());
+
+        // Helper closure to run one conntrack -D invocation and parse the
+        // deleted-entry count from its stderr output.
+        let run = |flag: &'static str| {
+            let executor = &self.executor;
+            async move {
+                match executor.run("conntrack", &["-D", flag, src_ip]).await {
+                    Ok(o) => Ok(o),
+                    Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                        tracing::warn!(
+                            "`conntrack` command not found; install conntrack to enable \
+                             conntrack flushing on routing changes"
+                        );
+                        // Return a synthetic "success with 0 deletions" so the caller
+                        // does not treat a missing binary as a hard error.
+                        Ok(CommandOutput {
+                            success: true,
+                            stdout: String::new(),
+                            stderr: String::new(),
+                        })
+                    }
+                    Err(e) => Err(anyhow::anyhow!("failed to execute `conntrack`: {e}")),
+                }
             }
-            Err(e) => return Err(anyhow::anyhow!("failed to execute `conntrack`: {e}")),
         };
 
-        let deleted = output
-            .stderr
-            .split_whitespace()
-            .collect::<Vec<_>>()
-            .windows(2)
-            .find_map(|w| (w[1] == "flow").then(|| w[0].parse::<u32>().ok()).flatten())
-            .unwrap_or(0);
+        let parse_deleted = |output: &CommandOutput| -> u32 {
+            output
+                .stderr
+                .split_whitespace()
+                .collect::<Vec<_>>()
+                .windows(2)
+                .find_map(|w| (w[1] == "flow").then(|| w[0].parse::<u32>().ok()).flatten())
+                .unwrap_or(0)
+        };
 
-        if output.success || output.stderr.contains("flow entries have been deleted") {
-            tracing::info!(src_ip, deleted, "flushed conntrack entries for source IP");
-            return Ok(());
+        // Flush flows where the device is the source (outbound NAT entries).
+        let src_output = run("-s").await?;
+        if !src_output.success && !src_output.stderr.contains("flow entries have been deleted") {
+            anyhow::bail!(
+                "`conntrack -D -s {}` failed: {}",
+                src_ip,
+                src_output.stderr.trim()
+            );
         }
+        let deleted_src = parse_deleted(&src_output);
 
-        anyhow::bail!(
-            "`conntrack -D -s {}` failed: {}",
+        // Flush flows where the device is the destination (return-path entries
+        // created by server-initiated or push-notification traffic).
+        let dst_output = run("-d").await?;
+        if !dst_output.success && !dst_output.stderr.contains("flow entries have been deleted") {
+            anyhow::bail!(
+                "`conntrack -D -d {}` failed: {}",
+                src_ip,
+                dst_output.stderr.trim()
+            );
+        }
+        let deleted_dst = parse_deleted(&dst_output);
+
+        tracing::info!(
             src_ip,
-            output.stderr.trim()
-        )
+            deleted_src,
+            deleted_dst,
+            "flushed conntrack entries for device IP (source + destination)"
+        );
+        Ok(())
     }
 
     async fn flush_route_cache(&self) -> anyhow::Result<()> {


### PR DESCRIPTION
Closes #82

## Summary

- **Routing (flow persistence):** `conntrack -D` now flushes both source (`-s`) and destination (`-d`) directions when a device switches routes, clearing return-path entries created by push notifications and server-initiated traffic. The TCP RST hold window is also raised from 500 ms to 1 500 ms to cover Android's default RTO, preventing the "No Internet" captive portal fallback that forced a manual Wi-Fi toggle.

- **DHCP IP conflict (issue #82):** `renew_lease` now detects when a device's active lease points to a different IP than its reservation. Instead of blindly extending the old lease, it expires it and immediately assigns the reserved IP in the same call. This closes the window where the vacated IP could be handed to a new device while the original device still held it on the wire.

## Test plan

- [ ] Verify routing: change a phone's VPN tunnel in the UI — traffic should switch without a Wi-Fi toggle
- [ ] Verify DHCP: assign a device a reservation for a different IP, then trigger a DHCP renewal — confirm the device receives the reserved IP and the old IP is no longer shown as active
- [ ] Run unit tests: `cargo test` (pre-existing profiling test failure is unrelated)

https://claude.ai/code/session_017Y5mJY5L9NjTVp6vVm5K6V