### PR TITLE
Add Snyk security scanning for Rust and Node.js projects

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -7,12 +7,20 @@ on:
       - "source/daemon/**/Cargo.toml"
       - "source/daemon/Cargo.lock"
       - "source/daemon/.cargo/audit.toml"
+      - "source/web-ui/package.json"
+      - "source/web-ui/yarn.lock"
+      - "source/site/package.json"
+      - "source/site/yarn.lock"
   pull_request:
     branches: [main]
     paths:
       - "source/daemon/**/Cargo.toml"
       - "source/daemon/Cargo.lock"
       - "source/daemon/.cargo/audit.toml"
+      - "source/web-ui/package.json"
+      - "source/web-ui/yarn.lock"
+      - "source/site/package.json"
+      - "source/site/yarn.lock"
   schedule:
     # Run daily at 06:00 UTC to catch newly disclosed advisories
     - cron: "0 6 * * *"
@@ -37,3 +45,114 @@ jobs:
 
       - name: Run cargo-audit
         run: cd source/daemon && cargo audit
+
+  snyk-rust:
+    name: Snyk - Rust
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: "1.94"
+
+      - name: Install Snyk CLI
+        uses: snyk/actions/setup@master
+
+      - name: Snyk test
+        run: snyk test --file=source/daemon/Cargo.toml --all-projects --sarif-file-output=snyk-rust.sarif
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+        continue-on-error: true
+
+      - name: Upload SARIF to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: snyk-rust.sarif
+
+      - name: Snyk monitor
+        if: github.ref == 'refs/heads/main' && github.event_name != 'pull_request'
+        run: snyk monitor --file=source/daemon/Cargo.toml --all-projects --project-name=wardnet-daemon
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+
+  snyk-web-ui:
+    name: Snyk - Web UI
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Install dependencies
+        run: cd source/web-ui && yarn install
+
+      - name: Install Snyk CLI
+        uses: snyk/actions/setup@master
+
+      - name: Snyk test
+        run: snyk test --file=source/web-ui/package.json --sarif-file-output=snyk-web-ui.sarif
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+        continue-on-error: true
+
+      - name: Upload SARIF to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: snyk-web-ui.sarif
+
+      - name: Snyk monitor
+        if: github.ref == 'refs/heads/main' && github.event_name != 'pull_request'
+        run: snyk monitor --file=source/web-ui/package.json --project-name=wardnet-web-ui
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+
+  snyk-site:
+    name: Snyk - Site
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Install dependencies
+        run: cd source/site && yarn install
+
+      - name: Install Snyk CLI
+        uses: snyk/actions/setup@master
+
+      - name: Snyk test
+        run: snyk test --file=source/site/package.json --sarif-file-output=snyk-site.sarif
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+        continue-on-error: true
+
+      - name: Upload SARIF to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: snyk-site.sarif
+
+      - name: Snyk monitor
+        if: github.ref == 'refs/heads/main' && github.event_name != 'pull_request'
+        run: snyk monitor --file=source/site/package.json --project-name=wardnet-site
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -49,6 +49,7 @@ jobs:
   snyk-rust:
     name: Snyk - Rust
     runs-on: ubuntu-latest
+    if: ${{ secrets.SNYK_TOKEN != '' }}
     permissions:
       security-events: write
     steps:
@@ -82,6 +83,7 @@ jobs:
   snyk-web-ui:
     name: Snyk - Web UI
     runs-on: ubuntu-latest
+    if: ${{ secrets.SNYK_TOKEN != '' }}
     permissions:
       security-events: write
     steps:
@@ -121,6 +123,7 @@ jobs:
   snyk-site:
     name: Snyk - Site
     runs-on: ubuntu-latest
+    if: ${{ secrets.SNYK_TOKEN != '' }}
     permissions:
       security-events: write
     steps:

--- a/.snyk
+++ b/.snyk
@@ -1,0 +1,12 @@
+# Snyk (https://snyk.io) policy file
+version: v1.25.1
+
+# Ignore rules can be added here to suppress specific vulnerabilities.
+# Example:
+# ignore:
+#   SNYK-RUST-CRATENAME-12345:
+#     - '*':
+#         reason: Not exploitable in this context
+#         expires: '2026-12-31T00:00:00.000Z'
+ignore: {}
+patch: {}

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![Rust](https://img.shields.io/badge/rust-1.94-orange.svg)](https://www.rust-lang.org)
 [![Rust Report Card](https://rust-reportcard.xuri.me/badge/github.com/pedromvgomes/wardnet)](https://rust-reportcard.xuri.me/report/github.com/pedromvgomes/wardnet)
 [![Security Audit](https://github.com/pedromvgomes/wardnet/actions/workflows/security.yml/badge.svg)](https://github.com/pedromvgomes/wardnet/actions/workflows/security.yml)
+[![Known Vulnerabilities](https://snyk.io/test/github/pedromvgomes/wardnet/badge.svg)](https://snyk.io/test/github/pedromvgomes/wardnet)
 [![Dependabot](https://badgen.net/github/dependabot/pedromvgomes/wardnet)](https://github.com/pedromvgomes/wardnet/pulls?q=is%3Apr+author%3Aapp%2Fdependabot)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 


### PR DESCRIPTION
Extends the security workflow with three new Snyk jobs covering the Rust
daemon workspace and both Node.js projects (web-ui and site). Each job runs
`snyk test`, uploads SARIF results to the GitHub Security tab, and runs
`snyk monitor` on main-branch pushes to track projects in the Snyk dashboard.
Also adds a `.snyk` policy file and a Known Vulnerabilities badge to the README.

Requires a SNYK_TOKEN secret to be added to the repository settings.

https://claude.ai/code/session_01AH8BQFWFSXvfgLWR4q4ypC