### PR TITLE
Add Codecov Test Analytics via cargo-nextest JUnit output

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,10 +118,18 @@ jobs:
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov
 
-      - name: Generate daemon coverage
+      - name: Install cargo-nextest
+        uses: taiki-e/install-action@cargo-nextest
+
+      - name: Generate daemon coverage and test results
         run: |
           mkdir -p coverage
-          make coverage-daemon COV_FMT="--lcov --output-path ../../coverage/daemon-lcov.info"
+          cd source/daemon && cargo llvm-cov nextest \
+            --workspace \
+            --profile ci \
+            --lcov --output-path ../../coverage/daemon-lcov.info \
+            --ignore-filename-regex '(main\.rs|noop_.*\.rs|db\.rs|web\.rs|api/mod\.rs|auth_context\.rs|command\.rs|policy_router_netlink\.rs|route_monitor\.rs|wardnet-test-agent/.*|wardnetd-mock/src/events\.rs|wardnetd-data/src/lib\.rs)'
+          cp target/nextest/ci/junit.xml ../../coverage/daemon-junit.xml
 
       - name: Enable Corepack
         run: corepack enable
@@ -132,16 +140,26 @@ jobs:
           cache: yarn
           cache-dependency-path: source/site/yarn.lock
 
-      - name: Generate site coverage
+      - name: Generate site coverage and test results
         run: cd source/site && yarn install --immutable && yarn test:coverage
 
-      - name: Collect site coverage
-        run: cp source/site/coverage/lcov.info coverage/site-lcov.info
+      - name: Collect coverage and test results
+        run: |
+          cp source/site/coverage/lcov.info coverage/site-lcov.info
+          cp source/site/test-results/junit.xml coverage/site-junit.xml
 
-      - name: Upload to Codecov
+      - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v6
         with:
           files: coverage/daemon-lcov.info,coverage/site-lcov.info
+          fail_ci_if_error: false
+          token: ${{ secrets.CODECOV_TOKEN }}
+
+      - name: Upload test results to Codecov
+        if: ${{ !cancelled() }}
+        uses: codecov/test-results-action@v1
+        with:
+          files: coverage/daemon-junit.xml,coverage/site-junit.xml
           fail_ci_if_error: false
           token: ${{ secrets.CODECOV_TOKEN }}
 

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ source/web-ui/dist/
 !source/web-ui/dist/index.html
 source/site/dist/
 source/site/coverage/
+source/site/test-results/
 **/.yarn/install-state.gz
 *.db
 *.db-shm

--- a/source/daemon/.config/nextest.toml
+++ b/source/daemon/.config/nextest.toml
@@ -1,0 +1,2 @@
+[profile.ci]
+junit = { path = "junit.xml" }

--- a/source/site/vite.config.ts
+++ b/source/site/vite.config.ts
@@ -21,6 +21,10 @@ export default defineConfig({
     environment: "jsdom",
     setupFiles: "./tests/setup.ts",
     css: false,
+    reporters: ["default", "junit"],
+    outputFile: {
+      junit: "./test-results/junit.xml",
+    },
     coverage: {
       provider: "v8",
       reporter: ["text", "lcov", "cobertura"],


### PR DESCRIPTION
- Add source/daemon/.config/nextest.toml with a CI profile that emits JUnit XML
- Switch coverage job from cargo llvm-cov to cargo llvm-cov nextest so coverage
  and test results are collected in a single test run
- Add JUnit reporter to Vitest config for site tests
- Upload JUnit XMLs to Codecov using codecov/test-results-action@v1
  (runs even on test failure via if: !cancelled())
- Gitignore source/site/test-results/

https://claude.ai/code/session_014Yqy5dkGGquJuUtpAZUd6T