### PR TITLE
fix: drain duplicate ip rules on removal and in reconcile (closes #78)

### DIFF
--- a/source/daemon/crates/wardnetd-services/src/routing/service.rs
+++ b/source/daemon/crates/wardnetd-services/src/routing/service.rs
@@ -211,14 +211,40 @@ impl RoutingServiceImpl {
                 tracing::debug!(
                     device_ip = %rule.device_ip,
                     table,
-                    "removing ip rule"
+                    "removing ip rule for device {device_ip}, table={table}",
+                    device_ip = rule.device_ip,
+                    table = table
                 );
-                if let Err(e) = self.netlink.remove_ip_rule(&rule.device_ip, table).await {
+                // Loop until the kernel reports no matching rule, clearing any
+                // duplicates that accumulated from restarts or races (issue #78).
+                let mut removed = 0u32;
+                loop {
+                    match self.netlink.remove_ip_rule(&rule.device_ip, table).await {
+                        Ok(()) => removed += 1,
+                        Err(e) => {
+                            if removed == 0 {
+                                tracing::warn!(
+                                    error = %e,
+                                    device_ip = %rule.device_ip,
+                                    table,
+                                    "failed to remove ip rule for {device_ip}, table={table}: {e}",
+                                    device_ip = rule.device_ip,
+                                    table = table
+                                );
+                            }
+                            break;
+                        }
+                    }
+                }
+                if removed > 1 {
                     tracing::warn!(
-                        error = %e,
                         device_ip = %rule.device_ip,
                         table,
-                        "failed to remove ip rule"
+                        removed,
+                        "drained duplicate ip rules for {device_ip}: device_ip={device_ip}, table={table}, removed={removed}",
+                        device_ip = rule.device_ip,
+                        table = table,
+                        removed = removed
                     );
                 }
             }
@@ -1059,20 +1085,83 @@ impl RoutingService for RoutingServiceImpl {
                     .filter_map(|r| r.table.map(|_| r.device_ip.as_str()))
                     .collect();
 
-                let mut orphan_count = 0u32;
+                // Group by (ip, table) to detect both orphans and duplicates.
+                let mut ip_rule_counts: HashMap<(String, u32), u32> = HashMap::new();
                 for (src_ip, table) in &kernel_rules {
+                    *ip_rule_counts.entry((src_ip.clone(), *table)).or_insert(0) += 1;
+                }
+
+                let mut orphan_count = 0u32;
+                let mut duplicate_count = 0u32;
+                for ((src_ip, table), count) in &ip_rule_counts {
                     if !known_ips.contains(src_ip.as_str()) {
-                        orphan_count += 1;
-                        tracing::warn!(src_ip, table, "removing orphaned ip rule");
-                        if let Err(e) = self.netlink.remove_ip_rule(src_ip, *table).await {
-                            tracing::warn!(error = %e, src_ip, table, "failed to remove orphaned ip rule");
+                        // Orphan: remove all occurrences of this rule.
+                        for _ in 0..*count {
+                            tracing::warn!(
+                                src_ip = %src_ip,
+                                table,
+                                "removing orphaned ip rule: src_ip={src_ip}, table={table}",
+                                src_ip = src_ip,
+                                table = table
+                            );
+                            if let Err(e) = self.netlink.remove_ip_rule(src_ip, *table).await {
+                                tracing::warn!(
+                                    error = %e,
+                                    src_ip = %src_ip,
+                                    table,
+                                    "failed to remove orphaned ip rule for {src_ip}, table={table}: {e}",
+                                    src_ip = src_ip,
+                                    table = table
+                                );
+                                break;
+                            }
+                            orphan_count += 1;
+                        }
+                    } else if *count > 1 {
+                        // Active IP with duplicates: keep one, remove the rest.
+                        let extras = count - 1;
+                        tracing::warn!(
+                            src_ip = %src_ip,
+                            table,
+                            count,
+                            extras,
+                            "pruning duplicate ip rules for active device: src_ip={src_ip}, table={table}, count={count}, extras={extras}",
+                            src_ip = src_ip,
+                            table = table,
+                            count = count,
+                            extras = extras
+                        );
+                        for _ in 0..extras {
+                            if let Err(e) = self.netlink.remove_ip_rule(src_ip, *table).await {
+                                tracing::warn!(
+                                    error = %e,
+                                    src_ip = %src_ip,
+                                    table,
+                                    "failed to remove duplicate ip rule for {src_ip}, table={table}: {e}",
+                                    src_ip = src_ip,
+                                    table = table
+                                );
+                                break;
+                            }
+                            duplicate_count += 1;
                         }
                     }
                 }
                 if orphan_count > 0 {
-                    tracing::info!(orphan_count, "cleaned up orphaned ip rules");
+                    tracing::info!(
+                        orphan_count,
+                        "cleaned up orphaned ip rules: orphan_count={orphan_count}",
+                        orphan_count = orphan_count
+                    );
                 } else {
                     tracing::debug!("no orphaned ip rules found");
+                }
+                if duplicate_count > 0 {
+                    tracing::info!(
+                        duplicate_count,
+                        "pruned duplicate ip rules: duplicate_count={duplicate_count}",
+                        duplicate_count = duplicate_count
+                    );
                 }
             }
             Err(e) => {

--- a/source/daemon/crates/wardnetd-services/src/routing/tests/routing.rs
+++ b/source/daemon/crates/wardnetd-services/src/routing/tests/routing.rs
@@ -264,6 +264,11 @@ struct MockNetlink {
     has_route_table_result: Arc<Mutex<bool>>,
     /// When `true`, `has_route_table` returns an error instead of the result.
     has_route_table_error: Arc<Mutex<bool>>,
+    /// Tracks the number of ip rules installed per (ip, table).
+    /// Incremented by `add_ip_rule`, decremented by `remove_ip_rule`.
+    /// Pre-seeded from `wardnet_rules` to simulate pre-existing kernel state.
+    /// Returns an error when count reaches 0 (no such rule).
+    rule_counts: Arc<Mutex<HashMap<(String, u32), u32>>>,
 }
 
 #[async_trait]
@@ -313,6 +318,12 @@ impl PolicyRouter for MockNetlink {
             .lock()
             .await
             .push(format!("add_ip_rule:{src_ip}:{table}"));
+        *self
+            .rule_counts
+            .lock()
+            .await
+            .entry((src_ip.to_owned(), table))
+            .or_insert(0) += 1;
         Ok(())
     }
 
@@ -321,6 +332,12 @@ impl PolicyRouter for MockNetlink {
             .lock()
             .await
             .push(format!("remove_ip_rule:{src_ip}:{table}"));
+        let mut counts = self.rule_counts.lock().await;
+        let count = counts.entry((src_ip.to_owned(), table)).or_insert(0);
+        if *count == 0 {
+            anyhow::bail!("RTNETLINK answers: No such process");
+        }
+        *count -= 1;
         Ok(())
     }
 
@@ -462,6 +479,8 @@ struct TestSetup {
     has_route_table_result: Arc<Mutex<bool>>,
     has_route_table_error: Arc<Mutex<bool>>,
     add_tcp_reset_reject_fail: Arc<Mutex<bool>>,
+    /// Exposed so tests can pre-seed duplicate rule counts.
+    netlink_rule_counts: Arc<Mutex<HashMap<(String, u32), u32>>>,
 }
 
 fn device_id_1() -> Uuid {
@@ -572,12 +591,14 @@ fn setup_with_devices_and_tunnel(
         bring_ups: bring_ups.clone(),
         tear_downs: tear_downs.clone(),
     });
+    let rule_counts: Arc<Mutex<HashMap<(String, u32), u32>>> = Arc::new(Mutex::new(HashMap::new()));
     let netlink: Arc<dyn PolicyRouter> = Arc::new(MockNetlink {
         calls: netlink_calls.clone(),
         wardnet_rules: vec![],
         route_add_failures_remaining: Arc::new(Mutex::new(0)),
         has_route_table_result: has_route_table_result.clone(),
         has_route_table_error: has_route_table_error.clone(),
+        rule_counts: rule_counts.clone(),
     });
     let nftables: Arc<dyn FirewallManager> = Arc::new(MockNftables {
         calls: nftables_calls.clone(),
@@ -603,6 +624,7 @@ fn setup_with_devices_and_tunnel(
         has_route_table_result,
         has_route_table_error,
         add_tcp_reset_reject_fail,
+        netlink_rule_counts: rule_counts,
     }
 }
 
@@ -631,12 +653,21 @@ fn setup_with_orphaned_rules(
         bring_ups: bring_ups.clone(),
         tear_downs: tear_downs.clone(),
     });
+    let initial_counts: HashMap<(String, u32), u32> =
+        kernel_rules
+            .iter()
+            .fold(HashMap::new(), |mut m, (ip, table)| {
+                *m.entry((ip.clone(), *table)).or_insert(0) += 1;
+                m
+            });
+    let rule_counts: Arc<Mutex<HashMap<(String, u32), u32>>> = Arc::new(Mutex::new(initial_counts));
     let netlink: Arc<dyn PolicyRouter> = Arc::new(MockNetlink {
         calls: netlink_calls.clone(),
         wardnet_rules: kernel_rules,
         route_add_failures_remaining: Arc::new(Mutex::new(0)),
         has_route_table_result: has_route_table_result.clone(),
         has_route_table_error: has_route_table_error.clone(),
+        rule_counts: rule_counts.clone(),
     });
     let nftables: Arc<dyn FirewallManager> = Arc::new(MockNftables {
         calls: nftables_calls.clone(),
@@ -662,6 +693,7 @@ fn setup_with_orphaned_rules(
         has_route_table_result,
         has_route_table_error,
         add_tcp_reset_reject_fail,
+        netlink_rule_counts: rule_counts,
     }
 }
 
@@ -688,12 +720,14 @@ fn setup_with_route_add_failures(failures: u32) -> TestSetup {
         bring_ups: bring_ups.clone(),
         tear_downs: tear_downs.clone(),
     });
+    let rule_counts: Arc<Mutex<HashMap<(String, u32), u32>>> = Arc::new(Mutex::new(HashMap::new()));
     let netlink: Arc<dyn PolicyRouter> = Arc::new(MockNetlink {
         calls: netlink_calls.clone(),
         wardnet_rules: vec![],
         route_add_failures_remaining: Arc::new(Mutex::new(failures)),
         has_route_table_result: has_route_table_result.clone(),
         has_route_table_error: has_route_table_error.clone(),
+        rule_counts: rule_counts.clone(),
     });
     let nftables: Arc<dyn FirewallManager> = Arc::new(MockNftables {
         calls: nftables_calls.clone(),
@@ -719,6 +753,7 @@ fn setup_with_route_add_failures(failures: u32) -> TestSetup {
         has_route_table_result,
         has_route_table_error,
         add_tcp_reset_reject_fail,
+        netlink_rule_counts: rule_counts,
     }
 }
 
@@ -1601,6 +1636,93 @@ async fn handle_route_table_lost_re_applies_rules() {
     assert!(
         nl.contains(&"add_ip_rule:192.168.1.10:100".to_owned()),
         "expected ip rule to be re-applied: {nl:?}"
+    );
+}
+
+// -- Tests: duplicate ip rule cleanup (issue #78) ----------------------------
+
+#[tokio::test]
+async fn remove_device_kernel_state_drains_duplicate_ip_rules() {
+    let ts = setup();
+    let target = RoutingTarget::Tunnel {
+        tunnel_id: tunnel_id_1(),
+    };
+
+    // Apply a tunnel rule — rule_counts[("192.168.1.10", 100)] becomes 1.
+    as_admin(
+        ts.routing
+            .apply_rule(device_id_1(), "192.168.1.10", &target),
+    )
+    .await
+    .unwrap();
+
+    // Simulate a stale duplicate by bumping the kernel count to 2.
+    ts.netlink_rule_counts
+        .lock()
+        .await
+        .insert(("192.168.1.10".to_owned(), 100), 2);
+    ts.netlink_calls.lock().await.clear();
+
+    // Removing routes should loop until remove_ip_rule fails (count 0).
+    as_admin(
+        ts.routing
+            .remove_device_routes(device_id_1(), "192.168.1.10"),
+    )
+    .await
+    .unwrap();
+
+    let nl = ts.netlink_calls.lock().await;
+    // Count=2 → 2 successes + 1 failing attempt = 3 calls total.
+    let remove_count = nl
+        .iter()
+        .filter(|c| c.as_str() == "remove_ip_rule:192.168.1.10:100")
+        .count();
+    assert_eq!(
+        remove_count, 3,
+        "expected 3 remove_ip_rule calls (2 successes + 1 drain attempt): {nl:?}"
+    );
+}
+
+#[tokio::test]
+async fn reconcile_prunes_duplicate_rules_for_active_device() {
+    let tid = tunnel_id_1();
+    let d1 = sample_device(device_id_1(), "192.168.1.10");
+    let mut rules = HashMap::new();
+    rules.insert(
+        DEVICE_1_ID.to_owned(),
+        RoutingRule {
+            device_id: device_id_1(),
+            target: RoutingTarget::Tunnel { tunnel_id: tid },
+            created_by: RuleCreator::User,
+        },
+    );
+
+    // Kernel has 3 entries for the same (ip, table) — 2 are duplicates.
+    let kernel_rules = vec![
+        ("192.168.1.10".to_owned(), 100u32),
+        ("192.168.1.10".to_owned(), 100u32),
+        ("192.168.1.10".to_owned(), 100u32),
+    ];
+    let ts = setup_with_orphaned_rules(
+        vec![d1],
+        rules,
+        Some(sample_tunnel(tunnel_id_1(), "wg_ward0", TunnelStatus::Up)),
+        Some(sample_tunnel_config(vec!["1.1.1.1".to_owned()])),
+        kernel_rules,
+    );
+
+    as_admin(ts.routing.reconcile()).await.unwrap();
+
+    let nl = ts.netlink_calls.lock().await;
+    // Reconcile applies 1 rule via apply_rule, then sees count=3 in kernel →
+    // extras=2 → exactly 2 remove_ip_rule calls for the duplicate pruning.
+    let remove_count = nl
+        .iter()
+        .filter(|c| c.as_str() == "remove_ip_rule:192.168.1.10:100")
+        .count();
+    assert_eq!(
+        remove_count, 2,
+        "expected exactly 2 remove_ip_rule calls to prune 2 duplicate rules: {nl:?}"
     );
 }
 


### PR DESCRIPTION
Two complementary fixes for stale duplicate `ip rule` entries:

1. `remove_device_kernel_state` now loops calling `remove_ip_rule` until
   the kernel returns an error (no such rule), clearing any duplicates
   that accumulated from daemon restarts or races.

2. `reconcile` groups kernel rules by (ip, table) before the orphan-
   cleanup pass. IPs still active in the database are pruned if they have
   more than one matching kernel rule; orphaned IPs have all their copies
   removed.

MockNetlink updated to track rule counts so the drain loop terminates
correctly in unit tests. Two new tests cover both scenarios.

https://claude.ai/code/session_01XgD3wTBNTmBpvpzvY8YLfr