### PR TITLE
feat: add router, managed_switch, server device types and fix settop_box icon (closes #95)

### DIFF
--- a/source/daemon/crates/wardnet-common/src/device.rs
+++ b/source/daemon/crates/wardnet-common/src/device.rs
@@ -13,6 +13,9 @@ pub enum DeviceType {
     GameConsole,
     SettopBox,
     Iot,
+    Router,
+    ManagedSwitch,
+    Server,
     Unknown,
 }
 

--- a/source/sdk/wardnet-js/src/types/device.ts
+++ b/source/sdk/wardnet-js/src/types/device.ts
@@ -10,6 +10,9 @@ export type DeviceType =
   | "game_console"
   | "settop_box"
   | "iot"
+  | "router"
+  | "managed_switch"
+  | "server"
   | "unknown";
 
 /** A discovered network device. */

--- a/source/web-ui/src/components/compound/DeviceIcon.tsx
+++ b/source/web-ui/src/components/compound/DeviceIcon.tsx
@@ -1,6 +1,27 @@
-import { Monitor, Smartphone, Laptop, Tablet, Gamepad2, Tv, Cpu, HelpCircle } from "lucide-react";
+import { Smartphone, Laptop, Tablet, Gamepad2, Tv, Cpu, HelpCircle, Router, Network, Server } from "lucide-react";
 import type { DeviceType } from "@wardnet/js";
 import { cn } from "@/lib/utils";
+
+function SetTopBox({ size = 24, className }: { size?: number; className?: string }) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+    >
+      <rect x="2" y="8" width="20" height="10" rx="2" />
+      <path d="M6.01 13H6" />
+      <path d="M10.01 13H10" />
+      <path d="M14 13h4" />
+    </svg>
+  );
+}
 
 const iconMap: Record<DeviceType, React.ElementType> = {
   tv: Tv,
@@ -8,8 +29,11 @@ const iconMap: Record<DeviceType, React.ElementType> = {
   laptop: Laptop,
   tablet: Tablet,
   game_console: Gamepad2,
-  settop_box: Monitor,
+  settop_box: SetTopBox,
   iot: Cpu,
+  router: Router,
+  managed_switch: Network,
+  server: Server,
   unknown: HelpCircle,
 };
 

--- a/source/web-ui/src/components/compound/DeviceIcon.tsx
+++ b/source/web-ui/src/components/compound/DeviceIcon.tsx
@@ -1,4 +1,15 @@
-import { Smartphone, Laptop, Tablet, Gamepad2, Tv, Cpu, HelpCircle, Router, Network, Server } from "lucide-react";
+import {
+  Smartphone,
+  Laptop,
+  Tablet,
+  Gamepad2,
+  Tv,
+  Cpu,
+  HelpCircle,
+  Router,
+  Network,
+  Server,
+} from "lucide-react";
 import type { DeviceType } from "@wardnet/js";
 import { cn } from "@/lib/utils";
 

--- a/source/web-ui/src/components/compound/DeviceTable.tsx
+++ b/source/web-ui/src/components/compound/DeviceTable.tsx
@@ -13,6 +13,9 @@ const DEVICE_TYPE_OPTIONS: { value: DeviceType; label: string }[] = [
   { value: "game_console", label: "Console" },
   { value: "settop_box", label: "Set-top Box" },
   { value: "iot", label: "IoT" },
+  { value: "router", label: "Router" },
+  { value: "managed_switch", label: "Managed Switch" },
+  { value: "server", label: "Server" },
   { value: "unknown", label: "Unknown" },
 ];
 

--- a/source/web-ui/src/components/features/EditDeviceForm.tsx
+++ b/source/web-ui/src/components/features/EditDeviceForm.tsx
@@ -25,6 +25,9 @@ const DEVICE_TYPE_OPTIONS: { value: DeviceType; label: string }[] = [
   { value: "game_console", label: "Console" },
   { value: "settop_box", label: "Set-top Box" },
   { value: "iot", label: "IoT" },
+  { value: "router", label: "Router" },
+  { value: "managed_switch", label: "Managed Switch" },
+  { value: "server", label: "Server" },
   { value: "unknown", label: "Unknown" },
 ];
 


### PR DESCRIPTION
- Daemon: add Router, ManagedSwitch, Server variants to DeviceType enum
- SDK: add "router", "managed_switch", "server" to DeviceType union
- Web UI: add custom SetTopBox SVG icon (Lucide-style box with LEDs + slot bar),
  Router/Network/Server Lucide icons for new types, update device type selectors

https://claude.ai/code/session_01Y6ewmUS4dySGY6w7RsH4EM