### PR TITLE
Harden CI security posture to improve OpenSSF Scorecard score

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,8 @@ on:
       - "Makefile"
       - ".github/workflows/ci.yml"
 
+permissions: read-all
+
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
@@ -23,12 +25,12 @@ jobs:
     name: Check Web
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Enable Corepack
         run: corepack enable
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: "25"
           cache: yarn
@@ -41,12 +43,12 @@ jobs:
     name: Check Site
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Enable Corepack
         run: corepack enable
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: "25"
           cache: yarn
@@ -60,12 +62,12 @@ jobs:
     needs: check-web
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Enable Corepack
         run: corepack enable
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: "25"
           cache: yarn
@@ -75,7 +77,7 @@ jobs:
         run: make build-web
 
       - name: Upload dist
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: web-ui-dist
           path: source/web-ui/dist/
@@ -85,15 +87,15 @@ jobs:
     name: Check Daemon
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@master
+        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
         with:
           toolchain: "1.94"
           components: clippy, rustfmt
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           workspaces: source/daemon
 
@@ -104,22 +106,22 @@ jobs:
     name: Code Coverage
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@master
+        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
         with:
           toolchain: "1.94"
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           workspaces: source/daemon
 
       - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@cargo-llvm-cov
+        uses: taiki-e/install-action@87d97b95c884523e049410b5322ea91b2acdbc89 # cargo-llvm-cov
 
       - name: Install cargo-nextest
-        uses: taiki-e/install-action@cargo-nextest
+        uses: taiki-e/install-action@024e8cba30d328c34bf69b86cfaaaad61ad5c4cb # cargo-nextest
 
       - name: Generate daemon coverage and test results
         run: |
@@ -134,7 +136,7 @@ jobs:
       - name: Enable Corepack
         run: corepack enable
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: "25"
           cache: yarn
@@ -149,7 +151,7 @@ jobs:
           cp source/site/test-results/junit.xml coverage/site-junit.xml
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v6
+        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6
         with:
           files: coverage/daemon-lcov.info,coverage/site-lcov.info
           fail_ci_if_error: false
@@ -157,7 +159,7 @@ jobs:
 
       - name: Upload test results to Codecov
         if: ${{ !cancelled() }}
-        uses: codecov/test-results-action@v1
+        uses: codecov/test-results-action@0fa95f0e1eeaafde2c782583b36b28ad0d8c77d3 # v1
         with:
           files: coverage/daemon-junit.xml,coverage/site-junit.xml
           fail_ci_if_error: false
@@ -177,24 +179,24 @@ jobs:
             runner: ubuntu-latest
             cross: true
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       # The web UI was built in the `build-web` job; `rust-embed` picks it up
       # from this directory at daemon compile time. All three matrix entries
       # reuse the single artifact instead of each re-running `yarn build`.
       - name: Download web-ui dist
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: web-ui-dist
           path: source/web-ui/dist/
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@master
+        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
         with:
           toolchain: "1.94"
           targets: ${{ matrix.target }}
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           workspaces: source/daemon
 

--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -21,12 +21,12 @@ jobs:
     name: Build Site
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Enable Corepack
         run: corepack enable
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: "25"
           cache: yarn
@@ -38,7 +38,7 @@ jobs:
           VITE_BASE_PATH: /wardnet/
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v4
+        uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4
         with:
           path: source/site/dist
 
@@ -52,4 +52,4 @@ jobs:
     steps:
       - name: Deploy
         id: deployment
-        uses: actions/deploy-pages@v5
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -21,18 +21,18 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
 
       - name: Run Scorecard
-        uses: ossf/scorecard-action@v2.4.0
+        uses: ossf/scorecard-action@62b2cac7ed8198b15735ed49ab1e5cf35480ba46 # v2.4.0
         with:
           results_file: scorecard.sarif
           results_format: sarif
           publish_results: true
 
       - name: Upload SARIF to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@ce64ddcb0d8d890d2df4a9d1c04ff297367dea2a # v3
         with:
           sarif_file: scorecard.sarif

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -17,6 +17,8 @@ on:
     # Run daily at 06:00 UTC to catch newly disclosed advisories
     - cron: "0 6 * * *"
 
+permissions: read-all
+
 env:
   CARGO_TERM_COLOR: always
 
@@ -25,10 +27,10 @@ jobs:
     name: Cargo Audit
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@master
+        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
         with:
           toolchain: "1.94"
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,22 @@
+# Security Policy
+
+## Supported Versions
+
+Wardnet is in active development (Phase 1 MVP). Only the latest code on the `main` branch receives security fixes. There are no versioned releases yet.
+
+## Reporting a Vulnerability
+
+Please **do not** report security vulnerabilities through public GitHub issues, as this exposes the vulnerability to everyone before a fix is available.
+
+Instead, use GitHub's private vulnerability reporting:
+
+**[Report a vulnerability](https://github.com/pedromvgomes/wardnet/security/advisories/new)**
+
+You can expect:
+- Acknowledgment within **48 hours**
+- A status update within **7 days**
+- A fix or mitigation plan for critical issues within **14 days**
+
+## Scope
+
+This policy covers the `wardnetd` daemon, the `wctl` CLI, and the web UI served by the daemon. Third-party dependencies are tracked via Dependabot; if you find a vulnerability in a dependency that is not yet covered by an advisory, please report it upstream to the relevant project as well.


### PR DESCRIPTION
## Summary

Three changes to address the main gaps in the OpenSSF Scorecard score (currently 3.5/10):

- **Pin all GitHub Actions to commit SHAs** across every workflow — `ci.yml`, `security.yml`, `scorecard.yml`, `deploy-site.yml`. Previously all used mutable tags (`@v6`, `@master`, etc.) which is the primary Scorecard deduction.
- **Add `permissions: read-all`** to `ci.yml` and `security.yml` — the two workflows with no explicit permissions declaration.
- **Add `SECURITY.md`** with a private vulnerability reporting policy.

## Scorecard checks addressed

| Check | Before | After |
|-------|--------|-------|
| Pinned-Dependencies | ❌ mutable tags | ✅ commit SHAs |
| Token-Permissions | ❌ implicit on ci + security | ✅ explicit `read-all` |
| Security-Policy | ❌ no SECURITY.md | ✅ added |
| Dangerous-Workflow | ⚠️ `@master` refs | ✅ pinned |

## Remaining improvements (GitHub settings, not code)

Enabling **branch protection on `main`** (require PR review + status checks) would address the Branch-Protection and Code-Review checks, which are also heavily weighted.

## Test plan

- [ ] Verify all CI jobs still pass after the action SHA pins
- [ ] Confirm the next Scorecard run (weekly Monday 07:00 UTC) shows an improved score
- [ ] Verify SECURITY.md appears under the repo's Security tab

https://claude.ai/code/session_01AH8BQFWFSXvfgLWR4q4ypC