### PR TITLE
chore(ci): extract reusable composite actions for Node and Rust setup

### DIFF
--- a/.github/actions/setup-node-yarn/action.yml
+++ b/.github/actions/setup-node-yarn/action.yml
@@ -1,0 +1,28 @@
+name: Setup Node and Yarn
+description: >
+  Enables Corepack, installs a pinned Node.js, and configures Yarn 4 caching
+  against a caller-provided yarn.lock path. One-step replacement for the
+  "Enable Corepack + actions/setup-node with yarn cache" pattern used across
+  the web UI and site builds.
+
+inputs:
+  cache-dependency-path:
+    description: Path to the yarn.lock used as the cache key (e.g. source/web-ui/yarn.lock).
+    required: true
+  node-version:
+    description: Node.js major version to install.
+    required: false
+    default: "25"
+
+runs:
+  using: composite
+  steps:
+    - name: Enable Corepack
+      shell: bash
+      run: corepack enable
+
+    - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+      with:
+        node-version: ${{ inputs.node-version }}
+        cache: yarn
+        cache-dependency-path: ${{ inputs.cache-dependency-path }}

--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -1,0 +1,40 @@
+name: Setup Rust
+description: >
+  Installs the pinned Rust toolchain and enables the Swatinem build cache
+  against the daemon workspace. Used by every job that compiles Rust
+  (check-daemon, build-daemon, coverage, release).
+
+inputs:
+  toolchain:
+    description: Rust toolchain version (must match `rust-toolchain.toml`).
+    required: false
+    default: "1.94"
+  targets:
+    description: Comma- or space-separated list of additional Rust targets to install.
+    required: false
+    default: ""
+  components:
+    description: Comma-separated list of toolchain components (e.g. "clippy, rustfmt").
+    required: false
+    default: ""
+  cache-key:
+    description: >
+      Optional suffix appended to the cache key. Use to isolate caches between
+      workflows that build different crates/profiles (e.g. "release-aarch64").
+    required: false
+    default: ""
+
+runs:
+  using: composite
+  steps:
+    - name: Install Rust toolchain
+      uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
+      with:
+        toolchain: ${{ inputs.toolchain }}
+        targets: ${{ inputs.targets }}
+        components: ${{ inputs.components }}
+
+    - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      with:
+        workspaces: source/daemon
+        key: ${{ inputs.cache-key }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,7 @@ on:
       - "Makefile"
       - "VERSION"
       - ".github/workflows/ci.yml"
+      - ".github/actions/**"
   pull_request:
     branches: [main]
     paths:
@@ -15,6 +16,7 @@ on:
       - "Makefile"
       - "VERSION"
       - ".github/workflows/ci.yml"
+      - ".github/actions/**"
 
 permissions: read-all
 
@@ -38,13 +40,8 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - name: Enable Corepack
-        run: corepack enable
-
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+      - uses: ./.github/actions/setup-node-yarn
         with:
-          node-version: "25"
-          cache: yarn
           cache-dependency-path: source/web-ui/yarn.lock
 
       - name: Check
@@ -75,13 +72,8 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - name: Enable Corepack
-        run: corepack enable
-
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+      - uses: ./.github/actions/setup-node-yarn
         with:
-          node-version: "25"
-          cache: yarn
           cache-dependency-path: source/web-ui/yarn.lock
 
       - name: Build
@@ -105,15 +97,9 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
+      - uses: ./.github/actions/setup-rust
         with:
-          toolchain: "1.94"
           components: clippy, rustfmt
-
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
-        with:
-          workspaces: source/daemon
 
       - name: Install clippy SARIF tooling
         uses: taiki-e/install-action@v2
@@ -225,15 +211,9 @@ jobs:
           name: web-ui-dist
           path: source/web-ui/dist/
 
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
+      - uses: ./.github/actions/setup-rust
         with:
-          toolchain: "1.94"
           targets: ${{ matrix.target }}
-
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
-        with:
-          workspaces: source/daemon
 
       - name: Install cross-compilation toolchain
         if: matrix.cross


### PR DESCRIPTION
## Summary

- Extract `setup-node-yarn` (corepack + setup-node with yarn cache) and `setup-rust` (toolchain + Swatinem cache) into composite actions under `.github/actions/`.
- Refactor `check-web`, `build-web`, `check-daemon`, `build-daemon` in `ci.yml` to consume the new actions.
- No behaviour change: same pinned SHAs, same inputs, same job graph, same artifacts.

This lays the groundwork for the upcoming release workflow, which needs the identical setup sequence. With this change, pinned action SHAs and the toolchain version live in one place — one PR to roll, not four.

`coverage` and `check-site` are intentionally left inline. They differ enough that forcing reuse would add complexity with little gain.

## Test plan

- [ ] CI green on this PR (proves the composite actions produce the same setup)
- [ ] `check-web`, `build-web`, `check-daemon`, `build-daemon` all pass
- [ ] Clippy SARIF still uploaded (`check-daemon` permissions preserved)
- [ ] Web UI dist artifact still flows from `build-web` → `build-daemon`

🤖 Generated with [Claude Code](https://claude.com/claude-code)