### PR TITLE
fix(ci): feed minisign password via stdin for release signing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -181,11 +181,16 @@ jobs:
           echo "${MINISIGN_KEY_B64}" | base64 -d > minisign.key
           chmod 0600 minisign.key
 
-          MINISIGN_PASSWORD="${MINISIGN_PASSWORD}" minisign -Sm "${TARBALL}" \
-            -s minisign.key \
-            -t "wardnetd ${VERSION} (${TARGET})" \
-            -c "Wardnet release signing key" \
-            -x "${MINISIG_FILE}"
+          # Feed the password both via stdin (older minisigns fall back to
+          # stdin when /dev/tty isn't available — which is the case on
+          # GitHub runners) and via the MINISIGN_PASSWORD env var (honoured
+          # by newer versions). Using both is safe and version-agnostic.
+          printf '%s\n' "${MINISIGN_PASSWORD}" | \
+            MINISIGN_PASSWORD="${MINISIGN_PASSWORD}" minisign -Sm "${TARBALL}" \
+              -s minisign.key \
+              -t "wardnetd ${VERSION} (${TARGET})" \
+              -c "Wardnet release signing key" \
+              -x "${MINISIG_FILE}"
 
           # Destroy the key material immediately so it never leaks into uploads.
           shred -u minisign.key


### PR DESCRIPTION
## Summary

The v0.2.0 release attempt failed at the minisign signing step. The version of minisign installed by ubuntu-latest's apt (0.11) prompted for a password interactively and exited — it didn't honour the `MINISIGN_PASSWORD` env var we were relying on.

**Fix:** pipe the password to stdin via `printf`, which minisign reads when `/dev/tty` isn't available (as is the case on GitHub runners). The env var is kept as belt-and-braces for newer versions that do support it.

## After merge

The v0.2.0 tag exists but there's no GitHub Release (the signing failure aborted the workflow before the publish step). To re-run:

```sh
git checkout main && git pull
git push origin --delete v0.2.0
git tag -d v0.2.0
git tag -a v0.2.0 origin/main -m "Wardnet 0.2.0 Release"
git push origin v0.2.0
```

The new workflow should sign + publish successfully.

## Test plan

- [ ] CI green on this PR
- [ ] After tag re-push, release workflow completes; both `aarch64-unknown-linux-gnu` and `x86_64-unknown-linux-gnu` tarballs published with valid `.sha256` and `.minisig` files
- [ ] Marketing site rebuilds with `/releases/stable.json` populated

🤖 Generated with [Claude Code](https://claude.com/claude-code)