### PR TITLE
fix(ci, site): dispatch deploy-site from release, drop Pi-only copy

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -221,7 +221,10 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     permissions:
+      # `contents: write` — create the Release.
+      # `actions: write` — dispatch the deploy-site workflow at the end.
       contents: write
+      actions: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
@@ -261,3 +264,12 @@ jobs:
             release-artefacts/*.tar.gz \
             release-artefacts/*.tar.gz.sha256 \
             release-artefacts/*.tar.gz.minisig
+
+      - name: Dispatch deploy-site so the marketing site picks up the new release
+        # `release: [published]` on deploy-site.yml does NOT fire when the
+        # release is created by GITHUB_TOKEN (GitHub blocks cascading events
+        # from the default token). An explicit `workflow_dispatch` IS allowed
+        # from GITHUB_TOKEN, so we kick off the site build ourselves here.
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh workflow run deploy-site.yml --ref main

--- a/source/site/src/components/layouts/Hero.tsx
+++ b/source/site/src/components/layouts/Hero.tsx
@@ -17,8 +17,9 @@ export function Hero({ onExplore }: HeroProps) {
       <h1 className="mb-3 text-5xl font-bold tracking-tight text-white sm:text-6xl">Wardnet</h1>
       <p className="mb-2 text-xl text-gray-300 sm:text-2xl">Your network. Your rules.</p>
       <p className="mb-6 max-w-xl text-base leading-relaxed text-gray-400">
-        A self-hosted privacy gateway for Raspberry Pi. Per-device VPN routing, DNS ad blocking, and
-        a web dashboard — all in a single binary.
+        A self-hosted privacy gateway you run on your own hardware — a Raspberry Pi, a mini-PC, or
+        any Linux host. Per-device VPN routing, DNS ad blocking, and a web dashboard, all in a
+        single binary.
       </p>
       <LatestReleaseBadge variant="dark" className="mb-8" />
       <div className="flex w-full max-w-xs flex-col gap-4 sm:max-w-none sm:flex-row sm:justify-center">

--- a/source/site/src/components/layouts/HowItWorks.tsx
+++ b/source/site/src/components/layouts/HowItWorks.tsx
@@ -3,8 +3,9 @@ import { StepCard } from "@/components/compound/StepCard";
 const STEPS = [
   {
     step: 1,
-    title: "Install on your Pi",
-    description: "Flash your Raspberry Pi, run the install script, and Wardnet is ready.",
+    title: "Install on your gateway",
+    description:
+      "Run the install script on a Raspberry Pi, a mini-PC, or any Linux host with a spare NIC.",
   },
   {
     step: 2,

--- a/source/site/tests/layouts/HowItWorks.test.tsx
+++ b/source/site/tests/layouts/HowItWorks.test.tsx
@@ -10,7 +10,7 @@ describe("HowItWorks", () => {
 
   it("renders all three steps", () => {
     render(<HowItWorks />);
-    expect(screen.getByText("Install on your Pi")).toBeInTheDocument();
+    expect(screen.getByText("Install on your gateway")).toBeInTheDocument();
     expect(screen.getByText("Connect your devices")).toBeInTheDocument();
     expect(screen.getByText("Control from the dashboard")).toBeInTheDocument();
   });


### PR DESCRIPTION
## Summary

Two small fixes bundled:

### Release → deploy-site dispatch

After v0.2.0 published, the site's `release: [published]` trigger never fired — GitHub blocks workflows created via `GITHUB_TOKEN` from cascading into further workflow runs. I had to dispatch deploy-site manually to get the manifests refreshed.

`workflow_dispatch` is one of the documented exceptions to that cascade rule. This adds an explicit `gh workflow run deploy-site.yml --ref main` step at the end of the publish job, plus `actions: write` permission so the dispatch is allowed. Next release triggers the site rebuild automatically.

### Hero copy — drop Pi-only framing

The homepage hero read *"A self-hosted privacy gateway for Raspberry Pi"*, and HowItWorks step 1 said *"Install on your Pi"*. Both aarch64-linux and x86_64-linux are first-class release targets — the copy didn't reflect that. Rewords to include Pi, mini-PC, and general Linux hosts without dropping the Pi mention (still the most common target).

## Test plan

- [ ] CI green
- [ ] Site tests pass (renamed assertion in HowItWorks.test.tsx)
- [ ] Next release tag triggers deploy-site automatically with no manual intervention

🤖 Generated with [Claude Code](https://claude.com/claude-code)