### PR TITLE
feat(site): SPA 404 fallback + styled NotFound / ErrorBoundary

### DIFF
--- a/source/site/package.json
+++ b/source/site/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "yarn generate:release-manifests && tsc -b && vite build",
+    "build": "yarn generate:release-manifests && tsc -b && vite build && cp dist/index.html dist/404.html",
     "preview": "vite preview",
     "type-check": "yarn generate:release-manifests && tsc -b",
     "test": "yarn generate:release-manifests && vitest run",

--- a/source/site/src/App.tsx
+++ b/source/site/src/App.tsx
@@ -1,17 +1,37 @@
 import { BrowserRouter, Routes, Route } from "react-router";
+import { ErrorBoundary } from "@/components/compound/ErrorBoundary";
 import { Home } from "@/pages/Home";
 import { Docs } from "@/pages/Docs";
+import { NotFound } from "@/pages/NotFound";
 
 /**
  * Root application component with routing for the public site.
+ *
+ * Wrapped in [`ErrorBoundary`] so any uncaught render error bubbles up to
+ * a styled fallback instead of showing the browser's default crash view.
+ * The trailing `path="*"` route catches unknown URLs — GitHub Pages is
+ * configured (via `cp index.html 404.html` at build time) to serve the
+ * SPA for any path, so this component is what the user actually sees for
+ * non-existent routes.
  */
 export default function App() {
   return (
-    <BrowserRouter basename={import.meta.env.BASE_URL}>
-      <Routes>
-        <Route path="/" element={<Home />} />
-        <Route path="/docs" element={<Docs />} />
-      </Routes>
-    </BrowserRouter>
+    <ErrorBoundary>
+      <BrowserRouter basename={import.meta.env.BASE_URL}>
+        <Routes>
+          <Route path="/" element={<Home />} />
+          <Route path="/docs" element={<Docs />} />
+          {/* Dev-only: force a render-time error so the ErrorBoundary can be
+              exercised locally. Stripped from production builds by Vite's
+              dead-code elimination on `import.meta.env.DEV`. */}
+          {import.meta.env.DEV && <Route path="/throw" element={<ThrowOnRender />} />}
+          <Route path="*" element={<NotFound />} />
+        </Routes>
+      </BrowserRouter>
+    </ErrorBoundary>
   );
+}
+
+function ThrowOnRender(): never {
+  throw new Error("forced error from /throw (dev only)");
 }

--- a/source/site/src/components/compound/ErrorBoundary.tsx
+++ b/source/site/src/components/compound/ErrorBoundary.tsx
@@ -1,0 +1,47 @@
+import { Component, type ErrorInfo, type ReactNode } from "react";
+import { ErrorView } from "@/pages/ErrorView";
+
+interface ErrorBoundaryProps {
+  children: ReactNode;
+}
+
+interface ErrorBoundaryState {
+  error: Error | null;
+}
+
+/**
+ * Root-level React error boundary. Catches exceptions thrown during render,
+ * lifecycle, or event handlers of any descendant component and swaps the
+ * subtree for a styled [`ErrorView`].
+ *
+ * Class component because React still only supports error boundaries as
+ * classes (`getDerivedStateFromError` + `componentDidCatch`). No hook
+ * equivalent is available as of React 19.
+ */
+export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  state: ErrorBoundaryState = { error: null };
+
+  static getDerivedStateFromError(error: Error): ErrorBoundaryState {
+    return { error };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo) {
+    // Log for dev console + any installed reporter. The UI only shows the
+    // short message; the full stack + component trace stay in logs.
+    // eslint-disable-next-line no-console
+    console.error("ErrorBoundary caught:", error, info.componentStack);
+  }
+
+  handleRetry = () => {
+    // Clear the error so the subtree re-renders. Callers that want a full
+    // reload can pass their own handler via the <ErrorView> they render.
+    this.setState({ error: null });
+  };
+
+  render() {
+    if (this.state.error) {
+      return <ErrorView message={this.state.error.message} onRetry={this.handleRetry} />;
+    }
+    return this.props.children;
+  }
+}

--- a/source/site/src/pages/ErrorView.tsx
+++ b/source/site/src/pages/ErrorView.tsx
@@ -31,8 +31,8 @@ export function ErrorView({ message, onRetry }: ErrorViewProps) {
         Something broke on our end
       </h1>
       <p className="mb-2 max-w-md text-base leading-relaxed text-gray-400">
-        The page hit an error while rendering. Try reloading — if it keeps
-        happening, file an issue and include what you were doing.
+        The page hit an error while rendering. Try reloading — if it keeps happening, file an issue
+        and include what you were doing.
       </p>
       {message && (
         <p className="mb-10 max-w-md rounded-md border border-white/10 bg-white/5 px-4 py-2 font-mono text-xs text-gray-300">

--- a/source/site/src/pages/ErrorView.tsx
+++ b/source/site/src/pages/ErrorView.tsx
@@ -1,0 +1,62 @@
+import { AlertTriangle, RefreshCw } from "lucide-react";
+import { Logo } from "@/components/compound/Logo";
+
+interface ErrorViewProps {
+  /** The error message to surface. Kept short — full details go to the
+   *  console/reporter, not the UI. */
+  message?: string;
+  /** Called when the user clicks "Try again". Typically re-runs the query
+   *  that threw, or forces a reload. */
+  onRetry?: () => void;
+}
+
+/**
+ * Generic error screen rendered by [`ErrorBoundary`] when an uncaught
+ * exception bubbles up, and by Suspense/data-loader failures that choose
+ * to surface through the boundary.
+ *
+ * Visually matches the NotFound page so users see a consistent "something's
+ * off" styling rather than a raw browser error.
+ */
+export function ErrorView({ message, onRetry }: ErrorViewProps) {
+  return (
+    <section className="relative flex min-h-screen flex-col items-center justify-center bg-gradient-to-br from-[oklch(0.22_0.12_275)] to-[oklch(0.16_0.08_260)] px-6 text-center">
+      <Logo size={96} className="mb-8" />
+
+      <div className="mb-3 inline-flex items-center gap-2 text-sm font-semibold uppercase tracking-[0.3em] text-white/40">
+        <AlertTriangle size={14} aria-hidden="true" />
+        Unexpected error
+      </div>
+      <h1 className="mb-3 text-4xl font-bold tracking-tight text-white sm:text-5xl">
+        Something broke on our end
+      </h1>
+      <p className="mb-2 max-w-md text-base leading-relaxed text-gray-400">
+        The page hit an error while rendering. Try reloading — if it keeps
+        happening, file an issue and include what you were doing.
+      </p>
+      {message && (
+        <p className="mb-10 max-w-md rounded-md border border-white/10 bg-white/5 px-4 py-2 font-mono text-xs text-gray-300">
+          {message}
+        </p>
+      )}
+      {!message && <div className="mb-10" />}
+
+      <div className="flex w-full max-w-xs flex-col gap-4 sm:max-w-none sm:flex-row sm:justify-center">
+        <button
+          type="button"
+          onClick={onRetry ?? (() => window.location.reload())}
+          className="inline-flex w-full items-center justify-center gap-2 rounded-lg bg-[var(--brand-green)] px-8 py-3 text-sm font-semibold text-white transition-colors hover:bg-[var(--brand-green-hover)] sm:w-48"
+        >
+          <RefreshCw size={16} aria-hidden="true" />
+          Try again
+        </button>
+        <a
+          href="https://github.com/wardnet/wardnet/issues/new"
+          className="inline-flex w-full items-center justify-center rounded-lg border border-white/20 bg-white/5 px-8 py-3 text-sm font-semibold text-white transition-colors hover:bg-white/10 sm:w-48"
+        >
+          Report issue
+        </a>
+      </div>
+    </section>
+  );
+}

--- a/source/site/src/pages/NotFound.tsx
+++ b/source/site/src/pages/NotFound.tsx
@@ -1,0 +1,47 @@
+import { Compass, SearchX } from "lucide-react";
+import { Link } from "react-router";
+import { Logo } from "@/components/compound/Logo";
+
+/**
+ * Catch-all 404 view. Reached when React Router finds no matching route —
+ * either because the user typed an unknown URL, followed a stale link, or
+ * hit a path that hasn't been deployed yet.
+ *
+ * Visually mirrors the Hero section so the user stays grounded in the site's
+ * look even when they're off the beaten path.
+ */
+export function NotFound() {
+  return (
+    <section className="relative flex min-h-screen flex-col items-center justify-center bg-gradient-to-br from-[oklch(0.22_0.12_275)] to-[oklch(0.16_0.08_260)] px-6 text-center">
+      <Logo size={96} className="mb-8" />
+
+      <div className="mb-3 inline-flex items-center gap-2 text-sm font-semibold uppercase tracking-[0.3em] text-white/40">
+        <SearchX size={14} aria-hidden="true" />
+        Page not found
+      </div>
+      <h1 className="mb-3 text-4xl font-bold tracking-tight text-white sm:text-5xl">
+        Off the map
+      </h1>
+      <p className="mb-10 max-w-md text-base leading-relaxed text-gray-400">
+        This URL doesn't route anywhere. If you followed a link from somewhere,
+        it's probably out of date.
+      </p>
+
+      <div className="flex w-full max-w-xs flex-col gap-4 sm:max-w-none sm:flex-row sm:justify-center">
+        <Link
+          to="/"
+          className="inline-block w-full rounded-lg bg-[var(--brand-green)] px-8 py-3 text-center text-sm font-semibold text-white transition-colors hover:bg-[var(--brand-green-hover)] sm:w-48"
+        >
+          Back home
+        </Link>
+        <Link
+          to="/docs"
+          className="inline-flex w-full items-center justify-center gap-2 rounded-lg border border-white/20 bg-white/5 px-8 py-3 text-sm font-semibold text-white transition-colors hover:bg-white/10 sm:w-48"
+        >
+          <Compass size={16} aria-hidden="true" />
+          Browse docs
+        </Link>
+      </div>
+    </section>
+  );
+}

--- a/source/site/src/pages/NotFound.tsx
+++ b/source/site/src/pages/NotFound.tsx
@@ -19,12 +19,10 @@ export function NotFound() {
         <SearchX size={14} aria-hidden="true" />
         Page not found
       </div>
-      <h1 className="mb-3 text-4xl font-bold tracking-tight text-white sm:text-5xl">
-        Off the map
-      </h1>
+      <h1 className="mb-3 text-4xl font-bold tracking-tight text-white sm:text-5xl">Off the map</h1>
       <p className="mb-10 max-w-md text-base leading-relaxed text-gray-400">
-        This URL doesn't route anywhere. If you followed a link from somewhere,
-        it's probably out of date.
+        This URL doesn't route anywhere. If you followed a link from somewhere, it's probably out of
+        date.
       </p>
 
       <div className="flex w-full max-w-xs flex-col gap-4 sm:max-w-none sm:flex-row sm:justify-center">


### PR DESCRIPTION
## Summary

Two closely-related site-only changes:

- **GitHub Pages SPA 404 fallback.** Direct navigation to client-side routes like \`/docs\` (or any future \`/api\`, \`/releases/*\`) currently returns a raw GH Pages 404 because Pages only serves the files it has. Fix: add \`cp dist/index.html dist/404.html\` to the site build — Pages then serves the SPA for any unknown URL, and React Router matches against the client-side route table. One-liner in the \`build\` script.
- **Catch-all \`NotFound\` page + root-level \`ErrorBoundary\`.** Without a catch-all route, unknown URLs would load the SPA shell and render *nothing* (a regression from today's raw 404). Added:
  - \`pages/NotFound.tsx\` — rendered from \`<Route path="*">\`. Matches the Hero's purple gradient with an icon + caption header (\`SearchX\` + "Page not found"), a big "Off the map" headline, and two buttons (Back home / Browse docs).
  - \`components/compound/ErrorBoundary.tsx\` — class component (React still has no hook equivalent) wrapping the router. Catches render / lifecycle / handler exceptions and swaps the subtree for \`ErrorView\`. Full stack stays in \`console.error\`; UI only surfaces the short message.
  - \`pages/ErrorView.tsx\` — same visual pattern as NotFound (\`AlertTriangle\` + "Unexpected error"). Buttons: "Try again" (resets the boundary) and "Report issue" (links to the issues tracker).

Both views share the Hero's styling so error states feel on-brand rather than jarring.

## Dev validation

Added a dev-only \`/throw\` route that throws during render so the boundary can be exercised locally. Gated on \`import.meta.env.DEV\` — Vite strips it from production builds.

- \`/nonexistent\` → \`NotFound\`
- \`/throw\` → \`ErrorBoundary\` → \`ErrorView\`

## Test plan

- [x] \`yarn type-check\` clean
- [x] \`yarn build\` produces \`dist/index.html\` and \`dist/404.html\`
- [x] Manually verified \`/nonexistent\` and \`/throw\` render the new views locally
- [ ] Once merged + deployed: hit \`https://wardnet.dev/docs\` directly (no soft nav) and confirm the Docs page renders instead of GH Pages' default 404