### PR TITLE
ci: restructure workflows into reusable leaves + ClusterFuzzLite fuzzing

### DIFF
--- a/.clusterfuzzlite/Dockerfile
+++ b/.clusterfuzzlite/Dockerfile
@@ -1,0 +1,10 @@
+# ClusterFuzzLite build container.
+#
+# Inherits the OSS-Fuzz Rust base image (nightly toolchain + libFuzzer
+# + sanitizer rustflags preconfigured). CFLite copies the repo into
+# $SRC/wardnet and invokes build.sh at image-build time.
+FROM gcr.io/oss-fuzz-base/base-builder-rust
+
+COPY . $SRC/wardnet
+COPY .clusterfuzzlite/build.sh $SRC/
+WORKDIR $SRC/wardnet

--- a/.clusterfuzzlite/README.md
+++ b/.clusterfuzzlite/README.md
@@ -1,0 +1,96 @@
+# ClusterFuzzLite
+
+Coverage-guided fuzzing for wardnet's deserialization boundaries —
+bundle archiver, SQLite restore, and bundle-manifest JSON.
+
+## Layout
+
+- `project.yaml` — tells CFLite the language is Rust.
+- `Dockerfile` — builds on top of `gcr.io/oss-fuzz-base/base-builder-rust`,
+  copies the repo, and stages `build.sh`.
+- `build.sh` — invoked inside the image at build time. Runs
+  `cargo fuzz build -O` against `source/daemon/fuzz/` and copies the
+  resulting binaries into `$OUT/`.
+
+Fuzz targets and harnesses live at `source/daemon/fuzz/` — a
+**standalone** cargo workspace (the daemon workspace excludes it)
+so `libfuzzer-sys` + nightly sanitizer rustflags stay out of the
+normal daemon build path.
+
+## Running locally
+
+```
+cd source/daemon/fuzz
+cargo +nightly fuzz run archiver_unpack
+cargo +nightly fuzz run sqlite_restore
+cargo +nightly fuzz run bundle_manifest
+```
+
+`cargo fuzz` needs nightly Rust even though the daemon pins stable —
+that's what the `+nightly` override is for.
+
+## Triaging a crash
+
+CI fuzzing runs (`fuzzing-scheduled.yml` twice daily in batch mode,
+`fuzzing-maintenance.yml` weekly for coverage reports + corpus
+pruning) store the corpus and crash reproducers in the companion repo
+`wardnet/wardnet-fuzz-corpus`. When a fuzz job fails:
+
+1. Download the crash reproducer artifact from the failed Actions run
+   (it's attached as `artifacts.zip`).
+2. Reproduce locally:
+   ```
+   cd source/daemon/fuzz
+   cargo +nightly fuzz run <target> path/to/crash-input
+   ```
+3. Fix the bug. Keep the crash input as a regression seed by
+   committing it to `source/daemon/fuzz/regression-inputs/<target>/`.
+4. File a GitHub issue with the stack trace + reproducer path.
+
+## Secrets
+
+The PR and weekly workflows need a fine-grained PAT scoped to
+`wardnet/wardnet-fuzz-corpus` with `Contents: read and write`,
+stored as the `FUZZ_CORPUS_PAT` secret on the main wardnet repo.
+
+Fine-grained PATs expire (GitHub's max is 1 year). When it does,
+the fuzzing workflows fail loudly on `git push`; main CI is
+unaffected and the corpus itself doesn't corrupt. To rotate:
+
+1. Generate a new PAT at
+   https://github.com/settings/personal-access-tokens/new with the
+   same scopes.
+2. `gh secret set FUZZ_CORPUS_PAT --repo wardnet/wardnet` and paste
+   the new token.
+3. Delete the old token.
+
+## Scope — what's fuzzed and what isn't
+
+Fuzzing targets the trust boundaries where wardnet parses
+attacker-influenceable bytes. Currently that's the backup/restore
+pipeline — four stacked parsers (age → gzip → tar → JSON+SQLite) on a
+path an operator can be tricked into triggering with a crafted bundle.
+
+Candidates to add incrementally as new features land:
+
+- **DNS response parsing** — once DNS forwarding is implemented.
+- **VPN provider config parsers** — `.ovpn` / similar user-uploaded files.
+- **Update manifest JSON** — fetched from the release endpoint.
+- **TOML config parsing** — lower priority; admin-supplied.
+
+Deliberately NOT fuzzed:
+
+- HTTP request bodies — axum + serde + utoipa handle deserialization,
+  and serde_json itself is heavily fuzzed upstream in rust-fuzz.
+  Handler-level fuzzing would mostly rediscover known bugs.
+- Repository methods / service orchestration — no untrusted input.
+- OUI database — bundled at build time from our own data.
+
+Scorecard's `Fuzzing` check is binary: 3 targets and 300 targets score
+identically, so there's no pressure to over-expand.
+
+## References
+
+- ClusterFuzzLite docs: https://google.github.io/clusterfuzzlite/
+- cargo-fuzz book: https://rust-fuzz.github.io/book/cargo-fuzz.html
+- libFuzzer tutorial: https://llvm.org/docs/LibFuzzer.html

--- a/.clusterfuzzlite/build.sh
+++ b/.clusterfuzzlite/build.sh
@@ -1,0 +1,17 @@
+#!/bin/bash -eu
+#
+# Build all wardnet fuzz targets and copy them into $OUT for
+# ClusterFuzzLite to run. Invoked by the base-builder-rust image.
+#
+# The fuzz workspace lives at source/daemon/fuzz and is explicitly
+# excluded from the daemon workspace so `libfuzzer-sys` + nightly
+# sanitizer rustflags never leak into normal `cargo build` paths.
+
+cd "$SRC/wardnet/source/daemon/fuzz"
+
+cargo fuzz build -O
+
+FUZZ_TARGETS=(archiver_unpack sqlite_restore bundle_manifest)
+for target in "${FUZZ_TARGETS[@]}"; do
+    cp "target/x86_64-unknown-linux-gnu/release/${target}" "$OUT/"
+done

--- a/.clusterfuzzlite/project.yaml
+++ b/.clusterfuzzlite/project.yaml
@@ -1,0 +1,1 @@
+language: rust

--- a/.github/actions/check-version/action.yml
+++ b/.github/actions/check-version/action.yml
@@ -1,0 +1,15 @@
+name: Check Version
+description: >-
+  Verifies that ./VERSION agrees with the workspace version in
+  source/daemon/Cargo.toml and every package.json that carries
+  wardnet's version. Catches the failure mode where a version bump
+  lands in one file but not the others.
+
+  Expects the repo to already be checked out.
+
+runs:
+  using: composite
+  steps:
+    - name: Verify all versioned files match ./VERSION
+      shell: bash
+      run: make check-version

--- a/.github/actions/detect-changes/action.yml
+++ b/.github/actions/detect-changes/action.yml
@@ -1,0 +1,40 @@
+name: Detect changes
+description: >-
+  Classifies the changed paths of a push/PR into named buckets
+  (daemon, site, ci, ...). Used by orchestrator workflows to gate
+  heavy reusable leaves and skip noop builds.
+
+  All filter rules live here so adding a new area (e.g. docs) is a
+  one-file change instead of editing every orchestrator.
+
+outputs:
+  daemon:
+    description: "'true' when daemon code, Makefile, or VERSION changed."
+    value: ${{ steps.filter.outputs.daemon }}
+  site:
+    description: "'true' when marketing-site code or the Makefile changed."
+    value: ${{ steps.filter.outputs.site }}
+  ci:
+    description: "'true' when a workflow or composite action changed."
+    value: ${{ steps.filter.outputs.ci }}
+
+runs:
+  using: composite
+  steps:
+    - uses: dorny/paths-filter@v3
+      id: filter
+      with:
+        # Every orchestrator should treat `ci == true` as "run everything":
+        # a workflow/action change can invalidate any assumption and the
+        # only honest response is a full validation.
+        filters: |
+          daemon:
+            - 'source/daemon/**'
+            - 'Makefile'
+            - 'VERSION'
+          site:
+            - 'source/site/**'
+            - 'Makefile'
+          ci:
+            - '.github/workflows/**'
+            - '.github/actions/**'

--- a/.github/workflows/build-daemon.yml
+++ b/.github/workflows/build-daemon.yml
@@ -1,0 +1,210 @@
+name: Build Daemon
+
+# Reusable leaf for daemon lint + test + release builds.
+#
+# Callers: ci.yml (push to main), pr.yml (PRs), indirectly release.yml
+# (via pr.yml). Produces three artifacts with fixed names that
+# downstream jobs and workflows download by reference:
+#
+#   - wardnetd-x86_64-unsigned   — stripped wardnetd binary, tarball
+#   - wardnetd-aarch64-unsigned  — stripped wardnetd binary, tarball
+#   - wardnet-mock-x86_64        — stripped wardnetd-mock binary, tarball
+#
+# No version in the filename — release-daemon.yml renames to
+# wardnetd-<version>-<arch>.tar.gz at publish time. Keeping build-daemon
+# release-agnostic means every PR run produces a tarball in the same
+# shape a release consumes, so signing+publishing is a thin wrapper.
+#
+# The wardnetd-mock binary is x86_64-only on purpose — it's a dev/test
+# tool, not a release asset, and building it for aarch64 would add
+# ~3min of cross-compile time with zero consumers.
+
+on:
+  workflow_call:
+
+permissions: read-all
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: 1
+
+jobs:
+  check-daemon:
+    name: Check Daemon
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      # Upload clippy SARIF to Code Scanning.
+      security-events: write
+      actions: read
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - uses: ./.github/actions/setup-rust
+        with:
+          components: clippy, rustfmt
+
+      - name: Install clippy SARIF tooling
+        uses: taiki-e/install-action@v2
+        with:
+          tool: clippy-sarif,sarif-fmt
+
+      - name: Check
+        # SARIF_OUT flips `make check-daemon` into piping clippy output
+        # through clippy-sarif — single clippy run, SARIF as by-product.
+        run: make check-daemon SARIF_OUT=rust-clippy-results.sarif
+
+      - name: Upload clippy findings to Code Scanning
+        # Upload even if Check failed (captures the warnings that caused
+        # the failure) — but only when SARIF was actually written. If
+        # cargo fmt --check fails (runs before clippy), no SARIF exists;
+        # hashFiles evaluates to empty and the upload is skipped.
+        if: always() && hashFiles('rust-clippy-results.sarif') != ''
+        uses: github/codeql-action/upload-sarif@v4
+        with:
+          sarif_file: rust-clippy-results.sarif
+          wait-for-processing: true
+
+  check-openapi:
+    name: Check OpenAPI drift
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - uses: ./.github/actions/setup-rust
+
+      - name: Regenerate docs/openapi.json and verify no drift
+        # `make check-openapi` runs `dump_openapi` against the current
+        # handler annotations and diffs against the committed file. Any
+        # API change must land with a fresh `docs/openapi.json`.
+        run: make check-openapi
+
+  build-web:
+    name: Build Web (for daemon embed)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - uses: ./.github/actions/setup-node-yarn
+        with:
+          cache-dependency-path: source/web-ui/yarn.lock
+
+      - name: Build
+        run: make build-web
+
+      - name: Upload dist
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: web-ui-dist
+          path: source/web-ui/dist/
+          retention-days: 1
+
+  build:
+    name: Build Daemon (${{ matrix.arch }})
+    needs: [build-web, check-daemon]
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: x86_64
+            target: x86_64-unknown-linux-gnu
+            strip: strip
+            build-mock: true
+          - arch: aarch64
+            target: aarch64-unknown-linux-gnu
+            strip: aarch64-linux-gnu-strip
+            cross_apt_packages: gcc-aarch64-linux-gnu
+            build-mock: false
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      # rust-embed picks the web UI up from this directory at daemon
+      # compile time. Downloading the shared artifact avoids re-running
+      # `yarn build` per matrix entry.
+      - name: Download web-ui dist
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: web-ui-dist
+          path: source/web-ui/dist/
+
+      - uses: ./.github/actions/setup-rust
+        with:
+          targets: ${{ matrix.target }}
+
+      - name: Install cross-compilation toolchain
+        if: matrix.cross_apt_packages != ''
+        run: sudo apt-get update && sudo apt-get install -y ${{ matrix.cross_apt_packages }}
+
+      - name: Build wardnetd
+        env:
+          TARGET: ${{ matrix.target }}
+          CRATE: wardnetd
+        run: make build-daemon
+
+      - name: Build wardnetd-mock (x86_64 only)
+        if: matrix.build-mock
+        env:
+          TARGET: ${{ matrix.target }}
+          CRATE: wardnetd-mock
+        run: make build-daemon
+
+      - name: Strip binaries
+        env:
+          STRIP_TOOL: ${{ matrix.strip }}
+          TARGET: ${{ matrix.target }}
+          BUILD_MOCK: ${{ matrix.build-mock }}
+        run: |
+          set -euo pipefail
+          BIN_DIR="source/daemon/target/${TARGET}/release"
+          "${STRIP_TOOL}" "${BIN_DIR}/wardnetd"
+          ls -l "${BIN_DIR}/wardnetd"
+          if [[ "${BUILD_MOCK}" == "true" ]]; then
+            "${STRIP_TOOL}" "${BIN_DIR}/wardnetd-mock"
+            ls -l "${BIN_DIR}/wardnetd-mock"
+          fi
+
+      - name: Package wardnetd
+        env:
+          TARGET: ${{ matrix.target }}
+          ARCH: ${{ matrix.arch }}
+        run: |
+          set -euo pipefail
+          mkdir -p build-artefacts/staged-wardnetd
+          cp "source/daemon/target/${TARGET}/release/wardnetd" \
+            "build-artefacts/staged-wardnetd/wardnetd"
+          chmod 0755 "build-artefacts/staged-wardnetd/wardnetd"
+          tar -C build-artefacts/staged-wardnetd \
+            -czf "build-artefacts/wardnetd-${ARCH}.tar.gz" wardnetd
+
+      - name: Upload wardnetd artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: wardnetd-${{ matrix.arch }}-unsigned
+          path: build-artefacts/wardnetd-${{ matrix.arch }}.tar.gz
+          retention-days: 7
+
+      - name: Package wardnetd-mock (x86_64 only)
+        if: matrix.build-mock
+        env:
+          TARGET: ${{ matrix.target }}
+        run: |
+          set -euo pipefail
+          mkdir -p build-artefacts/staged-mock
+          cp "source/daemon/target/${TARGET}/release/wardnetd-mock" \
+            "build-artefacts/staged-mock/wardnetd-mock"
+          chmod 0755 "build-artefacts/staged-mock/wardnetd-mock"
+          tar -C build-artefacts/staged-mock \
+            -czf "build-artefacts/wardnet-mock-x86_64.tar.gz" wardnetd-mock
+
+      - name: Upload wardnetd-mock artifact (x86_64 only)
+        if: matrix.build-mock
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: wardnet-mock-x86_64
+          path: build-artefacts/wardnet-mock-x86_64.tar.gz
+          retention-days: 7

--- a/.github/workflows/build-site.yml
+++ b/.github/workflows/build-site.yml
@@ -1,0 +1,76 @@
+name: Build Site
+
+# Reusable leaf for marketing-site lint + build.
+#
+# Callers: ci.yml (push to main), pr.yml (PRs), indirectly release.yml.
+# Produces a single artifact with a fixed name:
+#
+#   - site-dist — source/site/dist/ tree (raw, not pages-artifact)
+#
+# deploy-site.yml wraps it into a pages-artifact at deploy time. This
+# split keeps build-site.yml callable from orchestrators that don't
+# deploy (PR, CI-on-main), and keeps deploy-site.yml strictly about
+# shipping to Pages.
+#
+# Site coverage lives in coverage.yml, NOT here — Codecov expects a
+# single coordinated upload per PR, and splitting across leaves
+# produces dueling PR comments.
+
+on:
+  workflow_call:
+
+permissions: read-all
+
+jobs:
+  check-site:
+    name: Check Site
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: "25"
+          cache: yarn
+          cache-dependency-path: source/site/yarn.lock
+
+      # Run type-check + format:check only. The site unit tests run in
+      # coverage.yml with instrumentation; running them here too would
+      # be duplicated work.
+      - name: Install deps
+        run: cd source/site && yarn install --immutable
+
+      - name: Type check
+        run: cd source/site && yarn type-check
+
+      - name: Format check
+        run: cd source/site && yarn format:check
+
+  build:
+    name: Build Site bundle
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - uses: ./.github/actions/setup-node-yarn
+        with:
+          cache-dependency-path: source/site/yarn.lock
+
+      - name: Build
+        env:
+          # Authenticated token lifts the manifest generator's GitHub
+          # API rate-limit from 60/hr (anonymous) to 5000/hr.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: make build-site
+
+      - name: Upload site bundle
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: site-dist
+          path: source/site/dist/
+          retention-days: 7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,22 +1,25 @@
 name: CI
 
+# Orchestrator for pushes to `main`.
+#
+# Composes the same reusable leaves as pr.yml but skips the PR-only
+# gates (coverage, tests-e2e). Coverage runs only on PR because
+# Codecov's patch-coverage + PR-comment flow is PR-keyed; running it
+# on push-to-main would just produce uncommented uploads.
+#
+# Structure:
+#   preflight     — detect-changes + check-version composite actions
+#                   in a single job (outputs gate the leaves below)
+#   build-daemon  — lint + tests + release build + artifacts (gated)
+#   build-site    — lint + release build + artifact (gated)
+#
+# Site deploy happens ONLY on release.yml (on tag push) — marketing
+# content ships in lockstep with daemon releases, not on every
+# main commit.
+
 on:
   push:
     branches: [main]
-    paths:
-      - "source/**"
-      - "Makefile"
-      - "VERSION"
-      - ".github/workflows/ci.yml"
-      - ".github/actions/**"
-  pull_request:
-    branches: [main]
-    paths:
-      - "source/**"
-      - "Makefile"
-      - "VERSION"
-      - ".github/workflows/ci.yml"
-      - ".github/actions/**"
 
 permissions: read-all
 
@@ -25,219 +28,32 @@ env:
   RUST_BACKTRACE: 1
 
 jobs:
-  check-version:
-    name: Check Version
+  preflight:
+    name: Preflight
     runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-
-      - name: Verify all versioned files match ./VERSION
-        run: make check-version
-
-  check-web:
-    name: Check Web
-    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      daemon: ${{ steps.detect.outputs.daemon }}
+      site: ${{ steps.detect.outputs.site }}
+      ci: ${{ steps.detect.outputs.ci }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-
-      - uses: ./.github/actions/setup-node-yarn
-        with:
-          cache-dependency-path: source/web-ui/yarn.lock
-
-      - name: Check
-        run: make check-web
-
-  check-site:
-    name: Check Site
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-
-      - name: Enable Corepack
-        run: corepack enable
-
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
-        with:
-          node-version: "25"
-          cache: yarn
-          cache-dependency-path: source/site/yarn.lock
-
-      - name: Check
-        run: make check-site
-
-  build-web:
-    name: Build Web
-    needs: check-web
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-
-      - uses: ./.github/actions/setup-node-yarn
-        with:
-          cache-dependency-path: source/web-ui/yarn.lock
-
-      - name: Build
-        run: make build-web
-
-      - name: Upload dist
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
-        with:
-          name: web-ui-dist
-          path: source/web-ui/dist/
-          retention-days: 1
-
-  check-daemon:
-    name: Check Daemon
-    runs-on: ubuntu-latest
-    permissions:
-      # Needed to upload the clippy SARIF file to Code Scanning.
-      security-events: write
-      actions: read
-      contents: read
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-
-      - uses: ./.github/actions/setup-rust
-        with:
-          components: clippy, rustfmt
-
-      - name: Install clippy SARIF tooling
-        uses: taiki-e/install-action@v2
-        with:
-          tool: clippy-sarif,sarif-fmt
-
-      - name: Check
-        # `SARIF_OUT` flips `make check-daemon` into piping clippy output
-        # through clippy-sarif — single clippy run, SARIF as a by-product.
-        run: make check-daemon SARIF_OUT=rust-clippy-results.sarif
-
-      - name: Upload clippy findings to Code Scanning
-        # Upload even if the Check step failed (so SARIF captures the
-        # warnings that caused the failure) — but only when the file was
-        # actually written. A failure in `cargo fmt --check` (which runs
-        # before clippy) means no SARIF exists, and `hashFiles` evaluates
-        # to an empty string, skipping the upload.
-        if: always() && hashFiles('rust-clippy-results.sarif') != ''
-        uses: github/codeql-action/upload-sarif@v4
-        with:
-          sarif_file: rust-clippy-results.sarif
-          wait-for-processing: true
-
-  check-openapi:
-    name: Check OpenAPI drift
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-
-      - uses: ./.github/actions/setup-rust
-
-      - name: Regenerate docs/openapi.json and verify no drift
-        # `make check-openapi` runs `dump_openapi` against the current
-        # handler annotations and diffs against the committed file. Any
-        # API change must land with a fresh `docs/openapi.json`.
-        run: make check-openapi
-
-  coverage:
-    name: Code Coverage
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
-        with:
-          toolchain: "1.94"
-
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
-        with:
-          workspaces: source/daemon
-
-      - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@87d97b95c884523e049410b5322ea91b2acdbc89 # cargo-llvm-cov
-
-      - name: Install cargo-nextest
-        uses: taiki-e/install-action@024e8cba30d328c34bf69b86cfaaaad61ad5c4cb # cargo-nextest
-
-      - name: Generate daemon coverage and test results
-        run: |
-          mkdir -p coverage
-          cd source/daemon && cargo llvm-cov nextest \
-            --workspace \
-            --profile ci \
-            --lcov --output-path ../../coverage/daemon-lcov.info \
-            --ignore-filename-regex '(main\.rs|noop_.*\.rs|db\.rs|web\.rs|api/mod\.rs|auth_context\.rs|command\.rs|policy_router_netlink\.rs|route_monitor\.rs|wardnet-test-agent/.*|wardnetd-mock/src/events\.rs|wardnetd-data/src/lib\.rs)'
-          cp target/nextest/ci/junit.xml ../../coverage/daemon-junit.xml
-
-      - name: Enable Corepack
-        run: corepack enable
-
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
-        with:
-          node-version: "25"
-          cache: yarn
-          cache-dependency-path: source/site/yarn.lock
-
-      - name: Generate site coverage and test results
-        run: cd source/site && yarn install --immutable && yarn test:coverage
-
-      - name: Collect coverage and test results
-        run: |
-          cp source/site/coverage/lcov.info coverage/site-lcov.info
-          cp source/site/test-results/junit.xml coverage/site-junit.xml
-
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6
-        with:
-          files: coverage/daemon-lcov.info,coverage/site-lcov.info
-          fail_ci_if_error: false
-          token: ${{ secrets.CODECOV_TOKEN }}
-
-      - name: Upload test results to Codecov
-        if: ${{ !cancelled() }}
-        uses: codecov/test-results-action@0fa95f0e1eeaafde2c782583b36b28ad0d8c77d3 # v1
-        with:
-          files: coverage/daemon-junit.xml,coverage/site-junit.xml
-          fail_ci_if_error: false
-          token: ${{ secrets.CODECOV_TOKEN }}
+      - uses: ./.github/actions/detect-changes
+        id: detect
+      # Runs after detect because check-version is cheaper to rerun
+      # (3-4 s) than pays the VM spin-up cost of its own job.
+      - uses: ./.github/actions/check-version
 
   build-daemon:
-    name: Build Daemon (${{ matrix.target }})
-    needs: [build-web, check-daemon]
-    runs-on: ${{ matrix.runner }}
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - target: x86_64-unknown-linux-gnu
-            runner: ubuntu-latest
-          - target: aarch64-unknown-linux-gnu
-            runner: ubuntu-latest
-            cross: true
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+    name: Build Daemon
+    needs: preflight
+    if: needs.preflight.outputs.daemon == 'true' || needs.preflight.outputs.ci == 'true'
+    uses: ./.github/workflows/build-daemon.yml
+    secrets: inherit
 
-      # The web UI was built in the `build-web` job; `rust-embed` picks it up
-      # from this directory at daemon compile time. All three matrix entries
-      # reuse the single artifact instead of each re-running `yarn build`.
-      - name: Download web-ui dist
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
-        with:
-          name: web-ui-dist
-          path: source/web-ui/dist/
-
-      - uses: ./.github/actions/setup-rust
-        with:
-          targets: ${{ matrix.target }}
-
-      - name: Install cross-compilation toolchain
-        if: matrix.cross
-        run: sudo apt-get update && sudo apt-get install -y gcc-aarch64-linux-gnu
-
-      # Native targets build the whole workspace; cross-compile jobs build
-      # only the daemon crate for the requested target (other crates like
-      # wctl and wardnet-test-agent don't need aarch64-linux binaries in CI).
-      - name: Build
-        env:
-          TARGET: ${{ matrix.cross && matrix.target || '' }}
-          CRATE: ${{ matrix.cross && 'wardnetd' || '' }}
-        run: make build-daemon
+  build-site:
+    name: Build Site
+    needs: preflight
+    if: needs.preflight.outputs.site == 'true' || needs.preflight.outputs.ci == 'true'
+    uses: ./.github/workflows/build-site.yml
+    secrets: inherit

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,149 @@
+name: Coverage
+
+# Reusable leaf for daemon + site coverage.
+#
+# Called only from pr.yml (coverage doesn't run on push-to-main —
+# Codecov's patch-coverage feature keys off PRs). Daemon and site
+# coverage run in parallel jobs, and a single `upload` job combines
+# both LCOV/JUnit files into ONE Codecov invocation per PR so we get a
+# single PR comment with a coherent base comparison rather than
+# dueling uploads from separate leaves.
+
+on:
+  workflow_call:
+    secrets:
+      CODECOV_TOKEN:
+        description: Codecov upload token
+        required: true
+
+permissions: read-all
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: 1
+
+jobs:
+  daemon-coverage:
+    name: Daemon coverage
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
+        with:
+          toolchain: "1.94"
+
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          workspaces: source/daemon
+
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@87d97b95c884523e049410b5322ea91b2acdbc89 # cargo-llvm-cov
+
+      - name: Install cargo-nextest
+        uses: taiki-e/install-action@024e8cba30d328c34bf69b86cfaaaad61ad5c4cb # cargo-nextest
+
+      - name: Generate daemon coverage + test results
+        run: |
+          mkdir -p coverage
+          cd source/daemon && cargo llvm-cov nextest \
+            --workspace \
+            --profile ci \
+            --lcov --output-path ../../coverage/daemon-lcov.info \
+            --ignore-filename-regex '(main\.rs|noop_.*\.rs|db\.rs|web\.rs|api/mod\.rs|auth_context\.rs|command\.rs|policy_router_netlink\.rs|route_monitor\.rs|wardnet-test-agent/.*|wardnetd-mock/src/events\.rs|wardnetd-data/src/lib\.rs)'
+          cp target/nextest/ci/junit.xml ../../coverage/daemon-junit.xml
+
+      - name: Upload daemon coverage artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: coverage-daemon
+          path: coverage/
+          retention-days: 1
+
+  site-coverage:
+    name: Site coverage
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: "25"
+          cache: yarn
+          cache-dependency-path: source/site/yarn.lock
+
+      - name: Generate site coverage + test results
+        run: cd source/site && yarn install --immutable && yarn test:coverage
+
+      - name: Collect into shared layout
+        run: |
+          mkdir -p coverage
+          cp source/site/coverage/lcov.info coverage/site-lcov.info
+          cp source/site/test-results/junit.xml coverage/site-junit.xml
+
+      - name: Upload site coverage artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: coverage-site
+          path: coverage/
+          retention-days: 1
+
+  upload:
+    name: Upload to Codecov
+    needs: [daemon-coverage, site-coverage]
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    # Run even if one side failed so partial coverage still uploads —
+    # a failing daemon test shouldn't hide a site coverage regression.
+    if: always() && (needs.daemon-coverage.result == 'success' || needs.site-coverage.result == 'success')
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Download daemon coverage
+        if: needs.daemon-coverage.result == 'success'
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: coverage-daemon
+          path: coverage/
+
+      - name: Download site coverage
+        if: needs.site-coverage.result == 'success'
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: coverage-site
+          path: coverage/
+
+      - name: Resolve present coverage files
+        id: files
+        run: |
+          set -euo pipefail
+          LCOV=""
+          JUNIT=""
+          [[ -f coverage/daemon-lcov.info ]] && LCOV="${LCOV}coverage/daemon-lcov.info,"
+          [[ -f coverage/site-lcov.info ]] && LCOV="${LCOV}coverage/site-lcov.info,"
+          [[ -f coverage/daemon-junit.xml ]] && JUNIT="${JUNIT}coverage/daemon-junit.xml,"
+          [[ -f coverage/site-junit.xml ]] && JUNIT="${JUNIT}coverage/site-junit.xml,"
+          echo "lcov=${LCOV%,}" >> $GITHUB_OUTPUT
+          echo "junit=${JUNIT%,}" >> $GITHUB_OUTPUT
+
+      - name: Upload coverage to Codecov
+        if: steps.files.outputs.lcov != ''
+        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6
+        with:
+          files: ${{ steps.files.outputs.lcov }}
+          fail_ci_if_error: false
+          token: ${{ secrets.CODECOV_TOKEN }}
+
+      - name: Upload test results to Codecov
+        if: ${{ !cancelled() && steps.files.outputs.junit != '' }}
+        uses: codecov/test-results-action@0fa95f0e1eeaafde2c782583b36b28ad0d8c77d3 # v1
+        with:
+          files: ${{ steps.files.outputs.junit }}
+          fail_ci_if_error: false
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -1,17 +1,21 @@
 name: Deploy Site
 
+# Reusable leaf for GitHub Pages deployment.
+#
+# Downloads a pre-built site bundle (produced by build-site.yml) and
+# publishes it. No build step here — deploy-site.yml is strictly about
+# shipping, so `bundle-artifact` is a required input.
+#
+# Callers: ci.yml (on push to main, when site changed), release.yml
+# (on every tag). Manual redeploy: `gh workflow run ci.yml`.
+
 on:
-  push:
-    branches: [main]
-    paths:
-      - "source/site/**"
-      - ".github/workflows/deploy-site.yml"
-      - ".github/actions/**"
-  # Rebuild when a release is published so the manifest generator picks up
-  # the new GitHub Release and emits fresh /releases/{stable,beta}.json files.
-  release:
-    types: [published]
-  workflow_dispatch:
+  workflow_call:
+    inputs:
+      bundle-artifact:
+        description: Artifact name produced by build-site.yml.
+        type: string
+        default: site-dist
 
 permissions:
   contents: read
@@ -23,36 +27,25 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build:
-    name: Build Site
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-
-      - uses: ./.github/actions/setup-node-yarn
-        with:
-          cache-dependency-path: source/site/yarn.lock
-
-      - name: Build
-        env:
-          # Gives the manifest generator an authenticated GitHub token for
-          # higher API rate limits than anonymous access (5000/hr vs 60/hr).
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: make build-site
-
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
-        with:
-          path: source/site/dist
-
   deploy:
     name: Deploy to GitHub Pages
-    needs: build
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
+      - name: Download site bundle
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: ${{ inputs.bundle-artifact }}
+          path: site/
+
+      - name: Upload as Pages artifact
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
+        with:
+          path: site/
+
       - name: Deploy
         id: deployment
         uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5

--- a/.github/workflows/fuzzing-maintenance.yml
+++ b/.github/workflows/fuzzing-maintenance.yml
@@ -1,0 +1,72 @@
+name: Fuzzing (maintenance)
+
+# Weekly ClusterFuzzLite maintenance — coverage reports + corpus
+# pruning. Separated from fuzzing-scheduled.yml because these jobs
+# don't need twice-daily cadence and the reports are cheaper to
+# produce all at once on a quiet schedule.
+#
+# Coverage output publishes to the `gh-pages` branch of
+# wardnet/wardnet-fuzz-corpus; browse at
+# https://github.com/wardnet/wardnet-fuzz-corpus/tree/gh-pages/coverage
+# (or the GH Pages URL once that branch is Pages-enabled).
+
+on:
+  schedule:
+    - cron: "0 3 * * 0"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  coverage:
+    name: Coverage report
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Build Fuzzers (coverage sanitizer)
+        uses: google/clusterfuzzlite/actions/build_fuzzers@v1
+        with:
+          language: rust
+          sanitizer: coverage
+
+      - name: Run Fuzzers
+        uses: google/clusterfuzzlite/actions/run_fuzzers@v1
+        with:
+          language: rust
+          fuzz-seconds: 600
+          mode: coverage
+          sanitizer: coverage
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          storage-repo: https://x-access-token:${{ secrets.FUZZ_CORPUS_PAT }}@github.com/wardnet/wardnet-fuzz-corpus.git
+          storage-repo-branch: main
+          storage-repo-branch-coverage: gh-pages
+
+  prune:
+    name: Prune corpus
+    needs: coverage
+    runs-on: ubuntu-latest
+    # fuzz-seconds (20) + CFLite build + setup.
+    timeout-minutes: 40
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Build Fuzzers
+        uses: google/clusterfuzzlite/actions/build_fuzzers@v1
+        with:
+          language: rust
+          sanitizer: address
+
+      - name: Run Fuzzers
+        uses: google/clusterfuzzlite/actions/run_fuzzers@v1
+        with:
+          language: rust
+          fuzz-seconds: 1200
+          mode: prune
+          sanitizer: address
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          storage-repo: https://x-access-token:${{ secrets.FUZZ_CORPUS_PAT }}@github.com/wardnet/wardnet-fuzz-corpus.git
+          storage-repo-branch: main

--- a/.github/workflows/fuzzing-scheduled.yml
+++ b/.github/workflows/fuzzing-scheduled.yml
@@ -1,0 +1,64 @@
+name: Fuzzing (scheduled)
+
+# ClusterFuzzLite batch-mode fuzzing on a 12-hour cadence.
+#
+# Runs twice daily against the three trust-boundary targets in
+# source/daemon/fuzz/:
+#
+#   - archiver_unpack   (AgeArchiver::unpack on untrusted bytes)
+#   - sqlite_restore    (SqliteDumper::restore on untrusted bytes)
+#   - bundle_manifest   (serde_json::from_slice::<BundleManifest>)
+#
+# Corpus is persisted in a companion repo wardnet/wardnet-fuzz-corpus
+# via a fine-grained PAT stored as FUZZ_CORPUS_PAT. See
+# .clusterfuzzlite/README.md for triage + rotation.
+#
+# Cadence rationale: 12 hours gives sub-day attribution when a
+# regression lands (`git log --since=12h` narrows the suspects). Free
+# on public repos — weekly would save ~60 min/week of minutes that
+# this repo doesn't pay for.
+#
+# PR-gate fuzzing was evaluated and skipped — contributor friction
+# (~15 min added per relevant PR) isn't worth it when the scheduled
+# run catches regressions within half a day anyway.
+
+on:
+  schedule:
+    - cron: "0 */12 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  # `issues: write` lets CFLite file a GitHub Issue when a fuzzer
+  # reports a new crash. Nothing else on this repo writes.
+  issues: write
+
+jobs:
+  batch:
+    name: Batch fuzz (600s)
+    runs-on: ubuntu-latest
+    # fuzz-seconds (10) + CFLite build + setup. Caps a hung target
+    # before it eats a runner for GitHub's 6h default.
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Build Fuzzers
+        id: build
+        uses: google/clusterfuzzlite/actions/build_fuzzers@v1
+        with:
+          language: rust
+          sanitizer: address
+
+      - name: Run Fuzzers
+        uses: google/clusterfuzzlite/actions/run_fuzzers@v1
+        with:
+          language: rust
+          fuzz-seconds: 600
+          mode: batch
+          sanitizer: address
+          output-sarif: true
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          storage-repo: https://x-access-token:${{ secrets.FUZZ_CORPUS_PAT }}@github.com/wardnet/wardnet-fuzz-corpus.git
+          storage-repo-branch: main
+          storage-repo-branch-coverage: gh-pages

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,0 +1,74 @@
+name: PR
+
+# Orchestrator for pull requests targeting `main`.
+#
+# Also `workflow_call`-able from release.yml so a release tag exercises
+# the same gauntlet a PR would.
+#
+# Structure:
+#   preflight     — detect-changes + check-version composite actions
+#                   in a single job (outputs gate the leaves below)
+#   build-daemon  — lint + tests + release build + artifacts
+#   build-site    — lint + release build + artifact
+#   coverage      — daemon + site coverage, single Codecov upload
+#   tests-e2e     — stub today; needs both daemon + site artifacts
+#
+# Each heavy leaf is gated on `preflight.<area> || preflight.ci`. A
+# change to `.github/workflows/**` runs everything (CI config changes
+# must be fully validated).
+
+on:
+  pull_request:
+    branches: [main]
+  workflow_call:
+
+permissions: read-all
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: 1
+
+jobs:
+  preflight:
+    name: Preflight
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      daemon: ${{ steps.detect.outputs.daemon }}
+      site: ${{ steps.detect.outputs.site }}
+      ci: ${{ steps.detect.outputs.ci }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: ./.github/actions/detect-changes
+        id: detect
+      - uses: ./.github/actions/check-version
+
+  build-daemon:
+    name: Build Daemon
+    needs: preflight
+    if: needs.preflight.outputs.daemon == 'true' || needs.preflight.outputs.ci == 'true'
+    uses: ./.github/workflows/build-daemon.yml
+    secrets: inherit
+
+  build-site:
+    name: Build Site
+    needs: preflight
+    if: needs.preflight.outputs.site == 'true' || needs.preflight.outputs.ci == 'true'
+    uses: ./.github/workflows/build-site.yml
+    secrets: inherit
+
+  coverage:
+    name: Coverage
+    needs: preflight
+    if: needs.preflight.outputs.daemon == 'true' || needs.preflight.outputs.site == 'true' || needs.preflight.outputs.ci == 'true'
+    uses: ./.github/workflows/coverage.yml
+    secrets: inherit
+
+  tests-e2e:
+    name: E2E Tests
+    needs: [build-daemon, build-site]
+    # tests-e2e consumes artifacts from both leaves, so it runs only
+    # when both produced output (i.e. both were invoked).
+    if: needs.build-daemon.result == 'success' && needs.build-site.result == 'success'
+    uses: ./.github/workflows/tests-e2e.yml
+    secrets: inherit

--- a/.github/workflows/release-daemon.yml
+++ b/.github/workflows/release-daemon.yml
@@ -1,0 +1,144 @@
+name: Release Daemon
+
+# Reusable leaf that turns build-daemon.yml's unsigned artifacts into a
+# published GitHub Release: rename to include the version, sha256, sign
+# with minisign, verify the signature against the committed pubkey,
+# and attach to a `gh release create` call.
+#
+# The wardnetd-mock artifact is deliberately NOT attached — it's a
+# dev/test tool, not a shipped binary.
+
+on:
+  workflow_call:
+    inputs:
+      version:
+        description: Semantic version (e.g. `0.2.1`, `0.2.1-beta.1`).
+        type: string
+        required: true
+      tag:
+        description: Git tag (e.g. `v0.2.1`).
+        type: string
+        required: true
+      prerelease:
+        description: Mark as pre-release on GitHub.
+        type: boolean
+        required: true
+
+permissions:
+  contents: write
+
+jobs:
+  publish:
+    name: Publish GitHub Release
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Download wardnetd x86_64
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: wardnetd-x86_64-unsigned
+          path: release-staging/
+
+      - name: Download wardnetd aarch64
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: wardnetd-aarch64-unsigned
+          path: release-staging/
+
+      - name: Rename, sha256, sign
+        env:
+          VERSION: ${{ inputs.version }}
+          MINISIGN_KEY_B64: ${{ secrets.WARDNET_MINISIGN_KEY }}
+          MINISIGN_PASSWORD: ${{ secrets.WARDNET_MINISIGN_PASSWORD }}
+        run: |
+          set -euo pipefail
+
+          if [[ -z "${MINISIGN_KEY_B64:-}" || -z "${MINISIGN_PASSWORD:-}" ]]; then
+            echo "::error::WARDNET_MINISIGN_KEY and WARDNET_MINISIGN_PASSWORD secrets are required. See deploy/keys/README.md."
+            exit 1
+          fi
+
+          sudo apt-get update && sudo apt-get install -y minisign
+
+          cd release-staging
+
+          # Write the encrypted private key once. Shredded in the
+          # trailing step regardless of earlier failure.
+          echo "${MINISIGN_KEY_B64}" | base64 -d > minisign.key
+          chmod 0600 minisign.key
+          trap 'shred -u minisign.key || true' EXIT
+
+          for ARCH in x86_64 aarch64; do
+            # build-daemon.yml names the tarball wardnetd-<arch>.tar.gz;
+            # release assets carry the version for end-user clarity and
+            # for the daemon's auto-updater, which builds the URL as
+            # `wardnetd-<version>-<arch>.tar.gz`.
+            SRC="wardnetd-${ARCH}.tar.gz"
+            DST="wardnetd-${VERSION}-${ARCH}.tar.gz"
+            mv "${SRC}" "${DST}"
+
+            sha256sum "${DST}" | awk '{print $1}' > "${DST}.sha256"
+
+            # Feed password both via stdin and env — older minisigns
+            # fall back to stdin, newer honour MINISIGN_PASSWORD.
+            # GitHub runners have no tty, so env-only doesn't always
+            # work.
+            printf '%s\n' "${MINISIGN_PASSWORD}" | \
+              MINISIGN_PASSWORD="${MINISIGN_PASSWORD}" minisign -Sm "${DST}" \
+                -s minisign.key \
+                -t "wardnetd ${VERSION} (${ARCH})" \
+                -c "Wardnet release signing key" \
+                -x "${DST}.minisig"
+
+            # Sanity check against the committed public key.
+            minisign -Vm "${DST}" \
+              -p "../deploy/keys/wardnet-release.pub" \
+              -x "${DST}.minisig"
+          done
+
+          ls -l
+
+      - name: Stage OpenAPI spec + sha256
+        # Published alongside the binary so external consumers can
+        # download the spec for a specific daemon version without
+        # running the daemon. The site's manifest generator dedupes
+        # across historical releases using the .sha256.
+        run: |
+          set -euo pipefail
+          cp docs/openapi.json release-staging/openapi.json
+          sha256sum release-staging/openapi.json | awk '{print $1}' \
+            > release-staging/openapi.json.sha256
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ inputs.tag }}
+          VERSION: ${{ inputs.version }}
+          PRERELEASE: ${{ inputs.prerelease }}
+        run: |
+          set -euo pipefail
+          ARGS=(--verify-tag --title "Wardnet ${VERSION}")
+
+          # Prefer hand-written release notes at docs/releases/vX.Y.Z.md.
+          # Fall back to GitHub's auto-generated notes (diff since last tag).
+          NOTES_FILE="docs/releases/v${VERSION}.md"
+          if [[ -f "${NOTES_FILE}" ]]; then
+            echo "Using release notes from ${NOTES_FILE}"
+            ARGS+=(--notes-file "${NOTES_FILE}")
+          else
+            echo "No ${NOTES_FILE} found — falling back to auto-generated notes"
+            ARGS+=(--generate-notes)
+          fi
+
+          if [[ "${PRERELEASE}" == "true" ]]; then
+            ARGS+=(--prerelease)
+          fi
+
+          gh release create "${TAG}" "${ARGS[@]}" \
+            release-staging/*.tar.gz \
+            release-staging/*.tar.gz.sha256 \
+            release-staging/*.tar.gz.minisig \
+            release-staging/openapi.json \
+            release-staging/openapi.json.sha256

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,23 +1,15 @@
 name: Release
 
-# Tag-driven release workflow.
+# Tag-driven release orchestrator.
 #
-# Triggered by pushing an annotated tag matching `v*.*.*`. For every target
-# listed in the build matrix, cross-compiles the daemon, signs the tarball
-# with minisign, and attaches the artefacts to a GitHub Release.
+# Composes the same leaves as ci.yml + pr.yml plus release-specific
+# ones. Release does NOT nest pr.yml — pr.yml's preflight gating
+# (paths-filter) is meaningless on a tag push, and coverage shouldn't
+# run on release (Codecov's patch-coverage is PR-keyed).
 #
-# Adding a new target is a one-line matrix entry — no other plumbing changes.
-# v1 ships aarch64-linux-gnu only (Raspberry Pi), but the workflow is not
-# Pi-specific.
-#
-# Channel classification is SemVer-driven and handled by the marketing site's
-# manifest generator at build time (see source/site/scripts/generate-manifests.ts).
-# A tag with a pre-release suffix (e.g. `v0.2.1-beta.1`, `v0.2.1-rc.1`) is
-# marked as a GitHub "pre-release" and feeds the `beta` channel; a clean
-# `vX.Y.Z` tag feeds the `stable` channel.
-#
-# `workflow_dispatch` is supported for dry runs on non-tag refs: the build
-# and signing steps all run, but the publish job is skipped.
+# `workflow_dispatch` is supported for dry runs on non-tag refs: the
+# build + sign paths all run, but `release-daemon` (publish) is gated
+# on the ref being a tag so nothing reaches GitHub Releases.
 
 on:
   push:
@@ -35,6 +27,7 @@ jobs:
   resolve:
     name: Resolve version and channel
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     outputs:
       version: ${{ steps.version.outputs.version }}
       tag: ${{ steps.version.outputs.tag }}
@@ -81,221 +74,44 @@ jobs:
 
           echo "Release version: ${VERSION} (tag=${TAG:-<dispatch>}, prerelease=${PRERELEASE})"
 
-  build:
-    name: Build ${{ matrix.target }}
+  build-daemon:
+    name: Build Daemon
     needs: resolve
-    runs-on: ${{ matrix.runner }}
-    permissions:
-      contents: read
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          # Raspberry Pi and other aarch64 Linux boards.
-          # `arch` is the short-form name embedded in release asset filenames
-          # (`wardnetd-<version>-<arch>.tar.gz`) — only Linux targets ship, so
-          # the full `<arch>-unknown-linux-gnu` triple would just be noise for
-          # users. The daemon's auto-update runner constructs the tarball URL
-          # using this same short form (see `wardnetd_services::update::short_arch`).
-          - target: aarch64-unknown-linux-gnu
-            arch: aarch64
-            runner: ubuntu-latest
-            cross_apt_packages: gcc-aarch64-linux-gnu
-            strip: aarch64-linux-gnu-strip
-          # Non-Pi Linux hosts (mini-PCs, x86_64 servers, etc.). Built natively
-          # on the x86_64 runner, no cross-linker needed.
-          - target: x86_64-unknown-linux-gnu
-            arch: x86_64
-            runner: ubuntu-latest
-            cross_apt_packages: ""
-            strip: strip
-          # Additional targets slot in here as new matrix entries — no other
-          # plumbing changes needed.
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        with:
-          fetch-depth: 0
+    uses: ./.github/workflows/build-daemon.yml
+    secrets: inherit
 
-      - uses: ./.github/actions/setup-node-yarn
-        with:
-          cache-dependency-path: source/web-ui/yarn.lock
+  build-site:
+    name: Build Site
+    needs: resolve
+    uses: ./.github/workflows/build-site.yml
+    secrets: inherit
 
-      - name: Build web UI (embedded into the daemon binary)
-        run: make build-web
+  tests-e2e:
+    name: E2E Tests
+    needs: [build-daemon, build-site]
+    uses: ./.github/workflows/tests-e2e.yml
+    secrets: inherit
 
-      - uses: ./.github/actions/setup-rust
-        with:
-          targets: ${{ matrix.target }}
-          cache-key: release-${{ matrix.target }}
+  deploy-site:
+    name: Deploy Site
+    needs: [build-site, tests-e2e]
+    # Dry-run (workflow_dispatch on non-tag) still deploys the site —
+    # harmless, idempotent, and confirms the Pages path works.
+    uses: ./.github/workflows/deploy-site.yml
+    with:
+      bundle-artifact: site-dist
+    secrets: inherit
 
-      - name: Install cross-compilation toolchain
-        if: matrix.cross_apt_packages != ''
-        run: sudo apt-get update && sudo apt-get install -y ${{ matrix.cross_apt_packages }}
-
-      - name: Cross-compile daemon
-        env:
-          TARGET: ${{ matrix.target }}
-          CRATE: wardnetd
-        run: make build-daemon
-
-      - name: Strip binary
-        env:
-          STRIP_TOOL: ${{ matrix.strip }}
-          TARGET: ${{ matrix.target }}
-        run: |
-          set -euo pipefail
-          BIN="source/daemon/target/${TARGET}/release/wardnetd"
-          "${STRIP_TOOL}" "${BIN}"
-          ls -l "${BIN}"
-
-      - name: Install minisign
-        run: sudo apt-get install -y minisign
-
-      - name: Package and sign artefact
-        env:
-          VERSION: ${{ needs.resolve.outputs.version }}
-          TARGET: ${{ matrix.target }}
-          ARCH: ${{ matrix.arch }}
-          MINISIGN_KEY_B64: ${{ secrets.WARDNET_MINISIGN_KEY }}
-          MINISIGN_PASSWORD: ${{ secrets.WARDNET_MINISIGN_PASSWORD }}
-        run: |
-          set -euo pipefail
-
-          if [[ -z "${MINISIGN_KEY_B64:-}" || -z "${MINISIGN_PASSWORD:-}" ]]; then
-            echo "::error::WARDNET_MINISIGN_KEY and WARDNET_MINISIGN_PASSWORD secrets are required to produce a signed release. See deploy/keys/README.md."
-            exit 1
-          fi
-
-          # Asset naming: short arch only (no OS/vendor suffix) — everything
-          # we ship is Linux. The daemon's auto-update runner builds the same
-          # filename from `short_arch(target_triple)`; see release.yml matrix.
-          BASENAME="wardnetd-${VERSION}-${ARCH}"
-          TARBALL="${BASENAME}.tar.gz"
-          SHA256_FILE="${TARBALL}.sha256"
-          MINISIG_FILE="${TARBALL}.minisig"
-
-          mkdir -p release-artefacts
-          pushd release-artefacts >/dev/null
-
-          # Stage just the `wardnetd` binary in a clean directory so the
-          # tarball contains `wardnetd` at the top level (no leading dir).
-          mkdir staged
-          cp "../source/daemon/target/${TARGET}/release/wardnetd" staged/wardnetd
-          chmod 0755 staged/wardnetd
-
-          tar -C staged -czf "${TARBALL}" wardnetd
-          sha256sum "${TARBALL}" | awk '{print $1}' > "${SHA256_FILE}"
-
-          # Write the encrypted private key to a local file and sign. The
-          # MINISIGN_PASSWORD env var is honoured by minisign >= 0.10, which
-          # is what ubuntu-latest ships.
-          echo "${MINISIGN_KEY_B64}" | base64 -d > minisign.key
-          chmod 0600 minisign.key
-
-          # Feed the password both via stdin (older minisigns fall back to
-          # stdin when /dev/tty isn't available — which is the case on
-          # GitHub runners) and via the MINISIGN_PASSWORD env var (honoured
-          # by newer versions). Using both is safe and version-agnostic.
-          printf '%s\n' "${MINISIGN_PASSWORD}" | \
-            MINISIGN_PASSWORD="${MINISIGN_PASSWORD}" minisign -Sm "${TARBALL}" \
-              -s minisign.key \
-              -t "wardnetd ${VERSION} (${TARGET})" \
-              -c "Wardnet release signing key" \
-              -x "${MINISIG_FILE}"
-
-          # Destroy the key material immediately so it never leaks into uploads.
-          shred -u minisign.key
-
-          # Sanity check: the public key in the repo must verify the signature.
-          minisign -Vm "${TARBALL}" \
-            -p "../deploy/keys/wardnet-release.pub" \
-            -x "${MINISIG_FILE}"
-
-          ls -l
-          popd >/dev/null
-
-      - name: Upload artefacts
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
-        with:
-          name: release-artefacts-${{ matrix.target }}
-          path: |
-            release-artefacts/*.tar.gz
-            release-artefacts/*.sha256
-            release-artefacts/*.minisig
-          retention-days: 7
-
-  publish:
-    name: Publish GitHub Release
-    needs: [resolve, build]
-    # Only publish when triggered by an actual tag push. workflow_dispatch runs
-    # exercise the full build path but stop short of creating a release.
+  release-daemon:
+    name: Release Daemon
+    needs: [resolve, build-daemon, tests-e2e]
+    # Only publish when triggered by an actual tag push. workflow_dispatch
+    # runs exercise the full build + sign path but stop short of the
+    # `gh release create` call.
     if: startsWith(github.ref, 'refs/tags/v')
-    runs-on: ubuntu-latest
-    permissions:
-      # `contents: write` — create the Release.
-      # `actions: write` — dispatch the deploy-site workflow at the end.
-      contents: write
-      actions: write
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-
-      - name: Download artefacts from all targets
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
-        with:
-          pattern: release-artefacts-*
-          path: release-artefacts/
-          merge-multiple: true
-
-      - name: Stage OpenAPI spec + sha256
-        # Publish the committed `docs/openapi.json` alongside the binary as
-        # a release asset so external consumers can download the spec for a
-        # specific daemon version without running the daemon itself. The
-        # .sha256 companion lets the site's manifest generator dedupe across
-        # releases without fetching the full JSON for every historical tag.
-        run: |
-          set -euo pipefail
-          cp docs/openapi.json release-artefacts/openapi.json
-          sha256sum release-artefacts/openapi.json | awk '{print $1}' \
-            > release-artefacts/openapi.json.sha256
-          ls -l release-artefacts/openapi.*
-
-      - name: Create GitHub Release
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAG: ${{ needs.resolve.outputs.tag }}
-          VERSION: ${{ needs.resolve.outputs.version }}
-          PRERELEASE: ${{ needs.resolve.outputs.prerelease }}
-        run: |
-          set -euo pipefail
-          ARGS=(--verify-tag --title "Wardnet ${VERSION}")
-
-          # Prefer hand-written release notes at docs/releases/vX.Y.Z.md.
-          # Fall back to GitHub's auto-generated notes (diff since last tag).
-          NOTES_FILE="docs/releases/v${VERSION}.md"
-          if [[ -f "${NOTES_FILE}" ]]; then
-            echo "Using release notes from ${NOTES_FILE}"
-            ARGS+=(--notes-file "${NOTES_FILE}")
-          else
-            echo "No ${NOTES_FILE} found — falling back to auto-generated notes"
-            ARGS+=(--generate-notes)
-          fi
-
-          if [[ "${PRERELEASE}" == "true" ]]; then
-            ARGS+=(--prerelease)
-          fi
-
-          gh release create "${TAG}" "${ARGS[@]}" \
-            release-artefacts/*.tar.gz \
-            release-artefacts/*.tar.gz.sha256 \
-            release-artefacts/*.tar.gz.minisig \
-            release-artefacts/openapi.json \
-            release-artefacts/openapi.json.sha256
-
-      - name: Dispatch deploy-site so the marketing site picks up the new release
-        # `release: [published]` on deploy-site.yml does NOT fire when the
-        # release is created by GITHUB_TOKEN (GitHub blocks cascading events
-        # from the default token). An explicit `workflow_dispatch` IS allowed
-        # from GITHUB_TOKEN, so we kick off the site build ourselves here.
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh workflow run deploy-site.yml --ref main
+    uses: ./.github/workflows/release-daemon.yml
+    with:
+      version: ${{ needs.resolve.outputs.version }}
+      tag: ${{ needs.resolve.outputs.tag }}
+      prerelease: ${{ fromJSON(needs.resolve.outputs.prerelease) }}
+    secrets: inherit

--- a/.github/workflows/tests-e2e.yml
+++ b/.github/workflows/tests-e2e.yml
@@ -1,0 +1,52 @@
+name: E2E Tests
+
+# Reusable leaf for end-to-end tests.
+#
+# STUB TODAY. Real tests will live in `source/system-tests/` and
+# exercise wardnetd in a privileged Linux container (needs root for
+# WireGuard + netlink). Deliberately runs against the real `wardnetd`
+# binary, not `wardnetd-mock` — the mock is a dev-loop tool for running
+# the HTTP API without elevated privileges; e2e wants the full kernel
+# path.
+#
+# Artifacts consumed (fixed names; see build-daemon.yml / build-site.yml):
+#   - wardnetd-x86_64-unsigned  (the tarball, inside is `wardnetd`)
+#   - site-dist                 (raw dist/ tree)
+
+on:
+  workflow_call:
+
+permissions: read-all
+
+jobs:
+  placeholder:
+    name: E2E placeholder
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Download wardnetd x86_64
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: wardnetd-x86_64-unsigned
+          path: e2e/daemon/
+
+      - name: Download site bundle
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: site-dist
+          path: e2e/site/
+
+      - name: Unpack wardnetd
+        run: |
+          set -euo pipefail
+          tar -C e2e/daemon -xzf e2e/daemon/wardnetd-x86_64.tar.gz
+          ls -l e2e/daemon/wardnetd
+
+      - name: Run placeholder e2e
+        # TODO: swap for `source/system-tests/` runner. Needs a
+        # privileged container so `wardnetd` can create wireguard
+        # interfaces and touch the routing table.
+        run: |
+          echo "TODO: real e2e suite against wardnetd (not the mock)."
+          echo "Daemon binary: $(file e2e/daemon/wardnetd)"
+          echo "Site bundle:   $(ls e2e/site | wc -l) files"

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -203,7 +203,7 @@ The `WARDNET_VERSION` env var seen by the daemon at compile time is derived from
 3. Annotated tag: `git tag -a vX.Y.Z -m "..."`.
 4. Push: `git push && git push --tags`.
 5. The [Release workflow](../.github/workflows/release.yml) builds the daemon for every matrix target, signs each tarball with minisign, and publishes a GitHub Release with the `tarball + .sha256 + .minisig` for each target. It also attaches the committed `docs/openapi.json` and its `.sha256` as release assets so external consumers can download the OpenAPI spec for a specific daemon version.
-6. The [Deploy Site workflow](../.github/workflows/deploy-site.yml) rebuilds the marketing site on `release: [published]`, regenerating `public/releases/stable.json`, `public/releases/beta.json`, and `public/releases/openapi-versions.json` from the GitHub API. The daemon's auto-update runner (v0.3.0+) reads the stable/beta manifests; the site's docs page uses `openapi-versions.json` to list distinct published specs (deduped by content hash).
+6. The [Release workflow](../.github/workflows/release.yml) also calls [`build-site.yml`](../.github/workflows/build-site.yml), which regenerates `public/releases/stable.json`, `public/releases/beta.json`, and `public/releases/openapi-versions.json` from the GitHub API, then hands the bundle to [`deploy-site.yml`](../.github/workflows/deploy-site.yml) for publication to GitHub Pages. The daemon's auto-update runner (v0.3.0+) reads the stable/beta manifests; the site's docs page uses `openapi-versions.json` to list distinct published specs (deduped by content hash).
 
 SemVer pre-release tags (`vX.Y.Z-beta.N`, `vX.Y.Z-rc.N`) are automatically flagged as GitHub pre-releases and feed the `beta` channel. Clean `vX.Y.Z` tags feed `stable`.
 
@@ -236,18 +236,34 @@ For signing-key setup and rotation, see [`deploy/keys/README.md`](../deploy/keys
 
 ## Continuous integration
 
-[`.github/workflows/ci.yml`](../.github/workflows/ci.yml) runs on every PR:
+CI is split into thin orchestrators (one per event type) that compose
+reusable `workflow_call` leaves. Every orchestrator starts with a
+`preflight` job that runs the [detect-changes](../.github/actions/detect-changes/action.yml)
+and [check-version](../.github/actions/check-version/action.yml)
+composite actions; its outputs gate the heavy leaves.
 
-1. `check-version` — all versioned files agree with `./VERSION`
-2. `check-web`, `check-site`, `check-daemon` — format + lint + type-check + tests
-3. `build-web`, `build-daemon` (x86_64 + aarch64 matrix) — verifies release artefacts build
-4. `coverage` — daemon + site coverage uploaded to Codecov, clippy findings to GitHub Code Scanning
+[`.github/workflows/pr.yml`](../.github/workflows/pr.yml) runs on every PR to `main`:
 
-[`.github/workflows/release.yml`](../.github/workflows/release.yml) runs on `v*.*.*` tag pushes: cross-compile + sign + create GitHub Release.
+1. `preflight` — detect-changes + check-version.
+2. `build-daemon` — [reusable leaf](../.github/workflows/build-daemon.yml). Lints, runs `cargo test --workspace`, verifies OpenAPI drift, builds the embedded web UI, cross-compiles `wardnetd` (x86_64 + aarch64) and `wardnetd-mock` (x86_64), uploads tarballs as artifacts.
+3. `build-site` — [reusable leaf](../.github/workflows/build-site.yml). Lints + type-checks, builds the marketing site, uploads `site-dist`.
+4. `coverage` — [reusable leaf](../.github/workflows/coverage.yml). Generates daemon + site coverage in parallel and performs a single coordinated Codecov upload with the `daemon` / `site` flags.
+5. `tests-e2e` — [reusable leaf](../.github/workflows/tests-e2e.yml). Stub today; consumes daemon + site artifacts.
 
-[`.github/workflows/deploy-site.yml`](../.github/workflows/deploy-site.yml) runs on push-to-main, release-published, and manual dispatch: build + publish the marketing site + release manifests.
+[`.github/workflows/ci.yml`](../.github/workflows/ci.yml) runs on pushes to `main` and reuses the same `build-daemon` + `build-site` leaves but skips `coverage` and `tests-e2e` (Codecov patch-coverage is PR-keyed; e2e is a PR gate).
+
+[`.github/workflows/release.yml`](../.github/workflows/release.yml) runs on `v*.*.*` tag pushes: `resolve` → the same build leaves → `tests-e2e` → [`deploy-site.yml`](../.github/workflows/deploy-site.yml) (publishes the `site-dist` bundle to GitHub Pages) → [`release-daemon.yml`](../.github/workflows/release-daemon.yml) (renames tarballs with the version, signs each with minisign, publishes the GitHub Release).
+
+[`.github/workflows/deploy-site.yml`](../.github/workflows/deploy-site.yml) is a reusable `workflow_call` leaf: it downloads a pre-built `site-dist` artifact and publishes it to GitHub Pages. It is invoked from `release.yml` only.
+
+Fuzzing is handled by two separate workflows driven by cron and the [ClusterFuzzLite](../.clusterfuzzlite/README.md) setup:
+
+- [`.github/workflows/fuzzing-scheduled.yml`](../.github/workflows/fuzzing-scheduled.yml) runs every 12 hours in batch mode against the fuzz targets under `source/daemon/fuzz/`, files GitHub Issues on new crashes.
+- [`.github/workflows/fuzzing-maintenance.yml`](../.github/workflows/fuzzing-maintenance.yml) runs weekly for coverage reports + corpus pruning.
 
 [`.github/workflows/security.yml`](../.github/workflows/security.yml) runs `cargo audit` nightly and on dependency changes.
+
+[`.github/workflows/codeql.yml`](../.github/workflows/codeql.yml) runs CodeQL analysis weekly + on PRs.
 
 [`.github/workflows/scorecard.yml`](../.github/workflows/scorecard.yml) runs OpenSSF Scorecard weekly.
 

--- a/source/daemon/Cargo.toml
+++ b/source/daemon/Cargo.toml
@@ -9,6 +9,9 @@ members = [
     "crates/wardnetd-services",
     "crates/wctl",
 ]
+# The fuzz harness is its own workspace — libfuzzer-sys + nightly
+# sanitizer rustflags must not leak into normal daemon builds.
+exclude = ["fuzz"]
 resolver = "3"
 
 [workspace.package]

--- a/source/daemon/crates/wardnetd-services/Cargo.toml
+++ b/source/daemon/crates/wardnetd-services/Cargo.toml
@@ -8,6 +8,14 @@ license.workspace = true
 [lints]
 workspace = true
 
+[features]
+# Exposes the synchronous core of AgeArchiver::unpack for fuzz harnesses.
+# NEVER enable this in production builds — calling the sync path from
+# async code will block the tokio runtime. The flag exists so
+# source/daemon/fuzz/ can skip the spawn_blocking + buffer clone that
+# the public async API pays per call.
+fuzz-internals = []
+
 [dependencies]
 # Internal
 wardnet-common.workspace = true

--- a/source/daemon/crates/wardnetd-services/src/backup/archiver.rs
+++ b/source/daemon/crates/wardnetd-services/src/backup/archiver.rs
@@ -159,6 +159,17 @@ impl BackupArchiver for AgeArchiver {
     }
 }
 
+/// Synchronous unpack exposed for fuzz harnesses. Gated on the
+/// `fuzz-internals` cargo feature so production builds never pick up a
+/// public sync entry-point by accident — calling it from async code
+/// blocks the tokio runtime, defeating `spawn_blocking`.
+///
+/// See `source/daemon/fuzz/fuzz_targets/archiver_unpack.rs`.
+#[cfg(feature = "fuzz-internals")]
+pub fn unpack_sync_for_fuzz(passphrase: &str, bytes: &[u8]) -> anyhow::Result<BundleContents> {
+    unpack_sync(passphrase, bytes)
+}
+
 /// Synchronous core of [`AgeArchiver::pack`].
 fn pack_sync(passphrase: &str, contents: &BundleContents) -> anyhow::Result<Vec<u8>> {
     let manifest_bytes = serde_json::to_vec_pretty(&contents.manifest)

--- a/source/daemon/fuzz/Cargo.toml
+++ b/source/daemon/fuzz/Cargo.toml
@@ -1,0 +1,68 @@
+# Standalone cargo workspace for ClusterFuzzLite / cargo-fuzz.
+#
+# The parent daemon workspace excludes this directory (see
+# `source/daemon/Cargo.toml` `[workspace] exclude`), so libfuzzer-sys
+# and its nightly sanitizer rustflags never leak into normal
+# `cargo build --workspace` paths.
+#
+# The fuzz targets link against the real daemon crates via path
+# dependencies, which is deliberate: a fuzz target that drifts away
+# from the production types would only find bugs in the harness.
+
+[package]
+name = "wardnet-fuzz"
+version = "0.0.0"
+publish = false
+edition = "2024"
+
+[package.metadata]
+cargo-fuzz = true
+
+[workspace]
+
+[dependencies]
+libfuzzer-sys = "0.4"
+
+# Shared runtime for the async harnesses. "rt-multi-thread" is
+# sufficient; we don't need the full feature set.
+tokio = { version = "1", features = ["rt-multi-thread", "fs", "macros"] }
+once_cell = "1"
+
+# Needed to construct a throwaway SqlitePool for the sqlite_restore
+# harness (SqliteDumper::new takes a pool it later replaces).
+sqlx = { version = "0.8", default-features = false, features = ["runtime-tokio", "sqlite"] }
+serde_json = "1"
+
+# Production crates under fuzz — path deps, no versions, so the fuzz
+# workspace always tracks the in-repo code.
+wardnet-common = { path = "../crates/wardnet-common" }
+wardnetd-data = { path = "../crates/wardnetd-data" }
+# `fuzz-internals` exposes the synchronous unpack core so the
+# archiver_unpack harness can skip spawn_blocking + the per-input
+# buffer clone that AgeArchiver::unpack pays.
+wardnetd-services = { path = "../crates/wardnetd-services", features = ["fuzz-internals"] }
+
+# Enable debug info in release so crash stacks symbolicate cleanly.
+[profile.release]
+debug = 1
+
+[[bin]]
+name = "archiver_unpack"
+path = "fuzz_targets/archiver_unpack.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "sqlite_restore"
+path = "fuzz_targets/sqlite_restore.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "bundle_manifest"
+path = "fuzz_targets/bundle_manifest.rs"
+test = false
+doc = false
+bench = false

--- a/source/daemon/fuzz/fuzz_targets/archiver_unpack.rs
+++ b/source/daemon/fuzz/fuzz_targets/archiver_unpack.rs
@@ -1,0 +1,24 @@
+#![no_main]
+//! Fuzz target: feed arbitrary bytes to the synchronous bundle
+//! unpacker and watch for panics.
+//!
+//! Calls `unpack_sync_for_fuzz` directly — the feature-gated sync
+//! core of `AgeArchiver::unpack`. Going through the async public API
+//! would cost a tokio runtime hop, a `spawn_blocking` call, and a
+//! per-iteration `bytes.to_vec()` on libfuzzer's hottest path.
+//!
+//! Most random inputs fail at the age header check (very cheap) —
+//! that exercises the decryption error path. Occasionally the mutator
+//! stumbles into something that decrypts far enough to reach the gzip
+//! / tar / manifest layers, which is where the interesting bugs
+//! would be.
+
+use libfuzzer_sys::fuzz_target;
+use wardnetd_services::backup::archiver::unpack_sync_for_fuzz;
+
+fuzz_target!(|data: &[u8]| {
+    // A fixed passphrase keeps mutation focused on the byte stream.
+    // Fuzzing the passphrase separately has low yield — age's scrypt
+    // KDF dominates the error path regardless.
+    let _ = unpack_sync_for_fuzz("fuzz-passphrase-placeholder-1234", data);
+});

--- a/source/daemon/fuzz/fuzz_targets/bundle_manifest.rs
+++ b/source/daemon/fuzz/fuzz_targets/bundle_manifest.rs
@@ -1,0 +1,15 @@
+#![no_main]
+//! Fuzz target: `serde_json::from_slice::<BundleManifest>` on
+//! arbitrary bytes.
+//!
+//! Simplest and cheapest of the three targets — no async, no I/O, no
+//! decryption. libfuzzer will saturate this at high throughput and
+//! exercise the chrono `DateTime<Utc>` parser + serde's numeric-bound
+//! checks on `schema_version` / `bundle_format_version` / `key_count`.
+
+use libfuzzer_sys::fuzz_target;
+use wardnet_common::backup::BundleManifest;
+
+fuzz_target!(|data: &[u8]| {
+    let _ = serde_json::from_slice::<BundleManifest>(data);
+});

--- a/source/daemon/fuzz/fuzz_targets/sqlite_restore.rs
+++ b/source/daemon/fuzz/fuzz_targets/sqlite_restore.rs
@@ -1,0 +1,52 @@
+#![no_main]
+//! Fuzz target: feed arbitrary bytes to `SqliteDumper::restore` and
+//! watch for panics.
+//!
+//! `restore` writes the bytes to disk, reopens the file as SQLite, and
+//! reads the `_sqlx_migrations` table. Invalid SQLite files fail fast
+//! (magic-byte check); valid-looking-but-malformed ones drive deeper
+//! into sqlx / rusqlite parsing.
+//!
+//! Two perf-relevant choices:
+//! - The placeholder `SqlitePool` is hoisted into a `Lazy` static.
+//!   `SqliteDumper::new` takes a pool but `restore` reconnects
+//!   internally to the target path, so the same in-memory pool is
+//!   reusable across iterations. Recreating it per iteration paid
+//!   ~10ms of connection setup + a slow async drop that leaks file
+//!   descriptors under libfuzzer's loop.
+//! - A single per-process target path (overwritten each call) keeps
+//!   disk footprint constant.
+
+use libfuzzer_sys::fuzz_target;
+use once_cell::sync::Lazy;
+use sqlx::SqlitePool;
+use sqlx::sqlite::SqlitePoolOptions;
+use std::path::PathBuf;
+use tokio::runtime::Runtime;
+use wardnetd_data::database_dumper::{DatabaseDumper, SqliteDumper};
+
+static RUNTIME: Lazy<Runtime> = Lazy::new(|| Runtime::new().expect("runtime init"));
+
+static POOL: Lazy<SqlitePool> = Lazy::new(|| {
+    RUNTIME.block_on(async {
+        SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect("sqlite::memory:")
+            .await
+            .expect("placeholder pool")
+    })
+});
+
+fn fuzz_db_path() -> PathBuf {
+    std::env::temp_dir().join(format!("wardnet-fuzz-restore-{}.db", std::process::id()))
+}
+
+fuzz_target!(|data: &[u8]| {
+    RUNTIME.block_on(async {
+        // `SqlitePool` is `Arc`-backed internally, so `clone()` is cheap
+        // and the real pool underneath is shared across every fuzz
+        // iteration in this process.
+        let dumper = SqliteDumper::new(POOL.clone(), fuzz_db_path());
+        let _ = dumper.restore(data).await;
+    });
+});


### PR DESCRIPTION
## Summary

Two related changes, one PR:

1. **CI restructure** — collapse the old 8-job ci.yml monolith + duplicated release.yml builds + standalone deploy-site.yml into per-event orchestrators (ci.yml, pr.yml, release.yml) composing reusable `workflow_call` leaves (build-daemon, build-site, coverage, tests-e2e, deploy-site, release-daemon). Shared logic moves to composite actions (detect-changes, check-version). Every job gets a `timeout-minutes`. Site deploy now happens on release only.

2. **ClusterFuzzLite fuzzing** — wire coverage-guided fuzzing against the backup subsystem's three trust boundaries: `AgeArchiver::unpack`, `SqliteDumper::restore`, and `BundleManifest` JSON deser. Corpus persists to a companion repo (`wardnet/wardnet-fuzz-corpus`). Runs every 12h in batch mode + weekly coverage/prune.

## Highlights

**Orchestrator → leaf call graph:**

```
ci.yml        (push main)        ─► preflight + build-daemon + build-site
pr.yml        (PR + workflow_call)─► preflight + build-daemon + build-site + coverage + tests-e2e
release.yml   (tag v*.*.*)       ─► resolve + build-daemon + build-site + tests-e2e + deploy-site + release-daemon

fuzzing-scheduled.yml   (cron 0 */12 * * *)  — CFLite batch mode, 600s
fuzzing-maintenance.yml (cron 0 3 * * 0)     — CFLite coverage + prune
```

**What's new:**
- 8 new reusable workflows, 2 new composite actions
- 3 fuzz targets in standalone `source/daemon/fuzz/` workspace (excluded from daemon workspace so `libfuzzer-sys` + nightly rustflags stay out of normal builds)
- `wardnetd-services` `fuzz-internals` feature gates a sync unpack helper for the archiver harness
- `dorny/paths-filter` gates heavy leaves on what actually changed

**What's removed:**
- Old `ci.yml` 8-job sprawl (check-version, check-web, check-site, build-web, check-daemon, check-openapi, coverage, build-daemon → moved into leaves)
- Old `release.yml` inline build+sign (now orchestrator + `release-daemon.yml` leaf)
- Old `deploy-site.yml` standalone triggers (now `workflow_call` only, invoked by `release.yml`)

## Prerequisites already satisfied

- `wardnet/wardnet-fuzz-corpus` repo created (public)
- `FUZZ_CORPUS_PAT` secret set on this repo (fine-grained, scoped to corpus repo, `contents: write`)

## Test plan

- [ ] Merge-queue: confirm new `pr.yml` fires on this PR and the full set of jobs run (preflight + build-daemon + build-site + coverage + tests-e2e stub) — check status checks.
- [ ] Confirm `build-daemon` produces the three expected artifacts (`wardnetd-x86_64-unsigned`, `wardnetd-aarch64-unsigned`, `wardnet-mock-x86_64`) visible under the Actions run.
- [ ] Confirm Codecov receives ONE coordinated upload (daemon + site flags) instead of two dueling ones.
- [ ] Dispatch `fuzzing-scheduled.yml` manually to validate CFLite plumbing end-to-end (corpus repo push, GitHub Issue creation on crash).
- [ ] Run `cargo fuzz run archiver_unpack` locally under nightly to confirm the harness builds.
- [ ] Dry-run the release path: `gh workflow run release.yml --ref feature/ci-restructure-and-fuzzing`; confirm `release-daemon` and `deploy-site` are both skipped on non-tag refs.

## Follow-ups (from the code-panel review on this branch, not blockers)

- **H1** — release.yml version guard strips prerelease suffix before comparing (preexisting behavior copied across; flagged).
- **H2** — `detect-changes` daemon filter misses `source/web-ui/**` and `source/sdk/**`.
- **H3** — `workflow_dispatch` dry run still deploys to production Pages environment.
- **L1** — `build-daemon.yml` interpolates `matrix.cross_apt_packages` directly into a `run:` block (defense-in-depth).

🤖 Generated with [Claude Code](https://claude.com/claude-code)