### PR TITLE
feat(docker): production wardnetd image + install --container-mode

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+# The production Dockerfile (source/daemon/Dockerfile) only needs deploy/.
+# Exclude everything else to keep the build context small.
+#
+# When Dockerfile.test is added (Stage 5) this file will be updated to
+# allow source/daemon/, source/web-ui/, and source/sdk/wardnet-js/ while
+# still excluding their build artefacts (target/, node_modules/, dist/).
+
+*
+!deploy/

--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,14 @@ OTEL_HOST    ?=
 CONTAINER_RT := $(shell command -v podman 2>/dev/null || command -v docker 2>/dev/null)
 CONTAINER_RT_NAME := $(notdir $(CONTAINER_RT))
 RUST_IMAGE   := docker.io/library/rust:1.94
+
+# Docker image build settings.
+# Override IMAGE_TAG on the CLI to name the local image differently, e.g.:
+#   make image IMAGE_TAG=wardnetd:v0.2.0
+# Override IMAGE_VERSION to pin a specific release (no v-prefix):
+#   make image IMAGE_VERSION=0.2.0
+IMAGE_TAG     ?= wardnetd:dev
+IMAGE_VERSION ?= latest
 # Linux build artefacts live here (gitignored, persists on host for
 # incremental compilation). Separate from the macOS target/ directory.
 LINUX_TARGET := $(CURDIR)/.target-linux
@@ -45,6 +53,7 @@ COV_FMT    ?= --summary-only
         coverage-daemon coverage-daemon-native coverage-daemon-container \
         openapi check-openapi \
         fmt clippy test \
+        image image-multiarch \
         deploy run-pi run-dev run-dev-daemon run-dev-web system-test system-test-setup system-test-teardown \
         sync-version check-version \
         clean help
@@ -430,6 +439,30 @@ system-test: build-system-test
 		ssh $(PI_REMOTE) 'sudo $(SYSTEST_REMOTE_DIR)/run-tests.sh teardown'; \
 		exit $$TEST_EXIT
 
+# ---------- Container images ----------
+
+# Build the production image for the local architecture and load it into the
+# local container daemon. Uses the wardnet release specified by VERSION
+# (default: latest stable via the GitHub Releases API).
+image:
+	@test -n "$(CONTAINER_RT)" || { echo "Error: podman or docker is required"; exit 1; }
+	$(CONTAINER_RT) build \
+		--build-arg WARDNET_VERSION=$(IMAGE_VERSION) \
+		-f source/daemon/Dockerfile \
+		-t $(IMAGE_TAG) \
+		.
+
+# Build multi-arch production images (linux/amd64 + linux/arm64) via buildx.
+# Requires `docker buildx` or `podman buildx`. Does not load into the local
+# daemon (use --push or --output to export). Intended for the release workflow.
+image-multiarch:
+	@test -n "$(CONTAINER_RT)" || { echo "Error: podman or docker is required"; exit 1; }
+	$(CONTAINER_RT) buildx build \
+		--platform linux/amd64,linux/arm64 \
+		--build-arg WARDNET_VERSION=$(IMAGE_VERSION) \
+		-f source/daemon/Dockerfile \
+		.
+
 # ---------- Utilities ----------
 
 clean:
@@ -475,6 +508,12 @@ help:
 	@echo "                 make system-test PI_HOST=10.232.1.1"
 	@echo "  system-test-setup    Deploy and start test environment (leave running)"
 	@echo "  system-test-teardown Stop test environment on Pi"
+	@echo ""
+	@echo "  image          Build production container image (downloads latest release)"
+	@echo "                 make image                              (latest stable release)"
+	@echo "                 make image IMAGE_VERSION=0.2.0          (specific version)"
+	@echo "                 make image IMAGE_TAG=wardnetd:v0.2.0"
+	@echo "  image-multiarch  Build multi-arch image via buildx (amd64 + arm64; no local load)"
 	@echo ""
 	@echo "  sync-version   Propagate ./VERSION into daemon Cargo.toml + package.json files"
 	@echo "  check-version  Verify all versioned files match ./VERSION (CI gate)"

--- a/README.md
+++ b/README.md
@@ -38,18 +38,35 @@ Learn more at [**wardnet.network**](https://wardnet.network).
 
 ## Install
 
+### Run with Docker
+
+```sh
+docker run -d \
+  --name wardnetd \
+  --cap-add NET_ADMIN --cap-add NET_RAW \
+  --device /dev/net/tun \
+  --sysctl net.ipv4.ip_forward=1 \
+  --tmpfs /run --tmpfs /run/lock \
+  -p 7411:7411 \
+  -v wardnet-data:/var/lib/wardnet \
+  ghcr.io/wardnet/wardnetd:latest
+```
+
+Open **http://localhost:7411** to complete the setup wizard. Auto-update and crash-loop rollback work inside the container because systemd runs as PID 1, but recreating the container resets to the image's baked-in version — only `docker restart` preserves an auto-updated binary. See [`source/daemon/examples/docker-compose.yaml`](source/daemon/examples/docker-compose.yaml) for a reference compose file with all networking options documented.
+
+### Bare-metal install
+
+For setups where you prefer to run the daemon directly on the host:
+
 ```sh
 curl -sSL https://wardnet.network/install.sh | sudo bash
 ```
 
-Full walkthrough, configuration reference, and more in the [**user documentation**](https://wardnet.network/docs).
+Supported targets: `aarch64-unknown-linux-gnu` (Raspberry Pi, aarch64 SBCs) and `x86_64-unknown-linux-gnu` (mini-PCs, x86_64 servers).
 
-Supported targets:
+---
 
-- **Raspberry Pi** (and other aarch64 Linux SBCs) — `aarch64-unknown-linux-gnu`
-- **Mini-PC / x86_64 Linux host** — `x86_64-unknown-linux-gnu`
-
-Both are first-class targets — install on whichever fits your network. See the [latest release](https://github.com/wardnet/wardnet/releases/latest) for signed artefacts and verification instructions.
+Full walkthrough, configuration reference, and guides in the [**user documentation**](https://wardnet.network/docs). See the [latest release](https://github.com/wardnet/wardnet/releases/latest) for signed artefacts and verification instructions.
 
 ## Documentation
 

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -23,6 +23,7 @@ CHANNEL="${CHANNEL:-stable}"
 MANIFEST_URL="${MANIFEST_URL:-https://releases.wardnet.network/${CHANNEL}.json}"
 LAN_INTERFACE="${LAN_INTERFACE:-}"
 OFFLINE_DIR=""
+CONTAINER_MODE=""
 
 # Embedded release-signing public key. Baking it into the installer is the
 # authenticity anchor: even if DNS or Cloudflare is hijacked, an attacker
@@ -46,6 +47,10 @@ Options:
                         Ignored when --from is given.
   --lan-interface <if>  Bind the daemon to this LAN interface. If omitted,
                         the script prompts (tty) or picks the first candidate.
+  --container-mode      Skip systemctl daemon-reload, start, and restart.
+                        Use when running inside a Docker image build: systemd
+                        is not running yet, but the enable symlink is still
+                        created so systemd starts the service at boot.
   -h, --help            Show this help text.
 
 Environment overrides:
@@ -60,6 +65,7 @@ while [[ $# -gt 0 ]]; do
         --from)           OFFLINE_DIR="$2";       shift 2 ;;
         --channel)        CHANNEL="$2";           shift 2 ;;
         --lan-interface)  LAN_INTERFACE="$2";     shift 2 ;;
+        --container-mode) CONTAINER_MODE=true;    shift   ;;
         -h|--help)        print_usage; exit 0 ;;
         *) echo "Unknown option: $1" >&2; print_usage >&2; exit 1 ;;
     esac
@@ -215,7 +221,7 @@ if [[ -n "$OFFLINE_DIR" ]]; then
     VERSION="${VERSION%-${ARCH}.tar.gz}"
 else
     echo "Fetching release manifest from $MANIFEST_URL..."
-    curl -fsSL "$MANIFEST_URL" -o "$WORKDIR/manifest.json"
+    curl -fsSL --connect-timeout 15 --max-time 60 --retry 3 --retry-delay 5 "$MANIFEST_URL" -o "$WORKDIR/manifest.json"
 
     VERSION="$(jq -r '.version'        "$WORKDIR/manifest.json")"
     ASSET_BASE="$(jq -r '.asset_base_url' "$WORKDIR/manifest.json")"
@@ -228,9 +234,9 @@ else
     TARBALL_URL="${ASSET_BASE%/}/${TARBALL_NAME}"
 
     echo "Downloading v$VERSION ($ARCH)..."
-    curl -fsSL "$TARBALL_URL"           -o "$WORKDIR/$TARBALL_NAME"
-    curl -fsSL "${TARBALL_URL}.sha256"  -o "$WORKDIR/${TARBALL_NAME}.sha256"
-    curl -fsSL "${TARBALL_URL}.minisig" -o "$WORKDIR/${TARBALL_NAME}.minisig"
+    curl -fsSL --connect-timeout 15 --max-time 120 --retry 3 --retry-delay 5 "$TARBALL_URL"           -o "$WORKDIR/$TARBALL_NAME"
+    curl -fsSL --connect-timeout 15 --max-time 120 --retry 3 --retry-delay 5 "${TARBALL_URL}.sha256"  -o "$WORKDIR/${TARBALL_NAME}.sha256"
+    curl -fsSL --connect-timeout 15 --max-time 120 --retry 3 --retry-delay 5 "${TARBALL_URL}.minisig" -o "$WORKDIR/${TARBALL_NAME}.minisig"
 fi
 
 # ---------------------------------------------------------------------------
@@ -324,26 +330,38 @@ for unit in wardnetd.service wardnetd-rollback.service; do
     if [[ -n "$src" ]]; then
         install -m 0644 "$src" "/etc/systemd/system/$unit"
     else
-        curl -fsSL "$UNIT_BASE/$unit" -o "/etc/systemd/system/$unit"
+        curl -fsSL --connect-timeout 15 --max-time 60 --retry 3 "$UNIT_BASE/$unit" -o "/etc/systemd/system/$unit"
         chmod 0644 "/etc/systemd/system/$unit"
     fi
 done
-systemctl daemon-reload
+if [[ -z "$CONTAINER_MODE" ]]; then
+    systemctl daemon-reload
+fi
 
-# 6. Enable + start (or restart if upgrading).
-systemctl enable --now wardnetd
-systemctl restart wardnetd
+# 6. Enable (always — creates the WantedBy symlink so the service starts at
+#    boot). In container mode systemd is not running yet during the image
+#    build, so we skip daemon-reload, the immediate start, and the port wait;
+#    systemd will start wardnetd when it initialises as PID 1 at runtime.
+if [[ -n "$CONTAINER_MODE" ]]; then
+    systemctl enable wardnetd
+    echo ""
+    echo "=== Image build complete ==="
+    echo "wardnetd will start when the container initialises (systemd as PID 1)."
+else
+    systemctl enable --now wardnetd
+    systemctl restart wardnetd
 
-# Wait briefly for the daemon to bind its HTTP port so the URL we print is
-# already reachable when the user opens it.
-for _ in 1 2 3 4 5 6 7 8 9 10; do
-    if ss -lnt 'sport = :7411' 2>/dev/null | grep -q ':7411'; then
-        break
-    fi
-    sleep 1
-done
+    # Wait briefly for the daemon to bind its HTTP port so the URL we print is
+    # already reachable when the user opens it.
+    for _ in 1 2 3 4 5 6 7 8 9 10; do
+        if ss -lnt 'sport = :7411' 2>/dev/null | grep -q ':7411'; then
+            break
+        fi
+        sleep 1
+    done
 
-IP=$(hostname -I 2>/dev/null | awk '{print $1}')
-echo ""
-echo "=== Install complete ==="
-echo "Web UI: http://${IP:-<host>}:7411"
+    IP=$(hostname -I 2>/dev/null | awk '{print $1}')
+    echo ""
+    echo "=== Install complete ==="
+    echo "Web UI: http://${IP:-<host>}:7411"
+fi

--- a/deploy/wardnetd-rollback.service
+++ b/deploy/wardnetd-rollback.service
@@ -1,0 +1,32 @@
+[Unit]
+Description=Wardnet Auto-Update Rollback
+# Triggered by OnFailure= in wardnetd.service when the daemon crash-loops
+# after an auto-update. Restores the previous binary from the .old backup
+# that the update runner leaves in place for exactly this purpose, then
+# re-enables the wardnetd unit so systemd will attempt a clean restart.
+DefaultDependencies=no
+After=wardnetd.service
+
+[Service]
+Type=oneshot
+NoNewPrivileges=yes
+ProtectSystem=strict
+ReadWritePaths=/usr/local/bin
+ProtectHome=yes
+PrivateTmp=yes
+# Only reset-failed + restart when a backup binary was actually restored.
+# Absent .old means the crash is not update-related — exit 0 without
+# restarting so the unit stays failed and the operator can investigate
+# instead of spinning through an infinite crash loop.
+ExecStart=/bin/sh -c '\
+    if [ -f /usr/local/bin/wardnetd.old ]; then \
+        echo "wardnetd-rollback: restoring previous binary" && \
+        mv /usr/local/bin/wardnetd.old /usr/local/bin/wardnetd && \
+        /bin/systemctl reset-failed wardnetd.service && \
+        /bin/systemctl start wardnetd.service; \
+    else \
+        echo "wardnetd-rollback: no backup binary found, not restarting"; \
+    fi'
+
+[Install]
+WantedBy=multi-user.target

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -121,10 +121,12 @@ Installs the Rust cross-compilation target, the aarch64-linux-gnu linker, and ya
 ### Build
 
 ```sh
-make build         # web UI + daemon (host target)
-make build-web     # web UI only
-make build-daemon  # daemon only (host target)
-make build-pi      # cross-compile daemon for Raspberry Pi (aarch64-unknown-linux-gnu)
+make build           # web UI + daemon (host target)
+make build-web       # web UI only
+make build-daemon    # daemon only (host target)
+make build-pi        # cross-compile daemon for Raspberry Pi (aarch64-unknown-linux-gnu)
+make image           # build the production container image (downloads latest release)
+make image-multiarch # build linux/amd64 + linux/arm64 production images via buildx
 ```
 
 ### Run locally (no Pi hardware)

--- a/source/daemon/Dockerfile
+++ b/source/daemon/Dockerfile
@@ -1,0 +1,126 @@
+# syntax=docker/dockerfile:1
+#
+# wardnetd production image.
+#
+# Downloads a signed GitHub release and installs it via deploy/install.sh,
+# the same script used for bare-metal installs. Systemd runs as PID 1 so
+# auto-update and the crash-loop rollback (OnFailure=wardnetd-rollback.service)
+# both work end-to-end inside the container — identical to bare metal. The
+# only difference is that a fresh `docker run` from this image always starts
+# at the baked-in version; `docker restart` preserves any auto-updated binary.
+#
+# Build context: repo root
+#   docker build -f source/daemon/Dockerfile .
+#   docker build --build-arg WARDNET_VERSION=0.2.0 -f source/daemon/Dockerfile .
+#   make image
+#   make image VERSION=0.2.0
+#
+# For the test image that builds from source and adds wardnet-test-agent,
+# see source/daemon/Dockerfile.test.
+#
+# Required runtime flags (see source/daemon/examples/docker-compose.yaml):
+#   --cap-add NET_ADMIN --cap-add NET_RAW
+#   --device /dev/net/tun
+#   --sysctl net.ipv4.ip_forward=1
+#   --tmpfs /run --tmpfs /run/lock
+
+FROM debian:bookworm-slim
+
+# Runtime dependencies that stay in the final image.
+# wget is kept for the HEALTHCHECK; curl and minisign are purged after install.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        systemd \
+        systemd-sysv \
+        iproute2 \
+        nftables \
+        wireguard-tools \
+        ca-certificates \
+        wget \
+        curl \
+        minisign \
+    && rm -rf /var/lib/apt/lists/* \
+    # Remove default-enabled systemd units that cannot work inside a container
+    # (hardware enumeration, real-disk remounts, etc.). wardnetd is re-enabled
+    # by install.sh below.
+    && rm -f \
+        /lib/systemd/system/multi-user.target.wants/* \
+        /etc/systemd/system/*.wants/* \
+        /lib/systemd/system/local-fs.target.wants/* \
+        /lib/systemd/system/sockets.target.wants/*udev* \
+        /lib/systemd/system/sockets.target.wants/*initctl* \
+        /lib/systemd/system/sysinit.target.wants/* \
+        /lib/systemd/system/systemd-remount-fs.service
+
+# wardnet release version to install (no `v` prefix, e.g. "0.2.0").
+# "latest" resolves to the most recent stable release via the GitHub Releases API.
+ARG WARDNET_VERSION=latest
+
+# The deploy/ directory is copied so install.sh can find the service unit
+# files locally, avoiding a second fetch from GitHub raw during the build.
+COPY deploy/ /tmp/wardnet-deploy/
+
+# Download the signed release bundle, run install.sh in container mode,
+# then purge the build-time tools. Everything in one layer so the downloaded
+# tarballs don't persist in intermediate layers.
+#
+# --container-mode tells install.sh to skip systemctl daemon-reload, start,
+# and restart (systemd is not running during `docker build`). It still calls
+# `systemctl enable wardnetd` which creates the WantedBy symlink so systemd
+# starts the service when it initialises as PID 1 at container runtime.
+#
+# In offline mode (--from) install.sh does NOT need curl — only minisign,
+# tar, sha256sum, and systemctl. curl is used only for the bundle download
+# step below, after which it is purged from the image.
+RUN set -euo pipefail; \
+    \
+    # uname -m returns aarch64 or x86_64, matching release asset filenames. \
+    ARCH="$(uname -m)"; \
+    \
+    if [ "$WARDNET_VERSION" = "latest" ]; then \
+        VERSION="$(curl -fsSL \
+            https://api.github.com/repos/wardnet/wardnet/releases/latest \
+            | grep '"tag_name"' | head -1 \
+            | sed 's/.*"v\([^"]*\)".*/\1/')"; \
+    else \
+        VERSION="$WARDNET_VERSION"; \
+    fi; \
+    echo "wardnetd: installing v${VERSION} (${ARCH})"; \
+    \
+    BUNDLE=/tmp/wardnet-bundle; \
+    mkdir "$BUNDLE"; \
+    BASE="https://github.com/wardnet/wardnet/releases/download/v${VERSION}"; \
+    TARBALL="wardnetd-${VERSION}-${ARCH}.tar.gz"; \
+    curl -fsSL "${BASE}/${TARBALL}"         -o "${BUNDLE}/${TARBALL}"; \
+    curl -fsSL "${BASE}/${TARBALL}.sha256"  -o "${BUNDLE}/${TARBALL}.sha256"; \
+    curl -fsSL "${BASE}/${TARBALL}.minisig" -o "${BUNDLE}/${TARBALL}.minisig"; \
+    \
+    LAN_INTERFACE=eth0 bash /tmp/wardnet-deploy/install.sh \
+        --from "$BUNDLE" \
+        --container-mode; \
+    \
+    apt-get purge -y curl minisign; \
+    apt-get autoremove -y; \
+    rm -rf /var/lib/apt/lists/* "$BUNDLE" /tmp/wardnet-deploy
+
+# Container-specific service drop-in.
+# ProtectSystem=strict and PrivateTmp=yes set up mount namespaces that require
+# CAP_SYS_ADMIN, which Docker strips from its default capability set.
+# Everything else — capabilities, NoNewPrivileges, auto-update, and the
+# crash-loop rollback via OnFailure= — is left exactly as-is.
+RUN mkdir -p /etc/systemd/system/wardnetd.service.d \
+    && printf '[Service]\nProtectSystem=no\nPrivateTmp=no\n' \
+        > /etc/systemd/system/wardnetd.service.d/container.conf \
+    && chmod 0644 /etc/systemd/system/wardnetd.service.d/container.conf
+
+# DNS (53/tcp+udp), DHCP (67/udp), daemon API + embedded web UI (7411),
+# dev-proxy port used by wardnetd-mock (7412)
+EXPOSE 53/udp 53/tcp 67/udp 7411/tcp 7412/tcp
+
+# systemd's graceful-shutdown signal when running as PID 1 inside a container
+STOPSIGNAL SIGRTMIN+3
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=30s --retries=3 \
+    CMD wget -qO- http://127.0.0.1:7411/api/info > /dev/null || exit 1
+
+CMD ["/lib/systemd/systemd"]

--- a/source/daemon/examples/docker-compose.yaml
+++ b/source/daemon/examples/docker-compose.yaml
@@ -1,0 +1,60 @@
+# wardnetd reference compose.
+#
+# Copy this file to your project, adjust the configuration, and run:
+#   docker compose up -d
+#
+# The daemon needs a few host-level permissions to manage WireGuard interfaces,
+# nftables rules, and DHCP/DNS sockets. None of these require `privileged: true`.
+
+services:
+  wardnetd:
+    image: ghcr.io/wardnet/wardnetd:latest
+    container_name: wardnetd
+    restart: unless-stopped
+
+    # NET_ADMIN — create/configure WireGuard interfaces, add ip rules, manage nftables.
+    # NET_RAW   — raw sockets used by the packet-capture device detector.
+    cap_add:
+      - NET_ADMIN
+      - NET_RAW
+
+    # WireGuard tunnels use the tun/tap device.
+    devices:
+      - /dev/net/tun
+
+    # IP forwarding is required to route LAN traffic through WireGuard tunnels.
+    sysctls:
+      net.ipv4.ip_forward: "1"
+
+    # systemd (PID 1) requires a writable /run. Do not use a named volume here —
+    # systemd's runtime state must not persist across container restarts.
+    tmpfs:
+      - /run
+      - /run/lock
+
+    ports:
+      # Web UI and daemon API. Open this to any host that needs dashboard access.
+      - "7411:7411/tcp"
+      # DNS: publish only on the LAN-facing interface if your host has multiple.
+      # Example: - "192.168.1.1:53:53/udp"
+      - "53:53/udp"
+      - "53:53/tcp"
+      # DHCP: UDP broadcast — the container must share the LAN bridge for DHCP
+      # to reach clients. Binding the port alone is not sufficient; see the
+      # network section below or use `network_mode: host` for simple setups.
+      - "67:67/udp"
+
+    volumes:
+      # Persistent state: database, WireGuard keys, staged updates, logs.
+      # Mount this volume on a persistent (non-tmpfs) filesystem.
+      - wardnet-data:/var/lib/wardnet
+      # Optional: override the default configuration.
+      # - ./wardnet.toml:/etc/wardnet/wardnet.toml:ro
+
+    # Optional: attach the container directly to the host network so DHCP
+    # broadcasts reach LAN clients without additional bridge configuration.
+    # Comment out the `ports` section above when using this.
+    # network_mode: host
+
+volumes:
+  wardnet-data:

--- a/source/site/content/docs/installation.md
+++ b/source/site/content/docs/installation.md
@@ -1,11 +1,52 @@
 # Installation
 
-Wardnet ships as a single, signed Linux binary. The installer handles
-everything: downloading the latest release, verifying its signature,
-creating a locked-down system user, writing a default configuration, and
-starting the systemd service.
+Wardnet can be installed via Docker or directly on the host (bare-metal).
+Docker is the simpler path — no dependency management, and auto-update +
+crash-loop rollback work identically because systemd runs as PID 1 inside
+the container.
 
-## Requirements
+## Run with Docker
+
+```bash
+docker run -d \
+  --name wardnetd \
+  --cap-add NET_ADMIN --cap-add NET_RAW \
+  --device /dev/net/tun \
+  --sysctl net.ipv4.ip_forward=1 \
+  --tmpfs /run --tmpfs /run/lock \
+  -p 7411:7411 \
+  -v wardnet-data:/var/lib/wardnet \
+  ghcr.io/wardnet/wardnetd:latest
+```
+
+Open **http://localhost:7411** to complete the setup wizard.
+
+The flags are required:
+
+| Flag | Why |
+| --- | --- |
+| `--cap-add NET_ADMIN` | Create/configure WireGuard interfaces, manage nftables and `ip rule`. |
+| `--cap-add NET_RAW` | Raw sockets for the packet-capture device detector. |
+| `--device /dev/net/tun` | WireGuard tunnels use the tun device. |
+| `--sysctl net.ipv4.ip_forward=1` | Required to route LAN traffic through WireGuard tunnels. |
+| `--tmpfs /run --tmpfs /run/lock` | systemd (PID 1) needs a writable, non-persistent `/run`. |
+| `-v wardnet-data:/var/lib/wardnet` | Persistent state: database, WireGuard keys, staged updates. |
+
+A reference compose file with all options documented is at
+[`source/daemon/examples/docker-compose.yaml`](https://github.com/wardnet/wardnet/blob/main/source/daemon/examples/docker-compose.yaml).
+
+### Auto-update in Docker
+
+The daemon's built-in auto-update runner works inside the container:
+systemd restarts `wardnetd` in place, and `wardnetd-rollback.service`
+fires on crash-loop just as it does on bare metal. One caveat: recreating
+the container (`docker rm` + `docker run`) resets to the image's baked-in
+version. Use `docker restart` to preserve an auto-updated binary, or
+re-pull a newer image tag.
+
+## Bare-metal install
+
+### Requirements
 
 - A Raspberry Pi (aarch64) or x86_64 Linux host.
 - A Debian/Ubuntu-based distribution (other distros work too, as long as
@@ -35,7 +76,7 @@ If any tool is missing, the installer fails early with a clear message
 listing the missing packages — it never installs anything behind your
 back.
 
-## One-shot install
+### One-shot install
 
 ```bash
 curl -sSL https://wardnet.network/install.sh | sudo bash
@@ -58,7 +99,7 @@ Verification flow the installer runs, in order:
 5. Extract, install the binary owned by the `wardnet` user at
    `/usr/local/bin/wardnetd`, drop the systemd units, enable, and start.
 
-## What the installer sets up
+### What the installer sets up
 
 | Path | Purpose |
 | --- | --- |
@@ -73,7 +114,7 @@ Verification flow the installer runs, in order:
 The `wardnet` system user owns all of the above. The daemon never runs
 as root.
 
-## Air-gapped install
+### Air-gapped install
 
 No outbound network from the target machine? Download the release bundle
 on a machine that does have internet, copy it across, and point the
@@ -93,7 +134,7 @@ The bundle directory must contain:
 The installer still verifies SHA-256 and the minisign signature against
 its embedded public key — air-gapped mode does not skip verification.
 
-## Choosing a channel
+### Choosing a channel
 
 By default the installer pulls from the `stable` channel. To install a
 pre-release build, pass `--channel beta`:
@@ -106,7 +147,7 @@ You can also switch channels at any time from the daemon's Settings page
 (Auto-update card) — the background runner will then track the chosen
 channel for future updates.
 
-## Verifying the service
+### Verifying the service
 
 After the installer finishes, it prints the web UI URL, for example:
 
@@ -137,7 +178,7 @@ sudo journalctl -u wardnetd -f
 sudo -u wardnet wctl status
 ```
 
-## Upgrades
+### Upgrades
 
 You never need to re-run `install.sh` for upgrades — the daemon's
 auto-update runner polls the release manifest every six hours and, when
@@ -148,7 +189,7 @@ If an upgrade produces a crash-looping daemon, systemd automatically
 fires the `wardnetd-rollback.service` unit after three failures within
 120 seconds, which restores the previous binary (`/usr/local/bin/wardnetd.old`).
 
-## Uninstall
+### Uninstall
 
 ```bash
 sudo systemctl disable --now wardnetd

--- a/source/site/src/components/layouts/GetStarted.tsx
+++ b/source/site/src/components/layouts/GetStarted.tsx
@@ -1,8 +1,18 @@
 import { CodeBlock } from "@/components/compound/CodeBlock";
 import { LatestReleaseBadge } from "@/components/compound/LatestReleaseBadge";
 
+const DOCKER_RUN = `docker run -d \\
+  --name wardnetd \\
+  --cap-add NET_ADMIN --cap-add NET_RAW \\
+  --device /dev/net/tun \\
+  --sysctl net.ipv4.ip_forward=1 \\
+  --tmpfs /run --tmpfs /run/lock \\
+  -p 7411:7411 \\
+  -v wardnet-data:/var/lib/wardnet \\
+  ghcr.io/wardnet/wardnetd:latest`;
+
 /**
- * Quick-start section with an install command and a link to the GitHub repository.
+ * Quick-start section with Docker (recommended) and bare-metal install options.
  */
 export function GetStarted() {
   return (
@@ -12,9 +22,29 @@ export function GetStarted() {
         <div className="mb-6 flex justify-center">
           <LatestReleaseBadge />
         </div>
-        <CodeBlock code="curl -sSL https://wardnet.network/install.sh | sudo bash" />
+
+        <p className="mb-2 text-left text-xs font-semibold uppercase tracking-wider text-gray-400 dark:text-gray-500">
+          Run with Docker
+        </p>
+        <CodeBlock code={DOCKER_RUN} className="text-left" />
+
+        <div className="my-6 flex items-center gap-3">
+          <hr className="flex-1 border-gray-300 dark:border-gray-700" />
+          <span className="text-xs text-gray-400 dark:text-gray-500">or</span>
+          <hr className="flex-1 border-gray-300 dark:border-gray-700" />
+        </div>
+
+        <p className="mb-2 text-left text-xs font-semibold uppercase tracking-wider text-gray-400 dark:text-gray-500">
+          Bare-metal install
+        </p>
+        <CodeBlock code="curl -sSL https://wardnet.network/install.sh | sudo bash" className="text-left" />
+
         <p className="mt-6 text-sm text-gray-500 dark:text-gray-400">
-          Or clone from GitHub and build from source.
+          See the{" "}
+          <a href="/docs/installation" className="text-[var(--brand-green)] hover:underline">
+            installation guide
+          </a>{" "}
+          for compose options, air-gapped installs, and channel selection.
         </p>
         <a
           href="https://github.com/wardnet/wardnet"


### PR DESCRIPTION
## Summary

- **`source/daemon/Dockerfile`** — downloads a signed GitHub release, runs `install.sh --container-mode` inside the image, systemd as PID 1. `debian:bookworm-slim` base; `curl`/`minisign` purged after install.
- **`source/daemon/examples/docker-compose.yaml`** — reference compose with all required flags documented.
- **`deploy/wardnetd-rollback.service`** — ships the missing auto-update rollback unit referenced by `wardnetd.service OnFailure=`. Restart gated on `.old` backup existing (prevents infinite crash loop on non-update failures). Security-hardened (`NoNewPrivileges`, `ProtectSystem=strict`, `ReadWritePaths=/usr/local/bin`).
- **`deploy/install.sh`** — `--container-mode` flag: skips `daemon-reload`/`start`, calls only `systemctl enable wardnetd` (pure symlink, no D-Bus). All `curl` calls get `--connect-timeout`/`--max-time`/`--retry` so unattended installs don't hang indefinitely.
- **`Makefile`** — `make image` / `make image-multiarch` targets; `IMAGE_VERSION` variable (avoids shadowing `VERSION := $(shell cat VERSION)`).
- **`README.md`** — Docker as primary install path, bare-metal as secondary. Auto-update parity caveat corrected (`docker restart` vs `docker rm`+`docker run`).
- **`docs/DEVELOPMENT.md`** — `make image` / `make image-multiarch` added to the build section.
- **`source/site/content/docs/installation.md`** — Docker section added as primary install path; existing bare-metal content reorganised underneath.
- **`source/site/src/components/layouts/GetStarted.tsx`** — home page CTA shows both Docker (primary) and bare-metal install options.
- **`.dockerignore`** — excludes everything except `deploy/`.

## Notes

- **No changes to the bare-metal install path** — `--container-mode` is purely additive.
- The container drop-in (`wardnetd.service.d/container.conf`) only removes `ProtectSystem=strict` and `PrivateTmp=yes` (require `CAP_SYS_ADMIN` that Docker strips). `OnFailure=wardnetd-rollback.service` is preserved so auto-update and rollback work inside the container.
- `Dockerfile.test` (adds `wardnet-test-agent`) is Stage 5.
- `publish-image` release job (GHCR multi-arch push) is Stage 3.

## Test plan

- [ ] `make image` builds locally — `docker images | grep wardnetd` shows `wardnetd:dev`
- [ ] `docker run --rm -d --name wn --cap-add NET_ADMIN --cap-add NET_RAW --device /dev/net/tun --sysctl net.ipv4.ip_forward=1 --tmpfs /run --tmpfs /run/lock wardnetd:dev && sleep 5 && docker exec wn wget -qO- http://127.0.0.1:7411/api/info && docker rm -f wn`
- [ ] `make image IMAGE_VERSION=0.2.0` bakes the pinned release (not `latest`)
- [ ] `make image-multiarch` completes without error (no `--push`)
- [ ] `sudo ./deploy/install.sh --help` still shows correct bare-metal usage
- [ ] Site home page shows Docker + bare-metal options in the "Get started" section
- [ ] `/docs/installation` renders with Docker section first

🤖 Generated with [Claude Code](https://claude.com/claude-code)