### PR TITLE
fix(ci): pin CI deps + base images and restore permissions/aggregator

### DIFF
--- a/.clusterfuzzlite/Dockerfile
+++ b/.clusterfuzzlite/Dockerfile
@@ -3,7 +3,12 @@
 # Inherits the OSS-Fuzz Rust base image (nightly toolchain + libFuzzer
 # + sanitizer rustflags preconfigured). CFLite copies the repo into
 # $SRC/wardnet and invokes build.sh at image-build time.
-FROM gcr.io/oss-fuzz-base/base-builder-rust
+# Pinned by digest for Scorecard / supply-chain integrity. The
+# OSS-Fuzz base images are rebuilt frequently; refresh this digest on
+# a regular cadence when upstream ships a Rust toolchain bump worth
+# picking up. Resolve a fresh digest with:
+#   docker buildx imagetools inspect gcr.io/oss-fuzz-base/base-builder-rust
+FROM gcr.io/oss-fuzz-base/base-builder-rust@sha256:9a80cc494382b81e29446653d91255470daf26aa6591b1f04d46575f3c3eb117
 
 COPY . $SRC/wardnet
 COPY .clusterfuzzlite/build.sh $SRC/

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,3 +27,22 @@ updates:
       interval: "weekly"
     commit-message:
       prefix: "chore(ci):"
+
+  # Production wardnetd image (source/daemon/Dockerfile) — pinned by
+  # digest for Scorecard / supply-chain integrity, so Dependabot is
+  # the channel that surfaces base-image updates.
+  - package-ecosystem: "docker"
+    directory: "/source/daemon"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore(deps):"
+
+  # ClusterFuzzLite build image (.clusterfuzzlite/Dockerfile) — same
+  # pin-then-bump story.
+  - package-ecosystem: "docker"
+    directory: "/.clusterfuzzlite"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore(deps):"

--- a/.github/workflows/build-daemon.yml
+++ b/.github/workflows/build-daemon.yml
@@ -46,7 +46,7 @@ jobs:
           components: clippy, rustfmt
 
       - name: Install clippy SARIF tooling
-        uses: taiki-e/install-action@v2
+        uses: taiki-e/install-action@74e87cbfa15a59692b158178d8905a61bf6fca95 # v2
         with:
           tool: clippy-sarif,sarif-fmt
 
@@ -61,7 +61,7 @@ jobs:
         # cargo fmt --check fails (runs before clippy), no SARIF exists;
         # hashFiles evaluates to empty and the upload is skipped.
         if: always() && hashFiles('rust-clippy-results.sarif') != ''
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4
         with:
           sarif_file: rust-clippy-results.sarif
           wait-for-processing: true

--- a/.github/workflows/build-daemon.yml
+++ b/.github/workflows/build-daemon.yml
@@ -22,7 +22,12 @@ name: Build Daemon
 on:
   workflow_call:
 
-permissions: read-all
+# Explicit scopes (not read-all) so this leaf's workflow-level stays a
+# subset of the caller's workflow-level — GitHub's reusable-workflow
+# permission rules reject leaf > caller. `check-daemon` escalates to
+# `security-events: write` via its own job-level block.
+permissions:
+  contents: read
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/build-site.yml
+++ b/.github/workflows/build-site.yml
@@ -19,7 +19,11 @@ name: Build Site
 on:
   workflow_call:
 
-permissions: read-all
+# Explicit scopes (not read-all) so this leaf's workflow-level stays a
+# subset of the caller's workflow-level — GitHub's reusable-workflow
+# permission rules reject leaf > caller.
+permissions:
+  contents: read
 
 jobs:
   check-site:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,14 @@ on:
   push:
     branches: [main]
 
-permissions: read-all
+# Workflow-level permissions must be the union of every leaf's
+# declared permissions (called reusable workflows must be a subset of
+# the caller). `security-events: write` is for build-daemon's clippy
+# SARIF upload.
+permissions:
+  contents: read
+  actions: read
+  security-events: write
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -45,13 +45,13 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4
+        uses: github/codeql-action/init@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4
         with:
           languages: ${{ matrix.language }}
           build-mode: none
           config-file: .github/codeql/codeql-config.yml
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v4
+        uses: github/codeql-action/analyze@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4
         with:
           category: "/language:${{ matrix.language }}"

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -16,7 +16,11 @@ on:
         description: Codecov upload token
         required: true
 
-permissions: read-all
+# Explicit scopes (not read-all) so this leaf's workflow-level stays a
+# subset of the caller's workflow-level — GitHub's reusable-workflow
+# permission rules reject leaf > caller.
+permissions:
+  contents: read
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/fuzzing-maintenance.yml
+++ b/.github/workflows/fuzzing-maintenance.yml
@@ -28,13 +28,13 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Build Fuzzers (coverage sanitizer)
-        uses: google/clusterfuzzlite/actions/build_fuzzers@v1
+        uses: google/clusterfuzzlite/actions/build_fuzzers@884713a6c30a92e5e8544c39945cd7cb630abcd1 # v1
         with:
           language: rust
           sanitizer: coverage
 
       - name: Run Fuzzers
-        uses: google/clusterfuzzlite/actions/run_fuzzers@v1
+        uses: google/clusterfuzzlite/actions/run_fuzzers@884713a6c30a92e5e8544c39945cd7cb630abcd1 # v1
         with:
           language: rust
           fuzz-seconds: 600
@@ -55,13 +55,13 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Build Fuzzers
-        uses: google/clusterfuzzlite/actions/build_fuzzers@v1
+        uses: google/clusterfuzzlite/actions/build_fuzzers@884713a6c30a92e5e8544c39945cd7cb630abcd1 # v1
         with:
           language: rust
           sanitizer: address
 
       - name: Run Fuzzers
-        uses: google/clusterfuzzlite/actions/run_fuzzers@v1
+        uses: google/clusterfuzzlite/actions/run_fuzzers@884713a6c30a92e5e8544c39945cd7cb630abcd1 # v1
         with:
           language: rust
           fuzz-seconds: 1200

--- a/.github/workflows/fuzzing-scheduled.yml
+++ b/.github/workflows/fuzzing-scheduled.yml
@@ -45,13 +45,13 @@ jobs:
 
       - name: Build Fuzzers
         id: build
-        uses: google/clusterfuzzlite/actions/build_fuzzers@v1
+        uses: google/clusterfuzzlite/actions/build_fuzzers@884713a6c30a92e5e8544c39945cd7cb630abcd1 # v1
         with:
           language: rust
           sanitizer: address
 
       - name: Run Fuzzers
-        uses: google/clusterfuzzlite/actions/run_fuzzers@v1
+        uses: google/clusterfuzzlite/actions/run_fuzzers@884713a6c30a92e5e8544c39945cd7cb630abcd1 # v1
         with:
           language: rust
           fuzz-seconds: 600

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -22,7 +22,14 @@ on:
     branches: [main]
   workflow_call:
 
-permissions: read-all
+# Workflow-level permissions must be the union of every leaf's
+# declared permissions — GitHub requires the called reusable workflow
+# to be a subset of the caller. `security-events: write` is for
+# build-daemon's clippy SARIF upload.
+permissions:
+  contents: read
+  actions: read
+  security-events: write
 
 env:
   CARGO_TERM_COLOR: always
@@ -72,3 +79,36 @@ jobs:
     if: needs.build-daemon.result == 'success' && needs.build-site.result == 'success'
     uses: ./.github/workflows/tests-e2e.yml
     secrets: inherit
+
+  # Aggregator for branch protection. Lists every other job as a
+  # dependency, runs unconditionally (if: always()), and passes iff
+  # each dependency either succeeded or was legitimately skipped via
+  # the changes filter. Failing or cancelled leaves short-circuit to
+  # exit 1.
+  #
+  # Required-check on main branch protection: require ONLY
+  # "All checks passed". Single source of truth, immune to the
+  # gated-leaf trap where a skipped job never reports and blocks the
+  # PR forever.
+  all-checks-passed:
+    name: All checks passed
+    needs: [preflight, build-daemon, build-site, coverage, tests-e2e]
+    if: always()
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - name: Verify no failure/cancelled among required leaves
+        env:
+          RESULTS: ${{ toJSON(needs.*.result) }}
+        run: |
+          set -euo pipefail
+          echo "Leaf results: ${RESULTS}"
+          if [[ "${{ contains(needs.*.result, 'failure') }}" == "true" ]]; then
+            echo "::error::a required check failed"
+            exit 1
+          fi
+          if [[ "${{ contains(needs.*.result, 'cancelled') }}" == "true" ]]; then
+            echo "::error::a required check was cancelled"
+            exit 1
+          fi
+          echo "all checks succeeded or were legitimately skipped."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,18 @@ on:
       - "v*.*.*"
   workflow_dispatch:
 
-permissions: read-all
+# Workflow-level permissions must be the union of every leaf's
+# declared permissions (called reusable workflows must be a subset of
+# the caller). release.yml needs everything its leaves touch:
+#   - security-events: write  → build-daemon clippy SARIF upload
+#   - pages: write, id-token: write → deploy-site GH Pages publish
+#   - contents: write → release-daemon `gh release create`
+permissions:
+  contents: write
+  actions: read
+  security-events: write
+  pages: write
+  id-token: write
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/tests-e2e.yml
+++ b/.github/workflows/tests-e2e.yml
@@ -16,7 +16,11 @@ name: E2E Tests
 on:
   workflow_call:
 
-permissions: read-all
+# Explicit scopes (not read-all) so this leaf's workflow-level stays a
+# subset of the caller's workflow-level — GitHub's reusable-workflow
+# permission rules reject leaf > caller.
+permissions:
+  contents: read
 
 jobs:
   placeholder:

--- a/source/daemon/Dockerfile
+++ b/source/daemon/Dockerfile
@@ -24,7 +24,10 @@
 #   --sysctl net.ipv4.ip_forward=1
 #   --tmpfs /run --tmpfs /run/lock
 
-FROM debian:bookworm-slim
+# Pinned by digest for Scorecard / supply-chain integrity.
+# Dependabot (.github/dependabot.yml) watches this and opens PRs
+# when Debian publishes a new bookworm-slim image.
+FROM debian:bookworm-slim@sha256:f9c6a2fd2ddbc23e336b6257a5245e31f996953ef06cd13a59fa0a1df2d5c252
 
 # Runtime dependencies that stay in the final image.
 # wget is kept for the HEALTHCHECK; curl and minisign are purged after install.

--- a/source/site/src/components/layouts/GetStarted.tsx
+++ b/source/site/src/components/layouts/GetStarted.tsx
@@ -37,7 +37,10 @@ export function GetStarted() {
         <p className="mb-2 text-left text-xs font-semibold uppercase tracking-wider text-gray-400 dark:text-gray-500">
           Bare-metal install
         </p>
-        <CodeBlock code="curl -sSL https://wardnet.network/install.sh | sudo bash" className="text-left" />
+        <CodeBlock
+          code="curl -sSL https://wardnet.network/install.sh | sudo bash"
+          className="text-left"
+        />
 
         <p className="mt-6 text-sm text-gray-500 dark:text-gray-400">
           See the{" "}


### PR DESCRIPTION
## Summary

Two unrelated hygiene fixes, one PR:

1. **Scorecard pinning warnings** — pin every unpinned GitHub Action and base image to a digest, and add two `docker` entries to `.github/dependabot.yml` so pinned digests get bumped weekly instead of drifting.
2. **Restore commits lost in the #142 squash** — `be537fe` (explicit `permissions:` scopes on orchestrators) and `40fa1cc` (PR aggregator job) didn't make it into the squash of PR #142. Without them, `ci.yml` / `pr.yml` / `release.yml` startup-fail on every PR (subset-violation on `security-events: write` etc.), and there's no clean single-check to require on main branch protection.

## Pinning changes

**Actions**:
- `taiki-e/install-action@v2` → `74e87cb...`
- `github/codeql-action/{upload-sarif,init,analyze}@v4` → `95e58e9...`
- `google/clusterfuzzlite/actions/{build_fuzzers,run_fuzzers}@v1` → `884713a...`

**Images**:
- `gcr.io/oss-fuzz-base/base-builder-rust` → `sha256:9a80cc4...`
- `debian:bookworm-slim` → `sha256:f9c6a2f...`

**Dependabot**: added `docker` ecosystem watchers for `/source/daemon` and `/.clusterfuzzlite`.

## Restored from #142

- `ci.yml` / `pr.yml`: explicit `permissions: { contents: read, actions: read, security-events: write }` matching the union of leaf permission declarations.
- `release.yml`: additionally grants `contents: write` (release-daemon), `pages: write` + `id-token: write` (deploy-site).
- `pr.yml`: `all-checks-passed` aggregator job — runs with `if: always()`, fails iff any leaf failed or was cancelled, skips are valid passes. This is the single check to require on main branch protection.

## Test plan

- [ ] Confirm PR workflow starts (no startup_failure this time).
- [ ] Confirm `All checks passed` appears as a status check on the PR.
- [ ] Set `All checks passed` as the only required check on main branch protection (Settings → Branches).
- [ ] Confirm Dependabot picks up the new docker entries on its next run (visible under Settings → Code security → Dependabot → configuration file).
- [ ] Confirm CodeQL + Security Audit still pass (didn't break from the CodeQL action pin).

🤖 Generated with [Claude Code](https://claude.com/claude-code)