### PR TITLE
fix(fuzz): pin nightly toolchain for cargo-fuzz builds

### DIFF
--- a/source/daemon/fuzz/rust-toolchain.toml
+++ b/source/daemon/fuzz/rust-toolchain.toml
@@ -1,0 +1,24 @@
+# Pinned nightly for cargo-fuzz.
+#
+# cargo-fuzz is hard-requires nightly — the libFuzzer + sanitizer
+# rustc flags (-Zsanitizer=address, -Cpasses=sancov-module, etc.) are
+# nightly-only. Floating `channel = "nightly"` would work but pulls
+# whatever nightly happens to be current on each CI run, which means
+# (a) a reproducer from yesterday's crash may not reproduce today,
+# (b) rust-lang nightly regressions break the fuzz job silently.
+#
+# Dated pin gives reproducibility and a deliberate update cadence
+# (typical OSS-Fuzz projects bump quarterly). Bumping procedure:
+#
+#   1. Pick a recent nightly that satisfies the daemon's MSRV
+#      (rust-version = "1.94" in the workspace crates).
+#      Check dates at https://rust-lang.github.io/rustup-components-history/
+#   2. Update the channel below + `cargo +nightly-<date> fuzz build`
+#      locally once to confirm.
+#   3. Commit. The next fuzzing-scheduled run will pick it up.
+#
+# Dependabot doesn't auto-bump this — no ecosystem support for
+# nightly-date pins.
+[toolchain]
+channel = "nightly-2026-04-15"
+components = ["rust-src"]


### PR DESCRIPTION
## Summary

The `fuzzing-scheduled` workflow failed on the most recent run because the pinned OSS-Fuzz `base-builder-rust` image ships nightly 1.91, which is older than the daemon crates' MSRV (`rust-version = "1.94"`). Cargo rejected the build with:

\`\`\`
error: rustc 1.91.0-nightly is not supported by the following packages:
  wardnet-common@0.2.0 requires rustc 1.94
  wardnetd-data@0.2.0 requires rustc 1.94
  wardnetd-services@0.2.0 requires rustc 1.94
\`\`\`

## Why nightly is mandatory

cargo-fuzz requires nightly rustc flags (\`-Zsanitizer=address\`, \`-Cpasses=sancov-module\`, etc.) that stable doesn't expose. Using the daemon's pinned stable 1.94 isn't an option for the fuzz workspace.

## Why a dated pin (not floating nightly)

Mirrors OSS-Fuzz's own practice:

- **Reproducibility** — when a fuzzer finds a crash, you want the same compiler to reproduce it locally. Floating nightly breaks that.
- **Insulation from regressions** — rust-lang occasionally ships broken nightlies. Floating channel = those break our fuzz job silently; dated pin = doesn't budge until we bump it.

## Implementation

Single file added: \`source/daemon/fuzz/rust-toolchain.toml\` pinning \`nightly-2026-04-15\`. cargo-fuzz picks it up when run from \`source/daemon/fuzz/\`. The CFLite container's rustup auto-installs it on first build.

Bump cadence documented in the file header — typical OSS-Fuzz cadence is quarterly, or whenever a compiler feature is needed. Dependabot doesn't auto-bump nightly-date pins (no ecosystem support), so it's manual.

## Test plan

- [ ] After merge, watch the next scheduled fuzzing run (\`fuzzing-scheduled.yml\`, cron 12h) or dispatch manually: \`gh workflow run fuzzing-scheduled.yml\`.
- [ ] Confirm the rust toolchain step logs \`nightly-2026-04-15\` (not 1.91).
- [ ] Confirm \`cargo fuzz build\` succeeds and the three fuzz targets get copied into \`$OUT\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)