### PR TITLE
fix(ci): skip coverage for bots; make CODECOV_TOKEN optional for forks

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -13,8 +13,13 @@ on:
   workflow_call:
     secrets:
       CODECOV_TOKEN:
-        description: Codecov upload token
-        required: true
+        description: |
+          Codecov upload token. Optional so fork PRs — which GitHub
+          denies access to repo secrets — don't fail at the reusable-
+          workflow validation step. When empty, codecov-action falls
+          back to tokenless upload, accepted for unprotected (fork-
+          prefixed) branch refs on public repos.
+        required: false
 
 # Explicit scopes (not read-all) so this leaf's workflow-level stays a
 # subset of the caller's workflow-level — GitHub's reusable-workflow

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -67,11 +67,14 @@ jobs:
   coverage:
     name: Coverage
     needs: preflight
-    # Skip for Dependabot: dep bumps don't add or remove tests, so coverage is
-    # identical to main — no value in re-running, and Dependabot PRs can't
-    # access repository secrets (CODECOV_TOKEN) anyway.
+    # Skip for any bot-authored PR (actor ends with '[bot]'): bots push to
+    # same-repo branches, which GitHub denies access to repo secrets for, and
+    # Codecov requires a token for same-repo branches on public repos. Bots
+    # here (Dependabot, step-security-bot) don't change source code anyway.
+    # Fork PRs from community members keep running — they use Codecov's
+    # tokenless upload (unprotected branch ref with colon prefix).
     if: |
-      github.actor != 'dependabot[bot]' && (
+      !endsWith(github.actor, '[bot]') && (
         needs.preflight.outputs.daemon == 'true' ||
         needs.preflight.outputs.site == 'true' ||
         needs.preflight.outputs.ci == 'true'

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -67,7 +67,15 @@ jobs:
   coverage:
     name: Coverage
     needs: preflight
-    if: needs.preflight.outputs.daemon == 'true' || needs.preflight.outputs.site == 'true' || needs.preflight.outputs.ci == 'true'
+    # Skip for Dependabot: dep bumps don't add or remove tests, so coverage is
+    # identical to main — no value in re-running, and Dependabot PRs can't
+    # access repository secrets (CODECOV_TOKEN) anyway.
+    if: |
+      github.actor != 'dependabot[bot]' && (
+        needs.preflight.outputs.daemon == 'true' ||
+        needs.preflight.outputs.site == 'true' ||
+        needs.preflight.outputs.ci == 'true'
+      )
     uses: ./.github/workflows/coverage.yml
     secrets: inherit
 

--- a/source/daemon/fuzz/rust-toolchain.toml
+++ b/source/daemon/fuzz/rust-toolchain.toml
@@ -1,0 +1,24 @@
+# Pinned nightly for cargo-fuzz.
+#
+# cargo-fuzz is hard-requires nightly — the libFuzzer + sanitizer
+# rustc flags (-Zsanitizer=address, -Cpasses=sancov-module, etc.) are
+# nightly-only. Floating `channel = "nightly"` would work but pulls
+# whatever nightly happens to be current on each CI run, which means
+# (a) a reproducer from yesterday's crash may not reproduce today,
+# (b) rust-lang nightly regressions break the fuzz job silently.
+#
+# Dated pin gives reproducibility and a deliberate update cadence
+# (typical OSS-Fuzz projects bump quarterly). Bumping procedure:
+#
+#   1. Pick a recent nightly that satisfies the daemon's MSRV
+#      (rust-version = "1.94" in the workspace crates).
+#      Check dates at https://rust-lang.github.io/rustup-components-history/
+#   2. Update the channel below + `cargo +nightly-<date> fuzz build`
+#      locally once to confirm.
+#   3. Commit. The next fuzzing-scheduled run will pick it up.
+#
+# Dependabot doesn't auto-bump this — no ecosystem support for
+# nightly-date pins.
+[toolchain]
+channel = "nightly-2026-04-15"
+components = ["rust-src"]


### PR DESCRIPTION
## Problem

Every bot-authored PR is failing with:

> Error when evaluating 'secrets'. .github/workflows/pr.yml (Line: 76, Col: 11): Secret CODECOV_TOKEN is required, but not provided while calling.

Root cause: `coverage.yml` declares `CODECOV_TOKEN` as a **required** secret. Bots (Dependabot, step-security-bot) push to same-repo branches but GitHub denies them access to repository secrets, so `secrets: inherit` passes nothing and the reusable-workflow call fails at invocation — before any step runs.

Fork PRs from community members hit the same validation failure for the same reason (GitHub's fork isolation).

## Codecov's actual token rules (public repos)

- **Same-repo branches** ("protected" in Codecov's terms) → token required
- **Fork branches** (ref has a colon prefix like `user:branch`, "unprotected") → tokenless works

So tokenless doesn't rescue bots — they push to same-repo branches. But it *does* rescue fork PRs from community members.

## Fix

Two small changes:

1. **`pr.yml`** — skip coverage for any actor ending with `[bot]`. GitHub App bots all carry that suffix, so this covers Dependabot, step-security-bot, and any future bot without maintaining a list. Fork PRs (human actor) keep running.

2. **`coverage.yml`** — make `CODECOV_TOKEN` optional. Fork PRs inherit no secrets, so without this the reusable-workflow validation still fails for community PRs. codecov-action falls back to tokenless upload, which Codecov accepts for fork-prefixed branch refs.

## Gating matrix

| PR source | How uploaded | Gated? |
|---|---|---|
| Member (same-repo branch) | Token | ✅ |
| Community (fork) | Tokenless | ✅ |
| Bot (Dependabot, step-security-bot) | Skipped | ❌ (they don't change source) |

The only case that loses gating is bot PRs pushing to same-repo branches — inherent to GitHub's secret-isolation design. Recovering it would require the `workflow_run` pattern (privileged context running after PR workflow completes), which isn't worth the complexity for bots that don't change source.

## Test plan

- [ ] Merge and observe next Dependabot PR — `coverage` reports `skipped`, `all-checks-passed` reports success
- [ ] Observe the pending step-security-bot PR (#162) — same behavior
- [ ] Non-bot PR still runs coverage + uploads with token
- [ ] A community fork PR runs coverage + uploads tokenless (harder to rehearse; deferred to when one arrives)

🤖 Generated with [Claude Code](https://claude.com/claude-code)