### PR TITLE
ci(release): publish multi-arch wardnetd image to GHCR on tag

### DIFF
--- a/.github/workflows/release-image.yml
+++ b/.github/workflows/release-image.yml
@@ -1,0 +1,86 @@
+name: Release Image
+
+# Reusable leaf that publishes the production wardnetd Docker image to
+# GitHub Container Registry (ghcr.io). Builds a multi-arch manifest
+# (linux/amd64 + linux/arm64) and tags it with the release version plus
+# `:latest` (for stable releases only — pre-releases skip `:latest` so
+# `docker pull ghcr.io/.../wardnetd:latest` never resolves to a beta).
+#
+# Runs AFTER release-daemon because source/daemon/Dockerfile downloads
+# the signed release tarball from GitHub Releases at build time. Without
+# an existing `v${VERSION}` release the Dockerfile has nothing to pull.
+#
+# Stage 5 will add a sibling variant (wardnetd-test) built from the same
+# Dockerfile with a test-agent overlay. Stage 12 will rewire release.yml
+# so this job also depends on the e2e test jobs.
+#
+# Artifacts: none — the image manifest lives in ghcr.io.
+
+on:
+  workflow_call:
+    inputs:
+      version:
+        description: Semantic version (e.g. `0.2.1`, `0.2.1-beta.1`).
+        type: string
+        required: true
+      prerelease:
+        description: When true, skip the `:latest` tag.
+        type: boolean
+        required: true
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  publish:
+    name: Publish to GHCR
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+
+      - name: Log in to GHCR
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Compute tags
+        id: tags
+        env:
+          VERSION: ${{ inputs.version }}
+          PRERELEASE: ${{ inputs.prerelease }}
+          REGISTRY: ghcr.io/${{ github.repository_owner }}/wardnetd
+        run: |
+          set -euo pipefail
+          TAGS="${REGISTRY}:${VERSION}"
+          if [[ "${PRERELEASE}" != "true" ]]; then
+            TAGS="${TAGS},${REGISTRY}:latest"
+          fi
+          echo "tags=${TAGS}" >> "${GITHUB_OUTPUT}"
+          echo "Computed tags: ${TAGS}"
+
+      - name: Build and push
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
+        with:
+          context: .
+          file: source/daemon/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.tags.outputs.tags }}
+          build-args: |
+            WARDNET_VERSION=${{ inputs.version }}
+          # Attach an SBOM (SPDX) and SLSA provenance attestation to the
+          # pushed image manifest. Both ride in the OCI manifest — no
+          # separate upload step, no additional permissions needed
+          # beyond `packages: write`.
+          sbom: true
+          provenance: mode=max

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,12 +23,14 @@ on:
 #   - security-events: write  → build-daemon clippy SARIF upload
 #   - pages: write, id-token: write → deploy-site GH Pages publish
 #   - contents: write → release-daemon `gh release create`
+#   - packages: write → release-image GHCR push
 permissions:
   contents: write
   actions: read
   security-events: write
   pages: write
   id-token: write
+  packages: write
 
 env:
   CARGO_TERM_COLOR: always
@@ -124,5 +126,18 @@ jobs:
     with:
       version: ${{ needs.resolve.outputs.version }}
       tag: ${{ needs.resolve.outputs.tag }}
+      prerelease: ${{ fromJSON(needs.resolve.outputs.prerelease) }}
+    secrets: inherit
+
+  release-image:
+    name: Release Image
+    # release-image consumes the published release tarball, so it
+    # must run AFTER release-daemon — the Dockerfile curls
+    # `https://github.com/.../releases/download/v${VERSION}/...`.
+    needs: [resolve, release-daemon]
+    if: startsWith(github.ref, 'refs/tags/v')
+    uses: ./.github/workflows/release-image.yml
+    with:
+      version: ${{ needs.resolve.outputs.version }}
       prerelease: ${{ fromJSON(needs.resolve.outputs.prerelease) }}
     secrets: inherit


### PR DESCRIPTION
## Summary

- **`.github/workflows/release-image.yml`** (new leaf) — builds the production wardnetd image for `linux/amd64` + `linux/arm64` via `docker buildx`, logs into `ghcr.io` with `GITHUB_TOKEN`, pushes `ghcr.io/<owner>/wardnetd:<version>` plus `:latest` (skipped for pre-releases so `:latest` never resolves to a beta). Attaches SBOM (SPDX) and SLSA provenance (`mode=max`) attestations via buildkit — both ride in the OCI manifest, no separate upload.
- **`.github/workflows/release.yml`** — new `release-image` job wired in as the final step. `needs: [resolve, release-daemon]` — ordering is load-bearing because `source/daemon/Dockerfile` curls from GitHub Releases at build time. `packages: write` added to the workflow-level permission union.

## Why `release-image` needs `release-daemon`

The Dockerfile downloads the signed tarball from the GitHub release:

```
https://github.com/wardnet/wardnet/releases/download/v${VERSION}/wardnetd-${VERSION}-${ARCH}.tar.gz
```

If we built the image before `release-daemon` has published the release, the `curl` would 404. Chaining ensures the published release is the single source of truth for both bare-metal and Docker users.

## Gating

Same `if: startsWith(github.ref, 'refs/tags/v')` as `release-daemon` — `workflow_dispatch` dry-runs exercise the build path but stop short of publishing.

## Stage 12 follow-up

This job's `needs:` will be extended to include the three `end2end-tests-*` jobs once they exist, so a flake anywhere blocks the image publish.

## Test plan

- [ ] Dry-run via `workflow_dispatch` on a non-tag ref: `release-image` is skipped (condition false), all other jobs complete as before
- [ ] Next tag push (`v0.2.1` or similar): `release-image` runs after `release-daemon`, pushes `ghcr.io/wardnet/wardnetd:0.2.1` + `:latest`, both arches visible via `docker manifest inspect`
- [ ] Pre-release tag (e.g. `v0.2.1-beta.1`): only the version tag pushed, `:latest` skipped
- [ ] `docker pull ghcr.io/wardnet/wardnetd:<version>` succeeds on both amd64 and arm64 hosts
- [ ] `cosign verify-attestation --type slsaprovenance ghcr.io/wardnet/wardnetd:<version>` or equivalent confirms the attestation is attached

🤖 Generated with [Claude Code](https://claude.com/claude-code)