### PR TITLE
fix(ci): scope .dockerignore to the production Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,9 +1,0 @@
-# The production Dockerfile (source/daemon/Dockerfile) only needs deploy/.
-# Exclude everything else to keep the build context small.
-#
-# When Dockerfile.test is added (Stage 5) this file will be updated to
-# allow source/daemon/, source/web-ui/, and source/sdk/wardnet-js/ while
-# still excluding their build artefacts (target/, node_modules/, dist/).
-
-*
-!deploy/

--- a/source/daemon/Dockerfile.dockerignore
+++ b/source/daemon/Dockerfile.dockerignore
@@ -1,0 +1,16 @@
+# Scoped to source/daemon/Dockerfile only. BuildKit picks up
+# <dockerfile>.dockerignore alongside the Dockerfile and uses it in
+# preference to any context-root .dockerignore.
+#
+# The production Dockerfile only copies deploy/, so exclude everything
+# else to keep the build context small. Living next to the Dockerfile
+# (rather than at repo root) means other builds rooted at the repo —
+# notably ClusterFuzzLite (.clusterfuzzlite/Dockerfile) — see the full
+# context and aren't blocked by this filter.
+#
+# When Dockerfile.test is added (Stage 5) this file will be updated to
+# allow source/daemon/, source/web-ui/, and source/sdk/wardnet-js/ while
+# still excluding their build artefacts (target/, node_modules/, dist/).
+
+*
+!deploy/


### PR DESCRIPTION
## Problem

The scheduled Fuzzing workflow has been failing since #143 landed:

> \`\`\`
> Dockerfile:14
>   12 |
>   13 |     COPY . \$SRC/wardnet
>   14 | >>> COPY .clusterfuzzlite/build.sh \$SRC/
>   15 |     WORKDIR \$SRC/wardnet
>
> ERROR: failed to compute cache key: failed to calculate checksum of ref
>   ...::\"/.clusterfuzzlite/build.sh\": not found
> \`\`\`

Run: https://github.com/wardnet/wardnet/actions/runs/24868394440/job/72809439944

## Root cause

\`.dockerignore\` at the repo root was added in #143 to keep the production image's build context small:

\`\`\`
*
!deploy/
\`\`\`

That file is meant for \`source/daemon/Dockerfile\` — but Docker applies **any** \`.dockerignore\` at the build-context root to every build rooted there, including \`.clusterfuzzlite/Dockerfile\`. ClusterFuzzLite's Dockerfile does:

\`\`\`dockerfile
COPY . \$SRC/wardnet
COPY .clusterfuzzlite/build.sh \$SRC/
\`\`\`

With the root ignore in place, only \`deploy/**\` is visible — so \`build.sh\` and all source code get filtered out before Docker reads the \`COPY\` lines, and the build fails.

## Fix

Move the ignore rules from \`/.dockerignore\` to \`source/daemon/Dockerfile.dockerignore\`. BuildKit looks for \`<dockerfile>.dockerignore\` alongside the Dockerfile and uses it in preference to the context's \`.dockerignore\`.

Effect:

| Build | Context | Which ignore applies | Result |
|---|---|---|---|
| \`make image-multiarch\` (\`-f source/daemon/Dockerfile .\`) | repo root | \`source/daemon/Dockerfile.dockerignore\` | Tight context (\`* + !deploy/\`), same as before |
| \`.clusterfuzzlite/Dockerfile\` | repo root | none | Full repo context, build.sh visible |

The comment in the file header was also updated to document why it lives next to the Dockerfile rather than at the repo root.

## Test plan

- [ ] Merge and dispatch the fuzzing workflow manually: \`gh workflow run fuzzing-scheduled.yml\`. Confirm the \`COPY .clusterfuzzlite/build.sh \$SRC/\` step no longer errors.
- [ ] Later: when \`make image-multiarch\` runs locally or in a release workflow, confirm the context is still tight (build log should show the transfer is small, only deploy/).

🤖 Generated with [Claude Code](https://claude.com/claude-code)