### PR TITLE
fix(ci): pin a stable SARIF category for clippy uploads

### DIFF
--- a/.github/workflows/build-daemon.yml
+++ b/.github/workflows/build-daemon.yml
@@ -65,10 +65,19 @@ jobs:
         # the failure) — but only when SARIF was actually written. If
         # cargo fmt --check fails (runs before clippy), no SARIF exists;
         # hashFiles evaluates to empty and the upload is skipped.
+        #
+        # `category` is pinned explicitly so main (caller = ci.yml) and
+        # PRs (caller = pr.yml) publish under the same identifier.
+        # Without this, upload-sarif derives the category from the
+        # caller workflow path, and code-scanning flags PRs with
+        # "1 configuration not found" because the PR's category has no
+        # counterpart in main's baseline — which surfaces as a NEUTRAL
+        # conclusion and blocks merges under the `code_quality` rule.
         if: always() && hashFiles('rust-clippy-results.sarif') != ''
         uses: github/codeql-action/upload-sarif@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4
         with:
           sarif_file: rust-clippy-results.sarif
+          category: rust-clippy
           wait-for-processing: true
 
   check-openapi:


### PR DESCRIPTION
## Problem

PR #162 (step-security-bot) has every CI check green but is stuck with \`mergeable: MERGEABLE / mergeStateStatus: BLOCKED\`. The \`clippy\` check-run reports NEUTRAL with this message:

> Code scanning cannot determine the alerts introduced by this pull request, because 1 configuration present on \`refs/heads/main\` was not found:
> * Actions workflow (\`ci.yml:check-daemon\`)

The \`code_quality\` rule on main's ruleset treats NEUTRAL as "unable to verify" and blocks the merge.

## Root cause

After the CI restructure in #142, \`build-daemon.yml\` became a reusable workflow called from **two** orchestrators:

- \`ci.yml\` (push to main)
- \`pr.yml\` (pull requests)

\`github/codeql-action/upload-sarif\` defaults its \`category\` to \`{caller_workflow}:{job_name}\`, so the same clippy SARIF ships under two different identifiers:

- Main baseline → \`.github/workflows/ci.yml:check-daemon\`
- PR uploads → \`.github/workflows/pr.yml:check-daemon\`

Code-scanning compares PR uploads against main's baseline **by category**. Mismatched categories mean main's baseline has no PR counterpart → "1 configuration not found" → NEUTRAL → blocked.

## Fix

Pin \`category: rust-clippy\` on the SARIF upload step. Both callers now publish under the same identifier, so main's baseline and PRs can be compared properly. Main's next \`ci.yml\` run re-baselines under this category; subsequent PRs get a conclusive comparison.

## Test plan

- [ ] Merge and wait for main's \`ci.yml\` to run, re-baselining under \`rust-clippy\`.
- [ ] Rebase PR #162 onto updated main; verify the \`clippy\` check is now SUCCESS (not NEUTRAL) and the PR becomes mergeable.
- [ ] Same on any other pending PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)