### PR TITLE
fix(fuzz): force rustup to install the pinned nightly

### DIFF
--- a/.clusterfuzzlite/build.sh
+++ b/.clusterfuzzlite/build.sh
@@ -9,6 +9,15 @@
 
 cd "$SRC/wardnet/source/daemon/fuzz"
 
+# Force the pinned nightly in rust-toolchain.toml to be installed.
+# The OSS-Fuzz base-builder-rust image ships with a pre-baked rustc
+# (1.91-nightly at the current digest) that doesn't satisfy the daemon
+# workspace's MSRV (1.94). `rustup show` from a directory containing
+# rust-toolchain.toml triggers rustup to install the pinned toolchain
+# when it's missing — single source of truth (the .toml), no version
+# string duplicated here.
+rustup show
+
 cargo fuzz build -O
 
 FUZZ_TARGETS=(archiver_unpack sqlite_restore bundle_manifest)


### PR DESCRIPTION
## Problem

Scheduled fuzzing still fails after #165 unblocked the Docker build. Latest run: https://github.com/wardnet/wardnet/actions/runs/24872486791

\`\`\`
error: rustc 1.91.0-nightly is not supported by the following packages:
  wardnet-common@0.2.0 requires rustc 1.94
  wardnetd-data@0.2.0 requires rustc 1.94
  wardnetd-services@0.2.0 requires rustc 1.94
\`\`\`

## Root cause

\`source/daemon/fuzz/rust-toolchain.toml\` pins \`nightly-2026-04-15\` — which does satisfy the daemon crates' MSRV 1.94. But the OSS-Fuzz \`base-builder-rust\` image at the pinned digest ships with a pre-baked rustc (\`1.91.0-nightly\`) installed outside rustup's control.

\`cargo fuzz build\` invokes that pre-baked rustc directly and never triggers rustup's auto-install path, so \`rust-toolchain.toml\` is silently ignored. Hence the MSRV mismatch.

## Fix

Add \`rustup show\` to \`.clusterfuzzlite/build.sh\` before the fuzz build. Running it from a directory with \`rust-toolchain.toml\` triggers rustup to install the pinned toolchain when it's missing. Single source of truth — the toml is still the only place the nightly date lives.

## Why nightly is non-negotiable (for context)

cargo-fuzz README, top of the doc: *"This also needs a nightly compiler since it uses some unstable command-line flags."* The flags (\`-Zsanitizer=address\`, \`-Cpasses=sancov-module\`, \`-Cllvm-args=-sanitizer-coverage-*\`) are nightly-gated by rustc; stable rejects them outright.

## Test plan

- [ ] Merge and dispatch the fuzzing workflow: \`gh workflow run fuzzing-scheduled.yml\`. Confirm \`cargo fuzz build\` succeeds and the three fuzz targets (\`archiver_unpack\`, \`sqlite_restore\`, \`bundle_manifest\`) land in \`\$OUT/\`.
- [ ] Job log should show rustup downloading \`nightly-2026-04-15\` before the \`cargo fuzz build\` step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)