### PR TITLE
feat(ci): auto-merge Dependabot patch/minor PRs after 3-day cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,12 @@ updates:
       interval: "weekly"
     commit-message:
       prefix: "chore(deps):"
+    # 3-day cooldown before Dependabot opens a PR for a new version.
+    # Gives the wider ecosystem time to surface supply-chain issues
+    # (yanked releases, compromised publishers) before an auto-merge
+    # eligible PR lands on main.
+    cooldown:
+      default-days: 3
 
   - package-ecosystem: "npm"
     directory: "/source/web-ui"
@@ -13,6 +19,8 @@ updates:
       interval: "weekly"
     commit-message:
       prefix: "chore(deps):"
+    cooldown:
+      default-days: 3
 
   - package-ecosystem: "npm"
     directory: "/source/site"
@@ -20,11 +28,15 @@ updates:
       interval: "weekly"
     commit-message:
       prefix: "chore(deps):"
-  
+    cooldown:
+      default-days: 3
+
   - package-ecosystem: npm
     directory: /source/sdk/wardnet-js
     schedule:
       interval: daily
+    cooldown:
+      default-days: 3
 
   - package-ecosystem: "github-actions"
     directory: "/"
@@ -32,6 +44,8 @@ updates:
       interval: "weekly"
     commit-message:
       prefix: "chore(ci):"
+    cooldown:
+      default-days: 3
 
   # Production wardnetd image (source/daemon/Dockerfile) — pinned by
   # digest for Scorecard / supply-chain integrity, so Dependabot is
@@ -42,6 +56,8 @@ updates:
       interval: "weekly"
     commit-message:
       prefix: "chore(deps):"
+    cooldown:
+      default-days: 3
 
   # ClusterFuzzLite build image (.clusterfuzzlite/Dockerfile) — same
   # pin-then-bump story.
@@ -51,3 +67,5 @@ updates:
       interval: "weekly"
     commit-message:
       prefix: "chore(deps):"
+    cooldown:
+      default-days: 3

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,117 @@
+name: Dependabot auto-merge
+
+# Daily batch window for merging Dependabot's patch and minor bumps.
+#
+# The Dependabot cooldown (3 days, set in .github/dependabot.yml) is
+# the supply-chain guard — by the time a PR exists, the upstream
+# release has been in the wild long enough to surface yanks /
+# compromises. This workflow is the merge executor on top of that:
+#
+#   1. List open Dependabot PRs
+#   2. For each: parse the bump type from the title, check the PR is
+#      actually mergeable (all required checks green, no review blocks)
+#   3. Squash-merge the eligible ones
+#
+# Major bumps are skipped — those get a human review. Non-Dependabot
+# PRs are untouched.
+#
+# Production exposure is further bounded by the release cycle:
+# dependency updates ride the next tagged release, not every merge to
+# main, so a bad merge has more chances to be caught before users see
+# it.
+
+on:
+  schedule:
+    - cron: "0 1 * * *"  # 01:00 UTC daily
+  workflow_dispatch:     # allow manual triggering for debugging
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    name: Auto-merge Dependabot patch/minor PRs
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Merge eligible Dependabot PRs
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          # Pull every open Dependabot PR's merge-relevant fields.
+          # mergeStateStatus ∈ {BEHIND, BLOCKED, CLEAN, DIRTY, DRAFT,
+          # HAS_HOOKS, UNKNOWN, UNSTABLE}; CLEAN / HAS_HOOKS mean the
+          # PR is ready per branch protection.
+          gh pr list --repo "$REPO" \
+            --author app/dependabot \
+            --state open \
+            --json number,title,mergeable,mergeStateStatus,isDraft \
+            > prs.json
+
+          count=$(jq 'length' prs.json)
+          echo "Found ${count} open Dependabot PR(s)."
+
+          # Extract "from X.Y.Z to A.B.C" out of the title, classify
+          # the bump via semver comparison, merge if patch/minor and
+          # the PR is ready.
+          jq -c '.[]' prs.json | while read -r pr; do
+            number=$(echo "$pr" | jq -r '.number')
+            title=$(echo "$pr" | jq -r '.title')
+            mergeable=$(echo "$pr" | jq -r '.mergeable')
+            state=$(echo "$pr" | jq -r '.mergeStateStatus')
+            draft=$(echo "$pr" | jq -r '.isDraft')
+
+            echo ""
+            echo "── PR #${number}: ${title}"
+            echo "   mergeable=${mergeable} state=${state} draft=${draft}"
+
+            if [[ "$draft" == "true" ]]; then
+              echo "   → skip: draft"
+              continue
+            fi
+            if [[ "$mergeable" != "MERGEABLE" ]]; then
+              echo "   → skip: not mergeable (conflicts?)"
+              continue
+            fi
+            if [[ "$state" != "CLEAN" && "$state" != "HAS_HOOKS" && "$state" != "UNSTABLE" ]]; then
+              # UNSTABLE = required checks passed but optional checks failed.
+              # Treat as eligible; branch protection already enforces the required set.
+              echo "   → skip: mergeStateStatus=${state} (checks not green)"
+              continue
+            fi
+
+            # Parse versions from the title. Dependabot's format is
+            # stable: "bump <pkg> from <old> to <new>" (possibly with
+            # " in /path" suffix). Extract old/new.
+            if [[ ! "$title" =~ from\ ([0-9]+\.[0-9]+\.[0-9]+)(-[A-Za-z0-9\.\-]+)?\ to\ ([0-9]+\.[0-9]+\.[0-9]+)(-[A-Za-z0-9\.\-]+)? ]]; then
+              echo "   → skip: couldn't parse versions from title"
+              continue
+            fi
+            old="${BASH_REMATCH[1]}"
+            new="${BASH_REMATCH[3]}"
+            old_major="${old%%.*}"
+            new_major="${new%%.*}"
+            old_rest="${old#*.}"; old_minor="${old_rest%%.*}"
+            new_rest="${new#*.}"; new_minor="${new_rest%%.*}"
+
+            if [[ "$old_major" != "$new_major" ]]; then
+              bump="major"
+            elif [[ "$old_minor" != "$new_minor" ]]; then
+              bump="minor"
+            else
+              bump="patch"
+            fi
+            echo "   bump: ${old} → ${new} (${bump})"
+
+            if [[ "$bump" == "major" ]]; then
+              echo "   → skip: major bumps require human review"
+              continue
+            fi
+
+            echo "   → merging (squash)"
+            gh pr merge "$number" --repo "$REPO" --squash --delete-branch
+          done


### PR DESCRIPTION
## Motivation

Dependabot currently opens ~10 PRs at a time and every one needs a human glance before merge. For patch and minor bumps — semver says they're backwards-compatible, and the existing CI (tests, clippy, cargo-audit, CodeQL) already gates them — that review is low-value. Goal: let boring updates flow automatically, keep eyes on majors.

## Design

Two pieces working together:

**1. Cooldown** — \`.github/dependabot.yml\` gets \`cooldown: { default-days: 3 }\` on every update block. Dependabot waits 3 days after a release before opening a PR. That's the supply-chain guard: by the time a PR exists, the upstream release has had enough time in the wild for yanks, compromised-publisher disclosures, and post-release bugfixes to surface.

**2. Auto-merge workflow** — \`.github/workflows/dependabot-auto-merge.yml\` runs on cron at 01:00 UTC. It:

- Lists open Dependabot PRs
- Parses \`from X.Y.Z to A.B.C\` out of each title
- Classifies as patch / minor / major via semver comparison
- Skips majors (human review required)
- Skips PRs that are draft, non-mergeable, or failing required checks
- Squash-merges the rest and deletes the branch

The daily batch window means main gets one cohesive drop of updates per day rather than a trickle throughout.

## Why this is safe enough for this repo

- **CI already gates it:** every Dependabot PR has to pass tests, clippy, cargo-audit, and CodeQL before auto-merge touches it. Branch protection requires \`All checks passed\`.
- **3-day cooldown** bounds zero-day supply-chain attacks (see \`xz-utils\` backdoor, 2024 — discovered within hours of publication).
- **Release cycle soak:** deps only hit production on the next tagged release, not on every merge to main. So there's an implicit second cooldown before users see anything.
- **Majors still manual.** Breaking changes by definition — no auto-merge.

## What needs to happen after merge

\`Settings → General → "Allow auto-merge"\` should be **on** (the workflow uses \`gh pr merge --squash\`, which doesn't strictly require the repo-level toggle, but having it on means manually-triggered \`gh pr merge --auto\` works too).

## Test plan

- [ ] Merge and trigger manually: \`gh workflow run dependabot-auto-merge.yml\`.
- [ ] Confirm the run lists the currently open Dependabot PRs, classifies each correctly, and merges the green patch/minor ones.
- [ ] Open Dependabot PRs for major bumps (there's at least one in the backlog) should be logged with "skip: major bumps require human review" and NOT be merged.
- [ ] After the first automated run, watch the next 01:00 UTC schedule fire cleanly on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)