### PR TITLE
fix(fuzz): override baked RUSTUP_TOOLCHAIN, bump to Rust 1.95

### DIFF
--- a/.agents/commands.md
+++ b/.agents/commands.md
@@ -12,7 +12,7 @@ All builds are driven by the root **Makefile**. Use `make help` to see all targe
 - **`make check`** — run all checks (SDK + web + site + daemon: format, lint, tests)
 - **`make check-sdk`** — SDK typecheck + format check
 - **`make check-web`** — web UI typecheck + lint + format check (depends on SDK)
-- **`make check-daemon`** — Rust format + clippy + tests. **Linux-only**: the daemon depends on Linux kernel interfaces (netlink, rtnetlink) and cannot compile on macOS. On non-Linux hosts this target auto-detects `podman` or `docker` and runs inside a `rust:1.94` container. Build artefacts are cached in `.target-linux/` (gitignored) and crate downloads in a named volume (`wardnet-cargo-cache`).
+- **`make check-daemon`** — Rust format + clippy + tests. **Linux-only**: the daemon depends on Linux kernel interfaces (netlink, rtnetlink) and cannot compile on macOS. On non-Linux hosts this target auto-detects `podman` or `docker` and runs inside a `rust:1.95` container. Build artefacts are cached in `.target-linux/` (gitignored) and crate downloads in a named volume (`wardnet-cargo-cache`).
 - **`make coverage-daemon`** — line-coverage summary via `cargo-llvm-cov`. Same platform auto-detection as `check-daemon` (container on macOS). Uses the same ignore regex as CI.
 - **`make run-dev`** — mock daemon + web UI dev server. `RESUME=true` persists the DB at `.wardnet-local/wardnet.db`.
 - **`make run-dev-daemon`** / **`make run-dev-web`** — run each piece independently.

--- a/.agents/technical-stack.md
+++ b/.agents/technical-stack.md
@@ -1,7 +1,7 @@
 # Technical Stack
 
 ## Daemon
-- Rust 1.94, edition 2024 (pinned in `rust-toolchain.toml`)
+- Rust 1.95 (pinned in `rust-toolchain.toml`)
 - **Multi-crate workspace**: `wardnet-common` (shared types/config) → `wardnetd-data` (repositories + database dumper + secret store) → `wardnetd-services` (business logic) → `wardnetd-api` (HTTP layer) → `wardnetd` (Linux binary)
 - axum 0.8 (with `macros`, `multipart`, `ws` features), tokio, tower-http
 - utoipa + utoipa-axum for OpenAPI generation, utoipa-scalar for the `/api/docs` UI

--- a/.claude/skills/bump-rust/SKILL.md
+++ b/.claude/skills/bump-rust/SKILL.md
@@ -1,0 +1,139 @@
+---
+name: bump-rust
+description: |
+  Use this skill when the user asks to bump the daemon's Rust toolchain
+  (stable channel + MSRV + README badge + fuzzing nightly). Changes land
+  atomically across source/daemon/Cargo.toml, the two rust-toolchain.toml
+  files, CI workflows, Makefile, README badge, and the agent/dev docs.
+  Also use this skill when the OSS-Fuzz builder reports
+  `rustc X.Y.Z-nightly is not supported by the following packages:
+  wardnet-common@0.2.0 requires rustc <MSRV>`.
+---
+
+# Bump Rust Toolchain
+
+Single-pass checklist for moving the daemon forward one (or more) Rust
+minor versions. Every pin below must move together — drifting pins
+cause confusing failures (CI green but fuzz red, local green but CI
+red, etc.).
+
+## Target version
+
+The daemon tracks **latest stable**. Confirm the current stable at
+<https://www.rust-lang.org/> or `rustup check`. Let `$NEW` be the new
+minor (e.g. `1.95`).
+
+## Pins to update
+
+One edit each. The final `grep -rn "1\.<OLD>" --include="*.md"
+--include="*.yml" --include="*.toml" --include="Dockerfile*"
+--include="Makefile"` must come back empty before committing.
+
+| File                                       | Line pattern                              |
+|--------------------------------------------|-------------------------------------------|
+| `source/daemon/Cargo.toml`                 | `rust-version = "<NEW>"`                  |
+| `source/daemon/rust-toolchain.toml`        | `channel = "<NEW>"`                       |
+| `.github/actions/setup-rust/action.yml`    | `default: "<NEW>"`                        |
+| `.github/workflows/coverage.yml`           | `toolchain: "<NEW>"`                      |
+| `.github/workflows/security.yml`           | `toolchain: "<NEW>"`                      |
+| `Makefile`                                 | `RUST_IMAGE := docker.io/library/rust:<NEW>` |
+| `README.md`                                | `[![Rust](...rust-<NEW>-orange...)]`      |
+| `.agents/technical-stack.md`               | `Rust <NEW> (pinned in ...)`              |
+| `.agents/commands.md`                      | `rust:<NEW>` in the check-daemon entry    |
+| `docs/DEVELOPMENT.md`                      | tech-stack table row + prerequisites line |
+
+Do **not** re-introduce `edition 2024` alongside the version. Editions
+live ~3 years, bumping them is a separate project-wide event, and
+mentioning the edition on every version line just means we forget to
+update it when the edition actually changes.
+
+The production `source/daemon/Dockerfile` has no Rust pin — it
+installs a pre-built release binary, so nothing to change there.
+
+## Fuzzing nightly
+
+Policy: the fuzz workspace uses the **last nightly of the matching
+minor version**, not whatever nightly is current. Running the fuzzer
+on two unreleased compiler versions ahead of production adds
+nightly-only codegen risk for no benefit.
+
+Rust's release cadence is strict 6 weeks. Given stable `<NEW>` shipped
+on date `S`, the `<NEW>`-nightly window ran from `S - 12 weeks` to
+`S - 6 weeks` (i.e. the cycle when `<NEW>` was in beta is *after*,
+the cycle when it was nightly is *before*). Pick a date near the end
+of that window — late fixes, no branch-cut risk.
+
+To resolve a specific date to a rustc minor, run:
+
+```bash
+podman run --rm --platform linux/amd64 \
+  gcr.io/oss-fuzz-base/base-builder-rust@sha256:<current-digest-from-.clusterfuzzlite/Dockerfile> \
+  bash -c 'rustup toolchain install nightly-YYYY-MM-DD --profile minimal --no-self-update 2>&1 | grep installed'
+```
+
+Output looks like `nightly-YYYY-MM-DD-... installed - rustc X.Y.Z-nightly (...)`.
+
+Update `source/daemon/fuzz/rust-toolchain.toml`:
+
+- `channel = "nightly-YYYY-MM-DD"`
+- Update the header comment's worked example (date window, MSRV
+  reference) so the next bumper has the numbers in front of them.
+
+Do **not** update `.clusterfuzzlite/build.sh` — it parses the channel
+out of the toml at build time.
+
+## Verify
+
+1. `make check-daemon` — runs fmt, clippy (`-D warnings`), and the
+   full workspace test matrix inside the `rust:<NEW>` container on
+   macOS, natively on Linux. Every new minor typically ships a handful
+   of pedantic clippy lints; fix them in the same commit (see *Common
+   new lints* below).
+2. Sanity-check the fuzz toolchain in the OSS-Fuzz base image:
+   ```bash
+   podman run --rm --platform linux/amd64 \
+     gcr.io/oss-fuzz-base/base-builder-rust@sha256:<digest> \
+     bash -c '
+       mkdir -p /tmp/t && cd /tmp/t
+       printf "[toolchain]\nchannel = \"nightly-YYYY-MM-DD\"\ncomponents = [\"rust-src\"]\n" > rust-toolchain.toml
+       rustup toolchain install "$(awk -F \" "/^channel/ {print \$2}" rust-toolchain.toml)" \
+           --profile minimal --component rust-src --no-self-update
+       export RUSTUP_TOOLCHAIN="$(awk -F \" "/^channel/ {print \$2}" rust-toolchain.toml)"
+       rustc --version
+     '
+   ```
+   Expected: `rustc <NEW>.0-nightly (...)`. Anything else (e.g.
+   `<NEW-1>` or `<NEW+1>`) means the date is outside the matching
+   window — pick another date.
+
+## Common new lints (reference, not exhaustive)
+
+Every stable bump adds or tightens clippy pedantic lints. Recent
+examples worth knowing:
+
+- `duration_suboptimal_units` (1.95+) — `Duration::from_secs(60)` →
+  `from_mins(1)`, `from_secs(3600)` → `from_hours(1)`, etc. Note:
+  `Duration::from_days` / `from_weeks` are still unstable as of 1.95
+  (tracking issue #120301) — use `from_hours(24 * N)` for day
+  literals.
+- `map_unwrap_or` — `.map(f).unwrap_or(a)` → `.map_or(a, f)`.
+- `unnecessary_sort_by` — `sort_by(|a, b| b.k.cmp(&a.k))` →
+  `sort_by_key(|x| std::cmp::Reverse(x.k))`.
+
+Fix them in the same commit as the version bump; never `#[allow]`
+just to unblock — if a new lint fires it usually caught something
+worth fixing.
+
+## Commit shape
+
+One commit, scoped `chore(rust):`. Subject names the new version.
+Body calls out:
+
+- The new stable version and why it's being bumped (latest stable,
+  or fixes an OSS-Fuzz MSRV error).
+- The new fuzz nightly date + resolved rustc (e.g.
+  `nightly-2026-02-20 → rustc 1.95.0-nightly (7f99507f5)`).
+- Any clippy fixes piggy-backed on the bump.
+
+See commit `566ba7e` for the canonical example (1.94 → 1.95 + fuzz
+`nightly-2026-04-15` → `nightly-2026-02-20`).

--- a/.clusterfuzzlite/build.sh
+++ b/.clusterfuzzlite/build.sh
@@ -9,14 +9,22 @@
 
 cd "$SRC/wardnet/source/daemon/fuzz"
 
-# Force the pinned nightly in rust-toolchain.toml to be installed.
-# The OSS-Fuzz base-builder-rust image ships with a pre-baked rustc
-# (1.91-nightly at the current digest) that doesn't satisfy the daemon
-# workspace's MSRV (1.94). `rustup show` from a directory containing
-# rust-toolchain.toml triggers rustup to install the pinned toolchain
-# when it's missing — single source of truth (the .toml), no version
-# string duplicated here.
-rustup show
+# The OSS-Fuzz base-builder-rust image sets `RUSTUP_TOOLCHAIN` as a
+# container env var (currently nightly-2025-09-05 → rustc 1.91-nightly).
+# That env var takes precedence over rust-toolchain.toml in every
+# rustup proxy call, so the pinned nightly in this directory is
+# silently ignored and builds fail with:
+#
+#   error: rustc 1.91.0-nightly is not supported by the following
+#   packages: wardnet-common@0.2.0 requires rustc 1.94, ...
+#
+# Parse the channel out of rust-toolchain.toml (kept as the single
+# source of truth), install it explicitly, then override the image's
+# RUSTUP_TOOLCHAIN for the rest of the script so cargo-fuzz and every
+# nested cargo/rustc invocation pick up our pin.
+TOOLCHAIN=$(awk -F '"' '/^channel/ {print $2}' rust-toolchain.toml)
+rustup toolchain install "$TOOLCHAIN" --profile minimal --component rust-src
+export RUSTUP_TOOLCHAIN="$TOOLCHAIN"
 
 cargo fuzz build -O
 

--- a/.clusterfuzzlite/build.sh
+++ b/.clusterfuzzlite/build.sh
@@ -16,7 +16,7 @@ cd "$SRC/wardnet/source/daemon/fuzz"
 # silently ignored and builds fail with:
 #
 #   error: rustc 1.91.0-nightly is not supported by the following
-#   packages: wardnet-common@0.2.0 requires rustc 1.94, ...
+#   packages: wardnet-common@0.2.0 requires rustc 1.95, ...
 #
 # Parse the channel out of rust-toolchain.toml (kept as the single
 # source of truth), install it explicitly, then override the image's

--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -8,7 +8,7 @@ inputs:
   toolchain:
     description: Rust toolchain version (must match `rust-toolchain.toml`).
     required: false
-    default: "1.94"
+    default: "1.95"
   targets:
     description: Comma- or space-separated list of additional Rust targets to install.
     required: false

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
         with:
-          toolchain: "1.94"
+          toolchain: "1.95"
 
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
         with:
-          toolchain: "1.94"
+          toolchain: "1.95"
 
       - name: Install cargo-audit
         run: cargo install cargo-audit

--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,5 @@ source/site/public/install.sh
 .idea/
 .claude/settings.local.json
 .claude/scheduled_tasks.lock
-.claude/skills/
 .wardnet-local/
 .target-linux/

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ OTEL_HOST    ?=
 # Container runtime: prefer podman, fall back to docker.
 CONTAINER_RT := $(shell command -v podman 2>/dev/null || command -v docker 2>/dev/null)
 CONTAINER_RT_NAME := $(notdir $(CONTAINER_RT))
-RUST_IMAGE   := docker.io/library/rust:1.94
+RUST_IMAGE   := docker.io/library/rust:1.95
 
 # Docker image build settings.
 # Override IMAGE_TAG on the CLI to name the local image differently, e.g.:

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 [![CI](https://github.com/wardnet/wardnet/actions/workflows/ci.yml/badge.svg)](https://github.com/wardnet/wardnet/actions/workflows/ci.yml)
 [![codecov](https://codecov.io/gh/wardnet/wardnet/branch/main/graph/badge.svg)](https://codecov.io/gh/wardnet/wardnet)
-[![Rust](https://img.shields.io/badge/rust-1.94-orange.svg)](https://www.rust-lang.org)
+[![Rust](https://img.shields.io/badge/rust-1.95-orange.svg)](https://www.rust-lang.org)
 [![Rust Report Card](https://rust-reportcard.xuri.me/badge/github.com/wardnet/wardnet)](https://rust-reportcard.xuri.me/report/github.com/wardnet/wardnet)
 [![Security Audit](https://github.com/wardnet/wardnet/actions/workflows/security.yml/badge.svg)](https://github.com/wardnet/wardnet/actions/workflows/security.yml)
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/wardnet/wardnet/badge)](https://securityscorecards.dev/viewer/?uri=github.com/wardnet/wardnet)

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -90,7 +90,7 @@ All business logic lives in `@wardnet/js`. Components are pure presentation. Hoo
 
 | Component       | Technology                                                    |
 |-----------------|---------------------------------------------------------------|
-| Daemon          | Rust 1.94 (edition 2024), axum 0.8, SQLite (sqlx 0.8)         |
+| Daemon          | Rust 1.95, axum 0.8, SQLite (sqlx 0.8)                        |
 | Web UI          | React 19, TypeScript 5.9, Vite 8, Tailwind CSS 4              |
 | SDK             | TypeScript 5.9, zero runtime dependencies, native `fetch`     |
 | Package manager | Yarn 4 (via Corepack)                                         |
@@ -105,7 +105,7 @@ All business logic lives in `@wardnet/js`. Components are pure presentation. Hoo
 
 ### Prerequisites
 
-- Rust 1.94+ (pinned via `rust-toolchain.toml`)
+- Rust 1.95+ (pinned via `rust-toolchain.toml`)
 - Node.js 25+
 - Yarn 4 (enabled via `corepack enable`)
 - **Daemon checks on macOS**: Podman or Docker. The daemon uses Linux-only kernel interfaces (netlink, rtnetlink) and cannot compile natively on macOS — `make check-daemon` runs checks inside a Linux container automatically.

--- a/source/daemon/Cargo.toml
+++ b/source/daemon/Cargo.toml
@@ -17,7 +17,7 @@ resolver = "3"
 [workspace.package]
 version = "0.2.0"
 edition = "2024"
-rust-version = "1.94"
+rust-version = "1.95"
 license = "MIT"
 
 [workspace.lints.clippy]

--- a/source/daemon/crates/wardnetd-services/src/backup/runner.rs
+++ b/source/daemon/crates/wardnetd-services/src/backup/runner.rs
@@ -20,7 +20,7 @@ use crate::backup::service::BackupService;
 /// deletes it. Long enough for an operator to realise a restore went
 /// wrong and manually recover from the `.bak-<ts>` siblings; short
 /// enough that we don't pile up snapshots indefinitely on an SD card.
-pub const DEFAULT_SNAPSHOT_RETENTION: Duration = Duration::from_secs(24 * 60 * 60);
+pub const DEFAULT_SNAPSHOT_RETENTION: Duration = Duration::from_hours(24);
 
 /// Background runner that periodically trims stale `.bak-*` snapshots
 /// out of the database directory.

--- a/source/daemon/crates/wardnetd-services/src/backup/service.rs
+++ b/source/daemon/crates/wardnetd-services/src/backup/service.rs
@@ -60,7 +60,7 @@ use crate::error::AppError;
 /// How long a preview token remains valid before `apply_import`
 /// refuses it. Short window on purpose — the operator is expected to
 /// confirm the restore within a few minutes of previewing it.
-const PREVIEW_TOKEN_TTL: Duration = Duration::from_secs(5 * 60);
+const PREVIEW_TOKEN_TTL: Duration = Duration::from_mins(5);
 
 /// `system_config` key flipped to `"true"` after a successful
 /// `apply_import`. The auto-update subsystem's rollback unit reads this
@@ -487,10 +487,7 @@ impl BackupServiceImpl {
                 dst.display()
             ))
         })?;
-        let size = tokio::fs::metadata(&dst)
-            .await
-            .map(|m| m.len())
-            .unwrap_or(0);
+        let size = tokio::fs::metadata(&dst).await.map_or(0, |m| m.len());
         Ok(Some(LocalSnapshot {
             path: dst.display().to_string(),
             kind,

--- a/source/daemon/crates/wardnetd-services/src/backup/tests/runner.rs
+++ b/source/daemon/crates/wardnetd-services/src/backup/tests/runner.rs
@@ -71,7 +71,7 @@ async fn runner_fires_cleanup_on_startup() {
 
     let runner = BackupCleanupRunner::start(
         svc.clone() as Arc<dyn BackupService>,
-        Duration::from_secs(3600),
+        Duration::from_hours(1),
         DEFAULT_SNAPSHOT_RETENTION,
         &parent,
     );
@@ -98,7 +98,7 @@ async fn runner_shuts_down_cleanly_without_tick() {
 
     let runner = BackupCleanupRunner::start(
         svc.clone() as Arc<dyn BackupService>,
-        Duration::from_secs(3600),
+        Duration::from_hours(1),
         DEFAULT_SNAPSHOT_RETENTION,
         &parent,
     );
@@ -108,8 +108,5 @@ async fn runner_shuts_down_cleanly_without_tick() {
 
 #[test]
 fn default_retention_is_24h() {
-    assert_eq!(
-        DEFAULT_SNAPSHOT_RETENTION,
-        Duration::from_secs(60 * 60 * 24)
-    );
+    assert_eq!(DEFAULT_SNAPSHOT_RETENTION, Duration::from_hours(24));
 }

--- a/source/daemon/crates/wardnetd-services/src/backup/tests/service.rs
+++ b/source/daemon/crates/wardnetd-services/src/backup/tests/service.rs
@@ -334,15 +334,14 @@ async fn cleanup_old_snapshots_deletes_expired_files() {
 
     // Backdate the mtime to well beyond the retention window so the
     // cleanup sweep treats it as expired.
-    let ten_days_ago = std::time::SystemTime::now() - Duration::from_secs(60 * 60 * 24 * 10);
+    let ten_days_ago = std::time::SystemTime::now() - Duration::from_hours(24 * 10);
     let file = std::fs::File::options().write(true).open(&fake).unwrap();
     file.set_modified(ten_days_ago).unwrap();
     drop(file);
 
     let deleted = auth_context::with_context(
         admin_ctx(),
-        h.svc
-            .cleanup_old_snapshots(Duration::from_secs(60 * 60 * 24)),
+        h.svc.cleanup_old_snapshots(Duration::from_hours(24)),
     )
     .await
     .unwrap();
@@ -367,8 +366,7 @@ async fn cleanup_old_snapshots_keeps_recent_files() {
 
     let deleted = auth_context::with_context(
         admin_ctx(),
-        h.svc
-            .cleanup_old_snapshots(Duration::from_secs(60 * 60 * 24)),
+        h.svc.cleanup_old_snapshots(Duration::from_hours(24)),
     )
     .await
     .unwrap();
@@ -431,7 +429,7 @@ async fn cleanup_old_snapshots_requires_admin() {
     let h = build_harness(42);
     let err = h
         .svc
-        .cleanup_old_snapshots(Duration::from_secs(60))
+        .cleanup_old_snapshots(Duration::from_mins(1))
         .await
         .unwrap_err();
     assert!(matches!(err, AppError::Forbidden(_)));

--- a/source/daemon/crates/wardnetd-services/src/dhcp/runner.rs
+++ b/source/daemon/crates/wardnetd-services/src/dhcp/runner.rs
@@ -81,8 +81,8 @@ async fn runner_loop(
         }
     }
 
-    // Periodic lease cleanup interval (every 60 seconds).
-    let mut cleanup_interval = tokio::time::interval(Duration::from_secs(60));
+    // Periodic lease cleanup interval.
+    let mut cleanup_interval = tokio::time::interval(Duration::from_mins(1));
 
     loop {
         tokio::select! {

--- a/source/daemon/crates/wardnetd-services/src/jobs.rs
+++ b/source/daemon/crates/wardnetd-services/src/jobs.rs
@@ -23,9 +23,9 @@ use uuid::Uuid;
 use wardnet_common::jobs::{Job, JobKind, JobStatus};
 
 /// How long a terminated job stays in the registry before GC removes it.
-const JOB_GC_TTL: Duration = Duration::from_secs(30 * 60);
+const JOB_GC_TTL: Duration = Duration::from_mins(30);
 /// How often the GC task sweeps expired jobs.
-const JOB_GC_INTERVAL: Duration = Duration::from_secs(60);
+const JOB_GC_INTERVAL: Duration = Duration::from_mins(1);
 
 /// Type-erased job closure: takes a [`ProgressReporter`] and returns a future
 /// resolving to the job result. Callers should prefer [`JobServiceExt::dispatch`]

--- a/source/daemon/crates/wardnetd-services/src/logging/service.rs
+++ b/source/daemon/crates/wardnetd-services/src/logging/service.rs
@@ -127,7 +127,7 @@ impl LogService for LogServiceImpl {
         }
 
         // Most recent first.
-        files.sort_by(|a, b| b.modified_at.cmp(&a.modified_at));
+        files.sort_by_key(|f| std::cmp::Reverse(f.modified_at));
 
         Ok(files)
     }

--- a/source/daemon/crates/wardnetd-services/src/update/tests/runner.rs
+++ b/source/daemon/crates/wardnetd-services/src/update/tests/runner.rs
@@ -71,7 +71,7 @@ async fn runner_performs_initial_check_on_start() {
     });
     let service_dyn: Arc<dyn UpdateService> = service.clone();
     let parent = tracing::Span::none();
-    let runner = UpdateRunner::start(service_dyn, Duration::from_secs(3600), &parent);
+    let runner = UpdateRunner::start(service_dyn, Duration::from_hours(1), &parent);
 
     // Wait for the initial check.
     for _ in 0..40 {
@@ -94,7 +94,7 @@ async fn runner_shutdown_is_responsive() {
     });
     let service_dyn: Arc<dyn UpdateService> = service;
     let parent = tracing::Span::none();
-    let runner = UpdateRunner::start(service_dyn, Duration::from_secs(3600), &parent);
+    let runner = UpdateRunner::start(service_dyn, Duration::from_hours(1), &parent);
 
     tokio::time::timeout(Duration::from_secs(5), runner.shutdown())
         .await

--- a/source/daemon/crates/wardnetd/src/main.rs
+++ b/source/daemon/crates/wardnetd/src/main.rs
@@ -353,7 +353,7 @@ async fn run(
         blocklist_fetcher,
         services.event_publisher.as_ref(),
         &root_span,
-        Duration::from_secs(60),
+        Duration::from_mins(1),
     );
 
     // Start the auto-update poller. An initial check runs immediately; then
@@ -369,7 +369,7 @@ async fn run(
     // so every log line carries the daemon version.
     let backup_cleanup_runner = wardnetd_services::backup::BackupCleanupRunner::start(
         services.backup.clone(),
-        Duration::from_secs(60 * 60),
+        Duration::from_hours(1),
         wardnetd_services::backup::DEFAULT_SNAPSHOT_RETENTION,
         &root_span,
     );

--- a/source/daemon/crates/wardnetd/src/tests/tunnel_idle.rs
+++ b/source/daemon/crates/wardnetd/src/tests/tunnel_idle.rs
@@ -753,8 +753,8 @@ async fn sweep_skips_non_expired_tunnels() {
     let mut idle_since = HashMap::new();
     idle_since.insert(tunnel_id, tokio::time::Instant::now());
 
-    // Timeout is 300 seconds — nowhere near expired.
-    let timeout = Duration::from_secs(300);
+    // Timeout is 5 minutes — nowhere near expired.
+    let timeout = Duration::from_mins(5);
 
     let now = tokio::time::Instant::now();
     let mut expired = Vec::new();

--- a/source/daemon/crates/wardnetd/src/tests/tunnel_interface_wireguard.rs
+++ b/source/daemon/crates/wardnetd/src/tests/tunnel_interface_wireguard.rs
@@ -137,7 +137,7 @@ fn aggregate_picks_latest_handshake_when_later_comes_first() {
 #[test]
 fn aggregate_three_peers_with_mixed_handshakes() {
     let t1 = SystemTime::UNIX_EPOCH + Duration::from_secs(100);
-    let t2 = SystemTime::UNIX_EPOCH + Duration::from_secs(300);
+    let t2 = SystemTime::UNIX_EPOCH + Duration::from_mins(5);
     let t3 = SystemTime::UNIX_EPOCH + Duration::from_secs(200);
 
     let peers = vec![

--- a/source/daemon/fuzz/rust-toolchain.toml
+++ b/source/daemon/fuzz/rust-toolchain.toml
@@ -10,9 +10,13 @@
 # Dated pin gives reproducibility and a deliberate update cadence
 # (typical OSS-Fuzz projects bump quarterly). Bumping procedure:
 #
-#   1. Pick a recent nightly that satisfies the daemon's MSRV
-#      (rust-version = "1.94" in the workspace crates).
-#      Check dates at https://rust-lang.github.io/rustup-components-history/
+#   1. Pick a nightly from the same minor version as the daemon's
+#      stable pin (currently 1.95 — see ../rust-toolchain.toml and
+#      the workspace `rust-version`). Tracking the stable minor avoids
+#      running the fuzzer on unreleased compiler features that would
+#      never be exercised by production builds. The 1.95 nightly
+#      window was roughly 2026-01-22 → 2026-03-03; resolve a specific
+#      date at https://rust-lang.github.io/rustup-components-history/
 #   2. Update the channel below + `cargo +nightly-<date> fuzz build`
 #      locally once to confirm.
 #   3. Commit. The next fuzzing-scheduled run will pick it up.
@@ -20,5 +24,5 @@
 # Dependabot doesn't auto-bump this — no ecosystem support for
 # nightly-date pins.
 [toolchain]
-channel = "nightly-2026-04-15"
+channel = "nightly-2026-02-20"
 components = ["rust-src"]

--- a/source/daemon/rust-toolchain.toml
+++ b/source/daemon/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.94"
+channel = "1.95"
 components = ["clippy", "rustfmt"]
 targets = ["aarch64-unknown-linux-gnu"]


### PR DESCRIPTION
## Summary

Three commits, tightly related — the OSS-Fuzz fix forced a full audit of how the daemon pins Rust, the MSRV bump came out of that, and the skill captures the procedure so the next bump is a one-pass job instead of a scavenger hunt.

- **05b72ea fix(fuzz):** the OSS-Fuzz base-builder-rust image bakes `RUSTUP_TOOLCHAIN=nightly-2025-09-05` (rustc 1.91-nightly) into its container env. Per rustup's override precedence that env var beats any `rust-toolchain.toml` on disk, so every prior fix (pin the nightly in the toml, `rustup show` in build.sh) silently did nothing — `cargo fuzz build` kept resolving to the baked 1.91 and failing MSRV. Parse the channel out of `source/daemon/fuzz/rust-toolchain.toml`, install it explicitly, then re-export `RUSTUP_TOOLCHAIN` so cargo-fuzz and every nested cargo/rustc invocation pick up our pin.
- **566ba7e chore(rust):** bump stable pin 1.94 → 1.95 (current stable, released 2026-04-16) across the ten places it lives. Fuzz nightly moves to `nightly-2026-02-20` — rustc 1.95.0-nightly (7f99507f5), the last 1.95 nightly before branch-cut — to match the stable minor rather than running two unreleased compiler versions ahead for no upside. Picked up three new pedantic clippy lints along the way (`duration_suboptimal_units`, `map_unwrap_or`, `unnecessary_sort_by`) — all caught real call sites, fixed in the same commit. Dropped `(edition 2024)` from the two places it appeared; editions live ~3 years and mentioning them on every version line invites rot.
- **181bd52 chore(skills):** adds a `bump-rust` skill documenting the full procedure (pin matrix, fuzz-nightly window arithmetic, podman one-liner to resolve a date to a rustc, common new-lint rewrites), and drops `.claude/skills/` from .gitignore so project-scope skills ship with the repo like `.claude/agents/` and `.claude/agent-memory/` already do. `settings.local.json` and `scheduled_tasks.lock` stay ignored because they're per-user.

## Test plan

- [x] `make check-daemon` green (fmt + clippy `-D warnings` + full workspace test matrix, inside `rust:1.95` container)
- [x] Fuzz toolchain swap sanity-checked inside the OSS-Fuzz base image (pinned digest): rustup installs `nightly-2026-02-20`, `rustc --version` reports `1.95.0-nightly (7f99507f5 2026-02-19)`, cargo proceeds past MSRV into compilation
- [ ] CI build-daemon job
- [ ] CI coverage job
- [ ] CI security audit job
- [ ] Next scheduled ClusterFuzzLite run picks up the pin and builds without `rustc is not supported`