### PR TITLE
fix(fuzz): use target-specific RUSTFLAGS to avoid proc-macro sancov failure

### DIFF
--- a/.clusterfuzzlite/README.md
+++ b/.clusterfuzzlite/README.md
@@ -9,8 +9,10 @@ bundle archiver, SQLite restore, and bundle-manifest JSON.
 - `Dockerfile` — builds on top of `gcr.io/oss-fuzz-base/base-builder-rust`,
   copies the repo, and stages `build.sh`.
 - `build.sh` — invoked inside the image at build time. Runs
-  `cargo fuzz build -O` against `source/daemon/fuzz/` and copies the
-  resulting binaries into `$OUT/`.
+  `cargo build` (not `cargo fuzz build`) against `source/daemon/fuzz/`
+  with sanitizer flags set via target-specific `RUSTFLAGS` so
+  proc-macro crates are not instrumented, then copies the resulting
+  binaries into `$OUT/`.
 
 Fuzz targets and harnesses live at `source/daemon/fuzz/` — a
 **standalone** cargo workspace (the daemon workspace excludes it)

--- a/.clusterfuzzlite/build.sh
+++ b/.clusterfuzzlite/build.sh
@@ -9,6 +9,7 @@
 
 cd "$SRC/wardnet/source/daemon/fuzz"
 
+# ── Toolchain override ───────────────────────────────────────────
 # The OSS-Fuzz base-builder-rust image sets `RUSTUP_TOOLCHAIN` as a
 # container env var (currently nightly-2025-09-05 → rustc 1.91-nightly).
 # That env var takes precedence over rust-toolchain.toml in every
@@ -20,15 +21,53 @@ cd "$SRC/wardnet/source/daemon/fuzz"
 #
 # Parse the channel out of rust-toolchain.toml (kept as the single
 # source of truth), install it explicitly, then override the image's
-# RUSTUP_TOOLCHAIN for the rest of the script so cargo-fuzz and every
-# nested cargo/rustc invocation pick up our pin.
+# RUSTUP_TOOLCHAIN for the rest of the script so every nested
+# cargo/rustc invocation picks up our pin.
 TOOLCHAIN=$(awk -F '"' '/^channel/ {print $2}' rust-toolchain.toml)
 rustup toolchain install "$TOOLCHAIN" --profile minimal --component rust-src
 export RUSTUP_TOOLCHAIN="$TOOLCHAIN"
 
-cargo fuzz build -O
+# ── Target-specific RUSTFLAGS ────────────────────────────────────
+# cargo-fuzz sets sanitizer + coverage flags via global RUSTFLAGS,
+# which also instruments proc-macro crates (sqlx-macros, etc.).
+# Proc-macros are host-side compiler plugins loaded via dlopen —
+# they don't link against the sanitizer runtime, so symbols like
+# __sancov_lowest_stack are undefined at load time, failing the
+# build.
+#
+# Fix: bypass `cargo fuzz build` and call `cargo build` directly,
+# placing all instrumentation flags in the *target-specific*
+# CARGO_TARGET_<triple>_RUSTFLAGS so they apply only to the fuzz
+# binaries, not to proc-macros compiled for the host.
+TARGET=x86_64-unknown-linux-gnu
+
+TARGET_RUSTFLAGS=""
+TARGET_RUSTFLAGS+=" -Cpasses=sancov-module"
+TARGET_RUSTFLAGS+=" -Cllvm-args=-sanitizer-coverage-level=4"
+TARGET_RUSTFLAGS+=" -Cllvm-args=-sanitizer-coverage-inline-8bit-counters"
+TARGET_RUSTFLAGS+=" -Cllvm-args=-sanitizer-coverage-pc-table"
+TARGET_RUSTFLAGS+=" -Cllvm-args=-sanitizer-coverage-trace-compares"
+TARGET_RUSTFLAGS+=" --cfg fuzzing"
+TARGET_RUSTFLAGS+=" -Cllvm-args=-simplifycfg-branch-fold-threshold=0"
+TARGET_RUSTFLAGS+=" -Zsanitizer=address"
+TARGET_RUSTFLAGS+=" -Cllvm-args=-sanitizer-coverage-stack-depth"
+TARGET_RUSTFLAGS+=" -Ccodegen-units=1"
+TARGET_RUSTFLAGS+=" -Cdebuginfo=1"
+TARGET_RUSTFLAGS+=" -Cforce-frame-pointers"
+
+export CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUSTFLAGS="$TARGET_RUSTFLAGS"
+unset RUSTFLAGS 2>/dev/null || true
+
+export ASAN_OPTIONS="${ASAN_OPTIONS:+$ASAN_OPTIONS:}detect_odr_violation=0"
+
+cargo build \
+    --manifest-path Cargo.toml \
+    --target "$TARGET" \
+    --release \
+    --config 'profile.release.debug="line-tables-only"' \
+    --bins
 
 FUZZ_TARGETS=(archiver_unpack sqlite_restore bundle_manifest)
 for target in "${FUZZ_TARGETS[@]}"; do
-    cp "target/x86_64-unknown-linux-gnu/release/${target}" "$OUT/"
+    cp "target/${TARGET}/release/${target}" "$OUT/"
 done


### PR DESCRIPTION
## Problem

`cargo fuzz build` applies sanitizer coverage flags via global `RUSTFLAGS`, which instruments **all** crates — including proc-macros like `sqlx-macros`. Proc-macros are host-side compiler plugins loaded via `dlopen`; they do not link against the sanitizer runtime, so `__sancov_lowest_stack` (introduced by `-sanitizer-coverage-stack-depth`) is undefined at load time.

## Fix

Bypass `cargo fuzz build` and call `cargo build` directly, placing all instrumentation flags in `CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUSTFLAGS` (target-specific) so they apply only to the fuzz binaries, not to proc-macros compiled for the host.

The flags replicate exactly what cargo-fuzz 0.13.x would generate for `cargo fuzz build -O` on Linux with address sanitizer.

## What changed

- `.clusterfuzzlite/build.sh` — replaced `cargo fuzz build -O` with a direct `cargo build` call using target-specific RUSTFLAGS
- `.clusterfuzzlite/README.md` — updated the build description