### PR TITLE
fix(ci): scope workflow write permissions to the jobs that need them

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,14 +21,11 @@ on:
   push:
     branches: [main]
 
-# Workflow-level permissions must be the union of every leaf's
-# declared permissions (called reusable workflows must be a subset of
-# the caller). `security-events: write` is for build-daemon's clippy
-# SARIF upload.
+# Workflow-level permissions stay read-only. Each job/leaf elevates
+# to the writes it actually needs via its own `permissions:` block —
+# Scorecard's Token-Permissions check rewards this scoping.
 permissions:
   contents: read
-  actions: read
-  security-events: write
 
 env:
   CARGO_TERM_COLOR: always
@@ -60,6 +57,14 @@ jobs:
     name: Build Daemon
     needs: preflight
     if: needs.preflight.outputs.daemon == 'true' || needs.preflight.outputs.ci == 'true'
+    # build-daemon.yml's `check-daemon` job uploads clippy SARIF to
+    # Code Scanning — it needs `security-events: write` granted by the
+    # caller. Scoped here (not at workflow-level) so the rest of the
+    # run stays read-only.
+    permissions:
+      contents: read
+      actions: read
+      security-events: write
     uses: ./.github/workflows/build-daemon.yml
     secrets: inherit
 

--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -19,8 +19,6 @@ on:
 
 permissions:
   contents: read
-  pages: write
-  id-token: write
 
 concurrency:
   group: pages
@@ -34,6 +32,13 @@ jobs:
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
+    permissions:
+      # `pages: write` + `id-token: write` scoped to this job — needed
+      # by actions/deploy-pages. Top-level stays read-only so
+      # Scorecard's Token-Permissions check doesn't flag the workflow.
+      contents: read
+      pages: write
+      id-token: write
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -22,14 +22,11 @@ on:
     branches: [main]
   workflow_call:
 
-# Workflow-level permissions must be the union of every leaf's
-# declared permissions — GitHub requires the called reusable workflow
-# to be a subset of the caller. `security-events: write` is for
-# build-daemon's clippy SARIF upload.
+# Workflow-level permissions stay read-only. Each job/leaf elevates
+# to the writes it actually needs via its own `permissions:` block —
+# Scorecard's Token-Permissions check rewards this scoping.
 permissions:
   contents: read
-  actions: read
-  security-events: write
 
 env:
   CARGO_TERM_COLOR: always
@@ -59,6 +56,14 @@ jobs:
     name: Build Daemon
     needs: preflight
     if: needs.preflight.outputs.daemon == 'true' || needs.preflight.outputs.ci == 'true'
+    # build-daemon.yml's `check-daemon` job uploads clippy SARIF to
+    # Code Scanning — it needs `security-events: write` granted by the
+    # caller. Scoped here (not at workflow-level) so the rest of the
+    # run stays read-only.
+    permissions:
+      contents: read
+      actions: read
+      security-events: write
     uses: ./.github/workflows/build-daemon.yml
     secrets: inherit
 

--- a/.github/workflows/release-daemon.yml
+++ b/.github/workflows/release-daemon.yml
@@ -25,13 +25,18 @@ on:
         required: true
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   publish:
     name: Publish GitHub Release
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    permissions:
+      # `contents: write` scoped to this job — needed by `gh release
+      # create`. Top-level stays read-only so Scorecard's
+      # Token-Permissions check doesn't flag the workflow.
+      contents: write
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0

--- a/.github/workflows/release-image.yml
+++ b/.github/workflows/release-image.yml
@@ -30,13 +30,18 @@ on:
 
 permissions:
   contents: read
-  packages: write
 
 jobs:
   publish:
     name: Publish to GHCR
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    permissions:
+      # `packages: write` scoped to this job — the only thing that
+      # pushes to ghcr.io. Top-level stays read-only so Scorecard's
+      # Token-Permissions check doesn't flag the workflow.
+      contents: read
+      packages: write
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,20 +17,16 @@ on:
       - "v*.*.*"
   workflow_dispatch:
 
-# Workflow-level permissions must be the union of every leaf's
-# declared permissions (called reusable workflows must be a subset of
-# the caller). release.yml needs everything its leaves touch:
-#   - security-events: write  → build-daemon clippy SARIF upload
-#   - pages: write, id-token: write → deploy-site GH Pages publish
-#   - contents: write → release-daemon `gh release create`
-#   - packages: write → release-image GHCR push
+# Workflow-level permissions stay read-only. Each leaf elevates to
+# the writes it actually needs via its own `permissions:` block —
+# Scorecard's Token-Permissions check rewards this scoping. The
+# write-scoped permissions per leaf are:
+#   - build-daemon  → security-events: write (clippy SARIF upload)
+#   - deploy-site   → pages: write, id-token: write (GH Pages publish)
+#   - release-daemon → contents: write (`gh release create`)
+#   - release-image → packages: write (GHCR push)
 permissions:
-  contents: write
-  actions: read
-  security-events: write
-  pages: write
-  id-token: write
-  packages: write
+  contents: read
 
 env:
   CARGO_TERM_COLOR: always
@@ -95,6 +91,10 @@ jobs:
   build-daemon:
     name: Build Daemon
     needs: resolve
+    permissions:
+      contents: read
+      actions: read
+      security-events: write
     uses: ./.github/workflows/build-daemon.yml
     secrets: inherit
 
@@ -115,6 +115,10 @@ jobs:
     needs: [build-site, tests-e2e]
     # Dry-run (workflow_dispatch on non-tag) still deploys the site —
     # harmless, idempotent, and confirms the Pages path works.
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
     uses: ./.github/workflows/deploy-site.yml
     with:
       bundle-artifact: site-dist
@@ -127,6 +131,8 @@ jobs:
     # runs exercise the full build + sign path but stop short of the
     # `gh release create` call.
     if: startsWith(github.ref, 'refs/tags/v')
+    permissions:
+      contents: write
     uses: ./.github/workflows/release-daemon.yml
     with:
       version: ${{ needs.resolve.outputs.version }}
@@ -141,6 +147,9 @@ jobs:
     # `https://github.com/.../releases/download/v${VERSION}/...`.
     needs: [resolve, release-daemon]
     if: startsWith(github.ref, 'refs/tags/v')
+    permissions:
+      contents: read
+      packages: write
     uses: ./.github/workflows/release-image.yml
     with:
       version: ${{ needs.resolve.outputs.version }}


### PR DESCRIPTION
## Summary
Top-level \`permissions:\` blocks were granting writes (\`contents\`, \`packages\`, \`security-events\`, \`pages\`, \`id-token\`) to every job in each workflow run. OpenSSF Scorecard's Token-Permissions check flagged this as a high-severity finding across 7 open alerts in 5 workflows.

Each write is now scoped to the single job that needs it:

- \`build-daemon\` (clippy SARIF upload) → \`security-events: write\`
- \`release-daemon\` (\`gh release create\`) → \`contents: write\`
- \`release-image\` (GHCR push) → \`packages: write\`
- \`deploy-site\` (GH Pages) → \`pages: write\`, \`id-token: write\`

Workflow-level stays at \`contents: read\` everywhere. Per-job \`permissions:\` on \`uses:\` invocations propagate through to called reusable workflows, so the effective permission set per job is unchanged — only the blast radius across other jobs in the same run shrinks.

Closes the 7 open Token-Permissions Scorecard findings: #143, #84, #83, #82, #78, #77, #66.

## Test plan
- [x] All 6 touched workflows parse as valid YAML
- [ ] CI green on this PR (build-daemon's clippy SARIF still uploads — relies on the new job-level grant on caller workflows)
- [ ] Next Scorecard scan after merge clears the 7 Token-Permissions alerts

🤖 Generated with [Claude Code](https://claude.com/claude-code)