### PR TITLE
feat(image): add wardnet-base shared OS layer + GHCR publish workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -47,9 +47,13 @@ updates:
     cooldown:
       default-days: 3
 
-  # Production wardnetd image (source/daemon/Dockerfile) — pinned by
-  # digest for Scorecard / supply-chain integrity, so Dependabot is
-  # the channel that surfaces base-image updates.
+  # source/daemon/ Dockerfiles — all FROM lines are pinned by digest
+  # for Scorecard / supply-chain integrity, so Dependabot is the
+  # channel that surfaces upstream image updates.
+  #
+  #   Dockerfile        — production image (FROM wardnet-base)
+  #   Dockerfile.base   — shared OS layer (FROM debian:bookworm-slim)
+  #   Dockerfile.test   — end-to-end test image (FROM rust + wardnet-base)
   - package-ecosystem: "docker"
     directory: "/source/daemon"
     schedule:

--- a/.github/workflows/release-base-image.yml
+++ b/.github/workflows/release-base-image.yml
@@ -1,0 +1,116 @@
+name: Release Base Image
+
+# Publishes wardnet-base to ghcr.io. Updates are infrequent — base
+# image bumps land only when Debian publishes a new digest, when we
+# add or remove a runtime apt package, or when the systemd container
+# quirks change. Each publish is followed by a digest-bump PR in the
+# consuming Dockerfiles (source/daemon/Dockerfile and
+# source/daemon/Dockerfile.test).
+#
+# Triggers
+#
+# 1) workflow_dispatch — manual button. Useful for first-time setup
+#    and for ad-hoc test publishes. The dispatcher chooses the tag
+#    (default `bookworm-1`) and whether to also push `:latest`.
+#
+# 2) Tag push matching `base-v*` — `git tag base-v2 && git push --tags`
+#    triggers a build that pushes `:bookworm-2` and `:latest`.
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Image tag (e.g. bookworm-1).'
+        type: string
+        required: true
+        default: bookworm-1
+      latest:
+        description: 'Also push :latest.'
+        type: boolean
+        default: false
+  push:
+    tags:
+      - 'base-v*'
+
+# Top-level read-only — `packages: write` is escalated only on the
+# job that pushes to ghcr.io. Keeps Scorecard's Token-Permissions
+# check happy.
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    name: Publish to GHCR
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+
+      - name: Log in to GHCR
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Compute tags
+        id: tags
+        env:
+          REGISTRY: ghcr.io/${{ github.repository_owner }}/wardnet-base
+          REF: ${{ github.ref }}
+          REF_TYPE: ${{ github.ref_type }}
+          DISPATCH_TAG: ${{ inputs.tag }}
+          DISPATCH_LATEST: ${{ inputs.latest }}
+        run: |
+          set -euo pipefail
+          if [[ "${REF_TYPE}" == "tag" ]]; then
+            # base-v1 -> bookworm-1, also push :latest on tag pushes.
+            VERSION_NUM="${REF#refs/tags/base-v}"
+            BASE_TAG="bookworm-${VERSION_NUM}"
+            TAGS="${REGISTRY}:${BASE_TAG},${REGISTRY}:latest"
+          else
+            TAGS="${REGISTRY}:${DISPATCH_TAG}"
+            if [[ "${DISPATCH_LATEST}" == "true" ]]; then
+              TAGS="${TAGS},${REGISTRY}:latest"
+            fi
+          fi
+          echo "tags=${TAGS}" >> "${GITHUB_OUTPUT}"
+          echo "Computed tags: ${TAGS}"
+
+      - name: Build and push
+        id: build
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
+        with:
+          context: .
+          file: source/daemon/Dockerfile.base
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.tags.outputs.tags }}
+          # SBOM (SPDX) + SLSA provenance ride in the OCI manifest —
+          # no separate upload, no additional permissions needed.
+          sbom: true
+          provenance: mode=max
+
+      - name: Print digest
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+          OWNER: ${{ github.repository_owner }}
+        run: |
+          echo "Image digest: ${DIGEST}"
+          echo ""
+          echo "Use in consuming Dockerfiles:"
+          echo "  FROM ghcr.io/${OWNER}/wardnet-base@${DIGEST}"

--- a/Makefile
+++ b/Makefile
@@ -22,9 +22,10 @@ RUST_IMAGE   := docker.io/library/rust:1.95
 #   make image IMAGE_TAG=wardnetd:v0.2.0
 # Override IMAGE_VERSION to pin a specific release (no v-prefix):
 #   make image IMAGE_VERSION=0.2.0
-IMAGE_TAG     ?= wardnetd:dev
+IMAGE_TAG      ?= wardnetd:dev
 IMAGE_TEST_TAG ?= wardnetd:dev-test
-IMAGE_VERSION ?= latest
+IMAGE_BASE_TAG ?= wardnet-base:dev
+IMAGE_VERSION  ?= latest
 # Linux build artefacts live here (gitignored, persists on host for
 # incremental compilation). Separate from the macOS target/ directory.
 LINUX_TARGET := $(CURDIR)/.target-linux
@@ -43,7 +44,7 @@ COV_FMT    ?= --summary-only
         coverage-daemon coverage-daemon-native coverage-daemon-container \
         openapi check-openapi \
         fmt clippy test \
-        image image-multiarch image-test \
+        image image-multiarch image-test image-base \
         run-dev run-dev-daemon run-dev-web \
         sync-version check-version \
         clean help
@@ -340,6 +341,18 @@ image-test:
 		-t $(IMAGE_TEST_TAG) \
 		.
 
+# Build the wardnet-base image locally. Published copies of this image
+# live on GHCR (see .github/workflows/release-base-image.yml); use this
+# target to validate Dockerfile.base changes before tagging a base-vN
+# release. The consuming Dockerfiles pin GHCR digests, not the local
+# tag, so this target is for inspection / iteration.
+image-base:
+	@test -n "$(CONTAINER_RT)" || { echo "Error: podman or docker is required"; exit 1; }
+	$(CONTAINER_RT) build \
+		-f source/daemon/Dockerfile.base \
+		-t $(IMAGE_BASE_TAG) \
+		.
+
 # ---------- Utilities ----------
 
 clean:
@@ -380,6 +393,8 @@ help:
 	@echo "  image-multiarch  Build multi-arch image via buildx (amd64 + arm64; no local load)"
 	@echo "  image-test     Build end-to-end test image (wardnet-test-agent on wardnetd:dev)"
 	@echo "                 Requires 'make image' to have produced wardnetd:dev first."
+	@echo "  image-base     Build wardnet-base locally (Dockerfile.base inspection)."
+	@echo "                 Released copies live on ghcr.io; consuming Dockerfiles pin digests."
 	@echo ""
 	@echo "  sync-version   Propagate ./VERSION into daemon Cargo.toml + package.json files"
 	@echo "  check-version  Verify all versioned files match ./VERSION (CI gate)"

--- a/source/daemon/Dockerfile.base
+++ b/source/daemon/Dockerfile.base
@@ -1,0 +1,77 @@
+# syntax=docker/dockerfile:1
+#
+# wardnet-base — shared OS layer for the wardnetd production image and
+# the end-to-end test image.
+#
+# Contains the apt + systemd setup that is identical across both
+# downstream images:
+#   - debian:bookworm-slim (pinned by digest, watched by Dependabot)
+#   - apt: systemd, systemd-sysv, iproute2, nftables, wireguard-tools,
+#          ca-certificates, wget, curl, minisign
+#   - cleanup of default-enabled systemd units that don't run inside a
+#     container (hardware enumeration, real-disk remounts, ...)
+#   - container drop-in for wardnetd.service that disables
+#     ProtectSystem=strict + PrivateTmp=yes (those need CAP_SYS_ADMIN,
+#     which Docker strips from its default capset)
+#   - EXPOSE for wardnet's runtime ports + STOPSIGNAL + systemd as PID 1
+#
+# wardnetd itself is NOT installed here. install.sh runs in the
+# consuming image (source/daemon/Dockerfile or Dockerfile.test).
+#
+# Build:
+#   docker build -f source/daemon/Dockerfile.base -t wardnet-base:bookworm-1 .
+#
+# Publish: .github/workflows/release-base-image.yml pushes multi-arch
+# (linux/amd64 + linux/arm64) to ghcr.io/wardnet/wardnet-base. Tag the
+# bump commit `base-vN` (e.g. `base-v1`) and push to trigger.
+
+# Pinned by digest. Dependabot watches this via .github/dependabot.yml.
+FROM debian:bookworm-slim@sha256:f9c6a2fd2ddbc23e336b6257a5245e31f996953ef06cd13a59fa0a1df2d5c252
+
+# Single-layer apt setup so the package cache and lists don't persist
+# in intermediate layers.
+#
+# wget stays for HEALTHCHECK in the prod image; curl + minisign are
+# needed by install.sh's --from path (signature verification + the
+# release-tarball download in the prod image).
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        systemd \
+        systemd-sysv \
+        iproute2 \
+        nftables \
+        wireguard-tools \
+        ca-certificates \
+        wget \
+        curl \
+        minisign \
+    && rm -rf /var/lib/apt/lists/* \
+    # Remove default-enabled systemd units that cannot work inside a
+    # container. wardnetd is enabled by install.sh in the consuming
+    # image (which runs after this base layer).
+    && rm -f \
+        /lib/systemd/system/multi-user.target.wants/* \
+        /etc/systemd/system/*.wants/* \
+        /lib/systemd/system/local-fs.target.wants/* \
+        /lib/systemd/system/sockets.target.wants/*udev* \
+        /lib/systemd/system/sockets.target.wants/*initctl* \
+        /lib/systemd/system/sysinit.target.wants/* \
+        /lib/systemd/system/systemd-remount-fs.service
+
+# Container drop-in for wardnetd.service. The directory
+# /etc/systemd/system/wardnetd.service.d/ is created and populated here
+# even though wardnetd.service itself is dropped later by install.sh —
+# systemd reads the drop-in at unit-load time.
+RUN mkdir -p /etc/systemd/system/wardnetd.service.d \
+    && printf '[Service]\nProtectSystem=no\nPrivateTmp=no\n' \
+        > /etc/systemd/system/wardnetd.service.d/container.conf \
+    && chmod 0644 /etc/systemd/system/wardnetd.service.d/container.conf
+
+# DNS (53/tcp+udp), DHCP (67/udp), daemon API + embedded web UI (7411).
+# The test image layers EXPOSE 3001/tcp on top for its probe API.
+EXPOSE 53/udp 53/tcp 67/udp 7411/tcp
+
+# systemd's graceful-shutdown signal when running as PID 1.
+STOPSIGNAL SIGRTMIN+3
+
+CMD ["/lib/systemd/systemd"]

--- a/source/daemon/Dockerfile.base.dockerignore
+++ b/source/daemon/Dockerfile.base.dockerignore
@@ -1,0 +1,7 @@
+# Scoped to source/daemon/Dockerfile.base only.
+#
+# The base image has no COPY directives — its contents are entirely
+# from apt + RUN. Excluding everything keeps the build context tiny so
+# `docker build` doesn't upload the whole repo to the daemon for
+# nothing.
+*


### PR DESCRIPTION
## Summary

PR 2 of the multi-PR image refactor. Introduces \`source/daemon/Dockerfile.base\`, the shared apt + systemd setup currently duplicated between the production Dockerfile and the (Stage 5) end-to-end test Dockerfile. Both will eventually \`FROM ghcr.io/wardnet/wardnet-base@<digest>\` so the duplicated apt install / systemd cleanup / container drop-in lives in exactly one place.

This PR is **infra only** — it does not change either consuming Dockerfile yet. Follow-up PRs (3a for Dockerfile.test, 3b for prod Dockerfile) will pin the published digest and remove the duplicated setup.

### What's in the base image

- \`debian:bookworm-slim\` (pinned by sha256, watched by Dependabot)
- apt: \`systemd systemd-sysv iproute2 nftables wireguard-tools ca-certificates wget curl minisign\`
- systemd-unit cleanup (the \`rm -f /lib/systemd/system/...\` block)
- container drop-in for \`wardnetd.service.d/container.conf\` (disables \`ProtectSystem=strict\` + \`PrivateTmp=yes\` since both need \`CAP_SYS_ADMIN\`)
- \`EXPOSE 53/udp 53/tcp 67/udp 7411/tcp\`, \`STOPSIGNAL SIGRTMIN+3\`, \`CMD ["/lib/systemd/systemd"]\`

### Publishing

\`.github/workflows/release-base-image.yml\` pushes multi-arch (linux/amd64 + linux/arm64) to \`ghcr.io/wardnet/wardnet-base\`. Triggers:

1. \`workflow_dispatch\` — manual button. Inputs: \`tag\` (default \`bookworm-1\`), \`latest\` (default false).
2. Tag push matching \`base-v*\` — \`git tag base-v1 && git push --tags\` builds and pushes \`:bookworm-1\` + \`:latest\`.

The job is \`packages: write\` scoped at the job level only; top-level stays \`contents: read\`. SBOM (SPDX) and SLSA provenance attestations ride in the OCI manifest.

### Bootstrap step (after merge)

1. Merge this PR.
2. Trigger the workflow once via the Actions UI (\`workflow_dispatch\` with default inputs).
3. Capture the printed digest from the \`Print digest\` step output.
4. Set the GHCR package's visibility to public.
5. Open PR 3a (Dockerfile.test refactor) using the captured digest.

## Test plan

- [x] \`actionlint .github/workflows/release-base-image.yml\` clean.
- [x] \`make image-base\` builds locally on macOS/podman.
- [ ] After merge: trigger \`Release Base Image\` via \`workflow_dispatch\` and confirm a multi-arch manifest lands at \`ghcr.io/wardnet/wardnet-base:bookworm-1\`.
- [ ] After publish: confirm the package is public on GHCR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)