### PR TITLE
fix(image): Dockerfile.test FROM wardnet-base@digest

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -331,10 +331,17 @@ image-multiarch:
 		-f source/daemon/Dockerfile \
 		.
 
-# Build the end-to-end test image (wardnet-test-agent on top of wardnetd:dev).
-# Requires `make image` to have produced $(IMAGE_TAG) first; the Dockerfile
-# layers FROM wardnetd:dev so the daemon and the test agent share one container.
-image-test:
+# Build the end-to-end test image. Self-contained: compiles wardnetd
+# + wardnet-test-agent from local sources, signs a synthetic release
+# tarball with an ephemeral minisign key, and runs install.sh against
+# it on top of the published wardnet-base image (pinned by digest).
+# No dependency on `make image` — the prod and test images share an
+# OS layer (wardnet-base) but not a build chain.
+#
+# Depends on `build-web` so source/web-ui/dist/ exists; wardnetd's
+# rust-embed annotation pulls those static assets into the daemon
+# binary at compile time.
+image-test: build-web
 	@test -n "$(CONTAINER_RT)" || { echo "Error: podman or docker is required"; exit 1; }
 	$(CONTAINER_RT) build \
 		-f source/daemon/Dockerfile.test \
@@ -391,8 +398,9 @@ help:
 	@echo "                 make image IMAGE_VERSION=0.2.0          (specific version)"
 	@echo "                 make image IMAGE_TAG=wardnetd:v0.2.0"
 	@echo "  image-multiarch  Build multi-arch image via buildx (amd64 + arm64; no local load)"
-	@echo "  image-test     Build end-to-end test image (wardnet-test-agent on wardnetd:dev)"
-	@echo "                 Requires 'make image' to have produced wardnetd:dev first."
+	@echo "  image-test     Build end-to-end test image (self-contained: compiles wardnetd"
+	@echo "                 + wardnet-test-agent from sources, signs a synthetic release"
+	@echo "                 with an ephemeral key, runs install.sh on top of wardnet-base)."
 	@echo "  image-base     Build wardnet-base locally (Dockerfile.base inspection)."
 	@echo "                 Released copies live on ghcr.io; consuming Dockerfiles pin digests."
 	@echo ""

--- a/source/daemon/Dockerfile.test
+++ b/source/daemon/Dockerfile.test
@@ -1,37 +1,122 @@
 # syntax=docker/dockerfile:1
 #
-# wardnetd test image -- adds the wardnet-test-agent binary and a systemd unit
-# that starts it on boot. Built FROM wardnetd:dev so the daemon and test agent
-# share a single container; end-to-end tests query the agent over HTTP and
-# look at the same kernel state the daemon manipulates.
+# wardnetd test image — adds the wardnet-test-agent binary on top of a
+# self-contained wardnetd install. End-to-end tests query the agent
+# over HTTP and inspect the same kernel state the daemon manipulates.
+#
+# Self-contained build: this image does NOT pull a signed release from
+# GitHub. It compiles wardnetd + the test-agent from local sources,
+# packages wardnetd into the same release-tarball layout install.sh
+# consumes, signs it with an ephemeral minisign key generated during
+# the build, and runs the unmodified install.sh against that bundle.
+# That way the test image exercises the real install path end-to-end
+# (binary placement, user/group setup, systemd unit drop, signature
+# verification) while still being buildable from a PR branch where no
+# release tag exists.
 #
 # Build context: repo root
 #   docker build -f source/daemon/Dockerfile.test -t wardnetd:dev-test .
-#   make image-test            (after `make image`)
-#
-# The test agent listens on :3001 by default and is enabled at install time,
-# so it starts automatically when systemd comes up as PID 1.
+#   make image-test            (builds source/web-ui/dist first)
 
-# ---- Builder stage: compile wardnet-test-agent from source ----
+# ---- Builder stage: compile wardnetd + wardnet-test-agent ----
 # Pinned by digest for supply-chain integrity. Matches the workspace
 # rust-version in source/daemon/rust-toolchain.toml.
 FROM rust:1.95-slim-bookworm@sha256:caaf9ca7acd474892186860307d6f28e51fdbc1a4eada459fcff81517cf46a36 AS builder
 
+# minisign is needed at build time to generate the ephemeral signing
+# key + sign the synthetic release tarball that install.sh consumes.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends minisign \
+    && rm -rf /var/lib/apt/lists/*
+
 WORKDIR /build
+# Rust workspace lives at /build; the web-ui/dist tree must be at
+# /web-ui/dist so wardnetd-api's `#[folder = "../../../web-ui/dist"]`
+# rust-embed annotation resolves correctly from
+# /build/crates/wardnetd-api/. /deploy/keys/wardnet-release.pub is
+# baked into wardnetd-services via include_str! against a six-level
+# relative path that walks back to the repo root, so the deploy tree
+# must mirror its repo location too.
 COPY source/daemon/ /build/
+COPY source/web-ui/dist/ /web-ui/dist/
+# wardnetd-api also `include_bytes!`s web-ui/src/assets/logo.png (the
+# OpenAPI swagger logo). Same anchor reasoning as web-ui/dist.
+COPY source/web-ui/src/assets/ /web-ui/src/assets/
+COPY deploy/ /deploy/
 
-# Build only the test-agent crate (and its workspace deps). Release profile
-# matches the daemon image so binary size is comparable.
-RUN cargo build --release -p wardnet-test-agent \
-    && strip target/release/wardnet-test-agent
+# Default to a synthetic dev version when no release tag exists.
+# install.sh extracts the version from the tarball filename, so any
+# value that round-trips through `wardnetd-<version>-<arch>.tar.gz`
+# works.
+ARG WARDNET_VERSION=0.0.0-dev
 
-# ---- Final stage: layer onto the dev daemon image ----
-FROM wardnetd:dev
+RUN cargo build --release -p wardnetd -p wardnet-test-agent \
+    && strip target/release/wardnetd target/release/wardnet-test-agent
 
-# `dig` (DNS probe), `iputils-ping`, `isc-dhcp-client` are needed by the
-# `client` subcommands when this image is reused as a generic test client
-# (Stage 6 docker-compose). They are negligible in size and not in the
-# production image's surface.
+# Build the synthetic release bundle that install.sh --from consumes:
+# tarball + sha256 + minisig + the two systemd units. The signing key
+# is generated here, used to sign the tarball, then the private half
+# is dropped — only the public key leaves this stage so the runtime
+# stage can patch it into install.sh's embedded MINISIGN_PUBLIC_KEY.
+RUN <<"EOF" bash
+set -euo pipefail
+case "$(uname -m)" in
+    aarch64|arm64) ARCH=aarch64 ;;
+    x86_64|amd64)  ARCH=x86_64 ;;
+    *) echo "unsupported arch: $(uname -m)" >&2; exit 1 ;;
+esac
+mkdir -p /tmp/local-bundle
+TARBALL="wardnetd-${WARDNET_VERSION}-${ARCH}.tar.gz"
+
+# Stage the tarball contents (only the wardnetd binary; install.sh
+# expects to find it at the root of the archive).
+STAGE=$(mktemp -d)
+cp target/release/wardnetd "$STAGE/wardnetd"
+tar -C "$STAGE" -czf "/tmp/local-bundle/${TARBALL}" wardnetd
+rm -rf "$STAGE"
+
+# SHA-256 sidecar. install.sh reads the hash with `awk '{print $1}'`,
+# so the standard `sha256sum` two-column format works as-is.
+( cd /tmp/local-bundle && sha256sum "${TARBALL}" > "${TARBALL}.sha256" )
+
+# Ephemeral minisign keypair. -W = no password (prompt-free); -f =
+# overwrite if a key file already exists. Kept under /tmp so the
+# private key cannot leak into a runtime layer even by accident.
+minisign -G -W -f \
+    -p /tmp/local-bundle/local-bundle.pub \
+    -s /tmp/local-bundle/local-bundle.key
+
+# Sign the tarball. -t pins the trusted comment so install.sh's
+# verification produces stable output across rebuilds.
+minisign -S -W \
+    -s /tmp/local-bundle/local-bundle.key \
+    -t "wardnet-test-image local build" \
+    -m "/tmp/local-bundle/${TARBALL}"
+
+# Bundle the systemd units alongside the tarball — install.sh's
+# --from path looks them up next to the archive.
+cp /deploy/wardnetd.service /deploy/wardnetd-rollback.service /tmp/local-bundle/
+
+# Drop the private key. The public key stays so the runtime stage
+# can patch install.sh's embedded MINISIGN_PUBLIC_KEY before invoking
+# the script.
+rm -f /tmp/local-bundle/local-bundle.key
+EOF
+
+# ---- Runtime stage: layer onto wardnet-base + run install.sh ----
+# wardnet-base provides debian:bookworm-slim + apt: systemd,
+# systemd-sysv, iproute2, nftables, wireguard-tools, ca-certificates,
+# wget, curl, minisign + the systemd unit cleanup + the wardnetd
+# container drop-in + EXPOSE 53/53/67/7411 + STOPSIGNAL +
+# CMD ["/lib/systemd/systemd"]. Pinned by the multi-arch index digest
+# so the per-arch manifest is selected at pull time.
+# Source: ghcr.io/wardnet/wardnet-base:bookworm-1
+FROM ghcr.io/wardnet/wardnet-base@sha256:ba478f4a8b6441af3ebe8b3b4918d44040905a4b92dcefaf0d150eede8aad53b
+
+# Test-only client tooling: dig (DNS probe), ping (reachability),
+# dhclient (lease renew). Not in wardnet-base because the prod image
+# doesn't need them; they only exist for the wardnet-test-agent client
+# subcommands that the end-to-end suite drives.
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         dnsutils \
@@ -39,6 +124,50 @@ RUN apt-get update \
         isc-dhcp-client \
     && rm -rf /var/lib/apt/lists/*
 
+# install.sh + service units copied from the repo (online manifest
+# fetch is not used; --from overrides it). The bundle from the
+# builder stage carries the tarball + signatures.
+COPY deploy/ /tmp/wardnet-deploy/
+COPY --from=builder /tmp/local-bundle /tmp/local-bundle/
+
+# Run install.sh against the local bundle. Two pre-steps:
+#   1. Patch the embedded MINISIGN_PUBLIC_KEY with the ephemeral
+#      pubkey so signature verification accepts the locally-signed
+#      tarball. The pub file from `minisign -G` is the same two-line
+#      format install.sh expects (untrusted-comment + base64 body).
+#   2. LAN_INTERFACE=eth0 short-circuits the interactive prompt; the
+#      value is irrelevant inside the test container (the daemon's
+#      LAN attach is reconfigured by the e2e compose), but install.sh
+#      requires *something*.
+#
+# After the install, scrub the bundle + deploy dir + apt-purge
+# build-only deps. minisign stays purged in this image — the prod
+# Dockerfile keeps it for auto-update; the test image has no
+# auto-update path so it can be removed.
+RUN <<"EOF" bash
+set -euo pipefail
+awk -v pub="$(cat /tmp/local-bundle/local-bundle.pub)" '
+    /^MINISIGN_PUBLIC_KEY='\''/ { print "MINISIGN_PUBLIC_KEY='\''" pub "'\''"; skip=1; next }
+    skip && /'\''[[:space:]]*$/ { skip=0; next }
+    skip { next }
+    { print }
+' /tmp/wardnet-deploy/install.sh > /tmp/install.sh.new
+mv /tmp/install.sh.new /tmp/wardnet-deploy/install.sh
+chmod +x /tmp/wardnet-deploy/install.sh
+
+LAN_INTERFACE=eth0 bash /tmp/wardnet-deploy/install.sh \
+    --from /tmp/local-bundle \
+    --container-mode
+
+apt-get purge -y minisign
+apt-get autoremove -y
+rm -rf /tmp/local-bundle /tmp/wardnet-deploy /var/lib/apt/lists/*
+EOF
+
+# Drop in the test-agent binary + systemd unit. The unit is enabled
+# via a manual symlink because systemctl is not running during the
+# image build; systemd will start the service when it initialises as
+# PID 1 at container runtime, alongside wardnetd.service.
 COPY --from=builder /build/target/release/wardnet-test-agent /usr/local/bin/wardnet-test-agent
 COPY source/daemon/packaging/test-agent/wardnet-test-agent.service \
     /etc/systemd/system/wardnet-test-agent.service
@@ -48,4 +177,7 @@ RUN chmod 0755 /usr/local/bin/wardnet-test-agent \
     && ln -s /etc/systemd/system/wardnet-test-agent.service \
         /etc/systemd/system/multi-user.target.wants/wardnet-test-agent.service
 
+# wardnet-base already exposes 53/udp 53/tcp 67/udp 7411/tcp for the
+# daemon; the test-agent's HTTP probe API listens on 3001 (see
+# source/daemon/packaging/test-agent/wardnet-test-agent.service).
 EXPOSE 3001/tcp

--- a/source/daemon/Dockerfile.test.dockerignore
+++ b/source/daemon/Dockerfile.test.dockerignore
@@ -1,0 +1,31 @@
+# Scoped to source/daemon/Dockerfile.test only. BuildKit picks up
+# <dockerfile>.dockerignore alongside the Dockerfile and uses it in
+# preference to any context-root .dockerignore.
+#
+# The test Dockerfile compiles the Rust workspace from local sources,
+# embeds source/web-ui/dist/ via rust-embed, and runs deploy/install.sh
+# against a synthetic release bundle. Everything else in the repo is
+# noise — exclude build artefacts, IDE state, and unrelated workspaces
+# to keep the build context small and avoid cache invalidation when
+# files outside the daemon scope change.
+
+# Default-deny, then allow the three trees the Dockerfile copies.
+*
+
+!source/daemon/
+!source/web-ui/dist/
+!source/web-ui/src/assets/
+!deploy/
+
+# Re-deny build artefacts inside the allowed trees. These are large
+# (Rust target/, node_modules/) and bust the build cache on every
+# touch even when the Dockerfile inputs haven't changed.
+source/daemon/target/
+source/daemon/.target-linux/
+source/daemon/fuzz/target/
+source/daemon/fuzz/corpus/
+source/daemon/fuzz/artifacts/
+**/node_modules/
+**/.DS_Store
+.git/
+.target-linux/


### PR DESCRIPTION
## Summary

- Closes the OpenSSF Scorecard pinned-deps alert that flagged the original `Dockerfile.test`'s `FROM wardnetd:dev` (locally-built tag, no digest, drifts on every `make image`).
- Layers onto the published `ghcr.io/wardnet/wardnet-base` image, pinned by its multi-arch index digest. Apt + systemd setup is no longer duplicated with `source/daemon/Dockerfile`; `wardnet-base` is the single source of truth for the OS layer shared by both downstream images.
- Self-contained: compiles `wardnetd` + `wardnet-test-agent` from local sources, packages `wardnetd` into the release-tarball layout `install.sh` consumes, signs it with an ephemeral `minisign` keypair generated during the build, patches the embedded `MINISIGN_PUBLIC_KEY` in `install.sh` with the matching pubkey, then runs the unmodified `install.sh --from --container-mode` against that synthetic bundle. The test image therefore exercises the real install path end-to-end (binary placement, user/group, systemd unit drop, sha256 + minisign verification) without depending on an external release tag, so it builds from any PR branch.
- Test-only tooling — `dnsutils`, `iputils-ping`, `isc-dhcp-client` — is layered on top of `wardnet-base` because the `wardnet-test-agent client` subcommands (added in #199) need `dig`, `ping`, and `dhclient`. Those packages aren't in `wardnet-base` because the prod image doesn't need them.

## Files

- `source/daemon/Dockerfile.test` — full rewrite as a multi-stage build (rust:1.95 builder + `wardnet-base@sha256` runtime).
- `source/daemon/Dockerfile.test.dockerignore` — new. Allows `source/daemon/`, `source/web-ui/dist/` + asset bytes embedded by `wardnetd-api`, and `deploy/`. Excludes Rust `target/`, `node_modules/`, fuzz artefacts, and `.git/`.
- `Makefile` — `image-test` now depends on `build-web` (rust-embed needs `source/web-ui/dist/`) and no longer requires `make image` to have run. The prod and test images stop sharing a build chain. Help text updated.

## Test plan

- [x] `make build-web` succeeds.
- [x] `make image-test` succeeds without `make image` first; `install.sh` reports "SHA-256 verified" + "minisign signature verified" + creates the `wardnetd.service` symlink in `multi-user.target.wants/`.
- [x] `make check-daemon` passes.
- [ ] Linux CI runtime smoke (next session, as part of PR4): bring the image up, confirm `/run/wardnetd.pid` populates and `wardnet-test-agent` is reachable on `:3001`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)