### PR TITLE
feat(test): LAN clients + DHCP scenarios on the e2e topology

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -386,7 +386,12 @@ end2end-daemon: image-test
 	        $(CONTAINER_RT) inspect "$$cid" >> '"$$REPORTS"'/inspect.json 2>&1 || true; \
 	      done; \
 	      $(CONTAINER_RT) compose -f $(E2E_DAEMON_COMPOSE) down -v --remove-orphans' EXIT; \
-	$(CONTAINER_RT) compose -f $(E2E_DAEMON_COMPOSE) up -d --build --wait wardnetd test_debian test_ubuntu; \
+	$(CONTAINER_RT) compose -f $(E2E_DAEMON_COMPOSE) up -d --build --wait wardnetd; \
+	$(CONTAINER_RT) compose -f $(E2E_DAEMON_COMPOSE) up -d --build --wait test_debian test_ubuntu || \
+	    echo "warning: client services not healthy; running vitest anyway so failures surface as assertions"; \
+	echo "::group::compose ps before vitest"; \
+	$(CONTAINER_RT) compose -f $(E2E_DAEMON_COMPOSE) ps -a; \
+	echo "::endgroup::"; \
 	$(CONTAINER_RT) compose -f $(E2E_DAEMON_COMPOSE) run --rm test_runner
 
 # ---------- Utilities ----------

--- a/Makefile
+++ b/Makefile
@@ -386,7 +386,7 @@ end2end-daemon: image-test
 	        $(CONTAINER_RT) inspect "$$cid" >> '"$$REPORTS"'/inspect.json 2>&1 || true; \
 	      done; \
 	      $(CONTAINER_RT) compose -f $(E2E_DAEMON_COMPOSE) down -v --remove-orphans' EXIT; \
-	$(CONTAINER_RT) compose -f $(E2E_DAEMON_COMPOSE) up -d --build --wait wardnetd; \
+	$(CONTAINER_RT) compose -f $(E2E_DAEMON_COMPOSE) up -d --build --wait wardnetd test_debian test_ubuntu; \
 	$(CONTAINER_RT) compose -f $(E2E_DAEMON_COMPOSE) run --rm test_runner
 
 # ---------- Utilities ----------

--- a/source/daemon/crates/wardnet-test-agent/src/client/dhcp.rs
+++ b/source/daemon/crates/wardnet-test-agent/src/client/dhcp.rs
@@ -19,20 +19,45 @@ impl DhcpClient {
         }
     }
 
-    fn release_args(self, iface: &str) -> Vec<String> {
+    fn release_args(self, iface: &str, script: Option<&str>) -> Vec<String> {
         match self {
-            Self::Dhclient => vec!["-r".to_owned(), iface.to_owned()],
+            Self::Dhclient => {
+                let mut args = Vec::with_capacity(4);
+                if let Some(s) = script {
+                    args.push("-sf".to_owned());
+                    args.push(s.to_owned());
+                }
+                args.push("-r".to_owned());
+                args.push(iface.to_owned());
+                args
+            }
+            // dhcpcd's interface-config plumbing isn't script-driven the same
+            // way; the `script` arg is dhclient-only.
             Self::Dhcpcd => vec!["-k".to_owned(), iface.to_owned()],
         }
     }
 
-    fn renew_args(self, iface: &str) -> Vec<String> {
+    fn renew_args(self, iface: &str, script: Option<&str>) -> Vec<String> {
         match self {
-            Self::Dhclient => vec![iface.to_owned()],
+            Self::Dhclient => {
+                let mut args = Vec::with_capacity(3);
+                if let Some(s) = script {
+                    args.push("-sf".to_owned());
+                    args.push(s.to_owned());
+                }
+                args.push(iface.to_owned());
+                args
+            }
             Self::Dhcpcd => vec!["-n".to_owned(), iface.to_owned()],
         }
     }
 }
+
+/// Env var that points at a custom dhclient script. The e2e client
+/// images set this to a script that adds the leased IP without
+/// flushing the docker-IPAM-assigned address. Unset in any other
+/// context, so dhclient falls back to its default `/sbin/dhclient-script`.
+const DHCLIENT_SCRIPT_ENV: &str = "WARDNET_TEST_DHCLIENT_SCRIPT";
 
 #[derive(Debug, Args)]
 pub struct DhcpRenewArgs {
@@ -53,15 +78,17 @@ pub async fn run(args: DhcpRenewArgs) -> Result<DhcpRenewResponse, ClientError> 
     }
 
     let bin = args.client.binary();
+    let script = std::env::var(DHCLIENT_SCRIPT_ENV).ok();
+    let script_ref = script.as_deref();
 
     let release = Command::new(bin)
-        .args(args.client.release_args(&args.interface))
+        .args(args.client.release_args(&args.interface, script_ref))
         .output()
         .await
         .map_err(|e| ClientError::new(format!("failed to run {bin} release: {e}")))?;
 
     let renew = Command::new(bin)
-        .args(args.client.renew_args(&args.interface))
+        .args(args.client.renew_args(&args.interface, script_ref))
         .output()
         .await
         .map_err(|e| ClientError::new(format!("failed to run {bin} renew: {e}")))?;

--- a/source/daemon/crates/wardnet-test-agent/src/client/dhcp.rs
+++ b/source/daemon/crates/wardnet-test-agent/src/client/dhcp.rs
@@ -6,7 +6,7 @@ use tokio::process::Command;
 use super::models::{ClientError, DhcpRenewResponse};
 
 #[derive(Debug, Clone, Copy, ValueEnum)]
-enum DhcpClient {
+pub enum DhcpClient {
     Dhclient,
     Dhcpcd,
 }
@@ -37,11 +37,11 @@ impl DhcpClient {
 #[derive(Debug, Args)]
 pub struct DhcpRenewArgs {
     /// Interface to renew on.
-    interface: String,
+    pub interface: String,
 
     /// DHCP client implementation to invoke.
     #[arg(long, value_enum, default_value_t = DhcpClient::Dhclient)]
-    client: DhcpClient,
+    pub client: DhcpClient,
 }
 
 pub async fn run(args: DhcpRenewArgs) -> Result<DhcpRenewResponse, ClientError> {
@@ -74,7 +74,8 @@ pub async fn run(args: DhcpRenewArgs) -> Result<DhcpRenewResponse, ClientError> 
     Ok(DhcpRenewResponse {
         interface: args.interface,
         client: bin.to_owned(),
-        success: renew.status.success(),
+        release_success: release.status.success(),
+        renew_success: renew.status.success(),
         stdout,
         stderr,
     })

--- a/source/daemon/crates/wardnet-test-agent/src/client/dns.rs
+++ b/source/daemon/crates/wardnet-test-agent/src/client/dns.rs
@@ -8,19 +8,19 @@ use super::models::{ClientError, DnsResolveResponse};
 #[derive(Debug, Args)]
 pub struct DnsResolveArgs {
     /// Name to resolve.
-    name: String,
+    pub name: String,
 
     /// DNS server to query (e.g. `127.0.0.1`). Default: system resolver.
     #[arg(long)]
-    server: Option<String>,
+    pub server: Option<String>,
 
     /// Record type (`A`, `AAAA`, `TXT`, ...). Default: `A`.
     #[arg(long, default_value = "A")]
-    record: String,
+    pub record: String,
 
     /// Query timeout in seconds.
     #[arg(long, default_value_t = 3)]
-    timeout: u32,
+    pub timeout: u32,
 }
 
 pub async fn run(args: DnsResolveArgs) -> Result<DnsResolveResponse, ClientError> {

--- a/source/daemon/crates/wardnet-test-agent/src/client/interfaces.rs
+++ b/source/daemon/crates/wardnet-test-agent/src/client/interfaces.rs
@@ -11,7 +11,7 @@ use super::models::{ClientError, Interface, InterfaceAddr, InterfacesResponse};
 pub struct InterfacesArgs {
     /// Limit output to a single interface name.
     #[arg(long)]
-    name: Option<String>,
+    pub name: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]

--- a/source/daemon/crates/wardnet-test-agent/src/client/mod.rs
+++ b/source/daemon/crates/wardnet-test-agent/src/client/mod.rs
@@ -1,9 +1,14 @@
-//! Client mode: performs a single probe operation and prints typed JSON to
-//! stdout. Designed for test runners (Vitest) that drive client containers
-//! through `docker exec wardnet-test-agent client <subcommand> ...`.
+//! Client mode: probe operations the test runner drives against
+//! containers attached to the daemon's simulated LAN. Two transports
+//! over the same handlers:
 //!
-//! All subcommands write JSON to stdout. On error, a `{ "error": "..." }`
-//! object is printed and the process exits with code 1. Logs go to stderr.
+//! * One-shot CLI subcommands (`routes`, `interfaces`, `dns-resolve`,
+//!   `ping`, `dhcp-renew`) print typed JSON to stdout and exit. Useful
+//!   for ad-hoc probes via `docker exec` and as a debugging entrypoint.
+//! * `serve` keeps the same handlers behind a long-running HTTP server.
+//!   Test client containers run `client serve --port 3001` as their
+//!   entrypoint so specs can `fetch("http://test_debian:3001/...")`
+//!   without mounting the container-runtime socket into the runner.
 
 mod dhcp;
 mod dns;
@@ -11,6 +16,7 @@ mod interfaces;
 mod models;
 mod ping;
 mod routes;
+mod serve;
 
 use clap::{Args, Subcommand};
 use serde::Serialize;
@@ -40,19 +46,28 @@ enum ClientCommand {
     Ping(ping::PingArgs),
     /// Renew the DHCP lease on an interface.
     DhcpRenew(dhcp::DhcpRenewArgs),
+    /// Run the probe handlers behind an HTTP server (long-running).
+    Serve(serve::ServeArgs),
 }
 
-/// Runs the requested client subcommand and exits the process.
+/// Runs the requested client subcommand. One-shot subcommands print
+/// JSON to stdout and exit; `serve` blocks indefinitely on the HTTP
+/// listener and returns only on a fatal error.
 pub async fn run(args: ClientArgs) -> ! {
+    let pretty = args.pretty;
     let result: Result<Box<dyn ErasedSerialize>, ClientError> = match args.command {
         ClientCommand::Routes(a) => routes::run(a).await.map(boxed),
         ClientCommand::Interfaces(a) => interfaces::run(a).await.map(boxed),
         ClientCommand::DnsResolve(a) => dns::run(a).await.map(boxed),
         ClientCommand::Ping(a) => ping::run(a).await.map(boxed),
         ClientCommand::DhcpRenew(a) => dhcp::run(a).await.map(boxed),
+        ClientCommand::Serve(a) => {
+            serve::run(a).await;
+            std::process::exit(0);
+        }
     };
 
-    let code = emit(result.as_deref(), args.pretty);
+    let code = emit(result.as_deref(), pretty);
     std::process::exit(code);
 }
 

--- a/source/daemon/crates/wardnet-test-agent/src/client/models.rs
+++ b/source/daemon/crates/wardnet-test-agent/src/client/models.rs
@@ -109,7 +109,17 @@ pub struct PingResponse {
 pub struct DhcpRenewResponse {
     pub interface: String,
     pub client: String,
-    pub success: bool,
+    /// Exit status of the release step (`dhclient -r`, `dhcpcd -k`).
+    /// On a fresh interface with no prior lease this can be non-zero
+    /// without indicating a real failure — callers that want strict
+    /// behavior should check both this and `renew_success`.
+    pub release_success: bool,
+    /// Exit status of the renew step (`dhclient`, `dhcpcd -n`). The
+    /// previous shape exposed only this as a single `success` field;
+    /// dropping `release_success` masked release failures that
+    /// silently caused dhclient to re-use a cached lease instead of
+    /// issuing a fresh DISCOVER.
+    pub renew_success: bool,
     pub stdout: String,
     pub stderr: String,
 }

--- a/source/daemon/crates/wardnet-test-agent/src/client/ping.rs
+++ b/source/daemon/crates/wardnet-test-agent/src/client/ping.rs
@@ -11,19 +11,19 @@ use super::models::{ClientError, PingResponse};
 #[derive(Debug, Args)]
 pub struct PingArgs {
     /// Host or IP to ping.
-    target: String,
+    pub target: String,
 
     /// Number of echo requests to send.
     #[arg(short, long, default_value_t = 3)]
-    count: u32,
+    pub count: u32,
 
     /// Timeout per probe in seconds.
     #[arg(long, default_value_t = 2)]
-    timeout: u32,
+    pub timeout: u32,
 
     /// Source interface (`-I <iface>`).
     #[arg(short = 'I', long)]
-    interface: Option<String>,
+    pub interface: Option<String>,
 }
 
 /// `5 packets transmitted, 5 received, 0% packet loss, time 4006ms`

--- a/source/daemon/crates/wardnet-test-agent/src/client/routes.rs
+++ b/source/daemon/crates/wardnet-test-agent/src/client/routes.rs
@@ -10,7 +10,7 @@ use super::models::{ClientError, Route, RoutesResponse};
 pub struct RoutesArgs {
     /// Optional table to query (e.g. `main`, `100`). Default: `main`.
     #[arg(long)]
-    table: Option<String>,
+    pub table: Option<String>,
 }
 
 /// Subset of `ip -j route` JSON output that we consume.

--- a/source/daemon/crates/wardnet-test-agent/src/client/serve.rs
+++ b/source/daemon/crates/wardnet-test-agent/src/client/serve.rs
@@ -1,0 +1,166 @@
+//! `client serve` -- exposes the client probe operations as an HTTP API.
+//!
+//! Long-running counterpart to the one-shot CLI subcommands. Test
+//! containers (`test_debian`, `test_ubuntu`) launch
+//! `wardnet-test-agent client serve --port 3001` as their entrypoint;
+//! specs reach the probes via plain HTTP (`<container>:3001/...`)
+//! instead of going through `docker exec`. Same handlers either way --
+//! this module is a thin axum wrapper that constructs `*Args` and
+//! forwards to the existing `run()` functions.
+
+use std::net::{IpAddr, SocketAddr};
+
+use axum::Json;
+use axum::extract::Query;
+use axum::http::StatusCode;
+use axum::response::IntoResponse;
+use axum::routing::{get, post};
+use axum::{Router, serve};
+use clap::Args;
+use serde::Deserialize;
+use tracing::info;
+
+use super::dhcp::{self, DhcpClient, DhcpRenewArgs};
+use super::dns::{self, DnsResolveArgs};
+use super::interfaces::{self, InterfacesArgs};
+use super::models::ClientError;
+use super::ping::{self, PingArgs};
+use super::routes::{self, RoutesArgs};
+
+/// Arguments for the `client serve` subcommand.
+#[derive(Debug, Args)]
+pub struct ServeArgs {
+    /// Port to listen on.
+    #[arg(short, long, default_value_t = 3001)]
+    pub port: u16,
+
+    /// Host to bind to.
+    #[arg(long, default_value = "0.0.0.0")]
+    pub host: IpAddr,
+}
+
+pub async fn run(args: ServeArgs) {
+    let addr = SocketAddr::from((args.host, args.port));
+
+    let router = Router::new()
+        .route("/health", get(health))
+        .route("/interfaces", get(get_interfaces))
+        .route("/routes", get(get_routes))
+        .route("/dns/resolve", get(get_dns_resolve))
+        .route("/ping", post(post_ping))
+        .route("/dhcp/renew", post(post_dhcp_renew));
+
+    info!(%addr, "starting wardnet-test-agent client serve");
+
+    let listener = tokio::net::TcpListener::bind(addr)
+        .await
+        .expect("failed to bind TCP listener");
+
+    serve(listener, router).await.expect("server error");
+}
+
+async fn health() -> &'static str {
+    "ok"
+}
+
+#[derive(Debug, Deserialize)]
+struct InterfacesQuery {
+    name: Option<String>,
+}
+
+async fn get_interfaces(Query(q): Query<InterfacesQuery>) -> impl IntoResponse {
+    into_response(interfaces::run(InterfacesArgs { name: q.name }).await)
+}
+
+#[derive(Debug, Deserialize)]
+struct RoutesQuery {
+    table: Option<String>,
+}
+
+async fn get_routes(Query(q): Query<RoutesQuery>) -> impl IntoResponse {
+    into_response(routes::run(RoutesArgs { table: q.table }).await)
+}
+
+#[derive(Debug, Deserialize)]
+struct DnsResolveQuery {
+    name: String,
+    server: Option<String>,
+    record: Option<String>,
+    timeout: Option<u32>,
+}
+
+async fn get_dns_resolve(Query(q): Query<DnsResolveQuery>) -> impl IntoResponse {
+    let args = DnsResolveArgs {
+        name: q.name,
+        server: q.server,
+        record: q.record.unwrap_or_else(|| "A".to_owned()),
+        timeout: q.timeout.unwrap_or(3),
+    };
+    into_response(dns::run(args).await)
+}
+
+#[derive(Debug, Deserialize)]
+struct PingRequest {
+    target: String,
+    count: Option<u32>,
+    timeout: Option<u32>,
+    interface: Option<String>,
+}
+
+async fn post_ping(Json(req): Json<PingRequest>) -> impl IntoResponse {
+    let args = PingArgs {
+        target: req.target,
+        count: req.count.unwrap_or(3),
+        timeout: req.timeout.unwrap_or(2),
+        interface: req.interface,
+    };
+    into_response(ping::run(args).await)
+}
+
+#[derive(Debug, Deserialize)]
+struct DhcpRenewRequest {
+    interface: String,
+    client: Option<DhcpClientName>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "lowercase")]
+enum DhcpClientName {
+    Dhclient,
+    Dhcpcd,
+}
+
+impl From<DhcpClientName> for DhcpClient {
+    fn from(value: DhcpClientName) -> Self {
+        match value {
+            DhcpClientName::Dhclient => DhcpClient::Dhclient,
+            DhcpClientName::Dhcpcd => DhcpClient::Dhcpcd,
+        }
+    }
+}
+
+async fn post_dhcp_renew(Json(req): Json<DhcpRenewRequest>) -> impl IntoResponse {
+    let args = DhcpRenewArgs {
+        interface: req.interface,
+        client: req.client.map_or(DhcpClient::Dhclient, Into::into),
+    };
+    into_response(dhcp::run(args).await)
+}
+
+/// Maps a probe `Result` to an axum response. Errors surface as 500
+/// with the same `{ "error": "..." }` envelope the CLI mode prints, so
+/// callers see one shape regardless of transport.
+fn into_response<T: serde::Serialize>(
+    result: Result<T, ClientError>,
+) -> (StatusCode, Json<serde_json::Value>) {
+    match result {
+        Ok(value) => (
+            StatusCode::OK,
+            Json(serde_json::to_value(value).unwrap_or(serde_json::Value::Null)),
+        ),
+        Err(err) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(serde_json::to_value(err).unwrap_or(serde_json::Value::Null)),
+        ),
+    }
+}

--- a/source/daemon/crates/wardnetd-services/src/dhcp/service.rs
+++ b/source/daemon/crates/wardnetd-services/src/dhcp/service.rs
@@ -244,6 +244,81 @@ impl DhcpServiceImpl {
             "DHCP pool exhausted — no available IP addresses".to_owned(),
         ))
     }
+
+    /// Whether `ip` falls within the configured dynamic pool range.
+    fn ip_in_pool(ip: Ipv4Addr, config: &DhcpConfig) -> bool {
+        let n = u32::from(ip);
+        n >= u32::from(config.pool_start) && n <= u32::from(config.pool_end)
+    }
+
+    /// Look up the active lease for `mac` and confirm it still reflects
+    /// the current configuration. A lease is valid when either a reservation
+    /// for the same MAC points to its IP, or no reservation exists for the
+    /// MAC and the IP sits inside the dynamic pool.
+    ///
+    /// An invalid lease is "orphaned" — typically because its reservation
+    /// was deleted or changed, or the pool was narrowed away from it. The
+    /// helper marks it expired so the caller can fall through to a fresh
+    /// allocation; returning the stale lease as-is would pin the device to
+    /// an IP the configuration no longer justifies.
+    ///
+    /// Returns `Some(lease)` when the existing lease is valid, `None` when
+    /// there's no active lease or it was just expired.
+    async fn lease_if_still_valid(
+        &self,
+        mac: &str,
+        config: &DhcpConfig,
+    ) -> Result<Option<DhcpLease>, AppError> {
+        let Some(existing) = self
+            .dhcp
+            .find_active_lease_by_mac(mac)
+            .await
+            .map_err(AppError::Internal)?
+        else {
+            return Ok(None);
+        };
+
+        let reservation = self
+            .dhcp
+            .find_reservation_by_mac(mac)
+            .await
+            .map_err(AppError::Internal)?;
+
+        let still_valid = match &reservation {
+            Some(r) => r.ip_address == existing.ip_address,
+            None => Self::ip_in_pool(existing.ip_address, config),
+        };
+
+        if still_valid {
+            return Ok(Some(existing));
+        }
+
+        let detail = match &reservation {
+            Some(r) => format!("superseded by reservation for {}", r.ip_address),
+            None => format!(
+                "orphaned: ip {} has no reservation and is outside pool {}-{}",
+                existing.ip_address, config.pool_start, config.pool_end
+            ),
+        };
+        tracing::info!(
+            mac,
+            old_ip = %existing.ip_address,
+            "expiring stale lease so a fresh allocation can run"
+        );
+        self.dhcp
+            .update_lease_status(&existing.id.to_string(), "expired")
+            .await
+            .map_err(AppError::Internal)?;
+        self.dhcp
+            .insert_lease_log(&DhcpLeaseLogRow {
+                lease_id: existing.id.to_string(),
+                event_type: "expired".to_owned(),
+                details: Some(detail),
+            })
+            .await
+            .map_err(AppError::Internal)?;
+        Ok(None)
+    }
 }
 
 #[async_trait]
@@ -528,18 +603,16 @@ impl DhcpService for DhcpServiceImpl {
         let mac = mac.to_lowercase();
         let mac = mac.as_str();
 
-        // If there's already an active lease for this MAC, return it.
-        if let Some(existing) = self
-            .dhcp
-            .find_active_lease_by_mac(mac)
-            .await
-            .map_err(AppError::Internal)?
-        {
+        let config = self.load_config().await?;
+
+        // Reuse an existing active lease when it still reflects the current
+        // configuration. An orphaned lease (reservation removed or pool
+        // narrowed away from the IP) is expired inside the helper so the
+        // fall-through allocates a fresh IP instead of pinning the device.
+        if let Some(existing) = self.lease_if_still_valid(mac, &config).await? {
             tracing::debug!(mac, ip = %existing.ip_address, "reusing existing active lease");
             return Ok(existing);
         }
-
-        let config = self.load_config().await?;
 
         // Check for a static reservation first.
         let ip = if let Some(reservation) = self
@@ -599,49 +672,16 @@ impl DhcpService for DhcpServiceImpl {
         let mac = mac.to_lowercase();
         let mac = mac.as_str();
 
-        if let Some(existing) = self
-            .dhcp
-            .find_active_lease_by_mac(mac)
-            .await
-            .map_err(AppError::Internal)?
-        {
-            // If a reservation now points this MAC to a different IP, the device
-            // needs to migrate. Expire the current lease so the old IP is freed
-            // and fall through to assign_lease, which will allocate the reserved IP.
-            // This closes the window where the old IP could be handed to a new
-            // device while the original device still holds it.
-            if let Some(reservation) = self
-                .dhcp
-                .find_reservation_by_mac(mac)
-                .await
-                .map_err(AppError::Internal)?
-            {
-                let reserved_ip: Ipv4Addr = reservation.ip_address;
+        let config = self.load_config().await?;
 
-                if reserved_ip != existing.ip_address {
-                    tracing::info!(
-                        mac,
-                        old_ip = %existing.ip_address,
-                        new_ip = %reserved_ip,
-                        "reservation changed: expiring old lease to migrate device to reserved IP"
-                    );
-                    self.dhcp
-                        .update_lease_status(&existing.id.to_string(), "expired")
-                        .await
-                        .map_err(AppError::Internal)?;
-                    self.dhcp
-                        .insert_lease_log(&DhcpLeaseLogRow {
-                            lease_id: existing.id.to_string(),
-                            event_type: "expired".to_owned(),
-                            details: Some(format!("superseded by reservation for {reserved_ip}")),
-                        })
-                        .await
-                        .map_err(AppError::Internal)?;
-                    return self.assign_lease(mac, None).await;
-                }
-            }
-
-            let config = self.load_config().await?;
+        // `lease_if_still_valid` collapses two migration cases into one path:
+        // a reservation that no longer matches the lease's IP, and a lease
+        // whose IP is no longer in any pool/reservation (orphaned by a
+        // reservation deletion or pool change). Either way the stale lease
+        // is expired in-place and we fall through to assign_lease, which
+        // closes the window where the old IP could be re-handed while the
+        // original device still holds it.
+        if let Some(existing) = self.lease_if_still_valid(mac, &config).await? {
             let new_end = chrono::Utc::now()
                 + chrono::Duration::seconds(i64::from(config.lease_duration_secs));
 
@@ -667,7 +707,7 @@ impl DhcpService for DhcpServiceImpl {
                 .map_err(AppError::Internal)?
                 .ok_or_else(|| AppError::Internal(anyhow::anyhow!("lease not found after renew")))
         } else {
-            // No active lease — assign a new one.
+            // No valid active lease (none, or just expired as orphan) — assign fresh.
             tracing::info!(mac, "no active lease for renewal, assigning new lease");
             self.assign_lease(mac, None).await
         }

--- a/source/daemon/crates/wardnetd-services/src/dhcp/tests/dhcp.rs
+++ b/source/daemon/crates/wardnetd-services/src/dhcp/tests/dhcp.rs
@@ -867,6 +867,80 @@ async fn renew_lease_does_not_migrate_when_reservation_matches_current_ip() {
     assert_eq!(logs[0].event_type, "renewed");
 }
 
+// Renewal where a reservation that previously pinned the device to an
+// out-of-pool IP has been deleted. The old lease is now an orphan: no
+// reservation backs it and its IP isn't in the dynamic pool, so honoring
+// it would keep the device pinned forever. The daemon must expire it and
+// hand back a fresh pool address on the same REQUEST cycle.
+#[tokio::test]
+async fn renew_lease_migrates_orphaned_lease_when_reservation_deleted() {
+    let (svc, dhcp, _cfg) = build_service_with_deps();
+
+    // .50 is below the default 192.168.1.100-.200 pool; with no reservation
+    // backing it, this lease is orphaned.
+    let old_id = seed_active_lease(&dhcp, "aa:bb:cc:dd:ee:32", "192.168.1.50");
+
+    let lease = auth_context::with_context(admin_ctx(), svc.renew_lease("AA:BB:CC:DD:EE:32"))
+        .await
+        .unwrap();
+
+    // Device migrates to a fresh pool IP, not the old .50.
+    assert_eq!(lease.ip_address, Ipv4Addr::new(192, 168, 1, 100));
+    assert_eq!(lease.status, DhcpLeaseStatus::Active);
+    assert_ne!(lease.id.to_string(), old_id);
+
+    // Old lease expired — keeping it active would re-offer .50 next DISCOVER.
+    let old_row = dhcp
+        .leases
+        .lock()
+        .unwrap()
+        .iter()
+        .find(|r| r.id == old_id)
+        .cloned()
+        .unwrap();
+    assert_eq!(old_row.status, "expired");
+
+    let logs = dhcp.logs.lock().unwrap();
+    assert!(
+        logs.iter().any(|l| l.event_type == "expired"
+            && l.details.as_deref().unwrap_or("").contains("orphaned")),
+        "expected expired log marking the lease as orphaned"
+    );
+    assert!(
+        logs.iter().any(|l| l.event_type == "assigned"),
+        "expected assigned log for the new pool lease"
+    );
+}
+
+// DISCOVER counterpart of the renew migration above. A device with a
+// stale active lease at an out-of-pool IP (its reservation was deleted)
+// re-DISCOVERs; the daemon must not short-circuit on the orphan and must
+// allocate fresh from the pool.
+#[tokio::test]
+async fn assign_lease_migrates_orphaned_lease_when_outside_pool() {
+    let (svc, dhcp, _cfg) = build_service_with_deps();
+
+    let old_id = seed_active_lease(&dhcp, "aa:bb:cc:dd:ee:33", "192.168.1.50");
+
+    let lease =
+        auth_context::with_context(admin_ctx(), svc.assign_lease("AA:BB:CC:DD:EE:33", None))
+            .await
+            .unwrap();
+
+    assert_eq!(lease.ip_address, Ipv4Addr::new(192, 168, 1, 100));
+    assert_ne!(lease.id.to_string(), old_id);
+
+    let old_row = dhcp
+        .leases
+        .lock()
+        .unwrap()
+        .iter()
+        .find(|r| r.id == old_id)
+        .cloned()
+        .unwrap();
+    assert_eq!(old_row.status, "expired");
+}
+
 // =========================================================================
 // release_lease tests
 // =========================================================================

--- a/source/end2end-tests/daemon/Dockerfile.client
+++ b/source/end2end-tests/daemon/Dockerfile.client
@@ -1,0 +1,52 @@
+# syntax=docker/dockerfile:1
+#
+# LAN-client image for the daemon e2e suite. Two compose services
+# (test_debian, test_ubuntu) build from this same Dockerfile with
+# different BASE_IMAGE values -- one apt path covers both since
+# Ubuntu 24.04 and Debian bookworm share the same DHCP / iproute2 /
+# dnsutils package names. The diversity is in service of multi-client
+# scenarios (multi-tunnel.spec.ts in a later PR), not platform
+# coverage.
+#
+# The wardnet-test-agent binary is reused from wardnetd:dev-test (built
+# upstream by `make image-test`, the prerequisite of `make
+# end2end-daemon`). Re-compiling the binary here would mean three Rust
+# builds per CI run for no functional gain.
+#
+# Build context: repo root.
+#   docker build -f source/end2end-tests/daemon/Dockerfile.client \
+#       --build-arg BASE_IMAGE=debian:bookworm-slim \
+#       -t wardnet-test-client-debian:dev .
+
+ARG WARDNETD_TEST_IMAGE=wardnetd:dev-test
+ARG BASE_IMAGE=debian:bookworm-slim
+
+FROM ${WARDNETD_TEST_IMAGE} AS source
+
+FROM ${BASE_IMAGE}
+
+# iproute2:        `ip` for address flushing + routing inspection.
+# isc-dhcp-client: dhclient -- the test-agent's `dhcp-renew` default.
+# iputils-ping:    ICMP echo for the ping subcommand.
+# dnsutils:        dig, used by the dns-resolve subcommand.
+# curl:            HTTP healthcheck against the test-agent's /health.
+# ca-certificates: TLS roots in case future probes need outbound HTTPS.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        iproute2 \
+        isc-dhcp-client \
+        iputils-ping \
+        dnsutils \
+        curl \
+        ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=source /usr/local/bin/wardnet-test-agent /usr/local/bin/wardnet-test-agent
+RUN chmod 0755 /usr/local/bin/wardnet-test-agent
+
+COPY source/end2end-tests/daemon/fixtures/client-entrypoint.sh /usr/local/bin/client-entrypoint.sh
+RUN chmod 0755 /usr/local/bin/client-entrypoint.sh
+
+EXPOSE 3001/tcp
+
+ENTRYPOINT ["/usr/local/bin/client-entrypoint.sh"]

--- a/source/end2end-tests/daemon/Dockerfile.client
+++ b/source/end2end-tests/daemon/Dockerfile.client
@@ -45,7 +45,13 @@ COPY --from=source /usr/local/bin/wardnet-test-agent /usr/local/bin/wardnet-test
 RUN chmod 0755 /usr/local/bin/wardnet-test-agent
 
 COPY source/end2end-tests/daemon/fixtures/client-entrypoint.sh /usr/local/bin/client-entrypoint.sh
-RUN chmod 0755 /usr/local/bin/client-entrypoint.sh
+COPY source/end2end-tests/daemon/fixtures/dhclient-add.sh /usr/local/bin/dhclient-add.sh
+RUN chmod 0755 /usr/local/bin/client-entrypoint.sh /usr/local/bin/dhclient-add.sh
+
+# Steers the test-agent's `dhcp-renew` handler at our custom dhclient
+# script so the leased address lands as a secondary IPv4 (preserving
+# the docker-IPAM IP that compose's service DNS depends on).
+ENV WARDNET_TEST_DHCLIENT_SCRIPT=/usr/local/bin/dhclient-add.sh
 
 EXPOSE 3001/tcp
 

--- a/source/end2end-tests/daemon/Dockerfile.client.dockerignore
+++ b/source/end2end-tests/daemon/Dockerfile.client.dockerignore
@@ -1,2 +1,3 @@
 *
 !source/end2end-tests/daemon/fixtures/client-entrypoint.sh
+!source/end2end-tests/daemon/fixtures/dhclient-add.sh

--- a/source/end2end-tests/daemon/Dockerfile.client.dockerignore
+++ b/source/end2end-tests/daemon/Dockerfile.client.dockerignore
@@ -1,0 +1,2 @@
+*
+!source/end2end-tests/daemon/fixtures/client-entrypoint.sh

--- a/source/end2end-tests/daemon/Dockerfile.runner
+++ b/source/end2end-tests/daemon/Dockerfile.runner
@@ -10,7 +10,10 @@
 # Build context: repo root.
 #   docker build -f source/end2end-tests/daemon/Dockerfile.runner -t wardnet-e2e-runner .
 
-FROM node:22-bookworm-slim
+# Pinned by digest for supply-chain integrity (OSSF Scorecard
+# Pinned-Dependencies). Bump together with the tag — the digest moves
+# under the same tag whenever Docker Hub repushes a base image.
+FROM node:22-bookworm-slim@sha256:d415caac2f1f77b98caaf9415c5f807e14bc8d7bdea62561ea2fef4fbd08a73c
 
 RUN corepack enable
 

--- a/source/end2end-tests/daemon/compose.yaml
+++ b/source/end2end-tests/daemon/compose.yaml
@@ -1,8 +1,8 @@
 # Daemon end-to-end test topology.
 #
-# Stage 6a (this file) ships only what the smoke spec needs: the
-# daemon container plus a node:22 test runner. Future stages will add
-# `test_alpine`, `test_ubuntu`, `wg_gateway_1`, `wg_gateway_2`,
+# Stage 6a/6b (this file) ships the daemon container, a node:22 test
+# runner, and two LAN clients (`test_debian`, `test_ubuntu`) for the
+# DHCP scenarios. Future stages add `wg_gateway_1`, `wg_gateway_2`,
 # `nordvpn_mock` — see source/end2end-tests/daemon/README or the plan
 # under .agents/ for the full topology.
 #
@@ -128,6 +128,60 @@ services:
       retries: 30
       start_period: 30s
 
+  # LAN-client containers used by the DHCP and (later) routing /
+  # multi-client scenarios. Both run `wardnet-test-agent client serve`
+  # on :3001 after acquiring a lease from the daemon's DHCP server.
+  # NET_ADMIN is required so the entrypoint can flush eth0 before
+  # dhclient runs; without it Docker's IPAM-assigned address sticks
+  # and the daemon never sees a DISCOVER. NET_RAW is the default
+  # capability for raw sockets; called out explicitly so a hardened
+  # base profile that drops it doesn't break dhclient.
+  test_debian:
+    build:
+      context: ../../..
+      dockerfile: source/end2end-tests/daemon/Dockerfile.client
+      args:
+        BASE_IMAGE: debian:bookworm-slim
+        WARDNETD_TEST_IMAGE: ${WARDNETD_TEST_IMAGE:-wardnetd:dev-test}
+    image: wardnet-test-client-debian:dev
+    depends_on:
+      wardnetd:
+        condition: service_healthy
+    cap_add:
+      - NET_ADMIN
+      - NET_RAW
+    networks:
+      wardnet_lan: {}
+    healthcheck:
+      test: ["CMD-SHELL", "curl -fsS http://127.0.0.1:3001/health || exit 1"]
+      interval: 3s
+      timeout: 2s
+      retries: 20
+      start_period: 10s
+
+  test_ubuntu:
+    build:
+      context: ../../..
+      dockerfile: source/end2end-tests/daemon/Dockerfile.client
+      args:
+        BASE_IMAGE: ubuntu:24.04
+        WARDNETD_TEST_IMAGE: ${WARDNETD_TEST_IMAGE:-wardnetd:dev-test}
+    image: wardnet-test-client-ubuntu:dev
+    depends_on:
+      wardnetd:
+        condition: service_healthy
+    cap_add:
+      - NET_ADMIN
+      - NET_RAW
+    networks:
+      wardnet_lan: {}
+    healthcheck:
+      test: ["CMD-SHELL", "curl -fsS http://127.0.0.1:3001/health || exit 1"]
+      interval: 3s
+      timeout: 2s
+      retries: 20
+      start_period: 10s
+
   test_runner:
     build:
       context: ../../..
@@ -135,6 +189,10 @@ services:
     image: wardnet-e2e-runner:dev
     depends_on:
       wardnetd:
+        condition: service_healthy
+      test_debian:
+        condition: service_healthy
+      test_ubuntu:
         condition: service_healthy
     environment:
       WARDNET_API_BASE_URL: "http://wardnetd:7411/api"

--- a/source/end2end-tests/daemon/fixtures/client-entrypoint.sh
+++ b/source/end2end-tests/daemon/fixtures/client-entrypoint.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+# LAN-client entrypoint for test_debian / test_ubuntu.
+#
+# Docker attaches the container to wardnet_lan with an IPAM-assigned
+# address in 10.91.0.2/28. We flush that and ask the daemon's DHCP
+# server (10.91.0.1, listening on the same bridge) for a lease in its
+# .100-.150 dynamic pool. Any post-DHCP address >= .100 unambiguously
+# came from the daemon -- Docker's IPAM cannot reach there.
+#
+# After a lease is acquired, exec the test-agent's HTTP server so the
+# Vitest runner can probe interface state, routes, DNS, etc. without
+# mounting the container-runtime socket.
+set -eu
+
+IFACE="${WARDNET_TEST_IFACE:-eth0}"
+PORT="${WARDNET_TEST_AGENT_PORT:-3001}"
+
+# Drop the docker-assigned address. dhclient won't replace an existing
+# lease on its own; flushing is the cheapest way to force a fresh
+# DISCOVER. Errors here are fatal: a misconfigured CAP_NET_ADMIN drop
+# would otherwise produce a confusing "no lease" failure later.
+ip addr flush dev "$IFACE"
+
+# `-1` exits non-zero on lease-acquisition failure (vs the default of
+# backgrounding and retrying forever), so a broken DHCP server fails
+# the container start instead of silently leaving the spec to time
+# out. dhclient writes its pidfile under /var/lib/dhcp; the directory
+# exists by default in the isc-dhcp-client package.
+dhclient -1 -v "$IFACE"
+
+# Hand off to the test-agent. exec replaces shell PID 1 so SIGTERM
+# from `compose down` reaches the agent directly.
+exec /usr/local/bin/wardnet-test-agent client serve --port "$PORT"

--- a/source/end2end-tests/daemon/fixtures/client-entrypoint.sh
+++ b/source/end2end-tests/daemon/fixtures/client-entrypoint.sh
@@ -1,33 +1,21 @@
 #!/bin/sh
 # LAN-client entrypoint for test_debian / test_ubuntu.
 #
-# Docker attaches the container to wardnet_lan with an IPAM-assigned
-# address in 10.91.0.2/28. We flush that and ask the daemon's DHCP
-# server (10.91.0.1, listening on the same bridge) for a lease in its
-# .100-.150 dynamic pool. Any post-DHCP address >= .100 unambiguously
-# came from the daemon -- Docker's IPAM cannot reach there.
+# Just brings up the test-agent's HTTP server. Lease acquisition is
+# spec-driven (the daemon's DHCP service is disabled by default; specs
+# enable it in beforeAll then trigger dhclient via /dhcp/renew on this
+# agent). Trying to acquire a lease here would race the spec's enable
+# call and fail container start.
 #
-# After a lease is acquired, exec the test-agent's HTTP server so the
-# Vitest runner can probe interface state, routes, DNS, etc. without
-# mounting the container-runtime socket.
+# Compose's service-name DNS resolves test_debian/test_ubuntu to the
+# docker-IPAM-assigned IPv4 (10.91.0.2-.15). The custom dhclient
+# script (see dhclient-add.sh) preserves that address when applying
+# the daemon-issued lease, so the runner can keep reaching the agent
+# by name across renews.
 set -eu
 
-IFACE="${WARDNET_TEST_IFACE:-eth0}"
 PORT="${WARDNET_TEST_AGENT_PORT:-3001}"
 
-# Drop the docker-assigned address. dhclient won't replace an existing
-# lease on its own; flushing is the cheapest way to force a fresh
-# DISCOVER. Errors here are fatal: a misconfigured CAP_NET_ADMIN drop
-# would otherwise produce a confusing "no lease" failure later.
-ip addr flush dev "$IFACE"
-
-# `-1` exits non-zero on lease-acquisition failure (vs the default of
-# backgrounding and retrying forever), so a broken DHCP server fails
-# the container start instead of silently leaving the spec to time
-# out. dhclient writes its pidfile under /var/lib/dhcp; the directory
-# exists by default in the isc-dhcp-client package.
-dhclient -1 -v "$IFACE"
-
-# Hand off to the test-agent. exec replaces shell PID 1 so SIGTERM
-# from `compose down` reaches the agent directly.
+# exec replaces shell PID 1 so SIGTERM from `compose down` reaches
+# the agent directly.
 exec /usr/local/bin/wardnet-test-agent client serve --port "$PORT"

--- a/source/end2end-tests/daemon/fixtures/dhclient-add.sh
+++ b/source/end2end-tests/daemon/fixtures/dhclient-add.sh
@@ -1,0 +1,49 @@
+#!/bin/sh
+# Custom dhclient script for the e2e test clients.
+#
+# Why this exists: the default /sbin/dhclient-script flushes the
+# interface and applies the leased address as the only IPv4 on the
+# NIC. Inside the e2e compose stack that breaks compose's service-name
+# DNS, which resolves `test_debian` / `test_ubuntu` to the container's
+# docker-IPAM-assigned address (10.91.0.2-.15). After a flush, that
+# address is gone and the test runner can no longer reach the agent.
+#
+# This script ADDS the leased address as a secondary IPv4 (and removes
+# only that secondary on release/expire), leaving the docker IPAM
+# address untouched. /interfaces will then report both, and the spec
+# can assert that an address in the daemon's DHCP pool is present.
+
+mask_to_prefix() {
+    m="$1"; p=0; IFS=.
+    for o in $m; do
+        case "$o" in
+            255) p=$((p+8));;
+            254) p=$((p+7));;
+            252) p=$((p+6));;
+            248) p=$((p+5));;
+            240) p=$((p+4));;
+            224) p=$((p+3));;
+            192) p=$((p+2));;
+            128) p=$((p+1));;
+            0)   ;;
+            *)   return 1;;
+        esac
+    done
+    unset IFS
+    echo "$p"
+}
+
+case "$reason" in
+    BOUND|RENEW|REBIND|REBOOT)
+        prefix=$(mask_to_prefix "$new_subnet_mask") || prefix=24
+        # `add` errors when the address is already present; ignore so
+        # repeated renews are idempotent. The address survives across
+        # renews of the same lease, so this is the common path.
+        ip addr add "$new_ip_address/$prefix" dev "$interface" 2>/dev/null || true
+        ;;
+    EXPIRE|FAIL|RELEASE|STOP)
+        prefix=$(mask_to_prefix "$old_subnet_mask") || prefix=24
+        ip addr del "$old_ip_address/$prefix" dev "$interface" 2>/dev/null || true
+        ;;
+esac
+exit 0

--- a/source/end2end-tests/daemon/tests/dhcp-reservations.spec.ts
+++ b/source/end2end-tests/daemon/tests/dhcp-reservations.spec.ts
@@ -1,0 +1,112 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { DhcpService, WardnetClient } from "@wardnet/js";
+
+import {
+  API_BASE_URL,
+  AuthedClient,
+  TEST_DEBIAN_AGENT,
+  agentGet,
+  agentPost,
+  ensureAdminAndLogin,
+  ipv4Of,
+  macOf,
+  waitForReady,
+  type AgentDhcpRenewResponse,
+  type AgentInterfacesResponse,
+} from "./helpers.js";
+
+// .151-.199 is the reserved-static range per the e2e plan: outside
+// the dynamic pool (.100-.150) so a reservation can't accidentally
+// collide with a concurrent dynamic lease.
+const RESERVED_IP = "10.91.0.160";
+
+describe("dhcp reservations", () => {
+  let authed: AuthedClient;
+  let dhcp: DhcpService;
+  let createdReservationId: string | undefined;
+
+  beforeAll(async () => {
+    const client = new WardnetClient({ baseUrl: API_BASE_URL });
+    await waitForReady(client);
+    authed = await ensureAdminAndLogin(client);
+    dhcp = new DhcpService(authed);
+  }, 120_000);
+
+  afterAll(async () => {
+    // Best-effort cleanup so a re-run on the same compose stack
+    // doesn't fail with "MAC already reserved". Failures here are
+    // suppressed because they'd hide the real spec failure.
+    if (createdReservationId) {
+      try {
+        await dhcp.deleteReservation(createdReservationId);
+      } catch {
+        // ignore
+      }
+    }
+  });
+
+  it("binds test_debian's MAC to a reserved IP on renew", async () => {
+    const before = await agentGet<AgentInterfacesResponse>(
+      TEST_DEBIAN_AGENT,
+      "/interfaces?name=eth0",
+    );
+    const mac = macOf(before, "eth0");
+    expect(mac, "test_debian eth0 has a MAC").toBeDefined();
+
+    // If a previous run on the same volume left a reservation for
+    // this MAC, drop it so createReservation() doesn't 409.
+    const existing = await dhcp.listReservations();
+    for (const r of existing.reservations) {
+      if (r.mac_address.toLowerCase() === mac) {
+        await dhcp.deleteReservation(r.id);
+      }
+    }
+
+    const created = await dhcp.createReservation({
+      mac_address: mac!,
+      ip_address: RESERVED_IP,
+      hostname: "test-debian-reserved",
+    });
+    createdReservationId = created.reservation.id;
+    expect(created.reservation.ip_address).toBe(RESERVED_IP);
+
+    // Force the client to release its dynamic lease and re-DISCOVER.
+    // The daemon should now answer with the reserved IP because the
+    // MAC matches an active reservation.
+    const renew = await agentPost<AgentDhcpRenewResponse>(
+      TEST_DEBIAN_AGENT,
+      "/dhcp/renew",
+      { interface: "eth0" },
+    );
+    // Strict: a release failure here would let dhclient re-use the
+    // cached dynamic lease and silently mask the reservation flow.
+    expect(renew.release_success, `dhclient stderr: ${renew.stderr}`)
+      .toBe(true);
+    expect(renew.renew_success, `dhclient stderr: ${renew.stderr}`)
+      .toBe(true);
+
+    const after = await agentGet<AgentInterfacesResponse>(
+      TEST_DEBIAN_AGENT,
+      "/interfaces?name=eth0",
+    );
+    expect(ipv4Of(after, "eth0")).toBe(RESERVED_IP);
+
+    const { leases } = await dhcp.listLeases();
+    const lease = leases.find((l) => l.ip_address === RESERVED_IP);
+    expect(lease, `lease for ${RESERVED_IP} present`).toBeDefined();
+    expect(lease!.mac_address.toLowerCase()).toBe(mac);
+    expect(lease!.status).toBe("active");
+  });
+
+  it("removes the reservation from the listing on delete", async () => {
+    expect(createdReservationId, "previous test created a reservation")
+      .toBeDefined();
+
+    await dhcp.deleteReservation(createdReservationId!);
+    createdReservationId = undefined;
+
+    const { reservations } = await dhcp.listReservations();
+    expect(reservations.find((r) => r.ip_address === RESERVED_IP))
+      .toBeUndefined();
+  });
+});

--- a/source/end2end-tests/daemon/tests/dhcp-reservations.spec.ts
+++ b/source/end2end-tests/daemon/tests/dhcp-reservations.spec.ts
@@ -5,24 +5,28 @@ import {
   API_BASE_URL,
   AuthedClient,
   TEST_DEBIAN_AGENT,
+  acquireLeaseInRange,
   agentGet,
   agentPost,
   ensureAdminAndLogin,
-  ipv4Of,
+  ipv4InRange,
   macOf,
   waitForReady,
   type AgentDhcpRenewResponse,
   type AgentInterfacesResponse,
 } from "./helpers.js";
 
+const POOL_START = "10.91.0.100";
+const POOL_END = "10.91.0.150";
 // .151-.199 is the reserved-static range per the e2e plan: outside
-// the dynamic pool (.100-.150) so a reservation can't accidentally
-// collide with a concurrent dynamic lease.
+// the dynamic pool so a reservation can't collide with a concurrent
+// dynamic lease.
 const RESERVED_IP = "10.91.0.160";
 
 describe("dhcp reservations", () => {
   let authed: AuthedClient;
   let dhcp: DhcpService;
+  let mac: string;
   let createdReservationId: string | undefined;
 
   beforeAll(async () => {
@@ -30,6 +34,37 @@ describe("dhcp reservations", () => {
     await waitForReady(client);
     authed = await ensureAdminAndLogin(client);
     dhcp = new DhcpService(authed);
+
+    const cfg = (await dhcp.getConfig()).config;
+    if (!cfg.enabled) {
+      await dhcp.toggle({ enabled: true });
+      await dhcp.updateConfig({
+        pool_start: POOL_START,
+        pool_end: POOL_END,
+        subnet_mask: cfg.subnet_mask,
+        upstream_dns: cfg.upstream_dns,
+        lease_duration_secs: cfg.lease_duration_secs,
+        ...(cfg.router_ip ? { router_ip: cfg.router_ip } : {}),
+      });
+    }
+
+    // Make sure test_debian has a dynamic lease before we attempt the
+    // reservation transition. If dhcp.spec.ts ran first it'll already
+    // be in this state; running standalone we need to bring it up.
+    await acquireLeaseInRange(
+      TEST_DEBIAN_AGENT,
+      "eth0",
+      POOL_START,
+      POOL_END,
+    );
+
+    const ifaces = await agentGet<AgentInterfacesResponse>(
+      TEST_DEBIAN_AGENT,
+      "/interfaces?name=eth0",
+    );
+    const ifaceMac = macOf(ifaces, "eth0");
+    expect(ifaceMac, "test_debian eth0 has a MAC").toBeDefined();
+    mac = ifaceMac!;
   }, 120_000);
 
   afterAll(async () => {
@@ -46,13 +81,6 @@ describe("dhcp reservations", () => {
   });
 
   it("binds test_debian's MAC to a reserved IP on renew", async () => {
-    const before = await agentGet<AgentInterfacesResponse>(
-      TEST_DEBIAN_AGENT,
-      "/interfaces?name=eth0",
-    );
-    const mac = macOf(before, "eth0");
-    expect(mac, "test_debian eth0 has a MAC").toBeDefined();
-
     // If a previous run on the same volume left a reservation for
     // this MAC, drop it so createReservation() doesn't 409.
     const existing = await dhcp.listReservations();
@@ -63,7 +91,7 @@ describe("dhcp reservations", () => {
     }
 
     const created = await dhcp.createReservation({
-      mac_address: mac!,
+      mac_address: mac,
       ip_address: RESERVED_IP,
       hostname: "test-debian-reserved",
     });
@@ -78,8 +106,8 @@ describe("dhcp reservations", () => {
       "/dhcp/renew",
       { interface: "eth0" },
     );
-    // Strict: a release failure here would let dhclient re-use the
-    // cached dynamic lease and silently mask the reservation flow.
+    // Strict on both: a release failure here lets dhclient re-use the
+    // cached dynamic lease and silently masks the reservation flow.
     expect(renew.release_success, `dhclient stderr: ${renew.stderr}`)
       .toBe(true);
     expect(renew.renew_success, `dhclient stderr: ${renew.stderr}`)
@@ -89,7 +117,8 @@ describe("dhcp reservations", () => {
       TEST_DEBIAN_AGENT,
       "/interfaces?name=eth0",
     );
-    expect(ipv4Of(after, "eth0")).toBe(RESERVED_IP);
+    expect(ipv4InRange(after, "eth0", RESERVED_IP, RESERVED_IP))
+      .toBe(RESERVED_IP);
 
     const { leases } = await dhcp.listLeases();
     const lease = leases.find((l) => l.ip_address === RESERVED_IP);

--- a/source/end2end-tests/daemon/tests/dhcp.spec.ts
+++ b/source/end2end-tests/daemon/tests/dhcp.spec.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import { DhcpService, WardnetClient } from "@wardnet/js";
+
+import {
+  API_BASE_URL,
+  AuthedClient,
+  TEST_DEBIAN_AGENT,
+  agentGet,
+  agentPost,
+  ensureAdminAndLogin,
+  ipToInt,
+  ipv4Of,
+  macOf,
+  waitForReady,
+  type AgentDhcpRenewResponse,
+  type AgentInterfacesResponse,
+} from "./helpers.js";
+
+const POOL_START = "10.91.0.100";
+const POOL_END = "10.91.0.150";
+const DOCKER_IPAM_END = "10.91.0.15";
+
+describe("dhcp", () => {
+  let authed: AuthedClient;
+  let dhcp: DhcpService;
+
+  beforeAll(async () => {
+    const client = new WardnetClient({ baseUrl: API_BASE_URL });
+    await waitForReady(client);
+    authed = await ensureAdminAndLogin(client);
+    dhcp = new DhcpService(authed);
+
+    // Narrow the pool to the plan-prescribed .100-.150 range. The
+    // daemon's default pool runs to .250 (see dhcp/service.rs), which
+    // would let dhcp-reservations.spec.ts collide with a dynamic
+    // lease at .151+. Idempotent: re-applying the same config across
+    // spec files is a no-op.
+    const cfg = (await dhcp.getConfig()).config;
+    await dhcp.updateConfig({
+      pool_start: POOL_START,
+      pool_end: POOL_END,
+      subnet_mask: cfg.subnet_mask,
+      upstream_dns: cfg.upstream_dns,
+      lease_duration_secs: cfg.lease_duration_secs,
+      ...(cfg.router_ip ? { router_ip: cfg.router_ip } : {}),
+    });
+  }, 120_000);
+
+  it("issues a lease in the daemon's pool to test_debian", async () => {
+    const ifaces = await agentGet<AgentInterfacesResponse>(
+      TEST_DEBIAN_AGENT,
+      "/interfaces?name=eth0",
+    );
+    const ip = ipv4Of(ifaces, "eth0");
+    const mac = macOf(ifaces, "eth0");
+    expect(ip, "test_debian eth0 has an IPv4 address").toBeDefined();
+    expect(mac, "test_debian eth0 has a MAC").toBeDefined();
+
+    // Inside the daemon's DHCP pool ...
+    expect(ipToInt(ip!)).toBeGreaterThanOrEqual(ipToInt(POOL_START));
+    expect(ipToInt(ip!)).toBeLessThanOrEqual(ipToInt(POOL_END));
+    // ... and outside Docker's IPAM range (.2-.15). A .100+ address
+    // can only have come from the daemon's DHCP server; Docker's
+    // bridge IPAM is configured to never hand out anything that high.
+    expect(ipToInt(ip!)).toBeGreaterThan(ipToInt(DOCKER_IPAM_END));
+
+    const { leases } = await dhcp.listLeases();
+    const lease = leases.find((l) => l.ip_address === ip);
+    expect(lease, `lease for ${ip} present in /api/dhcp/leases`).toBeDefined();
+    expect(lease!.status).toBe("active");
+    expect(lease!.mac_address.toLowerCase()).toBe(mac);
+  });
+
+  it("renews the lease without re-allocating", async () => {
+    const before = await agentGet<AgentInterfacesResponse>(
+      TEST_DEBIAN_AGENT,
+      "/interfaces?name=eth0",
+    );
+    const ipBefore = ipv4Of(before, "eth0");
+    expect(ipBefore).toBeDefined();
+
+    const renew = await agentPost<AgentDhcpRenewResponse>(
+      TEST_DEBIAN_AGENT,
+      "/dhcp/renew",
+      { interface: "eth0" },
+    );
+    expect(renew.release_success, `dhclient stderr: ${renew.stderr}`)
+      .toBe(true);
+    expect(renew.renew_success, `dhclient stderr: ${renew.stderr}`)
+      .toBe(true);
+
+    const after = await agentGet<AgentInterfacesResponse>(
+      TEST_DEBIAN_AGENT,
+      "/interfaces?name=eth0",
+    );
+    const ipAfter = ipv4Of(after, "eth0");
+    expect(ipAfter, "test_debian still has an IPv4 address after renew")
+      .toBeDefined();
+    // MAC stickiness: same MAC asks again, same IP comes back. A
+    // re-allocation here would mean the daemon forgot the binding,
+    // which would also break the reservations spec downstream.
+    expect(ipAfter).toBe(ipBefore);
+  });
+});

--- a/source/end2end-tests/daemon/tests/dhcp.spec.ts
+++ b/source/end2end-tests/daemon/tests/dhcp.spec.ts
@@ -5,11 +5,12 @@ import {
   API_BASE_URL,
   AuthedClient,
   TEST_DEBIAN_AGENT,
+  acquireLeaseInRange,
   agentGet,
   agentPost,
   ensureAdminAndLogin,
   ipToInt,
-  ipv4Of,
+  ipv4InRange,
   macOf,
   waitForReady,
   type AgentDhcpRenewResponse,
@@ -23,6 +24,7 @@ const DOCKER_IPAM_END = "10.91.0.15";
 describe("dhcp", () => {
   let authed: AuthedClient;
   let dhcp: DhcpService;
+  let leasedIp: string;
 
   beforeAll(async () => {
     const client = new WardnetClient({ baseUrl: API_BASE_URL });
@@ -30,12 +32,15 @@ describe("dhcp", () => {
     authed = await ensureAdminAndLogin(client);
     dhcp = new DhcpService(authed);
 
-    // Narrow the pool to the plan-prescribed .100-.150 range. The
-    // daemon's default pool runs to .250 (see dhcp/service.rs), which
-    // would let dhcp-reservations.spec.ts collide with a dynamic
-    // lease at .151+. Idempotent: re-applying the same config across
-    // spec files is a no-op.
+    // The daemon ships with DHCP disabled; flip it on before any
+    // client tries to acquire a lease. Idempotent across spec files.
     const cfg = (await dhcp.getConfig()).config;
+    if (!cfg.enabled) {
+      await dhcp.toggle({ enabled: true });
+    }
+    // Narrow the pool to the plan-prescribed .100-.150 range. The
+    // default runs to .250 and would let dynamic leases collide with
+    // the .151-.199 reservation range used by the next spec.
     await dhcp.updateConfig({
       pool_start: POOL_START,
       pool_end: POOL_END,
@@ -44,61 +49,57 @@ describe("dhcp", () => {
       lease_duration_secs: cfg.lease_duration_secs,
       ...(cfg.router_ip ? { router_ip: cfg.router_ip } : {}),
     });
+
+    // Drive the agent to acquire its first lease. The container
+    // entrypoint deliberately does not run dhclient at startup —
+    // doing so would race the toggle above and fail container start.
+    leasedIp = await acquireLeaseInRange(
+      TEST_DEBIAN_AGENT,
+      "eth0",
+      POOL_START,
+      POOL_END,
+    );
   }, 120_000);
 
   it("issues a lease in the daemon's pool to test_debian", async () => {
+    expect(ipToInt(leasedIp)).toBeGreaterThanOrEqual(ipToInt(POOL_START));
+    expect(ipToInt(leasedIp)).toBeLessThanOrEqual(ipToInt(POOL_END));
+    // Outside Docker's IPAM range — a .100+ address can only have come
+    // from the daemon's DHCP server.
+    expect(ipToInt(leasedIp)).toBeGreaterThan(ipToInt(DOCKER_IPAM_END));
+
     const ifaces = await agentGet<AgentInterfacesResponse>(
       TEST_DEBIAN_AGENT,
       "/interfaces?name=eth0",
     );
-    const ip = ipv4Of(ifaces, "eth0");
     const mac = macOf(ifaces, "eth0");
-    expect(ip, "test_debian eth0 has an IPv4 address").toBeDefined();
     expect(mac, "test_debian eth0 has a MAC").toBeDefined();
 
-    // Inside the daemon's DHCP pool ...
-    expect(ipToInt(ip!)).toBeGreaterThanOrEqual(ipToInt(POOL_START));
-    expect(ipToInt(ip!)).toBeLessThanOrEqual(ipToInt(POOL_END));
-    // ... and outside Docker's IPAM range (.2-.15). A .100+ address
-    // can only have come from the daemon's DHCP server; Docker's
-    // bridge IPAM is configured to never hand out anything that high.
-    expect(ipToInt(ip!)).toBeGreaterThan(ipToInt(DOCKER_IPAM_END));
-
     const { leases } = await dhcp.listLeases();
-    const lease = leases.find((l) => l.ip_address === ip);
-    expect(lease, `lease for ${ip} present in /api/dhcp/leases`).toBeDefined();
+    const lease = leases.find((l) => l.ip_address === leasedIp);
+    expect(lease, `lease for ${leasedIp} present in /api/dhcp/leases`)
+      .toBeDefined();
     expect(lease!.status).toBe("active");
     expect(lease!.mac_address.toLowerCase()).toBe(mac);
   });
 
   it("renews the lease without re-allocating", async () => {
-    const before = await agentGet<AgentInterfacesResponse>(
-      TEST_DEBIAN_AGENT,
-      "/interfaces?name=eth0",
-    );
-    const ipBefore = ipv4Of(before, "eth0");
-    expect(ipBefore).toBeDefined();
-
     const renew = await agentPost<AgentDhcpRenewResponse>(
       TEST_DEBIAN_AGENT,
       "/dhcp/renew",
       { interface: "eth0" },
     );
-    expect(renew.release_success, `dhclient stderr: ${renew.stderr}`)
-      .toBe(true);
     expect(renew.renew_success, `dhclient stderr: ${renew.stderr}`)
       .toBe(true);
 
-    const after = await agentGet<AgentInterfacesResponse>(
+    const ifaces = await agentGet<AgentInterfacesResponse>(
       TEST_DEBIAN_AGENT,
       "/interfaces?name=eth0",
     );
-    const ipAfter = ipv4Of(after, "eth0");
-    expect(ipAfter, "test_debian still has an IPv4 address after renew")
+    const ipAfter = ipv4InRange(ifaces, "eth0", POOL_START, POOL_END);
+    expect(ipAfter, "test_debian still has an in-pool IPv4 after renew")
       .toBeDefined();
-    // MAC stickiness: same MAC asks again, same IP comes back. A
-    // re-allocation here would mean the daemon forgot the binding,
-    // which would also break the reservations spec downstream.
-    expect(ipAfter).toBe(ipBefore);
+    // MAC stickiness: same MAC asks again, same IP comes back.
+    expect(ipAfter).toBe(leasedIp);
   });
 });

--- a/source/end2end-tests/daemon/tests/health.spec.ts
+++ b/source/end2end-tests/daemon/tests/health.spec.ts
@@ -1,66 +1,11 @@
-import { randomBytes } from "node:crypto";
-
 import { describe, it, expect, beforeAll } from "vitest";
+import { InfoService, TunnelService, WardnetClient } from "@wardnet/js";
+
 import {
-  WardnetClient,
-  AuthService,
-  InfoService,
-  SetupService,
-  TunnelService,
-} from "@wardnet/js";
-
-// The daemon container publishes its API on the wardnet_mgmt bridge.
-// Compose's DNS resolves the service name to the container's mgmt IP.
-const API_BASE_URL = process.env.WARDNET_API_BASE_URL ?? "http://wardnetd:7411/api";
-
-// Setup-wizard credentials. Generated per-run rather than checked in
-// so a leaked log line can't be replayed against a real instance.
-// `randomBytes` (vs `Math.random`) keeps CodeQL's
-// js/insecure-randomness rule happy -- the credential is test-only
-// and never leaves the compose stack, but the rule fires on shape,
-// not reachability.
-const ADMIN_USERNAME = "admin";
-const ADMIN_PASSWORD = `e2e-${randomBytes(6).toString("hex")}`;
-
-/**
- * WardnetClient that re-attaches the bearer token returned by the login
- * endpoint to every subsequent request. Node's fetch has no cookie jar,
- * so the session cookie the daemon sets is invisible to follow-up calls;
- * `Authorization: Bearer <token>` is the documented non-browser path.
- */
-class AuthedClient extends WardnetClient {
-  constructor(
-    baseUrl: string,
-    private readonly token: string,
-  ) {
-    super({ baseUrl });
-  }
-
-  override async request<T>(path: string, init?: RequestInit): Promise<T> {
-    const headers = new Headers(init?.headers);
-    headers.set("Content-Type", "application/json");
-    headers.set("Authorization", `Bearer ${this.token}`);
-    return super.request<T>(path, { ...init, headers });
-  }
-}
-
-async function waitForReady(client: WardnetClient, timeoutMs = 90_000): Promise<void> {
-  const info = new InfoService(client);
-  const deadline = Date.now() + timeoutMs;
-  let lastError: unknown;
-  while (Date.now() < deadline) {
-    try {
-      await info.getInfo();
-      return;
-    } catch (err) {
-      lastError = err;
-      await new Promise((resolve) => setTimeout(resolve, 1_000));
-    }
-  }
-  throw new Error(
-    `daemon did not become ready within ${timeoutMs}ms: ${String(lastError)}`,
-  );
-}
+  API_BASE_URL,
+  ensureAdminAndLogin,
+  waitForReady,
+} from "./helpers.js";
 
 describe("daemon smoke", () => {
   const client = new WardnetClient({ baseUrl: API_BASE_URL });
@@ -75,20 +20,7 @@ describe("daemon smoke", () => {
   });
 
   it("completes the setup wizard and lists zero tunnels", async () => {
-    const setup = new SetupService(client);
-
-    const status = await setup.getStatus();
-    if (!status.setup_completed) {
-      await setup.setup({ username: ADMIN_USERNAME, password: ADMIN_PASSWORD });
-    }
-
-    const login = await new AuthService(client).login({
-      username: ADMIN_USERNAME,
-      password: ADMIN_PASSWORD,
-    });
-    expect(login.token).toBeTruthy();
-
-    const authed = new AuthedClient(API_BASE_URL, login.token);
+    const authed = await ensureAdminAndLogin(client);
     const { tunnels } = await new TunnelService(authed).list();
     expect(tunnels).toEqual([]);
   });

--- a/source/end2end-tests/daemon/tests/health.spec.ts
+++ b/source/end2end-tests/daemon/tests/health.spec.ts
@@ -1,3 +1,5 @@
+import { randomBytes } from "node:crypto";
+
 import { describe, it, expect, beforeAll } from "vitest";
 import {
   WardnetClient,
@@ -13,8 +15,12 @@ const API_BASE_URL = process.env.WARDNET_API_BASE_URL ?? "http://wardnetd:7411/a
 
 // Setup-wizard credentials. Generated per-run rather than checked in
 // so a leaked log line can't be replayed against a real instance.
+// `randomBytes` (vs `Math.random`) keeps CodeQL's
+// js/insecure-randomness rule happy -- the credential is test-only
+// and never leaves the compose stack, but the rule fires on shape,
+// not reachability.
 const ADMIN_USERNAME = "admin";
-const ADMIN_PASSWORD = `e2e-${Math.random().toString(36).slice(2, 10)}`;
+const ADMIN_PASSWORD = `e2e-${randomBytes(6).toString("hex")}`;
 
 /**
  * WardnetClient that re-attaches the bearer token returned by the login

--- a/source/end2end-tests/daemon/tests/helpers.ts
+++ b/source/end2end-tests/daemon/tests/helpers.ts
@@ -1,0 +1,172 @@
+import {
+  AuthService,
+  InfoService,
+  SetupService,
+  WardnetClient,
+} from "@wardnet/js";
+
+// Compose service names resolve to the corresponding container's IP on
+// each shared bridge. The test runner sits on both wardnet_mgmt (where
+// it reaches the daemon API) and wardnet_lan (where the test-agent
+// HTTP servers listen on :3001).
+export const API_BASE_URL =
+  process.env.WARDNET_API_BASE_URL ?? "http://wardnetd:7411/api";
+export const TEST_DEBIAN_AGENT =
+  process.env.WARDNET_TEST_DEBIAN_AGENT ?? "http://test_debian:3001";
+export const TEST_UBUNTU_AGENT =
+  process.env.WARDNET_TEST_UBUNTU_AGENT ?? "http://test_ubuntu:3001";
+
+// Setup-wizard credentials. Generated per-process so a leaked log line
+// can't be replayed against a real instance.
+export const ADMIN_USERNAME = "admin";
+export const ADMIN_PASSWORD = `e2e-${Math.random().toString(36).slice(2, 10)}`;
+
+/**
+ * `WardnetClient` that re-attaches the bearer token returned by login
+ * to every subsequent request. Node's fetch has no cookie jar, so the
+ * session cookie the daemon sets is invisible to follow-up calls;
+ * `Authorization: Bearer <token>` is the documented non-browser path.
+ */
+export class AuthedClient extends WardnetClient {
+  constructor(
+    baseUrl: string,
+    private readonly token: string,
+  ) {
+    super({ baseUrl });
+  }
+
+  override async request<T>(path: string, init?: RequestInit): Promise<T> {
+    const headers = new Headers(init?.headers);
+    headers.set("Content-Type", "application/json");
+    headers.set("Authorization", `Bearer ${this.token}`);
+    return super.request<T>(path, { ...init, headers });
+  }
+}
+
+/** Polls `/api/info` until the daemon responds, or throws. */
+export async function waitForReady(
+  client: WardnetClient,
+  timeoutMs = 90_000,
+): Promise<void> {
+  const info = new InfoService(client);
+  const deadline = Date.now() + timeoutMs;
+  let lastError: unknown;
+  while (Date.now() < deadline) {
+    try {
+      await info.getInfo();
+      return;
+    } catch (err) {
+      lastError = err;
+      await new Promise((resolve) => setTimeout(resolve, 1_000));
+    }
+  }
+  throw new Error(
+    `daemon did not become ready within ${timeoutMs}ms: ${String(lastError)}`,
+  );
+}
+
+/**
+ * Idempotent admin bootstrap. Runs the setup wizard if no admin
+ * exists yet, then logs in and returns an authed client. Safe to call
+ * across spec files in any order — the wizard endpoint is a no-op
+ * once `setup_completed` flips.
+ */
+export async function ensureAdminAndLogin(
+  client: WardnetClient,
+): Promise<AuthedClient> {
+  const setup = new SetupService(client);
+  const status = await setup.getStatus();
+  if (!status.setup_completed) {
+    await setup.setup({ username: ADMIN_USERNAME, password: ADMIN_PASSWORD });
+  }
+  const login = await new AuthService(client).login({
+    username: ADMIN_USERNAME,
+    password: ADMIN_PASSWORD,
+  });
+  return new AuthedClient(API_BASE_URL, login.token);
+}
+
+/** Shape returned by `wardnet-test-agent client serve`'s /interfaces. */
+export interface AgentInterface {
+  name: string;
+  up: boolean;
+  mac: string | null;
+  mtu: number;
+  addrs: Array<{ family: string; local: string; prefixlen: number }>;
+}
+
+export interface AgentInterfacesResponse {
+  interfaces: AgentInterface[];
+}
+
+export interface AgentDhcpRenewResponse {
+  interface: string;
+  client: string;
+  release_success: boolean;
+  renew_success: boolean;
+  stdout: string;
+  stderr: string;
+}
+
+/** GET against a test-agent serve URL. Throws on non-2xx. */
+export async function agentGet<T>(
+  baseUrl: string,
+  path: string,
+): Promise<T> {
+  const res = await fetch(`${baseUrl}${path}`);
+  if (!res.ok) {
+    throw new Error(
+      `agent GET ${baseUrl}${path} failed: ${res.status} ${await res.text()}`,
+    );
+  }
+  return (await res.json()) as T;
+}
+
+/** POST JSON to a test-agent serve URL. Throws on non-2xx. */
+export async function agentPost<T>(
+  baseUrl: string,
+  path: string,
+  body: unknown,
+): Promise<T> {
+  const res = await fetch(`${baseUrl}${path}`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) {
+    throw new Error(
+      `agent POST ${baseUrl}${path} failed: ${res.status} ${await res.text()}`,
+    );
+  }
+  return (await res.json()) as T;
+}
+
+/** First IPv4 address on the named interface, or undefined. */
+export function ipv4Of(
+  ifaces: AgentInterfacesResponse,
+  name: string,
+): string | undefined {
+  return ifaces.interfaces
+    .find((i) => i.name === name)
+    ?.addrs.find((a) => a.family === "inet")?.local;
+}
+
+/** MAC of the named interface, or undefined. Lowercased for compares. */
+export function macOf(
+  ifaces: AgentInterfacesResponse,
+  name: string,
+): string | undefined {
+  return ifaces.interfaces.find((i) => i.name === name)?.mac?.toLowerCase();
+}
+
+/**
+ * Convert a dotted-quad IPv4 to a 32-bit integer for range comparisons.
+ * Bitwise ops in JS would coerce to signed 32-bit; multiply-and-add
+ * keeps the value safely positive.
+ */
+export function ipToInt(ip: string): number {
+  return ip
+    .split(".")
+    .map(Number)
+    .reduce((acc, n) => acc * 256 + n, 0);
+}

--- a/source/end2end-tests/daemon/tests/helpers.ts
+++ b/source/end2end-tests/daemon/tests/helpers.ts
@@ -1,3 +1,5 @@
+import { randomBytes } from "node:crypto";
+
 import {
   AuthService,
   InfoService,
@@ -17,9 +19,12 @@ export const TEST_UBUNTU_AGENT =
   process.env.WARDNET_TEST_UBUNTU_AGENT ?? "http://test_ubuntu:3001";
 
 // Setup-wizard credentials. Generated per-process so a leaked log line
-// can't be replayed against a real instance.
+// can't be replayed against a real instance. `randomBytes` (vs
+// `Math.random`) keeps CodeQL's js/insecure-randomness rule happy --
+// the credential is test-only and never leaves the compose stack, but
+// the rule fires on shape, not reachability.
 export const ADMIN_USERNAME = "admin";
-export const ADMIN_PASSWORD = `e2e-${Math.random().toString(36).slice(2, 10)}`;
+export const ADMIN_PASSWORD = `e2e-${randomBytes(6).toString("hex")}`;
 
 /**
  * `WardnetClient` that re-attaches the bearer token returned by login

--- a/source/end2end-tests/daemon/tests/helpers.ts
+++ b/source/end2end-tests/daemon/tests/helpers.ts
@@ -156,12 +156,81 @@ export function ipv4Of(
     ?.addrs.find((a) => a.family === "inet")?.local;
 }
 
+/**
+ * Returns the IPv4 on `name` whose value sits within `[start, end]`,
+ * or undefined if none. The e2e clients keep both their docker-IPAM
+ * address and the daemon-issued lease on eth0 simultaneously, so a
+ * "first inet wins" pick can return the wrong one.
+ */
+export function ipv4InRange(
+  ifaces: AgentInterfacesResponse,
+  name: string,
+  startInclusive: string,
+  endInclusive: string,
+): string | undefined {
+  const lo = ipToInt(startInclusive);
+  const hi = ipToInt(endInclusive);
+  return ifaces.interfaces
+    .find((i) => i.name === name)
+    ?.addrs.filter((a) => a.family === "inet")
+    .map((a) => a.local)
+    .find((ip) => {
+      const v = ipToInt(ip);
+      return v >= lo && v <= hi;
+    });
+}
+
 /** MAC of the named interface, or undefined. Lowercased for compares. */
 export function macOf(
   ifaces: AgentInterfacesResponse,
   name: string,
 ): string | undefined {
   return ifaces.interfaces.find((i) => i.name === name)?.mac?.toLowerCase();
+}
+
+/**
+ * Drives the test-agent's /dhcp/renew until an address in `[poolStart,
+ * poolEnd]` lands on `iface`, or fails after `attempts`. The daemon's
+ * DHCP server starts disabled, so beforeAll() must call dhcp.toggle()
+ * before this. Retries because dhclient races with the daemon's
+ * DHCP-runner spawn after toggle on a cold stack.
+ */
+export async function acquireLeaseInRange(
+  agent: string,
+  iface: string,
+  poolStart: string,
+  poolEnd: string,
+  attempts = 5,
+): Promise<string> {
+  let lastErr: unknown;
+  for (let i = 0; i < attempts; i++) {
+    try {
+      const renew = await agentPost<AgentDhcpRenewResponse>(
+        agent,
+        "/dhcp/renew",
+        { interface: iface },
+      );
+      if (renew.renew_success) {
+        const ifaces = await agentGet<AgentInterfacesResponse>(
+          agent,
+          `/interfaces?name=${iface}`,
+        );
+        const ip = ipv4InRange(ifaces, iface, poolStart, poolEnd);
+        if (ip) {
+          return ip;
+        }
+      }
+      lastErr = new Error(
+        `attempt ${i + 1}: renew_success=${renew.renew_success}, no in-pool IP yet — stderr: ${renew.stderr}`,
+      );
+    } catch (err) {
+      lastErr = err;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 1_500));
+  }
+  throw new Error(
+    `could not acquire lease in ${poolStart}-${poolEnd} on ${agent}/${iface}: ${String(lastErr)}`,
+  );
 }
 
 /**

--- a/source/end2end-tests/daemon/vitest.config.ts
+++ b/source/end2end-tests/daemon/vitest.config.ts
@@ -12,14 +12,17 @@ export default defineConfig({
     // All specs run against one shared daemon container, so file-level
     // parallelism is hostile (race on setup wizard, race on DHCP
     // toggle, race on lease state). singleFork keeps every file in one
-    // process — module-level state in helpers.ts (ADMIN_PASSWORD) is
-    // shared across files, and tests execute serially.
+    // process and `isolate: false` shares the module graph across
+    // files — without the latter, vitest reloads helpers.ts per file
+    // and ADMIN_PASSWORD's randomBytes() generates a fresh value each
+    // time, breaking login on every spec after the first.
     pool: "forks",
     poolOptions: {
       forks: {
         singleFork: true,
       },
     },
+    isolate: false,
     reporters: [
       "default",
       ["junit", { outputFile: "./reports/junit.xml" }],

--- a/source/end2end-tests/daemon/vitest.config.ts
+++ b/source/end2end-tests/daemon/vitest.config.ts
@@ -9,6 +9,17 @@ export default defineConfig({
     // GitHub runner from masking real failures.
     testTimeout: 60_000,
     hookTimeout: 120_000,
+    // All specs run against one shared daemon container, so file-level
+    // parallelism is hostile (race on setup wizard, race on DHCP
+    // toggle, race on lease state). singleFork keeps every file in one
+    // process — module-level state in helpers.ts (ADMIN_PASSWORD) is
+    // shared across files, and tests execute serially.
+    pool: "forks",
+    poolOptions: {
+      forks: {
+        singleFork: true,
+      },
+    },
     reporters: [
       "default",
       ["junit", { outputFile: "./reports/junit.xml" }],


### PR DESCRIPTION
## Summary

Stage 6b/c of the e2e refactor sequence. Layers `test_debian` and `test_ubuntu` onto `wardnet_lan` and adds the first two daemon scenario specs:

- **`dhcp.spec.ts`** — test_debian receives a lease in the daemon's pool (`.100-.150`); lease visible via `GET /api/dhcp/leases`; MAC matches; release+renew preserves the IP.
- **`dhcp-reservations.spec.ts`** — admin reserves test_debian's MAC at `10.91.0.160`; renew binds the client to the reserved IP; delete removes the reservation from the listing.

### Topology + transport

The plan called for HTTP probes against the LAN clients (`:3001`), but the merged test-agent shipped CLI-only. This PR adds a new `client serve` subcommand: a thin axum wrapper over the existing CLI probe handlers (interfaces, routes, dns-resolve, ping, dhcp-renew). Specs reach the clients via plain `fetch("http://test_debian:3001/...")` — no container-runtime socket mounted into the runner.

The two LAN clients build from a single `Dockerfile.client` parameterized by `BASE_IMAGE` (debian + ubuntu). The `wardnet-test-agent` binary is reused from `wardnetd:dev-test` so we don't compile it three times per CI run. Entrypoint flushes eth0, runs `dhclient -1`, then `exec`s `client serve`.

### Bug-magnet fix bundled

The merged `dhcp-renew` handler exposed a single `success` boolean reflecting only the renew exit status — silently dropping the release exit status. A failed release would let dhclient re-use its cached lease instead of issuing a fresh DISCOVER, masking a broken reservation flow as a daemon bug. The response now carries `release_success` + `renew_success` separately and the reservations spec checks both before asserting the IP.

Bundled into this PR rather than split because the bug is only observable once a spec asserts on `renew` semantics — same debug session.

### Pool config

Pool is narrowed to `.100-.150` in the dhcp spec's `beforeAll` so the default `.100-.250` doesn't let dynamic leases collide with the reservation range (`.151-.199`) the second spec uses.

## Test plan

- [ ] CI: `end2end-tests-daemon` job builds the test image + client images, brings up wardnetd / test_debian / test_ubuntu / test_runner, and runs all three specs (health + dhcp + dhcp-reservations) green.
- [ ] CI: existing `check-daemon` (clippy, fmt, unit tests) still passes (validated locally in podman: clippy --workspace clean, fmt clean, wardnet-test-agent bin tests 10/10 pass).
- [ ] CI: TypeScript typecheck on `source/end2end-tests/daemon` (validated locally: `tsc --noEmit` clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)