### PR TITLE
fix(ci): gate coverage skip on PR author, not github.actor

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -77,14 +77,20 @@ jobs:
   coverage:
     name: Coverage
     needs: preflight
-    # Skip for any bot-authored PR (actor ends with '[bot]'): bots push to
-    # same-repo branches, which GitHub denies access to repo secrets for, and
-    # Codecov requires a token for same-repo branches on public repos. Bots
-    # here (Dependabot, step-security-bot) don't change source code anyway.
-    # Fork PRs from community members keep running — they use Codecov's
-    # tokenless upload (unprotected branch ref with colon prefix).
+    # Skip for any bot-authored PR: bots push to same-repo branches, which
+    # GitHub denies access to repo secrets for, and Codecov requires a token
+    # for same-repo branches on public repos. Bots here (Dependabot,
+    # step-security-bot) don't change source code anyway. Fork PRs from
+    # community members keep running — they use Codecov's tokenless upload
+    # (unprotected branch ref with colon prefix).
+    #
+    # Gate on the PR author, not `github.actor`: re-running a workflow flips
+    # `github.actor` to whoever clicked re-run, which would let coverage run
+    # on a Dependabot PR and then fail at the Codecov upload. For
+    # `workflow_call` from release.yml there's no pull_request context, so
+    # `user.type` is empty and coverage runs as intended.
     if: |
-      !endsWith(github.actor, '[bot]') && (
+      github.event.pull_request.user.type != 'Bot' && (
         needs.preflight.outputs.daemon == 'true' ||
         needs.preflight.outputs.site == 'true' ||
         needs.preflight.outputs.ci == 'true'


### PR DESCRIPTION
## Summary
- The bot-skip on the `coverage` leaf in `pr.yml` keys off `github.actor`, but re-running a workflow flips `github.actor` to whoever clicked re-run. That's how PR #204 (Dependabot) ended up running coverage on attempt 3 and failing at the Codecov upload — there's no `CODECOV_TOKEN` access on a bot-authored same-repo branch.
- Switch the gate to `github.event.pull_request.user.type != 'Bot'`, which is stable across re-runs. The `workflow_call` path from `release.yml` is unaffected (no pull_request context → expression truthy → coverage still runs on releases).

## Test plan
- [ ] Re-run coverage on PR #204 once this lands and confirm the leaf is skipped.
- [ ] Verify a normal human PR still runs coverage (this PR itself).

🤖 Generated with [Claude Code](https://claude.com/claude-code)