### PR TITLE
fix: bump hickory crates to 0.26.1 + unblock coverage CI

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -53,11 +53,21 @@ jobs:
         with:
           workspaces: source/daemon
 
+      # taiki-e/install-action 2.75.21 made `tool` a required input;
+      # earlier per-tool tags (e.g. @cargo-llvm-cov) baked the tool
+      # name into the action.yml at publish time, so SHA-pinning to a
+      # per-tool tag's head used to work without `with: tool:`. After
+      # the bump in #204 the SHA points at the generic action and
+      # the tool must be passed explicitly.
       - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@87d97b95c884523e049410b5322ea91b2acdbc89 # cargo-llvm-cov
+        uses: taiki-e/install-action@74e87cbfa15a59692b158178d8905a61bf6fca95 # v2.75.21
+        with:
+          tool: cargo-llvm-cov
 
       - name: Install cargo-nextest
-        uses: taiki-e/install-action@024e8cba30d328c34bf69b86cfaaaad61ad5c4cb # cargo-nextest
+        uses: taiki-e/install-action@74e87cbfa15a59692b158178d8905a61bf6fca95 # v2.75.21
+        with:
+          tool: cargo-nextest
 
       - name: Generate daemon coverage + test results
         run: |

--- a/source/daemon/.cargo/audit.toml
+++ b/source/daemon/.cargo/audit.toml
@@ -20,8 +20,26 @@
 # don't install a custom logger that touches rand internals, so the
 # unsoundness is unreachable in our usage. Re-evaluate when sqlx
 # bumps rand.
+#
+# RUSTSEC-2026-0118: hickory-proto NSEC3 closest-encloser proof
+# validation enters an unbounded loop on cross-zone responses.
+# Transitive via dhcproto 0.14.0, which pins hickory-proto ^0.25.2
+# with `default-features = false`. The vulnerability is in the
+# DNSSEC validation code, which isn't compiled without the dnssec
+# features. No 0.25.x backport exists; the fix is only in the
+# 0.26.x line, and dhcproto hasn't bumped yet. Re-evaluate when
+# dhcproto upgrades to hickory-proto 0.26.
+#
+# RUSTSEC-2026-0119: hickory-proto O(n²) name compression during
+# message encoding. Transitive via dhcproto 0.14.0 (same pin as
+# above). Triggered by DNS messages with many compressible names;
+# wardnetd only uses dhcproto to encode DHCPv4 packets, which carry
+# at most a single FQDN (option 81), so the quadratic blow-up isn't
+# reachable. No 0.25.x backport. Re-evaluate when dhcproto upgrades.
 ignore = [
     "RUSTSEC-2023-0071",
     "RUSTSEC-2024-0436",
     "RUSTSEC-2026-0097",
+    "RUSTSEC-2026-0118",
+    "RUSTSEC-2026-0119",
 ]

--- a/source/daemon/Cargo.lock
+++ b/source/daemon/Cargo.lock
@@ -1495,9 +1495,9 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hickory-net"
-version = "0.26.0"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c61c8db47fae51ba9f8f2a2748bd87542acfbe22f2ec9cf9c8ec72d1ee6e9a6"
+checksum = "e2295ed2f9c31e471e1428a8f88a3f0e1f4b27c15049592138d1eebe9c35b183"
 dependencies = [
  "async-trait",
  "cfg-if",
@@ -1505,7 +1505,7 @@ dependencies = [
  "futures-channel",
  "futures-io",
  "futures-util",
- "hickory-proto 0.26.0",
+ "hickory-proto 0.26.1",
  "idna",
  "ipnet",
  "jni 0.22.4",
@@ -1541,9 +1541,9 @@ dependencies = [
 
 [[package]]
 name = "hickory-proto"
-version = "0.26.0"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a916d0494600d99ecb15aadfab677ad97c4de559e8f1af0c129353a733ac1fcc"
+checksum = "0bab31817bfb44672a252e97fe81cd0c18d1b2cf892108922f6818820df8c643"
 dependencies = [
  "data-encoding",
  "idna",
@@ -1561,14 +1561,14 @@ dependencies = [
 
 [[package]]
 name = "hickory-resolver"
-version = "0.26.0"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a10bd64d950b4d38ca21e25c8ae230712e4955fb8290cfcb29a5e5dc6017e544"
+checksum = "f0d58d28879ceecde6607729660c2667a081ccdc082e082675042793960f178c"
 dependencies = [
  "cfg-if",
  "futures-util",
  "hickory-net",
- "hickory-proto 0.26.0",
+ "hickory-proto 0.26.1",
  "ipconfig",
  "ipnet",
  "jni 0.22.4",
@@ -5237,7 +5237,7 @@ dependencies = [
  "cron",
  "dhcproto",
  "futures",
- "hickory-proto 0.26.0",
+ "hickory-proto 0.26.1",
  "hickory-resolver",
  "ipnetwork",
  "netlink-packet-route 0.30.0",
@@ -5354,7 +5354,7 @@ dependencies = [
  "cron",
  "flate2",
  "hex",
- "hickory-proto 0.26.0",
+ "hickory-proto 0.26.1",
  "ipnetwork",
  "minisign-verify",
  "password-hash 0.6.1",
@@ -5591,7 +5591,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Bumps `hickory-proto`, `hickory-net`, `hickory-resolver` 0.26.0 → 0.26.1, closing **RUSTSEC-2026-0119**, **RUSTSEC-2026-0120**, and the 0.26 hit of **RUSTSEC-2026-0118**.
- The transitive `hickory-proto 0.25.2` pulled by `dhcproto 0.14.0` keeps getting flagged for -0118 and -0119 (no 0.25.x backport, `dhcproto` pins `^0.25.2`). Both are unreachable in our usage — `dhcproto` disables hickory-proto default features (no DNSSEC, no NSEC3 code), and we only encode DHCPv4 packets that carry at most a single FQDN (option 81), so the O(n²) name-compression scaling can't blow up. Documented in `audit.toml` with revisit-when-dhcproto-bumps.
- Unblocks coverage CI on `main`: #204 bumped `taiki-e/install-action` to 2.75.21 by SHA, but the new `action.yml` makes `tool` a required input where the older per-tool tags had it baked in at publish time. Both `Install cargo-llvm-cov` / `Install cargo-nextest` steps silently no-op'd, and `cargo llvm-cov nextest` then failed with `no such command: llvm-cov` on #207. Now passing `tool:` explicitly to both steps.

## Test plan

- [x] `cargo audit` exits 0 with the new ignores.
- [x] `make check-daemon-container` passes (fmt + clippy `-D warnings` + 595 nextest tests).
- [ ] PR CI green — coverage step in particular, since that's what we're fixing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)