### PR TITLE
fix(security): add osv-scanner ignores for hickory transitives

### DIFF
--- a/source/daemon/osv-scanner.toml
+++ b/source/daemon/osv-scanner.toml
@@ -31,3 +31,26 @@ transitives still pin the older 0.8 / 0.9.2 lines. We don't install a
 custom logger that touches rand internals, so the unsoundness is
 unreachable in our usage. Re-evaluate when sqlx bumps rand.
 """
+
+[[IgnoredVulns]]
+id = "RUSTSEC-2026-0118"
+reason = """
+hickory-proto NSEC3 closest-encloser proof validation enters an
+unbounded loop on cross-zone responses. Transitive via dhcproto 0.14.0,
+which pins hickory-proto ^0.25.2 with `default-features = false`. The
+vulnerable code path is gated behind hickory-proto's DNSSEC features,
+which dhcproto disables, so it isn't compiled into wardnetd. No
+0.25.x backport exists; the fix is only in the 0.26.x line and
+dhcproto hasn't bumped. Re-evaluate when dhcproto upgrades.
+"""
+
+[[IgnoredVulns]]
+id = "RUSTSEC-2026-0119"
+reason = """
+hickory-proto O(n²) name compression during message encoding. Same
+transitive path (dhcproto 0.14.0 → hickory-proto 0.25.2). Triggered by
+DNS messages with many compressible names; wardnetd only uses dhcproto
+to encode DHCPv4 packets, which carry at most a single FQDN (option
+81), so the quadratic blow-up isn't reachable. No 0.25.x backport.
+Re-evaluate when dhcproto upgrades.
+"""


### PR DESCRIPTION
## Summary

- Scorecard alert #42 came back after #209 because the two RUSTSEC ignores only landed in `.cargo/audit.toml` (cargo-audit), not in `osv-scanner.toml` (osv-scanner / Scorecard's Vulnerabilities check). Same rationale, same advisories — just the second config file the parallel scanner needs.
- Both vulns hit the transitive `hickory-proto 0.25.2` pulled by `dhcproto 0.14.0` and are unreachable in our usage: dhcproto disables hickory-proto default features (so the NSEC3 DNSSEC path doesn't compile), and we only encode DHCPv4 packets that carry at most one FQDN (option 81), so the O(n²) compression vuln has no input to scale on.

## Test plan

- [x] `osv-scanner.toml` parses (validated with `tomllib`).
- [ ] Scorecard re-runs after merge and alert #42 closes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)