### PR TITLE
feat(test): Stage 7 DNS scenarios on the e2e topology

### DIFF
--- a/source/end2end-tests/PLAN.md
+++ b/source/end2end-tests/PLAN.md
@@ -1,0 +1,374 @@
+# End-to-end test plan
+
+Living document for the wardnet e2e initiative. Adjacent to the two
+suites it governs:
+
+- `source/end2end-tests/daemon/` — API + kernel specs (Vitest + JS SDK
+  + `wardnet-test-agent` probes); already in place through Stage 6c.
+- `source/end2end-tests/web-ui/` — browser specs (Playwright); not yet
+  scaffolded. **Stage U-0** below sets it up.
+
+The daemon's `compose.yaml` header points readers here for the full
+topology and roadmap.
+
+The suites drive the real `wardnetd` binary in a Docker topology, hit
+its HTTP API via the typed JS SDK, and probe kernel state from inside
+LAN clients via `wardnet-test-agent`. The UI suite drives the React app
+served by `wardnetd` (rust-embed) through Playwright. No mocks of the
+daemon itself — mocks live only at the *upstream* boundary (NordVPN
+API, blocklist HTTP servers, future update manifest server).
+
+## Coverage today (Stages 6a–6c, PR #207)
+
+### Daemon suite
+
+| Spec | Touches |
+|---|---|
+| `health.spec.ts` | `/api/info` (unauth), setup wizard idempotent, empty tunnels list |
+| `dhcp.spec.ts` | DHCP toggle, pool narrowing, dynamic lease in `.100–.150`, renew = same IP |
+| `dhcp-reservations.spec.ts` | reservation in `.151–.199`, force re-DISCOVER, reserved IP returned, delete |
+
+Helpers: `helpers.ts` covers `WardnetClient` auth (bearer),
+`waitForReady`, `acquireLeaseInRange`, `agentGet`/`agentPost`,
+range-aware `ipv4InRange`.
+
+### Web UI suite
+
+Nothing yet — no test framework wired up; only `lint` / `type-check` /
+`format:check` exist on `web-ui/package.json`. Stage U-0 introduces
+Playwright.
+
+## Topology today
+
+```
+                 wardnet_mgmt 10.90/24            wardnet_lan 10.91/24
+                       │                                  │
+  test_runner ─────────┤                                  ├───── test_debian (eth0, dhclient)
+   .10                 │                                  │       :3001 client serve
+                       │      ┌─────────────────┐         │
+                       └──────│    wardnetd     │─────────┤
+                       .2     │  10.90.0.2 mgmt │  .1     │
+                              │  10.91.0.1  lan │         ├───── test_ubuntu (eth0, dhclient)
+                              │  10.92.0.2  wan │         │       :3001 client serve
+                              └────────┬────────┘
+                                       │
+                                wardnet_wan 10.92/24 (provisioned, no peers yet)
+```
+
+## Untested surface (inventory)
+
+Asterisk (\*) marks day-zero scope per project memory ("ad blocking is
+day-zero, replaces Pi-hole").
+
+### API / daemon
+
+Grouped by SDK service (`source/sdk/wardnet-js/src/services/`).
+
+- **DnsService** \* — `getConfig` / `updateConfig` / `toggle` /
+  `status` / `flushCache`; blocklists CRUD + `updateBlocklistNow` job;
+  allowlist CRUD; custom filter rules CRUD. **Plus** end-to-end
+  resolution from a LAN client via `/dns/resolve` probe.
+- **TunnelService** — `create` (import `.conf`), `delete`, plus the
+  bring-up/tear-down lifecycle and stats collection (currently observed
+  only via `list`).
+- **DeviceService** — `list`, `getById`, `getMe` (source-IP), `setMyRule`,
+  admin-lock enforcement, `update`.
+- **ProviderService** — `list`, `listCountries`, `validateCredentials`,
+  `listServers`, `setupTunnel`. Requires a NordVPN-API mock.
+- **BackupService** — `export`, `previewImport`, `applyImport`,
+  `listSnapshots` round-trip with a known reservation/blocklist.
+- **UpdateService** — `status`, `check`, `install`, `rollback`,
+  `updateConfig`, `history`. Requires a manifest-server mock.
+- **SystemService** — `getStatus`, `restart`.
+- **AuthService** — login negatives (bad creds, missing/expired token),
+  setup wizard reject-after-completion path.
+- **JobsService** — exercised indirectly via blocklist refresh; no
+  dedicated spec.
+- **LogService** WebSocket — connect, receive, `set_filter`,
+  pause/resume, lag handling.
+
+Plus two **infra capabilities** not yet deployed:
+
+1. The test-agent's *server mode* (`/pid`, `/ip-rules`, `/nft-rules`,
+   `/wg/{iface}`, `/link/{iface}`, `/fixtures/{name}`) — required to
+   assert kernel state on the wardnetd side. Today only the LAN-side
+   `client serve` probes are running. Need a sidecar (or daemon-side
+   co-located process) exposing this on `wardnet_mgmt` to the runner.
+2. **LAN-side API proxy** — `/devices/me` and `/devices/me/rule` are
+   classified by source IP. To drive them as a real LAN client we need
+   the test-agent's `client serve` to grow a thin
+   `POST /proxy { method, path, body }` that forwards to
+   `http://wardnetd:7411/api/...` from inside the client's network
+   namespace.
+
+### Web UI
+
+The suite must cover every page at least at the smoke level (loads,
+no console errors, reachable from the layout) and exercise the primary
+flows on each. Pages on disk today (`source/web-ui/src/pages/`):
+`Setup`, `Login`, `Dashboard`, `Devices`, `MyDevice`, `Dhcp`, `Dns`,
+`AdBlocking`, `Tunnels`, `Settings`, `NotFound`.
+
+Untested flows worth calling out:
+- First-run setup wizard.
+- Login form (good + bad creds, redirect to original target).
+- Devices table → drill into device → change routing rule.
+- DHCP page — toggle, edit pool, create/delete reservation.
+- Ad-blocking page \* — add blocklist, force update, see status,
+  add/remove allowlist entry, add/remove custom rule.
+- DNS page — toggle, edit upstream, flush cache.
+- Tunnels page — import a `.conf`, see it listed, delete.
+- Settings page — admin password change, restart daemon (modal/progress
+  dialog).
+- NotFound, layout sidebar/topnav, theme toggle, mobile menu.
+
+## Staged rollout
+
+Stages are ordered by dependency and value. Each stage = one PR.
+
+### Daemon lane
+
+#### Stage 7 — DNS subsystem \* (LAN topology, no new client/gateway containers)
+
+Specs:
+- `dns-config.spec.ts` — toggle on/off, `getConfig` round-trip,
+  `status` reports running + upstream, `flushCache` clears counters.
+- `dns-resolve.spec.ts` — drive test_debian's
+  `/dns/resolve?server=10.91.0.1` for a public name; verify daemon
+  answered (cache miss → hit on second call).
+- `dns-blocklists.spec.ts` — bring up a tiny static-file HTTP server
+  on `wardnet_lan` serving a 3-line hosts blocklist; `createBlocklist`
+  pointing at it, `updateBlocklistNow`, poll `JobsService.get` until
+  `succeeded`; resolve a listed name → NXDOMAIN / 0.0.0.0.
+- `dns-allowlist.spec.ts` — same blocklist, then `createAllowlistEntry`
+  for one domain → resolves normally; delete restores blocked behavior.
+- `dns-rules.spec.ts` — custom block rule (regex/glob), custom allow
+  rule overrides a blocklisted domain; precedence semantics.
+
+Infra: `blocklist_server` container on `wardnet_lan` (busybox httpd or
+nginx:alpine) serving fixtures from a bind-mounted dir.
+
+Helpers: `resolveViaAgent(agent, name, server?)`, `waitForJob(jobs, id, timeoutMs)`.
+
+#### Stage 8 — Devices & per-device routing (LAN-only)
+
+Specs:
+- `devices-list.spec.ts` — both LAN clients with leases → ARP
+  discovery surfaces them in `/devices`; `getById` returns expected
+  fields.
+- `devices-me.spec.ts` — drive `/devices/me` from each LAN client via
+  the proxy; verify source-IP classification.
+- `devices-rules.spec.ts` — `setMyRule` to `Direct` / `Block`; assert
+  the resulting `ip rule` set on the daemon side via the kernel-state
+  agent.
+- `admin-lock.spec.ts` — admin locks device → `setMyRule` returns 403.
+
+Infra:
+- Extend `wardnet-test-agent` (`client serve`) with `POST /proxy`
+  forwarding to a configured base URL.
+- Deploy the test-agent's *server mode* alongside wardnetd. Two
+  options, decide during impl:
+  - (a) sidecar container sharing the daemon's network namespace
+        (`network_mode: "service:wardnetd"`).
+  - (b) co-locate a second binary inside the wardnetd container,
+        launched by a systemd unit drop-in.
+
+#### Stage 9 — Tunnels & WireGuard topology
+
+Add `wg_gateway_1`, `wg_gateway_2` on `wardnet_wan` (real `wg`; static
+keys baked into fixtures).
+
+Specs:
+- `tunnel-import.spec.ts` — create from fixture conf, `list` shows it,
+  delete clears it. No bring-up.
+- `tunnel-bringup.spec.ts` — bring up via the path the daemon supports
+  (today: assigning a device to the tunnel); kernel-state agent confirms
+  `wg show wgN` reports the peer; tear-down removes the interface.
+- `tunnel-stats.spec.ts` — drive ping through the tunnel from a routed
+  device; `list` shows non-zero rx/tx counters.
+
+Open question: `TunnelService` SDK only exposes `list` / `create` /
+`delete`. Bring-up is automatic when a device targets the tunnel. The
+bring-up spec will set a device rule and observe the tunnel-up event
+indirectly — confirm with the daemon team before adding a `bringUp`
+SDK method.
+
+#### Stage 10 — VPN provider integration
+
+Add `nordvpn_mock` container — small HTTP server (Node) implementing
+the subset of the NordVPN API that
+`wardnetd-services/src/vpn/nordvpn.rs` calls. Static fixture data.
+
+Specs:
+- `provider-list.spec.ts` — NordVPN registered.
+- `provider-validate.spec.ts` — happy-path token + 401 path.
+- `provider-countries.spec.ts` — listCountries returns fixture set.
+- `provider-setup.spec.ts` — `setupTunnel` creates a tunnel; appears
+  in `tunnels.list()`; cleanup deletes it.
+
+#### Stage 11 — System, backup, update
+
+- `system-status.spec.ts` — version/uptime fields, device count.
+- `system-restart.spec.ts` — request restart, `/api/info` recovers.
+  Order-sensitive — keep in its own file, run via setup that re-runs
+  `waitForReady` on the next spec.
+- `backup-roundtrip.spec.ts` — pre-seed a unique reservation and
+  blocklist; export bundle (passphrase ≥12 chars), delete the seeds,
+  `previewImport` + `applyImport` of the same bundle, verify both
+  reappear; `listSnapshots` shows the pre-restore snapshot.
+- `update-status.spec.ts` — read `status`; switch channel via
+  `updateConfig`; `check` against a fixture manifest server returns
+  "no update available" or a fixture release.
+
+Infra: `update_manifest_server` (Stage 11) — static-file HTTPS server
+with the daemon's expected JSON shape. May reuse the blocklist HTTP
+fixture container with TLS termination.
+
+#### Stage 12 — Auth negatives & coverage
+
+- `auth-login.spec.ts` — wrong password → 401; missing bearer → 401
+  on admin endpoint; setup wizard returns "already completed" once
+  flipped.
+- `auth-coverage.spec.ts` — table-driven matrix asserting representative
+  admin endpoints reject unauth (DHCP config, DNS config, devices list,
+  tunnels list, backup status). One spec.
+
+#### Stage 13 — Logs WebSocket
+
+- `logs-stream.spec.ts` — connect via `LogService` (Node uses undici's
+  WebSocket polyfill), receive ≥1 entry, `set_filter`, pause/resume.
+
+### Web UI lane (Playwright)
+
+The UI is served by `wardnetd` (rust-embed in `web.rs`). The Playwright
+runner is a new container in the same compose, pointed at
+`http://wardnetd:7411/`. Specs share the same daemon as the daemon-suite
+specs but live in a parallel directory.
+
+Layout under `source/end2end-tests/web-ui/`:
+- `playwright.config.ts` — Chromium only initially (Firefox/WebKit
+  optional later); JUnit reporter into `reports/`.
+- `tests/` — one file per page or flow.
+- `Dockerfile.ui-runner` — `mcr.microsoft.com/playwright:v1.x-jammy`
+  base.
+- Compose service `ui_runner` on `wardnet_mgmt`, mirroring `test_runner`.
+
+#### Stage U-0 — Scaffold (no specs yet)
+
+- Add Playwright deps and config; `yarn` install pinned versions
+  (deterministic CI).
+- New compose service `ui_runner` with health gate on wardnetd, a
+  bind mount for `reports/`, repo mounted read-only.
+- Add `make e2e-ui` (and roll into `make e2e-all`) — symmetric with
+  the daemon target.
+- One smoke spec `home.spec.ts`: navigate to `/`, expect the app
+  shell renders without console errors.
+- CI: extend `.github/workflows/tests-e2e.yml` with a parallel UI job.
+
+#### Stage U-1 — Auth & setup flow
+
+- `setup.spec.ts` — first-run wizard happy path: navigate to fresh
+  daemon (fixture: backup/import a "blank" snapshot, or a separate
+  compose project for isolation), submit credentials, redirected to
+  Dashboard.
+- `login.spec.ts` — bad creds shows error; good creds redirects;
+  deep-link redirect target preserved.
+
+Open question: setup wizard is one-shot. Two options:
+- (a) Run UI specs first while daemon is still pre-setup. Daemon
+      specs after will pick up the admin user the UI created. Removes
+      the password constant from `helpers.ts` — it must instead be
+      written by the UI spec and read by daemon specs.
+- (b) Run UI specs against a dedicated compose project (separate
+      daemon instance). More isolation, more CI minutes.
+
+Recommended: (a) for cost; share the password through an env var the
+UI spec sets and the daemon-suite helper reads.
+
+#### Stage U-2 — Dashboard, layout, theme
+
+- `dashboard.spec.ts` — primary tiles render with seeded data.
+- `layout.spec.ts` — sidebar links navigate; mobile menu opens;
+  theme toggle persists.
+- `notfound.spec.ts` — unknown route shows 404 page.
+
+#### Stage U-3 — DHCP page
+
+- `dhcp.spec.ts` — toggle on/off, edit pool start/end (form
+  validation), create reservation (use the reservation range from
+  the daemon-side helper to avoid colliding), delete reservation.
+- `dhcp-leases.spec.ts` — leases table populated after LAN clients
+  have leases (depends on the daemon-suite Stage 6c state).
+
+#### Stage U-4 — DNS + AdBlocking pages \*
+
+- `dns.spec.ts` — toggle, edit upstream, flush cache, status banner.
+- `adblocking.spec.ts` — add blocklist (URL fixture from the
+  blocklist_server in Stage 7 daemon infra), force update, status
+  reaches `succeeded`; add allowlist entry; add custom rule.
+
+#### Stage U-5 — Devices & MyDevice
+
+- `devices.spec.ts` — table shows discovered LAN clients, drill-in
+  page shows fields, change routing rule.
+- `mydevice.spec.ts` — when accessed *from* a LAN client (Playwright
+  driving Chromium *inside* the client container, see infra below),
+  shows the calling device.
+
+Infra for `mydevice`: optionally run a second Playwright runner on
+`wardnet_lan` so the source IP matches a discovered device. Skip if
+costly — assert the API behavior in the daemon suite instead.
+
+#### Stage U-6 — Tunnels & Providers
+
+- `tunnels.spec.ts` — import from `.conf` (file upload), see in list,
+  delete. Depends on Stage 9 daemon infra (gateway containers) only
+  if we want to actually bring the tunnel up; configuration import
+  alone doesn't.
+- `providers.spec.ts` — wizard through the provider setup flow
+  (NordVPN), depends on Stage 10 daemon infra (`nordvpn_mock`).
+
+#### Stage U-7 — Settings
+
+- `settings.spec.ts` — admin password change (then re-login),
+  restart daemon shows progress dialog and recovers, language/theme
+  persistence.
+
+#### Stage U-8 — Visual regression (optional)
+
+- Playwright screenshot snapshots for Dashboard, AdBlocking, Devices.
+  CI baseline maintained per platform; update flow documented in
+  `web-ui/README.md`.
+
+## Cross-cutting conventions
+
+- One daemon, shared across spec files (`isolate: false`,
+  `singleFork: true` for Vitest; Playwright `fullyParallel: false`,
+  `workers: 1`). Specs MUST clean up after themselves OR be written
+  order-tolerant. Setup wizard, DHCP toggle, and DHCP pool config
+  are idempotent; new specs must keep that property.
+- IP ranges, per the topology comments in `compose.yaml`:
+  - `.100–.150` dynamic DHCP pool
+  - `.151–.199` reservation range
+  - `.200+` static service addresses (blocklist server, mocks)
+- All admin-authed work (daemon suite) reuses
+  `ensureAdminAndLogin(client)` — it's idempotent and reads the
+  shared module-scoped admin password constant. UI Stage U-1
+  changes how this constant is sourced (see open question above).
+- New helpers go in `helpers.ts` (daemon) or `tests/fixtures/` (UI).
+  Keep specs declarative.
+- Each new container is added to `compose.yaml` with a `healthcheck`
+  and `depends_on: { condition: service_healthy }` from the runner.
+- macOS dev: `cargo clippy --workspace` fails on linux-only crates;
+  scope clippy to touched crates and rely on `make check-daemon` for
+  the full pass before push.
+
+## Non-goals
+
+- No multi-host scenarios (Pi cluster) — single-daemon only.
+- No load / benchmark tests — correctness only.
+- No DPI / packet-content assertions beyond what the test-agent's
+  `/ping` and `/dns/resolve` give. Wire-level inspection remains a
+  manual ops task.
+- No accessibility audit suite — covered by lint plugins on the UI
+  side, not e2e.

--- a/source/end2end-tests/daemon/compose.yaml
+++ b/source/end2end-tests/daemon/compose.yaml
@@ -1,10 +1,11 @@
 # Daemon end-to-end test topology.
 #
-# Stage 6a/6b (this file) ships the daemon container, a node:22 test
-# runner, and two LAN clients (`test_debian`, `test_ubuntu`) for the
-# DHCP scenarios. Future stages add `wg_gateway_1`, `wg_gateway_2`,
-# `nordvpn_mock` — see source/end2end-tests/daemon/README or the plan
-# under .agents/ for the full topology.
+# Stage 6 ships the daemon container, a node:22 test runner, and two
+# LAN clients (`test_debian`, `test_ubuntu`) for the DHCP scenarios.
+# Stage 7 adds `blocklist_server` (busybox httpd) on wardnet_lan to
+# serve the blocklist fixtures consumed by the DNS specs. Future
+# stages add `wg_gateway_1`, `wg_gateway_2`, `nordvpn_mock` — see
+# source/end2end-tests/PLAN.md for the full topology and roadmap.
 #
 # Networks (per the e2e plan, Deliverable 5):
 #   wardnet_mgmt 10.90.0.0/24 — test runner ↔ daemon API.
@@ -182,6 +183,31 @@ services:
       retries: 20
       start_period: 10s
 
+  # Static-file HTTP server for blocklist fixtures consumed by the
+  # Stage 7 DNS specs. busybox httpd keeps the image tiny and avoids
+  # nginx's directory-listing / CRLF normalisation on text bodies that
+  # the daemon's blocklist parser would have to tolerate. Pinned to
+  # 10.91.0.200 (outside wardnet_lan's IPAM range .2-.15) so specs
+  # reference a stable URL even if container restart order shifts.
+  blocklist_server:
+    image: busybox:1.36@sha256:73aaf090f3d85aa34ee199857f03fa3a95c8ede2ffd4cc2cdb5b94e566b11662
+    command: ["httpd", "-f", "-v", "-p", "80", "-h", "/srv"]
+    volumes:
+      - ./fixtures/blocklists:/srv:ro
+    networks:
+      wardnet_lan:
+        ipv4_address: 10.91.0.200
+    healthcheck:
+      # busybox httpd has no built-in healthcheck endpoint; a HEAD
+      # against a known fixture file is the cheapest liveness signal.
+      # wget --spider returns 0 on 2xx and is part of the busybox
+      # image already.
+      test: ["CMD-SHELL", "wget --spider -q http://127.0.0.1/dns-blocklists.txt"]
+      interval: 3s
+      timeout: 2s
+      retries: 10
+      start_period: 5s
+
   test_runner:
     build:
       context: ../../..
@@ -193,6 +219,8 @@ services:
       test_debian:
         condition: service_healthy
       test_ubuntu:
+        condition: service_healthy
+      blocklist_server:
         condition: service_healthy
     environment:
       WARDNET_API_BASE_URL: "http://wardnetd:7411/api"

--- a/source/end2end-tests/daemon/fixtures/blocklists/dns-allowlist.txt
+++ b/source/end2end-tests/daemon/fixtures/blocklists/dns-allowlist.txt
@@ -1,0 +1,8 @@
+# Blocklist consumed by `dns-allowlist.spec.ts`. example.com is real
+# (RFC 2606), which is essential here: the spec needs the domain to
+# resolve via upstream once an allowlist entry overrides the block.
+# A fictitious .test domain returns NXDOMAIN from upstream too, so
+# allowlist-vs-block could not be distinguished from the resolver
+# answer alone. The spec deletes both the blocklist and the
+# allowlist entry in afterAll so global DNS state is restored.
+0.0.0.0 example.com

--- a/source/end2end-tests/daemon/fixtures/blocklists/dns-blocklists.txt
+++ b/source/end2end-tests/daemon/fixtures/blocklists/dns-blocklists.txt
@@ -1,0 +1,15 @@
+# Static blocklist served by the e2e blocklist_server fixture and
+# pulled by `dns-blocklists.spec.ts` via createBlocklist +
+# updateBlocklistNow. Hosts-file format; the daemon's
+# blocklist_downloader.parse_blocklist_body recognises the leading
+# 0.0.0.0 sentinel and drops the rest.
+#
+# www.iana.org is real (RFC 7042 example domain) and is the canary
+# the spec uses to distinguish "blocklist active" from
+# "filter passthrough" — block path returns NXDOMAIN, post-delete
+# returns the real upstream answer. The .test entries are present
+# to verify entry_count > 1 without coupling more public domains
+# than necessary.
+0.0.0.0 www.iana.org
+0.0.0.0 ads.fixture.test
+0.0.0.0 banner.fixture.test

--- a/source/end2end-tests/daemon/fixtures/blocklists/dns-rules.txt
+++ b/source/end2end-tests/daemon/fixtures/blocklists/dns-rules.txt
@@ -1,0 +1,7 @@
+# Blocklist consumed by `dns-rules.spec.ts`. iana.org is the
+# allowlist target — see the spec's afterAll for cleanup. We pin a
+# real domain in the blocklist (rather than a .test domain) for the
+# same reason as dns-allowlist.txt: the @@-rule precedence test
+# needs the override path to forward upstream and return real
+# answers, which only works if the domain actually exists.
+0.0.0.0 iana.org

--- a/source/end2end-tests/daemon/tests/dns-allowlist.spec.ts
+++ b/source/end2end-tests/daemon/tests/dns-allowlist.spec.ts
@@ -1,0 +1,145 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { DnsService, JobsService, WardnetClient } from "@wardnet/js";
+
+import {
+  API_BASE_URL,
+  AuthedClient,
+  TEST_DEBIAN_AGENT,
+  ensureAdminAndLogin,
+  resolveViaAgent,
+  waitForJob,
+  waitForReady,
+} from "./helpers.js";
+
+const BLOCKLIST_URL = "http://10.91.0.200/dns-allowlist.txt";
+const BLOCKLIST_NAME = "e2e-dns-allowlist";
+const CRON_NEVER = "0 0 1 1 *";
+
+// Real public domain — required because the allow-overrides-block
+// assertion needs the override path to forward upstream and produce a
+// real answer. See fixtures/blocklists/dns-allowlist.txt.
+const TARGET_DOMAIN = "example.com";
+
+describe("dns allowlist", () => {
+  let authed: AuthedClient;
+  let dns: DnsService;
+  let jobs: JobsService;
+  let blocklistId: string | undefined;
+  let allowlistEntryId: string | undefined;
+
+  beforeAll(async () => {
+    const client = new WardnetClient({ baseUrl: API_BASE_URL });
+    await waitForReady(client);
+    authed = await ensureAdminAndLogin(client);
+    dns = new DnsService(authed);
+    jobs = new JobsService(authed);
+
+    if (!(await dns.getConfig()).config.enabled) {
+      await dns.toggle({ enabled: true });
+    }
+
+    // Clean leftover allowlist entries / blocklists from prior runs
+    // on the same wardnet_state volume.
+    const allow = await dns.listAllowlist();
+    for (const e of allow.entries) {
+      if (e.domain === TARGET_DOMAIN) {
+        await dns.deleteAllowlistEntry(e.id);
+      }
+    }
+    const lists = await dns.listBlocklists();
+    for (const b of lists.blocklists) {
+      if (b.name === BLOCKLIST_NAME || b.url === BLOCKLIST_URL) {
+        await dns.deleteBlocklist(b.id);
+      }
+    }
+
+    const created = await dns.createBlocklist({
+      name: BLOCKLIST_NAME,
+      url: BLOCKLIST_URL,
+      cron_schedule: CRON_NEVER,
+      enabled: true,
+    });
+    blocklistId = created.blocklist.id;
+    const dispatched = await dns.updateBlocklistNow(blocklistId);
+    const job = await waitForJob(jobs, dispatched.job_id, 30_000);
+    expect(job.status, `job error: ${job.error ?? "(none)"}`).toBe("SUCCEED");
+  }, 90_000);
+
+  afterAll(async () => {
+    if (allowlistEntryId) {
+      try {
+        await dns.deleteAllowlistEntry(allowlistEntryId);
+      } catch {
+        // ignore
+      }
+    }
+    if (blocklistId) {
+      try {
+        await dns.deleteBlocklist(blocklistId);
+      } catch {
+        // ignore
+      }
+    }
+    try {
+      await dns.flushCache();
+    } catch {
+      // ignore
+    }
+  });
+
+  it("blocks the domain until an allowlist entry overrides", async () => {
+    // Sanity check the blocklist is in effect — without this, a
+    // false-pass ("allowlist works because nothing was blocked") is
+    // possible if the fixture didn't load.
+    await expect
+      .poll(
+        async () =>
+          (await resolveViaAgent(TEST_DEBIAN_AGENT, TARGET_DOMAIN)).addrs
+            .length,
+        { interval: 250, timeout: 10_000 },
+      )
+      .toBe(0);
+
+    const created = await dns.createAllowlistEntry({
+      domain: TARGET_DOMAIN,
+      reason: "e2e dns-allowlist spec",
+    });
+    allowlistEntryId = created.entry.id;
+
+    // Cached NXDOMAIN from the block phase would mask the allowlist
+    // override (DnsCache.get serves stale negative answers within
+    // their TTL). Flush so the post-allowlist query is a fresh
+    // filter pass + upstream forward.
+    await dns.flushCache();
+
+    await expect
+      .poll(
+        async () =>
+          (await resolveViaAgent(TEST_DEBIAN_AGENT, TARGET_DOMAIN)).addrs
+            .length,
+        { interval: 500, timeout: 15_000 },
+      )
+      .toBeGreaterThan(0);
+  });
+
+  it("re-blocks the domain when the allowlist entry is removed", async () => {
+    expect(allowlistEntryId, "previous test created an allowlist entry")
+      .toBeDefined();
+
+    await dns.deleteAllowlistEntry(allowlistEntryId!);
+    allowlistEntryId = undefined;
+
+    // Same caching subtlety as above, in reverse: a cached real
+    // answer would be served regardless of the rebuilt filter.
+    await dns.flushCache();
+
+    await expect
+      .poll(
+        async () =>
+          (await resolveViaAgent(TEST_DEBIAN_AGENT, TARGET_DOMAIN)).addrs
+            .length,
+        { interval: 250, timeout: 10_000 },
+      )
+      .toBe(0);
+  });
+});

--- a/source/end2end-tests/daemon/tests/dns-blocklists.spec.ts
+++ b/source/end2end-tests/daemon/tests/dns-blocklists.spec.ts
@@ -1,0 +1,153 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { DnsService, JobsService, WardnetClient } from "@wardnet/js";
+
+import {
+  API_BASE_URL,
+  AuthedClient,
+  TEST_DEBIAN_AGENT,
+  ensureAdminAndLogin,
+  resolveViaAgent,
+  waitForJob,
+  waitForReady,
+} from "./helpers.js";
+
+// Static IP of the blocklist_server fixture (compose.yaml). Pinned by
+// IP rather than service hostname so the daemon's HTTP client never
+// has to round-trip through Docker DNS to fetch the file.
+const BLOCKLIST_URL = "http://10.91.0.200/dns-blocklists.txt";
+const BLOCKLIST_NAME = "e2e-dns-blocklists";
+// Annual cron — picked so the runner's periodic check in
+// dns/runner.rs cannot fire mid-spec and re-download the file
+// against its own ad-hoc clock. Manual updateBlocklistNow() is what
+// drives state in the spec.
+const CRON_NEVER = "0 0 1 1 *";
+
+// Real public domain so block (NXDOMAIN) vs delete (real answer)
+// can be distinguished from the resolver response alone. See
+// fixtures/blocklists/dns-blocklists.txt for why this beats a
+// fictitious .test domain.
+const BLOCKED_DOMAIN = "www.iana.org";
+const PASSTHROUGH_DOMAIN = "example.org";
+
+describe("dns blocklists", () => {
+  let authed: AuthedClient;
+  let dns: DnsService;
+  let jobs: JobsService;
+  let blocklistId: string | undefined;
+
+  beforeAll(async () => {
+    const client = new WardnetClient({ baseUrl: API_BASE_URL });
+    await waitForReady(client);
+    authed = await ensureAdminAndLogin(client);
+    dns = new DnsService(authed);
+    jobs = new JobsService(authed);
+
+    if (!(await dns.getConfig()).config.enabled) {
+      await dns.toggle({ enabled: true });
+    }
+
+    // Drop any blocklist left over from a prior run on the same
+    // wardnet_state volume — createBlocklist doesn't enforce name
+    // uniqueness, but stale entries would still serve their old
+    // domains via the in-memory filter and skew assertions.
+    const existing = await dns.listBlocklists();
+    for (const b of existing.blocklists) {
+      if (b.name === BLOCKLIST_NAME || b.url === BLOCKLIST_URL) {
+        await dns.deleteBlocklist(b.id);
+      }
+    }
+  }, 60_000);
+
+  afterAll(async () => {
+    if (blocklistId) {
+      try {
+        await dns.deleteBlocklist(blocklistId);
+      } catch {
+        // ignore
+      }
+    }
+    // Cached NXDOMAIN entries from the blocking phase would leak
+    // into other specs; flush so subsequent resolves see the real
+    // upstream answer for BLOCKED_DOMAIN.
+    try {
+      await dns.flushCache();
+    } catch {
+      // ignore
+    }
+  });
+
+  it("fetches the blocklist and starts blocking listed domains", async () => {
+    const created = await dns.createBlocklist({
+      name: BLOCKLIST_NAME,
+      url: BLOCKLIST_URL,
+      cron_schedule: CRON_NEVER,
+      enabled: true,
+    });
+    blocklistId = created.blocklist.id;
+    expect(created.blocklist.entry_count).toBe(0);
+
+    const dispatched = await dns.updateBlocklistNow(blocklistId);
+    const job = await waitForJob(jobs, dispatched.job_id, 30_000);
+    expect(job.status, `job error: ${job.error ?? "(none)"}`).toBe("SUCCEED");
+    expect(job.percentage_done).toBe(100);
+
+    const refreshed = (await dns.listBlocklists()).blocklists.find(
+      (b) => b.id === blocklistId,
+    );
+    expect(refreshed, "blocklist still listed after refresh").toBeDefined();
+    // Three domains in the fixture file — see
+    // fixtures/blocklists/dns-blocklists.txt.
+    expect(refreshed!.entry_count).toBe(3);
+    expect(refreshed!.last_error).toBeNull();
+    expect(refreshed!.last_updated).not.toBeNull();
+
+    // Filter rebuild is async (DnsBlocklistUpdated → runner rebuilds
+    // DnsFilter on the next event-bus tick). Poll the resolver until
+    // the new state is visible, with a short ceiling so a real
+    // regression still fails fast.
+    await expect
+      .poll(
+        async () =>
+          (await resolveViaAgent(TEST_DEBIAN_AGENT, BLOCKED_DOMAIN)).addrs
+            .length,
+        { interval: 250, timeout: 10_000 },
+      )
+      .toBe(0);
+
+    // Sanity: a non-listed domain still resolves via upstream. This
+    // separates "blocklist working" from "DNS server broken".
+    const passthrough = await resolveViaAgent(
+      TEST_DEBIAN_AGENT,
+      PASSTHROUGH_DOMAIN,
+    );
+    expect(
+      passthrough.addrs.length,
+      `${PASSTHROUGH_DOMAIN} should still resolve through upstream`,
+    ).toBeGreaterThan(0);
+  });
+
+  it("stops blocking once the blocklist is deleted", async () => {
+    expect(blocklistId, "previous test created a blocklist").toBeDefined();
+
+    await dns.deleteBlocklist(blocklistId!);
+    blocklistId = undefined;
+
+    // Cached NXDOMAINs from the blocking phase would mask the
+    // delete's effect on the filter; flush so the next query is a
+    // fresh forward to upstream.
+    await dns.flushCache();
+
+    await expect
+      .poll(
+        async () =>
+          (await resolveViaAgent(TEST_DEBIAN_AGENT, BLOCKED_DOMAIN)).addrs
+            .length,
+        { interval: 500, timeout: 15_000 },
+      )
+      .toBeGreaterThan(0);
+
+    const after = await dns.listBlocklists();
+    expect(after.blocklists.find((b) => b.url === BLOCKLIST_URL))
+      .toBeUndefined();
+  });
+});

--- a/source/end2end-tests/daemon/tests/dns-config.spec.ts
+++ b/source/end2end-tests/daemon/tests/dns-config.spec.ts
@@ -1,0 +1,130 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { DnsService, WardnetClient } from "@wardnet/js";
+
+import {
+  API_BASE_URL,
+  AuthedClient,
+  ensureAdminAndLogin,
+  waitForReady,
+} from "./helpers.js";
+
+// Cloudflare's public resolver — picked because it's the same default
+// the daemon falls back to when no upstreams are configured (see
+// build_resolver in wardnetd/src/dns/server.rs), so the round-trip
+// here doesn't change runtime behaviour for any spec running after.
+const UPSTREAM_ADDRESS = "1.1.1.1";
+
+describe("dns config", () => {
+  let authed: AuthedClient;
+  let dns: DnsService;
+  let initialEnabled: boolean;
+
+  beforeAll(async () => {
+    const client = new WardnetClient({ baseUrl: API_BASE_URL });
+    await waitForReady(client);
+    authed = await ensureAdminAndLogin(client);
+    dns = new DnsService(authed);
+
+    initialEnabled = (await dns.getConfig()).config.enabled;
+  }, 60_000);
+
+  afterAll(async () => {
+    // Leave DNS enabled so downstream specs (dns-resolve, blocklists,
+    // ...) can rely on a running server without re-toggling. The
+    // dhcp specs follow the same convention.
+    try {
+      const cfg = (await dns.getConfig()).config;
+      if (!cfg.enabled) {
+        await dns.toggle({ enabled: true });
+      }
+    } catch {
+      // ignore — best-effort, real failure surfaces from the spec body
+    }
+    void initialEnabled;
+  });
+
+  it("toggles the DNS server on and off", async () => {
+    // Disable first so we observe a true off→on transition regardless
+    // of which DNS spec ran before this one.
+    if ((await dns.getConfig()).config.enabled) {
+      await dns.toggle({ enabled: false });
+    }
+
+    let off = await dns.status();
+    expect(off.enabled).toBe(false);
+    expect(off.running).toBe(false);
+
+    const onResp = await dns.toggle({ enabled: true });
+    expect(onResp.config.enabled).toBe(true);
+
+    const on = await dns.status();
+    expect(on.enabled).toBe(true);
+    // The /api/dns/config/toggle handler starts the server inline (see
+    // wardnetd-api/src/api/dns.rs) so `running` flips synchronously
+    // with the toggle response — no settling delay needed.
+    expect(on.running).toBe(true);
+    expect(on.cache_capacity).toBe(onResp.config.cache_size);
+
+    const offAgain = await dns.toggle({ enabled: false });
+    expect(offAgain.config.enabled).toBe(false);
+    const final = await dns.status();
+    expect(final.running).toBe(false);
+  });
+
+  it("round-trips config updates through getConfig", async () => {
+    const before = (await dns.getConfig()).config;
+
+    const updated = await dns.updateConfig({
+      cache_size: 5_000,
+      cache_ttl_min_secs: 30,
+      cache_ttl_max_secs: 3_600,
+      upstream_servers: [
+        {
+          address: UPSTREAM_ADDRESS,
+          name: "cloudflare-1",
+          protocol: "udp",
+        },
+      ],
+      ad_blocking_enabled: true,
+    });
+    expect(updated.config.cache_size).toBe(5_000);
+    expect(updated.config.cache_ttl_min_secs).toBe(30);
+    expect(updated.config.cache_ttl_max_secs).toBe(3_600);
+    expect(updated.config.upstream_servers).toEqual([
+      {
+        address: UPSTREAM_ADDRESS,
+        name: "cloudflare-1",
+        protocol: "udp",
+      },
+    ]);
+    expect(updated.config.ad_blocking_enabled).toBe(true);
+
+    // Independent re-read confirms persistence (not just the
+    // synchronous response shape).
+    const refetched = (await dns.getConfig()).config;
+    expect(refetched.cache_size).toBe(5_000);
+    expect(refetched.upstream_servers).toEqual(updated.config.upstream_servers);
+
+    // Restore the cache_size to the previous value so a later
+    // config-sensitive spec (or rerun on the same volume) sees the
+    // pre-test capacity. ad_blocking_enabled / TTLs are left at the
+    // updated values — they're harmless for downstream specs.
+    await dns.updateConfig({ cache_size: before.cache_size });
+  });
+
+  it("flushCache returns a count and a message", async () => {
+    // Turn DNS on so the server-side cache exists; flushing while
+    // disabled is also legal but the call exercises a less interesting
+    // path (no live server to ask).
+    if (!(await dns.getConfig()).config.enabled) {
+      await dns.toggle({ enabled: true });
+    }
+    const flush = await dns.flushCache();
+    expect(typeof flush.entries_cleared).toBe("number");
+    expect(flush.entries_cleared).toBeGreaterThanOrEqual(0);
+    expect(flush.message.length).toBeGreaterThan(0);
+
+    const after = await dns.status();
+    expect(after.cache_size).toBe(0);
+  });
+});

--- a/source/end2end-tests/daemon/tests/dns-resolve.spec.ts
+++ b/source/end2end-tests/daemon/tests/dns-resolve.spec.ts
@@ -1,0 +1,67 @@
+import { beforeAll, describe, expect, it } from "vitest";
+import { DnsService, WardnetClient } from "@wardnet/js";
+
+import {
+  API_BASE_URL,
+  AuthedClient,
+  TEST_DEBIAN_AGENT,
+  ensureAdminAndLogin,
+  resolveViaAgent,
+  waitForReady,
+} from "./helpers.js";
+
+// example.org is RFC 2606 reserved-for-documentation and resolves to
+// stable public addresses. Pinned here (vs example.com used in the
+// allowlist spec) so cache-state assertions stay isolated from the
+// allowlist spec's blocklist toggling.
+const RESOLVE_TARGET = "example.org";
+
+describe("dns resolve", () => {
+  let authed: AuthedClient;
+  let dns: DnsService;
+
+  beforeAll(async () => {
+    const client = new WardnetClient({ baseUrl: API_BASE_URL });
+    await waitForReady(client);
+    authed = await ensureAdminAndLogin(client);
+    dns = new DnsService(authed);
+
+    if (!(await dns.getConfig()).config.enabled) {
+      await dns.toggle({ enabled: true });
+    }
+
+    // Start with an empty cache so the first resolve is a guaranteed
+    // miss. flushCache also resets the hit/miss counters that drive
+    // cache_hit_rate.
+    await dns.flushCache();
+  }, 60_000);
+
+  it("forwards a query and caches the answer", async () => {
+    const first = await resolveViaAgent(TEST_DEBIAN_AGENT, RESOLVE_TARGET);
+    expect(
+      first.addrs.length,
+      `expected at least one A record for ${RESOLVE_TARGET}; got ${JSON.stringify(first)}`,
+    ).toBeGreaterThan(0);
+    // Sanity check the answer parses as IPv4 — guards against the
+    // probe accidentally returning dig's diagnostic banner instead of
+    // the +short answer body.
+    expect(first.addrs[0]).toMatch(/^\d{1,3}(\.\d{1,3}){3}$/);
+
+    const afterFirst = await dns.status();
+    expect(
+      afterFirst.cache_size,
+      "first query should populate one cache entry",
+    ).toBeGreaterThan(0);
+
+    // Same name, same record type — has to come back from the cache
+    // (DnsCache.get bumps hits) provided the entry hasn't expired.
+    const second = await resolveViaAgent(TEST_DEBIAN_AGENT, RESOLVE_TARGET);
+    expect(second.addrs).toEqual(first.addrs);
+
+    const afterSecond = await dns.status();
+    expect(
+      afterSecond.cache_hit_rate,
+      "second query should land a cache hit",
+    ).toBeGreaterThan(0);
+  });
+});

--- a/source/end2end-tests/daemon/tests/dns-rules.spec.ts
+++ b/source/end2end-tests/daemon/tests/dns-rules.spec.ts
@@ -1,0 +1,160 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { DnsService, JobsService, WardnetClient } from "@wardnet/js";
+
+import {
+  API_BASE_URL,
+  AuthedClient,
+  TEST_DEBIAN_AGENT,
+  ensureAdminAndLogin,
+  resolveViaAgent,
+  waitForJob,
+  waitForReady,
+} from "./helpers.js";
+
+const BLOCKLIST_URL = "http://10.91.0.200/dns-rules.txt";
+const BLOCKLIST_NAME = "e2e-dns-rules";
+const CRON_NEVER = "0 0 1 1 *";
+
+// Real public domain whose block-vs-allow can be distinguished from
+// the resolver answer alone. iana.org isn't used in any other Stage 7
+// spec so the @@-allow override doesn't fight a stale rule cached
+// elsewhere.
+const OVERRIDE_DOMAIN = "iana.org";
+
+// Fictitious target for the $dnsrewrite assertion. The IP is a TEST-NET-2
+// (RFC 5737) address — guaranteed unreachable, so any answer matching
+// it can only have come from our rewrite rule.
+const REWRITE_DOMAIN = "rewrite-target.fixture.test";
+const REWRITE_IP = "198.51.100.99";
+
+describe("dns custom filter rules", () => {
+  let authed: AuthedClient;
+  let dns: DnsService;
+  let jobs: JobsService;
+  let blocklistId: string | undefined;
+  let rewriteRuleId: string | undefined;
+  let allowRuleId: string | undefined;
+
+  beforeAll(async () => {
+    const client = new WardnetClient({ baseUrl: API_BASE_URL });
+    await waitForReady(client);
+    authed = await ensureAdminAndLogin(client);
+    dns = new DnsService(authed);
+    jobs = new JobsService(authed);
+
+    if (!(await dns.getConfig()).config.enabled) {
+      await dns.toggle({ enabled: true });
+    }
+
+    // Drop leftover state from a prior run — name match for our
+    // blocklist, rule_text match for our custom rules.
+    const existingLists = await dns.listBlocklists();
+    for (const b of existingLists.blocklists) {
+      if (b.name === BLOCKLIST_NAME || b.url === BLOCKLIST_URL) {
+        await dns.deleteBlocklist(b.id);
+      }
+    }
+    const existingRules = await dns.listFilterRules();
+    for (const r of existingRules.rules) {
+      if (
+        r.rule_text.includes(REWRITE_DOMAIN) ||
+        r.rule_text.includes(OVERRIDE_DOMAIN)
+      ) {
+        await dns.deleteFilterRule(r.id);
+      }
+    }
+  }, 60_000);
+
+  afterAll(async () => {
+    for (const id of [rewriteRuleId, allowRuleId]) {
+      if (id) {
+        try {
+          await dns.deleteFilterRule(id);
+        } catch {
+          // ignore
+        }
+      }
+    }
+    if (blocklistId) {
+      try {
+        await dns.deleteBlocklist(blocklistId);
+      } catch {
+        // ignore
+      }
+    }
+    try {
+      await dns.flushCache();
+    } catch {
+      // ignore
+    }
+  });
+
+  it("applies a $dnsrewrite custom rule", async () => {
+    const created = await dns.createFilterRule({
+      rule_text: `||${REWRITE_DOMAIN}^$dnsrewrite=${REWRITE_IP}`,
+      enabled: true,
+      comment: "e2e dns-rules: rewrite",
+    });
+    rewriteRuleId = created.rule.id;
+    expect(created.rule.enabled).toBe(true);
+
+    // The rewrite path bypasses upstream entirely — the daemon
+    // synthesizes an answer record. Asserting on the literal IP is
+    // the unambiguous signal that our custom rule fired (vs the
+    // domain coincidentally resolving to something else).
+    await expect
+      .poll(
+        async () => {
+          const r = await resolveViaAgent(TEST_DEBIAN_AGENT, REWRITE_DOMAIN);
+          return r.addrs;
+        },
+        { interval: 250, timeout: 10_000 },
+      )
+      .toEqual([REWRITE_IP]);
+  });
+
+  it("@@-rule overrides a blocklist match", async () => {
+    // Stand up the blocklist that puts OVERRIDE_DOMAIN into the
+    // blocked set; verify the block before installing the @@-rule.
+    const created = await dns.createBlocklist({
+      name: BLOCKLIST_NAME,
+      url: BLOCKLIST_URL,
+      cron_schedule: CRON_NEVER,
+      enabled: true,
+    });
+    blocklistId = created.blocklist.id;
+    const dispatched = await dns.updateBlocklistNow(blocklistId);
+    const job = await waitForJob(jobs, dispatched.job_id, 30_000);
+    expect(job.status, `job error: ${job.error ?? "(none)"}`).toBe("SUCCEED");
+
+    await expect
+      .poll(
+        async () =>
+          (await resolveViaAgent(TEST_DEBIAN_AGENT, OVERRIDE_DOMAIN)).addrs
+            .length,
+        { interval: 250, timeout: 10_000 },
+      )
+      .toBe(0);
+
+    const allow = await dns.createFilterRule({
+      rule_text: `@@||${OVERRIDE_DOMAIN}^`,
+      enabled: true,
+      comment: "e2e dns-rules: allow override",
+    });
+    allowRuleId = allow.rule.id;
+
+    // Negative-cache flush: the prior block populated a cached
+    // NXDOMAIN that would otherwise be served before the rebuilt
+    // filter even runs.
+    await dns.flushCache();
+
+    await expect
+      .poll(
+        async () =>
+          (await resolveViaAgent(TEST_DEBIAN_AGENT, OVERRIDE_DOMAIN)).addrs
+            .length,
+        { interval: 500, timeout: 15_000 },
+      )
+      .toBeGreaterThan(0);
+  });
+});

--- a/source/end2end-tests/daemon/tests/dns-rules.spec.ts
+++ b/source/end2end-tests/daemon/tests/dns-rules.spec.ts
@@ -27,6 +27,12 @@ const OVERRIDE_DOMAIN = "iana.org";
 const REWRITE_DOMAIN = "rewrite-target.fixture.test";
 const REWRITE_IP = "198.51.100.99";
 
+// Exact rule_text values created by this spec. Used (not substring-
+// matched) for prior-run cleanup so a user-authored rule that happens
+// to mention iana.org or rewrite-target.fixture.test isn't deleted.
+const REWRITE_RULE_TEXT = `||${REWRITE_DOMAIN}^$dnsrewrite=${REWRITE_IP}`;
+const ALLOW_RULE_TEXT = `@@||${OVERRIDE_DOMAIN}^`;
+
 describe("dns custom filter rules", () => {
   let authed: AuthedClient;
   let dns: DnsService;
@@ -56,10 +62,7 @@ describe("dns custom filter rules", () => {
     }
     const existingRules = await dns.listFilterRules();
     for (const r of existingRules.rules) {
-      if (
-        r.rule_text.includes(REWRITE_DOMAIN) ||
-        r.rule_text.includes(OVERRIDE_DOMAIN)
-      ) {
+      if (r.rule_text === REWRITE_RULE_TEXT || r.rule_text === ALLOW_RULE_TEXT) {
         await dns.deleteFilterRule(r.id);
       }
     }
@@ -91,7 +94,7 @@ describe("dns custom filter rules", () => {
 
   it("applies a $dnsrewrite custom rule", async () => {
     const created = await dns.createFilterRule({
-      rule_text: `||${REWRITE_DOMAIN}^$dnsrewrite=${REWRITE_IP}`,
+      rule_text: REWRITE_RULE_TEXT,
       enabled: true,
       comment: "e2e dns-rules: rewrite",
     });
@@ -137,7 +140,7 @@ describe("dns custom filter rules", () => {
       .toBe(0);
 
     const allow = await dns.createFilterRule({
-      rule_text: `@@||${OVERRIDE_DOMAIN}^`,
+      rule_text: ALLOW_RULE_TEXT,
       enabled: true,
       comment: "e2e dns-rules: allow override",
     });

--- a/source/end2end-tests/daemon/tests/helpers.ts
+++ b/source/end2end-tests/daemon/tests/helpers.ts
@@ -3,8 +3,11 @@ import { randomBytes } from "node:crypto";
 import {
   AuthService,
   InfoService,
+  JobsService,
   SetupService,
   WardnetClient,
+  isJobTerminal,
+  type Job,
 } from "@wardnet/js";
 
 // Compose service names resolve to the corresponding container's IP on
@@ -243,4 +246,57 @@ export function ipToInt(ip: string): number {
     .split(".")
     .map(Number)
     .reduce((acc, n) => acc * 256 + n, 0);
+}
+
+export interface DnsResolveResponse {
+  name: string;
+  server?: string;
+  addrs: string[];
+}
+
+export interface ResolveOptions {
+  server?: string;
+  record?: "A" | "AAAA" | "TXT" | "CNAME";
+  timeout?: number;
+}
+
+/**
+ * Drive a LAN-client agent's `/dns/resolve` probe. Defaults to
+ * querying the wardnetd LAN-side DNS at 10.91.0.1 over A records.
+ */
+export async function resolveViaAgent(
+  agent: string,
+  name: string,
+  opts: ResolveOptions = {},
+): Promise<DnsResolveResponse> {
+  const params = new URLSearchParams({ name });
+  params.set("server", opts.server ?? "10.91.0.1");
+  if (opts.record) params.set("record", opts.record);
+  if (opts.timeout !== undefined) params.set("timeout", String(opts.timeout));
+  return agentGet<DnsResolveResponse>(agent, `/dns/resolve?${params}`);
+}
+
+/**
+ * Poll `JobsService.get` until the job reaches a terminal state, or
+ * throw on timeout. Returns the final `Job` so callers can assert on
+ * `status === "SUCCEED"` and surface `error` on failure paths.
+ */
+export async function waitForJob(
+  jobs: JobsService,
+  id: string,
+  timeoutMs = 30_000,
+  pollIntervalMs = 500,
+): Promise<Job> {
+  const deadline = Date.now() + timeoutMs;
+  let last: Job | undefined;
+  while (Date.now() < deadline) {
+    last = await jobs.get(id);
+    if (isJobTerminal(last.status)) {
+      return last;
+    }
+    await new Promise((resolve) => setTimeout(resolve, pollIntervalMs));
+  }
+  throw new Error(
+    `job ${id} did not reach a terminal state within ${timeoutMs}ms (last status=${last?.status})`,
+  );
 }


### PR DESCRIPTION
## Summary

Adds the **Stage 7 — DNS subsystem** slice from `source/end2end-tests/PLAN.md` to the daemon e2e suite. Five Vitest specs drive the full DNS surface against a real `wardnetd` over the existing compose topology, plus a tiny busybox-httpd `blocklist_server` fixture on `wardnet_lan` for the blocklist URL the daemon refreshes.

- **Specs** (`source/end2end-tests/daemon/tests/`):
  - `dns-config.spec.ts` — toggle off→on→off (server start/stop is synchronous in the API handler), config round-trip, `flushCache` returns count + zeroes `cache_size`.
  - `dns-resolve.spec.ts` — `example.org` via `test_debian` agent at `@10.91.0.1`; first query populates cache, second lands a hit (`cache_hit_rate > 0`).
  - `dns-blocklists.spec.ts` — create + `updateBlocklistNow` + poll job; `entry_count == 3`; blocked-vs-passthrough split using a real public canary (`www.iana.org`) so block (NXDOMAIN) and post-delete (real answer) are distinguishable.
  - `dns-allowlist.spec.ts` — blocklists `example.com`, allowlist entry overrides, delete re-blocks. Cache flushed between phases (negative-cache TTL would mask the rebuilt filter).
  - `dns-rules.spec.ts` — `||domain^$dnsrewrite=198.51.100.99` synthesizes an answer; `@@||iana.org^` overrides a blocklist match.
- **Helpers** (`tests/helpers.ts`):
  - `resolveViaAgent(agent, name, opts?)` — wraps the agent's `/dns/resolve`, defaults `server=10.91.0.1`.
  - `waitForJob(jobs, id, timeoutMs?)` — polls `JobsService.get` until terminal.
- **Compose**: `blocklist_server` (busybox 1.36 pinned by digest) on `wardnet_lan` at `10.91.0.200`, serves `fixtures/blocklists/` over HTTP. `wget --spider` healthcheck; `test_runner` `depends_on` it.
- **Plan**: lands `source/end2end-tests/PLAN.md`, the previously-uncheckedin roadmap the compose header now points at.

## Why-non-obvious choices

- Real public domains where block-vs-pass needs to be distinguished — `.test` returns NXDOMAIN both ways.
- `$dnsrewrite` for the custom-rule positive assertion: the rewritten IP is unambiguous proof the rule fired.
- `cron_schedule: "0 0 1 1 *"` on test blocklists so the runner's periodic cron can't race manual `updateBlocklistNow`.
- `expect.poll` for filter-rebuild assertions — runner rebuilds the filter on the event-bus tick after the job finishes, not synchronously.
- `flushCache` between block↔allow transitions because `DnsCache` serves stale answers (positive *and* negative) within their TTL regardless of the rebuilt filter.

## Test plan

- [ ] CI E2E job (`E2E Tests / E2E Daemon Tests`) green — runs the full suite end-to-end (e2e doesn't run on macOS).
- [ ] Daemon `compose logs` show `blocklist refreshed domains=3` for each spec that creates a blocklist.
- [ ] Suite total runtime stays in budget (was ~3 min on the DHCP slice; new specs add ~30–60 s of polling).

🤖 Generated with [Claude Code](https://claude.com/claude-code)