### PR TITLE
fix(site): manifest generator parses CalVer instead of strict semver

### DIFF
--- a/source/site/scripts/generate-release-manifests.ts
+++ b/source/site/scripts/generate-release-manifests.ts
@@ -28,10 +28,98 @@ import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 import { Octokit } from "@octokit/rest";
-import semver from "semver";
 
 const REPO_OWNER = "wardnet";
 const REPO_NAME = "wardnet";
+
+/**
+ * Parsed release version, structured for component-wise comparison.
+ *
+ * The npm `semver` package rejects CalVer with leading zeros
+ * (`2026.05.00`), the form Wardnet uses for release tags. Using a
+ * dotted-numeric parser instead lets the manifest generator handle
+ * both legacy SemVer (`0.1.0`) and CalVer (`2026.05.00`, `2026.5.10`,
+ * etc.) uniformly. Pre-release / build suffixes are split off into
+ * their own field so they can be classified separately.
+ */
+interface ParsedVersion {
+  /** Original version string with leading `v` stripped. */
+  version: string;
+  /**
+   * Numeric components (`2026.05.00` → `[2026, 5, 0]`). Leading
+   * zeros are coerced; comparison is component-wise as `u64`.
+   */
+  parts: number[];
+  /** `-beta.1`, `-rc.2`, etc. Empty array when there's no suffix. */
+  prerelease: string[];
+}
+
+/** Strip a leading `v` and split into base + pre-release components. */
+function parseVersion(tag: string): ParsedVersion | null {
+  const stripped = tag.replace(/^v/, "");
+  if (!stripped) return null;
+  // `+build` metadata isn't carried into the manifest; drop it.
+  const noBuild = stripped.split("+", 1)[0]!;
+  const dashAt = noBuild.indexOf("-");
+  const head = dashAt === -1 ? noBuild : noBuild.slice(0, dashAt);
+  const tail = dashAt === -1 ? "" : noBuild.slice(dashAt + 1);
+
+  const parts: number[] = [];
+  for (const segment of head.split(".")) {
+    if (!/^\d+$/.test(segment)) return null;
+    parts.push(parseInt(segment, 10));
+  }
+  if (parts.length === 0) return null;
+
+  return {
+    version: noBuild,
+    parts,
+    prerelease: tail ? tail.split(".") : [],
+  };
+}
+
+/**
+ * Compare two parsed versions numerically. Mirrors the daemon's
+ * `is_newer` comparator (wardnetd-services::update::service): split
+ * on `.`, compare components as integers, then break ties on the
+ * pre-release suffix (any pre-release sorts before the release of
+ * the same base, lexicographic tiebreak otherwise).
+ */
+function compareVersion(a: ParsedVersion, b: ParsedVersion): number {
+  const len = Math.max(a.parts.length, b.parts.length);
+  for (let i = 0; i < len; i++) {
+    const ai = a.parts[i] ?? 0;
+    const bi = b.parts[i] ?? 0;
+    if (ai !== bi) return ai - bi;
+  }
+  if (a.prerelease.length === 0 && b.prerelease.length === 0) return 0;
+  if (a.prerelease.length === 0) return 1;
+  if (b.prerelease.length === 0) return -1;
+  for (let i = 0; i < Math.max(a.prerelease.length, b.prerelease.length); i++) {
+    const ai = a.prerelease[i];
+    const bi = b.prerelease[i];
+    if (ai === undefined) return -1;
+    if (bi === undefined) return 1;
+    const ar = /^\d+$/.test(ai);
+    const br = /^\d+$/.test(bi);
+    // Numeric identifiers always rank lower than alphanumeric — same
+    // tiebreak rule as semver §11.4.3, kept so beta numbering still
+    // sorts predictably.
+    if (ar && !br) return -1;
+    if (!ar && br) return 1;
+    if (ar && br) {
+      const diff = parseInt(ai, 10) - parseInt(bi, 10);
+      if (diff !== 0) return diff;
+    } else if (ai !== bi) {
+      return ai < bi ? -1 : 1;
+    }
+  }
+  return 0;
+}
+
+function rcompareVersion(a: ParsedVersion, b: ParsedVersion): number {
+  return -compareVersion(a, b);
+}
 
 const ROOT = resolve(fileURLToPath(import.meta.url), "../..");
 const PUBLIC_RELEASES = resolve(ROOT, "public/releases");
@@ -105,17 +193,11 @@ async function fetchReleases(): Promise<GithubRelease[]> {
   return releases as GithubRelease[];
 }
 
-/** Strip a leading `v` and validate as semver. Returns null if not valid. */
-function parseVersion(tag: string): semver.SemVer | null {
-  const stripped = tag.replace(/^v/, "");
-  return semver.parse(stripped);
-}
-
 /** Build a per-release manifest. Returns null if the release has no tarball. */
 function buildManifest(release: GithubRelease): Manifest | null {
   const parsed = parseVersion(release.tag_name);
   if (!parsed) {
-    console.warn(`skipping release with non-semver tag: ${release.tag_name}`);
+    console.warn(`skipping release with unparseable tag: ${release.tag_name}`);
     return null;
   }
 
@@ -158,20 +240,20 @@ function classifyChannels(releases: GithubRelease[]): {
 } {
   const nonDraft = releases.filter((r) => !r.draft);
 
-  // Pre-compute parsed versions for sorting. Drop releases whose tag is not
-  // valid semver.
+  // Pre-compute parsed versions for sorting. Drop releases whose tag is
+  // not parseable as dotted-numeric (legacy SemVer or CalVer).
   const withVersions = nonDraft
     .map((r) => ({ release: r, version: parseVersion(r.tag_name) }))
     .filter(
-      (entry): entry is { release: GithubRelease; version: semver.SemVer } =>
+      (entry): entry is { release: GithubRelease; version: ParsedVersion } =>
         entry.version !== null,
     );
 
-  // Descending by semver precedence (pre-release sorts before release of same base).
-  withVersions.sort((a, b) => semver.rcompare(a.version, b.version));
+  // Descending by version precedence (pre-release sorts before release of same base).
+  withVersions.sort((a, b) => rcompareVersion(a.version, b.version));
 
   const stable =
-    withVersions.find((entry) => !entry.release.prerelease && !entry.version.prerelease.length)
+    withVersions.find((entry) => !entry.release.prerelease && entry.version.prerelease.length === 0)
       ?.release ?? null;
 
   const beta = withVersions[0]?.release ?? null;
@@ -216,10 +298,10 @@ async function buildOpenapiVersions(releases: GithubRelease[]): Promise<OpenapiV
     .filter((r) => !r.draft)
     .map((r) => ({ release: r, version: parseVersion(r.tag_name) }))
     .filter(
-      (entry): entry is { release: GithubRelease; version: semver.SemVer } =>
+      (entry): entry is { release: GithubRelease; version: ParsedVersion } =>
         entry.version !== null,
     );
-  ordered.sort((a, b) => semver.rcompare(a.version, b.version));
+  ordered.sort((a, b) => rcompareVersion(a.version, b.version));
 
   // Keep only entries that actually carry the openapi assets, then fan out
   // the sha256 fetches in parallel. One round-trip per release but bounded
@@ -257,7 +339,7 @@ async function buildOpenapiVersions(releases: GithubRelease[]): Promise<OpenapiV
     {
       sha256: string;
       openapi_url: string;
-      versions: { version: string; parsed: semver.SemVer }[];
+      versions: { version: string; parsed: ParsedVersion }[];
       includes_prerelease: boolean;
     }
   >();
@@ -292,7 +374,7 @@ async function buildOpenapiVersions(releases: GithubRelease[]): Promise<OpenapiV
   // groups themselves by their latest_version descending.
   const rows: OpenapiVersion[] = [];
   for (const g of groups.values()) {
-    g.versions.sort((a, b) => semver.compare(a.parsed, b.parsed));
+    g.versions.sort((a, b) => compareVersion(a.parsed, b.parsed));
     const versions = g.versions.map((v) => v.version);
     rows.push({
       sha256: g.sha256,
@@ -303,7 +385,13 @@ async function buildOpenapiVersions(releases: GithubRelease[]): Promise<OpenapiV
       includes_prerelease: g.includes_prerelease,
     });
   }
-  rows.sort((a, b) => semver.rcompare(a.latest_version, b.latest_version));
+  // Group sort uses the latest_version string. Re-parse on the fly
+  // since rcompareVersion takes ParsedVersion. Both sides are
+  // guaranteed parseable (they came from `parseVersion` upstream), so
+  // the non-null assertion is safe.
+  rows.sort((a, b) =>
+    rcompareVersion(parseVersion(a.latest_version)!, parseVersion(b.latest_version)!),
+  );
   return rows;
 }
 


### PR DESCRIPTION
## Why

\`stable.json\` came up empty after v2026.05.00 was released even with the workflow ordering fix from #275 in place. Root cause: \`semver.parse('2026.05.00')\` returns \`null\` because the npm \`semver\` package strictly enforces SemVer §2 (no leading zeros). The manifest generator filtered v2026.05.00 out before reaching \`buildManifest\`, fell through to the \"no parseable releases\" branch, and emitted the empty placeholder.

This is the **same** issue that hit the daemon's \`update::service::is_newer\` comparator — same fix.

## Fix

Replace the \`semver\` library calls in \`scripts/generate-release-manifests.ts\` with a small dotted-numeric parser:

- \`parseVersion(tag)\` — strips a leading \`v\`, splits on \`.\`, parses each component as integer, separates pre-release suffix.
- \`compareVersion / rcompareVersion\` — component-wise integer compare. Pre-release tiebreak follows semver §11.4.3 (numeric < alphanumeric, then numeric value, then lexicographic) so beta numbering stays predictable.

The dependency is no longer used by the script (kept in package.json for now since other tools may pull it transitively; can be removed in a follow-up).

## Verification

Locally with \`GITHUB_TOKEN\` set:

\`\`\`
$ yarn generate:release-manifests
fetched 1 releases from wardnet/wardnet
wrote .../public/releases/stable.json
wrote .../public/releases/beta.json
wrote .../public/releases/openapi-versions.json (1 distinct spec versions)
wrote .../src/generated/release-info.ts
stable: 2026.05.00
beta: 2026.05.00
\`\`\`

\`stable.json\` content:

\`\`\`json
{
  \"version\": \"2026.05.00\",
  \"tag\": \"v2026.05.00\",
  \"prerelease\": false,
  \"published_at\": \"2026-05-03T09:40:48Z\",
  \"asset_base_url\": \"https://github.com/wardnet/wardnet/releases/download/v2026.05.00\",
  \"binary\": { \"name\": \"wardnetd-2026.05.00-aarch64.tar.gz\", \"size_bytes\": 13543662 },
  \"notes_url\": \"https://github.com/wardnet/wardnet/releases/tag/v2026.05.00\"
}
\`\`\`

\`yarn type-check\`, \`yarn test\` (57 tests), \`yarn format:check\` all pass.

## After merge

Workflow_dispatch \`release.yml\` on \`main\` (from the UI). \`release-daemon\` skips (no tag in ref), \`build-site\` runs the corrected generator, \`refresh-manifest\` (from #275) re-runs it after — both produce the same populated stable.json. \`deploy-site\` publishes. \`https://wardnet.network/releases/stable.json\` should then carry v2026.05.00 and the Pi install one-liner works.