### PR TITLE
fix(ci): force deploy-site to evaluate immediate needs only

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -185,8 +185,19 @@ jobs:
   deploy-site:
     name: Deploy Site
     needs: [refresh-manifest, tests-e2e]
-    # Dry-run (workflow_dispatch on non-tag) still deploys the site —
-    # harmless, idempotent, and confirms the Pages path works.
+    # The default `success()` predicate walks the transitive needs
+    # graph: release-daemon is in deploy-site's ancestors via
+    # refresh-manifest, and release-daemon is skipped on every
+    # workflow_dispatch (gated to tag pushes). With the default `if`
+    # that propagates as a skip onto deploy-site, even though both
+    # immediate needs ran cleanly. Pin the predicate to the immediate
+    # needs so dispatch runs (which are the only path that refreshes
+    # the manifest without re-publishing the GitHub release) actually
+    # ship to Pages.
+    if: |
+      always() &&
+      needs.refresh-manifest.result == 'success' &&
+      needs.tests-e2e.result == 'success'
     permissions:
       contents: read
       pages: write


### PR DESCRIPTION
## Why

After #275 (refresh-manifest) and #276 (parser), the dispatched run still left \`stable.json\` empty. Inspection:

- \`refresh-manifest\` ran and succeeded.
- \`tests-e2e\` succeeded.
- \`deploy-site\` was **skipped**.

GitHub's default \`if: success()\` walks the *transitive* needs graph. \`release-daemon\` is in \`deploy-site\`'s ancestors via \`refresh-manifest\`, and \`release-daemon\` is gated to tag pushes — so on every \`workflow_dispatch\` run it's skipped, and that skip propagates through \`success()\` onto \`deploy-site\` regardless of whether the immediate needs ran cleanly.

## Fix

Pin \`deploy-site\`'s \`if\` to the immediate needs only:

\`\`\`yaml
if: |
  always() &&
  needs.refresh-manifest.result == 'success' &&
  needs.tests-e2e.result == 'success'
\`\`\`

\`refresh-manifest\` already has the same shape, so this just brings \`deploy-site\` in line.

## After merge

Dispatch \`release.yml\` on \`main\` from the UI. With #276's parser change AND this fix, the chain runs end-to-end: refresh-manifest → fresh stable.json → deploy-site → Pages → \`https://wardnet.network/releases/stable.json\` populates with v2026.05.00.

## Test plan

- [ ] Verify \`/releases/stable.json\` reflects v2026.05.00 after the dispatch run.
- [ ] Pi install one-liner (\`curl -sSL https://wardnet.network/install.sh | sudo bash\`) finds the binary.