### PR TITLE
fix(web): pre-fill MAC when reserving from device edit panel

### DIFF
--- a/source/web-ui/src/components/features/EditDeviceSheet.tsx
+++ b/source/web-ui/src/components/features/EditDeviceSheet.tsx
@@ -42,6 +42,7 @@ export function EditDeviceSheet({ deviceId, open, onOpenChange }: EditDeviceShee
       </Sheet>
 
       <CreateReservationSheet
+        key={reservationDefaults ? JSON.stringify(reservationDefaults) : "closed"}
         open={!!reservationDefaults}
         onOpenChange={(o) => {
           if (!o) setReservationDefaults(null);


### PR DESCRIPTION
## Summary

- `CreateReservationSheet` initializes its internal MAC state from `defaults` only on first mount. When rendered alongside `EditDeviceSheet`, the very first render had `defaults = null`, so the MAC stayed empty even after the Reserve button populated `reservationDefaults`.
- Adopt the same `key={...}` remount pattern that `Dhcp.tsx` already uses, so the sheet re-mounts whenever `reservationDefaults` changes — the MAC pre-fills from the device and renders read-only as intended.

## Test plan

- [x] `make check-web` (typecheck + eslint + prettier) — clean
- [x] Manually validated in `make run-dev`: open Devices → pick any device → Reserve DHCP Address → MAC field is pre-filled, greyed, non-editable

Closes #94