### PR TITLE
fix(tunnel): only mark tunnel up after observed handshake (#79)

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -10909,11 +10909,12 @@
       },
       "TunnelStatus": {
         "type": "string",
-        "description": "The current status of a `WireGuard` tunnel.",
+        "description": "The current status of a `WireGuard` tunnel.\n\nState machine driven by user/admin actions and the tunnel monitor's\nhealth-check loop:\n\n- `Down` — kernel interface not configured (initial state, after\n  tear-down, or after delete).\n- `Connecting` — `bring_up` succeeded; kernel interface is configured;\n  no handshake observed yet.\n- `Up` — recent (≤ 3 min) handshake observed.\n- `Reconnecting` — was `Up`, last handshake stale (> 3 min) or absent;\n  the iface is still configured and `WireGuard` keepalive is retrying.",
         "enum": [
           "up",
           "down",
-          "connecting"
+          "connecting",
+          "reconnecting"
         ]
       },
       "TunnelSummary": {

--- a/source/daemon/crates/wardnet-common/src/event.rs
+++ b/source/daemon/crates/wardnet-common/src/event.rs
@@ -30,12 +30,34 @@ pub enum WardnetEvent {
         last_ip: String,
         timestamp: DateTime<Utc>,
     },
+    /// Bring-up succeeded; kernel interface is configured. No handshake has
+    /// been observed yet — the tunnel is awaiting its first peer reply.
+    TunnelConnecting {
+        tunnel_id: Uuid,
+        interface_name: String,
+        endpoint: String,
+        timestamp: DateTime<Utc>,
+    },
+    /// First handshake observed for a `Connecting` tunnel, or recovery from
+    /// `Reconnecting` after the peer started replying again.
     TunnelUp {
         tunnel_id: Uuid,
         interface_name: String,
         endpoint: String,
         timestamp: DateTime<Utc>,
     },
+    /// Previously `Up` tunnel has not seen a handshake in over 3 minutes.
+    /// The kernel interface remains configured; `WireGuard` keepalive is
+    /// retrying. Status will flip back to `Up` automatically when the peer
+    /// replies, or the operator can intervene.
+    TunnelReconnecting {
+        tunnel_id: Uuid,
+        interface_name: String,
+        last_handshake: Option<DateTime<Utc>>,
+        timestamp: DateTime<Utc>,
+    },
+    /// Kernel interface torn down by user/admin action (manual tear-down or
+    /// tunnel deletion).
     TunnelDown {
         tunnel_id: Uuid,
         interface_name: String,

--- a/source/daemon/crates/wardnet-common/src/tunnel.rs
+++ b/source/daemon/crates/wardnet-common/src/tunnel.rs
@@ -3,12 +3,24 @@ use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
 /// The current status of a `WireGuard` tunnel.
+///
+/// State machine driven by user/admin actions and the tunnel monitor's
+/// health-check loop:
+///
+/// - `Down` — kernel interface not configured (initial state, after
+///   tear-down, or after delete).
+/// - `Connecting` — `bring_up` succeeded; kernel interface is configured;
+///   no handshake observed yet.
+/// - `Up` — recent (≤ 3 min) handshake observed.
+/// - `Reconnecting` — was `Up`, last handshake stale (> 3 min) or absent;
+///   the iface is still configured and `WireGuard` keepalive is retrying.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, utoipa::ToSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum TunnelStatus {
     Up,
     Down,
     Connecting,
+    Reconnecting,
 }
 
 /// A `WireGuard` tunnel configuration and its live state.

--- a/source/daemon/crates/wardnetd-data/src/repository/sqlite/tunnel.rs
+++ b/source/daemon/crates/wardnetd-data/src/repository/sqlite/tunnel.rs
@@ -41,6 +41,7 @@ impl DbTunnelRow {
         let status = match self.status.as_str() {
             "up" => TunnelStatus::Up,
             "connecting" => TunnelStatus::Connecting,
+            "reconnecting" => TunnelStatus::Reconnecting,
             _ => TunnelStatus::Down,
         };
 

--- a/source/daemon/crates/wardnetd-data/src/repository/tunnel.rs
+++ b/source/daemon/crates/wardnetd-data/src/repository/tunnel.rs
@@ -19,7 +19,7 @@ pub struct TunnelRow {
     pub interface_name: String,
     /// Peer endpoint in `host:port` form.
     pub endpoint: String,
-    /// Tunnel status string (`"up"`, `"down"`, `"connecting"`).
+    /// Tunnel status string (`"up"`, `"down"`, `"connecting"`, `"reconnecting"`).
     pub status: String,
     /// JSON-encoded list of local addresses.
     pub address: String,

--- a/source/daemon/crates/wardnetd-services/src/tunnel/service.rs
+++ b/source/daemon/crates/wardnetd-services/src/tunnel/service.rs
@@ -157,8 +157,10 @@ impl TunnelServiceImpl {
     async fn bring_up_core(&self, id: Uuid) -> Result<(), AppError> {
         let tunnel = self.require_tunnel(id).await?;
 
-        // No-op if already up.
-        if tunnel.status == TunnelStatus::Up {
+        // No-op if the kernel interface is already configured. `Up`,
+        // `Connecting`, and `Reconnecting` all mean "iface exists" — only
+        // `Down` requires (re)creation.
+        if tunnel.status != TunnelStatus::Down {
             return Ok(());
         }
 
@@ -254,14 +256,17 @@ impl TunnelServiceImpl {
             .await
             .map_err(AppError::Internal)?;
 
-        // Update status in the database.
+        // Update status in the database. Stays `connecting` until the
+        // health-check loop observes the first handshake — see
+        // `run_health_check`.
         self.tunnels
-            .update_status(&id.to_string(), "up")
+            .update_status(&id.to_string(), "connecting")
             .await
             .map_err(AppError::Internal)?;
 
-        // Publish domain event.
-        self.events.publish(WardnetEvent::TunnelUp {
+        // Publish domain event. `TunnelUp` is reserved for the moment a
+        // handshake is actually observed.
+        self.events.publish(WardnetEvent::TunnelConnecting {
             tunnel_id: id,
             interface_name: tunnel.interface_name,
             endpoint: tunnel.endpoint,
@@ -461,8 +466,8 @@ impl TunnelService for TunnelServiceImpl {
             }
         }
 
-        // If the tunnel is up, tear it down first.
-        if tunnel.status == TunnelStatus::Up {
+        // If the kernel interface is configured, tear it down first.
+        if tunnel.status != TunnelStatus::Down {
             self.tear_down_core(id, "tunnel deleted").await?;
         }
 
@@ -495,12 +500,15 @@ impl TunnelService for TunnelServiceImpl {
 
     async fn collect_stats(&self) -> Result<(), AppError> {
         let all_tunnels = self.tunnels.find_all().await.map_err(AppError::Internal)?;
-        let up_tunnels: Vec<_> = all_tunnels
+        // Stats apply to any tunnel whose kernel iface is configured —
+        // `Up`, `Connecting`, and `Reconnecting` all qualify. `Down`
+        // tunnels have no iface to read.
+        let active_tunnels: Vec<_> = all_tunnels
             .into_iter()
-            .filter(|t| t.status == wardnet_common::tunnel::TunnelStatus::Up)
+            .filter(|t| t.status != wardnet_common::tunnel::TunnelStatus::Down)
             .collect();
 
-        for tunnel in up_tunnels {
+        for tunnel in active_tunnels {
             let stats = match self
                 .tunnel_interface
                 .get_stats(&tunnel.interface_name)
@@ -541,7 +549,7 @@ impl TunnelService for TunnelServiceImpl {
             self.events
                 .publish(wardnet_common::event::WardnetEvent::TunnelStatsUpdated {
                     tunnel_id: tunnel.id,
-                    status: wardnet_common::tunnel::TunnelStatus::Up,
+                    status: tunnel.status,
                     bytes_tx: stats.bytes_tx,
                     bytes_rx: stats.bytes_rx,
                     last_handshake: stats.last_handshake,
@@ -553,50 +561,87 @@ impl TunnelService for TunnelServiceImpl {
 
     async fn run_health_check(&self) -> Result<(), AppError> {
         let stale_threshold = chrono::Duration::minutes(3);
+        let now = chrono::Utc::now();
         let all_tunnels = self.tunnels.find_all().await.map_err(AppError::Internal)?;
-        let up_tunnels: Vec<_> = all_tunnels
+        // Health judgement applies to every tunnel whose iface is up.
+        // `collect_stats` has just refreshed `last_handshake` for these.
+        let active_tunnels: Vec<_> = all_tunnels
             .into_iter()
-            .filter(|t| t.status == wardnet_common::tunnel::TunnelStatus::Up)
+            .filter(|t| t.status != wardnet_common::tunnel::TunnelStatus::Down)
             .collect();
 
-        for tunnel in up_tunnels {
-            match self
-                .tunnel_interface
-                .get_stats(&tunnel.interface_name)
-                .await
-            {
-                Ok(Some(stats)) => {
-                    if let Some(last_handshake) = stats.last_handshake {
-                        let age = chrono::Utc::now() - last_handshake;
-                        if age > stale_threshold {
-                            tracing::warn!(
-                                tunnel_id = %tunnel.id,
-                                interface = %tunnel.interface_name,
-                                last_handshake = %last_handshake,
-                                age_secs = age.num_seconds(),
-                                "health check: last handshake is stale (>3 minutes) for {}: age={}s",
-                                tunnel.interface_name,
-                                age.num_seconds()
-                            );
-                        }
+        for tunnel in active_tunnels {
+            // A handshake is "fresh" if we have one and it's within the
+            // stale threshold. `None` is treated as stale.
+            let fresh_handshake = tunnel
+                .last_handshake
+                .is_some_and(|ts| (now - ts) <= stale_threshold);
+
+            match (tunnel.status, fresh_handshake) {
+                // Connecting → Up: first handshake observed.
+                // Reconnecting → Up: peer started replying again.
+                (
+                    wardnet_common::tunnel::TunnelStatus::Connecting
+                    | wardnet_common::tunnel::TunnelStatus::Reconnecting,
+                    true,
+                ) => {
+                    if let Err(e) = self
+                        .tunnels
+                        .update_status(&tunnel.id.to_string(), "up")
+                        .await
+                    {
+                        tracing::error!(
+                            tunnel_id = %tunnel.id,
+                            error = %e,
+                            "health check: failed to mark tunnel up for {}: {e}",
+                            tunnel.interface_name
+                        );
+                        continue;
                     }
-                }
-                Ok(None) => {
-                    tracing::error!(
+                    tracing::info!(
                         tunnel_id = %tunnel.id,
                         interface = %tunnel.interface_name,
-                        "health check: interface {} not found (may have been removed externally)",
-                        tunnel.interface_name
+                        previous_status = ?tunnel.status,
+                        "health check: tunnel is now up (handshake observed)"
                     );
+                    self.events.publish(WardnetEvent::TunnelUp {
+                        tunnel_id: tunnel.id,
+                        interface_name: tunnel.interface_name,
+                        endpoint: tunnel.endpoint,
+                        timestamp: now,
+                    });
                 }
-                Err(e) => {
-                    tracing::error!(
+                // Up → Reconnecting: handshake gone stale or absent.
+                (wardnet_common::tunnel::TunnelStatus::Up, false) => {
+                    if let Err(e) = self
+                        .tunnels
+                        .update_status(&tunnel.id.to_string(), "reconnecting")
+                        .await
+                    {
+                        tracing::error!(
+                            tunnel_id = %tunnel.id,
+                            error = %e,
+                            "health check: failed to mark tunnel reconnecting for {}: {e}",
+                            tunnel.interface_name
+                        );
+                        continue;
+                    }
+                    tracing::warn!(
                         tunnel_id = %tunnel.id,
                         interface = %tunnel.interface_name,
-                        error = %e,
-                        "health check: failed to get stats for {}: {e}", tunnel.interface_name
+                        last_handshake = ?tunnel.last_handshake,
+                        "health check: tunnel is reconnecting (handshake stale or absent)"
                     );
+                    self.events.publish(WardnetEvent::TunnelReconnecting {
+                        tunnel_id: tunnel.id,
+                        interface_name: tunnel.interface_name,
+                        last_handshake: tunnel.last_handshake,
+                        timestamp: now,
+                    });
                 }
+                // No-op: Up + fresh, Connecting + still no handshake,
+                // Reconnecting + still no handshake.
+                _ => {}
             }
         }
         Ok(())

--- a/source/daemon/crates/wardnetd-services/src/tunnel/tests/tunnel.rs
+++ b/source/daemon/crates/wardnetd-services/src/tunnel/tests/tunnel.rs
@@ -46,14 +46,25 @@ PersistentKeepalive = 25
 
 // -- Mock TunnelRepository ------------------------------------------------
 
+/// Stats persisted by `update_stats`; tracked separately because
+/// `TunnelRow` is the insert DTO and doesn't carry live stats columns.
+#[derive(Default, Clone)]
+struct TunnelStatsRow {
+    bytes_tx: i64,
+    bytes_rx: i64,
+    last_handshake: Option<chrono::DateTime<chrono::Utc>>,
+}
+
 struct MockTunnelRepo {
     rows: Mutex<Vec<TunnelRow>>,
+    stats: Mutex<std::collections::HashMap<String, TunnelStatsRow>>,
 }
 
 impl MockTunnelRepo {
     fn new() -> Self {
         Self {
             rows: Mutex::new(Vec::new()),
+            stats: Mutex::new(std::collections::HashMap::new()),
         }
     }
 }
@@ -62,13 +73,15 @@ impl MockTunnelRepo {
 impl TunnelRepository for MockTunnelRepo {
     async fn find_all(&self) -> anyhow::Result<Vec<Tunnel>> {
         let rows = self.rows.lock().unwrap();
-        rows.iter().map(row_to_tunnel).collect()
+        let stats = self.stats.lock().unwrap();
+        rows.iter().map(|r| row_to_tunnel(r, &stats)).collect()
     }
 
     async fn find_by_id(&self, id: &str) -> anyhow::Result<Option<Tunnel>> {
         let rows = self.rows.lock().unwrap();
+        let stats = self.stats.lock().unwrap();
         let row = rows.iter().find(|r| r.id == id);
-        row.map(row_to_tunnel).transpose()
+        row.map(|r| row_to_tunnel(r, &stats)).transpose()
     }
 
     async fn find_config_by_id(&self, id: &str) -> anyhow::Result<Option<TunnelConfig>> {
@@ -106,11 +119,20 @@ impl TunnelRepository for MockTunnelRepo {
 
     async fn update_stats(
         &self,
-        _id: &str,
-        _bytes_tx: i64,
-        _bytes_rx: i64,
-        _last_handshake: Option<&str>,
+        id: &str,
+        bytes_tx: i64,
+        bytes_rx: i64,
+        last_handshake: Option<&str>,
     ) -> anyhow::Result<()> {
+        let parsed = last_handshake.map(str::parse).transpose()?;
+        self.stats.lock().unwrap().insert(
+            id.to_owned(),
+            TunnelStatsRow {
+                bytes_tx,
+                bytes_rx,
+                last_handshake: parsed,
+            },
+        );
         Ok(())
     }
 
@@ -141,13 +163,19 @@ impl TunnelRepository for MockTunnelRepo {
     }
 }
 
-/// Convert a `TunnelRow` into a `Tunnel` for mock responses.
-fn row_to_tunnel(r: &TunnelRow) -> anyhow::Result<Tunnel> {
-    let status = match r.status.as_str() {
+/// Convert a `TunnelRow` into a `Tunnel` for mock responses, layering in
+/// the latest stats observation if one exists.
+fn row_to_tunnel(
+    r: &TunnelRow,
+    stats_map: &std::collections::HashMap<String, TunnelStatsRow>,
+) -> anyhow::Result<Tunnel> {
+    let parsed_status = match r.status.as_str() {
         "up" => TunnelStatus::Up,
         "connecting" => TunnelStatus::Connecting,
+        "reconnecting" => TunnelStatus::Reconnecting,
         _ => TunnelStatus::Down,
     };
+    let s = stats_map.get(&r.id).cloned().unwrap_or_default();
     Ok(Tunnel {
         id: r.id.parse()?,
         label: r.label.clone(),
@@ -155,10 +183,10 @@ fn row_to_tunnel(r: &TunnelRow) -> anyhow::Result<Tunnel> {
         provider: r.provider.clone(),
         interface_name: r.interface_name.clone(),
         endpoint: r.endpoint.clone(),
-        status,
-        last_handshake: None,
-        bytes_tx: 0,
-        bytes_rx: 0,
+        status: parsed_status,
+        last_handshake: s.last_handshake,
+        bytes_tx: s.bytes_tx.cast_unsigned(),
+        bytes_rx: s.bytes_rx.cast_unsigned(),
         created_at: chrono::Utc::now(),
     })
 }
@@ -456,6 +484,7 @@ impl DeviceRepository for MockDeviceRepoWithSwitchedDevices {
 
 struct TestHarness {
     svc: TunnelServiceImpl,
+    tunnels: Arc<MockTunnelRepo>,
     tunnel_iface: Arc<MockTunnelInterface>,
     events: Arc<MockEventPublisher>,
     keys: Arc<MockKeyStore>,
@@ -469,7 +498,7 @@ fn build_harness() -> TestHarness {
     let events = Arc::new(MockEventPublisher::new());
 
     let svc = TunnelServiceImpl::with_key_store(
-        repo,
+        repo.clone(),
         device_repo,
         tunnel_iface.clone(),
         keys.clone(),
@@ -478,6 +507,7 @@ fn build_harness() -> TestHarness {
 
     TestHarness {
         svc,
+        tunnels: repo,
         tunnel_iface,
         events,
         keys,
@@ -491,7 +521,7 @@ fn build_harness_with_device_repo(device_repo: Arc<dyn DeviceRepository>) -> Tes
     let events = Arc::new(MockEventPublisher::new());
 
     let svc = TunnelServiceImpl::with_key_store(
-        repo,
+        repo.clone(),
         device_repo,
         tunnel_iface.clone(),
         keys.clone(),
@@ -500,6 +530,7 @@ fn build_harness_with_device_repo(device_repo: Arc<dyn DeviceRepository>) -> Tes
 
     TestHarness {
         svc,
+        tunnels: repo,
         tunnel_iface,
         events,
         keys,
@@ -585,16 +616,19 @@ async fn bring_up_success() {
         assert_eq!(brought_up[0], "wg_ward0");
     }
 
-    // Verify TunnelUp event was published.
+    // Verify TunnelConnecting event was published — the tunnel only flips
+    // to `Up` once the health-check loop observes a handshake.
     let events = h.events.published_events();
     assert_eq!(events.len(), 1);
-    assert!(matches!(&events[0], WardnetEvent::TunnelUp { tunnel_id, .. } if *tunnel_id == id));
+    assert!(
+        matches!(&events[0], WardnetEvent::TunnelConnecting { tunnel_id, .. } if *tunnel_id == id)
+    );
 
-    // Verify tunnel status is now up.
+    // Verify tunnel status is now connecting.
     let tunnel = auth_context::with_context(admin_ctx(), h.svc.get_tunnel(id))
         .await
         .unwrap();
-    assert_eq!(tunnel.status, TunnelStatus::Up);
+    assert_eq!(tunnel.status, TunnelStatus::Connecting);
 }
 
 #[tokio::test]
@@ -779,14 +813,14 @@ async fn tear_down_internal_succeeds_without_admin_context() {
 }
 
 #[tokio::test]
-async fn bring_up_already_up_is_noop() {
+async fn bring_up_when_iface_already_configured_is_noop() {
     let h = build_harness();
     let resp = auth_context::with_context(admin_ctx(), h.svc.import_tunnel(sample_request()))
         .await
         .unwrap();
     let id = resp.tunnel.id;
 
-    // Bring up the first time.
+    // Bring up the first time — status becomes `Connecting`.
     auth_context::with_context(admin_ctx(), h.svc.bring_up(id))
         .await
         .unwrap();
@@ -794,7 +828,8 @@ async fn bring_up_already_up_is_noop() {
     // Clear events from the first bring_up.
     h.events.events.lock().unwrap().clear();
 
-    // Bring up again -- should be a no-op.
+    // Bring up again -- should be a no-op because the kernel iface is
+    // already configured.
     auth_context::with_context(admin_ctx(), h.svc.bring_up(id))
         .await
         .unwrap();
@@ -1114,32 +1149,63 @@ async fn collect_stats_ignores_down_tunnels() {
     );
 }
 
-#[tokio::test]
-async fn run_health_check_warns_on_stale_handshake() {
-    let h = build_harness();
-    let resp = auth_context::with_context(admin_ctx(), h.svc.import_tunnel(sample_request()))
-        .await
-        .unwrap();
-    let id = resp.tunnel.id;
-
+/// Helper: bring tunnel up + drive a stats observation through the iface
+/// mock, mimicking what the stats loop would persist into the DB.
+async fn bring_up_then_observe_handshake(
+    h: &TestHarness,
+    id: Uuid,
+    handshake: Option<chrono::DateTime<chrono::Utc>>,
+) {
     auth_context::with_context(admin_ctx(), h.svc.bring_up(id))
         .await
         .unwrap();
-
-    // Simulate a stale handshake (>3 minutes old).
-    let stale = chrono::Utc::now() - chrono::Duration::minutes(10);
     h.tunnel_iface.set_stats(TunnelStats {
         bytes_tx: 0,
         bytes_rx: 0,
-        last_handshake: Some(stale),
+        last_handshake: handshake,
     });
-
-    // Should succeed regardless — the staleness is only logged.
-    h.svc.run_health_check().await.unwrap();
+    h.svc.collect_stats().await.unwrap();
+    h.events.events.lock().unwrap().clear();
 }
 
 #[tokio::test]
-async fn run_health_check_fresh_handshake_succeeds() {
+async fn collect_stats_picks_up_connecting_tunnels() {
+    let h = build_harness();
+    let resp = auth_context::with_context(admin_ctx(), h.svc.import_tunnel(sample_request()))
+        .await
+        .unwrap();
+    let id = resp.tunnel.id;
+
+    // After bring_up the status is `Connecting` — not yet `Up`.
+    auth_context::with_context(admin_ctx(), h.svc.bring_up(id))
+        .await
+        .unwrap();
+    h.events.events.lock().unwrap().clear();
+
+    h.tunnel_iface.set_stats(TunnelStats {
+        bytes_tx: 64,
+        bytes_rx: 0,
+        last_handshake: None,
+    });
+    h.svc.collect_stats().await.unwrap();
+
+    let events = h.events.published_events();
+    assert!(
+        events.iter().any(|e| matches!(
+            e,
+            WardnetEvent::TunnelStatsUpdated {
+                tunnel_id, status, ..
+            } if *tunnel_id == id && *status == TunnelStatus::Connecting
+        )),
+        "expected TunnelStatsUpdated with Connecting status",
+    );
+}
+
+#[tokio::test]
+async fn collect_stats_does_not_change_status() {
+    // Separation-of-concerns guarantee: collect_stats is a pure observer
+    // and must never mutate tunnel status. Status transitions are owned
+    // by run_health_check.
     let h = build_harness();
     let resp = auth_context::with_context(admin_ctx(), h.svc.import_tunnel(sample_request()))
         .await
@@ -1150,6 +1216,8 @@ async fn run_health_check_fresh_handshake_succeeds() {
         .await
         .unwrap();
 
+    // A fresh handshake — the kind of signal that *would* have triggered
+    // a status flip in the old code.
     let fresh = chrono::Utc::now() - chrono::Duration::seconds(10);
     h.tunnel_iface.set_stats(TunnelStats {
         bytes_tx: 0,
@@ -1157,45 +1225,190 @@ async fn run_health_check_fresh_handshake_succeeds() {
         last_handshake: Some(fresh),
     });
 
-    h.svc.run_health_check().await.unwrap();
+    h.svc.collect_stats().await.unwrap();
+
+    // Status must still be `Connecting` — only run_health_check flips it.
+    let tunnel = auth_context::with_context(admin_ctx(), h.svc.get_tunnel(id))
+        .await
+        .unwrap();
+    assert_eq!(tunnel.status, TunnelStatus::Connecting);
 }
 
 #[tokio::test]
-async fn run_health_check_missing_interface_logs_and_returns_ok() {
-    // `get_stats` returning None triggers the "interface removed externally"
-    // error log path but health check overall returns Ok.
+async fn run_health_check_connecting_to_up_on_handshake() {
     let h = build_harness();
     let resp = auth_context::with_context(admin_ctx(), h.svc.import_tunnel(sample_request()))
         .await
         .unwrap();
     let id = resp.tunnel.id;
 
-    auth_context::with_context(admin_ctx(), h.svc.bring_up(id))
-        .await
-        .unwrap();
-    // Default stats_behavior (None) triggers the missing-interface branch.
+    let fresh = chrono::Utc::now() - chrono::Duration::seconds(10);
+    bring_up_then_observe_handshake(&h, id, Some(fresh)).await;
 
     h.svc.run_health_check().await.unwrap();
+
+    let tunnel = auth_context::with_context(admin_ctx(), h.svc.get_tunnel(id))
+        .await
+        .unwrap();
+    assert_eq!(tunnel.status, TunnelStatus::Up);
+
+    let events = h.events.published_events();
+    assert!(
+        events
+            .iter()
+            .any(|e| matches!(e, WardnetEvent::TunnelUp { tunnel_id, .. } if *tunnel_id == id)),
+        "expected TunnelUp event",
+    );
 }
 
 #[tokio::test]
-async fn run_health_check_stats_error_logs_and_returns_ok() {
+async fn run_health_check_connecting_stays_connecting_without_handshake() {
     let h = build_harness();
     let resp = auth_context::with_context(admin_ctx(), h.svc.import_tunnel(sample_request()))
         .await
         .unwrap();
     let id = resp.tunnel.id;
 
-    auth_context::with_context(admin_ctx(), h.svc.bring_up(id))
-        .await
-        .unwrap();
-    h.tunnel_iface.set_stats_error();
+    bring_up_then_observe_handshake(&h, id, None).await;
 
     h.svc.run_health_check().await.unwrap();
+
+    let tunnel = auth_context::with_context(admin_ctx(), h.svc.get_tunnel(id))
+        .await
+        .unwrap();
+    assert_eq!(tunnel.status, TunnelStatus::Connecting);
+
+    let events = h.events.published_events();
+    assert!(
+        events
+            .iter()
+            .all(|e| !matches!(e, WardnetEvent::TunnelUp { .. })
+                && !matches!(e, WardnetEvent::TunnelReconnecting { .. })),
+        "no transition events expected",
+    );
 }
 
 #[tokio::test]
-async fn run_health_check_no_up_tunnels_is_noop() {
+async fn run_health_check_up_to_reconnecting_when_handshake_stale() {
+    let h = build_harness();
+    let resp = auth_context::with_context(admin_ctx(), h.svc.import_tunnel(sample_request()))
+        .await
+        .unwrap();
+    let id = resp.tunnel.id;
+
+    // Drive Connecting → Up via a fresh handshake.
+    let fresh = chrono::Utc::now() - chrono::Duration::seconds(10);
+    bring_up_then_observe_handshake(&h, id, Some(fresh)).await;
+    h.svc.run_health_check().await.unwrap();
+    assert_eq!(
+        auth_context::with_context(admin_ctx(), h.svc.get_tunnel(id))
+            .await
+            .unwrap()
+            .status,
+        TunnelStatus::Up,
+    );
+
+    // Now simulate the handshake going stale — collect_stats persists the
+    // older timestamp.
+    let stale = chrono::Utc::now() - chrono::Duration::minutes(10);
+    h.tunnel_iface.set_stats(TunnelStats {
+        bytes_tx: 0,
+        bytes_rx: 0,
+        last_handshake: Some(stale),
+    });
+    h.svc.collect_stats().await.unwrap();
+    h.events.events.lock().unwrap().clear();
+
+    h.svc.run_health_check().await.unwrap();
+
+    let tunnel = auth_context::with_context(admin_ctx(), h.svc.get_tunnel(id))
+        .await
+        .unwrap();
+    assert_eq!(tunnel.status, TunnelStatus::Reconnecting);
+
+    let events = h.events.published_events();
+    assert!(
+        events.iter().any(|e| matches!(
+            e,
+            WardnetEvent::TunnelReconnecting { tunnel_id, .. } if *tunnel_id == id
+        )),
+        "expected TunnelReconnecting event",
+    );
+}
+
+#[tokio::test]
+async fn run_health_check_up_to_reconnecting_when_handshake_absent() {
+    let h = build_harness();
+    let resp = auth_context::with_context(admin_ctx(), h.svc.import_tunnel(sample_request()))
+        .await
+        .unwrap();
+    let id = resp.tunnel.id;
+
+    // Drive Connecting → Up via a fresh handshake.
+    let fresh = chrono::Utc::now() - chrono::Duration::seconds(10);
+    bring_up_then_observe_handshake(&h, id, Some(fresh)).await;
+    h.svc.run_health_check().await.unwrap();
+
+    // Handshake disappears (e.g. iface state lost between observations).
+    h.tunnels
+        .update_stats(&id.to_string(), 0, 0, None)
+        .await
+        .unwrap();
+    h.events.events.lock().unwrap().clear();
+
+    h.svc.run_health_check().await.unwrap();
+
+    let tunnel = auth_context::with_context(admin_ctx(), h.svc.get_tunnel(id))
+        .await
+        .unwrap();
+    assert_eq!(tunnel.status, TunnelStatus::Reconnecting);
+}
+
+#[tokio::test]
+async fn run_health_check_reconnecting_to_up_on_recovery() {
+    let h = build_harness();
+    let resp = auth_context::with_context(admin_ctx(), h.svc.import_tunnel(sample_request()))
+        .await
+        .unwrap();
+    let id = resp.tunnel.id;
+
+    // Drive the tunnel into Reconnecting.
+    bring_up_then_observe_handshake(&h, id, None).await;
+    // Force status to `Reconnecting` directly to set up the test, without
+    // waiting 3 min of wall-clock for the Up→Reconnecting transition.
+    h.tunnels
+        .update_status(&id.to_string(), "reconnecting")
+        .await
+        .unwrap();
+
+    // Peer starts replying — fresh handshake observed.
+    let fresh = chrono::Utc::now() - chrono::Duration::seconds(5);
+    h.tunnel_iface.set_stats(TunnelStats {
+        bytes_tx: 0,
+        bytes_rx: 0,
+        last_handshake: Some(fresh),
+    });
+    h.svc.collect_stats().await.unwrap();
+    h.events.events.lock().unwrap().clear();
+
+    h.svc.run_health_check().await.unwrap();
+
+    let tunnel = auth_context::with_context(admin_ctx(), h.svc.get_tunnel(id))
+        .await
+        .unwrap();
+    assert_eq!(tunnel.status, TunnelStatus::Up);
+
+    let events = h.events.published_events();
+    assert!(
+        events
+            .iter()
+            .any(|e| matches!(e, WardnetEvent::TunnelUp { tunnel_id, .. } if *tunnel_id == id)),
+        "expected TunnelUp event on recovery",
+    );
+}
+
+#[tokio::test]
+async fn run_health_check_no_active_tunnels_is_noop() {
     let h = build_harness();
     // No tunnels brought up; run_health_check iterates over an empty list.
     h.svc.run_health_check().await.unwrap();

--- a/source/daemon/crates/wardnetd/src/routing_listener.rs
+++ b/source/daemon/crates/wardnetd/src/routing_listener.rs
@@ -179,8 +179,13 @@ async fn handle_event(event: WardnetEvent, routing: &dyn RoutingService) {
             }
         }
 
-        // Events that do not affect routing.
-        WardnetEvent::TunnelStatsUpdated { .. }
+        // Events that do not affect routing. `TunnelConnecting` /
+        // `TunnelReconnecting` are status signals only — the kernel iface
+        // is still configured in both states, so existing routing rules
+        // continue to apply and no rebuild is needed.
+        WardnetEvent::TunnelConnecting { .. }
+        | WardnetEvent::TunnelReconnecting { .. }
+        | WardnetEvent::TunnelStatsUpdated { .. }
         | WardnetEvent::DhcpLeaseAssigned { .. }
         | WardnetEvent::DhcpLeaseRenewed { .. }
         | WardnetEvent::DhcpLeaseExpired { .. }

--- a/source/sdk/wardnet-js/src/types/tunnel.ts
+++ b/source/sdk/wardnet-js/src/types/tunnel.ts
@@ -1,5 +1,14 @@
-/** The current status of a WireGuard tunnel. */
-export type TunnelStatus = "up" | "down" | "connecting";
+/**
+ * The current status of a WireGuard tunnel.
+ *
+ * - `down` — kernel interface not configured (initial, after tear-down or delete).
+ * - `connecting` — kernel interface configured; no handshake observed yet
+ *   (initial bring-up).
+ * - `up` — recent (≤ 3 min) handshake observed.
+ * - `reconnecting` — was `up`, last handshake stale (> 3 min) or absent;
+ *   the iface is still configured and WireGuard keepalive is retrying.
+ */
+export type TunnelStatus = "up" | "down" | "connecting" | "reconnecting";
 
 /** A WireGuard tunnel configuration and its live state. */
 export interface Tunnel {

--- a/source/web-ui/src/components/compound/TunnelCard.tsx
+++ b/source/web-ui/src/components/compound/TunnelCard.tsx
@@ -11,6 +11,7 @@ function statusColor(status: TunnelStatus) {
     up: "default",
     down: "secondary",
     connecting: "outline",
+    reconnecting: "destructive",
   } as const;
   return map[status];
 }
@@ -23,6 +24,27 @@ function statusLabel(status: TunnelStatus): string {
       return "Down";
     case "connecting":
       return "Connecting";
+    case "reconnecting":
+      return "Reconnecting";
+  }
+}
+
+/**
+ * Hover text explaining a non-`up` tunnel status. `connecting` means the
+ * iface is configured but the peer hasn't replied yet; `reconnecting`
+ * means we previously had a handshake and it's gone stale (>3 min).
+ */
+function statusTooltip(tunnel: Tunnel): string | undefined {
+  switch (tunnel.status) {
+    case "connecting":
+      return "Waiting for first handshake from peer.";
+    case "reconnecting":
+      return tunnel.last_handshake
+        ? `Last handshake ${timeAgo(tunnel.last_handshake)} — peer not responding.`
+        : "Lost handshake — peer not responding.";
+    case "up":
+    case "down":
+      return undefined;
   }
 }
 
@@ -67,7 +89,9 @@ export function TunnelCard({ tunnel, providers, onDelete }: TunnelCardProps) {
             </p>
           </div>
         </div>
-        <Badge variant={statusColor(tunnel.status)}>{statusLabel(tunnel.status)}</Badge>
+        <Badge variant={statusColor(tunnel.status)} title={statusTooltip(tunnel)}>
+          {statusLabel(tunnel.status)}
+        </Badge>
       </CardHeader>
       <CardContent>
         <div className="grid grid-cols-2 gap-y-2 text-sm">


### PR DESCRIPTION
## Summary

- Introduces a four-state tunnel model — `down` / `connecting` / `up` / `reconnecting` — so daemon status reflects WireGuard reality instead of "interface configured."
- `bring_up` now leaves the tunnel `connecting` and emits `TunnelConnecting`; the health-check loop flips status to `up` only after observing a fresh handshake (≤ 3 min) and back to `reconnecting` when one goes stale.
- Cleans up the monitor-loop split: `collect_stats` is now pure observation (byte counters + `last_handshake`), `run_health_check` owns transitions and edge events. Future health probes (ping-through-tunnel, etc.) can plug into the latter without bloating the former.
- Web UI: `reconnecting` renders as a destructive "Reconnecting" badge with a tooltip showing the last-handshake age; `connecting` keeps the outline variant with a "waiting for first handshake" tooltip.

Closes #79. The full implementation plan is captured in the issue body.

## Test plan

- [x] `make check-daemon` (fmt + clippy + workspace tests in Linux container) — clean
- [x] `make check-sdk` — clean (regenerated `docs/openapi.json` includes `reconnecting` enum + new event variants; SDK type-checks)
- [x] `make check-web` — 0 errors (only pre-existing warnings)
- [x] New unit tests cover all four state transitions plus the separation-of-concerns guarantee that `collect_stats` never writes status
- [ ] Manual reproduction (deferred to deploy on hardware): unreachable peer → UI shows "Connecting" instead of "Active"; switch to a reachable peer → flips to "Active" within ~10s; block peer mid-session → flips to "Reconnecting" within 3 min; unblock → returns to "Active"

## Out of scope (tracked separately)

- Per-tunnel endpoint re-resolution at bring-up (best-server feature request).
- Surfacing affected-device state on the devices page when its assigned tunnel is `connecting`/`reconnecting` — added as an acceptance criterion on #225.

🤖 Generated with [Claude Code](https://claude.com/claude-code)