### PR TITLE
feat(daemon): privileged post-upgrade migration framework (#285)

### DIFF
--- a/.github/workflows/build-daemon.yml
+++ b/.github/workflows/build-daemon.yml
@@ -180,6 +180,25 @@ jobs:
           CRATE: wardnetd
         run: make build-daemon
 
+      - name: Build wardnet-postupgrade-runner
+        # Trust anchor for the privileged post-upgrade pipeline. Ships
+        # in the tarball; install.sh extracts it; FsBinaryApplier
+        # ignores it during auto-update so the runner only changes when
+        # an operator runs install.sh.
+        env:
+          TARGET: ${{ matrix.target }}
+          CRATE: wardnet-postupgrade-runner
+        run: make build-daemon
+
+      - name: Build wardnet-postupgrade
+        # Privileged migration runner. Signed by release-daemon.yml
+        # using the same minisign key as the tarball, then bundled into
+        # the tarball as `wardnet-postupgrade.bin` + `.minisig`.
+        env:
+          TARGET: ${{ matrix.target }}
+          CRATE: wardnet-postupgrade
+        run: make build-daemon
+
       - name: Build wardnetd-mock (x86_64 only)
         if: matrix.build-mock
         env:
@@ -196,13 +215,21 @@ jobs:
           set -euo pipefail
           BIN_DIR="source/daemon/target/${TARGET}/release"
           "${STRIP_TOOL}" "${BIN_DIR}/wardnetd"
-          ls -l "${BIN_DIR}/wardnetd"
+          "${STRIP_TOOL}" "${BIN_DIR}/wardnet-postupgrade-runner"
+          "${STRIP_TOOL}" "${BIN_DIR}/wardnet-postupgrade"
+          ls -l "${BIN_DIR}/wardnetd" \
+                "${BIN_DIR}/wardnet-postupgrade-runner" \
+                "${BIN_DIR}/wardnet-postupgrade"
           if [[ "${BUILD_MOCK}" == "true" ]]; then
             "${STRIP_TOOL}" "${BIN_DIR}/wardnetd-mock"
             ls -l "${BIN_DIR}/wardnetd-mock"
           fi
 
       - name: Package wardnetd
+        # Tarball ships unsigned at this stage; release-daemon.yml
+        # signs the post-upgrade payload (renaming wardnet-postupgrade
+        # → wardnet-postupgrade.bin and producing .minisig) and
+        # repacks before signing the outer tarball.
         env:
           TARGET: ${{ matrix.target }}
           ARCH: ${{ matrix.arch }}
@@ -211,9 +238,22 @@ jobs:
           mkdir -p build-artefacts/staged-wardnetd
           cp "source/daemon/target/${TARGET}/release/wardnetd" \
             "build-artefacts/staged-wardnetd/wardnetd"
-          chmod 0755 "build-artefacts/staged-wardnetd/wardnetd"
+          cp "source/daemon/target/${TARGET}/release/wardnet-postupgrade-runner" \
+            "build-artefacts/staged-wardnetd/wardnet-postupgrade-runner"
+          cp "source/daemon/target/${TARGET}/release/wardnet-postupgrade" \
+            "build-artefacts/staged-wardnetd/wardnet-postupgrade"
+          cp deploy/wardnet-postupgrade.service \
+            "build-artefacts/staged-wardnetd/wardnet-postupgrade.service"
+          chmod 0755 "build-artefacts/staged-wardnetd/wardnetd" \
+                     "build-artefacts/staged-wardnetd/wardnet-postupgrade-runner" \
+                     "build-artefacts/staged-wardnetd/wardnet-postupgrade"
+          chmod 0644 "build-artefacts/staged-wardnetd/wardnet-postupgrade.service"
           tar -C build-artefacts/staged-wardnetd \
-            -czf "build-artefacts/wardnetd-${ARCH}.tar.gz" wardnetd
+            -czf "build-artefacts/wardnetd-${ARCH}.tar.gz" \
+            wardnetd \
+            wardnet-postupgrade-runner \
+            wardnet-postupgrade \
+            wardnet-postupgrade.service
 
       - name: Upload wardnetd artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7

--- a/.github/workflows/release-daemon.yml
+++ b/.github/workflows/release-daemon.yml
@@ -57,7 +57,7 @@ jobs:
           name: wardnetd-aarch64-unsigned
           path: release-staging/
 
-      - name: Rename, sha256, sign
+      - name: Sign post-upgrade payload, repack, rename, sha256, sign tarball
         env:
           VERSION: ${{ inputs.version }}
           MINISIGN_KEY_B64: ${{ secrets.WARDNET_MINISIGN_KEY }}
@@ -81,11 +81,46 @@ jobs:
           trap 'shred -u minisign.key || true' EXIT
 
           for ARCH in x86_64 aarch64; do
-            # build-daemon.yml names the tarball wardnetd-<arch>.tar.gz;
-            # release assets carry the version for end-user clarity and
-            # for the daemon's auto-updater, which builds the URL as
-            # `wardnetd-<version>-<arch>.tar.gz`.
+            # build-daemon.yml ships the tarball with `wardnet-postupgrade`
+            # unsigned alongside `wardnetd` + `wardnet-postupgrade-runner`
+            # + `wardnet-postupgrade.service`. Two-step signing here:
+            #   1. Sign the postupgrade binary with the same release key
+            #      and rename it to `.bin` so the runtime trust anchor
+            #      finds it under the expected name.
+            #   2. Re-sign the outer tarball with the signed pair in
+            #      place. install.sh + the auto-updater verify the
+            #      tarball signature; the runner verifies the inner
+            #      .bin/.minisig pair. Defence in depth.
             SRC="wardnetd-${ARCH}.tar.gz"
+            WORK="staged-${ARCH}"
+            mkdir -p "${WORK}"
+            tar -C "${WORK}" -xzf "${SRC}"
+            rm "${SRC}"
+
+            mv "${WORK}/wardnet-postupgrade" "${WORK}/wardnet-postupgrade.bin"
+
+            printf '%s\n' "${MINISIGN_PASSWORD}" | \
+              MINISIGN_PASSWORD="${MINISIGN_PASSWORD}" minisign -Sm "${WORK}/wardnet-postupgrade.bin" \
+                -s minisign.key \
+                -t "wardnet-postupgrade ${VERSION} (${ARCH})" \
+                -c "Wardnet release signing key" \
+                -x "${WORK}/wardnet-postupgrade.minisig"
+
+            minisign -Vm "${WORK}/wardnet-postupgrade.bin" \
+              -p "../deploy/keys/wardnet-release.pub" \
+              -x "${WORK}/wardnet-postupgrade.minisig"
+
+            tar -C "${WORK}" -czf "${SRC}" \
+              wardnetd \
+              wardnet-postupgrade-runner \
+              wardnet-postupgrade.bin \
+              wardnet-postupgrade.minisig \
+              wardnet-postupgrade.service
+            rm -rf "${WORK}"
+
+            # Versioned filename for end-user clarity and the daemon's
+            # auto-updater, which builds the URL as
+            # `wardnetd-<version>-<arch>.tar.gz`.
             DST="wardnetd-${VERSION}-${ARCH}.tar.gz"
             mv "${SRC}" "${DST}"
 

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -24,6 +24,7 @@ MANIFEST_URL="${MANIFEST_URL:-https://releases.wardnet.network/${CHANNEL}.json}"
 LAN_INTERFACE="${LAN_INTERFACE:-}"
 OFFLINE_DIR=""
 CONTAINER_MODE=""
+UPGRADE_ONLY=""
 
 # Embedded release-signing public key. Baking it into the installer is the
 # authenticity anchor: even if DNS or Cloudflare is hijacked, an attacker
@@ -51,6 +52,13 @@ Options:
                         Use when running inside a Docker image build: systemd
                         is not running yet, but the enable symlink is still
                         created so systemd starts the service at boot.
+  --upgrade-only        Skip interactive prompts and the LAN-interface picker;
+                        do not create the wardnet user or rewrite
+                        /etc/wardnet/wardnet.toml. Re-installs the binary,
+                        systemd units, and the post-upgrade migration framework
+                        only. Use this on existing Pis to bootstrap the
+                        post-upgrade framework without disturbing operator
+                        config. Idempotent.
   -h, --help            Show this help text.
 
 Environment overrides:
@@ -66,6 +74,7 @@ while [[ $# -gt 0 ]]; do
         --channel)        CHANNEL="$2";           shift 2 ;;
         --lan-interface)  LAN_INTERFACE="$2";     shift 2 ;;
         --container-mode) CONTAINER_MODE=true;    shift   ;;
+        --upgrade-only)   UPGRADE_ONLY=true;      shift   ;;
         -h|--help)        print_usage; exit 0 ;;
         *) echo "Unknown option: $1" >&2; print_usage >&2; exit 1 ;;
     esac
@@ -187,7 +196,12 @@ pick_lan_interface() {
     echo "Using LAN interface: $LAN_INTERFACE"
 }
 
-pick_lan_interface
+# --upgrade-only skips the picker because the new run reuses the
+# LAN interface already recorded in /etc/wardnet/wardnet.toml from
+# the original install — no config rewrite, no new prompt.
+if [[ -z "$UPGRADE_ONLY" ]]; then
+    pick_lan_interface
+fi
 
 # ---------------------------------------------------------------------------
 # Stage release artefacts (online download OR offline pre-unpacked dir)
@@ -268,8 +282,12 @@ fi
 # Install
 # ---------------------------------------------------------------------------
 
-echo "=== Installing Wardnet v$VERSION ==="
-echo "LAN interface: $LAN_INTERFACE"
+if [[ -n "$UPGRADE_ONLY" ]]; then
+    echo "=== Wardnet upgrade-only run (v$VERSION) ==="
+else
+    echo "=== Installing Wardnet v$VERSION ==="
+    echo "LAN interface: $LAN_INTERFACE"
+fi
 
 # 1. System user. Locked-down account: no shell, no home dir.
 if ! id wardnet &>/dev/null; then
@@ -289,8 +307,10 @@ install -d -o wardnet -g wardnet -m 750 /var/lib/wardnet/updates
 install -d -o wardnet -g wardnet -m 750 /var/log/wardnet
 
 # 3. Default config — written only when none exists, so re-running (e.g.
-#    upgrade that bundles new units) preserves operator tweaks.
-if [[ ! -f /etc/wardnet/wardnet.toml ]]; then
+#    upgrade that bundles new units) preserves operator tweaks. Skipped
+#    explicitly under --upgrade-only so a stray missing config never gets
+#    rebuilt with whatever LAN_INTERFACE the picker chose.
+if [[ -z "$UPGRADE_ONLY" && ! -f /etc/wardnet/wardnet.toml ]]; then
     cat > /etc/wardnet/wardnet.toml <<EOF
 [database]
 provider = "sqlite"
@@ -315,13 +335,46 @@ fi
 #    rename a staged binary into place without setuid or a root helper.
 install -o wardnet -g wardnet -m 0755 "$WORKDIR/wardnetd" /usr/local/bin/wardnetd
 
-# 5. systemd units. The rollback unit is the `OnFailure=` target of the main
-#    unit (see wardnetd.service) — both must land together. Source them from
-#    the offline bundle, the script's sibling dir, or (as a last resort)
-#    GitHub raw for `curl | sudo bash` runs.
+# 5. Privileged post-upgrade migration framework. The runner is the trust
+#    anchor: root-owned, NOT in wardnetd.service's ReadWritePaths, so the
+#    unprivileged wardnet user can't replace it via auto-update. The
+#    signed payload + sig live in /var/lib/wardnet/postupgrade/ — wardnet-
+#    writable so auto-update can refresh them. The state file lives in
+#    /var/lib/wardnet-postupgrade/ (root:root, NOT under the wardnet tree)
+#    so the wardnet user can't mark a Required failure as `applied` and
+#    bypass the daemon-startup gate. Each install run is idempotent and
+#    safe to re-run (used by --upgrade-only on existing Pis).
+install -d -o root    -g root    -m 0755 /usr/local/libexec/wardnet
+install -d -o root    -g root    -m 0755 /usr/local/libexec/wardnet/runner
+install -d -o wardnet -g wardnet -m 0755 /var/lib/wardnet/postupgrade
+install -d -o root    -g root    -m 0755 /var/lib/wardnet-postupgrade
+
+if [[ -f "$WORKDIR/wardnet-postupgrade-runner" ]]; then
+    install -o root -g root -m 0755 \
+        "$WORKDIR/wardnet-postupgrade-runner" \
+        /usr/local/libexec/wardnet/runner/wardnet-postupgrade-runner
+fi
+if [[ -f "$WORKDIR/wardnet-postupgrade.bin" ]]; then
+    install -o wardnet -g wardnet -m 0644 \
+        "$WORKDIR/wardnet-postupgrade.bin" \
+        /var/lib/wardnet/postupgrade/wardnet-postupgrade.bin
+fi
+if [[ -f "$WORKDIR/wardnet-postupgrade.minisig" ]]; then
+    install -o wardnet -g wardnet -m 0644 \
+        "$WORKDIR/wardnet-postupgrade.minisig" \
+        /var/lib/wardnet/postupgrade/wardnet-postupgrade.minisig
+fi
+
+# 6. systemd units. The rollback unit is the `OnFailure=` target of the main
+#    unit (see wardnetd.service) — both must land together. The post-upgrade
+#    unit declares `RequiredBy=wardnetd.service` in its [Install] section,
+#    so `systemctl enable wardnet-postupgrade.service` materialises a
+#    requires/ symlink that gates wardnetd startup on the runner. Source
+#    units from the offline bundle, the script's sibling dir, or (as a
+#    last resort) GitHub raw for `curl | sudo bash` runs.
 SCRIPT_DIR="$(cd "$(dirname "$0")" 2>/dev/null && pwd)" || SCRIPT_DIR=""
 UNIT_BASE="https://raw.githubusercontent.com/wardnet/wardnet/main/deploy"
-for unit in wardnetd.service wardnetd-rollback.service; do
+for unit in wardnetd.service wardnetd-rollback.service wardnet-postupgrade.service; do
     src=""
     if [[ -n "$OFFLINE_DIR" && -f "$OFFLINE_DIR/$unit" ]]; then
         src="$OFFLINE_DIR/$unit"
@@ -339,16 +392,19 @@ if [[ -z "$CONTAINER_MODE" ]]; then
     systemctl daemon-reload
 fi
 
-# 6. Enable (always — creates the WantedBy symlink so the service starts at
-#    boot). In container mode systemd is not running yet during the image
+# 7. Enable (always — creates the WantedBy symlink so the service starts at
+#    boot, plus the wardnetd.service.requires/ symlink for the post-upgrade
+#    runner). In container mode systemd is not running yet during the image
 #    build, so we skip daemon-reload, the immediate start, and the port wait;
 #    systemd will start wardnetd when it initialises as PID 1 at runtime.
 if [[ -n "$CONTAINER_MODE" ]]; then
+    systemctl enable wardnet-postupgrade.service
     systemctl enable wardnetd
     echo ""
     echo "=== Image build complete ==="
     echo "wardnetd will start when the container initialises (systemd as PID 1)."
 else
+    systemctl enable wardnet-postupgrade.service
     systemctl enable --now wardnetd
     systemctl restart wardnetd
 
@@ -363,6 +419,10 @@ else
 
     IP=$(hostname -I 2>/dev/null | awk '{print $1}')
     echo ""
-    echo "=== Install complete ==="
-    echo "Web UI: http://${IP:-<host>}:7411"
+    if [[ -n "$UPGRADE_ONLY" ]]; then
+        echo "=== Upgrade complete ==="
+    else
+        echo "=== Install complete ==="
+        echo "Web UI: http://${IP:-<host>}:7411"
+    fi
 fi

--- a/deploy/wardnet-postupgrade.service
+++ b/deploy/wardnet-postupgrade.service
@@ -1,0 +1,30 @@
+[Unit]
+Description=Wardnet privileged post-upgrade migrations
+DefaultDependencies=yes
+# Runs before wardnetd so any privileged install steps required by the
+# new daemon binary land first. The Required= side of this relationship
+# is declared in [Install] (see RequiredBy= below) so `systemctl enable`
+# materialises a symlink in wardnetd.service.requires/.
+Before=wardnetd.service
+
+[Service]
+# Type=oneshot so systemd treats a clean exit as success rather than
+# restarting the unit. RemainAfterExit=no — there is no service state
+# to keep alive after migrations apply.
+Type=oneshot
+User=root
+ExecStart=/usr/local/libexec/wardnet/runner/wardnet-postupgrade-runner
+RemainAfterExit=no
+
+# Output goes to journald with a stable identifier so log queries can
+# scope to the runner without grepping wardnetd.
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=wardnet-postupgrade
+
+[Install]
+# `systemctl enable` creates wardnetd.service.requires/wardnet-postupgrade.service.
+# That makes wardnetd's start a hard dependency on a successful runner exit:
+# if the runner exits non-zero (signature failure or a Required migration
+# fails), systemd refuses to start wardnetd until the failure is cleared.
+RequiredBy=wardnetd.service

--- a/source/daemon/Cargo.lock
+++ b/source/daemon/Cargo.lock
@@ -825,6 +825,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ct-codecs"
+version = "1.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b10589d1a5e400d61f9f38f12f884cfd080ff345de8f17efda36fe0e4a02aa8"
+
+[[package]]
 name = "ctutils"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2353,6 +2359,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
+name = "minisign"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26541387415a1e829df5d532aad019fb11bc723e2b5bc99edefa4cf5bfad0de7"
+dependencies = [
+ "ct-codecs",
+ "getrandom 0.2.17",
+ "rpassword",
+ "scrypt",
+]
+
+[[package]]
 name = "minisign-verify"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3640,6 +3658,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3582f63211428f83597b51b2ddb88e2a91a9d52d12831f9d08f5e624e8977422"
 
 [[package]]
+name = "rpassword"
+version = "7.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ac5b223d9738ef56e0b98305410be40fa0941bf6036c56f1506751e43552d64"
+dependencies = [
+ "libc",
+ "rtoolbox",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "rsa"
 version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3675,6 +3704,16 @@ dependencies = [
  "nix 0.30.1",
  "thiserror 1.0.69",
  "tokio",
+]
+
+[[package]]
+name = "rtoolbox"
+version = "0.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50a0e551c1e27e1731aba276dbeaeac73f53c7cd34d1bda485d02bd1e0f36844"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5212,6 +5251,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "wardnet-postupgrade"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "chrono",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "wardnet-postupgrade-runner"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "chrono",
+ "libc",
+ "minisign",
+ "minisign-verify",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "wardnet-test-agent"
 version = "0.1.0"
 dependencies = [
@@ -5356,6 +5424,7 @@ dependencies = [
  "hex",
  "hickory-proto 0.26.1",
  "ipnetwork",
+ "minisign",
  "minisign-verify",
  "password-hash 0.6.1",
  "rand 0.10.1",
@@ -5368,6 +5437,7 @@ dependencies = [
  "sqlx",
  "sysinfo",
  "tar",
+ "tempfile",
  "thiserror 2.0.18",
  "tokio",
  "tokio-util",
@@ -5735,6 +5805,15 @@ name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
 ]

--- a/source/daemon/Cargo.toml
+++ b/source/daemon/Cargo.toml
@@ -1,5 +1,7 @@
 [workspace]
 members = [
+    "crates/wardnet-postupgrade",
+    "crates/wardnet-postupgrade-runner",
     "crates/wardnet-test-agent",
     "crates/wardnet-common",
     "crates/wardnetd",
@@ -123,6 +125,10 @@ flate2 = "1"
 tar = "0.4"
 # https://crates.io/crates/minisign-verify — verify minisign signatures on release artefacts
 minisign-verify = "0.2"
+# https://crates.io/crates/minisign — sign + keygen, used only by tests that need to forge signatures over synthetic payloads
+minisign = { version = "0.7", default-features = false }
+# https://crates.io/crates/libc — used by wardnet-postupgrade-runner for memfd_create + fexecve syscalls
+libc = "0.2"
 # https://crates.io/crates/age — symmetric passphrase encryption for backup bundles (scrypt KDF + ChaCha20-Poly1305)
 age = { version = "0.11", default-features = false }
 # https://crates.io/crates/futures

--- a/source/daemon/Dockerfile.test
+++ b/source/daemon/Dockerfile.test
@@ -55,13 +55,37 @@ COPY CALVER /CALVER
 # works.
 ARG WARDNET_VERSION=0.0.0-dev
 
-RUN cargo build --release -p wardnetd -p wardnet-test-agent \
-    && strip target/release/wardnetd target/release/wardnet-test-agent
+# Generate the ephemeral signing keypair BEFORE compiling so the
+# wardnet-postupgrade-runner build embeds the test pubkey via
+# WARDNET_POSTUPGRADE_PUBKEY_PATH. -W = no password (prompt-free);
+# -f = overwrite if a key file already exists. Kept under /tmp so
+# the private key never lands in a runtime layer.
+RUN mkdir -p /tmp/local-bundle \
+    && minisign -G -W -f \
+        -p /tmp/local-bundle/local-bundle.pub \
+        -s /tmp/local-bundle/local-bundle.key
+
+# Build wardnetd + the test agent + the post-upgrade pipeline binaries.
+# WARDNET_POSTUPGRADE_PUBKEY_PATH points at the ephemeral pubkey so the
+# runner's trust anchor in this image only honours signatures from the
+# same ephemeral keypair (production builds default to
+# deploy/keys/wardnet-release.pub).
+RUN WARDNET_POSTUPGRADE_PUBKEY_PATH=/tmp/local-bundle/local-bundle.pub \
+    cargo build --release \
+        -p wardnetd \
+        -p wardnet-test-agent \
+        -p wardnet-postupgrade-runner \
+        -p wardnet-postupgrade \
+    && strip \
+        target/release/wardnetd \
+        target/release/wardnet-test-agent \
+        target/release/wardnet-postupgrade-runner \
+        target/release/wardnet-postupgrade
 
 # Build the synthetic release bundle that install.sh --from consumes:
-# tarball + sha256 + minisig + the two systemd units. The signing key
-# is generated here, used to sign the tarball, then the private half
-# is dropped — only the public key leaves this stage so the runtime
+# tarball + sha256 + minisig + the systemd units. After signing the
+# inner postupgrade binary, the private half of the keypair is
+# dropped — only the public key leaves this stage so the runtime
 # stage can patch it into install.sh's embedded MINISIGN_PUBLIC_KEY.
 RUN <<"EOF" bash
 set -euo pipefail
@@ -70,37 +94,49 @@ case "$(uname -m)" in
     x86_64|amd64)  ARCH=x86_64 ;;
     *) echo "unsupported arch: $(uname -m)" >&2; exit 1 ;;
 esac
-mkdir -p /tmp/local-bundle
 TARBALL="wardnetd-${WARDNET_VERSION}-${ARCH}.tar.gz"
 
-# Stage the tarball contents (only the wardnetd binary; install.sh
-# expects to find it at the root of the archive).
+# Stage the tarball contents. The post-upgrade payload binary is
+# renamed to `wardnet-postupgrade.bin` (the runtime trust anchor's
+# expected filename) and signed with the ephemeral key — same trust
+# model as production, just keyed by an in-image keypair.
 STAGE=$(mktemp -d)
-cp target/release/wardnetd "$STAGE/wardnetd"
-tar -C "$STAGE" -czf "/tmp/local-bundle/${TARBALL}" wardnetd
+cp target/release/wardnetd                    "$STAGE/wardnetd"
+cp target/release/wardnet-postupgrade-runner  "$STAGE/wardnet-postupgrade-runner"
+cp target/release/wardnet-postupgrade         "$STAGE/wardnet-postupgrade.bin"
+cp /deploy/wardnet-postupgrade.service        "$STAGE/wardnet-postupgrade.service"
+minisign -S -W \
+    -s /tmp/local-bundle/local-bundle.key \
+    -t "wardnet-test-image postupgrade" \
+    -m "$STAGE/wardnet-postupgrade.bin" \
+    -x "$STAGE/wardnet-postupgrade.minisig"
+tar -C "$STAGE" -czf "/tmp/local-bundle/${TARBALL}" \
+    wardnetd \
+    wardnet-postupgrade-runner \
+    wardnet-postupgrade.bin \
+    wardnet-postupgrade.minisig \
+    wardnet-postupgrade.service
 rm -rf "$STAGE"
 
 # SHA-256 sidecar. install.sh reads the hash with `awk '{print $1}'`,
 # so the standard `sha256sum` two-column format works as-is.
 ( cd /tmp/local-bundle && sha256sum "${TARBALL}" > "${TARBALL}.sha256" )
 
-# Ephemeral minisign keypair. -W = no password (prompt-free); -f =
-# overwrite if a key file already exists. Kept under /tmp so the
-# private key cannot leak into a runtime layer even by accident.
-minisign -G -W -f \
-    -p /tmp/local-bundle/local-bundle.pub \
-    -s /tmp/local-bundle/local-bundle.key
-
-# Sign the tarball. -t pins the trusted comment so install.sh's
-# verification produces stable output across rebuilds.
+# Sign the outer tarball with the same ephemeral key. -t pins the
+# trusted comment so install.sh's verification produces stable
+# output across rebuilds.
 minisign -S -W \
     -s /tmp/local-bundle/local-bundle.key \
     -t "wardnet-test-image local build" \
     -m "/tmp/local-bundle/${TARBALL}"
 
 # Bundle the systemd units alongside the tarball — install.sh's
-# --from path looks them up next to the archive.
-cp /deploy/wardnetd.service /deploy/wardnetd-rollback.service /tmp/local-bundle/
+# --from path looks them up next to the archive (in addition to
+# whatever's inside the tarball, which it doesn't read here).
+cp /deploy/wardnetd.service \
+   /deploy/wardnetd-rollback.service \
+   /deploy/wardnet-postupgrade.service \
+   /tmp/local-bundle/
 
 # Drop the private key. The public key stays so the runtime stage
 # can patch install.sh's embedded MINISIGN_PUBLIC_KEY before invoking

--- a/source/daemon/crates/wardnet-postupgrade-runner/Cargo.toml
+++ b/source/daemon/crates/wardnet-postupgrade-runner/Cargo.toml
@@ -1,0 +1,37 @@
+[package]
+name = "wardnet-postupgrade-runner"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+
+[lints]
+workspace = true
+
+[[bin]]
+name = "wardnet-postupgrade-runner"
+path = "src/main.rs"
+
+[dependencies]
+# https://crates.io/crates/anyhow
+anyhow.workspace = true
+# https://crates.io/crates/chrono
+chrono.workspace = true
+# https://crates.io/crates/libc
+libc.workspace = true
+# https://crates.io/crates/minisign-verify
+minisign-verify.workspace = true
+# https://crates.io/crates/serde
+serde.workspace = true
+# https://crates.io/crates/serde_json
+serde_json.workspace = true
+# https://crates.io/crates/tracing
+tracing.workspace = true
+# https://crates.io/crates/tracing-subscriber
+tracing-subscriber.workspace = true
+
+[dev-dependencies]
+# https://crates.io/crates/minisign
+minisign.workspace = true
+# https://crates.io/crates/tempfile
+tempfile.workspace = true

--- a/source/daemon/crates/wardnet-postupgrade-runner/build.rs
+++ b/source/daemon/crates/wardnet-postupgrade-runner/build.rs
@@ -1,0 +1,37 @@
+// Resolves the minisign public key path used to verify the postupgrade
+// payload at runtime, then exposes it to `src/main.rs` via
+// `cargo:rustc-env=WARDNET_POSTUPGRADE_PUBKEY=…` so `include_str!`
+// can pull the file contents at compile time.
+//
+// Production builds use the same release key as wardnetd
+// (`deploy/keys/wardnet-release.pub`). The end-to-end test image
+// generates an ephemeral keypair during the Docker build and points
+// `WARDNET_POSTUPGRADE_PUBKEY_PATH` at the test pubkey so the runner
+// trusts the locally-signed test payload without leaking the test
+// private key into the trust anchor on real Pis.
+
+use std::path::PathBuf;
+
+fn main() {
+    println!("cargo:rerun-if-env-changed=WARDNET_POSTUPGRADE_PUBKEY_PATH");
+
+    let path = std::env::var("WARDNET_POSTUPGRADE_PUBKEY_PATH").unwrap_or_else(|_| {
+        // Default: walk back from this crate's manifest dir to the
+        // repo root and pick up the same key wardnetd embeds.
+        let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        manifest_dir
+            .join("../../../../deploy/keys/wardnet-release.pub")
+            .to_string_lossy()
+            .into_owned()
+    });
+
+    let canonical = std::fs::canonicalize(&path).unwrap_or_else(|e| {
+        panic!("WARDNET_POSTUPGRADE_PUBKEY_PATH resolution failed for {path}: {e}")
+    });
+
+    println!("cargo:rerun-if-changed={}", canonical.display());
+    println!(
+        "cargo:rustc-env=WARDNET_POSTUPGRADE_PUBKEY={}",
+        canonical.display()
+    );
+}

--- a/source/daemon/crates/wardnet-postupgrade-runner/src/exec.rs
+++ b/source/daemon/crates/wardnet-postupgrade-runner/src/exec.rs
@@ -1,0 +1,69 @@
+//! `memfd_create` + `fexecve` exec strategy for the verified payload.
+//!
+//! Holding the bytes in an anonymous in-memory file means the wardnet
+//! user cannot replace the payload between verify and exec, and there
+//! is no executable file on disk for an attacker to swap. `MFD_CLOEXEC`
+//! ensures the memfd is dropped if exec fails — no leak into a child
+//! process.
+//!
+//! `fexecve` on Linux is implemented by glibc as `execveat(fd, "",
+//! …, AT_EMPTY_PATH)` which does the right thing for memfds.
+
+use std::convert::Infallible;
+use std::ffi::CString;
+use std::io::Write;
+use std::os::fd::{AsRawFd, FromRawFd};
+
+use anyhow::Context;
+
+/// Write `payload` into a fresh memfd and `fexecve` it. On success this
+/// function does not return — the current process is replaced by the
+/// payload binary.
+///
+/// `name` is purely cosmetic (shows up in `/proc/<pid>/fd/`); the
+/// kernel does not enforce uniqueness.
+///
+/// `args` becomes the new process's `argv`. Convention: include the
+/// program name as `args[0]`.
+pub fn exec_memfd(name: &str, payload: &[u8], args: &[CString]) -> anyhow::Result<Infallible> {
+    let fd_name = CString::new(name).context("memfd name contained NUL")?;
+    let raw_fd = unsafe { libc::memfd_create(fd_name.as_ptr(), libc::MFD_CLOEXEC) };
+    if raw_fd < 0 {
+        return Err(
+            anyhow::Error::from(std::io::Error::last_os_error()).context("memfd_create failed")
+        );
+    }
+
+    // SAFETY: memfd_create returned a valid fd we own.
+    let mut memfile = unsafe { std::fs::File::from_raw_fd(raw_fd) };
+    memfile
+        .write_all(payload)
+        .context("write payload into memfd failed")?;
+
+    let envp: Vec<CString> = std::env::vars_os()
+        .filter_map(|(k, v)| {
+            let mut combined = k.into_encoded_bytes();
+            combined.push(b'=');
+            combined.extend_from_slice(v.as_encoded_bytes());
+            CString::new(combined).ok()
+        })
+        .collect();
+
+    let argv_ptrs: Vec<*const libc::c_char> = args
+        .iter()
+        .map(|s| s.as_ptr())
+        .chain(std::iter::once(std::ptr::null()))
+        .collect();
+    let envp_ptrs: Vec<*const libc::c_char> = envp
+        .iter()
+        .map(|s| s.as_ptr())
+        .chain(std::iter::once(std::ptr::null()))
+        .collect();
+
+    // SAFETY: argv/envp are valid until this call returns; the call
+    // either replaces the process (no return) or sets errno and
+    // returns -1.
+    let rc = unsafe { libc::fexecve(memfile.as_raw_fd(), argv_ptrs.as_ptr(), envp_ptrs.as_ptr()) };
+    debug_assert_eq!(rc, -1, "fexecve must not return on success");
+    Err(anyhow::Error::from(std::io::Error::last_os_error()).context("fexecve failed"))
+}

--- a/source/daemon/crates/wardnet-postupgrade-runner/src/lib.rs
+++ b/source/daemon/crates/wardnet-postupgrade-runner/src/lib.rs
@@ -1,0 +1,119 @@
+//! Runtime for the privileged post-upgrade migration runner.
+//!
+//! The runner is the trust anchor of the post-upgrade pipeline. It is
+//! installed by `install.sh` to `/usr/local/libexec/wardnet/runner/` as
+//! `root:root 0755`, lives outside `wardnetd.service`'s
+//! `ReadWritePaths`, and so cannot be replaced by the unprivileged
+//! `wardnet` user that auto-update runs as. Its embedded public key is
+//! the same minisign key that signs release tarballs.
+//!
+//! At every boot, systemd starts `wardnet-postupgrade.service` before
+//! `wardnetd.service`. The service `ExecStart` is the runner, which:
+//!   1. Reads the wardnet-writable payload + signature from
+//!      `/var/lib/wardnet/postupgrade/`.
+//!   2. Verifies the signature against the embedded public key.
+//!   3. Writes the payload bytes into a `memfd_create` anonymous file.
+//!   4. `fexecve`s the memfd as root, replacing this process with the
+//!      `wardnet-postupgrade` binary.
+//!
+//! Holding the verified bytes in a memfd (never on disk) closes the
+//! TOCTOU window between verify and exec — the wardnet user cannot
+//! swap the payload file between `read()` and `exec()` because the
+//! exec'd image is already in kernel memory.
+
+pub mod exec;
+pub mod state;
+pub mod verify;
+
+use std::path::PathBuf;
+
+/// Default location of the wardnet-writable signed payload.
+pub const DEFAULT_PAYLOAD_PATH: &str = "/var/lib/wardnet/postupgrade/wardnet-postupgrade.bin";
+/// Default location of the wardnet-writable detached minisign signature.
+pub const DEFAULT_SIGNATURE_PATH: &str = "/var/lib/wardnet/postupgrade/wardnet-postupgrade.minisig";
+/// Default location of the root-only state file.
+///
+/// Intentionally a sibling of `/var/lib/wardnet/` so the wardnet user
+/// (covered by `wardnetd.service`'s `ReadWritePaths=/var/lib/wardnet`)
+/// cannot rewrite this file to mark a `Required` failure as `applied`
+/// and bypass the daemon-startup gate.
+pub const DEFAULT_STATE_PATH: &str = "/var/lib/wardnet-postupgrade/state.json";
+
+/// Inputs the runner needs to verify and exec a payload. Mostly fixed
+/// at compile time; `Runner::with_default_paths` wires the production
+/// paths and tests construct alternate paths in tempdirs.
+pub struct Runner {
+    pub payload_path: PathBuf,
+    pub signature_path: PathBuf,
+    pub state_path: PathBuf,
+    pub public_key: &'static str,
+}
+
+/// What the runner did. Mapped to a process exit code by `main.rs`.
+#[derive(Debug)]
+pub enum RunOutcome {
+    /// Either the payload or its detached signature is missing.
+    /// The runner logs INFO and exits 0 — there is nothing to gate
+    /// daemon startup on. install.sh always places initial artifacts,
+    /// so this branch is reached only on a hand-deleted file or an
+    /// ancient tarball that predates the framework.
+    NoPayload,
+    /// Signature verification failed. The runner logs ERROR, records
+    /// the failure into `state.json`, and exits nonzero.
+    VerifyFailed(anyhow::Error),
+    /// `memfd_create` or `fexecve` failed. Successful exec replaces
+    /// the process and never returns this variant. Very rare in
+    /// practice (kernel out of memory, seccomp policy mismatch).
+    ExecFailed(anyhow::Error),
+}
+
+impl Runner {
+    /// Wire the production paths and embedded public key. Used by
+    /// `main.rs`. Tests construct `Runner` directly with tempdir paths.
+    #[must_use]
+    pub fn with_default_paths(public_key: &'static str) -> Self {
+        Self {
+            payload_path: PathBuf::from(DEFAULT_PAYLOAD_PATH),
+            signature_path: PathBuf::from(DEFAULT_SIGNATURE_PATH),
+            state_path: PathBuf::from(DEFAULT_STATE_PATH),
+            public_key,
+        }
+    }
+
+    /// Verify the payload and exec it. Successful exec never returns;
+    /// failure modes are mapped to [`RunOutcome`] variants. The caller
+    /// (`main.rs`) translates the variant to a logger call + exit code.
+    pub fn run(&self, args: &[std::ffi::CString]) -> RunOutcome {
+        let Some((payload, signature)) =
+            verify::read_artifacts(&self.payload_path, &self.signature_path)
+        else {
+            return RunOutcome::NoPayload;
+        };
+
+        if let Err(e) = verify::verify(self.public_key, &payload, &signature) {
+            // Record the failure best-effort; if state.json itself is
+            // unwritable (read-only fs, missing dir) we still want the
+            // ERROR log + nonzero exit to reach the journal.
+            let now = chrono::Utc::now();
+            if let Err(state_err) =
+                state::record_verification_failure(&self.state_path, &format!("{e:#}"), now)
+            {
+                tracing::warn!(
+                    error = %state_err,
+                    state = %self.state_path.display(),
+                    "could not record verification failure to {state}: {state_err}",
+                    state = self.state_path.display(),
+                );
+            }
+            return RunOutcome::VerifyFailed(e);
+        }
+
+        match exec::exec_memfd("wardnet-postupgrade", &payload, args) {
+            Ok(never) => match never {},
+            Err(e) => RunOutcome::ExecFailed(e),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/source/daemon/crates/wardnet-postupgrade-runner/src/main.rs
+++ b/source/daemon/crates/wardnet-postupgrade-runner/src/main.rs
@@ -1,0 +1,59 @@
+//! `wardnet-postupgrade-runner` entrypoint.
+//!
+//! Resolves to a process exit code and a single line of structured
+//! tracing output per outcome. The systemd unit captures stdout/stderr
+//! into journald with `SyslogIdentifier=wardnet-postupgrade`.
+
+use std::ffi::CString;
+
+use wardnet_postupgrade_runner::{RunOutcome, Runner};
+
+/// Embedded at compile time via `build.rs`. The default points at
+/// `deploy/keys/wardnet-release.pub`; the e2e test image overrides
+/// `WARDNET_POSTUPGRADE_PUBKEY_PATH` at build time to a test pubkey.
+const EMBEDDED_PUBLIC_KEY: &str = include_str!(env!("WARDNET_POSTUPGRADE_PUBKEY"));
+
+fn main() {
+    init_tracing();
+
+    let runner = Runner::with_default_paths(EMBEDDED_PUBLIC_KEY);
+    let argv = vec![CString::new("wardnet-postupgrade").expect("argv[0] has no NUL")];
+
+    match runner.run(&argv) {
+        RunOutcome::NoPayload => {
+            tracing::info!(
+                payload = %runner.payload_path.display(),
+                "no postupgrade payload present at {payload}; nothing to do",
+                payload = runner.payload_path.display(),
+            );
+            std::process::exit(0);
+        }
+        RunOutcome::VerifyFailed(e) => {
+            tracing::error!(
+                error = %e,
+                payload = %runner.payload_path.display(),
+                "postupgrade signature verification failed for {payload}: {e}",
+                payload = runner.payload_path.display(),
+            );
+            std::process::exit(1);
+        }
+        RunOutcome::ExecFailed(e) => {
+            tracing::error!(
+                error = %e,
+                "fexecve of postupgrade payload failed: {e}",
+            );
+            std::process::exit(2);
+        }
+    }
+}
+
+fn init_tracing() {
+    // Compact format suits journald: one line, structured fields
+    // visible in `journalctl -u wardnet-postupgrade`. No timestamp
+    // (journald already prefixes one).
+    let _ = tracing_subscriber::fmt()
+        .with_writer(std::io::stderr)
+        .with_target(false)
+        .without_time()
+        .try_init();
+}

--- a/source/daemon/crates/wardnet-postupgrade-runner/src/state.rs
+++ b/source/daemon/crates/wardnet-postupgrade-runner/src/state.rs
@@ -1,0 +1,78 @@
+//! Best-effort state.json writer for verification failures.
+//!
+//! On verify failure the runner records who/why/when into the
+//! root-only state file so operators can diagnose without scraping
+//! systemd journals. The migration runner (`wardnet-postupgrade`)
+//! owns the rest of the state schema; this module touches only the
+//! `last_verification_failure` field.
+
+use std::path::Path;
+
+use anyhow::Context;
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+/// Schema mirrors `wardnet-postupgrade::state::State`. Kept in sync
+/// manually because the runner cannot depend on the migration runner
+/// crate (the runner is the trust anchor; the migration runner is the
+/// thing it execs).
+#[derive(Debug, Default, Serialize, Deserialize)]
+struct State {
+    #[serde(default)]
+    applied: serde_json::Value,
+    #[serde(default)]
+    failed: serde_json::Value,
+    #[serde(default)]
+    last_verification_failure: Option<VerificationFailure>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct VerificationFailure {
+    error: String,
+    at: DateTime<Utc>,
+}
+
+/// Append a verification-failure record to `state.json`, preserving
+/// any `applied`/`failed` arrays already written by the migration
+/// runner. Atomic write-then-rename, root-only file.
+pub fn record_verification_failure(
+    state_path: &Path,
+    error_message: &str,
+    now: DateTime<Utc>,
+) -> anyhow::Result<()> {
+    if let Some(parent) = state_path.parent() {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("could not create state directory {}", parent.display()))?;
+    }
+
+    let mut state: State = match std::fs::read(state_path) {
+        Ok(bytes) => serde_json::from_slice(&bytes).unwrap_or_default(),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => State {
+            applied: serde_json::Value::Array(Vec::new()),
+            failed: serde_json::Value::Array(Vec::new()),
+            last_verification_failure: None,
+        },
+        Err(e) => {
+            return Err(anyhow::Error::from(e).context(format!(
+                "could not read existing state at {}",
+                state_path.display()
+            )));
+        }
+    };
+    state.last_verification_failure = Some(VerificationFailure {
+        error: error_message.to_owned(),
+        at: now,
+    });
+
+    let serialized = serde_json::to_vec_pretty(&state).context("serialize state.json")?;
+    let tmp = state_path.with_extension("json.tmp");
+    std::fs::write(&tmp, &serialized).with_context(|| format!("write {} failed", tmp.display()))?;
+    std::fs::rename(&tmp, state_path).with_context(|| {
+        format!(
+            "rename {} -> {} failed",
+            tmp.display(),
+            state_path.display()
+        )
+    })?;
+    Ok(())
+}

--- a/source/daemon/crates/wardnet-postupgrade-runner/src/tests/exec.rs
+++ b/source/daemon/crates/wardnet-postupgrade-runner/src/tests/exec.rs
@@ -1,0 +1,38 @@
+//! Tests for `exec::exec_memfd`. The function only returns on
+//! failure (success replaces the current process), so the only
+//! reachable test path is "fexecve fails because the bytes are not
+//! a valid executable image". The test still exercises the full
+//! `memfd_create` + `write` + `fexecve` syscall chain.
+
+use std::ffi::CString;
+
+use crate::exec::exec_memfd;
+
+#[test]
+fn returns_err_when_payload_is_not_a_valid_executable() {
+    // A handful of bytes that match no executable format (no #!,
+    // no ELF magic, no PE magic). fexecve will fall through every
+    // binfmt handler the kernel knows and return ENOEXEC.
+    let bogus_payload = b"this-is-not-an-executable-image";
+    let argv = [CString::new("test-payload").unwrap()];
+
+    let err = exec_memfd("test-payload", bogus_payload, &argv)
+        .expect_err("fexecve must fail on a non-executable payload");
+    let chain = format!("{err:#}");
+    assert!(
+        chain.contains("fexecve failed"),
+        "expected fexecve-failure message, got: {chain}"
+    );
+}
+
+#[test]
+fn returns_err_when_name_contains_nul() {
+    let argv = [CString::new("p").unwrap()];
+    let err = exec_memfd("bad\0name", b"_", &argv)
+        .expect_err("memfd name with NUL must be rejected before any syscall");
+    let chain = format!("{err:#}");
+    assert!(
+        chain.contains("NUL"),
+        "expected NUL-validation error, got: {chain}"
+    );
+}

--- a/source/daemon/crates/wardnet-postupgrade-runner/src/tests/mod.rs
+++ b/source/daemon/crates/wardnet-postupgrade-runner/src/tests/mod.rs
@@ -2,5 +2,7 @@
 //! module owns a sibling test file; `lib.rs` declares this module
 //! gated on `#[cfg(test)]`.
 
+mod exec;
+mod runner;
 mod state;
 mod verify;

--- a/source/daemon/crates/wardnet-postupgrade-runner/src/tests/mod.rs
+++ b/source/daemon/crates/wardnet-postupgrade-runner/src/tests/mod.rs
@@ -1,0 +1,6 @@
+//! Unit tests for the runner crate. Per project convention each
+//! module owns a sibling test file; `lib.rs` declares this module
+//! gated on `#[cfg(test)]`.
+
+mod state;
+mod verify;

--- a/source/daemon/crates/wardnet-postupgrade-runner/src/tests/runner.rs
+++ b/source/daemon/crates/wardnet-postupgrade-runner/src/tests/runner.rs
@@ -1,0 +1,150 @@
+//! End-to-end tests for `Runner::run` covering all three return
+//! variants: `NoPayload` (either file missing), `VerifyFailed`
+//! (signature mismatched against embedded pubkey), and `ExecFailed`
+//! (verify passes but `fexecve` rejects the bytes as a non-executable
+//! image — driven here with a throwaway keypair signing garbage
+//! bytes).
+//!
+//! Successful exec replaces the test process, so the success branch
+//! is only reachable from a real systemd unit invocation. The
+//! integration test in `source/end2end-tests/daemon/` covers it.
+
+use std::ffi::CString;
+use std::io::Cursor;
+
+use minisign::{KeyPair, sign};
+use tempfile::TempDir;
+
+use crate::{RunOutcome, Runner};
+
+/// `&'static str` is what `Runner::public_key` expects. Tests leak
+/// the freshly-generated pubkey for the duration of the process.
+fn leak(s: String) -> &'static str {
+    Box::leak(s.into_boxed_str())
+}
+
+/// Generate a keypair, sign `payload`, return `(pk_text, sig_text)`.
+fn signed_pair(payload: &[u8]) -> (String, String) {
+    let keypair = KeyPair::generate_unencrypted_keypair().expect("keypair");
+    let pk_text = keypair.pk.to_box().expect("pk box").into_string();
+    let mut reader = Cursor::new(payload);
+    let signature_box = sign(
+        None,
+        &keypair.sk,
+        &mut reader,
+        Some("test trusted"),
+        Some("test untrusted"),
+    )
+    .expect("sign");
+    (pk_text, signature_box.into_string())
+}
+
+fn build_runner(dir: &std::path::Path, public_key: &'static str) -> Runner {
+    Runner {
+        payload_path: dir.join("postupgrade.bin"),
+        signature_path: dir.join("postupgrade.minisig"),
+        state_path: dir.join("state.json"),
+        public_key,
+    }
+}
+
+#[test]
+fn no_payload_when_bin_file_missing() {
+    let dir = TempDir::new().unwrap();
+    // sig present, bin absent
+    std::fs::write(dir.path().join("postupgrade.minisig"), b"sig").unwrap();
+    let runner = build_runner(dir.path(), "untrusted comment: x\nAAAA");
+    let argv = [CString::new("p").unwrap()];
+    let outcome = runner.run(&argv);
+    assert!(
+        matches!(outcome, RunOutcome::NoPayload),
+        "expected NoPayload, got {outcome:?}"
+    );
+}
+
+#[test]
+fn no_payload_when_signature_file_missing() {
+    let dir = TempDir::new().unwrap();
+    // bin present, sig absent
+    std::fs::write(dir.path().join("postupgrade.bin"), b"bytes").unwrap();
+    let runner = build_runner(dir.path(), "untrusted comment: x\nAAAA");
+    let argv = [CString::new("p").unwrap()];
+    let outcome = runner.run(&argv);
+    assert!(
+        matches!(outcome, RunOutcome::NoPayload),
+        "expected NoPayload, got {outcome:?}"
+    );
+}
+
+#[test]
+fn verify_failed_records_state_and_returns_verify_failed() {
+    let dir = TempDir::new().unwrap();
+    let payload = b"some payload bytes";
+    let (pk_a, _sig_a) = signed_pair(payload);
+    let (_pk_b, sig_b) = signed_pair(payload);
+    // Signature was made with key B but the runner's embedded key
+    // is key A — verification rejects.
+    std::fs::write(dir.path().join("postupgrade.bin"), payload).unwrap();
+    std::fs::write(dir.path().join("postupgrade.minisig"), sig_b).unwrap();
+
+    let runner = build_runner(dir.path(), leak(pk_a));
+    let argv = [CString::new("p").unwrap()];
+    let outcome = runner.run(&argv);
+    let RunOutcome::VerifyFailed(err) = outcome else {
+        panic!("expected VerifyFailed, got {outcome:?}");
+    };
+    let chain = format!("{err:#}");
+    assert!(
+        chain.contains("verification failed"),
+        "expected verification-failure message, got: {chain}"
+    );
+
+    // state.json was created best-effort with the failure recorded.
+    let state_bytes = std::fs::read(dir.path().join("state.json")).expect("state.json written");
+    let state: serde_json::Value = serde_json::from_slice(&state_bytes).unwrap();
+    assert!(
+        state["last_verification_failure"]["error"].is_string(),
+        "expected last_verification_failure to be set, got {state}"
+    );
+}
+
+#[test]
+fn exec_failed_when_verified_payload_is_not_an_executable() {
+    let dir = TempDir::new().unwrap();
+    // Sign a non-executable payload. Verification passes (the
+    // signature matches the embedded pubkey), then `fexecve` fails
+    // because the bytes are not a valid executable image — exactly
+    // the rare-but-real case the runner's `ExecFailed` arm handles.
+    let bogus_payload = b"not-an-elf-file";
+    let (pk, sig) = signed_pair(bogus_payload);
+    std::fs::write(dir.path().join("postupgrade.bin"), bogus_payload).unwrap();
+    std::fs::write(dir.path().join("postupgrade.minisig"), sig).unwrap();
+
+    let runner = build_runner(dir.path(), leak(pk));
+    let argv = [CString::new("p").unwrap()];
+    let outcome = runner.run(&argv);
+    let RunOutcome::ExecFailed(err) = outcome else {
+        panic!("expected ExecFailed, got {outcome:?}");
+    };
+    assert!(
+        format!("{err:#}").contains("fexecve failed"),
+        "expected fexecve-failure message"
+    );
+}
+
+#[test]
+fn with_default_paths_uses_production_constants() {
+    let runner = Runner::with_default_paths("untrusted comment: x\nAAAA");
+    assert_eq!(
+        runner.payload_path,
+        std::path::PathBuf::from(crate::DEFAULT_PAYLOAD_PATH)
+    );
+    assert_eq!(
+        runner.signature_path,
+        std::path::PathBuf::from(crate::DEFAULT_SIGNATURE_PATH)
+    );
+    assert_eq!(
+        runner.state_path,
+        std::path::PathBuf::from(crate::DEFAULT_STATE_PATH)
+    );
+}

--- a/source/daemon/crates/wardnet-postupgrade-runner/src/tests/state.rs
+++ b/source/daemon/crates/wardnet-postupgrade-runner/src/tests/state.rs
@@ -49,3 +49,42 @@ fn creates_parent_directory() {
     record_verification_failure(&path, "boom", now).unwrap();
     assert!(path.exists());
 }
+
+#[test]
+fn invalid_json_falls_back_to_default_state() {
+    // If state.json is corrupted (e.g. truncated mid-write), we
+    // discard the contents and overwrite with a fresh record rather
+    // than refusing to mark the verification failure. The lost
+    // applied/failed history is the lesser evil — the journal entry
+    // still exists, and the next migration runner exit will rebuild
+    // applied[]/failed[] correctly.
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("state.json");
+    std::fs::write(&path, b"this is not json").unwrap();
+
+    let now = chrono::Utc::now();
+    record_verification_failure(&path, "boom", now).expect("recover from invalid json");
+
+    let v: serde_json::Value = serde_json::from_slice(&std::fs::read(&path).unwrap()).unwrap();
+    assert_eq!(v["last_verification_failure"]["error"], "boom");
+}
+
+#[test]
+fn read_error_other_than_not_found_returns_err() {
+    // Pass a directory as state_path. `std::fs::read` returns an
+    // Err with kind that's not `NotFound`, exercising the third
+    // match arm that surfaces I/O errors instead of silently
+    // defaulting.
+    let dir = TempDir::new().unwrap();
+    let path_as_directory = dir.path().join("state-as-dir");
+    std::fs::create_dir(&path_as_directory).unwrap();
+
+    let now = chrono::Utc::now();
+    let err = record_verification_failure(&path_as_directory, "boom", now)
+        .expect_err("reading a directory must surface as Err");
+    let chain = format!("{err:#}");
+    assert!(
+        chain.contains("could not read existing state"),
+        "expected read-error context, got: {chain}"
+    );
+}

--- a/source/daemon/crates/wardnet-postupgrade-runner/src/tests/state.rs
+++ b/source/daemon/crates/wardnet-postupgrade-runner/src/tests/state.rs
@@ -1,0 +1,51 @@
+//! Tests for state.rs's `record_verification_failure`.
+
+use chrono::TimeZone;
+use tempfile::TempDir;
+
+use crate::state::record_verification_failure;
+
+#[test]
+fn writes_fresh_state_when_file_absent() {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("state.json");
+    let now = chrono::Utc.with_ymd_and_hms(2026, 5, 4, 12, 0, 0).unwrap();
+    record_verification_failure(&path, "boom", now).unwrap();
+
+    let bytes = std::fs::read(&path).unwrap();
+    let v: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+    assert_eq!(v["last_verification_failure"]["error"], "boom");
+    assert!(v["applied"].is_array());
+    assert!(v["failed"].is_array());
+}
+
+#[test]
+fn preserves_applied_and_failed_arrays() {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("state.json");
+    std::fs::write(
+        &path,
+        br#"{
+            "applied": [{"id": "0001_keep_me"}],
+            "failed":  [{"id": "0002_keep_me_too"}]
+        }"#,
+    )
+    .unwrap();
+
+    let now = chrono::Utc.with_ymd_and_hms(2026, 5, 4, 12, 0, 0).unwrap();
+    record_verification_failure(&path, "tamper", now).unwrap();
+
+    let v: serde_json::Value = serde_json::from_slice(&std::fs::read(&path).unwrap()).unwrap();
+    assert_eq!(v["applied"][0]["id"], "0001_keep_me");
+    assert_eq!(v["failed"][0]["id"], "0002_keep_me_too");
+    assert_eq!(v["last_verification_failure"]["error"], "tamper");
+}
+
+#[test]
+fn creates_parent_directory() {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("nested/state.json");
+    let now = chrono::Utc::now();
+    record_verification_failure(&path, "boom", now).unwrap();
+    assert!(path.exists());
+}

--- a/source/daemon/crates/wardnet-postupgrade-runner/src/tests/verify.rs
+++ b/source/daemon/crates/wardnet-postupgrade-runner/src/tests/verify.rs
@@ -1,0 +1,115 @@
+//! Tests for `read_artifacts` + `verify`. Each test generates a fresh
+//! minisign keypair so fixtures stay hermetic and no private key is
+//! checked into the repo.
+
+use std::io::Cursor;
+
+use minisign::{KeyPair, sign};
+use tempfile::TempDir;
+
+use crate::verify::{read_artifacts, verify};
+
+/// Helper: generate a keypair, sign `payload`, return
+/// `(public_key_text, signature_text)`. Uses an unencrypted keypair —
+/// these keys live for the duration of one test.
+fn signed(payload: &[u8]) -> (String, String) {
+    let keypair = KeyPair::generate_unencrypted_keypair().expect("generate keypair");
+    let pk_text = keypair.pk.to_box().expect("pk to_box").into_string();
+    let mut reader = Cursor::new(payload);
+    let signature_box = sign(
+        None,
+        &keypair.sk,
+        &mut reader,
+        Some("test trusted"),
+        Some("test untrusted"),
+    )
+    .expect("sign");
+    (pk_text, signature_box.into_string())
+}
+
+#[test]
+fn verify_accepts_valid_signature() {
+    let payload = b"a small synthetic payload";
+    let (pk_text, sig_text) = signed(payload);
+    verify(&pk_text, payload, sig_text.as_bytes()).expect("verify ok");
+}
+
+#[test]
+fn verify_rejects_byte_flipped_payload() {
+    let payload = b"a small synthetic payload";
+    let (pk_text, sig_text) = signed(payload);
+    let mut tampered = payload.to_vec();
+    tampered[0] ^= 0x01;
+    let err = verify(&pk_text, &tampered, sig_text.as_bytes())
+        .expect_err("tampered payload must not verify");
+    let chain = format!("{err:#}");
+    assert!(
+        chain.contains("verification failed"),
+        "expected verification-failure message, got: {chain}"
+    );
+}
+
+#[test]
+fn verify_rejects_byte_flipped_signature() {
+    let payload = b"a small synthetic payload";
+    let (pk_text, sig_text) = signed(payload);
+    // Flip a byte well past the comment header to land inside the
+    // base64-encoded signature body.
+    let mut tampered = sig_text.into_bytes();
+    let target = tampered.len() - 8;
+    tampered[target] = if tampered[target] == b'A' { b'B' } else { b'A' };
+    let err =
+        verify(&pk_text, payload, &tampered).expect_err("byte-flipped signature must not verify");
+    // Either decoding bails ("invalid signature format") or
+    // verification bails ("signature verification failed"); both
+    // outcomes count as a rejection.
+    drop(err);
+}
+
+#[test]
+fn verify_rejects_signature_from_wrong_key() {
+    let payload = b"a small synthetic payload";
+    let (pk_a, _sig_a) = signed(payload);
+    let (_pk_b, sig_b) = signed(payload);
+    let err =
+        verify(&pk_a, payload, sig_b.as_bytes()).expect_err("wrong-key signature must not verify");
+    let chain = format!("{err:#}");
+    assert!(
+        chain.contains("verification failed"),
+        "expected verification-failure message, got: {chain}"
+    );
+}
+
+#[test]
+fn read_artifacts_returns_none_on_missing_payload() {
+    let dir = TempDir::new().expect("tempdir");
+    // signature exists, payload does not
+    std::fs::write(dir.path().join("sig"), b"sig").unwrap();
+    let result = read_artifacts(&dir.path().join("missing.bin"), &dir.path().join("sig"));
+    assert!(result.is_none());
+}
+
+#[test]
+fn read_artifacts_returns_none_on_missing_signature() {
+    let dir = TempDir::new().expect("tempdir");
+    std::fs::write(dir.path().join("payload.bin"), b"payload").unwrap();
+    let result = read_artifacts(
+        &dir.path().join("payload.bin"),
+        &dir.path().join("missing.minisig"),
+    );
+    assert!(result.is_none());
+}
+
+#[test]
+fn read_artifacts_returns_bytes_when_both_present() {
+    let dir = TempDir::new().expect("tempdir");
+    std::fs::write(dir.path().join("payload.bin"), b"payload").unwrap();
+    std::fs::write(dir.path().join("payload.minisig"), b"sig").unwrap();
+    let (p, s) = read_artifacts(
+        &dir.path().join("payload.bin"),
+        &dir.path().join("payload.minisig"),
+    )
+    .expect("both files present");
+    assert_eq!(p, b"payload");
+    assert_eq!(s, b"sig");
+}

--- a/source/daemon/crates/wardnet-postupgrade-runner/src/tests/verify.rs
+++ b/source/daemon/crates/wardnet-postupgrade-runner/src/tests/verify.rs
@@ -113,3 +113,53 @@ fn read_artifacts_returns_bytes_when_both_present() {
     assert_eq!(p, b"payload");
     assert_eq!(s, b"sig");
 }
+
+#[test]
+fn read_artifacts_returns_none_when_payload_path_is_a_directory() {
+    // `std::fs::read` on a directory returns an `Err` whose kind is
+    // not `NotFound`, exercising the unhappy I/O branch the runner
+    // logs as an ERROR before returning None.
+    let dir = TempDir::new().unwrap();
+    let dir_as_payload = dir.path().join("a-directory");
+    std::fs::create_dir(&dir_as_payload).unwrap();
+    std::fs::write(dir.path().join("sig"), b"sig").unwrap();
+
+    let result = read_artifacts(&dir_as_payload, &dir.path().join("sig"));
+    assert!(result.is_none());
+}
+
+#[test]
+fn read_artifacts_returns_none_when_signature_path_is_a_directory() {
+    let dir = TempDir::new().unwrap();
+    std::fs::write(dir.path().join("payload.bin"), b"payload").unwrap();
+    let dir_as_sig = dir.path().join("a-directory");
+    std::fs::create_dir(&dir_as_sig).unwrap();
+
+    let result = read_artifacts(&dir.path().join("payload.bin"), &dir_as_sig);
+    assert!(result.is_none());
+}
+
+#[test]
+fn verify_rejects_invalid_public_key_text() {
+    let err = verify("not-a-valid-pubkey", b"payload", b"sig")
+        .expect_err("garbage public key must be rejected");
+    let chain = format!("{err:#}");
+    assert!(
+        chain.contains("invalid embedded public key"),
+        "expected pubkey-decode error, got: {chain}"
+    );
+}
+
+#[test]
+fn verify_rejects_non_utf8_signature_bytes() {
+    let payload = b"payload";
+    let (pk_text, _sig_text) = signed(payload);
+    let invalid_utf8 = [0xFFu8, 0xFE, 0xFD, 0xFC];
+    let err = verify(&pk_text, payload, &invalid_utf8)
+        .expect_err("non-utf8 signature bytes must be rejected");
+    let chain = format!("{err:#}");
+    assert!(
+        chain.contains("not utf-8"),
+        "expected utf-8 error, got: {chain}"
+    );
+}

--- a/source/daemon/crates/wardnet-postupgrade-runner/src/verify.rs
+++ b/source/daemon/crates/wardnet-postupgrade-runner/src/verify.rs
@@ -1,0 +1,53 @@
+//! Read + verify the signed payload. Pure I/O + crypto, no exec.
+
+use std::path::Path;
+
+use anyhow::Context;
+
+/// Read the payload + detached signature from disk. Returns `None` if
+/// either file is missing — the caller maps this to exit-0 (nothing
+/// to do) per the framework's "tolerate missing payload" contract.
+/// Any other I/O error is surfaced as `Err`.
+pub fn read_artifacts(payload: &Path, signature: &Path) -> Option<(Vec<u8>, Vec<u8>)> {
+    let payload_bytes = match std::fs::read(payload) {
+        Ok(b) => b,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return None,
+        Err(e) => {
+            tracing::error!(
+                error = %e,
+                path = %payload.display(),
+                "failed to read payload at {path}: {e}",
+                path = payload.display(),
+            );
+            return None;
+        }
+    };
+    let signature_bytes = match std::fs::read(signature) {
+        Ok(b) => b,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return None,
+        Err(e) => {
+            tracing::error!(
+                error = %e,
+                path = %signature.display(),
+                "failed to read signature at {path}: {e}",
+                path = signature.display(),
+            );
+            return None;
+        }
+    };
+    Some((payload_bytes, signature_bytes))
+}
+
+/// Verify a detached minisign signature over `payload` using the
+/// PEM-style minisign public key text (two lines: untrusted comment,
+/// then base64 key). Mirrors the daemon's `Sha256MinisignVerifier`
+/// so production and post-upgrade trust the same key material.
+pub fn verify(public_key_text: &str, payload: &[u8], signature: &[u8]) -> anyhow::Result<()> {
+    let pk = minisign_verify::PublicKey::decode(public_key_text.trim())
+        .context("invalid embedded public key")?;
+    let sig_text = std::str::from_utf8(signature).context("signature is not utf-8")?;
+    let sig = minisign_verify::Signature::decode(sig_text).context("invalid signature format")?;
+    pk.verify(payload, &sig, /* allow_legacy */ false)
+        .context("signature verification failed")?;
+    Ok(())
+}

--- a/source/daemon/crates/wardnet-postupgrade/Cargo.toml
+++ b/source/daemon/crates/wardnet-postupgrade/Cargo.toml
@@ -1,0 +1,31 @@
+[package]
+name = "wardnet-postupgrade"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+
+[lints]
+workspace = true
+
+[[bin]]
+name = "wardnet-postupgrade"
+path = "src/main.rs"
+
+[dependencies]
+# https://crates.io/crates/anyhow
+anyhow.workspace = true
+# https://crates.io/crates/chrono
+chrono.workspace = true
+# https://crates.io/crates/serde
+serde.workspace = true
+# https://crates.io/crates/serde_json
+serde_json.workspace = true
+# https://crates.io/crates/tracing
+tracing.workspace = true
+# https://crates.io/crates/tracing-subscriber
+tracing-subscriber.workspace = true
+
+[dev-dependencies]
+# https://crates.io/crates/tempfile
+tempfile.workspace = true

--- a/source/daemon/crates/wardnet-postupgrade/src/lib.rs
+++ b/source/daemon/crates/wardnet-postupgrade/src/lib.rs
@@ -1,0 +1,28 @@
+//! Privileged post-upgrade migration runner.
+//!
+//! Compiled into a small standalone binary that ships inside each
+//! release tarball, signed with the same minisign key as `wardnetd`.
+//! The trust anchor (`wardnet-postupgrade-runner`) verifies the
+//! signature at every boot before exec'ing this binary as root.
+//!
+//! At each invocation the binary reads its persistent state from
+//! `/var/lib/wardnet-postupgrade/state.json`, iterates the
+//! compile-time migration list, and runs any migration that hasn't
+//! been recorded as `applied`. State writes are atomic
+//! (write-tmp-then-rename) so a power loss mid-migration leaves the
+//! previous state intact and the migration re-runs on next boot.
+//!
+//! Migration functions must be **idempotent reconcilers** — running
+//! the same migration twice must be a no-op once the desired state
+//! is reached.
+
+pub mod migrations;
+pub mod runner;
+pub mod state;
+
+pub use migrations::{Migration, Severity, migrations};
+pub use runner::{RunOutcome, RunReport, run};
+pub use state::{AppliedEntry, DEFAULT_STATE_PATH, FailedEntry, State};
+
+#[cfg(test)]
+mod tests;

--- a/source/daemon/crates/wardnet-postupgrade/src/main.rs
+++ b/source/daemon/crates/wardnet-postupgrade/src/main.rs
@@ -1,0 +1,61 @@
+//! `wardnet-postupgrade` entrypoint.
+//!
+//! Run by `wardnet-postupgrade-runner` (the trust anchor) via `fexecve`
+//! at every boot, after signature verification. systemd captures
+//! stdout/stderr via journald with `SyslogIdentifier=wardnet-postupgrade`.
+
+use std::path::PathBuf;
+
+use wardnet_postupgrade::{DEFAULT_STATE_PATH, RunOutcome, migrations, run};
+
+fn main() {
+    init_tracing();
+
+    let state_path = PathBuf::from(DEFAULT_STATE_PATH);
+    let migrations = migrations();
+
+    match run(&state_path, migrations) {
+        Ok(RunOutcome::Ok(report)) => {
+            tracing::info!(
+                already_applied = report.already_applied,
+                newly_applied = report.newly_applied,
+                optional_failures = report.optional_failures,
+                orphan_state_entries = report.orphan_state_entries,
+                "post-upgrade migrations complete: already_applied={already_applied}, newly_applied={newly_applied}, optional_failures={optional_failures}, orphan_state_entries={orphan_state_entries}",
+                already_applied = report.already_applied,
+                newly_applied = report.newly_applied,
+                optional_failures = report.optional_failures,
+                orphan_state_entries = report.orphan_state_entries,
+            );
+            std::process::exit(0);
+        }
+        Ok(RunOutcome::RequiredFailed(report)) => {
+            tracing::error!(
+                already_applied = report.already_applied,
+                newly_applied = report.newly_applied,
+                required_failures = report.required_failures,
+                "post-upgrade migrations halted on Required failure: already_applied={already_applied}, newly_applied={newly_applied}, required_failures={required_failures}",
+                already_applied = report.already_applied,
+                newly_applied = report.newly_applied,
+                required_failures = report.required_failures,
+            );
+            std::process::exit(1);
+        }
+        Err(e) => {
+            tracing::error!(
+                error = %e,
+                state = %state_path.display(),
+                "post-upgrade runner aborted before iterating migrations: {e}",
+            );
+            std::process::exit(2);
+        }
+    }
+}
+
+fn init_tracing() {
+    let _ = tracing_subscriber::fmt()
+        .with_writer(std::io::stderr)
+        .with_target(false)
+        .without_time()
+        .try_init();
+}

--- a/source/daemon/crates/wardnet-postupgrade/src/migrations.rs
+++ b/source/daemon/crates/wardnet-postupgrade/src/migrations.rs
@@ -1,0 +1,44 @@
+//! Compile-time migration list.
+//!
+//! Migrations are linearly ordered (sqlx-migrate-style) — there are
+//! no branching dependencies or `down` functions. Each migration is
+//! a function that brings the system to a desired state and is safe
+//! to re-run if it has already been applied. Severity controls what
+//! happens on failure:
+//!   - `Required` — failure exits the runner nonzero, blocking
+//!     wardnetd from starting (`RequiredBy=wardnetd.service`).
+//!   - `Optional` — failure is recorded but does not gate startup.
+//!
+//! The framework lands with an **empty list**. Future PRs (#215, #213,
+//! #222) push entries here.
+
+/// What happens when a migration's `up` function returns `Err`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Severity {
+    /// Failure exits the runner nonzero. `wardnetd.service` will not
+    /// start until the operator resolves the failure.
+    Required,
+    /// Failure is recorded but the runner continues and exits 0;
+    /// wardnetd starts. Use for cosmetic / non-load-bearing steps.
+    Optional,
+}
+
+/// One migration. Identified by a stable string id (sortable, unique
+/// within `migrations()`) plus a severity and an `up` function. Once
+/// a migration has been merged it MUST NEVER change its id, severity,
+/// or behaviour — append new migrations instead.
+pub struct Migration {
+    pub id: &'static str,
+    pub severity: Severity,
+    pub up: fn() -> anyhow::Result<()>,
+}
+
+/// The migration list applied at every boot. Order matters: each
+/// migration may rely on the system state established by earlier
+/// applied migrations.
+///
+/// Empty until #215 lands `0001_polkit_power_rule`.
+#[must_use]
+pub fn migrations() -> &'static [Migration] {
+    &[]
+}

--- a/source/daemon/crates/wardnet-postupgrade/src/runner.rs
+++ b/source/daemon/crates/wardnet-postupgrade/src/runner.rs
@@ -1,0 +1,119 @@
+//! Iterate the migration list, apply unapplied migrations, persist
+//! state. Runner logic is a free function so tests can drive it
+//! against a synthetic migration list and tempdir state path.
+
+use std::path::Path;
+
+use chrono::Utc;
+
+use crate::migrations::{Migration, Severity};
+use crate::state::{AppliedEntry, FailedEntry, State};
+
+/// Outcome of a `run` invocation. Mapped to a process exit code by
+/// `main.rs` (`Ok` → 0; `RequiredFailed` → 1).
+#[derive(Debug)]
+pub enum RunOutcome {
+    /// Either nothing to do, or all `Required` migrations succeeded
+    /// (with possibly some `Optional` failures recorded).
+    Ok(RunReport),
+    /// At least one `Required` migration failed. wardnetd must not
+    /// start. The failed entry is already persisted to state.json.
+    RequiredFailed(RunReport),
+}
+
+/// Per-run summary, suitable for a single INFO log line. Counts both
+/// what was attempted in this run and what was already applied from a
+/// previous boot.
+#[derive(Debug, Default)]
+pub struct RunReport {
+    pub already_applied: usize,
+    pub newly_applied: usize,
+    pub optional_failures: usize,
+    pub required_failures: usize,
+    pub orphan_state_entries: usize,
+}
+
+/// Apply every migration not already in `state.applied[]`. Persists
+/// state after each migration so a power loss leaves the partial
+/// progress on disk.
+pub fn run(state_path: &Path, migrations: &[Migration]) -> anyhow::Result<RunOutcome> {
+    let mut state = State::load(state_path)?;
+    let mut report = RunReport::default();
+
+    // Audit trail integrity: warn (do not delete) on state entries
+    // whose migration is no longer compiled in. Removed migrations
+    // must never re-run.
+    for entry in &state.applied {
+        if !migrations.iter().any(|m| m.id == entry.id) {
+            report.orphan_state_entries += 1;
+            tracing::warn!(
+                migration = %entry.id,
+                "applied state entry has no matching migration in this binary: id={migration}",
+                migration = entry.id,
+            );
+        }
+    }
+
+    for migration in migrations {
+        if state.is_applied(migration.id) {
+            report.already_applied += 1;
+            continue;
+        }
+
+        tracing::info!(
+            migration = %migration.id,
+            severity = ?migration.severity,
+            "applying migration: id={migration}",
+            migration = migration.id,
+        );
+
+        match (migration.up)() {
+            Ok(()) => {
+                state.applied.push(AppliedEntry {
+                    id: migration.id.to_owned(),
+                    applied_at: Utc::now(),
+                });
+                state.save(state_path)?;
+                report.newly_applied += 1;
+                tracing::info!(
+                    migration = %migration.id,
+                    "migration applied: id={migration}",
+                    migration = migration.id,
+                );
+            }
+            Err(e) => {
+                let entry = FailedEntry {
+                    id: migration.id.to_owned(),
+                    error: format!("{e:#}"),
+                    at: Utc::now(),
+                };
+                state.failed.push(entry);
+                state.save(state_path)?;
+
+                match migration.severity {
+                    Severity::Required => {
+                        tracing::error!(
+                            migration = %migration.id,
+                            error = %e,
+                            "Required migration failed: id={migration}, error={e}",
+                            migration = migration.id,
+                        );
+                        report.required_failures += 1;
+                        return Ok(RunOutcome::RequiredFailed(report));
+                    }
+                    Severity::Optional => {
+                        tracing::warn!(
+                            migration = %migration.id,
+                            error = %e,
+                            "Optional migration failed: id={migration}, error={e}",
+                            migration = migration.id,
+                        );
+                        report.optional_failures += 1;
+                    }
+                }
+            }
+        }
+    }
+
+    Ok(RunOutcome::Ok(report))
+}

--- a/source/daemon/crates/wardnet-postupgrade/src/runner.rs
+++ b/source/daemon/crates/wardnet-postupgrade/src/runner.rs
@@ -115,5 +115,12 @@ pub fn run(state_path: &Path, migrations: &[Migration]) -> anyhow::Result<RunOut
         }
     }
 
+    // Always persist final state — even when nothing changed in
+    // this run — so operators (and the e2e harness) have a stable
+    // "I ran and exited cleanly" marker. On a fresh host with an
+    // empty migration list, this writes the canonical empty state
+    // file the next boot's parse will read back unchanged.
+    state.save(state_path)?;
+
     Ok(RunOutcome::Ok(report))
 }

--- a/source/daemon/crates/wardnet-postupgrade/src/state.rs
+++ b/source/daemon/crates/wardnet-postupgrade/src/state.rs
@@ -1,0 +1,93 @@
+//! `state.json` schema + atomic read/write.
+//!
+//! Path: `/var/lib/wardnet-postupgrade/state.json`. Owner: `root:root`,
+//! mode `0600`. Intentionally outside `wardnetd.service`'s
+//! `ReadWritePaths` so the unprivileged `wardnet` user cannot rewrite
+//! it to mark a `Required` failure as `applied` and bypass the
+//! daemon-startup gate.
+//!
+//! State is append-only from the runner's perspective: applied and
+//! failed entries are preserved across boots, even if the underlying
+//! migration is later removed from the in-binary `migrations()`
+//! list. That keeps a stable audit trail an operator can inspect.
+
+use std::path::Path;
+
+use anyhow::Context;
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+/// Default location of `state.json` on a real Pi. Tests pass tempdir
+/// paths instead.
+pub const DEFAULT_STATE_PATH: &str = "/var/lib/wardnet-postupgrade/state.json";
+
+/// Persisted state. New optional fields land at the end so the
+/// runner can read state files written by older versions of itself.
+#[derive(Debug, Default, Serialize, Deserialize)]
+#[serde(default)]
+pub struct State {
+    pub applied: Vec<AppliedEntry>,
+    pub failed: Vec<FailedEntry>,
+    /// Recorded by `wardnet-postupgrade-runner` (the trust anchor)
+    /// when signature verification fails. The migration runner does
+    /// not touch this field — it only ever runs after verification
+    /// has succeeded.
+    pub last_verification_failure: Option<VerificationFailure>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AppliedEntry {
+    pub id: String,
+    pub applied_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FailedEntry {
+    pub id: String,
+    pub error: String,
+    pub at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct VerificationFailure {
+    pub error: String,
+    pub at: DateTime<Utc>,
+}
+
+impl State {
+    /// Read state from disk. Returns `Default::default()` when the
+    /// file is absent — first run on a fresh host.
+    pub fn load(path: &Path) -> anyhow::Result<Self> {
+        match std::fs::read(path) {
+            Ok(bytes) => serde_json::from_slice(&bytes)
+                .with_context(|| format!("parsing state file {}", path.display())),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(State::default()),
+            Err(e) => {
+                Err(anyhow::Error::from(e)
+                    .context(format!("reading state file {}", path.display())))
+            }
+        }
+    }
+
+    /// Atomic write-then-rename. Caller is responsible for ensuring
+    /// the parent directory exists with the right ownership/mode —
+    /// install.sh creates `/var/lib/wardnet-postupgrade/`.
+    pub fn save(&self, path: &Path) -> anyhow::Result<()> {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)
+                .with_context(|| format!("creating {}", parent.display()))?;
+        }
+        let bytes = serde_json::to_vec_pretty(self).context("serialize state")?;
+        let tmp = path.with_extension("json.tmp");
+        std::fs::write(&tmp, &bytes).with_context(|| format!("writing {}", tmp.display()))?;
+        std::fs::rename(&tmp, path)
+            .with_context(|| format!("rename {} -> {}", tmp.display(), path.display()))?;
+        Ok(())
+    }
+
+    /// Has the migration with this id ever been recorded as applied?
+    #[must_use]
+    pub fn is_applied(&self, id: &str) -> bool {
+        self.applied.iter().any(|e| e.id == id)
+    }
+}

--- a/source/daemon/crates/wardnet-postupgrade/src/tests/migrations.rs
+++ b/source/daemon/crates/wardnet-postupgrade/src/tests/migrations.rs
@@ -1,0 +1,26 @@
+//! Tests for the in-binary migration list.
+
+use crate::migrations::{Severity, migrations};
+
+#[test]
+fn empty_list_until_first_migration_lands() {
+    // The framework ships with no migrations — #215 (polkit power
+    // rule) is the first consumer. This test pins the empty state
+    // so an accidental insert here gets caught at PR time and the
+    // author goes through the proper migration-add review.
+    assert!(
+        migrations().is_empty(),
+        "migration list must stay empty until a deliberate migration is added"
+    );
+}
+
+#[test]
+fn severity_variants_are_distinct() {
+    assert_ne!(Severity::Required, Severity::Optional);
+    // `Copy` + `PartialEq` derives covered by usage but exercised
+    // here so accidental removal of either in a refactor surfaces
+    // immediately at compile time.
+    let a = Severity::Required;
+    let b = a;
+    assert_eq!(a, b);
+}

--- a/source/daemon/crates/wardnet-postupgrade/src/tests/mod.rs
+++ b/source/daemon/crates/wardnet-postupgrade/src/tests/mod.rs
@@ -1,0 +1,6 @@
+//! Unit tests for the migration runner. Per project convention each
+//! module owns a sibling test file; `lib.rs` declares this module
+//! gated on `#[cfg(test)]`.
+
+mod runner;
+mod state;

--- a/source/daemon/crates/wardnet-postupgrade/src/tests/mod.rs
+++ b/source/daemon/crates/wardnet-postupgrade/src/tests/mod.rs
@@ -2,5 +2,6 @@
 //! module owns a sibling test file; `lib.rs` declares this module
 //! gated on `#[cfg(test)]`.
 
+mod migrations;
 mod runner;
 mod state;

--- a/source/daemon/crates/wardnet-postupgrade/src/tests/runner.rs
+++ b/source/daemon/crates/wardnet-postupgrade/src/tests/runner.rs
@@ -1,0 +1,203 @@
+//! Tests for `runner::run` against synthetic migration lists.
+//!
+//! Migration `up` fns must match `fn() -> anyhow::Result<()>` and so
+//! cannot capture closure state. Tests assert outcome via the report
+//! and the on-disk state file (each test owns a tempdir state path),
+//! never through process-global counters — cargo runs tests in
+//! parallel and shared atomics race across tests.
+//!
+//! `panic_if_called` is used wherever a test needs to prove a
+//! migration is *not* re-run; if it ever runs the test panics and
+//! fails, regardless of test interleaving.
+#![allow(clippy::unnecessary_wraps)]
+
+use tempfile::TempDir;
+
+use crate::migrations::{Migration, Severity};
+use crate::runner::{RunOutcome, run};
+use crate::state::State;
+
+fn ok() -> anyhow::Result<()> {
+    Ok(())
+}
+fn fail() -> anyhow::Result<()> {
+    Err(anyhow::anyhow!("synthetic failure"))
+}
+fn panic_if_called() -> anyhow::Result<()> {
+    panic!("migration up fn was called when it should have been skipped");
+}
+
+#[test]
+fn empty_list_writes_default_state_and_returns_ok() {
+    let dir = TempDir::new().unwrap();
+    let state_path = dir.path().join("state.json");
+    let outcome = run(&state_path, &[]).expect("run");
+    assert!(matches!(outcome, RunOutcome::Ok(_)));
+    let state = State::load(&state_path).unwrap();
+    assert!(state.applied.is_empty());
+    assert!(state.failed.is_empty());
+}
+
+#[test]
+fn required_success_persists_applied_entry() {
+    let dir = TempDir::new().unwrap();
+    let state_path = dir.path().join("state.json");
+    let migrations = [Migration {
+        id: "0001_test_required_ok",
+        severity: Severity::Required,
+        up: ok,
+    }];
+    let outcome = run(&state_path, &migrations).expect("run");
+    let RunOutcome::Ok(report) = outcome else {
+        panic!("expected Ok, got {outcome:?}");
+    };
+    assert_eq!(report.newly_applied, 1);
+    assert_eq!(report.already_applied, 0);
+
+    let state = State::load(&state_path).unwrap();
+    assert_eq!(state.applied.len(), 1);
+    assert_eq!(state.applied[0].id, "0001_test_required_ok");
+}
+
+#[test]
+fn required_failure_returns_required_failed_and_persists() {
+    let dir = TempDir::new().unwrap();
+    let state_path = dir.path().join("state.json");
+    let migrations = [Migration {
+        id: "0001_test_required_fail",
+        severity: Severity::Required,
+        up: fail,
+    }];
+    let outcome = run(&state_path, &migrations).expect("run");
+    let RunOutcome::RequiredFailed(report) = outcome else {
+        panic!("expected RequiredFailed, got {outcome:?}");
+    };
+    assert_eq!(report.required_failures, 1);
+    assert_eq!(report.newly_applied, 0);
+
+    let state = State::load(&state_path).unwrap();
+    assert_eq!(state.failed.len(), 1);
+    assert_eq!(state.failed[0].id, "0001_test_required_fail");
+    assert!(state.applied.is_empty());
+}
+
+#[test]
+fn optional_failure_continues_run_and_logs() {
+    let dir = TempDir::new().unwrap();
+    let state_path = dir.path().join("state.json");
+    let migrations = [
+        Migration {
+            id: "0001_test_optional_fail",
+            severity: Severity::Optional,
+            up: fail,
+        },
+        Migration {
+            id: "0002_test_required_ok_after",
+            severity: Severity::Required,
+            up: ok,
+        },
+    ];
+    let outcome = run(&state_path, &migrations).expect("run");
+    let RunOutcome::Ok(report) = outcome else {
+        panic!("expected Ok, got {outcome:?}");
+    };
+    assert_eq!(report.optional_failures, 1);
+    assert_eq!(report.newly_applied, 1);
+
+    let state = State::load(&state_path).unwrap();
+    assert_eq!(state.failed.len(), 1);
+    assert_eq!(state.applied.len(), 1);
+    assert_eq!(state.applied[0].id, "0002_test_required_ok_after");
+}
+
+#[test]
+fn already_applied_migration_does_not_rerun() {
+    let dir = TempDir::new().unwrap();
+    let state_path = dir.path().join("state.json");
+
+    // First run records the migration as applied.
+    let first = [Migration {
+        id: "0001_test_idempotent",
+        severity: Severity::Required,
+        up: ok,
+    }];
+    let _ = run(&state_path, &first).expect("first run");
+
+    // Second run with a panic-on-call up fn proves the runner does
+    // not re-execute. If the migration's up fn ever runs, the test
+    // panics regardless of test interleaving.
+    let second = [Migration {
+        id: "0001_test_idempotent",
+        severity: Severity::Required,
+        up: panic_if_called,
+    }];
+    let outcome = run(&state_path, &second).expect("second run");
+    let RunOutcome::Ok(report) = outcome else {
+        panic!("expected Ok on rerun");
+    };
+    assert_eq!(report.already_applied, 1);
+    assert_eq!(report.newly_applied, 0);
+
+    // State file still records exactly one applied entry; no
+    // duplicate appended.
+    let state = State::load(&state_path).unwrap();
+    assert_eq!(state.applied.len(), 1);
+    assert_eq!(state.applied[0].id, "0001_test_idempotent");
+}
+
+#[test]
+fn orphan_state_entry_is_warned_not_pruned() {
+    let dir = TempDir::new().unwrap();
+    let state_path = dir.path().join("state.json");
+    // Pre-seed state with an entry whose id isn't in `migrations`
+    // (simulates a migration removed from the in-binary list).
+    let now = chrono::Utc::now();
+    let pre = State {
+        applied: vec![crate::state::AppliedEntry {
+            id: "0099_legacy_removed".into(),
+            applied_at: now,
+        }],
+        ..Default::default()
+    };
+    pre.save(&state_path).unwrap();
+
+    let outcome = run(&state_path, &[]).expect("run");
+    let RunOutcome::Ok(report) = outcome else {
+        panic!("expected Ok");
+    };
+    assert_eq!(report.orphan_state_entries, 1);
+
+    let state = State::load(&state_path).unwrap();
+    assert_eq!(state.applied.len(), 1, "orphan entry must be preserved");
+    assert_eq!(state.applied[0].id, "0099_legacy_removed");
+}
+
+#[test]
+fn second_required_failure_after_first_success_persists_both() {
+    let dir = TempDir::new().unwrap();
+    let state_path = dir.path().join("state.json");
+    let migrations = [
+        Migration {
+            id: "0001_first_ok",
+            severity: Severity::Required,
+            up: ok,
+        },
+        Migration {
+            id: "0002_second_required_fail",
+            severity: Severity::Required,
+            up: fail,
+        },
+    ];
+    let outcome = run(&state_path, &migrations).expect("run");
+    let RunOutcome::RequiredFailed(report) = outcome else {
+        panic!("expected RequiredFailed");
+    };
+    assert_eq!(report.newly_applied, 1);
+    assert_eq!(report.required_failures, 1);
+
+    let state = State::load(&state_path).unwrap();
+    assert_eq!(state.applied.len(), 1);
+    assert_eq!(state.failed.len(), 1);
+    assert_eq!(state.applied[0].id, "0001_first_ok");
+    assert_eq!(state.failed[0].id, "0002_second_required_fail");
+}

--- a/source/daemon/crates/wardnet-postupgrade/src/tests/state.rs
+++ b/source/daemon/crates/wardnet-postupgrade/src/tests/state.rs
@@ -1,0 +1,64 @@
+//! Tests for `state.rs`.
+
+use chrono::TimeZone;
+use tempfile::TempDir;
+
+use crate::state::{AppliedEntry, FailedEntry, State};
+
+#[test]
+fn load_returns_default_when_file_missing() {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("missing.json");
+    let state = State::load(&path).expect("load missing file");
+    assert!(state.applied.is_empty());
+    assert!(state.failed.is_empty());
+    assert!(state.last_verification_failure.is_none());
+}
+
+#[test]
+fn save_then_load_roundtrip() {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("state.json");
+    let now = chrono::Utc.with_ymd_and_hms(2026, 5, 4, 12, 0, 0).unwrap();
+    let state = State {
+        applied: vec![AppliedEntry {
+            id: "0001".into(),
+            applied_at: now,
+        }],
+        failed: vec![FailedEntry {
+            id: "0002".into(),
+            error: "oops".into(),
+            at: now,
+        }],
+        last_verification_failure: None,
+    };
+    state.save(&path).unwrap();
+
+    let loaded = State::load(&path).unwrap();
+    assert_eq!(loaded.applied.len(), 1);
+    assert_eq!(loaded.applied[0].id, "0001");
+    assert_eq!(loaded.failed.len(), 1);
+    assert_eq!(loaded.failed[0].id, "0002");
+}
+
+#[test]
+fn save_creates_parent_directories() {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("a/b/state.json");
+    State::default().save(&path).unwrap();
+    assert!(path.exists());
+}
+
+#[test]
+fn is_applied_matches_by_id() {
+    let now = chrono::Utc.with_ymd_and_hms(2026, 5, 4, 12, 0, 0).unwrap();
+    let state = State {
+        applied: vec![AppliedEntry {
+            id: "0001".into(),
+            applied_at: now,
+        }],
+        ..Default::default()
+    };
+    assert!(state.is_applied("0001"));
+    assert!(!state.is_applied("0002"));
+}

--- a/source/daemon/crates/wardnet-postupgrade/src/tests/state.rs
+++ b/source/daemon/crates/wardnet-postupgrade/src/tests/state.rs
@@ -62,3 +62,31 @@ fn is_applied_matches_by_id() {
     assert!(state.is_applied("0001"));
     assert!(!state.is_applied("0002"));
 }
+
+#[test]
+fn load_returns_err_on_invalid_json() {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("state.json");
+    std::fs::write(&path, b"definitely not json").unwrap();
+    let err = State::load(&path).expect_err("invalid json must surface as Err");
+    let chain = format!("{err:#}");
+    assert!(
+        chain.contains("parsing state file"),
+        "expected parse-error context, got: {chain}"
+    );
+}
+
+#[test]
+fn load_returns_err_when_path_is_a_directory() {
+    // `std::fs::read` on a directory returns Err with kind that is
+    // not `NotFound`, exercising the third match arm in `load`.
+    let dir = TempDir::new().unwrap();
+    let path_as_dir = dir.path().join("state-as-dir");
+    std::fs::create_dir(&path_as_dir).unwrap();
+    let err = State::load(&path_as_dir).expect_err("directory must surface as Err");
+    let chain = format!("{err:#}");
+    assert!(
+        chain.contains("reading state file"),
+        "expected read-error context, got: {chain}"
+    );
+}

--- a/source/daemon/crates/wardnet-test-agent/src/server/handlers/mod.rs
+++ b/source/daemon/crates/wardnet-test-agent/src/server/handlers/mod.rs
@@ -4,3 +4,4 @@ pub mod container;
 pub mod fixtures;
 pub mod kernel;
 pub mod pid;
+pub mod postupgrade;

--- a/source/daemon/crates/wardnet-test-agent/src/server/handlers/postupgrade.rs
+++ b/source/daemon/crates/wardnet-test-agent/src/server/handlers/postupgrade.rs
@@ -1,0 +1,38 @@
+//! Read-only handler for the post-upgrade migration runner's state file.
+//!
+//! End-to-end specs use this endpoint to verify the runner ran cleanly
+//! at container boot — the file at `/var/lib/wardnet-postupgrade/state.json`
+//! is root-owned and not exposed via the daemon's API, so we surface
+//! it through the test agent (which runs as root inside the same
+//! container).
+
+use axum::Json;
+use axum::http::StatusCode;
+use axum::response::IntoResponse;
+
+const STATE_PATH: &str = "/var/lib/wardnet-postupgrade/state.json";
+
+/// `GET /postupgrade/state` — returns the parsed `state.json` as
+/// JSON, or 404 if the file is absent (which would indicate the
+/// runner never ran or the install path placed the directory at the
+/// wrong location).
+pub async fn get_state() -> impl IntoResponse {
+    match tokio::fs::read(STATE_PATH).await {
+        Ok(bytes) => match serde_json::from_slice::<serde_json::Value>(&bytes) {
+            Ok(v) => (StatusCode::OK, Json(v)).into_response(),
+            Err(e) => (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("state.json is not valid JSON: {e}"),
+            )
+                .into_response(),
+        },
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            (StatusCode::NOT_FOUND, "state.json not found").into_response()
+        }
+        Err(e) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            format!("failed to read state.json: {e}"),
+        )
+            .into_response(),
+    }
+}

--- a/source/daemon/crates/wardnet-test-agent/src/server/mod.rs
+++ b/source/daemon/crates/wardnet-test-agent/src/server/mod.rs
@@ -62,6 +62,7 @@ fn build_router(state: Arc<AppState>) -> Router {
             post(handlers::container::post_container_exec),
         )
         .route("/fixtures/{name}", get(handlers::fixtures::get_fixture))
+        .route("/postupgrade/state", get(handlers::postupgrade::get_state))
         .with_state(state)
 }
 

--- a/source/daemon/crates/wardnetd-mock/src/main.rs
+++ b/source/daemon/crates/wardnetd-mock/src/main.rs
@@ -160,10 +160,15 @@ async fn run(
             .expect("failed to build mock release source"),
         ),
         verifier: Arc::new(Sha256MinisignVerifier::new(EMBEDDED_PUBLIC_KEY)),
-        applier: Arc::new(FsBinaryApplier::new(
-            mock_update_dir.join("wardnetd"),
-            mock_update_dir.join("staging"),
-        )),
+        applier: Arc::new(
+            FsBinaryApplier::new(
+                mock_update_dir.join("wardnetd"),
+                mock_update_dir.join("staging"),
+            )
+            // Mock postupgrade dir lives under the same temp tree so
+            // tearing down the mock leaves no /var/lib state behind.
+            .with_postupgrade(mock_update_dir.join("postupgrade"), EMBEDDED_PUBLIC_KEY),
+        ),
     };
     // Real file-backed secret store rooted under the OS temp directory so
     // the mock exercises the exact same save/load code path as production.

--- a/source/daemon/crates/wardnetd-services/Cargo.toml
+++ b/source/daemon/crates/wardnetd-services/Cargo.toml
@@ -87,3 +87,7 @@ age.workspace = true
 [dev-dependencies]
 # https://crates.io/crates/tokio
 tokio = { workspace = true, features = ["test-util"] }
+# https://crates.io/crates/minisign — keygen + signing, used by tests that build synthetic signed-tarball fixtures
+minisign.workspace = true
+# https://crates.io/crates/tempfile
+tempfile.workspace = true

--- a/source/daemon/crates/wardnetd-services/src/update/fs_applier.rs
+++ b/source/daemon/crates/wardnetd-services/src/update/fs_applier.rs
@@ -9,25 +9,77 @@ use tokio::task;
 
 use crate::update::applier::{BinaryApplier, SwapOutcome};
 
+/// File names extracted from the release tarball. Anything else
+/// (`wardnet-postupgrade-runner`, `wardnet-postupgrade.service`,
+/// `LICENSE`, …) is silently ignored during auto-update — the runner
+/// is the trust anchor and may only be replaced by `install.sh`.
+const ARCHIVE_NAME_DAEMON: &str = "wardnetd";
+const ARCHIVE_NAME_POSTUPGRADE_BIN: &str = "wardnet-postupgrade.bin";
+const ARCHIVE_NAME_POSTUPGRADE_SIG: &str = "wardnet-postupgrade.minisig";
+
+/// File names placed under [`PostupgradeConfig::dir`] on a successful
+/// swap.
+const POSTUPGRADE_BIN_FILENAME: &str = "wardnet-postupgrade.bin";
+const POSTUPGRADE_SIG_FILENAME: &str = "wardnet-postupgrade.minisig";
+
+/// Optional post-upgrade pipeline: where to place the wardnet-writable
+/// payload + signature, and which embedded public key to verify them
+/// against. Constructed via [`FsBinaryApplier::with_postupgrade`].
+struct PostupgradeConfig {
+    dir: PathBuf,
+    public_key: &'static str,
+}
+
 /// Write-then-rename applier bound to a live binary path and staging dir.
 ///
 /// The live binary and the staging directory must live on the same
 /// filesystem so the final `rename(2)` is atomic. `apply()` leaves the
 /// previous binary at `<live>.old`, which is the target `rollback()`
 /// swaps back into place.
+///
+/// When configured via [`Self::with_postupgrade`], the applier also
+/// extracts `wardnet-postupgrade.bin` + `wardnet-postupgrade.minisig`
+/// from the tarball, **pre-flight verifies** the signature against
+/// the embedded key before any rename, then swaps them into the
+/// post-upgrade dir after `wardnetd`. A pre-flight verification
+/// failure aborts the entire apply (wardnetd is not touched).
 pub struct FsBinaryApplier {
     live_path: PathBuf,
     staging_dir: PathBuf,
+    postupgrade: Option<PostupgradeConfig>,
+}
+
+/// Bytes plucked from the tarball, ready to stage. Held in memory
+/// before any disk write so verification can run on the exact bytes
+/// that will hit disk and a verification failure costs nothing.
+#[derive(Default)]
+struct Plucked {
+    wardnetd: Option<Vec<u8>>,
+    postupgrade_bin: Option<Vec<u8>>,
+    postupgrade_sig: Option<Vec<u8>>,
 }
 
 impl FsBinaryApplier {
-    /// Construct a new applier.
+    /// Construct a new applier without post-upgrade support. Tests use
+    /// this; production wires `.with_postupgrade(...)` on top.
     #[must_use]
     pub fn new(live_path: PathBuf, staging_dir: PathBuf) -> Self {
         Self {
             live_path,
             staging_dir,
+            postupgrade: None,
         }
+    }
+
+    /// Extend the applier with the post-upgrade pipeline. `dir` is the
+    /// wardnet-writable directory the payload + sig land in (typically
+    /// `/var/lib/wardnet/postupgrade/`). `public_key` is the embedded
+    /// minisign public key (the same key wardnetd verifies its own
+    /// release tarballs against).
+    #[must_use]
+    pub fn with_postupgrade(mut self, dir: PathBuf, public_key: &'static str) -> Self {
+        self.postupgrade = Some(PostupgradeConfig { dir, public_key });
+        self
     }
 
     fn old_path(&self) -> PathBuf {
@@ -42,11 +94,74 @@ impl FsBinaryApplier {
 
     fn extract_and_swap(&self, tarball: &[u8]) -> anyhow::Result<SwapOutcome> {
         std::fs::create_dir_all(&self.staging_dir)?;
+        let plucked = Self::pluck(tarball)?;
 
+        let wardnetd_bytes = plucked.wardnetd.ok_or_else(|| {
+            anyhow::anyhow!("tarball did not contain a `wardnetd` entry at any path")
+        })?;
+
+        // Pre-flight verify postupgrade artifacts (when configured AND
+        // both files are present). A failed verify aborts the apply
+        // before any rename. A missing pair is "lenient" — we leave
+        // the on-disk postupgrade alone and only swap wardnetd, which
+        // tolerates downgrades to pre-framework releases and CI
+        // regressions that briefly omit the artifacts.
+        let postupgrade_pair = match (
+            self.postupgrade.as_ref(),
+            plucked.postupgrade_bin,
+            plucked.postupgrade_sig,
+        ) {
+            (Some(cfg), Some(bin), Some(sig)) => {
+                Self::verify_postupgrade(cfg.public_key, &bin, &sig)?;
+                Some((cfg, bin, sig))
+            }
+            _ => None,
+        };
+
+        // Stage wardnetd (write to staging, set executable). All of
+        // this runs before any rename so a failure here also leaves
+        // the live tree untouched.
+        let staged_daemon = self.staging_dir.join("wardnetd.staged");
+        Self::write_file_executable(&staged_daemon, &wardnetd_bytes)?;
+
+        // Swap wardnetd: move live → live.old, staged → live.
+        let old_path = self.old_path();
+        if self.live_path.exists() {
+            if old_path.exists() {
+                std::fs::remove_file(&old_path)?;
+            }
+            std::fs::rename(&self.live_path, &old_path)?;
+        }
+        std::fs::rename(&staged_daemon, &self.live_path)?;
+
+        // Swap postupgrade artifacts (best-effort: a rename failure
+        // here is logged but does not roll back wardnetd, since the
+        // existing on-disk postupgrade is still consistent with
+        // either the previous or new wardnetd — and OnFailure=
+        // wardnetd-rollback covers any downstream daemon crash).
+        if let Some((cfg, bin, sig)) = postupgrade_pair
+            && let Err(e) = self.swap_postupgrade(cfg, &bin, &sig)
+        {
+            tracing::warn!(
+                error = %e,
+                dir = %cfg.dir.display(),
+                "postupgrade artifacts not swapped: dir={dir}, error={e}",
+                dir = cfg.dir.display(),
+            );
+        }
+
+        Ok(SwapOutcome {
+            previous_binary: old_path,
+        })
+    }
+
+    /// Single pass over the tarball. Plucks the three known names into
+    /// memory; everything else is skipped.
+    fn pluck(tarball: &[u8]) -> anyhow::Result<Plucked> {
         let decoder = GzDecoder::new(tarball);
         let mut archive = tar::Archive::new(decoder);
+        let mut out = Plucked::default();
 
-        let mut staged_binary: Option<PathBuf> = None;
         for entry in archive.entries()? {
             let mut entry = entry?;
             let path = entry.path()?.into_owned();
@@ -54,48 +169,74 @@ impl FsBinaryApplier {
                 .file_name()
                 .and_then(|s| s.to_str())
                 .unwrap_or_default();
-            if name != "wardnetd" {
-                continue;
+            let target: Option<&mut Option<Vec<u8>>> = match name {
+                ARCHIVE_NAME_DAEMON => Some(&mut out.wardnetd),
+                ARCHIVE_NAME_POSTUPGRADE_BIN => Some(&mut out.postupgrade_bin),
+                ARCHIVE_NAME_POSTUPGRADE_SIG => Some(&mut out.postupgrade_sig),
+                _ => None,
+            };
+            if let Some(slot) = target {
+                let mut buf = Vec::new();
+                entry.read_to_end(&mut buf)?;
+                *slot = Some(buf);
             }
-            let staged = self.staging_dir.join("wardnetd.staged");
-            let mut out = std::fs::File::create(&staged)?;
-            let mut buf = Vec::new();
-            entry.read_to_end(&mut buf)?;
-            std::io::Write::write_all(&mut out, &buf)?;
-            drop(out);
-            // Ensure the staged binary is executable.
-            #[cfg(unix)]
-            {
-                use std::os::unix::fs::PermissionsExt;
-                let mut perms = std::fs::metadata(&staged)?.permissions();
-                perms.set_mode(0o755);
-                std::fs::set_permissions(&staged, perms)?;
-            }
-            staged_binary = Some(staged);
-            break;
         }
 
-        let staged = staged_binary.ok_or_else(|| {
-            anyhow::anyhow!("tarball did not contain a `wardnetd` entry at any path")
-        })?;
+        Ok(out)
+    }
 
-        let old_path = self.old_path();
-        // Move current live binary aside. If no live binary exists (first install
-        // on a fresh host), skip this step — rollback simply won't be available
-        // until the next upgrade.
-        if self.live_path.exists() {
-            if old_path.exists() {
-                std::fs::remove_file(&old_path)?;
-            }
-            std::fs::rename(&self.live_path, &old_path)?;
+    fn verify_postupgrade(
+        public_key_text: &str,
+        payload: &[u8],
+        signature: &[u8],
+    ) -> anyhow::Result<()> {
+        let pk = minisign_verify::PublicKey::decode(public_key_text.trim())
+            .map_err(|e| anyhow::anyhow!("invalid embedded post-upgrade public key: {e}"))?;
+        let sig_text = std::str::from_utf8(signature)
+            .map_err(|e| anyhow::anyhow!("post-upgrade signature is not utf-8: {e}"))?;
+        let sig = minisign_verify::Signature::decode(sig_text)
+            .map_err(|e| anyhow::anyhow!("post-upgrade signature decode failed: {e}"))?;
+        pk.verify(payload, &sig, /* allow_legacy */ false)
+            .map_err(|e| anyhow::anyhow!("post-upgrade signature verification failed: {e}"))?;
+        Ok(())
+    }
+
+    fn write_file_executable(path: &std::path::Path, bytes: &[u8]) -> anyhow::Result<()> {
+        let mut out = std::fs::File::create(path)?;
+        std::io::Write::write_all(&mut out, bytes)?;
+        drop(out);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mut perms = std::fs::metadata(path)?.permissions();
+            perms.set_mode(0o755);
+            std::fs::set_permissions(path, perms)?;
         }
+        Ok(())
+    }
 
-        // Atomic rename into the live path.
-        std::fs::rename(&staged, &self.live_path)?;
+    fn swap_postupgrade(
+        &self,
+        cfg: &PostupgradeConfig,
+        bin: &[u8],
+        sig: &[u8],
+    ) -> anyhow::Result<()> {
+        std::fs::create_dir_all(&cfg.dir)?;
 
-        Ok(SwapOutcome {
-            previous_binary: old_path,
-        })
+        let staged_bin = self.staging_dir.join("wardnet-postupgrade.bin.staged");
+        let staged_sig = self.staging_dir.join("wardnet-postupgrade.minisig.staged");
+        std::fs::write(&staged_bin, bin)?;
+        std::fs::write(&staged_sig, sig)?;
+
+        // Rename the binary first, then the signature. If the second
+        // rename fails after the first succeeds we are left with a
+        // mismatched (.bin from this release, .minisig from the
+        // previous) pair — the runner will reject that on the next
+        // boot, blocking a malformed payload from running, which is
+        // exactly the failure mode we want.
+        std::fs::rename(&staged_bin, cfg.dir.join(POSTUPGRADE_BIN_FILENAME))?;
+        std::fs::rename(&staged_sig, cfg.dir.join(POSTUPGRADE_SIG_FILENAME))?;
+        Ok(())
     }
 }
 
@@ -103,10 +244,18 @@ impl FsBinaryApplier {
 impl BinaryApplier for FsBinaryApplier {
     async fn apply(&self, tarball: &[u8]) -> anyhow::Result<SwapOutcome> {
         let tarball = tarball.to_vec();
-        let this_live = self.live_path.clone();
-        let this_staging = self.staging_dir.clone();
+        let live = self.live_path.clone();
+        let staging = self.staging_dir.clone();
+        let postupgrade = self.postupgrade.as_ref().map(|cfg| PostupgradeConfig {
+            dir: cfg.dir.clone(),
+            public_key: cfg.public_key,
+        });
         task::spawn_blocking(move || {
-            let applier = FsBinaryApplier::new(this_live, this_staging);
+            let applier = FsBinaryApplier {
+                live_path: live,
+                staging_dir: staging,
+                postupgrade,
+            };
             applier.extract_and_swap(&tarball)
         })
         .await?

--- a/source/daemon/crates/wardnetd-services/src/update/mod.rs
+++ b/source/daemon/crates/wardnetd-services/src/update/mod.rs
@@ -39,6 +39,14 @@ pub use verifier::ReleaseVerifier;
 pub const EMBEDDED_PUBLIC_KEY: &str =
     include_str!("../../../../../../deploy/keys/wardnet-release.pub");
 
+/// Default directory for the wardnet-writable post-upgrade payload
+/// (`wardnet-postupgrade.bin` + `.minisig`). `FsBinaryApplier` writes
+/// freshly-extracted artifacts here on every successful auto-update;
+/// `wardnet-postupgrade-runner` reads them at boot to verify and exec.
+/// Wardnet-owned because auto-update runs as the wardnet user; the
+/// signature-verification check at boot is what makes that safe.
+pub const POSTUPGRADE_DIR: &str = "/var/lib/wardnet/postupgrade";
+
 /// Map a cargo target triple to the short arch name used in release asset
 /// filenames. Returns `None` for targets that aren't part of the release
 /// matrix.

--- a/source/daemon/crates/wardnetd-services/src/update/tests/fs_applier.rs
+++ b/source/daemon/crates/wardnetd-services/src/update/tests/fs_applier.rs
@@ -194,6 +194,44 @@ async fn tarball_missing_wardnetd_returns_err() {
 }
 
 #[tokio::test]
+async fn postupgrade_swap_failure_does_not_roll_back_wardnetd() {
+    // If the post-upgrade swap step fails AFTER wardnetd has been
+    // renamed (rare but possible: e.g. /var/lib/wardnet/postupgrade
+    // is a regular file, not a directory), the applier logs WARN and
+    // still returns Ok. The new wardnetd is in place; the existing
+    // on-disk postupgrade artifacts are consistent with either the
+    // previous or new wardnetd, and OnFailure=wardnetd-rollback.service
+    // catches any downstream daemon crash.
+    let dir = TempDir::new().unwrap();
+    let live_path = dir.path().join("wardnetd");
+    let staging = dir.path().join("staging");
+    let postupgrade_as_file = dir.path().join("postupgrade-is-a-file");
+    // Pre-create the postupgrade target as a regular file. The
+    // applier's `create_dir_all(&cfg.dir)` will fail because the
+    // path exists but isn't a directory.
+    std::fs::write(&postupgrade_as_file, b"not a directory").unwrap();
+
+    let postupgrade_bin: &[u8] = b"the migration runner binary bytes";
+    let (pk_text, sig_text) = signed_pair(postupgrade_bin);
+
+    let tarball = make_tarball(&[
+        ("wardnetd", b"NEW wardnetd"),
+        ("wardnet-postupgrade.bin", postupgrade_bin),
+        ("wardnet-postupgrade.minisig", sig_text.as_bytes()),
+    ]);
+
+    let applier = FsBinaryApplier::new(live_path.clone(), staging)
+        .with_postupgrade(postupgrade_as_file, leak(pk_text));
+    applier
+        .apply(&tarball)
+        .await
+        .expect("apply must succeed even when postupgrade swap can't proceed");
+
+    // wardnetd was still swapped. The postupgrade swap was skipped.
+    assert_eq!(std::fs::read(&live_path).unwrap(), b"NEW wardnetd");
+}
+
+#[tokio::test]
 async fn unconfigured_postupgrade_ignores_artifacts_in_tarball() {
     // Backwards-compat: an applier built without `.with_postupgrade(...)`
     // must skip the .bin/.minisig in the tarball entirely, even if

--- a/source/daemon/crates/wardnetd-services/src/update/tests/fs_applier.rs
+++ b/source/daemon/crates/wardnetd-services/src/update/tests/fs_applier.rs
@@ -1,0 +1,219 @@
+//! Tests for `FsBinaryApplier`. Each test generates a fresh minisign
+//! keypair, builds an in-memory gzip-tar with the requested entries,
+//! and exercises the apply path in a tempdir. No fixtures committed
+//! to disk.
+
+use std::io::Cursor;
+use std::path::Path;
+
+use flate2::Compression;
+use flate2::write::GzEncoder;
+use minisign::{KeyPair, sign};
+use tempfile::TempDir;
+
+use crate::update::applier::BinaryApplier;
+use crate::update::fs_applier::FsBinaryApplier;
+
+/// Build a gzip-compressed tar archive in memory with the given
+/// `(name, bytes)` entries at the archive root.
+fn make_tarball(entries: &[(&str, &[u8])]) -> Vec<u8> {
+    let mut gz = GzEncoder::new(Vec::new(), Compression::fast());
+    {
+        let mut tar = tar::Builder::new(&mut gz);
+        for (name, bytes) in entries {
+            let mut header = tar::Header::new_gnu();
+            header.set_size(bytes.len() as u64);
+            header.set_mode(0o755);
+            header.set_cksum();
+            tar.append_data(&mut header, name, *bytes).unwrap();
+        }
+        tar.finish().unwrap();
+    }
+    gz.finish().unwrap()
+}
+
+/// Generate a minisign keypair and sign `payload`. Returns
+/// `(public_key_text, signature_text)`.
+fn signed_pair(payload: &[u8]) -> (String, String) {
+    let keypair = KeyPair::generate_unencrypted_keypair().expect("keypair");
+    let pk_text = keypair.pk.to_box().expect("pk box").into_string();
+    let mut reader = Cursor::new(payload);
+    let signature_box = sign(
+        None,
+        &keypair.sk,
+        &mut reader,
+        Some("test trusted"),
+        Some("test untrusted"),
+    )
+    .expect("sign");
+    (pk_text, signature_box.into_string())
+}
+
+/// `&'static str` is what `with_postupgrade` expects (the embedded
+/// public key has 'static lifetime in production). Tests work around
+/// the constraint by leaking each generated key — the leak is bounded
+/// by the test process's lifetime.
+fn leak(s: String) -> &'static str {
+    Box::leak(s.into_boxed_str())
+}
+
+#[tokio::test]
+async fn valid_postupgrade_artifacts_swap_both() {
+    let dir = TempDir::new().unwrap();
+    let live_path = dir.path().join("wardnetd");
+    let staging = dir.path().join("staging");
+    let postupgrade = dir.path().join("postupgrade");
+
+    let postupgrade_bin: &[u8] = b"the migration runner binary bytes";
+    let (pk_text, sig_text) = signed_pair(postupgrade_bin);
+
+    let tarball = make_tarball(&[
+        ("wardnetd", b"the wardnetd binary bytes"),
+        ("wardnet-postupgrade.bin", postupgrade_bin),
+        ("wardnet-postupgrade.minisig", sig_text.as_bytes()),
+    ]);
+
+    let applier = FsBinaryApplier::new(live_path.clone(), staging)
+        .with_postupgrade(postupgrade.clone(), leak(pk_text));
+
+    applier.apply(&tarball).await.expect("apply ok");
+
+    assert_eq!(
+        std::fs::read(&live_path).unwrap(),
+        b"the wardnetd binary bytes",
+    );
+    assert_eq!(
+        std::fs::read(postupgrade.join("wardnet-postupgrade.bin")).unwrap(),
+        postupgrade_bin,
+    );
+    assert_eq!(
+        std::fs::read(postupgrade.join("wardnet-postupgrade.minisig")).unwrap(),
+        sig_text.as_bytes(),
+    );
+}
+
+#[tokio::test]
+async fn corrupted_postupgrade_signature_aborts_apply() {
+    let dir = TempDir::new().unwrap();
+    let live_path = dir.path().join("wardnetd");
+    let staging = dir.path().join("staging");
+    let postupgrade = dir.path().join("postupgrade");
+
+    // Pre-existing files we expect untouched after the failed apply.
+    std::fs::write(&live_path, b"OLD wardnetd").unwrap();
+    std::fs::create_dir_all(&postupgrade).unwrap();
+    std::fs::write(
+        postupgrade.join("wardnet-postupgrade.bin"),
+        b"OLD postupgrade bin",
+    )
+    .unwrap();
+    std::fs::write(postupgrade.join("wardnet-postupgrade.minisig"), b"OLD sig").unwrap();
+
+    let postupgrade_bin: &[u8] = b"the migration runner binary bytes";
+    let (pk_text, sig_text) = signed_pair(postupgrade_bin);
+    let mut tampered = sig_text.into_bytes();
+    let target = tampered.len() - 8;
+    tampered[target] = if tampered[target] == b'A' { b'B' } else { b'A' };
+
+    let tarball = make_tarball(&[
+        ("wardnetd", b"NEW wardnetd"),
+        ("wardnet-postupgrade.bin", postupgrade_bin),
+        ("wardnet-postupgrade.minisig", &tampered),
+    ]);
+
+    let applier = FsBinaryApplier::new(live_path.clone(), staging)
+        .with_postupgrade(postupgrade.clone(), leak(pk_text));
+    let err = applier.apply(&tarball).await.unwrap_err();
+    let chain = format!("{err:#}");
+    assert!(
+        chain.contains("verification failed") || chain.contains("decode failed"),
+        "expected verification failure, got: {chain}"
+    );
+
+    // Live binary and on-disk postupgrade artifacts remain at their
+    // pre-apply state — no half-finished swap.
+    assert_eq!(std::fs::read(&live_path).unwrap(), b"OLD wardnetd");
+    assert_eq!(
+        std::fs::read(postupgrade.join("wardnet-postupgrade.bin")).unwrap(),
+        b"OLD postupgrade bin",
+    );
+    assert_eq!(
+        std::fs::read(postupgrade.join("wardnet-postupgrade.minisig")).unwrap(),
+        b"OLD sig",
+    );
+    assert!(!exists(&dir.path().join("wardnetd.old")));
+}
+
+#[tokio::test]
+async fn tarball_without_postupgrade_only_swaps_wardnetd() {
+    let dir = TempDir::new().unwrap();
+    let live_path = dir.path().join("wardnetd");
+    let staging = dir.path().join("staging");
+    let postupgrade = dir.path().join("postupgrade");
+
+    // Pre-place an existing postupgrade payload to confirm it is left
+    // untouched (lenient downgrade tolerance).
+    std::fs::create_dir_all(&postupgrade).unwrap();
+    std::fs::write(
+        postupgrade.join("wardnet-postupgrade.bin"),
+        b"existing payload",
+    )
+    .unwrap();
+
+    let (pk_text, _sig_text) = signed_pair(b"unused");
+    let tarball = make_tarball(&[("wardnetd", b"NEW wardnetd")]);
+
+    let applier = FsBinaryApplier::new(live_path.clone(), staging)
+        .with_postupgrade(postupgrade.clone(), leak(pk_text));
+    applier.apply(&tarball).await.expect("apply ok");
+
+    assert_eq!(std::fs::read(&live_path).unwrap(), b"NEW wardnetd");
+    // Existing payload is preserved — applier never touched it.
+    assert_eq!(
+        std::fs::read(postupgrade.join("wardnet-postupgrade.bin")).unwrap(),
+        b"existing payload",
+    );
+}
+
+#[tokio::test]
+async fn tarball_missing_wardnetd_returns_err() {
+    let dir = TempDir::new().unwrap();
+    let live_path = dir.path().join("wardnetd");
+    let staging = dir.path().join("staging");
+
+    let tarball = make_tarball(&[("README", b"unrelated entry")]);
+
+    let applier = FsBinaryApplier::new(live_path.clone(), staging);
+    let err = applier.apply(&tarball).await.unwrap_err();
+    let chain = format!("{err:#}");
+    assert!(
+        chain.contains("wardnetd"),
+        "expected wardnetd-missing error, got: {chain}"
+    );
+    assert!(!exists(&live_path));
+}
+
+#[tokio::test]
+async fn unconfigured_postupgrade_ignores_artifacts_in_tarball() {
+    // Backwards-compat: an applier built without `.with_postupgrade(...)`
+    // must skip the .bin/.minisig in the tarball entirely, even if
+    // they're present. Useful for legacy callers and the in-tree
+    // wardnetd-mock when run without a postupgrade fixture path.
+    let dir = TempDir::new().unwrap();
+    let live_path = dir.path().join("wardnetd");
+    let staging = dir.path().join("staging");
+
+    let tarball = make_tarball(&[
+        ("wardnetd", b"daemon"),
+        ("wardnet-postupgrade.bin", b"would-be-payload"),
+        ("wardnet-postupgrade.minisig", b"would-be-signature"),
+    ]);
+
+    let applier = FsBinaryApplier::new(live_path.clone(), staging);
+    applier.apply(&tarball).await.expect("apply ok");
+    assert_eq!(std::fs::read(&live_path).unwrap(), b"daemon");
+}
+
+fn exists(p: &Path) -> bool {
+    p.exists()
+}

--- a/source/daemon/crates/wardnetd-services/src/update/tests/mod.rs
+++ b/source/daemon/crates/wardnetd-services/src/update/tests/mod.rs
@@ -1,2 +1,3 @@
+mod fs_applier;
 mod runner;
 mod service;

--- a/source/daemon/crates/wardnetd/src/main.rs
+++ b/source/daemon/crates/wardnetd/src/main.rs
@@ -178,10 +178,16 @@ async fn run(
             .expect("failed to build release manifest source"),
         ),
         verifier: Arc::new(Sha256MinisignVerifier::new(EMBEDDED_PUBLIC_KEY)),
-        applier: Arc::new(FsBinaryApplier::new(
-            config.update.live_binary_path.clone(),
-            config.update.staging_dir.clone(),
-        )),
+        applier: Arc::new(
+            FsBinaryApplier::new(
+                config.update.live_binary_path.clone(),
+                config.update.staging_dir.clone(),
+            )
+            .with_postupgrade(
+                std::path::PathBuf::from(wardnetd_services::update::POSTUPGRADE_DIR),
+                EMBEDDED_PUBLIC_KEY,
+            ),
+        ),
     };
 
     let host_id = sysinfo::System::host_name().unwrap_or_else(|| "wardnet".to_owned());

--- a/source/end2end-tests/daemon/tests/postupgrade.spec.ts
+++ b/source/end2end-tests/daemon/tests/postupgrade.spec.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import { WardnetClient } from "@wardnet/js";
+
+import { API_BASE_URL, agentGet, waitForReady } from "./helpers.js";
+
+// The test-agent runs inside the wardnetd container alongside the
+// daemon and exposes :3001 (see source/daemon/packaging/test-agent/
+// wardnet-test-agent.service). Compose DNS resolves `wardnetd` to the
+// container on wardnet_mgmt, which is shared with the test_runner.
+const TEST_AGENT_URL = "http://wardnetd:3001";
+
+interface PostupgradeState {
+  applied: Array<{ id: string; applied_at: string }>;
+  failed: Array<{ id: string; error: string; at: string }>;
+  last_verification_failure?: { error: string; at: string } | null;
+}
+
+describe("post-upgrade migration framework", () => {
+  const client = new WardnetClient({ baseUrl: API_BASE_URL });
+
+  beforeAll(async () => {
+    // wardnetd's healthcheck only flips healthy after wardnetd binds
+    // its API port, which itself is gated on the post-upgrade runner
+    // exiting cleanly (RequiredBy=wardnetd.service). Reaching this
+    // point already proves the systemd dependency chain works; the
+    // assertions below check the on-disk evidence.
+    await waitForReady(client);
+  }, 120_000);
+
+  it("runs cleanly at boot and writes an empty state.json", async () => {
+    const state = await agentGet<PostupgradeState>(
+      TEST_AGENT_URL,
+      "/postupgrade/state",
+    );
+
+    // Empty migration list ships with this PR — no entries should
+    // have been applied or failed. last_verification_failure must
+    // not be set (the runner only writes that field when the
+    // signature on the in-image payload doesn't verify).
+    expect(state.applied).toEqual([]);
+    expect(state.failed).toEqual([]);
+    expect(state.last_verification_failure ?? null).toBeNull();
+  });
+});

--- a/source/end2end-tests/daemon/tests/postupgrade.spec.ts
+++ b/source/end2end-tests/daemon/tests/postupgrade.spec.ts
@@ -28,10 +28,30 @@ describe("post-upgrade migration framework", () => {
   }, 120_000);
 
   it("runs cleanly at boot and writes an empty state.json", async () => {
-    const state = await agentGet<PostupgradeState>(
-      TEST_AGENT_URL,
-      "/postupgrade/state",
-    );
+    // wardnet-postupgrade.service is `Type=oneshot` and runs before
+    // wardnetd.service. By the time wardnetd is healthy, the runner
+    // has already exited and the migration runner has written
+    // state.json. Poll briefly anyway in case the test-agent picks
+    // up the API socket a moment before the migration runner's
+    // atomic rename lands.
+    let state: PostupgradeState | undefined;
+    const deadline = Date.now() + 10_000;
+    while (Date.now() < deadline) {
+      try {
+        state = await agentGet<PostupgradeState>(
+          TEST_AGENT_URL,
+          "/postupgrade/state",
+        );
+        break;
+      } catch (_err) {
+        await new Promise((resolve) => setTimeout(resolve, 500));
+      }
+    }
+    if (!state) {
+      throw new Error(
+        "wardnet-postupgrade did not write state.json within 10s",
+      );
+    }
 
     // Empty migration list ships with this PR — no entries should
     // have been applied or failed. last_verification_failure must

--- a/source/web-ui/dist/index.html
+++ b/source/web-ui/dist/index.html
@@ -6,8 +6,8 @@
     <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32.png" />
     <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16.png" />
     <title>Wardnet</title>
-    <script type="module" crossorigin src="/assets/index-U0sePmrm.js"></script>
-    <link rel="stylesheet" crossorigin href="/assets/index-DQtXCb5j.css">
+    <script type="module" crossorigin src="/assets/index-XWd0kLLI.js"></script>
+    <link rel="stylesheet" crossorigin href="/assets/index-VEqfkQRo.css">
   </head>
   <body>
     <div id="root"></div>


### PR DESCRIPTION
## Summary

- New signed, sqlx-migrate-style framework for privileged install steps delivered via auto-update. Tiny root-owned runner verifies a wardnet-writable signed payload at every boot and `fexecve`s it as root; `RequiredBy=wardnetd.service` gates daemon startup on a clean migration run.
- Empty migration list ships first; #215 (polkit), #213 (tcpdump caps), #222 (network configs) consume the framework.
- Trust anchor (`wardnet-postupgrade-runner`) is root-owned, NOT in `wardnetd.service` `ReadWritePaths`, and only changes when an operator runs `install.sh` (or `install.sh --upgrade-only`). Auto-update can only refresh the signed payload, not the verifier.

See issue #285 for the full architecture, decision log, and trust-model table.

## What's in the diff

- **New crate** `wardnet-postupgrade-runner` — `memfd_create` + `fexecve`, embedded pubkey via `build.rs` (defaults to `deploy/keys/wardnet-release.pub`; e2e overrides with `WARDNET_POSTUPGRADE_PUBKEY_PATH`).
- **New crate** `wardnet-postupgrade` — sqlx-migrate-style state machine; empty migration list.
- `FsBinaryApplier` — three-file allowlist (`wardnetd`, `wardnet-postupgrade.bin`, `wardnet-postupgrade.minisig`) + pre-flight signature verify + ordered swap; lenient on missing artifacts (downgrade-safe).
- `install.sh` — `--upgrade-only` flag for existing-Pi bootstrap; new privileged-component install steps.
- `build-daemon.yml` + `release-daemon.yml` — cross-compile postupgrade binaries; `release-daemon` signs the postupgrade binary and repacks the tarball before signing the outer tarball.
- `Dockerfile.test` — ephemeral keypair generated and embedded into the runner at compile time so the e2e harness exercises the same verify→exec path as production.
- `wardnet-test-agent` `/postupgrade/state` — read-only endpoint surfacing `state.json` to the e2e suite.
- New unit/integration coverage: 5 applier tests, 7 postupgrade-runner tests, 7 verify tests, 6 state tests.

## Test plan

- [x] `make check-daemon` passes (cargo fmt, clippy `-D warnings`, `cargo test --workspace` — 1,250+ tests green)
- [ ] CI `make end2end-daemon` happy-path spec asserts `state.json` is `{applied: [], failed: []}` after container start (local podman/macOS can't run systemd-as-PID-1; relying on Linux CI)
- [ ] On a real Pi (post-merge smoke): `install.sh --upgrade-only` lands runner, unit, dirs with correct ownership/modes; next boot's `wardnet-postupgrade.service` exits 0; daemon starts cleanly
- [ ] On a real Pi: auto-update with framework artifacts swaps both `wardnetd` and the postupgrade payload; runner verifies and execs on next boot
- [ ] On a real Pi: single-byte flip in `wardnet-postupgrade.minisig` causes runner to exit non-zero with verification error in journal; daemon STILL starts (empty Required list)

Closes #285.