### PR TITLE
Align admin UI with design guidelines (and extend the doc) — closes #300

### DIFF
--- a/docs/WEBUI-DESIGN-GUIDELINES.md
+++ b/docs/WEBUI-DESIGN-GUIDELINES.md
@@ -309,7 +309,7 @@ The default surface for grouping related content.
 | Slot | Use for |
 |---|---|
 | **Card head (top-right)** | The card's *primary* affordance: a status badge that may transform into the install button (state-as-button), an Edit-config button on read-mostly cards, or an overflow menu. |
-| **Body** | A primary CTA inherent to the card's purpose (Download backup is the point of the Backup card; the button sits in the body, not the footer). |
+| **Body** | A CTA inherent to the card's purpose, right-aligned at the bottom of the body. Use `primary` only when one action genuinely dominates the card; default to `secondary` when actions are utility-grade (Download backup, Export logs) so the page doesn't end up with one filled-primary per card. |
 | **Inset danger-zone block** | A destructive action sharing a card with safe ones (Restore from backup, Reset filters). |
 | **Footer action row** | Utility actions that operate on the card's state but aren't the card's reason for existing (Restart daemon, Check for updates, Flush cache). |
 

--- a/docs/WEBUI-DESIGN-GUIDELINES.md
+++ b/docs/WEBUI-DESIGN-GUIDELINES.md
@@ -287,6 +287,34 @@ The default surface for grouping related content.
 
 **Internal sections** are separated by a horizontal `0.5px` divider with `var(--gap-section)` spacing above and below.
 
+**Footer action row** — a card may end with a single action row anchored to its bottom edge. Use this for utility actions that operate on the whole card's state (Restart, Check for updates, Flush cache), distinct from body-level CTAs.
+
+```
+┌─ Auto-update ───────────────────────────── ✓ Up to date ─┐
+│  [body content: stats, toggles, fields]                  │
+│                                                          │
+│  ─────────────────────────────────────────────────────── │ ← 0.5px divider
+│  Updates are checked hourly.            [ ↻ Check now ]  │ ← helper left, action right
+└──────────────────────────────────────────────────────────┘
+```
+
+**Anatomy**:
+- Top edge: `0.5px solid --color-border-subtle` divider, with `var(--gap-section)` above
+- Layout: flex row, `space-between`, vertically centered
+- Left slot (optional): 13px secondary helper text — explains scope, last-run timestamp, or context. One line.
+- Right slot: 1–2 buttons, separated by 8px when paired. Use the destructive variant for risk-bearing utilities (Restart) and `outline`/`secondary` for the rest. Never put a filled-primary button here — primary belongs in the card head, the body, or the danger zone, not the footer row.
+
+**Rules for placing card-level actions** — pick one slot per concept:
+
+| Slot | Use for |
+|---|---|
+| **Card head (top-right)** | The card's *primary* affordance: a status badge that may transform into the install button (state-as-button), an Edit-config button on read-mostly cards, or an overflow menu. |
+| **Body** | A primary CTA inherent to the card's purpose (Download backup is the point of the Backup card; the button sits in the body, not the footer). |
+| **Inset danger-zone block** | A destructive action sharing a card with safe ones (Restore from backup, Reset filters). |
+| **Footer action row** | Utility actions that operate on the card's state but aren't the card's reason for existing (Restart daemon, Check for updates, Flush cache). |
+
+Mixing slots inside one card is fine, but a single concept never lives in two slots. Don't add a "Save" button to both the card head and the footer.
+
 **Rules**
 - Never nest cards inside cards. If you need internal grouping, use the inset pattern: `--color-bg-subtle` block with `--radius-md` (used for danger zones, metric tiles).
 - Cards stack vertically with `var(--gap-card-stack)` between them.
@@ -539,7 +567,7 @@ The location of an action signals its scope.
 | Scope | Location | Style |
 |---|---|---|
 | Page-level | Top-right of page header | Primary, filled |
-| Card-level (single action) | Bottom-right of card OR top-right of card head | Primary, filled — or secondary if it's not the main thing |
+| Card-level (single action) | Top-right of card head, body, or footer action row — pick one per [3.6](#36-card) | Head: primary or status-as-button. Body: primary, filled. Footer: secondary/destructive utility, never filled-primary. |
 | Action on a setting row | Right end of the row | Sized to match the row (sm or md) |
 | Row-level inside a table | Right end of the row, in a dedicated actions column | Tertiary inline |
 | Destructive | Bottom of card, in a danger-zone sub-block | Destructive variant |

--- a/docs/WEBUI-DESIGN-GUIDELINES.md
+++ b/docs/WEBUI-DESIGN-GUIDELINES.md
@@ -2,7 +2,7 @@
 
 > Single source of truth for the visual design and interaction patterns of the Wardnet admin UI. Both humans and AI coding agents should treat this as authoritative when building or refactoring UI. When the existing codebase conflicts with this document, the document wins — file an issue and migrate.
 
-Version 1.0 · Last updated 2026-05-04
+Version 1.1 · Last updated 2026-05-04
 
 ---
 
@@ -320,12 +320,16 @@ Used for listing many records with the same shape (Devices, DHCP leases, Reserva
 - Right-aligned in their own column
 - Destructive verbs ("Revoke", "Delete") get `--color-danger-fg` color but no background or border
 - Hover: underline
+- **0 actions**: omit the actions column entirely.
+- **1–2 actions**: render inline, separated by 16px.
+- **3+ actions**: collapse into an overflow menu (see [3.12](#312-dropdown-menu-overflow-actions)). Inline rows of three or more buttons overflow narrow viewports and read as a toolbar rather than per-row affordances.
 
 **Rules**
 - Sort indicators on column headers when sortable. Default sort is most-recent-first for time columns.
 - Never put a primary button inside a row. Row actions are always tertiary inline.
 - Empty cells use an em-dash `—`, never blank.
 - Long values truncate with ellipsis and reveal full value on hover (title attribute).
+- The actions column is the only column that may collapse to an overflow trigger; data columns hide via `meta.className: "hidden sm:table-cell"` instead.
 
 ### 3.8 Alert / callout
 
@@ -371,6 +375,43 @@ Used for utilization indicators (DHCP pool usage).
 
 **Rules**
 - Switch fill color to `--color-warning-fg` above 80% utilization, `--color-danger-fg` above 95%.
+
+### 3.11 Sheet (side drawer)
+
+Right-side panel for creating or editing a single record. Used in place of a full-page form when the surrounding context still matters (e.g., editing a device while the device list stays visible behind the sheet).
+
+**Anatomy**:
+- Slides in from the right, full viewport height
+- Width: 100% on mobile (`w-full`), capped to a comfortable column on wider viewports — content drives width, not the other way around
+- Padding: `var(--gap-card-inline)` (24px) horizontal, matching cards
+- Sections, top to bottom:
+  1. **Title** — sentence case, 16px/500, primary text. No subtitle unless the record needs context the title can't carry.
+  2. **Body** — form fields stacked vertically with `var(--gap-section)` (16px) between groups (see [4.7](#47-form-fields-anatomy))
+  3. **Footer action** — single full-width primary button at the bottom of the body, label is the verb that completes the task ("Create tunnel", "Save changes", "Allow domain")
+- Dismissal: Escape key, backdrop click, or the `×` close button rendered by the sheet primitive
+
+**Rules**
+- One sheet at a time. Sheets do not stack (this is the difference from modals; opening a child workflow from inside a sheet — e.g. "Reserve DHCP address" from the device editor — should close the parent sheet first or open the child as a separate top-level sheet).
+- No explicit Cancel button. Dismissal is always available via X / Escape / backdrop, and a Cancel button next to a full-width Save creates layout asymmetry.
+- For multi-step workflows (preview → apply, validate → submit), use a modal **dialog**, not a sheet. The dialog can morph its body and footer between steps; a sheet's full-height layout makes step transitions feel unanchored.
+- Save button stays disabled while the form is invalid or the mutation is pending. Pending state uses gerund copy ("Saving…") with the Unicode ellipsis (see [6.6](#66-loading-copy)).
+- Error states render via the `<ApiErrorAlert>` component above the save button, not as a toast — the sheet has visible space for the message.
+
+### 3.12 Dropdown menu (overflow actions)
+
+Used to collapse a list of row-level actions when there are too many to display inline.
+
+**Anatomy**:
+- Trigger: icon-only button, `more-horizontal` Lucide icon (the canonical "more actions" icon), 28px square, `tertiary` styling, `aria-label="More actions"`
+- Menu: anchored to the trigger, opens below-right by default, snaps above-right if there's no room below. Background `--color-bg-surface`, `0.5px solid --color-border-default`, `--radius-md`, no shadow heavier than a 1px halo
+- Menu items: 32px tall, 13px text, sentence case, left-aligned, optional 14px leading icon
+- Destructive items: `--color-danger-fg` text. Group them at the bottom with a `--color-border-subtle` separator above; never interleave destructive items with safe ones.
+
+**Rules**
+- Use only when a row has 3 or more actions, or when 2 actions don't fit in the available width on the smallest supported viewport. Never collapse a single action into a menu.
+- The overflow trigger lives in the rightmost column, replacing the inline-button strip — do not show both inline buttons and an overflow trigger in the same row.
+- Menu item labels are imperative verbs ("Edit", "Disable", "Delete"). Don't restate the row identity ("Delete this blocklist") — the row context is already established.
+- Keep menu items short — at most 5 items per row. If you have more, the row's data model is too overloaded for a table.
 
 ---
 
@@ -555,6 +596,24 @@ When showing multiple metrics together (System info card, DHCP overview).
 - All stats in a cluster use the same tile size. Don't make one bigger because it "feels more important".
 - Pair related stats: usage + capacity ("Active leases 16" / "Pool size 201") sit adjacent, not on opposite ends.
 
+### 4.7 Form fields anatomy
+
+The same field rules apply inside sheets, modals, settings rows, and inline edit forms.
+
+**Anatomy** (top to bottom):
+- **Label** — 13px medium, primary text, sentence case, sits above the field. Mark optional fields explicitly: `Hostname (optional)`. Required fields don't need an asterisk; the form's submit button gates the requirement.
+- **Field** — full width of the form column. Fields paired side-by-side (e.g. Pool start / Pool end) use `flex gap-3` and split evenly.
+- **Helper text** — optional, 12px secondary, max 2 lines. Sits below the field. Use it for context the label can't carry ("DNS servers advertised to clients") — never to repeat the label.
+- **Validation message** — 12px `--color-danger-fg`, replaces the helper slot when the field is invalid.
+
+**Rules**
+- One field per row unless two fields are conceptually paired (start/end, gateway/netmask). Don't grid for grid's sake.
+- Inputs use the same height (32px / `h-8`) as `secondary` buttons so save buttons align with the last field.
+- Toggles inside a form follow the [3.4](#34-toggle) rules: label on the left, switch on the right, full row is the click target.
+- Code-like inputs (WireGuard config, AdGuard rules) use `font-mono` and switch to a multi-line `<Textarea>` if more than ~100 characters are likely.
+- Don't use placeholder text as a label. Placeholders show example values, never field names.
+- Group related fields with a small heading or a `--color-border-subtle` divider rather than nesting them in a sub-card. Sheets and modals are already a contained surface — don't double-frame.
+
 ---
 
 ## 5. Page templates
@@ -624,6 +683,37 @@ Page title + stat cards row + tabs + table.
 - The `Edit` button on a config card sits in the card head (top-right), not bottom — these cards are read-mostly with occasional edits.
 - Tabs and table follow the [table page](#52-table-page-devices-reservations) rules.
 
+### 5.5 Detail page (My device)
+
+Single-record drill-down, always for the caller's own context (self-service routing, account preferences). Distinct from edit sheets — a detail page is the destination, not a workflow that closes back to a list.
+
+```
+┌───────────────────────────────────────────────┐
+│  My device                                    │  ← eyebrow, 12px secondary
+│  [icon]  Galaxy S21 Leilah                    │  ← h1, 24px/500, with type icon
+│                                               │
+│  ┌─ Internet access ───────────────────────┐  │
+│  │  ◉ Direct (no VPN)                       │  │
+│  │  ○ VPN: 🇸🇪 Sweden – Mullvad             │  │
+│  │                                          │  │
+│  │                          [   Save   ]    │  │
+│  └─────────────────────────────────────────┘  │
+└───────────────────────────────────────────────┘
+```
+
+**Anatomy**:
+- Container: centered, `max-width: 32rem`, top padding `var(--space-8)`. Detail pages are deliberately narrow — they hold a single record, not a list.
+- **Eyebrow**: 12px secondary text, sentence case, identifies the kind of record ("My device", "My account").
+- **h1**: 24px/500 (per [2.2](#22-typography)), with the record's type icon (24–28px, `--color-text-secondary`) rendered before the title.
+- **Cards** stacked vertically. Each card has its own h2 title (16px/500, sentence case) and one primary action.
+- **Locked state**: when an admin restricts the user from editing, render the current value as plain text, then a 14px lock icon + 13px secondary explanation in `--color-text-secondary`. No disabled controls — they read as broken rather than restricted.
+- **Empty state** (record not found): centered icon + h2 + helper paragraph, no CTA. The user can't act their way out — they're being told why the page is empty.
+
+**Rules**
+- One primary CTA per card. Save buttons in detail pages are full-width inside narrow containers (32rem feels cramped with side-by-side actions); this is the one place [4.4](#44-action-positioning)'s "bottom-right of card" rule does not apply.
+- Detail pages don't have tabs. If the record needs multiple lenses, use a navigation pattern (sidebar, breadcrumb) — tabs imply equal-weight peers, but a detail page already has one weight.
+- No page-level CTA. The actions live inside the cards. Add new actions by adding cards, not by crowding the header.
+
 ---
 
 ## 6. Content & microcopy
@@ -679,6 +769,23 @@ Single word preferred. Sentence case. No icons unless it's a confirming success.
 - Confident. State what something does, not what it might do. "Restart will disconnect active sessions" not "Restart may disconnect sessions".
 - Explain consequences for destructive actions in one sentence. "Cannot be undone" is a complete justification.
 - Avoid jargon when the user might not be technical. Where jargon is unavoidable (WireGuard, DHCP), use it without apology — your users know what these mean.
+
+### 6.6 Loading copy
+
+In-progress states use a gerund verb plus a single Unicode ellipsis character.
+
+| Use | Avoid |
+|---|---|
+| Saving… | Saving... |
+| Creating… | Creating ... |
+| Loading… | Loading |
+| Checking for updates… | Checking... |
+
+**Rules**
+- Always use the Unicode ellipsis (`…`, U+2026), never three ASCII dots (`...`). The dots have inconsistent spacing across fonts and copy-paste poorly into other surfaces.
+- Form: gerund + ellipsis. The verb mirrors the button label ("Create tunnel" → "Creating…", "Download backup" → "Downloading…"). Don't introduce new verbs ("Working…", "Please wait…") that don't match the action.
+- The same string sits inside the disabled button while the mutation is pending. Don't move the loading text elsewhere.
+- For longer-running ops where the user might wonder if anything is happening, supplement with a progress indicator (see [4.3](#43-loading-states)) — but the gerund label still wins: "Downloading (1.2 MB / 4.5 MB)" not "Please wait while we download".
 
 ---
 

--- a/source/daemon/crates/wardnetd-mock/src/seed.rs
+++ b/source/daemon/crates/wardnetd-mock/src/seed.rs
@@ -102,7 +102,12 @@ pub async fn populate(factory: &dyn RepositoryFactory) -> anyhow::Result<SeededI
         };
         device_repo.insert(&row).await?;
         device_ids.push(id);
-        device_lease_inputs.push((id, mac.to_owned(), hostname.map(str::to_owned), ip.to_owned()));
+        device_lease_inputs.push((
+            id,
+            mac.to_owned(),
+            hostname.map(str::to_owned),
+            ip.to_owned(),
+        ));
         tracing::debug!(
             device_id = %id,
             mac,

--- a/source/daemon/crates/wardnetd-mock/src/seed.rs
+++ b/source/daemon/crates/wardnetd-mock/src/seed.rs
@@ -11,7 +11,9 @@
 use chrono::{Duration, Utc};
 use uuid::Uuid;
 use wardnetd_data::RepositoryFactory;
-use wardnetd_data::repository::{AllowlistRow, CustomRuleRow, DeviceRow, TunnelRow};
+use wardnetd_data::repository::{
+    AllowlistRow, CustomRuleRow, DeviceRow, DhcpLeaseRow, DhcpReservationRow, TunnelRow,
+};
 
 /// IDs of the entities inserted by [`populate`], so the event emitter can
 /// refer to them.
@@ -30,6 +32,7 @@ pub async fn populate(factory: &dyn RepositoryFactory) -> anyhow::Result<SeededI
     let device_repo = factory.device();
     let tunnel_repo = factory.tunnel();
     let dns_repo = factory.dns();
+    let dhcp_repo = factory.dhcp();
 
     let now = Utc::now();
     let now_iso = now.to_rfc3339();
@@ -81,6 +84,7 @@ pub async fn populate(factory: &dyn RepositoryFactory) -> anyhow::Result<SeededI
     ];
 
     let mut device_ids = Vec::with_capacity(devices.len());
+    let mut device_lease_inputs = Vec::with_capacity(devices.len());
     for (mac, hostname, manufacturer, device_type, ip, last_seen_ago) in devices {
         let id = Uuid::new_v4();
         let first_seen = (now - Duration::days(7)).to_rfc3339();
@@ -98,12 +102,47 @@ pub async fn populate(factory: &dyn RepositoryFactory) -> anyhow::Result<SeededI
         };
         device_repo.insert(&row).await?;
         device_ids.push(id);
+        device_lease_inputs.push((id, mac.to_owned(), hostname.map(str::to_owned), ip.to_owned()));
         tracing::debug!(
             device_id = %id,
             mac,
             ip,
             "seeded device: device_id={id}, mac={mac}, ip={ip}",
         );
+    }
+
+    // ------------------------------------------------------------------
+    // DHCP leases — one active lease per seeded device so the Leases tab
+    // and the dashboard "Active leases" stat have something to render.
+    // The smart plug additionally gets a reservation so the Reservations
+    // tab is also non-empty.
+    // ------------------------------------------------------------------
+    let lease_start = (now - Duration::hours(6)).to_rfc3339();
+    let lease_end = (now + Duration::hours(18)).to_rfc3339();
+    for (device_id, mac, hostname, ip) in &device_lease_inputs {
+        let lease_id = Uuid::new_v4();
+        let lease = DhcpLeaseRow {
+            id: lease_id.to_string(),
+            mac_address: mac.clone(),
+            ip_address: ip.clone(),
+            hostname: hostname.clone(),
+            lease_start: lease_start.clone(),
+            lease_end: lease_end.clone(),
+            status: "active".to_owned(),
+            device_id: Some(device_id.to_string()),
+        };
+        dhcp_repo.insert_lease(&lease).await?;
+    }
+
+    if let Some((_, mac, hostname, ip)) = device_lease_inputs.last() {
+        let reservation = DhcpReservationRow {
+            id: Uuid::new_v4().to_string(),
+            mac_address: mac.clone(),
+            ip_address: ip.clone(),
+            hostname: hostname.clone(),
+            description: Some("Smart plug — kitchen".to_owned()),
+        };
+        dhcp_repo.insert_reservation(&reservation).await?;
     }
 
     // ------------------------------------------------------------------

--- a/source/web-ui/src/components/compound/AllowlistTable.tsx
+++ b/source/web-ui/src/components/compound/AllowlistTable.tsx
@@ -69,9 +69,7 @@ export function AllowlistTable({ entries, onDelete, onAdd }: AllowlistTableProps
   return (
     <div className="flex flex-col gap-4">
       <div className="flex justify-end">
-        <Button size="sm" onClick={onAdd}>
-          Add domain
-        </Button>
+        <Button onClick={onAdd}>Add domain</Button>
       </div>
 
       <DataTable columns={columns} data={entries} />

--- a/source/web-ui/src/components/compound/AllowlistTable.tsx
+++ b/source/web-ui/src/components/compound/AllowlistTable.tsx
@@ -60,7 +60,7 @@ export function AllowlistTable({ entries, onDelete, onAdd }: AllowlistTableProps
       <EmptyStatePlaceholder
         message="No allowlist entries"
         hint="Domains added here will never be blocked, even if they appear in a blocklist."
-        actionLabel="Add Domain"
+        actionLabel="Add domain"
         onAction={onAdd}
       />
     );
@@ -70,7 +70,7 @@ export function AllowlistTable({ entries, onDelete, onAdd }: AllowlistTableProps
     <div className="flex flex-col gap-4">
       <div className="flex justify-end">
         <Button size="sm" onClick={onAdd}>
-          Add Domain
+          Add domain
         </Button>
       </div>
 

--- a/source/web-ui/src/components/compound/AllowlistTable.tsx
+++ b/source/web-ui/src/components/compound/AllowlistTable.tsx
@@ -33,7 +33,11 @@ function createColumns(onDelete: (id: string) => void): ColumnDef<AllowlistEntry
       header: "",
       meta: { className: "text-right" },
       cell: ({ row }) => (
-        <Button variant="ghost" size="sm" onClick={() => onDelete(row.original.id)}>
+        <Button
+          variant="tertiary"
+          className="text-destructive hover:text-destructive"
+          onClick={() => onDelete(row.original.id)}
+        >
           Remove
         </Button>
       ),

--- a/source/web-ui/src/components/compound/BlocklistTable.tsx
+++ b/source/web-ui/src/components/compound/BlocklistTable.tsx
@@ -36,7 +36,7 @@ function createColumns(
     },
     {
       accessorKey: "last_updated",
-      header: "Last Updated",
+      header: "Last updated",
       meta: { className: "hidden md:table-cell" },
       cell: ({ row }) => (
         <span className="text-muted-foreground">
@@ -68,7 +68,7 @@ function createColumns(
             onClick={() => onRefresh(row.original.id)}
             disabled={refreshingId === row.original.id}
           >
-            {refreshingId === row.original.id ? "Updating..." : "Update Now"}
+            {refreshingId === row.original.id ? "Updating..." : "Update now"}
           </Button>
           <Button variant="ghost" size="sm" onClick={() => onDelete(row.original.id)}>
             Delete
@@ -107,7 +107,7 @@ export function BlocklistTable({
       <EmptyStatePlaceholder
         message="No blocklists configured"
         hint="Add a blocklist URL to start blocking ads and trackers network-wide."
-        actionLabel="Add Blocklist"
+        actionLabel="Add blocklist"
         onAction={onAdd}
       />
     );
@@ -117,7 +117,7 @@ export function BlocklistTable({
     <div className="flex flex-col gap-4">
       <div className="flex justify-end">
         <Button size="sm" onClick={onAdd}>
-          Add Blocklist
+          Add blocklist
         </Button>
       </div>
 

--- a/source/web-ui/src/components/compound/BlocklistTable.tsx
+++ b/source/web-ui/src/components/compound/BlocklistTable.tsx
@@ -68,7 +68,7 @@ function createColumns(
             onClick={() => onRefresh(row.original.id)}
             disabled={refreshingId === row.original.id}
           >
-            {refreshingId === row.original.id ? "Updating..." : "Update now"}
+            {refreshingId === row.original.id ? "Updating…" : "Update now"}
           </Button>
           <Button variant="ghost" size="sm" onClick={() => onDelete(row.original.id)}>
             Delete

--- a/source/web-ui/src/components/compound/BlocklistTable.tsx
+++ b/source/web-ui/src/components/compound/BlocklistTable.tsx
@@ -1,8 +1,8 @@
 import type { ColumnDef } from "@tanstack/react-table";
-import { Badge } from "@/components/core/ui/badge";
 import { Button } from "@/components/core/ui/button";
 import { DataTable } from "@/components/core/ui/data-table";
 import { EmptyStatePlaceholder } from "@/components/compound/EmptyStatePlaceholder";
+import { StatusBadge } from "@/components/compound/StatusBadge";
 import { timeAgo } from "@/lib/utils";
 import type { Blocklist } from "@wardnet/js";
 
@@ -48,9 +48,9 @@ function createColumns(
       accessorKey: "enabled",
       header: "Status",
       cell: ({ row }) => (
-        <Badge variant={row.original.enabled ? "default" : "secondary"}>
+        <StatusBadge tone={row.original.enabled ? "success" : "neutral"}>
           {row.original.enabled ? "Enabled" : "Disabled"}
-        </Badge>
+        </StatusBadge>
       ),
     },
     {

--- a/source/web-ui/src/components/compound/BlocklistTable.tsx
+++ b/source/web-ui/src/components/compound/BlocklistTable.tsx
@@ -116,9 +116,7 @@ export function BlocklistTable({
   return (
     <div className="flex flex-col gap-4">
       <div className="flex justify-end">
-        <Button size="sm" onClick={onAdd}>
-          Add blocklist
-        </Button>
+        <Button onClick={onAdd}>Add blocklist</Button>
       </div>
 
       <DataTable columns={columns} data={blocklists} onRowClick={onEdit} />

--- a/source/web-ui/src/components/compound/BlocklistTable.tsx
+++ b/source/web-ui/src/components/compound/BlocklistTable.tsx
@@ -1,6 +1,14 @@
 import type { ColumnDef } from "@tanstack/react-table";
+import { MoreHorizontalIcon } from "lucide-react";
 import { Button } from "@/components/core/ui/button";
 import { DataTable } from "@/components/core/ui/data-table";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/core/ui/dropdown-menu";
 import { EmptyStatePlaceholder } from "@/components/compound/EmptyStatePlaceholder";
 import { StatusBadge } from "@/components/compound/StatusBadge";
 import { timeAgo } from "@/lib/utils";
@@ -57,24 +65,33 @@ function createColumns(
       id: "actions",
       header: "",
       meta: { className: "text-right" },
-      cell: ({ row }) => (
-        <div className="flex justify-end gap-1" onClick={(e) => e.stopPropagation()}>
-          <Button variant="ghost" size="sm" onClick={() => onToggle(row.original)}>
-            {row.original.enabled ? "Disable" : "Enable"}
-          </Button>
-          <Button
-            variant="ghost"
-            size="sm"
-            onClick={() => onRefresh(row.original.id)}
-            disabled={refreshingId === row.original.id}
-          >
-            {refreshingId === row.original.id ? "Updating…" : "Update now"}
-          </Button>
-          <Button variant="ghost" size="sm" onClick={() => onDelete(row.original.id)}>
-            Delete
-          </Button>
-        </div>
-      ),
+      cell: ({ row }) => {
+        const blocklist = row.original;
+        const isRefreshing = refreshingId === blocklist.id;
+        return (
+          <div className="flex justify-end" onClick={(e) => e.stopPropagation()}>
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button variant="ghost" size="icon-sm" aria-label={`Actions for ${blocklist.name}`}>
+                  <MoreHorizontalIcon />
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent>
+                <DropdownMenuItem onSelect={() => onToggle(blocklist)}>
+                  {blocklist.enabled ? "Disable" : "Enable"}
+                </DropdownMenuItem>
+                <DropdownMenuItem disabled={isRefreshing} onSelect={() => onRefresh(blocklist.id)}>
+                  {isRefreshing ? "Updating…" : "Update now"}
+                </DropdownMenuItem>
+                <DropdownMenuSeparator />
+                <DropdownMenuItem variant="destructive" onSelect={() => onDelete(blocklist.id)}>
+                  Delete
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
+          </div>
+        );
+      },
     },
   ];
 }

--- a/source/web-ui/src/components/compound/ConfirmDialog.tsx
+++ b/source/web-ui/src/components/compound/ConfirmDialog.tsx
@@ -38,14 +38,7 @@ export function ConfirmDialog({
         </AlertDialogHeader>
         <AlertDialogFooter>
           <AlertDialogCancel>Cancel</AlertDialogCancel>
-          <AlertDialogAction
-            onClick={onConfirm}
-            className={
-              destructive
-                ? "bg-destructive text-destructive-foreground hover:bg-destructive/90"
-                : undefined
-            }
-          >
+          <AlertDialogAction variant={destructive ? "destructive" : "default"} onClick={onConfirm}>
             {confirmLabel}
           </AlertDialogAction>
         </AlertDialogFooter>

--- a/source/web-ui/src/components/compound/ConnectionStatus.tsx
+++ b/source/web-ui/src/components/compound/ConnectionStatus.tsx
@@ -6,7 +6,7 @@ export function ConnectionStatus() {
 
   const reachable = data?.reachable ?? false;
   const color = isLoading ? "bg-yellow-400" : reachable ? "bg-emerald-400" : "bg-red-400";
-  const label = isLoading ? "Connecting..." : reachable ? "Connected" : "Disconnected";
+  const label = isLoading ? "Connecting…" : reachable ? "Connected" : "Disconnected";
 
   return (
     <div className="flex items-center gap-2">

--- a/source/web-ui/src/components/compound/CountryCombobox.tsx
+++ b/source/web-ui/src/components/compound/CountryCombobox.tsx
@@ -56,7 +56,7 @@ export function CountryCombobox({
       </PopoverTrigger>
       <PopoverContent className="w-(--radix-popover-trigger-width) p-0" align="start">
         <Command>
-          <CommandInput placeholder="Search country..." />
+          <CommandInput placeholder="Search country…" />
           <CommandList>
             <CommandEmpty>No country found.</CommandEmpty>
             <CommandGroup>

--- a/source/web-ui/src/components/compound/DeviceTable.tsx
+++ b/source/web-ui/src/components/compound/DeviceTable.tsx
@@ -2,6 +2,7 @@ import type { ColumnDef } from "@tanstack/react-table";
 import { Badge } from "@/components/core/ui/badge";
 import { DataTable } from "@/components/core/ui/data-table";
 import { DeviceIcon } from "@/components/compound/DeviceIcon";
+import { StatusBadge } from "@/components/compound/StatusBadge";
 import { timeAgo } from "@/lib/utils";
 import type { Device, DeviceType, DhcpStatus } from "@wardnet/js";
 
@@ -72,11 +73,11 @@ const columns: ColumnDef<Device>[] = [
       const status: DhcpStatus = row.original.dhcp_status;
       switch (status) {
         case "lease":
-          return <Badge variant="default">Lease</Badge>;
+          return <StatusBadge tone="success">Lease</StatusBadge>;
         case "reservation":
-          return <Badge variant="default">Reserved</Badge>;
+          return <StatusBadge tone="success">Reserved</StatusBadge>;
         case "external":
-          return <Badge variant="secondary">External</Badge>;
+          return <StatusBadge tone="neutral">External</StatusBadge>;
       }
     },
   },

--- a/source/web-ui/src/components/compound/DeviceTable.tsx
+++ b/source/web-ui/src/components/compound/DeviceTable.tsx
@@ -12,10 +12,10 @@ const DEVICE_TYPE_OPTIONS: { value: DeviceType; label: string }[] = [
   { value: "laptop", label: "Laptop" },
   { value: "tablet", label: "Tablet" },
   { value: "game_console", label: "Console" },
-  { value: "settop_box", label: "Set-top Box" },
+  { value: "settop_box", label: "Set-top box" },
   { value: "iot", label: "IoT" },
   { value: "router", label: "Router" },
-  { value: "managed_switch", label: "Managed Switch" },
+  { value: "managed_switch", label: "Managed switch" },
   { value: "server", label: "Server" },
   { value: "unknown", label: "Unknown" },
 ];
@@ -83,7 +83,7 @@ const columns: ColumnDef<Device>[] = [
   },
   {
     accessorKey: "last_seen",
-    header: "Last Seen",
+    header: "Last seen",
     meta: { className: "text-right" },
     cell: ({ row }) => (
       <span className="text-muted-foreground">{timeAgo(row.original.last_seen)}</span>

--- a/source/web-ui/src/components/compound/DhcpConfigCard.tsx
+++ b/source/web-ui/src/components/compound/DhcpConfigCard.tsx
@@ -24,7 +24,7 @@ export function DhcpConfigCard({ config, onEdit }: DhcpConfigCardProps) {
         </Button>
       </CardHeader>
       <CardContent>
-        <dl className="grid grid-cols-2 gap-x-8 gap-y-3 text-sm sm:grid-cols-3">
+        <dl className="grid grid-cols-1 gap-x-8 gap-y-3 text-sm sm:grid-cols-2 lg:grid-cols-3">
           <div>
             <dt className="text-muted-foreground">Gateway IP</dt>
             <dd className="font-mono text-xs">{config.gateway_ip}</dd>

--- a/source/web-ui/src/components/compound/DhcpConfigCard.tsx
+++ b/source/web-ui/src/components/compound/DhcpConfigCard.tsx
@@ -30,7 +30,7 @@ export function DhcpConfigCard({ config, onEdit }: DhcpConfigCardProps) {
             <dd className="font-mono text-xs">{config.gateway_ip}</dd>
           </div>
           <div>
-            <dt className="text-muted-foreground">Pool Range</dt>
+            <dt className="text-muted-foreground">Pool range</dt>
             <dd className="font-mono text-xs">
               {config.pool_start} &ndash; {config.pool_end}
             </dd>
@@ -40,11 +40,11 @@ export function DhcpConfigCard({ config, onEdit }: DhcpConfigCardProps) {
             <dd className="font-mono text-xs">{config.subnet_mask}</dd>
           </div>
           <div>
-            <dt className="text-muted-foreground">Lease Duration</dt>
+            <dt className="text-muted-foreground">Lease duration</dt>
             <dd className="font-medium">{formatDuration(config.lease_duration_secs)}</dd>
           </div>
           <div>
-            <dt className="text-muted-foreground">Fallback Router</dt>
+            <dt className="text-muted-foreground">Fallback router</dt>
             <dd className="font-mono text-xs">{config.router_ip ?? "\u2014"}</dd>
           </div>
           <div>

--- a/source/web-ui/src/components/compound/DhcpLeaseTable.tsx
+++ b/source/web-ui/src/components/compound/DhcpLeaseTable.tsx
@@ -1,18 +1,17 @@
 import type { ColumnDef } from "@tanstack/react-table";
-import { Badge } from "@/components/core/ui/badge";
 import { Button } from "@/components/core/ui/button";
 import { DataTable } from "@/components/core/ui/data-table";
 import { DiscoveryPlaceholder } from "@/components/compound/DiscoveryPlaceholder";
+import { StatusBadge } from "@/components/compound/StatusBadge";
 import { timeAgo } from "@/lib/utils";
 import type { DhcpLease, DhcpLeaseStatus } from "@wardnet/js";
 
-function leaseStatusVariant(status: DhcpLeaseStatus) {
-  const map = {
-    active: "default",
-    expired: "secondary",
-    released: "outline",
-  } as const;
-  return map[status];
+function leaseStatusTone(status: DhcpLeaseStatus): "success" | "neutral" {
+  return status === "active" ? "success" : "neutral";
+}
+
+function leaseStatusLabel(status: DhcpLeaseStatus): string {
+  return status.charAt(0).toUpperCase() + status.slice(1);
 }
 
 function createColumns(
@@ -45,7 +44,9 @@ function createColumns(
       accessorKey: "status",
       header: "Status",
       cell: ({ row }) => (
-        <Badge variant={leaseStatusVariant(row.original.status)}>{row.original.status}</Badge>
+        <StatusBadge tone={leaseStatusTone(row.original.status)}>
+          {leaseStatusLabel(row.original.status)}
+        </StatusBadge>
       ),
     },
     {

--- a/source/web-ui/src/components/compound/DhcpLeaseTable.tsx
+++ b/source/web-ui/src/components/compound/DhcpLeaseTable.tsx
@@ -62,13 +62,17 @@ function createColumns(
       meta: { className: "text-right" },
       cell: ({ row }) =>
         row.original.status === "active" ? (
-          <div className="flex justify-end gap-1">
+          <div className="flex justify-end gap-4">
             {onMakeStatic && (
-              <Button variant="ghost" size="sm" onClick={() => onMakeStatic(row.original)}>
-                Make Static
+              <Button variant="tertiary" onClick={() => onMakeStatic(row.original)}>
+                Make static
               </Button>
             )}
-            <Button variant="ghost" size="sm" onClick={() => onRevoke(row.original.id)}>
+            <Button
+              variant="tertiary"
+              className="text-destructive hover:text-destructive"
+              onClick={() => onRevoke(row.original.id)}
+            >
               Revoke
             </Button>
           </div>

--- a/source/web-ui/src/components/compound/DhcpReservationTable.tsx
+++ b/source/web-ui/src/components/compound/DhcpReservationTable.tsx
@@ -67,9 +67,7 @@ export function DhcpReservationTable({ reservations, onDelete, onAdd }: DhcpRese
   return (
     <div className="flex flex-col gap-4">
       <div className="flex justify-end">
-        <Button size="sm" onClick={onAdd}>
-          Add reservation
-        </Button>
+        <Button onClick={onAdd}>Add reservation</Button>
       </div>
 
       <DataTable columns={columns} data={reservations} />

--- a/source/web-ui/src/components/compound/DhcpReservationTable.tsx
+++ b/source/web-ui/src/components/compound/DhcpReservationTable.tsx
@@ -58,7 +58,7 @@ export function DhcpReservationTable({ reservations, onDelete, onAdd }: DhcpRese
       <EmptyStatePlaceholder
         message="No DHCP reservations"
         hint="Add your first reservation to assign a permanent IP address to a device."
-        actionLabel="Add Reservation"
+        actionLabel="Add reservation"
         onAction={onAdd}
       />
     );
@@ -68,7 +68,7 @@ export function DhcpReservationTable({ reservations, onDelete, onAdd }: DhcpRese
     <div className="flex flex-col gap-4">
       <div className="flex justify-end">
         <Button size="sm" onClick={onAdd}>
-          Add Reservation
+          Add reservation
         </Button>
       </div>
 

--- a/source/web-ui/src/components/compound/DhcpReservationTable.tsx
+++ b/source/web-ui/src/components/compound/DhcpReservationTable.tsx
@@ -31,7 +31,11 @@ function createColumns(onDelete: (id: string) => void): ColumnDef<DhcpReservatio
       header: "",
       meta: { className: "text-right" },
       cell: ({ row }) => (
-        <Button variant="ghost" size="sm" onClick={() => onDelete(row.original.id)}>
+        <Button
+          variant="tertiary"
+          className="text-destructive hover:text-destructive"
+          onClick={() => onDelete(row.original.id)}
+        >
           Delete
         </Button>
       ),

--- a/source/web-ui/src/components/compound/DhcpStatusCard.tsx
+++ b/source/web-ui/src/components/compound/DhcpStatusCard.tsx
@@ -1,7 +1,7 @@
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/core/ui/card";
-import { Badge } from "@/components/core/ui/badge";
 import { Switch } from "@/components/core/ui/switch";
 import { Label } from "@/components/core/ui/label";
+import { StatusBadge } from "./StatusBadge";
 import { DashboardUsageBar } from "./DashboardUsageBar";
 import type { DhcpStatusResponse } from "@wardnet/js";
 
@@ -19,9 +19,9 @@ export function DhcpStatusCard({ status, onToggle, isPending }: DhcpStatusCardPr
     <Card>
       <CardHeader className="flex flex-row items-center justify-between">
         <CardTitle className="text-sm font-medium text-muted-foreground">DHCP Server</CardTitle>
-        <Badge variant={status.running ? "default" : "secondary"}>
+        <StatusBadge tone={status.running ? "success" : "neutral"} withIcon={status.running}>
           {status.running ? "Running" : "Stopped"}
-        </Badge>
+        </StatusBadge>
       </CardHeader>
       <CardContent>
         <div className="flex flex-col gap-4">

--- a/source/web-ui/src/components/compound/DhcpStatusCard.tsx
+++ b/source/web-ui/src/components/compound/DhcpStatusCard.tsx
@@ -18,7 +18,7 @@ export function DhcpStatusCard({ status, onToggle, isPending }: DhcpStatusCardPr
   return (
     <Card>
       <CardHeader className="flex flex-row items-center justify-between">
-        <CardTitle className="text-sm font-medium text-muted-foreground">DHCP Server</CardTitle>
+        <CardTitle className="text-sm font-medium text-muted-foreground">DHCP server</CardTitle>
         <StatusBadge tone={status.running ? "success" : "neutral"} withIcon={status.running}>
           {status.running ? "Running" : "Stopped"}
         </StatusBadge>
@@ -36,17 +36,17 @@ export function DhcpStatusCard({ status, onToggle, isPending }: DhcpStatusCardPr
           </div>
           <div className="grid grid-cols-2 gap-4 text-sm">
             <div>
-              <p className="text-muted-foreground">Active Leases</p>
+              <p className="text-muted-foreground">Active leases</p>
               <p className="text-2xl font-bold">{status.active_lease_count}</p>
             </div>
             <div>
-              <p className="text-muted-foreground">Pool Size</p>
+              <p className="text-muted-foreground">Pool size</p>
               <p className="text-2xl font-bold">{status.pool_total}</p>
             </div>
           </div>
           <div>
             <p className="mb-1 text-xs text-muted-foreground">
-              Pool Usage ({status.pool_used} / {status.pool_total})
+              Pool usage ({status.pool_used} / {status.pool_total})
             </p>
             <DashboardUsageBar value={poolUsagePercent} />
           </div>

--- a/source/web-ui/src/components/compound/DhcpSummaryCard.tsx
+++ b/source/web-ui/src/components/compound/DhcpSummaryCard.tsx
@@ -1,6 +1,6 @@
 import { Link } from "react-router";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/core/ui/card";
-import { Badge } from "@/components/core/ui/badge";
+import { StatusBadge } from "./StatusBadge";
 import type { DhcpStatusResponse } from "@wardnet/js";
 
 interface DhcpSummaryCardProps {
@@ -21,9 +21,9 @@ export function DhcpSummaryCard({ status, to }: DhcpSummaryCardProps) {
       <CardHeader>
         <CardTitle className="flex items-center justify-between text-sm font-semibold">
           DHCP
-          <Badge variant={status.running ? "default" : "secondary"}>
+          <StatusBadge tone={status.running ? "success" : "neutral"} withIcon={status.running}>
             {status.running ? "Running" : "Stopped"}
-          </Badge>
+          </StatusBadge>
         </CardTitle>
       </CardHeader>
       <CardContent>

--- a/source/web-ui/src/components/compound/FilterRuleTable.tsx
+++ b/source/web-ui/src/components/compound/FilterRuleTable.tsx
@@ -72,7 +72,7 @@ export function FilterRuleTable({ rules, onToggle, onDelete, onAdd }: FilterRule
       <EmptyStatePlaceholder
         message="No custom filter rules"
         hint="Add AdGuard-syntax rules for fine-grained control over what gets blocked or allowed."
-        actionLabel="Add Rule"
+        actionLabel="Add rule"
         onAction={onAdd}
       />
     );
@@ -82,7 +82,7 @@ export function FilterRuleTable({ rules, onToggle, onDelete, onAdd }: FilterRule
     <div className="flex flex-col gap-4">
       <div className="flex justify-end">
         <Button size="sm" onClick={onAdd}>
-          Add Rule
+          Add rule
         </Button>
       </div>
 

--- a/source/web-ui/src/components/compound/FilterRuleTable.tsx
+++ b/source/web-ui/src/components/compound/FilterRuleTable.tsx
@@ -1,8 +1,8 @@
 import type { ColumnDef } from "@tanstack/react-table";
-import { Badge } from "@/components/core/ui/badge";
 import { Button } from "@/components/core/ui/button";
 import { DataTable } from "@/components/core/ui/data-table";
 import { EmptyStatePlaceholder } from "@/components/compound/EmptyStatePlaceholder";
+import { StatusBadge } from "@/components/compound/StatusBadge";
 import type { CustomFilterRule } from "@wardnet/js";
 
 function createColumns(
@@ -26,9 +26,9 @@ function createColumns(
       accessorKey: "enabled",
       header: "Status",
       cell: ({ row }) => (
-        <Badge variant={row.original.enabled ? "default" : "secondary"}>
+        <StatusBadge tone={row.original.enabled ? "success" : "neutral"}>
           {row.original.enabled ? "Enabled" : "Disabled"}
-        </Badge>
+        </StatusBadge>
       ),
     },
     {

--- a/source/web-ui/src/components/compound/FilterRuleTable.tsx
+++ b/source/web-ui/src/components/compound/FilterRuleTable.tsx
@@ -81,9 +81,7 @@ export function FilterRuleTable({ rules, onToggle, onDelete, onAdd }: FilterRule
   return (
     <div className="flex flex-col gap-4">
       <div className="flex justify-end">
-        <Button size="sm" onClick={onAdd}>
-          Add rule
-        </Button>
+        <Button onClick={onAdd}>Add rule</Button>
       </div>
 
       <DataTable columns={columns} data={rules} />

--- a/source/web-ui/src/components/compound/FilterRuleTable.tsx
+++ b/source/web-ui/src/components/compound/FilterRuleTable.tsx
@@ -36,15 +36,18 @@ function createColumns(
       header: "",
       meta: { className: "text-right" },
       cell: ({ row }) => (
-        <div className="flex justify-end gap-1">
+        <div className="flex justify-end gap-4">
           <Button
-            variant="ghost"
-            size="sm"
+            variant="tertiary"
             onClick={() => onToggle(row.original.id, !row.original.enabled)}
           >
             {row.original.enabled ? "Disable" : "Enable"}
           </Button>
-          <Button variant="ghost" size="sm" onClick={() => onDelete(row.original.id)}>
+          <Button
+            variant="tertiary"
+            className="text-destructive hover:text-destructive"
+            onClick={() => onDelete(row.original.id)}
+          >
             Delete
           </Button>
         </div>

--- a/source/web-ui/src/components/compound/LogViewer.tsx
+++ b/source/web-ui/src/components/compound/LogViewer.tsx
@@ -112,7 +112,7 @@ export function LogViewer({ entries, connected, skipped, maxHeight = "24rem" }: 
       >
         {entries.length === 0 ? (
           <p className="p-4 text-center text-muted-foreground">
-            {connected ? "Waiting for log entries..." : "Not connected"}
+            {connected ? "Waiting for log entries…" : "Not connected"}
           </p>
         ) : (
           <div className="divide-y divide-border/50">

--- a/source/web-ui/src/components/compound/RecentErrorsCard.tsx
+++ b/source/web-ui/src/components/compound/RecentErrorsCard.tsx
@@ -19,7 +19,7 @@ export function RecentErrorsCard({ errors }: RecentErrorsCardProps) {
   return (
     <Card>
       <CardHeader>
-        <CardTitle className="text-sm font-semibold">Recent Errors</CardTitle>
+        <CardTitle className="text-sm font-semibold">Recent errors</CardTitle>
       </CardHeader>
       <CardContent>
         {errors.length === 0 ? (

--- a/source/web-ui/src/components/compound/RoutingSelector.tsx
+++ b/source/web-ui/src/components/compound/RoutingSelector.tsx
@@ -79,7 +79,7 @@ export function RoutingSelector({
         <div className="flex items-center gap-2">
           <RadioGroupItem value="tunnel" id="route-tunnel" />
           <Label htmlFor="route-tunnel" className="cursor-pointer font-normal">
-            Via Tunnel
+            Via tunnel
           </Label>
         </div>
       </RadioGroup>

--- a/source/web-ui/src/components/compound/Sidebar.tsx
+++ b/source/web-ui/src/components/compound/Sidebar.tsx
@@ -15,7 +15,7 @@ interface NavItem {
   end?: boolean;
 }
 
-const selfServiceLinks: NavItem[] = [{ to: "/", label: "My Device", end: true }];
+const selfServiceLinks: NavItem[] = [{ to: "/", label: "My device", end: true }];
 
 const adminLinks: NavItem[] = [
   { to: "/", label: "Dashboard", end: true },
@@ -23,7 +23,7 @@ const adminLinks: NavItem[] = [
   { to: "/tunnels", label: "Tunnels" },
   { to: "/dhcp", label: "DHCP" },
   { to: "/dns", label: "DNS" },
-  { to: "/ad-blocking", label: "Ad Blocking" },
+  { to: "/ad-blocking", label: "Ad blocking" },
   { to: "/settings", label: "Settings" },
 ];
 

--- a/source/web-ui/src/components/compound/StatusBadge.tsx
+++ b/source/web-ui/src/components/compound/StatusBadge.tsx
@@ -1,0 +1,34 @@
+import type { ReactNode } from "react";
+import { CheckIcon } from "lucide-react";
+import { Badge } from "@/components/core/ui/badge";
+
+type StatusBadgeTone = "success" | "neutral";
+
+interface StatusBadgeProps {
+  /** Visual tone. `success` for desirable states (Running, Up to date, Active),
+   *  `neutral` for off/idle states (Stopped, Disabled, External). */
+  tone: StatusBadgeTone;
+  /** Show a leading check icon. Per the design guidelines (§3.2), reserved for
+   *  card-level success states that confirm a desirable system condition
+   *  (Running, Up to date). Routine row-level statuses (Active, Lease,
+   *  Enabled) should leave this off. */
+  withIcon?: boolean;
+  children: ReactNode;
+}
+
+const variantForTone = {
+  success: "success",
+  neutral: "secondary",
+} as const;
+
+/** Status badge for a record's state. Wraps the {@link Badge} primitive with
+ *  the tone vocabulary from §3.2 of `WEBUI-DESIGN-GUIDELINES.md` so call sites
+ *  declare what the state *means* rather than picking a Tailwind variant. */
+export function StatusBadge({ tone, withIcon = false, children }: StatusBadgeProps) {
+  return (
+    <Badge variant={variantForTone[tone]}>
+      {withIcon && tone === "success" && <CheckIcon />}
+      {children}
+    </Badge>
+  );
+}

--- a/source/web-ui/src/components/compound/TunnelCard.tsx
+++ b/source/web-ui/src/components/compound/TunnelCard.tsx
@@ -1,18 +1,13 @@
 import { ArrowDown, ArrowUp } from "lucide-react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/core/ui/card";
-import { Badge } from "@/components/core/ui/badge";
 import { Button } from "@/components/core/ui/button";
+import { StatusBadge } from "./StatusBadge";
 import { formatBytes, timeAgo } from "@/lib/utils";
 import { countryFlag } from "@/lib/country";
 import type { Tunnel, TunnelStatus, ProviderInfo } from "@wardnet/js";
 
-function statusColor(status: TunnelStatus) {
-  const map = {
-    up: "default",
-    down: "secondary",
-    connecting: "outline",
-  } as const;
-  return map[status];
+function statusTone(status: TunnelStatus): "success" | "neutral" {
+  return status === "up" ? "success" : "neutral";
 }
 
 function statusLabel(status: TunnelStatus): string {
@@ -67,7 +62,7 @@ export function TunnelCard({ tunnel, providers, onDelete }: TunnelCardProps) {
             </p>
           </div>
         </div>
-        <Badge variant={statusColor(tunnel.status)}>{statusLabel(tunnel.status)}</Badge>
+        <StatusBadge tone={statusTone(tunnel.status)}>{statusLabel(tunnel.status)}</StatusBadge>
       </CardHeader>
       <CardContent>
         <div className="grid grid-cols-2 gap-y-2 text-sm">

--- a/source/web-ui/src/components/compound/TunnelCard.tsx
+++ b/source/web-ui/src/components/compound/TunnelCard.tsx
@@ -95,7 +95,7 @@ export function TunnelCard({ tunnel, providers, onDelete }: TunnelCardProps) {
           </div>
         </div>
         <div className="mt-4 flex justify-end">
-          <Button variant="destructive" size="sm" onClick={() => onDelete(tunnel.id)}>
+          <Button variant="destructive" onClick={() => onDelete(tunnel.id)}>
             Delete
           </Button>
         </div>

--- a/source/web-ui/src/components/compound/TunnelGrid.tsx
+++ b/source/web-ui/src/components/compound/TunnelGrid.tsx
@@ -9,7 +9,7 @@ interface TunnelGridProps {
   isLoading: boolean;
   isError: boolean;
   onDelete: (id: string) => void;
-  /** Called when the user clicks the "Add Tunnel" button in the empty state. */
+  /** Called when the user clicks the "Add tunnel" button in the empty state. */
   onAdd?: () => void;
 }
 
@@ -37,7 +37,7 @@ export function TunnelGrid({
       <EmptyStatePlaceholder
         message="No tunnels configured"
         hint="Add a WireGuard tunnel to route device traffic through a VPN provider."
-        actionLabel={onAdd ? "Add Tunnel" : undefined}
+        actionLabel={onAdd ? "Add tunnel" : undefined}
         onAction={onAdd}
       />
     );

--- a/source/web-ui/src/components/core/ui/badge.tsx
+++ b/source/web-ui/src/components/core/ui/badge.tsx
@@ -11,6 +11,7 @@ const badgeVariants = cva(
       variant: {
         default: "bg-primary text-primary-foreground [a]:hover:bg-primary/80",
         secondary: "bg-secondary text-secondary-foreground [a]:hover:bg-secondary/80",
+        success: "bg-success text-success-foreground [a]:hover:bg-success/80",
         destructive:
           "bg-destructive/10 text-destructive focus-visible:ring-destructive/20 dark:bg-destructive/20 dark:focus-visible:ring-destructive/40 [a]:hover:bg-destructive/20",
         outline: "border-border text-foreground [a]:hover:bg-muted [a]:hover:text-muted-foreground",

--- a/source/web-ui/src/components/core/ui/button.tsx
+++ b/source/web-ui/src/components/core/ui/button.tsx
@@ -19,6 +19,8 @@ const buttonVariants = cva(
         destructive:
           "bg-destructive/10 text-destructive hover:bg-destructive/20 focus-visible:border-destructive/40 focus-visible:ring-destructive/20 dark:bg-destructive/20 dark:hover:bg-destructive/30 dark:focus-visible:ring-destructive/40",
         link: "text-primary underline-offset-4 hover:underline",
+        tertiary:
+          "text-muted-foreground hover:bg-transparent hover:text-foreground hover:underline underline-offset-4",
       },
       size: {
         default:

--- a/source/web-ui/src/components/core/ui/command.tsx
+++ b/source/web-ui/src/components/core/ui/command.tsx
@@ -29,7 +29,7 @@ function Command({ className, ...props }: React.ComponentProps<typeof CommandPri
 
 function CommandDialog({
   title = "Command Palette",
-  description = "Search for a command to run...",
+  description = "Search for a command to run…",
   children,
   className,
   showCloseButton = false,

--- a/source/web-ui/src/components/core/ui/data-table.tsx
+++ b/source/web-ui/src/components/core/ui/data-table.tsx
@@ -46,7 +46,7 @@ export function DataTable<TData, TValue>({
   });
 
   return (
-    <div className="overflow-hidden rounded-xl border border-border">
+    <div className="overflow-x-auto rounded-xl border border-border">
       <Table>
         <TableHeader>
           {table.getHeaderGroups().map((headerGroup) => (

--- a/source/web-ui/src/components/core/ui/dropdown-menu.tsx
+++ b/source/web-ui/src/components/core/ui/dropdown-menu.tsx
@@ -1,0 +1,83 @@
+import * as React from "react";
+import { DropdownMenu as DropdownMenuPrimitive } from "radix-ui";
+
+import { cn } from "@/lib/utils";
+
+function DropdownMenu({ ...props }: React.ComponentProps<typeof DropdownMenuPrimitive.Root>) {
+  return <DropdownMenuPrimitive.Root data-slot="dropdown-menu" {...props} />;
+}
+
+function DropdownMenuTrigger({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Trigger>) {
+  return <DropdownMenuPrimitive.Trigger data-slot="dropdown-menu-trigger" {...props} />;
+}
+
+function DropdownMenuContent({
+  className,
+  align = "end",
+  sideOffset = 4,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Content>) {
+  return (
+    <DropdownMenuPrimitive.Portal>
+      <DropdownMenuPrimitive.Content
+        data-slot="dropdown-menu-content"
+        align={align}
+        sideOffset={sideOffset}
+        className={cn(
+          "z-50 min-w-32 origin-(--radix-dropdown-menu-content-transform-origin) overflow-hidden rounded-md bg-popover p-1 text-sm text-popover-foreground shadow-md ring-1 ring-foreground/10 outline-hidden duration-100 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+          className,
+        )}
+        {...props}
+      />
+    </DropdownMenuPrimitive.Portal>
+  );
+}
+
+function DropdownMenuItem({
+  className,
+  variant = "default",
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Item> & {
+  /** `destructive` items render in danger-fg color and should be grouped at the
+   *  bottom of the menu, separated from safe items by a {@link DropdownMenuSeparator}. */
+  variant?: "default" | "destructive";
+}) {
+  return (
+    <DropdownMenuPrimitive.Item
+      data-slot="dropdown-menu-item"
+      data-variant={variant}
+      className={cn(
+        "relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-none select-none data-disabled:pointer-events-none data-disabled:opacity-50",
+        "data-highlighted:bg-muted data-highlighted:text-foreground",
+        variant === "destructive" &&
+          "text-destructive data-highlighted:bg-destructive/10 data-highlighted:text-destructive",
+        "[&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-3.5",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function DropdownMenuSeparator({
+  className,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Separator>) {
+  return (
+    <DropdownMenuPrimitive.Separator
+      data-slot="dropdown-menu-separator"
+      className={cn("-mx-1 my-1 h-px bg-border", className)}
+      {...props}
+    />
+  );
+}
+
+export {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+};

--- a/source/web-ui/src/components/features/BackupCard.tsx
+++ b/source/web-ui/src/components/features/BackupCard.tsx
@@ -76,8 +76,8 @@ export function BackupCard({
           <span>Keep the passphrase somewhere safe. We can&apos;t recover it for you.</span>
         </div>
 
-        <div>
-          <Button onClick={() => setExportOpen(true)} disabled={isExporting}>
+        <div className="flex justify-end">
+          <Button variant="outline" onClick={() => setExportOpen(true)} disabled={isExporting}>
             <DownloadIcon />
             {isExporting ? "Exporting…" : "Download backup"}
           </Button>

--- a/source/web-ui/src/components/features/BackupCard.tsx
+++ b/source/web-ui/src/components/features/BackupCard.tsx
@@ -67,22 +67,39 @@ export function BackupCard({
           it to restore a fresh install, recover from an SD-card failure, or roll back a risky
           configuration change. Bundles are encrypted with age in passphrase mode.
         </p>
-        <p className="text-sm font-semibold">
-          Keep the passphrase somewhere safe. We can&apos;t recover it for you.
-        </p>
 
-        <div className="flex gap-2">
+        <div
+          role="alert"
+          className="flex gap-2 rounded-md bg-warning p-3 text-sm text-warning-foreground"
+        >
+          <AlertTriangleIcon className="mt-0.5 size-4 shrink-0" />
+          <span>Keep the passphrase somewhere safe. We can&apos;t recover it for you.</span>
+        </div>
+
+        <div>
           <Button onClick={() => setExportOpen(true)} disabled={isExporting}>
-            <DownloadIcon className="mr-2 h-4 w-4" />
+            <DownloadIcon />
             {isExporting ? "Exporting…" : "Download backup"}
           </Button>
+        </div>
+
+        {/* Danger zone — Restore overwrites state and is sequestered into a
+            subtle inset block so it never sits next to the safe Download CTA
+            (WEBUI-DESIGN-GUIDELINES §4.5). */}
+        <div className="flex items-start justify-between gap-4 rounded-md bg-muted p-4">
+          <div className="min-w-0">
+            <p className="text-sm font-medium">Restore from backup</p>
+            <p className="mt-0.5 text-xs text-muted-foreground">
+              Overwrites your current database, config, and keys. Cannot be undone.
+            </p>
+          </div>
           <Button
-            variant="outline"
+            variant="destructive"
             onClick={() => setRestoreOpen(true)}
             disabled={isPreviewing || isApplying}
           >
-            <UploadIcon className="mr-2 h-4 w-4" />
-            Restore from backup
+            <UploadIcon />
+            Restore…
           </Button>
         </div>
       </CardContent>
@@ -330,7 +347,7 @@ function RestoreDialog({
               onClick={() => onApply(preview.preview_token)}
               disabled={!preview.compatible || isApplying}
             >
-              {isApplying ? "Applying…" : "Apply restore"}
+              {isApplying ? "Restoring…" : "Restore"}
             </Button>
           )}
         </DialogFooter>

--- a/source/web-ui/src/components/features/BlocklistSheet.tsx
+++ b/source/web-ui/src/components/features/BlocklistSheet.tsx
@@ -48,7 +48,7 @@ export function BlocklistSheet({ open, onOpenChange, blocklist }: BlocklistSheet
   return (
     <Sheet open={open} onOpenChange={onOpenChange}>
       <SheetContent className="w-full overflow-y-auto p-6">
-        <SheetTitle>{isEdit ? "Edit Blocklist" : "Add Blocklist"}</SheetTitle>
+        <SheetTitle>{isEdit ? "Edit blocklist" : "Add blocklist"}</SheetTitle>
         <div className="mt-6 flex flex-col gap-5">
           <div className="flex flex-col gap-2">
             <Label htmlFor="bl-name">Name</Label>
@@ -73,7 +73,7 @@ export function BlocklistSheet({ open, onOpenChange, blocklist }: BlocklistSheet
             </p>
           </div>
 
-          <CronSchedulePicker label="Update Schedule" value={schedule} onChange={setSchedule} />
+          <CronSchedulePicker label="Update schedule" value={schedule} onChange={setSchedule} />
 
           <div className="flex items-center justify-between">
             <Label htmlFor="bl-enabled">{isEdit ? "Enabled" : "Enable immediately"}</Label>
@@ -93,8 +93,8 @@ export function BlocklistSheet({ open, onOpenChange, blocklist }: BlocklistSheet
                 ? "Saving..."
                 : "Adding..."
               : isEdit
-                ? "Save Changes"
-                : "Add Blocklist"}
+                ? "Save changes"
+                : "Add blocklist"}
           </Button>
         </div>
       </SheetContent>

--- a/source/web-ui/src/components/features/BlocklistSheet.tsx
+++ b/source/web-ui/src/components/features/BlocklistSheet.tsx
@@ -90,8 +90,8 @@ export function BlocklistSheet({ open, onOpenChange, blocklist }: BlocklistSheet
           <Button onClick={handleSave} disabled={mutation.isPending || !canSave} className="w-full">
             {mutation.isPending
               ? isEdit
-                ? "Saving..."
-                : "Adding..."
+                ? "Saving…"
+                : "Adding…"
               : isEdit
                 ? "Save changes"
                 : "Add blocklist"}

--- a/source/web-ui/src/components/features/CreateAllowlistSheet.tsx
+++ b/source/web-ui/src/components/features/CreateAllowlistSheet.tsx
@@ -28,7 +28,7 @@ export function CreateAllowlistSheet({ open, onOpenChange }: CreateAllowlistShee
   return (
     <Sheet open={open} onOpenChange={onOpenChange}>
       <SheetContent className="w-full overflow-y-auto p-6">
-        <SheetTitle>Allow Domain</SheetTitle>
+        <SheetTitle>Allow domain</SheetTitle>
         <div className="mt-6 flex flex-col gap-5">
           <div className="flex flex-col gap-2">
             <Label htmlFor="al-domain">Domain</Label>
@@ -62,7 +62,7 @@ export function CreateAllowlistSheet({ open, onOpenChange }: CreateAllowlistShee
             disabled={createEntry.isPending || domain.trim() === ""}
             className="w-full"
           >
-            {createEntry.isPending ? "Adding..." : "Allow Domain"}
+            {createEntry.isPending ? "Adding..." : "Allow domain"}
           </Button>
         </div>
       </SheetContent>

--- a/source/web-ui/src/components/features/CreateAllowlistSheet.tsx
+++ b/source/web-ui/src/components/features/CreateAllowlistSheet.tsx
@@ -62,7 +62,7 @@ export function CreateAllowlistSheet({ open, onOpenChange }: CreateAllowlistShee
             disabled={createEntry.isPending || domain.trim() === ""}
             className="w-full"
           >
-            {createEntry.isPending ? "Adding..." : "Allow domain"}
+            {createEntry.isPending ? "Adding…" : "Allow domain"}
           </Button>
         </div>
       </SheetContent>

--- a/source/web-ui/src/components/features/CreateFilterRuleSheet.tsx
+++ b/source/web-ui/src/components/features/CreateFilterRuleSheet.tsx
@@ -31,7 +31,7 @@ export function CreateFilterRuleSheet({ open, onOpenChange }: CreateFilterRuleSh
   return (
     <Sheet open={open} onOpenChange={onOpenChange}>
       <SheetContent className="w-full overflow-y-auto p-6">
-        <SheetTitle>Add Filter Rule</SheetTitle>
+        <SheetTitle>Add filter rule</SheetTitle>
         <div className="mt-6 flex flex-col gap-5">
           <div className="flex flex-col gap-2">
             <Label htmlFor="fr-rule">Rule</Label>
@@ -72,7 +72,7 @@ export function CreateFilterRuleSheet({ open, onOpenChange }: CreateFilterRuleSh
             disabled={createRule.isPending || ruleText.trim() === ""}
             className="w-full"
           >
-            {createRule.isPending ? "Adding..." : "Add Rule"}
+            {createRule.isPending ? "Adding..." : "Add rule"}
           </Button>
         </div>
       </SheetContent>

--- a/source/web-ui/src/components/features/CreateFilterRuleSheet.tsx
+++ b/source/web-ui/src/components/features/CreateFilterRuleSheet.tsx
@@ -72,7 +72,7 @@ export function CreateFilterRuleSheet({ open, onOpenChange }: CreateFilterRuleSh
             disabled={createRule.isPending || ruleText.trim() === ""}
             className="w-full"
           >
-            {createRule.isPending ? "Adding..." : "Add rule"}
+            {createRule.isPending ? "Adding…" : "Add rule"}
           </Button>
         </div>
       </SheetContent>

--- a/source/web-ui/src/components/features/CreateReservationSheet.tsx
+++ b/source/web-ui/src/components/features/CreateReservationSheet.tsx
@@ -104,7 +104,7 @@ export function CreateReservationSheet({
           )}
 
           <Button onClick={handleSave} disabled={createReservation.isPending} className="w-full">
-            {createReservation.isPending ? "Creating..." : "Create reservation"}
+            {createReservation.isPending ? "Creating…" : "Create reservation"}
           </Button>
         </div>
       </SheetContent>

--- a/source/web-ui/src/components/features/CreateReservationSheet.tsx
+++ b/source/web-ui/src/components/features/CreateReservationSheet.tsx
@@ -54,10 +54,10 @@ export function CreateReservationSheet({
   return (
     <Sheet open={open} onOpenChange={onOpenChange}>
       <SheetContent className="w-full overflow-y-auto p-6">
-        <SheetTitle>{defaults?.mac ? "Reserve Address" : "Add Reservation"}</SheetTitle>
+        <SheetTitle>{defaults?.mac ? "Reserve address" : "Add reservation"}</SheetTitle>
         <div className="mt-6 flex flex-col gap-5">
           <div className="flex flex-col gap-2">
-            <Label htmlFor="res-mac">MAC Address</Label>
+            <Label htmlFor="res-mac">MAC address</Label>
             <MacInput
               id="res-mac"
               value={macAddress}
@@ -67,7 +67,7 @@ export function CreateReservationSheet({
           </div>
 
           <div className="flex flex-col gap-2">
-            <Label htmlFor="res-ip">IP Address</Label>
+            <Label htmlFor="res-ip">IP address</Label>
             <Ipv4Input
               id="res-ip"
               value={ipAddress}
@@ -104,7 +104,7 @@ export function CreateReservationSheet({
           )}
 
           <Button onClick={handleSave} disabled={createReservation.isPending} className="w-full">
-            {createReservation.isPending ? "Creating..." : "Create Reservation"}
+            {createReservation.isPending ? "Creating..." : "Create reservation"}
           </Button>
         </div>
       </SheetContent>

--- a/source/web-ui/src/components/features/CreateTunnelSheet.tsx
+++ b/source/web-ui/src/components/features/CreateTunnelSheet.tsx
@@ -13,7 +13,7 @@ export function CreateTunnelSheet({ open, onOpenChange }: CreateTunnelSheetProps
   return (
     <Sheet open={open} onOpenChange={onOpenChange}>
       <SheetContent className="w-full overflow-y-auto p-6">
-        <SheetTitle>Add WireGuard Tunnel</SheetTitle>
+        <SheetTitle>Add WireGuard tunnel</SheetTitle>
         <Tabs defaultValue="manual" className="mt-6">
           <TabsList className="w-full">
             <TabsTrigger value="manual" className="flex-1">

--- a/source/web-ui/src/components/features/EditDeviceForm.tsx
+++ b/source/web-ui/src/components/features/EditDeviceForm.tsx
@@ -139,7 +139,7 @@ export function EditDeviceForm({
       )}
 
       <Button onClick={handleSave} disabled={updateDevice.isPending} className="w-full">
-        {updateDevice.isPending ? "Saving..." : "Save changes"}
+        {updateDevice.isPending ? "Saving…" : "Save changes"}
       </Button>
     </div>
   );

--- a/source/web-ui/src/components/features/EditDeviceForm.tsx
+++ b/source/web-ui/src/components/features/EditDeviceForm.tsx
@@ -23,10 +23,10 @@ const DEVICE_TYPE_OPTIONS: { value: DeviceType; label: string }[] = [
   { value: "laptop", label: "Laptop" },
   { value: "tablet", label: "Tablet" },
   { value: "game_console", label: "Console" },
-  { value: "settop_box", label: "Set-top Box" },
+  { value: "settop_box", label: "Set-top box" },
   { value: "iot", label: "IoT" },
   { value: "router", label: "Router" },
-  { value: "managed_switch", label: "Managed Switch" },
+  { value: "managed_switch", label: "Managed switch" },
   { value: "server", label: "Server" },
   { value: "unknown", label: "Unknown" },
 ];
@@ -78,7 +78,7 @@ export function EditDeviceForm({
       </div>
 
       <div className="flex flex-col gap-2">
-        <Label htmlFor="edit-name">Friendly Name</Label>
+        <Label htmlFor="edit-name">Friendly name</Label>
         <Input
           id="edit-name"
           value={name}
@@ -88,7 +88,7 @@ export function EditDeviceForm({
       </div>
 
       <div className="flex flex-col gap-2">
-        <Label>Device Type</Label>
+        <Label>Device type</Label>
         <Select value={deviceType} onValueChange={(v) => setDeviceType(v as DeviceType)}>
           <SelectTrigger className="w-full">
             <SelectValue />
@@ -130,7 +130,7 @@ export function EditDeviceForm({
             )
           }
         >
-          Reserve DHCP Address
+          Reserve DHCP address
         </Button>
       )}
 
@@ -139,7 +139,7 @@ export function EditDeviceForm({
       )}
 
       <Button onClick={handleSave} disabled={updateDevice.isPending} className="w-full">
-        {updateDevice.isPending ? "Saving..." : "Save Changes"}
+        {updateDevice.isPending ? "Saving..." : "Save changes"}
       </Button>
     </div>
   );

--- a/source/web-ui/src/components/features/EditDeviceSheet.tsx
+++ b/source/web-ui/src/components/features/EditDeviceSheet.tsx
@@ -36,7 +36,7 @@ export function EditDeviceSheet({ deviceId, open, onOpenChange }: EditDeviceShee
               }}
             />
           ) : (
-            <p className="mt-6 text-sm text-muted-foreground">Loading device...</p>
+            <p className="mt-6 text-sm text-muted-foreground">Loading device…</p>
           )}
         </SheetContent>
       </Sheet>

--- a/source/web-ui/src/components/features/EditDeviceSheet.tsx
+++ b/source/web-ui/src/components/features/EditDeviceSheet.tsx
@@ -20,7 +20,7 @@ export function EditDeviceSheet({ deviceId, open, onOpenChange }: EditDeviceShee
     <>
       <Sheet open={open} onOpenChange={onOpenChange}>
         <SheetContent className="w-full overflow-y-auto p-6">
-          <SheetTitle>Edit Device</SheetTitle>
+          <SheetTitle>Edit device</SheetTitle>
           {device ? (
             <EditDeviceForm
               key={device.id + String(data?.current_rule?.type)}

--- a/source/web-ui/src/components/features/EditDhcpConfigSheet.tsx
+++ b/source/web-ui/src/components/features/EditDhcpConfigSheet.tsx
@@ -120,7 +120,7 @@ export function EditDhcpConfigSheet({ config, open, onOpenChange }: EditDhcpConf
           )}
 
           <Button onClick={handleSave} disabled={updateConfig.isPending} className="w-full">
-            {updateConfig.isPending ? "Saving..." : "Save configuration"}
+            {updateConfig.isPending ? "Saving…" : "Save configuration"}
           </Button>
         </div>
       </SheetContent>

--- a/source/web-ui/src/components/features/EditDhcpConfigSheet.tsx
+++ b/source/web-ui/src/components/features/EditDhcpConfigSheet.tsx
@@ -43,11 +43,11 @@ export function EditDhcpConfigSheet({ config, open, onOpenChange }: EditDhcpConf
   return (
     <Sheet open={open} onOpenChange={onOpenChange}>
       <SheetContent className="w-full overflow-y-auto p-6">
-        <SheetTitle>Edit DHCP Configuration</SheetTitle>
+        <SheetTitle>Edit DHCP configuration</SheetTitle>
         <div className="mt-6 flex flex-col gap-5">
           <div className="flex gap-3">
             <div className="flex flex-1 flex-col gap-2">
-              <Label htmlFor="dhcp-pool-start">Pool Start</Label>
+              <Label htmlFor="dhcp-pool-start">Pool start</Label>
               <Ipv4Input
                 id="dhcp-pool-start"
                 value={poolStart}
@@ -56,7 +56,7 @@ export function EditDhcpConfigSheet({ config, open, onOpenChange }: EditDhcpConf
               />
             </div>
             <div className="flex flex-1 flex-col gap-2">
-              <Label htmlFor="dhcp-pool-end">Pool End</Label>
+              <Label htmlFor="dhcp-pool-end">Pool end</Label>
               <Ipv4Input
                 id="dhcp-pool-end"
                 value={poolEnd}
@@ -67,7 +67,7 @@ export function EditDhcpConfigSheet({ config, open, onOpenChange }: EditDhcpConf
           </div>
 
           <div className="flex flex-col gap-2">
-            <Label htmlFor="dhcp-subnet">Subnet Mask</Label>
+            <Label htmlFor="dhcp-subnet">Subnet mask</Label>
             <Ipv4Input
               id="dhcp-subnet"
               value={subnetMask}
@@ -77,7 +77,7 @@ export function EditDhcpConfigSheet({ config, open, onOpenChange }: EditDhcpConf
           </div>
 
           <div className="flex flex-col gap-2">
-            <Label htmlFor="dhcp-lease">Lease Duration (seconds)</Label>
+            <Label htmlFor="dhcp-lease">Lease duration (seconds)</Label>
             <Input
               id="dhcp-lease"
               type="number"
@@ -88,7 +88,7 @@ export function EditDhcpConfigSheet({ config, open, onOpenChange }: EditDhcpConf
           </div>
 
           <div className="flex flex-col gap-2">
-            <Label htmlFor="dhcp-router">Fallback Router</Label>
+            <Label htmlFor="dhcp-router">Fallback router</Label>
             <Ipv4Input
               id="dhcp-router"
               value={routerIp}
@@ -120,7 +120,7 @@ export function EditDhcpConfigSheet({ config, open, onOpenChange }: EditDhcpConf
           )}
 
           <Button onClick={handleSave} disabled={updateConfig.isPending} className="w-full">
-            {updateConfig.isPending ? "Saving..." : "Save Configuration"}
+            {updateConfig.isPending ? "Saving..." : "Save configuration"}
           </Button>
         </div>
       </SheetContent>

--- a/source/web-ui/src/components/features/ManualTunnelTab.tsx
+++ b/source/web-ui/src/components/features/ManualTunnelTab.tsx
@@ -51,7 +51,7 @@ export function ManualTunnelTab({ onSuccess }: ManualTunnelTabProps) {
       </div>
       <div className="flex gap-3">
         <div className="flex flex-1 flex-col gap-2">
-          <Label htmlFor="tunnel-country">Country Code</Label>
+          <Label htmlFor="tunnel-country">Country code</Label>
           <Input
             id="tunnel-country"
             value={countryCode}
@@ -72,7 +72,7 @@ export function ManualTunnelTab({ onSuccess }: ManualTunnelTabProps) {
         </div>
       </div>
       <div className="flex flex-col gap-2">
-        <Label htmlFor="tunnel-config">WireGuard Config</Label>
+        <Label htmlFor="tunnel-config">WireGuard config</Label>
         <Textarea
           id="tunnel-config"
           value={config}
@@ -87,7 +87,7 @@ export function ManualTunnelTab({ onSuccess }: ManualTunnelTabProps) {
         <ApiErrorAlert error={createTunnel.error} fallback="Failed to create tunnel" />
       )}
       <Button type="submit" disabled={createTunnel.isPending} className="w-full">
-        {createTunnel.isPending ? "Creating..." : "Create Tunnel"}
+        {createTunnel.isPending ? "Creating..." : "Create tunnel"}
       </Button>
     </form>
   );

--- a/source/web-ui/src/components/features/ManualTunnelTab.tsx
+++ b/source/web-ui/src/components/features/ManualTunnelTab.tsx
@@ -77,7 +77,7 @@ export function ManualTunnelTab({ onSuccess }: ManualTunnelTabProps) {
           id="tunnel-config"
           value={config}
           onChange={(e) => setConfig(e.target.value)}
-          placeholder="Paste your .conf file contents here..."
+          placeholder="Paste your .conf file contents here…"
           required
           rows={10}
           className="font-mono"
@@ -87,7 +87,7 @@ export function ManualTunnelTab({ onSuccess }: ManualTunnelTabProps) {
         <ApiErrorAlert error={createTunnel.error} fallback="Failed to create tunnel" />
       )}
       <Button type="submit" disabled={createTunnel.isPending} className="w-full">
-        {createTunnel.isPending ? "Creating..." : "Create tunnel"}
+        {createTunnel.isPending ? "Creating…" : "Create tunnel"}
       </Button>
     </form>
   );

--- a/source/web-ui/src/components/features/ProviderTunnelTab.tsx
+++ b/source/web-ui/src/components/features/ProviderTunnelTab.tsx
@@ -249,7 +249,7 @@ export function ProviderTunnelTab({ onSuccess }: ProviderTunnelTabProps) {
             onClick={handleValidate}
             disabled={!credsReady || validateCreds.isPending}
           >
-            {validateCreds.isPending ? "Validating..." : "Validate credentials"}
+            {validateCreds.isPending ? "Validating…" : "Validate credentials"}
           </Button>
           {validateCreds.isError && (
             <ApiErrorAlert error={validateCreds.error} fallback="Validation failed" />
@@ -293,7 +293,7 @@ export function ProviderTunnelTab({ onSuccess }: ProviderTunnelTabProps) {
               onClick={handleFetchServers}
               disabled={fetchServers.isPending}
             >
-              {fetchServers.isPending ? "Loading..." : "Refresh"}
+              {fetchServers.isPending ? "Loading…" : "Refresh"}
             </Button>
           </div>
 
@@ -343,7 +343,7 @@ export function ProviderTunnelTab({ onSuccess }: ProviderTunnelTabProps) {
           )}
 
           <Button onClick={handleSetup} disabled={setupTunnel.isPending} className="w-full">
-            {setupTunnel.isPending ? "Setting up..." : "Create tunnel"}
+            {setupTunnel.isPending ? "Setting up…" : "Create tunnel"}
           </Button>
         </>
       )}

--- a/source/web-ui/src/components/features/ProviderTunnelTab.tsx
+++ b/source/web-ui/src/components/features/ProviderTunnelTab.tsx
@@ -174,7 +174,7 @@ export function ProviderTunnelTab({ onSuccess }: ProviderTunnelTabProps) {
         <>
           {supportsToken && supportsCreds && (
             <div className="flex flex-col gap-2">
-              <Label>Auth Method</Label>
+              <Label>Auth method</Label>
               <Select
                 value={authMethod}
                 onValueChange={(v) => {
@@ -186,8 +186,8 @@ export function ProviderTunnelTab({ onSuccess }: ProviderTunnelTabProps) {
                   <SelectValue />
                 </SelectTrigger>
                 <SelectContent>
-                  <SelectItem value="token">Access Token</SelectItem>
-                  <SelectItem value="credentials">Username & Password</SelectItem>
+                  <SelectItem value="token">Access token</SelectItem>
+                  <SelectItem value="credentials">Username &amp; password</SelectItem>
                 </SelectContent>
               </Select>
             </div>
@@ -195,7 +195,7 @@ export function ProviderTunnelTab({ onSuccess }: ProviderTunnelTabProps) {
 
           {authMethod === "token" ? (
             <div className="flex flex-col gap-2">
-              <Label htmlFor="prov-token">Access Token</Label>
+              <Label htmlFor="prov-token">Access token</Label>
               <Input
                 id="prov-token"
                 type="password"
@@ -244,7 +244,7 @@ export function ProviderTunnelTab({ onSuccess }: ProviderTunnelTabProps) {
             onClick={handleValidate}
             disabled={!credsReady || validateCreds.isPending}
           >
-            {validateCreds.isPending ? "Validating..." : "Validate Credentials"}
+            {validateCreds.isPending ? "Validating..." : "Validate credentials"}
           </Button>
           {validateCreds.isError && (
             <ApiErrorAlert error={validateCreds.error} fallback="Validation failed" />
@@ -338,7 +338,7 @@ export function ProviderTunnelTab({ onSuccess }: ProviderTunnelTabProps) {
           )}
 
           <Button onClick={handleSetup} disabled={setupTunnel.isPending} className="w-full">
-            {setupTunnel.isPending ? "Setting up..." : "Create Tunnel"}
+            {setupTunnel.isPending ? "Setting up..." : "Create tunnel"}
           </Button>
         </>
       )}

--- a/source/web-ui/src/components/features/ProviderTunnelTab.tsx
+++ b/source/web-ui/src/components/features/ProviderTunnelTab.tsx
@@ -23,7 +23,12 @@ import type { ProviderCredentials, ProviderInfo, ServerInfo } from "@wardnet/js"
 
 /** Visual load indicator with a colored dot and percentage. */
 function LoadIndicator({ load }: { load: number }) {
-  const color = load < 30 ? "text-green-500" : load < 70 ? "text-yellow-500" : "text-red-500";
+  const color =
+    load < 30
+      ? "text-success-foreground"
+      : load < 70
+        ? "text-warning-foreground"
+        : "text-destructive";
   return (
     <span className={`flex items-center gap-1 text-xs ${color}`}>
       <span className="inline-block size-2 rounded-full bg-current" />

--- a/source/web-ui/src/components/features/UpdateCard.tsx
+++ b/source/web-ui/src/components/features/UpdateCard.tsx
@@ -137,26 +137,6 @@ export function UpdateCard({
           <p className="text-sm text-muted-foreground">Loading...</p>
         ) : (
           <>
-            {/* Channel row — the admin's primary choice sits first on its own
-                row so the rest of the card (state + actions) reads as
-                "consequences of this choice". */}
-            <div className="flex items-center gap-3">
-              <Label htmlFor="update-channel">Channel</Label>
-              <Select
-                value={status.channel}
-                onValueChange={(v) => onChangeChannel(v as UpdateChannel)}
-                disabled={phaseActive}
-              >
-                <SelectTrigger id="update-channel" className="w-[160px]">
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="stable">Stable</SelectItem>
-                  <SelectItem value="beta">Beta</SelectItem>
-                </SelectContent>
-              </Select>
-            </div>
-
             <dl className="grid grid-cols-2 gap-x-8 gap-y-3 text-sm sm:grid-cols-3">
               <div>
                 <dt className="text-muted-foreground">Current version</dt>
@@ -194,29 +174,55 @@ export function UpdateCard({
               </div>
             )}
 
-            <div className="flex items-center gap-3">
-              <Switch
-                id="auto-update-toggle"
-                checked={status.auto_update_enabled}
-                onCheckedChange={onToggleAutoUpdate}
-              />
-              <Label htmlFor="auto-update-toggle">Automatically install when available</Label>
+            {/* Channel + auto-install share one row: the channel is the
+                admin's primary choice, the toggle controls whether updates
+                land automatically once a new release matches it. */}
+            <div className="flex flex-wrap items-center justify-between gap-4">
+              <div className="flex items-center gap-3">
+                <Label htmlFor="update-channel">Channel</Label>
+                <Select
+                  value={status.channel}
+                  onValueChange={(v) => onChangeChannel(v as UpdateChannel)}
+                  disabled={phaseActive}
+                >
+                  <SelectTrigger id="update-channel" className="w-[160px]">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="stable">Stable</SelectItem>
+                    <SelectItem value="beta">Beta</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+              <div className="flex items-center gap-3">
+                <Switch
+                  id="auto-update-toggle"
+                  checked={status.auto_update_enabled}
+                  onCheckedChange={onToggleAutoUpdate}
+                />
+                <Label htmlFor="auto-update-toggle">Automatically install when available</Label>
+              </div>
             </div>
 
-            <div className="flex flex-wrap gap-2">
-              <Button variant="outline" onClick={onCheck} disabled={isChecking || phaseActive}>
-                <RefreshCwIcon className={isChecking ? "animate-spin" : undefined} />
-                {isChecking ? "Checking..." : "Check for updates"}
-              </Button>
-              {status.rollback_available && (
-                <Button
-                  variant="destructive"
-                  onClick={onRollback}
-                  disabled={isRollingBack || phaseActive}
-                >
-                  {isRollingBack ? "Rolling back..." : "Rollback to previous"}
+            {/* Footer action row: helper context on the left, utility
+                actions on the right (per WEBUI-DESIGN-GUIDELINES §3.6). */}
+            <div className="flex items-center justify-between gap-2 border-t pt-4">
+              <p className="text-sm text-muted-foreground">Updates are checked hourly.</p>
+              <div className="flex flex-wrap justify-end gap-2">
+                {status.rollback_available && (
+                  <Button
+                    variant="destructive"
+                    onClick={onRollback}
+                    disabled={isRollingBack || phaseActive}
+                  >
+                    {isRollingBack ? "Rolling back..." : "Rollback to previous"}
+                  </Button>
+                )}
+                <Button variant="outline" onClick={onCheck} disabled={isChecking || phaseActive}>
+                  <RefreshCwIcon className={isChecking ? "animate-spin" : undefined} />
+                  {isChecking ? "Checking..." : "Check now"}
                 </Button>
-              )}
+              </div>
             </div>
           </>
         )}

--- a/source/web-ui/src/components/features/UpdateCard.tsx
+++ b/source/web-ui/src/components/features/UpdateCard.tsx
@@ -134,7 +134,7 @@ export function UpdateCard({
       </CardHeader>
       <CardContent className="flex flex-col gap-4">
         {isLoading || !status ? (
-          <p className="text-sm text-muted-foreground">Loading...</p>
+          <p className="text-sm text-muted-foreground">Loading…</p>
         ) : (
           <>
             <dl className="grid grid-cols-2 gap-x-8 gap-y-3 text-sm sm:grid-cols-3">
@@ -215,12 +215,12 @@ export function UpdateCard({
                     onClick={onRollback}
                     disabled={isRollingBack || phaseActive}
                   >
-                    {isRollingBack ? "Rolling back..." : "Rollback to previous"}
+                    {isRollingBack ? "Rolling back…" : "Rollback to previous"}
                   </Button>
                 )}
                 <Button variant="outline" onClick={onCheck} disabled={isChecking || phaseActive}>
                   <RefreshCwIcon className={isChecking ? "animate-spin" : undefined} />
-                  {isChecking ? "Checking..." : "Check now"}
+                  {isChecking ? "Checking…" : "Check now"}
                 </Button>
               </div>
             </div>

--- a/source/web-ui/src/components/features/UpdateCard.tsx
+++ b/source/web-ui/src/components/features/UpdateCard.tsx
@@ -1,5 +1,5 @@
 import type { InstallPhase, UpdateChannel, UpdateStatus } from "@wardnet/js";
-import { DownloadIcon, Loader2Icon } from "lucide-react";
+import { DownloadIcon, Loader2Icon, RefreshCwIcon } from "lucide-react";
 import { Button } from "@/components/core/ui/button";
 import { Card, CardAction, CardContent, CardHeader, CardTitle } from "@/components/core/ui/card";
 import { Switch } from "@/components/core/ui/switch";
@@ -205,6 +205,7 @@ export function UpdateCard({
 
             <div className="flex flex-wrap gap-2">
               <Button variant="outline" onClick={onCheck} disabled={isChecking || phaseActive}>
+                <RefreshCwIcon className={isChecking ? "animate-spin" : undefined} />
                 {isChecking ? "Checking..." : "Check for updates"}
               </Button>
               {status.rollback_available && (

--- a/source/web-ui/src/components/features/UpdateCard.tsx
+++ b/source/web-ui/src/components/features/UpdateCard.tsx
@@ -1,6 +1,7 @@
 import type { InstallPhase, UpdateChannel, UpdateStatus } from "@wardnet/js";
+import { DownloadIcon, Loader2Icon } from "lucide-react";
 import { Button } from "@/components/core/ui/button";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/core/ui/card";
+import { Card, CardAction, CardContent, CardHeader, CardTitle } from "@/components/core/ui/card";
 import { Switch } from "@/components/core/ui/switch";
 import { Label } from "@/components/core/ui/label";
 import {
@@ -10,6 +11,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/core/ui/select";
+import { StatusBadge } from "@/components/compound/StatusBadge";
 
 /**
  * Whether a given install phase represents work in progress — i.e. a check/
@@ -32,16 +34,28 @@ function isPhaseActive(phase: InstallPhase): boolean {
 
 function describePhase(phase: InstallPhase): string {
   switch (phase.phase) {
+    case "checking":
+      return "Checking";
     case "downloading":
       return phase.total
         ? `Downloading (${phase.bytes.toLocaleString()} / ${phase.total.toLocaleString()} bytes)`
         : "Downloading";
+    case "verifying":
+      return "Verifying";
+    case "staging":
+      return "Staging";
+    case "swapping":
+      return "Swapping";
+    case "restart_pending":
+      return "Restart pending";
     // Failed phase renders its reason in the alert banner; the phase cell
     // only needs to flag the state, not restate the error.
     case "failed":
       return "Failed";
-    default:
-      return phase.phase;
+    case "idle":
+      return "Idle";
+    case "applied":
+      return "Applied";
   }
 }
 
@@ -80,18 +94,43 @@ export function UpdateCard({
   // off a second mutation after the first returns while the daemon is still
   // downloading in the background.
   const phaseActive = status ? isPhaseActive(status.install_phase) : false;
-  const installButtonLabel = !status
-    ? "Install"
-    : isInstalling || phaseActive
-      ? describePhase(status.install_phase) + "..."
-      : status.update_available
-        ? `Install v${status.latest_version}`
-        : "Up to date";
+  const installInProgress = isInstalling || phaseActive;
+
+  // The card head's right slot is a state-as-button transformation
+  // (WEBUI-DESIGN-GUIDELINES §4.4): a non-interactive "Up to date" badge
+  // when there's nothing to do, a primary "Install update" button when
+  // an update is available, and a disabled in-progress button while the
+  // install is running. The action row below carries only Check + Rollback.
+  const renderStateSlot = () => {
+    if (!status) return null;
+    if (installInProgress) {
+      return (
+        <Button disabled>
+          <Loader2Icon className="animate-spin" />
+          {describePhase(status.install_phase)}…
+        </Button>
+      );
+    }
+    if (status.update_available) {
+      return (
+        <Button onClick={onInstall}>
+          <DownloadIcon />
+          Install update
+        </Button>
+      );
+    }
+    return (
+      <StatusBadge tone="success" withIcon>
+        Up to date
+      </StatusBadge>
+    );
+  };
 
   return (
     <Card>
       <CardHeader>
         <CardTitle>Auto-update</CardTitle>
+        <CardAction>{renderStateSlot()}</CardAction>
       </CardHeader>
       <CardContent className="flex flex-col gap-4">
         {isLoading || !status ? (
@@ -167,12 +206,6 @@ export function UpdateCard({
             <div className="flex flex-wrap gap-2">
               <Button variant="outline" onClick={onCheck} disabled={isChecking || phaseActive}>
                 {isChecking ? "Checking..." : "Check for updates"}
-              </Button>
-              <Button
-                onClick={onInstall}
-                disabled={!status.update_available || isInstalling || phaseActive}
-              >
-                {installButtonLabel}
               </Button>
               {status.rollback_available && (
                 <Button

--- a/source/web-ui/src/index.css
+++ b/source/web-ui/src/index.css
@@ -29,6 +29,8 @@
   --accent: oklch(0.94 0.02 145);
   --accent-foreground: oklch(0.22 0.06 145);
   --destructive: oklch(0.58 0.22 27);
+  --success: oklch(0.94 0.06 145);
+  --success-foreground: oklch(0.32 0.1 145);
   --border: oklch(0.9 0.008 240);
   --input: oklch(0.9 0.008 240);
   --ring: oklch(0.62 0.16 145);
@@ -65,6 +67,8 @@
   --accent: oklch(0.28 0.03 235);
   --accent-foreground: oklch(0.92 0.01 240);
   --destructive: oklch(0.704 0.191 22.216);
+  --success: oklch(0.28 0.06 145);
+  --success-foreground: oklch(0.85 0.12 145);
   --border: oklch(1 0 0 / 10%);
   --input: oklch(1 0 0 / 12%);
   --ring: oklch(0.72 0.16 145);
@@ -102,6 +106,8 @@
   --color-input: var(--input);
   --color-border: var(--border);
   --color-destructive: var(--destructive);
+  --color-success: var(--success);
+  --color-success-foreground: var(--success-foreground);
   --color-accent-foreground: var(--accent-foreground);
   --color-accent: var(--accent);
   --color-muted-foreground: var(--muted-foreground);

--- a/source/web-ui/src/index.css
+++ b/source/web-ui/src/index.css
@@ -31,6 +31,8 @@
   --destructive: oklch(0.58 0.22 27);
   --success: oklch(0.94 0.06 145);
   --success-foreground: oklch(0.32 0.1 145);
+  --warning: oklch(0.95 0.06 80);
+  --warning-foreground: oklch(0.42 0.12 60);
   --border: oklch(0.9 0.008 240);
   --input: oklch(0.9 0.008 240);
   --ring: oklch(0.62 0.16 145);
@@ -69,6 +71,8 @@
   --destructive: oklch(0.704 0.191 22.216);
   --success: oklch(0.28 0.06 145);
   --success-foreground: oklch(0.85 0.12 145);
+  --warning: oklch(0.3 0.06 80);
+  --warning-foreground: oklch(0.85 0.12 80);
   --border: oklch(1 0 0 / 10%);
   --input: oklch(1 0 0 / 12%);
   --ring: oklch(0.72 0.16 145);
@@ -108,6 +112,8 @@
   --color-destructive: var(--destructive);
   --color-success: var(--success);
   --color-success-foreground: var(--success-foreground);
+  --color-warning: var(--warning);
+  --color-warning-foreground: var(--warning-foreground);
   --color-accent-foreground: var(--accent-foreground);
   --color-accent: var(--accent);
   --color-muted-foreground: var(--muted-foreground);

--- a/source/web-ui/src/pages/AdBlocking.tsx
+++ b/source/web-ui/src/pages/AdBlocking.tsx
@@ -54,7 +54,7 @@ export default function AdBlocking() {
 
   return (
     <>
-      <PageHeader title="Ad Blocking" />
+      <PageHeader title="Ad blocking" />
 
       {blocklistsLoading && (
         <Card>
@@ -84,7 +84,7 @@ export default function AdBlocking() {
               )}
             </TabsTrigger>
             <TabsTrigger value="rules">
-              Custom Rules
+              Custom rules
               {filterRules.length > 0 && (
                 <span className="ml-1.5 rounded-full bg-muted px-1.5 py-0.5 text-xs tabular-nums">
                   {filterRules.length}

--- a/source/web-ui/src/pages/Dns.tsx
+++ b/source/web-ui/src/pages/Dns.tsx
@@ -88,7 +88,7 @@ export default function Dns() {
                   onClick={() => flushCache.mutate()}
                   disabled={flushCache.isPending}
                 >
-                  {flushCache.isPending ? "Flushing..." : "Flush cache"}
+                  {flushCache.isPending ? "Flushing…" : "Flush cache"}
                 </Button>
               </CardHeader>
               <CardContent>

--- a/source/web-ui/src/pages/Dns.tsx
+++ b/source/web-ui/src/pages/Dns.tsx
@@ -42,7 +42,7 @@ export default function Dns() {
             <Card>
               <CardHeader className="flex flex-row items-center justify-between">
                 <CardTitle className="text-sm font-medium text-muted-foreground">
-                  DNS Server
+                  DNS server
                 </CardTitle>
                 <StatusBadge
                   tone={status.running ? "success" : "neutral"}
@@ -64,7 +64,7 @@ export default function Dns() {
                   </div>
                   <div className="grid grid-cols-2 gap-4 text-sm">
                     <div>
-                      <p className="text-muted-foreground">Resolution Mode</p>
+                      <p className="text-muted-foreground">Resolution mode</p>
                       <p className="text-lg font-semibold capitalize">{config.resolution_mode}</p>
                     </div>
                     <div>
@@ -88,7 +88,7 @@ export default function Dns() {
                   onClick={() => flushCache.mutate()}
                   disabled={flushCache.isPending}
                 >
-                  {flushCache.isPending ? "Flushing..." : "Flush Cache"}
+                  {flushCache.isPending ? "Flushing..." : "Flush cache"}
                 </Button>
               </CardHeader>
               <CardContent>
@@ -99,13 +99,13 @@ export default function Dns() {
                       <p className="text-2xl font-bold">{status.cache_size}</p>
                     </div>
                     <div>
-                      <p className="text-muted-foreground">Hit Rate</p>
+                      <p className="text-muted-foreground">Hit rate</p>
                       <p className="text-2xl font-bold">{status.cache_hit_rate.toFixed(1)}%</p>
                     </div>
                   </div>
                   <div>
                     <p className="mb-1 text-xs text-muted-foreground">
-                      Cache Usage ({status.cache_size} / {status.cache_capacity})
+                      Cache usage ({status.cache_size} / {status.cache_capacity})
                     </p>
                     <DashboardUsageBar value={cacheUsagePercent} />
                   </div>
@@ -118,7 +118,7 @@ export default function Dns() {
           <Card>
             <CardHeader>
               <CardTitle className="text-sm font-medium text-muted-foreground">
-                Upstream Servers
+                Upstream servers
               </CardTitle>
             </CardHeader>
             <CardContent>

--- a/source/web-ui/src/pages/Dns.tsx
+++ b/source/web-ui/src/pages/Dns.tsx
@@ -5,6 +5,7 @@ import { Label } from "@/components/core/ui/label";
 import { Button } from "@/components/core/ui/button";
 import { PageHeader } from "@/components/compound/PageHeader";
 import { DashboardUsageBar } from "@/components/compound/DashboardUsageBar";
+import { StatusBadge } from "@/components/compound/StatusBadge";
 import { useDnsStatus, useDnsConfig, useToggleDns, useFlushDnsCache } from "@/hooks/useDns";
 
 /** DNS server configuration page (admin only). */
@@ -43,9 +44,12 @@ export default function Dns() {
                 <CardTitle className="text-sm font-medium text-muted-foreground">
                   DNS Server
                 </CardTitle>
-                <Badge variant={status.running ? "default" : "secondary"}>
+                <StatusBadge
+                  tone={status.running ? "success" : "neutral"}
+                  withIcon={status.running}
+                >
                   {status.running ? "Running" : "Stopped"}
-                </Badge>
+                </StatusBadge>
               </CardHeader>
               <CardContent>
                 <div className="flex flex-col gap-4">

--- a/source/web-ui/src/pages/Login.tsx
+++ b/source/web-ui/src/pages/Login.tsx
@@ -75,7 +75,7 @@ export default function Login() {
           disabled={loading}
           className="h-12 w-full bg-[oklch(0.22_0.12_275)] text-base font-semibold tracking-wide text-white uppercase hover:bg-[oklch(0.28_0.12_275)] dark:bg-primary dark:hover:bg-primary/90"
         >
-          {loading ? "Signing in..." : "Log in"}
+          {loading ? "Signing in…" : "Log in"}
         </Button>
       </form>
     </div>

--- a/source/web-ui/src/pages/MyDevice.tsx
+++ b/source/web-ui/src/pages/MyDevice.tsx
@@ -141,7 +141,7 @@ export default function MyDevice() {
     return (
       <div className="mx-auto flex max-w-lg flex-col items-center gap-4 pt-16 text-center">
         <WifiOffIcon className="size-12 text-muted-foreground/50" />
-        <h2 className="text-lg font-semibold">Device not detected</h2>
+        <h2 className="text-base font-medium">Device not detected</h2>
         <p className="text-sm text-muted-foreground">
           Your device has not been detected on the network yet. Make sure you are accessing Wardnet
           directly from the local network. Connections through SSH tunnels or proxies cannot be
@@ -153,15 +153,15 @@ export default function MyDevice() {
 
   return (
     <div className="mx-auto max-w-lg pt-8">
-      <p className="text-xs text-muted-foreground">My Device</p>
+      <p className="text-xs text-muted-foreground">My device</p>
       <div className="mt-1 flex items-center gap-3">
         <DeviceIcon type={device.device_type} size={28} className="text-foreground/60" />
-        <h1 className="text-2xl font-bold">{device.name ?? device.hostname ?? device.mac}</h1>
+        <h1 className="text-2xl font-medium">{device.name ?? device.hostname ?? device.mac}</h1>
       </div>
 
       <Card className="mt-6">
         <CardHeader>
-          <CardTitle className="text-sm font-medium">Internet Access</CardTitle>
+          <CardTitle>Internet access</CardTitle>
         </CardHeader>
         <CardContent>
           {adminLocked ? (

--- a/source/web-ui/src/pages/MyDevice.tsx
+++ b/source/web-ui/src/pages/MyDevice.tsx
@@ -109,7 +109,7 @@ function RoutingForm({
       )}
 
       <Button onClick={handleSave} disabled={!hasChanges || setMyRule.isPending} className="w-full">
-        {setMyRule.isPending ? "Saving..." : "Save"}
+        {setMyRule.isPending ? "Saving…" : "Save"}
       </Button>
     </div>
   );
@@ -132,7 +132,7 @@ export default function MyDevice() {
   if (isLoading) {
     return (
       <div className="mx-auto max-w-lg pt-8">
-        <p className="text-sm text-muted-foreground">Loading...</p>
+        <p className="text-sm text-muted-foreground">Loading…</p>
       </div>
     );
   }

--- a/source/web-ui/src/pages/Settings.tsx
+++ b/source/web-ui/src/pages/Settings.tsx
@@ -67,7 +67,7 @@ export default function Settings() {
           </CardHeader>
           <CardContent>
             {isLoading ? (
-              <p className="text-sm text-muted-foreground">Loading...</p>
+              <p className="text-sm text-muted-foreground">Loading…</p>
             ) : status ? (
               <dl className="grid grid-cols-2 gap-x-8 gap-y-3 text-sm sm:grid-cols-3">
                 <div>

--- a/source/web-ui/src/pages/Settings.tsx
+++ b/source/web-ui/src/pages/Settings.tsx
@@ -19,7 +19,7 @@ import {
 } from "@/hooks/useUpdate";
 import { useAuthStore } from "@/stores/authStore";
 import { formatBytes, formatUptime } from "@/lib/utils";
-import { RotateCwIcon } from "lucide-react";
+import { RotateCcwIcon } from "lucide-react";
 
 /** Settings page for system configuration (admin only). */
 export default function Settings() {
@@ -104,8 +104,12 @@ export default function Settings() {
                   The daemon will be unreachable for a few seconds while it restarts.
                 </div>
               </div>
-              <Button variant="outline" onClick={() => restart.start()} disabled={restart.isOpen}>
-                <RotateCwIcon className="mr-2 h-4 w-4" />
+              <Button
+                variant="destructive"
+                onClick={() => restart.start()}
+                disabled={restart.isOpen}
+              >
+                <RotateCcwIcon />
                 Restart
               </Button>
             </div>

--- a/source/web-ui/src/pages/Settings.tsx
+++ b/source/web-ui/src/pages/Settings.tsx
@@ -63,7 +63,7 @@ export default function Settings() {
       <div className="flex flex-col gap-4">
         <Card>
           <CardHeader>
-            <CardTitle>System Information</CardTitle>
+            <CardTitle>System information</CardTitle>
           </CardHeader>
           <CardContent>
             {isLoading ? (
@@ -89,7 +89,7 @@ export default function Settings() {
                   <dd className="font-medium">{status.tunnel_count}</dd>
                 </div>
                 <div>
-                  <dt className="text-muted-foreground">Database Size</dt>
+                  <dt className="text-muted-foreground">Database size</dt>
                   <dd className="font-medium">{formatBytes(status.db_size_bytes)}</dd>
                 </div>
               </dl>

--- a/source/web-ui/src/pages/Setup.tsx
+++ b/source/web-ui/src/pages/Setup.tsx
@@ -111,7 +111,7 @@ export default function Setup() {
           disabled={setup.isPending}
           className="h-12 w-full bg-[oklch(0.22_0.12_275)] text-base font-semibold tracking-wide text-white uppercase hover:bg-[oklch(0.28_0.12_275)] dark:bg-primary dark:hover:bg-primary/90"
         >
-          {setup.isPending ? "Creating account..." : "Create Account"}
+          {setup.isPending ? "Creating account..." : "Create account"}
         </Button>
       </form>
     </div>

--- a/source/web-ui/src/pages/Setup.tsx
+++ b/source/web-ui/src/pages/Setup.tsx
@@ -111,7 +111,7 @@ export default function Setup() {
           disabled={setup.isPending}
           className="h-12 w-full bg-[oklch(0.22_0.12_275)] text-base font-semibold tracking-wide text-white uppercase hover:bg-[oklch(0.28_0.12_275)] dark:bg-primary dark:hover:bg-primary/90"
         >
-          {setup.isPending ? "Creating account..." : "Create account"}
+          {setup.isPending ? "Creating account…" : "Create account"}
         </Button>
       </form>
     </div>

--- a/source/web-ui/src/pages/Tunnels.tsx
+++ b/source/web-ui/src/pages/Tunnels.tsx
@@ -25,7 +25,7 @@ export default function Tunnels() {
       <PageHeader
         title="Tunnels"
         actions={
-          hasTunnels ? <Button onClick={() => setCreateOpen(true)}>Add Tunnel</Button> : undefined
+          hasTunnels ? <Button onClick={() => setCreateOpen(true)}>Add tunnel</Button> : undefined
         }
       />
 


### PR DESCRIPTION
## Summary

Closes #300 and goes a step further: brings the four admin pages
called out in the issue (Settings, Devices, Tunnels, DHCP) into line
with `docs/WEBUI-DESIGN-GUIDELINES.md`, then extends the same pass to
the detail surfaces the original issue didn't enumerate (sheets,
modals, the My device page, Ad blocking) and updates the guidelines
doc to v1.1 with the patterns that were previously implicit.

Highlights:

- **Foundation** — added a `StatusBadge` compound + `success` /
  `warning` semantic tokens so status pills stop reusing brand-green.
- **Issue 300 tasks (1–7)** — sentence case, "Up to date" state slot,
  refresh-cw icon, destructive Restart, Backup danger zone, tertiary
  row actions, soft-success Running badge.
- **Detail-surface alignment** — sentence case applied to every
  SheetTitle, form Label, and primary CTA; ConfirmDialog destructive
  styling now matches the destructive Button variant; LoadIndicator's
  raw palette colors replaced with semantic tokens.
- **Card / button placement consistency** — UpdateCard moved onto the
  new footer-action-row pattern; Download backup is now an
  outline/secondary right-aligned at the bottom of the body; all
  page- and card-level CTAs settle on the 32px default size; the
  tertiary inline action style applied across every table row.
- **Mobile** — DhcpConfigCard reflows 1→2→3 across breakpoints,
  DataTable wrapper uses overflow-x-auto, BlocklistTable's three
  inline actions collapse into a `more-horizontal` overflow menu via
  a new `DropdownMenu` primitive.
- **Microcopy** — every loading string uses the Unicode ellipsis (…).
- **MyDevice** — eyebrow, h1 weight, card title, and empty-state
  heading brought onto §5.5 / §2.2.
- **Guidelines v1.1** — added §3.11 Sheet, §3.12 Dropdown menu, §3.6
  footer-action-row, §4.7 Form fields anatomy, §5.5 Detail page,
  §6.6 Loading copy. Softened the body-CTA rule so utility cards
  default to `secondary` rather than filled-primary.
- **Mock seed** — daemon-mock now seeds DHCP leases and a reservation
  so dev review against the rendered Settings/DHCP pages works
  without a real Pi.

21 commits, one logical change per commit, so anything can be reverted
independently if a follow-up issue requires it.

## Test plan

- [x] `yarn type-check` clean
- [x] `yarn lint` — 0 errors (9 pre-existing warnings unrelated)
- [x] `yarn format:check` clean
- [x] `yarn build` succeeds
- [x] Manual review against the running mock daemon: Dashboard,
      Settings (System / Auto-update / Backup & restore), Devices
      (table + edit sheet), DHCP (status / config / leases /
      reservations + edit sheet + reservation sheet), Tunnels
      (cards + add sheet manual & provider tabs), DNS, Ad blocking
      (blocklists / allowlist / custom rules + sheets + overflow
      menu), My device, Setup
- [ ] Mobile / narrow viewport: reviewer to verify DHCP page no
      longer clips and BlocklistTable rows fit
- [ ] Confirm dialogs (Delete tunnel / Revoke lease / Delete
      reservation / Delete blocklist / Remove allowlist entry /
      Delete filter rule): destructive button uses the soft variant

## Follow-up work flagged in commit messages

- Raw palette colors elsewhere (RecentErrorsCard, DhcpSummaryCard /
  DashboardUsageBar progress fills, LogViewer, ConnectionStatus dots,
  ConnectionBanner, RestartProgressDialog, toaster) — needs a design
  call on whether to introduce vivid `success-solid` /
  `warning-solid` tokens for fills and dots.
- A few `font-bold` / `font-semibold` weight violations remain
  outside MyDevice (DashboardStatCard, RecentErrorsCard) — flagged
  for a follow-up "two weights only" sweep.
- The §9 "Known inconsistencies to fix" section listed in the
  guidelines table of contents was never written; left untouched
  here.