### PR TITLE
fix(daemon): poll for LAN IPv4 at startup instead of single-shot detection

### DIFF
--- a/source/daemon/crates/wardnetd/src/main.rs
+++ b/source/daemon/crates/wardnetd/src/main.rs
@@ -143,11 +143,19 @@ async fn run(
     let started_at = Instant::now();
 
     // Detect wardnet's own LAN IP for DHCP gateway advertisement.
-    let lan_ip = wardnetd::packet_capture_pnet::get_interface_ipv4(&config.network.lan_interface)
-        .unwrap_or_else(|e| {
-            tracing::warn!(error = %e, "failed to detect LAN IP, using 0.0.0.0");
-            std::net::Ipv4Addr::UNSPECIFIED
-        });
+    //
+    // After a cold boot, `network-online.target` is reached before the
+    // LAN interface has actually finished applying its IPv4. Single-shot
+    // detection here used to land in that gap, lock in `0.0.0.0` for the
+    // process lifetime, and poison every DHCP response. Poll until the
+    // address is up or the deadline expires.
+    let lan_ip = wardnetd::packet_capture_pnet::wait_for_interface_ipv4(
+        &config.network.lan_interface,
+        Duration::from_secs(30),
+        Duration::from_millis(500),
+    )
+    .await
+    .unwrap_or(std::net::Ipv4Addr::UNSPECIFIED);
     tracing::info!(
         lan_ip = %lan_ip,
         interface = %config.network.lan_interface,

--- a/source/daemon/crates/wardnetd/src/packet_capture_pnet.rs
+++ b/source/daemon/crates/wardnetd/src/packet_capture_pnet.rs
@@ -1,4 +1,5 @@
 use std::net::Ipv4Addr;
+use std::time::{Duration, Instant};
 
 use async_trait::async_trait;
 use pnet::datalink::{self, Channel, Config, NetworkInterface};
@@ -72,6 +73,60 @@ pub fn get_interface_ipv4(name: &str) -> anyhow::Result<std::net::Ipv4Addr> {
     }
 
     anyhow::bail!("no IPv4 address found on interface '{name}'")
+}
+
+/// Like [`get_interface_ipv4`], but polls until the interface has an IPv4
+/// address or the deadline is reached.
+///
+/// On a freshly-booted Pi, `network-online.target` (via
+/// `nm-online -s -q`) can fire before `NetworkManager` has finished
+/// applying the static IPv4 to the LAN interface. wardnetd then loses the
+/// race and would otherwise advertise `0.0.0.0` as its DHCP `siaddr`,
+/// `ServerIdentifier`, and router option for the rest of the process'
+/// lifetime — clients reject the lease or accept a useless gateway.
+pub async fn wait_for_interface_ipv4(
+    name: &str,
+    deadline: Duration,
+    interval: Duration,
+) -> Option<Ipv4Addr> {
+    let started = Instant::now();
+    let mut attempt: u32 = 0;
+    loop {
+        attempt += 1;
+        match get_interface_ipv4(name) {
+            Ok(ip) => {
+                if attempt > 1 {
+                    tracing::info!(
+                        interface = %name,
+                        attempts = attempt,
+                        elapsed_ms = u64::try_from(started.elapsed().as_millis()).unwrap_or(u64::MAX),
+                        "LAN IP became available after polling",
+                    );
+                }
+                return Some(ip);
+            }
+            Err(e) => {
+                if started.elapsed() >= deadline {
+                    tracing::warn!(
+                        error = %e,
+                        interface = %name,
+                        attempts = attempt,
+                        deadline_ms = u64::try_from(deadline.as_millis()).unwrap_or(u64::MAX),
+                        "LAN IP detection deadline expired",
+                    );
+                    return None;
+                }
+                if attempt == 1 {
+                    tracing::info!(
+                        error = %e,
+                        interface = %name,
+                        "LAN interface has no IPv4 yet, polling until ready",
+                    );
+                }
+            }
+        }
+        tokio::time::sleep(interval).await;
+    }
 }
 
 /// Format a `pnet` `MacAddr` as uppercase colon-separated "AA:BB:CC:DD:EE:FF".

--- a/source/daemon/crates/wardnetd/src/tests/packet_capture.rs
+++ b/source/daemon/crates/wardnetd/src/tests/packet_capture.rs
@@ -1,4 +1,5 @@
 use std::net::Ipv4Addr;
+use std::time::Duration;
 
 use pnet::packet::Packet;
 use pnet::packet::arp::{ArpHardwareTypes, ArpOperations, ArpPacket, MutableArpPacket};
@@ -8,6 +9,7 @@ use pnet::util::MacAddr;
 
 use crate::packet_capture_pnet::{
     build_arp_request, find_interface, format_mac, parse_frame, should_filter_mac, subnet_hosts,
+    wait_for_interface_ipv4,
 };
 use wardnetd_services::device::packet_capture::PacketSource;
 
@@ -329,5 +331,37 @@ fn find_interface_nonexistent() {
     assert!(
         err_msg.contains("not found"),
         "expected 'not found' in error: {err_msg}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// wait_for_interface_ipv4
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn wait_for_interface_ipv4_returns_immediately_when_address_present() {
+    // Loopback always has 127.0.0.1; the deadline should never be reached.
+    let result =
+        wait_for_interface_ipv4("lo", Duration::from_secs(5), Duration::from_millis(50)).await;
+    assert_eq!(result, Some(Ipv4Addr::LOCALHOST));
+}
+
+#[tokio::test]
+async fn wait_for_interface_ipv4_returns_none_after_deadline() {
+    let started = std::time::Instant::now();
+    let result = wait_for_interface_ipv4(
+        "this_interface_does_not_exist_xyz_12345",
+        Duration::from_millis(40),
+        Duration::from_millis(5),
+    )
+    .await;
+    let elapsed = started.elapsed();
+
+    assert_eq!(result, None);
+    // Confirm the loop actually polled (proves we didn't bail on the first
+    // attempt) by checking we waited at least the deadline.
+    assert!(
+        elapsed >= Duration::from_millis(40),
+        "expected to wait at least 40ms, waited {elapsed:?}"
     );
 }


### PR DESCRIPTION
## Summary

- Cold-boot race fix: replace single-shot LAN IP detection with a bounded polling loop (30s deadline, 500ms interval). Falls back to `0.0.0.0` only after the budget is exhausted, preserving existing behavior as a safety net.
- Two unit tests covering both the fast-path (loopback) and the deadline-expiry path.

## Why

After a Pi power cycle, devices on the LAN stop getting working DHCP until wardnetd is manually restarted. Root cause: `network-online.target` (satisfied here by `nm-online -s -q`) fires as soon as NetworkManager finishes its own startup — **before** eth0 has actually applied its static IPv4. wardnetd starts, calls `get_interface_ipv4("eth0")`, hits "no IPv4 address found", logs a warning, and silently falls back to `0.0.0.0`. That value becomes `DhcpServiceImpl.gateway_ip` for the daemon's lifetime and is injected into every DHCP response as `siaddr`, `ServerIdentifier`, and `Router`. Some clients reject the offer outright (no IP), others accept and end up with a useless gateway (no internet). Either way: outage until manual restart.

Daily logrotate-driven restarts and any post-boot manual restarts succeed because eth0 is already up by then — only cold boots lose the race. Today's incident, with the smoking-gun log line:

```
09:21:28.542  WARN  failed to detect LAN IP, using 0.0.0.0  error=no IPv4 address found on interface 'eth0'
09:21:28.543  INFO  detected LAN IP for DHCP gateway: lan_ip=0.0.0.0, interface=eth0
...
09:28:39.658  INFO  detected LAN IP for DHCP gateway: lan_ip=192.168.100.2, interface=eth0   ← manual restart
```

## Why not netlink-driven dynamic updates

Considered making `gateway_ip` mutable and watching netlink for address changes. Rejected: the codebase already treats LAN configuration as static-at-startup (`lan_interface` itself is loaded once from TOML with no reload path), so dynamic-IP-with-static-everything-else would be an inconsistent half-measure. Polling at startup closes the race for the actual incident class without expanding the surface area. If a runtime-renumber case ever shows up in the wild, the right move is a broader "react to LAN interface state" subsystem, not a one-off patch on DHCP.

## Test plan

- [x] `make check-daemon` (fmt, clippy `-D warnings`, full test suite — 1275+ tests pass)
- [x] New tests cover both branches:
  - `wait_for_interface_ipv4_returns_immediately_when_address_present` (loopback)
  - `wait_for_interface_ipv4_returns_none_after_deadline` (asserts the loop actually polled)
- [ ] Verify on the Pi after release: cold-boot the device with the wall power, confirm DHCP works without manual intervention.