### PR TITLE
docs(releases): add 2026.05.01 release notes

### DIFF
--- a/docs/releases/v2026.05.01.md
+++ b/docs/releases/v2026.05.01.md
@@ -1,0 +1,86 @@
+# Wardnet 2026.05.01
+
+A small bug-fix and UX-polish release on top of [`2026.05.00`](v2026.05.00.md). Auto-update will pick up the daemon binary and ship every bug fix below.
+
+> [!IMPORTANT]
+> **Action required when upgrading from `2026.05.00`.** This release introduces a new privileged post-upgrade migration framework (see [Improvements](#improvements)). The trust anchor is root-owned and **cannot be installed by auto-update** — auto-update can only refresh the signed payload it executes, never the verifier. You must run `sudo install.sh --upgrade-only` once after upgrading from `2026.05.00`. Skipping this step leaves your gateway unable to apply privileged changes from any future release, so future point releases that ship migrations (polkit rules, capability grants, network-config updates) will not be applied. The bootstrap is idempotent and only touches the post-upgrade plumbing — it does not disturb your `wardnet.toml`, the database, or the wardnet user.
+
+## Bug fixes
+
+### DHCP comes back automatically after a power cycle
+
+After a cold boot, wardnetd previously raced NetworkManager: the daemon could start before the LAN interface had finished applying its IPv4, lock in `0.0.0.0` as its DHCP server-identifier and gateway, and then poison every DHCP response for the rest of the process' lifetime — until somebody noticed and manually restarted the service. In practice that meant a power outage typically translated into "nobody on the LAN can reach the internet" until the gateway was rebooted by hand.
+
+The startup path now polls the LAN interface for up to 30 seconds (every 500 ms) before falling back, so the address is picked up correctly on cold boots without any operator intervention.
+
+### Tunnels are only "Active" after a real WireGuard handshake
+
+The tunnel status model was binary `up` / `down`, and the daemon flipped to `up` as soon as the WireGuard interface was configured — even if the upstream peer was unreachable. The dashboard could happily say "Active" while no traffic was flowing.
+
+Replaced with a four-state model:
+
+- **Down** — interface not configured.
+- **Connecting** — interface up, no handshake observed yet.
+- **Up** — handshake observed within the last 3 minutes.
+- **Reconnecting** — handshake has gone stale.
+
+The web UI surfaces the new states with their own badges and tooltips — the `Reconnecting` badge shows the age of the last handshake on hover, `Connecting` notes that it's waiting for the first handshake. `Connecting` no longer pretends to be `Up`. Closes [#79](https://github.com/wardnet/wardnet/issues/79).
+
+### MAC pre-fills when reserving DHCP from the device edit panel
+
+Opening the "Reserve DHCP address" sheet from a device's edit panel previously left the MAC field empty on the first open, even though the device's MAC was already known. The sheet now remounts when reservation defaults change, so the MAC pre-fills (and stays read-only, as intended). Closes [#94](https://github.com/wardnet/wardnet/issues/94).
+
+## Improvements
+
+### Admin UI aligned to the design system
+
+The four admin pages (Settings, Devices, Tunnels, DHCP) and the detail surfaces around them (sheets, modals, the My device page, Ad blocking) were brought into line with the design guidelines in a single pass. Notable user-visible changes:
+
+- Status pills use semantic `success` / `warning` tokens instead of brand-green; "Up to date" gets its own state slot.
+- "Restart" is correctly styled as a destructive action, and the Backup section is grouped under a danger zone.
+- Form labels and primary CTAs use sentence case throughout.
+- The destructive ConfirmDialog matches the destructive Button styling.
+- "Download backup" is now an outline/secondary action right-aligned in the body, consistent with the new footer-action-row pattern.
+
+Closes [#300](https://github.com/wardnet/wardnet/issues/300).
+
+### Foundation for privileged post-upgrade install steps
+
+Wardnet now ships a signed, root-verified post-upgrade runner alongside the daemon. Its job is to apply privileged install steps that the daemon itself can't perform (it runs as the `wardnet` user with a tight capability set) — things like installing polkit rules, granting `tcpdump` capabilities, and updating network configurations.
+
+`2026.05.01` ships the framework with an empty migration list, so this release applies no privileged changes on its own. The framework lays the groundwork for future releases to apply small privileged changes through auto-update without asking you to re-run `install.sh` for every one — but **this very transition (from `2026.05.00` to `2026.05.01`) is the one-time bootstrap that puts the runner in place**, and that step has to be done by an operator. See [Upgrading](#upgrading) below.
+
+## Upgrading
+
+### From `2026.05.00`
+
+Two steps:
+
+1. **Apply the daemon update.** Either let auto-update pick it up from **Settings → Updates** (one-click install applies the standard atomic-binary swap), or for manual installers re-run:
+
+   ```sh
+   curl -sSL https://wardnet.network/install.sh | bash
+   ```
+
+2. **Bootstrap the post-upgrade framework** — once, on the gateway host:
+
+   ```sh
+   curl -sSL https://wardnet.network/install.sh | sudo bash -s -- --upgrade-only
+   ```
+
+   `--upgrade-only` skips the LAN-interface picker, does not touch `/etc/wardnet/wardnet.toml`, and does not recreate the wardnet user — it only lays down the root-owned post-upgrade runner, the signed payload, and the systemd plumbing that wires it into `wardnetd.service`. The command is idempotent. Skip this and any future release that ships migrations (`x.YY.ZZ` with non-empty migration list) will boot with `wardnet-postupgrade.service` failing.
+
+After this release, auto-update is sufficient again — `--upgrade-only` is only needed for this `2026.05.00 → 2026.05.01` transition.
+
+### Fresh installs
+
+A first-time `install.sh` already lays down the post-upgrade framework, so there's nothing extra to do.
+
+## Targets in this release
+
+- `aarch64-unknown-linux-gnu` — Raspberry Pi (3 and newer) and other aarch64 Linux SBCs
+- `x86_64-unknown-linux-gnu` — mini-PCs, x86_64 servers, and other non-Pi Linux hosts
+
+---
+
+For setup help and troubleshooting, see the [README](https://github.com/wardnet/wardnet) and the [development guide](https://github.com/wardnet/wardnet/blob/main/docs/DEVELOPMENT.md). To report a vulnerability, use [GitHub's private reporting](https://github.com/wardnet/wardnet/security/advisories/new).


### PR DESCRIPTION
## Summary

Adds `docs/releases/v2026.05.01.md` covering everything user-facing that has landed since `2026.05.00` was tagged.

## In scope (covered)

- **Bug fixes**
  - DHCP cold-boot race fix ([#304](https://github.com/wardnet/wardnet/pull/304)).
  - Tunnel `up` status only after observed handshake — addresses the known limitation in `2026.05.00`'s release notes ([#301](https://github.com/wardnet/wardnet/pull/301), closes [#79](https://github.com/wardnet/wardnet/issues/79)).
  - DHCP reservation MAC pre-fill from device edit panel ([#286](https://github.com/wardnet/wardnet/pull/286), closes [#94](https://github.com/wardnet/wardnet/issues/94)).
- **Improvements**
  - Admin UI alignment with the design system ([#303](https://github.com/wardnet/wardnet/pull/303), closes [#300](https://github.com/wardnet/wardnet/issues/300)).
  - Privileged post-upgrade migration framework foundation ([#302](https://github.com/wardnet/wardnet/pull/302)).

## Action required when upgrading from `2026.05.00`

The notes prominently call out (top-of-file `> [!IMPORTANT]` callout + dedicated step in `## Upgrading`) that `sudo install.sh --upgrade-only` must be run **once** during the `2026.05.00 → 2026.05.01` transition. The post-upgrade runner is the root-owned trust anchor for future privileged migrations and cannot be installed by auto-update — auto-update can only refresh the signed payload it executes, never the verifier itself. Skipping the bootstrap leaves the gateway unable to apply migrations from any future release.

After this release, auto-update alone is sufficient again.

## Out of scope (intentionally excluded)

Per request, no internal-only changes are listed:

- Agent / contributor docs (e.g. web-ui design guidelines, agentic toolkit, plannotator scaffolding).
- CI plumbing (workflow / action SHA bumps, deploy-site evaluation fix, CalVer parsing in the release-manifest generator).
- Dependabot version bumps.

## Test plan

- [x] File renders correctly on GitHub (admonition syntax, code blocks, anchor links).
- [x] Cross-checked covered PRs against `git log v2026.05.00..origin/main` — every user-facing item is included; every excluded item falls under the "internal" categories above.
- [ ] Reviewer sanity-check on the upgrade instructions and post-upgrade-framework framing.