### PR TITLE
docs(releases): repoint v2026.05.00 nftables-netlink link to #307

### DIFF
--- a/docs/releases/v2026.05.00.md
+++ b/docs/releases/v2026.05.00.md
@@ -143,7 +143,7 @@ are tracked in [GitHub Issues](https://github.com/wardnet/wardnet/issues).
 - **Tunnel detail page** — click a tunnel to see live stats, current peer health, and assigned devices. ([#96](https://github.com/wardnet/wardnet/issues/96))
 - **NordVPN reliability** — re-resolve "best server" at bring-up and fix the false-`up` handshake gap. ([#79](https://github.com/wardnet/wardnet/issues/79), [#80](https://github.com/wardnet/wardnet/issues/80))
 - **DHCP UX polish** — edit hostname/IP/description on existing reservations, surface DHCP hostnames in the device list, mobile-friendly tables. ([#83](https://github.com/wardnet/wardnet/issues/83), [#84](https://github.com/wardnet/wardnet/issues/84), [#85](https://github.com/wardnet/wardnet/issues/85), [#87](https://github.com/wardnet/wardnet/issues/87), [#89](https://github.com/wardnet/wardnet/issues/89), [#94](https://github.com/wardnet/wardnet/issues/94))
-- **nftables → pure netlink** — drop the `nft` shell-out for direct netlink calls. ([#91](https://github.com/wardnet/wardnet/issues/91))
+- **nftables → pure netlink** — drop the `nft` shell-out for direct netlink calls. ([#307](https://github.com/wardnet/wardnet/issues/307))
 - **Gateway resilience** — keepalived active-passive, hardware watchdog, graceful-shutdown hooks.
 - **Mobile app** — read-only first, full control later.
 


### PR DESCRIPTION
## Summary

`#91` was closed and refiled as `#307` from the canonical account (the original was opened from a different identity that's been retired from this repo). Updates the single backlinked reference in `docs/releases/v2026.05.00.md` so the published release notes point at the active issue.

One-line edit, no code, no test impact.