### PR TITLE
feat(dhcp): option-12 hostname as primary device identity

### DIFF
--- a/source/daemon/crates/wardnet-common/src/event.rs
+++ b/source/daemon/crates/wardnet-common/src/event.rs
@@ -90,6 +90,7 @@ pub enum WardnetEvent {
         lease_id: Uuid,
         mac: String,
         ip: String,
+        hostname: Option<String>,
         new_expiry: DateTime<Utc>,
         timestamp: DateTime<Utc>,
     },

--- a/source/daemon/crates/wardnet-common/src/tests/event.rs
+++ b/source/daemon/crates/wardnet-common/src/tests/event.rs
@@ -77,6 +77,7 @@ fn dhcp_lease_renewed_tagged() {
         lease_id: Uuid::nil(),
         mac: "AA:BB:CC:DD:EE:01".to_owned(),
         ip: "192.168.1.100".to_owned(),
+        hostname: Some("myphone".to_owned()),
         new_expiry: "2026-03-09T00:00:00Z".parse().unwrap(),
         timestamp: "2026-03-08T00:00:00Z".parse().unwrap(),
     };

--- a/source/daemon/crates/wardnetd-api/src/api/tests/devices.rs
+++ b/source/daemon/crates/wardnetd-api/src/api/tests/devices.rs
@@ -207,7 +207,11 @@ impl DhcpService for MockDhcpService {
     ) -> Result<wardnet_common::dhcp::DhcpLease, AppError> {
         unimplemented!()
     }
-    async fn renew_lease(&self, _mac: &str) -> Result<wardnet_common::dhcp::DhcpLease, AppError> {
+    async fn renew_lease(
+        &self,
+        _mac: &str,
+        _hostname: Option<&str>,
+    ) -> Result<wardnet_common::dhcp::DhcpLease, AppError> {
         unimplemented!()
     }
     async fn release_lease(&self, _mac: &str) -> Result<(), AppError> {
@@ -243,7 +247,7 @@ impl DeviceDiscoveryService for MockDiscoveryService {
     async fn scan_departures(&self, _timeout_secs: u64) -> Result<Vec<Uuid>, AppError> {
         Ok(vec![])
     }
-    async fn resolve_hostname(&self, _device_id: Uuid, _ip: String) -> Result<(), AppError> {
+    async fn resolve_hostname(&self, _mac: &str, _ip: &str) -> Result<(), AppError> {
         Ok(())
     }
     async fn get_all_devices(&self) -> Result<Vec<Device>, AppError> {

--- a/source/daemon/crates/wardnetd-api/src/api/tests/dhcp.rs
+++ b/source/daemon/crates/wardnetd-api/src/api/tests/dhcp.rs
@@ -151,7 +151,11 @@ impl DhcpService for MockDhcpService {
     ) -> Result<DhcpLease, AppError> {
         unimplemented!()
     }
-    async fn renew_lease(&self, _mac: &str) -> Result<DhcpLease, AppError> {
+    async fn renew_lease(
+        &self,
+        _mac: &str,
+        _hostname: Option<&str>,
+    ) -> Result<DhcpLease, AppError> {
         unimplemented!()
     }
     async fn release_lease(&self, _mac: &str) -> Result<(), AppError> {

--- a/source/daemon/crates/wardnetd-api/src/tests/stubs.rs
+++ b/source/daemon/crates/wardnetd-api/src/tests/stubs.rs
@@ -124,7 +124,11 @@ impl DhcpService for StubDhcpService {
     ) -> Result<wardnet_common::dhcp::DhcpLease, AppError> {
         unimplemented!()
     }
-    async fn renew_lease(&self, _mac: &str) -> Result<wardnet_common::dhcp::DhcpLease, AppError> {
+    async fn renew_lease(
+        &self,
+        _mac: &str,
+        _hostname: Option<&str>,
+    ) -> Result<wardnet_common::dhcp::DhcpLease, AppError> {
         unimplemented!()
     }
     async fn release_lease(&self, _mac: &str) -> Result<(), AppError> {
@@ -243,7 +247,7 @@ impl DeviceDiscoveryService for StubDiscoveryService {
     async fn scan_departures(&self, _timeout_secs: u64) -> Result<Vec<Uuid>, AppError> {
         Ok(vec![])
     }
-    async fn resolve_hostname(&self, _device_id: Uuid, _ip: String) -> Result<(), AppError> {
+    async fn resolve_hostname(&self, _mac: &str, _ip: &str) -> Result<(), AppError> {
         Ok(())
     }
     async fn get_all_devices(&self) -> Result<Vec<Device>, AppError> {

--- a/source/daemon/crates/wardnetd-data/src/repository/dhcp.rs
+++ b/source/daemon/crates/wardnetd-data/src/repository/dhcp.rs
@@ -77,6 +77,9 @@ pub trait DhcpRepository: Send + Sync {
     /// Extend a lease by updating its `lease_end` timestamp.
     async fn renew_lease(&self, id: &str, new_end: &str) -> anyhow::Result<()>;
 
+    /// Update the option-12 hostname recorded on a lease.
+    async fn update_lease_hostname(&self, id: &str, hostname: Option<&str>) -> anyhow::Result<()>;
+
     /// Mark all active leases whose `lease_end` is in the past as expired.
     ///
     /// Returns the number of rows affected.

--- a/source/daemon/crates/wardnetd-data/src/repository/sqlite/dhcp.rs
+++ b/source/daemon/crates/wardnetd-data/src/repository/sqlite/dhcp.rs
@@ -221,6 +221,17 @@ impl DhcpRepository for SqliteDhcpRepository {
         Ok(())
     }
 
+    async fn update_lease_hostname(&self, id: &str, hostname: Option<&str>) -> anyhow::Result<()> {
+        let now = Utc::now().format("%Y-%m-%dT%H:%M:%SZ").to_string();
+        sqlx::query("UPDATE dhcp_leases SET hostname = ?, updated_at = ? WHERE id = ?")
+            .bind(hostname)
+            .bind(&now)
+            .bind(id)
+            .execute(&self.pool)
+            .await?;
+        Ok(())
+    }
+
     async fn expire_stale_leases(&self) -> anyhow::Result<u64> {
         let now = Utc::now().format("%Y-%m-%dT%H:%M:%SZ").to_string();
         let result = sqlx::query(

--- a/source/daemon/crates/wardnetd-data/src/repository/tests/dhcp.rs
+++ b/source/daemon/crates/wardnetd-data/src/repository/tests/dhcp.rs
@@ -179,6 +179,29 @@ async fn renew_lease() {
 }
 
 #[tokio::test]
+async fn update_lease_hostname_sets_value() {
+    let pool = test_pool().await;
+    let repo = SqliteDhcpRepository::new(pool);
+    let id = "00000000-0000-0000-0000-000000000001";
+
+    // Seed with no hostname so we exercise the None → Some transition.
+    let mut row = sample_lease_row(id, "aa:bb:cc:dd:ee:01", "192.168.1.100");
+    row.hostname = None;
+    repo.insert_lease(&row).await.unwrap();
+
+    repo.update_lease_hostname(id, Some("kitchen-tablet"))
+        .await
+        .unwrap();
+    let after_set = repo.find_lease_by_id(id).await.unwrap().unwrap();
+    assert_eq!(after_set.hostname.as_deref(), Some("kitchen-tablet"));
+
+    // None overwrites a previously-set hostname (e.g. an admin-driven clear).
+    repo.update_lease_hostname(id, None).await.unwrap();
+    let after_clear = repo.find_lease_by_id(id).await.unwrap().unwrap();
+    assert!(after_clear.hostname.is_none());
+}
+
+#[tokio::test]
 async fn expire_stale_leases() {
     let pool = test_pool().await;
     let repo = SqliteDhcpRepository::new(pool);

--- a/source/daemon/crates/wardnetd-services/src/device/discovery.rs
+++ b/source/daemon/crates/wardnetd-services/src/device/discovery.rs
@@ -17,6 +17,7 @@ use crate::error::AppError;
 use crate::event::EventPublisher;
 use wardnetd_data::oui;
 use wardnetd_data::repository::DeviceRepository;
+use wardnetd_data::repository::DhcpRepository;
 use wardnetd_data::repository::device::DeviceRow;
 
 /// In-memory tracking state for a device.
@@ -78,8 +79,15 @@ pub trait DeviceDiscoveryService: Send + Sync {
     /// Returns the IDs of newly departed devices.
     async fn scan_departures(&self, timeout_secs: u64) -> Result<Vec<Uuid>, AppError>;
 
-    /// Resolve hostname for a device and update the database.
-    async fn resolve_hostname(&self, device_id: Uuid, ip: String) -> Result<(), AppError>;
+    /// Resolve a hostname for a device and update the registry.
+    ///
+    /// Precedence: DHCP option-12 (active lease's `hostname`) wins when
+    /// non-empty; otherwise falls back to reverse DNS via the configured
+    /// [`HostnameResolver`]. The admin-assigned `Device.name` is a separate
+    /// column and overrides both at display time, so this method never
+    /// touches it. Tolerates a missing device (e.g. a lease event arriving
+    /// before packet capture has registered the MAC).
+    async fn resolve_hostname(&self, mac: &str, ip: &str) -> Result<(), AppError>;
 
     /// Get all devices (admin view).
     async fn get_all_devices(&self) -> Result<Vec<Device>, AppError>;
@@ -99,6 +107,7 @@ pub trait DeviceDiscoveryService: Send + Sync {
 /// Default implementation of [`DeviceDiscoveryService`].
 pub struct DeviceDiscoveryServiceImpl {
     devices: Arc<dyn DeviceRepository>,
+    dhcp: Arc<dyn DhcpRepository>,
     events: Arc<dyn EventPublisher>,
     resolver: Arc<dyn HostnameResolver>,
     /// LAN subnet — only observations from IPs within this range are processed.
@@ -112,12 +121,14 @@ impl DeviceDiscoveryServiceImpl {
     /// Create a new discovery service with the given dependencies.
     pub fn new(
         devices: Arc<dyn DeviceRepository>,
+        dhcp: Arc<dyn DhcpRepository>,
         events: Arc<dyn EventPublisher>,
         resolver: Arc<dyn HostnameResolver>,
         lan_subnet: ipnetwork::Ipv4Network,
     ) -> Self {
         Self {
             devices,
+            dhcp,
             events,
             resolver,
             lan_subnet,
@@ -426,10 +437,49 @@ impl DeviceDiscoveryService for DeviceDiscoveryServiceImpl {
         Ok(ids)
     }
 
-    async fn resolve_hostname(&self, device_id: Uuid, ip: String) -> Result<(), AppError> {
-        if let Some(hostname) = self.resolver.resolve(&ip).await {
+    async fn resolve_hostname(&self, mac: &str, ip: &str) -> Result<(), AppError> {
+        // MAC casing is currently inconsistent across the codebase: the
+        // device registry stores uppercase (set by `format_mac` in the
+        // packet-capture layer), the DHCP service stores lowercase
+        // (`mac.to_lowercase()` before insert/lookup). Until #312
+        // canonicalises this we normalise per-repo here so cross-source
+        // lookups succeed regardless of the caller's casing.
+        let mac_for_devices = mac.to_uppercase();
+        let mac_for_dhcp = mac.to_lowercase();
+
+        // The MAC may belong to a device the registry hasn't seen yet (e.g.
+        // a lease event arriving before packet capture observes the device).
+        // Treat that as a no-op rather than an error; the next observation
+        // will trigger another resolution attempt.
+        let Some(device) = self
+            .devices
+            .find_by_mac(&mac_for_devices)
+            .await
+            .map_err(AppError::Internal)?
+        else {
+            tracing::debug!(mac, "resolve_hostname: device not yet registered");
+            return Ok(());
+        };
+
+        // Prefer the client-supplied option-12 hostname when present; FR-022
+        // says it's the primary source. Fall back to reverse DNS otherwise.
+        let dhcp_hostname = self
+            .dhcp
+            .find_active_lease_by_mac(&mac_for_dhcp)
+            .await
+            .map_err(AppError::Internal)?
+            .and_then(|l| l.hostname)
+            .map(|h| h.trim().to_owned())
+            .filter(|h| !h.is_empty());
+
+        let hostname = match dhcp_hostname {
+            Some(h) => Some(h),
+            None => self.resolver.resolve(ip).await,
+        };
+
+        if let Some(hostname) = hostname {
             self.devices
-                .update_hostname(&device_id.to_string(), &hostname)
+                .update_hostname(&device.id.to_string(), &hostname)
                 .await
                 .map_err(AppError::Internal)?;
         }

--- a/source/daemon/crates/wardnetd-services/src/device/tests/discovery.rs
+++ b/source/daemon/crates/wardnetd-services/src/device/tests/discovery.rs
@@ -2,9 +2,12 @@ use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 
 use async_trait::async_trait;
+use chrono::Utc;
+use std::net::Ipv4Addr;
 use tokio::sync::broadcast;
 use uuid::Uuid;
 use wardnet_common::device::{Device, DeviceType};
+use wardnet_common::dhcp::{DhcpLease, DhcpLeaseLog, DhcpLeaseStatus, DhcpReservation};
 use wardnet_common::event::WardnetEvent;
 use wardnet_common::routing::RoutingRule;
 
@@ -19,6 +22,9 @@ use crate::error::AppError;
 use crate::event::EventPublisher;
 use wardnetd_data::repository::DeviceRepository;
 use wardnetd_data::repository::device::DeviceRow;
+use wardnetd_data::repository::{
+    DhcpLeaseLogRow, DhcpLeaseRow, DhcpRepository, DhcpReservationRow,
+};
 
 /// Helper to create an admin auth context for tests.
 fn admin_ctx() -> AuthContext {
@@ -252,6 +258,98 @@ impl EventPublisher for MockEventPublisher {
     }
 }
 
+// -- Mock DhcpRepository --------------------------------------------------
+
+/// Minimal `DhcpRepository` mock that returns a configurable hostname per MAC
+/// from the active-lease lookup. Other methods are unused by the discovery
+/// service and panic if called.
+struct MockDhcpRepository {
+    leases_by_mac: HashMap<String, Option<String>>,
+}
+
+impl MockDhcpRepository {
+    fn empty() -> Self {
+        Self {
+            leases_by_mac: HashMap::new(),
+        }
+    }
+
+    fn with_lease_hostnames(entries: Vec<(&str, Option<&str>)>) -> Self {
+        let mut leases_by_mac = HashMap::new();
+        for (mac, hostname) in entries {
+            leases_by_mac.insert(mac.to_owned(), hostname.map(ToOwned::to_owned));
+        }
+        Self { leases_by_mac }
+    }
+}
+
+#[async_trait]
+impl DhcpRepository for MockDhcpRepository {
+    async fn insert_lease(&self, _row: &DhcpLeaseRow) -> anyhow::Result<()> {
+        unreachable!("discovery service does not write leases")
+    }
+    async fn find_lease_by_id(&self, _id: &str) -> anyhow::Result<Option<DhcpLease>> {
+        unreachable!()
+    }
+    async fn find_active_lease_by_mac(&self, mac: &str) -> anyhow::Result<Option<DhcpLease>> {
+        Ok(self.leases_by_mac.get(mac).map(|hostname| DhcpLease {
+            id: Uuid::nil(),
+            mac_address: mac.to_owned(),
+            ip_address: Ipv4Addr::new(192, 168, 1, 10),
+            hostname: hostname.clone(),
+            lease_start: Utc::now(),
+            lease_end: Utc::now(),
+            status: DhcpLeaseStatus::Active,
+            device_id: None,
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+        }))
+    }
+    async fn find_active_lease_by_ip(&self, _ip: &str) -> anyhow::Result<Option<DhcpLease>> {
+        unreachable!()
+    }
+    async fn list_active_leases(&self) -> anyhow::Result<Vec<DhcpLease>> {
+        unreachable!()
+    }
+    async fn update_lease_status(&self, _id: &str, _status: &str) -> anyhow::Result<()> {
+        unreachable!()
+    }
+    async fn renew_lease(&self, _id: &str, _new_end: &str) -> anyhow::Result<()> {
+        unreachable!()
+    }
+    async fn update_lease_hostname(
+        &self,
+        _id: &str,
+        _hostname: Option<&str>,
+    ) -> anyhow::Result<()> {
+        unreachable!()
+    }
+    async fn expire_stale_leases(&self) -> anyhow::Result<u64> {
+        unreachable!()
+    }
+    async fn insert_reservation(&self, _row: &DhcpReservationRow) -> anyhow::Result<()> {
+        unreachable!()
+    }
+    async fn delete_reservation(&self, _id: &str) -> anyhow::Result<()> {
+        unreachable!()
+    }
+    async fn list_reservations(&self) -> anyhow::Result<Vec<DhcpReservation>> {
+        unreachable!()
+    }
+    async fn find_reservation_by_mac(&self, _mac: &str) -> anyhow::Result<Option<DhcpReservation>> {
+        unreachable!()
+    }
+    async fn find_reservation_by_ip(&self, _ip: &str) -> anyhow::Result<Option<DhcpReservation>> {
+        unreachable!()
+    }
+    async fn insert_lease_log(&self, _row: &DhcpLeaseLogRow) -> anyhow::Result<()> {
+        unreachable!()
+    }
+    async fn find_lease_logs(&self, _lease_id: &str) -> anyhow::Result<Vec<DhcpLeaseLog>> {
+        unreachable!()
+    }
+}
+
 // -- Helpers --------------------------------------------------------------
 
 fn sample_device(id: &str, mac: &str, ip: &str) -> Device {
@@ -289,10 +387,12 @@ fn build_harness() -> TestHarness {
 
 fn build_harness_with_devices(devices: Vec<Device>) -> TestHarness {
     let repo = Arc::new(MockDeviceRepo::with_devices(devices));
+    let dhcp = Arc::new(MockDhcpRepository::empty());
     let events = Arc::new(MockEventPublisher::new());
     let resolver = Arc::new(MockHostnameResolver::new());
     let svc = DeviceDiscoveryServiceImpl::new(
         repo.clone(),
+        dhcp,
         events.clone(),
         resolver,
         "192.168.1.0/24".parse().unwrap(),
@@ -305,11 +405,20 @@ fn build_harness_with_resolver(
     devices: Vec<Device>,
     resolver_mappings: HashMap<String, String>,
 ) -> TestHarness {
+    build_harness_with_resolver_and_dhcp(devices, resolver_mappings, MockDhcpRepository::empty())
+}
+
+fn build_harness_with_resolver_and_dhcp(
+    devices: Vec<Device>,
+    resolver_mappings: HashMap<String, String>,
+    dhcp: MockDhcpRepository,
+) -> TestHarness {
     let repo = Arc::new(MockDeviceRepo::with_devices(devices));
     let events = Arc::new(MockEventPublisher::new());
     let resolver = Arc::new(MockHostnameResolver::with_mappings(resolver_mappings));
     let svc = DeviceDiscoveryServiceImpl::new(
         repo.clone(),
+        Arc::new(dhcp),
         events.clone(),
         resolver,
         "192.168.1.0/24".parse().unwrap(),
@@ -693,7 +802,7 @@ async fn update_device_as_device_admin_locked_forbidden() {
 }
 
 #[tokio::test]
-async fn resolve_hostname_updates_db() {
+async fn resolve_hostname_falls_back_to_reverse_dns() {
     let device = sample_device(
         "00000000-0000-0000-0000-000000000001",
         "AA:BB:CC:DD:EE:01",
@@ -705,12 +814,13 @@ async fn resolve_hostname_updates_db() {
     let h = build_harness_with_resolver(vec![device], mappings);
 
     h.svc
-        .resolve_hostname(id, "192.168.1.10".to_owned())
+        .resolve_hostname("AA:BB:CC:DD:EE:01", "192.168.1.10")
         .await
         .unwrap();
 
     let updates = h.repo.hostname_updates.lock().unwrap();
     assert_eq!(updates.len(), 1);
+    assert_eq!(updates[0].0, id.to_string());
     assert_eq!(updates[0].1, "myphone.local");
 }
 
@@ -721,20 +831,147 @@ async fn resolve_hostname_no_result_does_not_update_db() {
         "AA:BB:CC:DD:EE:01",
         "192.168.1.10",
     );
-    let id = device.id;
-    // Empty resolver: no mappings, resolve returns None.
+    // Empty resolver and no DHCP lease: nothing to write.
     let h = build_harness_with_resolver(vec![device], HashMap::new());
 
     h.svc
-        .resolve_hostname(id, "192.168.1.10".to_owned())
+        .resolve_hostname("AA:BB:CC:DD:EE:01", "192.168.1.10")
         .await
         .unwrap();
 
     let updates = h.repo.hostname_updates.lock().unwrap();
     assert!(
         updates.is_empty(),
-        "no hostname update when resolver returns None"
+        "no hostname update when neither DHCP nor reverse DNS produce a value"
     );
+}
+
+#[tokio::test]
+async fn resolve_hostname_prefers_dhcp_over_reverse_dns() {
+    let device = sample_device(
+        "00000000-0000-0000-0000-000000000001",
+        "AA:BB:CC:DD:EE:01",
+        "192.168.1.10",
+    );
+    let id = device.id;
+
+    // Reverse DNS would return "generic.local", but the active lease has
+    // an option-12 hostname — that should win per FR-022.
+    let mut mappings = HashMap::new();
+    mappings.insert("192.168.1.10".to_owned(), "generic.local".to_owned());
+    // The real DHCP service writes MACs lowercase before insert, so the
+    // mock follows the same convention.
+    let dhcp = MockDhcpRepository::with_lease_hostnames(vec![(
+        "aa:bb:cc:dd:ee:01",
+        Some("living-room-tv"),
+    )]);
+    let h = build_harness_with_resolver_and_dhcp(vec![device], mappings, dhcp);
+
+    h.svc
+        .resolve_hostname("AA:BB:CC:DD:EE:01", "192.168.1.10")
+        .await
+        .unwrap();
+
+    let updates = h.repo.hostname_updates.lock().unwrap();
+    assert_eq!(updates.len(), 1);
+    assert_eq!(updates[0].0, id.to_string());
+    assert_eq!(updates[0].1, "living-room-tv");
+}
+
+#[tokio::test]
+async fn resolve_hostname_falls_back_when_dhcp_value_empty() {
+    let device = sample_device(
+        "00000000-0000-0000-0000-000000000001",
+        "AA:BB:CC:DD:EE:01",
+        "192.168.1.10",
+    );
+
+    // Empty / whitespace-only option-12 counts as absent — fall through.
+    let mut mappings = HashMap::new();
+    mappings.insert("192.168.1.10".to_owned(), "myphone.local".to_owned());
+    let dhcp = MockDhcpRepository::with_lease_hostnames(vec![("aa:bb:cc:dd:ee:01", Some("   "))]);
+    let h = build_harness_with_resolver_and_dhcp(vec![device], mappings, dhcp);
+
+    h.svc
+        .resolve_hostname("AA:BB:CC:DD:EE:01", "192.168.1.10")
+        .await
+        .unwrap();
+
+    let updates = h.repo.hostname_updates.lock().unwrap();
+    assert_eq!(updates.len(), 1);
+    assert_eq!(updates[0].1, "myphone.local");
+}
+
+#[tokio::test]
+async fn resolve_hostname_falls_back_when_no_active_lease() {
+    let device = sample_device(
+        "00000000-0000-0000-0000-000000000001",
+        "AA:BB:CC:DD:EE:01",
+        "192.168.1.10",
+    );
+
+    let mut mappings = HashMap::new();
+    mappings.insert("192.168.1.10".to_owned(), "myphone.local".to_owned());
+    // No DHCP lease for this MAC — should fall back to reverse DNS.
+    let h =
+        build_harness_with_resolver_and_dhcp(vec![device], mappings, MockDhcpRepository::empty());
+
+    h.svc
+        .resolve_hostname("AA:BB:CC:DD:EE:01", "192.168.1.10")
+        .await
+        .unwrap();
+
+    let updates = h.repo.hostname_updates.lock().unwrap();
+    assert_eq!(updates.len(), 1);
+    assert_eq!(updates[0].1, "myphone.local");
+}
+
+#[tokio::test]
+async fn resolve_hostname_no_op_when_device_not_registered() {
+    // Lease arrives before packet capture has registered the device — must
+    // not error, must not write.
+    let dhcp = MockDhcpRepository::with_lease_hostnames(vec![("aa:bb:cc:dd:ee:99", Some("ghost"))]);
+    let h = build_harness_with_resolver_and_dhcp(vec![], HashMap::new(), dhcp);
+
+    h.svc
+        .resolve_hostname("AA:BB:CC:DD:EE:99", "192.168.1.99")
+        .await
+        .unwrap();
+
+    let updates = h.repo.hostname_updates.lock().unwrap();
+    assert!(updates.is_empty());
+}
+
+#[tokio::test]
+async fn resolve_hostname_normalises_mac_case_across_sources() {
+    // Reproduces the production split: packet capture stores devices with
+    // uppercase MACs, DHCP service stores leases with lowercase. The
+    // lease-event listener calls resolve_hostname with the lowercase form.
+    // Both lookups must succeed regardless. Tracked for canonicalisation
+    // in wardnet/wardnet#312.
+    let device = sample_device(
+        "00000000-0000-0000-0000-000000000001",
+        "AA:BB:CC:DD:EE:01",
+        "192.168.1.10",
+    );
+    let id = device.id;
+
+    let dhcp = MockDhcpRepository::with_lease_hostnames(vec![(
+        "aa:bb:cc:dd:ee:01",
+        Some("kitchen-tablet"),
+    )]);
+    let h = build_harness_with_resolver_and_dhcp(vec![device], HashMap::new(), dhcp);
+
+    // Listener-driven call: lowercase MAC (matches the event payload).
+    h.svc
+        .resolve_hostname("aa:bb:cc:dd:ee:01", "192.168.1.10")
+        .await
+        .unwrap();
+
+    let updates = h.repo.hostname_updates.lock().unwrap();
+    assert_eq!(updates.len(), 1);
+    assert_eq!(updates[0].0, id.to_string());
+    assert_eq!(updates[0].1, "kitchen-tablet");
 }
 
 #[tokio::test]

--- a/source/daemon/crates/wardnetd-services/src/dhcp/service.rs
+++ b/source/daemon/crates/wardnetd-services/src/dhcp/service.rs
@@ -12,6 +12,8 @@ use wardnet_common::dhcp::{DhcpConfig, DhcpLease, DhcpLeaseStatus};
 
 use crate::auth_context;
 use crate::error::AppError;
+use crate::event::EventPublisher;
+use wardnet_common::event::WardnetEvent;
 use wardnetd_data::repository::SystemConfigRepository;
 use wardnetd_data::repository::{
     DhcpLeaseLogRow, DhcpLeaseRow, DhcpRepository, DhcpReservationRow,
@@ -68,8 +70,11 @@ pub trait DhcpService: Send + Sync {
     /// Renew/confirm a lease for a DHCP REQUEST -- used by the DHCP server runtime.
     ///
     /// Extends the existing lease if one is active, otherwise assigns a new one.
-    /// Requires admin auth context.
-    async fn renew_lease(&self, mac: &str) -> Result<DhcpLease, AppError>;
+    /// `hostname` is the option-12 value from the DHCPREQUEST packet; when
+    /// present and different from the stored value, the lease record is updated
+    /// so downstream consumers (device registry, lease list UI) reflect the
+    /// latest client-supplied identity. Requires admin auth context.
+    async fn renew_lease(&self, mac: &str, hostname: Option<&str>) -> Result<DhcpLease, AppError>;
 
     /// Release a lease for a DHCP RELEASE -- used by the DHCP server runtime.
     ///
@@ -93,6 +98,7 @@ pub trait DhcpService: Send + Sync {
 pub struct DhcpServiceImpl {
     dhcp: Arc<dyn DhcpRepository>,
     system_config: Arc<dyn SystemConfigRepository>,
+    events: Arc<dyn EventPublisher>,
     /// Wardnet's own LAN IP, auto-detected at startup.
     gateway_ip: Ipv4Addr,
 }
@@ -102,13 +108,21 @@ impl DhcpServiceImpl {
     pub fn new(
         dhcp: Arc<dyn DhcpRepository>,
         system_config: Arc<dyn SystemConfigRepository>,
+        events: Arc<dyn EventPublisher>,
         gateway_ip: Ipv4Addr,
     ) -> Self {
         Self {
             dhcp,
             system_config,
+            events,
             gateway_ip,
         }
+    }
+
+    /// Normalise an option-12 hostname: empty / whitespace-only values count
+    /// as absent (clients sometimes send empty strings to mean "no hostname").
+    fn normalised_hostname(hostname: Option<&str>) -> Option<&str> {
+        hostname.map(str::trim).filter(|h| !h.is_empty())
     }
 
     /// Load the current DHCP configuration from `system_config`.
@@ -602,6 +616,7 @@ impl DhcpService for DhcpServiceImpl {
         auth_context::require_admin()?;
         let mac = mac.to_lowercase();
         let mac = mac.as_str();
+        let hostname = Self::normalised_hostname(hostname);
 
         let config = self.load_config().await?;
 
@@ -609,8 +624,58 @@ impl DhcpService for DhcpServiceImpl {
         // configuration. An orphaned lease (reservation removed or pool
         // narrowed away from the IP) is expired inside the helper so the
         // fall-through allocates a fresh IP instead of pinning the device.
-        if let Some(existing) = self.lease_if_still_valid(mac, &config).await? {
+        if let Some(mut existing) = self.lease_if_still_valid(mac, &config).await? {
+            // Detect a real option-12 change so we only update + emit an
+            // event when something downstream consumers care about has
+            // actually moved. Plain DISCOVER retransmits with the same
+            // hostname produce no work.
+            let hostname_changed = match hostname {
+                Some(new_h) => existing.hostname.as_deref() != Some(new_h),
+                None => false,
+            };
+
+            if hostname_changed {
+                let new_h = hostname.expect("hostname_changed implies Some");
+                let old = existing.hostname.clone();
+                self.dhcp
+                    .update_lease_hostname(&existing.id.to_string(), Some(new_h))
+                    .await
+                    .map_err(AppError::Internal)?;
+                self.dhcp
+                    .insert_lease_log(&DhcpLeaseLogRow {
+                        lease_id: existing.id.to_string(),
+                        event_type: "assigned".to_owned(),
+                        details: Some(format!(
+                            "hostname updated: {} -> {new_h}",
+                            old.as_deref().unwrap_or("<none>")
+                        )),
+                    })
+                    .await
+                    .map_err(AppError::Internal)?;
+                tracing::info!(
+                    mac,
+                    lease_id = %existing.id,
+                    old = old.as_deref().unwrap_or("<none>"),
+                    new = new_h,
+                    "DHCP lease hostname updated on cached lease"
+                );
+                existing.hostname = Some(new_h.to_owned());
+            }
             tracing::debug!(mac, ip = %existing.ip_address, "reusing existing active lease");
+
+            // Only emit an event when state actually changed — quiets the
+            // listener for routine retransmits while still fanning out a
+            // genuine rename.
+            if hostname_changed {
+                self.events.publish(WardnetEvent::DhcpLeaseAssigned {
+                    lease_id: existing.id,
+                    mac: mac.to_owned(),
+                    ip: existing.ip_address.to_string(),
+                    hostname: existing.hostname.clone(),
+                    timestamp: chrono::Utc::now(),
+                });
+            }
+
             return Ok(existing);
         }
 
@@ -659,6 +724,14 @@ impl DhcpService for DhcpServiceImpl {
 
         tracing::info!(mac, %ip, lease_id = %id, "DHCP lease assigned");
 
+        self.events.publish(WardnetEvent::DhcpLeaseAssigned {
+            lease_id: id,
+            mac: mac.to_owned(),
+            ip: ip.to_string(),
+            hostname: hostname.map(ToOwned::to_owned),
+            timestamp: chrono::Utc::now(),
+        });
+
         // Return the newly created lease.
         self.dhcp
             .find_lease_by_id(&id.to_string())
@@ -667,10 +740,11 @@ impl DhcpService for DhcpServiceImpl {
             .ok_or_else(|| AppError::Internal(anyhow::anyhow!("lease not found after insert")))
     }
 
-    async fn renew_lease(&self, mac: &str) -> Result<DhcpLease, AppError> {
+    async fn renew_lease(&self, mac: &str, hostname: Option<&str>) -> Result<DhcpLease, AppError> {
         auth_context::require_admin()?;
         let mac = mac.to_lowercase();
         let mac = mac.as_str();
+        let hostname = Self::normalised_hostname(hostname);
 
         let config = self.load_config().await?;
 
@@ -681,7 +755,7 @@ impl DhcpService for DhcpServiceImpl {
         // is expired in-place and we fall through to assign_lease, which
         // closes the window where the old IP could be re-handed while the
         // original device still holds it.
-        if let Some(existing) = self.lease_if_still_valid(mac, &config).await? {
+        if let Some(mut existing) = self.lease_if_still_valid(mac, &config).await? {
             let new_end = chrono::Utc::now()
                 + chrono::Duration::seconds(i64::from(config.lease_duration_secs));
 
@@ -690,16 +764,56 @@ impl DhcpService for DhcpServiceImpl {
                 .await
                 .map_err(AppError::Internal)?;
 
+            // Refresh the stored option-12 value when the client sent a new one.
+            let hostname_changed = match hostname {
+                Some(new_h) => existing.hostname.as_deref() != Some(new_h),
+                None => false,
+            };
+            if hostname_changed {
+                let new_h = hostname.expect("hostname_changed implies Some");
+                let old = existing.hostname.clone();
+                self.dhcp
+                    .update_lease_hostname(&existing.id.to_string(), Some(new_h))
+                    .await
+                    .map_err(AppError::Internal)?;
+                tracing::info!(
+                    mac,
+                    lease_id = %existing.id,
+                    old = old.as_deref().unwrap_or("<none>"),
+                    new = new_h,
+                    "DHCP lease hostname updated during renewal"
+                );
+                existing.hostname = Some(new_h.to_owned());
+            }
+
+            // Roll the hostname change into the renewal audit row when
+            // applicable so a single log entry captures everything that
+            // happened on this REQUEST.
+            let renewal_details = if hostname_changed {
+                let new_h = hostname.expect("hostname_changed implies Some");
+                Some(format!("new expiry: {new_end}; hostname: {new_h}"))
+            } else {
+                Some(format!("new expiry: {new_end}"))
+            };
             self.dhcp
                 .insert_lease_log(&DhcpLeaseLogRow {
                     lease_id: existing.id.to_string(),
                     event_type: "renewed".to_owned(),
-                    details: Some(format!("new expiry: {new_end}")),
+                    details: renewal_details,
                 })
                 .await
                 .map_err(AppError::Internal)?;
 
             tracing::info!(mac, lease_id = %existing.id, %new_end, "DHCP lease renewed");
+
+            self.events.publish(WardnetEvent::DhcpLeaseRenewed {
+                lease_id: existing.id,
+                mac: mac.to_owned(),
+                ip: existing.ip_address.to_string(),
+                hostname: existing.hostname.clone(),
+                new_expiry: new_end,
+                timestamp: chrono::Utc::now(),
+            });
 
             self.dhcp
                 .find_lease_by_id(&existing.id.to_string())
@@ -707,9 +821,11 @@ impl DhcpService for DhcpServiceImpl {
                 .map_err(AppError::Internal)?
                 .ok_or_else(|| AppError::Internal(anyhow::anyhow!("lease not found after renew")))
         } else {
-            // No valid active lease (none, or just expired as orphan) — assign fresh.
+            // No valid active lease (none, or just expired as orphan) — assign
+            // fresh. Forward the option-12 hostname so it isn't dropped on
+            // the renew→assign fall-through.
             tracing::info!(mac, "no active lease for renewal, assigning new lease");
-            self.assign_lease(mac, None).await
+            self.assign_lease(mac, hostname).await
         }
     }
 

--- a/source/daemon/crates/wardnetd-services/src/dhcp/tests/dhcp.rs
+++ b/source/daemon/crates/wardnetd-services/src/dhcp/tests/dhcp.rs
@@ -11,8 +11,12 @@ use wardnet_common::api::{
 use wardnet_common::auth::AuthContext;
 use wardnet_common::dhcp::{DhcpLease, DhcpLeaseLog, DhcpLeaseStatus, DhcpReservation};
 
+use tokio::sync::broadcast;
+use wardnet_common::event::WardnetEvent;
+
 use crate::auth_context;
 use crate::error::AppError;
+use crate::event::EventPublisher;
 use crate::{DhcpService, DhcpServiceImpl};
 use wardnetd_data::repository::{
     DhcpLeaseLogRow, DhcpLeaseRow, DhcpRepository, DhcpReservationRow, SystemConfigRepository,
@@ -86,6 +90,14 @@ impl DhcpRepository for MockDhcpRepository {
         let mut rows = self.leases.lock().unwrap();
         if let Some(r) = rows.iter_mut().find(|r| r.id == id) {
             r.lease_end = new_end.to_owned();
+        }
+        Ok(())
+    }
+
+    async fn update_lease_hostname(&self, id: &str, hostname: Option<&str>) -> anyhow::Result<()> {
+        let mut rows = self.leases.lock().unwrap();
+        if let Some(r) = rows.iter_mut().find(|r| r.id == id) {
+            r.hostname = hostname.map(ToOwned::to_owned);
         }
         Ok(())
     }
@@ -194,6 +206,36 @@ fn row_to_reservation(r: &DhcpReservationRow) -> anyhow::Result<DhcpReservation>
     })
 }
 
+// -- Mock EventPublisher --------------------------------------------------
+
+/// Records published events for assertion in tests.
+struct MockEventPublisher {
+    events: Mutex<Vec<WardnetEvent>>,
+}
+
+impl MockEventPublisher {
+    fn new() -> Self {
+        Self {
+            events: Mutex::new(Vec::new()),
+        }
+    }
+
+    fn published(&self) -> Vec<WardnetEvent> {
+        self.events.lock().unwrap().clone()
+    }
+}
+
+impl EventPublisher for MockEventPublisher {
+    fn publish(&self, event: WardnetEvent) {
+        self.events.lock().unwrap().push(event);
+    }
+
+    fn subscribe(&self) -> broadcast::Receiver<WardnetEvent> {
+        let (_, rx) = broadcast::channel(16);
+        rx
+    }
+}
+
 // -- Mock SystemConfigRepository -------------------------------------------
 
 /// In-memory mock for `SystemConfigRepository`.
@@ -260,7 +302,8 @@ fn admin_ctx() -> AuthContext {
 fn build_service() -> DhcpServiceImpl {
     let dhcp = Arc::new(MockDhcpRepository::new());
     let system_config = Arc::new(MockSystemConfigRepository::new());
-    DhcpServiceImpl::new(dhcp, system_config, "10.0.0.1".parse().unwrap())
+    let events = Arc::new(MockEventPublisher::new());
+    DhcpServiceImpl::new(dhcp, system_config, events, "10.0.0.1".parse().unwrap())
 }
 
 // -- Tests -----------------------------------------------------------------
@@ -511,14 +554,28 @@ fn build_service_with_deps() -> (
     Arc<MockDhcpRepository>,
     Arc<MockSystemConfigRepository>,
 ) {
+    let (svc, dhcp, system_config, _events) = build_service_with_event_recorder();
+    (svc, dhcp, system_config)
+}
+
+/// Like [`build_service_with_deps`] but also returns the event recorder so
+/// tests can assert on published events.
+fn build_service_with_event_recorder() -> (
+    DhcpServiceImpl,
+    Arc<MockDhcpRepository>,
+    Arc<MockSystemConfigRepository>,
+    Arc<MockEventPublisher>,
+) {
     let dhcp = Arc::new(MockDhcpRepository::new());
     let system_config = Arc::new(MockSystemConfigRepository::new());
+    let events = Arc::new(MockEventPublisher::new());
     let svc = DhcpServiceImpl::new(
         dhcp.clone(),
         system_config.clone(),
+        events.clone(),
         "192.168.1.1".parse().unwrap(),
     );
-    (svc, dhcp, system_config)
+    (svc, dhcp, system_config, events)
 }
 
 /// Insert a pre-existing active lease into the mock repository.
@@ -620,11 +677,12 @@ async fn assign_lease_reuses_existing_active_lease() {
     .await
     .unwrap();
 
-    // Should return the existing lease, not create a new one.
+    // Should reuse the same lease ID + IP (no fresh allocation), but the
+    // option-12 value from the new request must propagate so the device
+    // registry sees the latest client-supplied identity.
     assert_eq!(lease.id.to_string(), existing_id);
     assert_eq!(lease.ip_address, Ipv4Addr::new(192, 168, 1, 150));
-    // The hostname should be from the existing lease (None), not the new request.
-    assert!(lease.hostname.is_none());
+    assert_eq!(lease.hostname.as_deref(), Some("other-host"));
 }
 
 #[tokio::test]
@@ -734,7 +792,7 @@ async fn renew_lease_extends_existing() {
 
     let existing_id = seed_active_lease(&dhcp, "aa:bb:cc:dd:ee:20", "192.168.1.105");
 
-    let lease = auth_context::with_context(admin_ctx(), svc.renew_lease("AA:BB:CC:DD:EE:20"))
+    let lease = auth_context::with_context(admin_ctx(), svc.renew_lease("AA:BB:CC:DD:EE:20", None))
         .await
         .unwrap();
 
@@ -755,7 +813,7 @@ async fn renew_lease_assigns_new_when_no_active_lease() {
     let (svc, dhcp, _cfg) = build_service_with_deps();
 
     // No existing lease for this MAC.
-    let lease = auth_context::with_context(admin_ctx(), svc.renew_lease("AA:BB:CC:DD:EE:21"))
+    let lease = auth_context::with_context(admin_ctx(), svc.renew_lease("AA:BB:CC:DD:EE:21", None))
         .await
         .unwrap();
 
@@ -789,7 +847,7 @@ async fn renew_lease_extends_expiry_into_the_future() {
         device_id: None,
     });
 
-    let lease = auth_context::with_context(admin_ctx(), svc.renew_lease("AA:BB:CC:DD:EE:22"))
+    let lease = auth_context::with_context(admin_ctx(), svc.renew_lease("AA:BB:CC:DD:EE:22", None))
         .await
         .unwrap();
 
@@ -813,7 +871,7 @@ async fn renew_lease_migrates_to_reserved_ip_when_reservation_changed() {
     let old_id = seed_active_lease(&dhcp, "aa:bb:cc:dd:ee:30", "192.168.1.105");
     seed_reservation(&dhcp, "aa:bb:cc:dd:ee:30", "192.168.1.106");
 
-    let lease = auth_context::with_context(admin_ctx(), svc.renew_lease("AA:BB:CC:DD:EE:30"))
+    let lease = auth_context::with_context(admin_ctx(), svc.renew_lease("AA:BB:CC:DD:EE:30", None))
         .await
         .unwrap();
 
@@ -854,7 +912,7 @@ async fn renew_lease_does_not_migrate_when_reservation_matches_current_ip() {
     let existing_id = seed_active_lease(&dhcp, "aa:bb:cc:dd:ee:31", "192.168.1.107");
     seed_reservation(&dhcp, "aa:bb:cc:dd:ee:31", "192.168.1.107");
 
-    let lease = auth_context::with_context(admin_ctx(), svc.renew_lease("AA:BB:CC:DD:EE:31"))
+    let lease = auth_context::with_context(admin_ctx(), svc.renew_lease("AA:BB:CC:DD:EE:31", None))
         .await
         .unwrap();
 
@@ -880,7 +938,7 @@ async fn renew_lease_migrates_orphaned_lease_when_reservation_deleted() {
     // backing it, this lease is orphaned.
     let old_id = seed_active_lease(&dhcp, "aa:bb:cc:dd:ee:32", "192.168.1.50");
 
-    let lease = auth_context::with_context(admin_ctx(), svc.renew_lease("AA:BB:CC:DD:EE:32"))
+    let lease = auth_context::with_context(admin_ctx(), svc.renew_lease("AA:BB:CC:DD:EE:32", None))
         .await
         .unwrap();
 
@@ -1164,7 +1222,8 @@ async fn load_config_missing_keys_uses_defaults() {
     let system_config = Arc::new(MockSystemConfigRepository {
         data: Mutex::new(HashMap::new()),
     });
-    let svc = DhcpServiceImpl::new(dhcp, system_config, "10.0.0.1".parse().unwrap());
+    let events = Arc::new(MockEventPublisher::new());
+    let svc = DhcpServiceImpl::new(dhcp, system_config, events, "10.0.0.1".parse().unwrap());
 
     let config = auth_context::with_context(admin_ctx(), svc.get_dhcp_config())
         .await
@@ -1292,9 +1351,10 @@ async fn full_lease_lifecycle_assign_renew_release() {
     let original_end = lease.lease_end;
 
     // 2. Renew the lease -- should extend expiry.
-    let renewed = auth_context::with_context(admin_ctx(), svc.renew_lease("AA:BB:CC:DD:EE:50"))
-        .await
-        .unwrap();
+    let renewed =
+        auth_context::with_context(admin_ctx(), svc.renew_lease("AA:BB:CC:DD:EE:50", None))
+            .await
+            .unwrap();
     assert_eq!(renewed.id, lease.id);
     assert!(renewed.lease_end >= original_end);
 
@@ -1549,4 +1609,103 @@ async fn pool_size_zero_when_end_before_start() {
         .await
         .unwrap();
     assert_eq!(resp.pool_total, 0);
+}
+
+// =========================================================================
+// Event publication
+// =========================================================================
+
+#[tokio::test]
+async fn assign_lease_publishes_event_with_hostname() {
+    let (svc, _dhcp, _system_config, events) = build_service_with_event_recorder();
+
+    auth_context::with_context(
+        admin_ctx(),
+        svc.assign_lease("aa:bb:cc:dd:ee:60", Some("living-room-tv")),
+    )
+    .await
+    .unwrap();
+
+    let published = events.published();
+    assert_eq!(published.len(), 1);
+    match &published[0] {
+        WardnetEvent::DhcpLeaseAssigned { mac, hostname, .. } => {
+            assert_eq!(mac, "aa:bb:cc:dd:ee:60");
+            assert_eq!(hostname.as_deref(), Some("living-room-tv"));
+        }
+        other => panic!("expected DhcpLeaseAssigned, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn assign_lease_publishes_event_with_none_when_no_hostname() {
+    let (svc, _dhcp, _system_config, events) = build_service_with_event_recorder();
+
+    auth_context::with_context(admin_ctx(), svc.assign_lease("aa:bb:cc:dd:ee:61", None))
+        .await
+        .unwrap();
+
+    match &events.published()[0] {
+        WardnetEvent::DhcpLeaseAssigned { hostname, .. } => assert!(hostname.is_none()),
+        other => panic!("expected DhcpLeaseAssigned, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn assign_lease_normalises_empty_hostname_to_none() {
+    let (svc, _dhcp, _system_config, events) = build_service_with_event_recorder();
+
+    // Some clients send empty / whitespace option-12 — treat as absent.
+    auth_context::with_context(
+        admin_ctx(),
+        svc.assign_lease("aa:bb:cc:dd:ee:62", Some("   ")),
+    )
+    .await
+    .unwrap();
+
+    match &events.published()[0] {
+        WardnetEvent::DhcpLeaseAssigned { hostname, .. } => assert!(hostname.is_none()),
+        other => panic!("expected DhcpLeaseAssigned, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn assign_lease_cached_lease_updates_hostname_and_emits_event() {
+    let (svc, dhcp, _system_config, events) = build_service_with_event_recorder();
+    let mac = "aa:bb:cc:dd:ee:63";
+    let _id = seed_active_lease(&dhcp, mac, "192.168.1.150");
+
+    // Same client re-DISCOVERs with a new option-12 value.
+    let lease = auth_context::with_context(admin_ctx(), svc.assign_lease(mac, Some("new-name")))
+        .await
+        .unwrap();
+
+    assert_eq!(lease.hostname.as_deref(), Some("new-name"));
+    match &events.published()[0] {
+        WardnetEvent::DhcpLeaseAssigned { hostname, .. } => {
+            assert_eq!(hostname.as_deref(), Some("new-name"));
+        }
+        other => panic!("expected DhcpLeaseAssigned, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn renew_lease_publishes_event_with_updated_hostname() {
+    let (svc, dhcp, _system_config, events) = build_service_with_event_recorder();
+    let mac = "aa:bb:cc:dd:ee:64";
+    seed_active_lease(&dhcp, mac, "192.168.1.151");
+
+    auth_context::with_context(admin_ctx(), svc.renew_lease(mac, Some("renamed")))
+        .await
+        .unwrap();
+
+    match &events.published()[0] {
+        WardnetEvent::DhcpLeaseRenewed {
+            hostname, mac: m, ..
+        } => {
+            assert_eq!(m, mac);
+            assert_eq!(hostname.as_deref(), Some("renamed"));
+        }
+        other => panic!("expected DhcpLeaseRenewed, got {other:?}"),
+    }
 }

--- a/source/daemon/crates/wardnetd-services/src/dhcp/tests/runner.rs
+++ b/source/daemon/crates/wardnetd-services/src/dhcp/tests/runner.rs
@@ -121,7 +121,11 @@ impl DhcpService for MockRunnerDhcpService {
     ) -> Result<DhcpLease, AppError> {
         unimplemented!()
     }
-    async fn renew_lease(&self, _mac: &str) -> Result<DhcpLease, AppError> {
+    async fn renew_lease(
+        &self,
+        _mac: &str,
+        _hostname: Option<&str>,
+    ) -> Result<DhcpLease, AppError> {
         unimplemented!()
     }
     async fn release_lease(&self, _mac: &str) -> Result<(), AppError> {
@@ -416,7 +420,11 @@ async fn runner_handles_config_load_failure() {
         ) -> Result<DhcpLease, AppError> {
             unimplemented!()
         }
-        async fn renew_lease(&self, _mac: &str) -> Result<DhcpLease, AppError> {
+        async fn renew_lease(
+            &self,
+            _mac: &str,
+            _hostname: Option<&str>,
+        ) -> Result<DhcpLease, AppError> {
             unimplemented!()
         }
         async fn release_lease(&self, _mac: &str) -> Result<(), AppError> {

--- a/source/daemon/crates/wardnetd-services/src/lib.rs
+++ b/source/daemon/crates/wardnetd-services/src/lib.rs
@@ -230,8 +230,9 @@ fn create_services(
     ));
 
     let dhcp_service: Arc<dyn DhcpService> = Arc::new(DhcpServiceImpl::new(
-        dhcp_repo,
+        dhcp_repo.clone(),
         system_config_repo.clone(),
+        event_publisher.clone(),
         lan_ip,
     ));
 
@@ -266,6 +267,7 @@ fn create_services(
 
     let discovery_service = build_discovery_service(
         device_repo.clone(),
+        dhcp_repo,
         event_publisher.clone(),
         backends.hostname_resolver,
         lan_ip,
@@ -319,6 +321,7 @@ fn create_services(
 /// from `lan_ip` (falls back to a `/24` on invalid inputs).
 fn build_discovery_service(
     device_repo: Arc<dyn wardnetd_data::repository::DeviceRepository>,
+    dhcp_repo: Arc<dyn wardnetd_data::repository::DhcpRepository>,
     event_publisher: Arc<dyn EventPublisher>,
     hostname_resolver: Arc<dyn device::HostnameResolver>,
     lan_ip: std::net::Ipv4Addr,
@@ -329,6 +332,7 @@ fn build_discovery_service(
     });
     Arc::new(DeviceDiscoveryServiceImpl::new(
         device_repo,
+        dhcp_repo,
         event_publisher,
         hostname_resolver,
         lan_subnet,

--- a/source/daemon/crates/wardnetd/src/device_detector.rs
+++ b/source/daemon/crates/wardnetd/src/device_detector.rs
@@ -1,23 +1,27 @@
 use std::sync::Arc;
 use std::time::Duration;
 
-use tokio::sync::mpsc;
+use tokio::sync::{broadcast, mpsc};
 use tokio::time::interval;
 use tokio_util::sync::CancellationToken;
 use tracing::Instrument;
 
 use wardnet_common::config::DetectionConfig;
+use wardnet_common::event::WardnetEvent;
 use wardnetd_services::device::packet_capture::PacketCapture;
+use wardnetd_services::event::EventPublisher;
 use wardnetd_services::{DeviceDiscoveryService, ObservationResult};
 
 /// Background device detection orchestrator.
 ///
-/// Spawns five subtasks:
+/// Spawns six subtasks:
 /// 1. Passive capture loop -- listens for ARP/IP packets, sends observations on mpsc channel
 /// 2. Observation processor -- receives from channel, calls discovery service, logs at info level
 /// 3. Batch flush loop -- every N seconds, flushes `last_seen` to DB
 /// 4. Departure scanner -- every N seconds, emits `DeviceGone` for stale devices
 /// 5. Active ARP scanner -- every N seconds, broadcasts ARP requests for all IPs in subnet
+/// 6. Hostname listener -- subscribes to DHCP lease events and re-resolves
+///    hostnames when a client supplies a new option-12 value
 pub struct DeviceDetector {
     cancel: CancellationToken,
     handles: Vec<tokio::task::JoinHandle<()>>,
@@ -35,6 +39,7 @@ impl DeviceDetector {
     pub fn start(
         capture: Arc<dyn PacketCapture>,
         discovery: Arc<dyn DeviceDiscoveryService>,
+        events: &dyn EventPublisher,
         config: &DetectionConfig,
         interface: String,
         parent: &tracing::Span,
@@ -42,6 +47,8 @@ impl DeviceDetector {
         let cancel = CancellationToken::new();
         let (tx, rx) = mpsc::channel(10_000);
         let span = tracing::info_span!(parent: parent, "device_detector");
+
+        let event_rx = events.subscribe();
 
         let capture_handle = tokio::spawn(
             capture_task(capture.clone(), interface.clone(), tx, cancel.clone())
@@ -63,7 +70,7 @@ impl DeviceDetector {
 
         let departure_handle = tokio::spawn(
             departure_task(
-                discovery,
+                discovery.clone(),
                 config.departure_timeout_secs,
                 config.departure_scan_interval_secs,
                 cancel.clone(),
@@ -78,7 +85,11 @@ impl DeviceDetector {
                 config.arp_scan_interval_secs,
                 cancel.clone(),
             )
-            .instrument(span),
+            .instrument(span.clone()),
+        );
+
+        let hostname_handle = tokio::spawn(
+            hostname_listener_task(discovery, event_rx, cancel.clone()).instrument(span),
         );
 
         Self {
@@ -89,6 +100,7 @@ impl DeviceDetector {
                 flush_handle,
                 departure_handle,
                 arp_handle,
+                hostname_handle,
             ],
         }
     }
@@ -135,12 +147,13 @@ async fn processor_task(
                         // the current span so log output includes the
                         // `device_detector` context.
                         let discovery_clone = discovery.clone();
+                        let mac = obs.mac.clone();
                         let ip = obs.ip.clone();
                         let resolve_span = tracing::Span::current();
                         tokio::spawn(
                             async move {
                                 if let Err(e) =
-                                    discovery_clone.resolve_hostname(device_id, ip).await
+                                    discovery_clone.resolve_hostname(&mac, &ip).await
                                 {
                                     tracing::warn!(
                                         device_id = %device_id,
@@ -258,6 +271,51 @@ async fn arp_scan_task(
             );
         } else {
             tracing::debug!(interface = %interface, "ARP scan sent on {interface}");
+        }
+    }
+}
+
+/// Subscribe to DHCP lease events and re-resolve hostnames whenever a client
+/// supplies a new option-12 value. Skips events with no hostname — the
+/// existing reverse-DNS-derived value is as good as it'll get without fresh
+/// option-12 input.
+async fn hostname_listener_task(
+    discovery: Arc<dyn DeviceDiscoveryService>,
+    mut event_rx: broadcast::Receiver<WardnetEvent>,
+    cancel: CancellationToken,
+) {
+    loop {
+        tokio::select! {
+            () = cancel.cancelled() => break,
+            result = event_rx.recv() => {
+                match result {
+                    Ok(
+                        WardnetEvent::DhcpLeaseAssigned { mac, ip, hostname: Some(h), .. }
+                        | WardnetEvent::DhcpLeaseRenewed { mac, ip, hostname: Some(h), .. },
+                    ) if !h.trim().is_empty() => {
+                        if let Err(e) = discovery.resolve_hostname(&mac, &ip).await {
+                            tracing::warn!(
+                                %mac,
+                                error = %e,
+                                "hostname re-resolution after DHCP lease event failed: {e}"
+                            );
+                        }
+                    }
+                    Ok(_) => {
+                        // Other events / leases without a hostname: nothing to do.
+                    }
+                    Err(broadcast::error::RecvError::Lagged(n)) => {
+                        tracing::warn!(
+                            skipped = n,
+                            "hostname listener lagged behind event bus, skipped {n} events"
+                        );
+                    }
+                    Err(broadcast::error::RecvError::Closed) => {
+                        tracing::info!("hostname listener: event bus closed");
+                        break;
+                    }
+                }
+            }
         }
     }
 }

--- a/source/daemon/crates/wardnetd/src/dhcp/server.rs
+++ b/source/daemon/crates/wardnetd/src/dhcp/server.rs
@@ -346,7 +346,10 @@ pub(crate) async fn handle_request(
     let admin_ctx = AuthContext::Admin {
         admin_id: Uuid::nil(),
     };
-    let lease = auth_context::with_context(admin_ctx, service.renew_lease(mac)).await?;
+    let hostname = extract_hostname(msg);
+    let lease =
+        auth_context::with_context(admin_ctx, service.renew_lease(mac, hostname.as_deref()))
+            .await?;
 
     tracing::info!(
         %mac,

--- a/source/daemon/crates/wardnetd/src/dhcp/tests/server.rs
+++ b/source/daemon/crates/wardnetd/src/dhcp/tests/server.rs
@@ -180,11 +180,12 @@ impl DhcpService for MockDhcpService {
         Ok(self.lease.clone())
     }
 
-    async fn renew_lease(&self, mac: &str) -> Result<DhcpLease, AppError> {
+    async fn renew_lease(&self, mac: &str, hostname: Option<&str>) -> Result<DhcpLease, AppError> {
+        let detail = hostname.map_or_else(String::new, |h| format!(":{h}"));
         self.calls
             .lock()
             .await
-            .push(("renew_lease".to_owned(), mac.to_owned()));
+            .push(("renew_lease".to_owned(), format!("{mac}{detail}")));
         Ok(self.lease.clone())
     }
 
@@ -610,7 +611,11 @@ async fn handle_discover_returns_error_when_service_fails() {
         ) -> Result<DhcpLease, AppError> {
             Err(AppError::Conflict("pool exhausted".to_owned()))
         }
-        async fn renew_lease(&self, _mac: &str) -> Result<DhcpLease, AppError> {
+        async fn renew_lease(
+            &self,
+            _mac: &str,
+            _hostname: Option<&str>,
+        ) -> Result<DhcpLease, AppError> {
             Err(AppError::NotFound("no active lease".to_owned()))
         }
         async fn release_lease(&self, _mac: &str) -> Result<(), AppError> {
@@ -682,7 +687,11 @@ async fn handle_request_returns_error_when_service_fails() {
         ) -> Result<DhcpLease, AppError> {
             unimplemented!()
         }
-        async fn renew_lease(&self, _mac: &str) -> Result<DhcpLease, AppError> {
+        async fn renew_lease(
+            &self,
+            _mac: &str,
+            _hostname: Option<&str>,
+        ) -> Result<DhcpLease, AppError> {
             Err(AppError::Internal(anyhow::anyhow!("database error")))
         }
         async fn release_lease(&self, _mac: &str) -> Result<(), AppError> {
@@ -1221,7 +1230,11 @@ async fn server_loop_handles_discover_error_gracefully() {
         ) -> Result<DhcpLease, AppError> {
             Err(AppError::Conflict("pool exhausted".to_owned()))
         }
-        async fn renew_lease(&self, _mac: &str) -> Result<DhcpLease, AppError> {
+        async fn renew_lease(
+            &self,
+            _mac: &str,
+            _hostname: Option<&str>,
+        ) -> Result<DhcpLease, AppError> {
             Err(AppError::NotFound("no lease".to_owned()))
         }
         async fn release_lease(&self, _mac: &str) -> Result<(), AppError> {
@@ -1302,7 +1315,11 @@ async fn server_loop_handles_request_error_gracefully() {
         ) -> Result<DhcpLease, AppError> {
             unimplemented!()
         }
-        async fn renew_lease(&self, _mac: &str) -> Result<DhcpLease, AppError> {
+        async fn renew_lease(
+            &self,
+            _mac: &str,
+            _hostname: Option<&str>,
+        ) -> Result<DhcpLease, AppError> {
             Err(AppError::Internal(anyhow::anyhow!("db error")))
         }
         async fn release_lease(&self, _mac: &str) -> Result<(), AppError> {

--- a/source/daemon/crates/wardnetd/src/main.rs
+++ b/source/daemon/crates/wardnetd/src/main.rs
@@ -281,6 +281,7 @@ async fn run(
         Some(DeviceDetector::start(
             packet_capture.clone(),
             services.discovery.clone(),
+            services.event_publisher.as_ref(),
             &config.detection,
             config.network.lan_interface.clone(),
             &root_span,

--- a/source/daemon/crates/wardnetd/src/tests/device_detector.rs
+++ b/source/daemon/crates/wardnetd/src/tests/device_detector.rs
@@ -6,12 +6,13 @@ use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
 use uuid::Uuid;
 use wardnet_common::device::{Device, DeviceType};
+use wardnet_common::event::WardnetEvent;
 
 use crate::device_detector::DeviceDetector;
 use wardnet_common::config::DetectionConfig;
 use wardnetd_services::device::packet_capture::{ObservedDevice, PacketCapture, PacketSource};
 use wardnetd_services::error::AppError;
-use wardnetd_services::event::BroadcastEventBus;
+use wardnetd_services::event::{BroadcastEventBus, EventPublisher};
 use wardnetd_services::{DeviceDiscoveryService, ObservationResult};
 
 // ---------------------------------------------------------------------------
@@ -486,5 +487,149 @@ async fn arp_scan_task_handles_error() {
     );
 
     // Should not crash; shutdown completes cleanly.
+    detector.shutdown().await;
+}
+
+// ---------------------------------------------------------------------------
+// Hostname listener tests
+// ---------------------------------------------------------------------------
+
+/// Build a detector that consumes from `events` so tests can publish their
+/// own DHCP lease events into the listener task.
+fn detector_with_event_bus(
+    discovery: Arc<dyn DeviceDiscoveryService>,
+    events: &BroadcastEventBus,
+) -> DeviceDetector {
+    let arp_count = Arc::new(AtomicUsize::new(0));
+    let capture: Arc<dyn PacketCapture> = Arc::new(MockCapture::new(arp_count));
+    DeviceDetector::start(
+        capture,
+        discovery,
+        events,
+        &fast_config(),
+        "eth0".to_owned(),
+        &test_span(),
+    )
+}
+
+fn assigned_with_hostname(hostname: Option<&str>) -> WardnetEvent {
+    WardnetEvent::DhcpLeaseAssigned {
+        lease_id: Uuid::nil(),
+        mac: "aa:bb:cc:dd:ee:01".to_owned(),
+        ip: "192.168.1.10".to_owned(),
+        hostname: hostname.map(ToOwned::to_owned),
+        timestamp: chrono::Utc::now(),
+    }
+}
+
+fn renewed_with_hostname(hostname: Option<&str>) -> WardnetEvent {
+    WardnetEvent::DhcpLeaseRenewed {
+        lease_id: Uuid::nil(),
+        mac: "aa:bb:cc:dd:ee:01".to_owned(),
+        ip: "192.168.1.10".to_owned(),
+        hostname: hostname.map(ToOwned::to_owned),
+        new_expiry: chrono::Utc::now(),
+        timestamp: chrono::Utc::now(),
+    }
+}
+
+/// Wait briefly for the spawned listener to consume an event before asserting,
+/// since `publish` returns immediately while the listener task is async.
+async fn drain_event_bus() {
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+}
+
+#[tokio::test]
+async fn hostname_listener_resolves_on_lease_assigned_with_hostname() {
+    let discovery = Arc::new(MockDiscovery::new(ObservationResultFactory::Seen));
+    let resolve_count = discovery.resolve_count.clone();
+    let events = test_events();
+
+    let detector = detector_with_event_bus(discovery as Arc<dyn DeviceDiscoveryService>, &events);
+
+    events.publish(assigned_with_hostname(Some("kitchen-tablet")));
+    drain_event_bus().await;
+
+    assert_eq!(
+        resolve_count.load(Ordering::SeqCst),
+        1,
+        "non-empty hostname on DhcpLeaseAssigned must trigger resolve_hostname"
+    );
+
+    detector.shutdown().await;
+}
+
+#[tokio::test]
+async fn hostname_listener_resolves_on_lease_renewed_with_hostname() {
+    let discovery = Arc::new(MockDiscovery::new(ObservationResultFactory::Seen));
+    let resolve_count = discovery.resolve_count.clone();
+    let events = test_events();
+
+    let detector = detector_with_event_bus(discovery as Arc<dyn DeviceDiscoveryService>, &events);
+
+    events.publish(renewed_with_hostname(Some("kitchen-tablet")));
+    drain_event_bus().await;
+
+    assert_eq!(resolve_count.load(Ordering::SeqCst), 1);
+
+    detector.shutdown().await;
+}
+
+#[tokio::test]
+async fn hostname_listener_skips_when_event_hostname_is_none() {
+    let discovery = Arc::new(MockDiscovery::new(ObservationResultFactory::Seen));
+    let resolve_count = discovery.resolve_count.clone();
+    let events = test_events();
+
+    let detector = detector_with_event_bus(discovery as Arc<dyn DeviceDiscoveryService>, &events);
+
+    events.publish(assigned_with_hostname(None));
+    events.publish(renewed_with_hostname(None));
+    drain_event_bus().await;
+
+    assert_eq!(
+        resolve_count.load(Ordering::SeqCst),
+        0,
+        "events without a hostname must not trigger resolve_hostname"
+    );
+
+    detector.shutdown().await;
+}
+
+#[tokio::test]
+async fn hostname_listener_skips_when_event_hostname_is_whitespace() {
+    let discovery = Arc::new(MockDiscovery::new(ObservationResultFactory::Seen));
+    let resolve_count = discovery.resolve_count.clone();
+    let events = test_events();
+
+    let detector = detector_with_event_bus(discovery as Arc<dyn DeviceDiscoveryService>, &events);
+
+    events.publish(assigned_with_hostname(Some("   ")));
+    drain_event_bus().await;
+
+    assert_eq!(resolve_count.load(Ordering::SeqCst), 0);
+
+    detector.shutdown().await;
+}
+
+#[tokio::test]
+async fn hostname_listener_ignores_unrelated_events() {
+    let discovery = Arc::new(MockDiscovery::new(ObservationResultFactory::Seen));
+    let resolve_count = discovery.resolve_count.clone();
+    let events = test_events();
+
+    let detector = detector_with_event_bus(discovery as Arc<dyn DeviceDiscoveryService>, &events);
+
+    // Random unrelated event — listener must ignore it cleanly.
+    events.publish(WardnetEvent::DeviceGone {
+        device_id: Uuid::nil(),
+        mac: "aa:bb:cc:dd:ee:01".to_owned(),
+        last_ip: "192.168.1.10".to_owned(),
+        timestamp: chrono::Utc::now(),
+    });
+    drain_event_bus().await;
+
+    assert_eq!(resolve_count.load(Ordering::SeqCst), 0);
+
     detector.shutdown().await;
 }

--- a/source/daemon/crates/wardnetd/src/tests/device_detector.rs
+++ b/source/daemon/crates/wardnetd/src/tests/device_detector.rs
@@ -11,6 +11,7 @@ use crate::device_detector::DeviceDetector;
 use wardnet_common::config::DetectionConfig;
 use wardnetd_services::device::packet_capture::{ObservedDevice, PacketCapture, PacketSource};
 use wardnetd_services::error::AppError;
+use wardnetd_services::event::BroadcastEventBus;
 use wardnetd_services::{DeviceDiscoveryService, ObservationResult};
 
 // ---------------------------------------------------------------------------
@@ -173,7 +174,7 @@ impl DeviceDiscoveryService for MockDiscovery {
         Ok(vec![])
     }
 
-    async fn resolve_hostname(&self, _device_id: Uuid, _ip: String) -> Result<(), AppError> {
+    async fn resolve_hostname(&self, _mac: &str, _ip: &str) -> Result<(), AppError> {
         self.resolve_count.fetch_add(1, Ordering::SeqCst);
         Ok(())
     }
@@ -225,6 +226,11 @@ fn test_span() -> tracing::Span {
     tracing::info_span!("test")
 }
 
+/// In-memory event bus the detector can subscribe to without external state.
+fn test_events() -> BroadcastEventBus {
+    BroadcastEventBus::new(16)
+}
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -239,6 +245,7 @@ async fn start_and_shutdown() {
     let detector = DeviceDetector::start(
         capture,
         discovery,
+        &test_events(),
         &fast_config(),
         "eth0".to_owned(),
         &test_span(),
@@ -259,6 +266,7 @@ async fn processor_handles_new_device() {
     let detector = DeviceDetector::start(
         capture,
         discovery as Arc<dyn DeviceDiscoveryService>,
+        &test_events(),
         &fast_config(),
         "eth0".to_owned(),
         &test_span(),
@@ -285,6 +293,7 @@ async fn processor_handles_ip_changed() {
     let detector = DeviceDetector::start(
         capture,
         discovery as Arc<dyn DeviceDiscoveryService>,
+        &test_events(),
         &fast_config(),
         "eth0".to_owned(),
         &test_span(),
@@ -310,6 +319,7 @@ async fn processor_handles_reappeared() {
     let detector = DeviceDetector::start(
         capture,
         discovery as Arc<dyn DeviceDiscoveryService>,
+        &test_events(),
         &fast_config(),
         "eth0".to_owned(),
         &test_span(),
@@ -335,6 +345,7 @@ async fn processor_handles_error() {
     let detector = DeviceDetector::start(
         capture,
         discovery as Arc<dyn DeviceDiscoveryService>,
+        &test_events(),
         &fast_config(),
         "eth0".to_owned(),
         &test_span(),
@@ -361,6 +372,7 @@ async fn capture_task_logs_error_on_failure() {
     let detector = DeviceDetector::start(
         capture,
         discovery,
+        &test_events(),
         &fast_config(),
         "eth0".to_owned(),
         &test_span(),
@@ -383,6 +395,7 @@ async fn flush_task_runs_and_cancels() {
     let detector = DeviceDetector::start(
         capture,
         discovery as Arc<dyn DeviceDiscoveryService>,
+        &test_events(),
         &fast_config(),
         "eth0".to_owned(),
         &test_span(),
@@ -409,6 +422,7 @@ async fn departure_task_runs_and_cancels() {
     let detector = DeviceDetector::start(
         capture,
         discovery as Arc<dyn DeviceDiscoveryService>,
+        &test_events(),
         &fast_config(),
         "eth0".to_owned(),
         &test_span(),
@@ -433,6 +447,7 @@ async fn arp_scan_task_runs_and_cancels() {
     let detector = DeviceDetector::start(
         capture,
         discovery,
+        &test_events(),
         &fast_config(),
         "eth0".to_owned(),
         &test_span(),
@@ -458,6 +473,7 @@ async fn arp_scan_task_handles_error() {
     let detector = DeviceDetector::start(
         capture,
         discovery,
+        &test_events(),
         &fast_config(),
         "eth0".to_owned(),
         &test_span(),

--- a/source/daemon/crates/wardnetd/src/tests/stubs.rs
+++ b/source/daemon/crates/wardnetd/src/tests/stubs.rs
@@ -154,7 +154,7 @@ impl DeviceDiscoveryService for StubDiscoveryService {
     async fn scan_departures(&self, _t: u64) -> Result<Vec<Uuid>, AppError> {
         unimplemented!()
     }
-    async fn resolve_hostname(&self, _id: Uuid, _ip: String) -> Result<(), AppError> {
+    async fn resolve_hostname(&self, _mac: &str, _ip: &str) -> Result<(), AppError> {
         unimplemented!()
     }
     async fn get_all_devices(&self) -> Result<Vec<Device>, AppError> {
@@ -396,7 +396,11 @@ impl DhcpService for StubDhcpService {
     ) -> Result<DhcpLease, AppError> {
         unimplemented!()
     }
-    async fn renew_lease(&self, _mac: &str) -> Result<DhcpLease, AppError> {
+    async fn renew_lease(
+        &self,
+        _mac: &str,
+        _hostname: Option<&str>,
+    ) -> Result<DhcpLease, AppError> {
         unimplemented!()
     }
     async fn release_lease(&self, _mac: &str) -> Result<(), AppError> {

--- a/source/web-ui/src/components/compound/DhcpLeaseTable.tsx
+++ b/source/web-ui/src/components/compound/DhcpLeaseTable.tsx
@@ -1,10 +1,14 @@
+import { useMemo } from "react";
 import type { ColumnDef } from "@tanstack/react-table";
+import { Clock } from "lucide-react";
 import { Button } from "@/components/core/ui/button";
 import { DataTable } from "@/components/core/ui/data-table";
+import { DeviceIcon } from "@/components/compound/DeviceIcon";
 import { DiscoveryPlaceholder } from "@/components/compound/DiscoveryPlaceholder";
+import { HostCell, buildDeviceIndex } from "@/components/compound/HostCell";
 import { StatusBadge } from "@/components/compound/StatusBadge";
-import { timeAgo } from "@/lib/utils";
-import type { DhcpLease, DhcpLeaseStatus } from "@wardnet/js";
+import { cn, timeAgo } from "@/lib/utils";
+import type { Device, DhcpLease, DhcpLeaseStatus } from "@wardnet/js";
 
 function leaseStatusTone(status: DhcpLeaseStatus): "success" | "neutral" {
   return status === "active" ? "success" : "neutral";
@@ -15,30 +19,34 @@ function leaseStatusLabel(status: DhcpLeaseStatus): string {
 }
 
 function createColumns(
+  deviceIndex: Map<string, Device>,
   onRevoke: (id: string) => void,
   onMakeStatic?: (lease: DhcpLease) => void,
 ): ColumnDef<DhcpLease>[] {
   return [
     {
+      accessorKey: "host",
+      header: "Host",
+      cell: ({ row }) => {
+        const lease = row.original;
+        const device = deviceIndex.get(lease.mac_address.toLowerCase());
+        const primary = device?.name ?? lease.hostname ?? device?.hostname ?? lease.mac_address;
+        const secondary = primary === lease.mac_address ? null : lease.mac_address;
+        // Known devices reuse the device-table icon for visual consistency;
+        // truly unknown MACs (no device record yet) fall back to a generic
+        // lease icon.
+        const icon = device ? (
+          <DeviceIcon type={device.device_type} />
+        ) : (
+          <Clock size={18} className={cn("text-muted-foreground")} />
+        );
+        return <HostCell primary={primary} secondary={secondary} icon={icon} />;
+      },
+    },
+    {
       accessorKey: "ip_address",
       header: "IP",
       cell: ({ row }) => <span className="font-mono text-xs">{row.original.ip_address}</span>,
-    },
-    {
-      accessorKey: "mac_address",
-      header: "MAC",
-      meta: { className: "hidden sm:table-cell" },
-      cell: ({ row }) => (
-        <span className="font-mono text-xs text-muted-foreground">{row.original.mac_address}</span>
-      ),
-    },
-    {
-      accessorKey: "hostname",
-      header: "Hostname",
-      meta: { className: "hidden md:table-cell" },
-      cell: ({ row }) => (
-        <span className="text-muted-foreground">{row.original.hostname ?? "\u2014"}</span>
-      ),
     },
     {
       accessorKey: "status",
@@ -84,18 +92,23 @@ function createColumns(
 
 interface DhcpLeaseTableProps {
   leases: DhcpLease[];
+  devices: Device[];
   onRevoke: (id: string) => void;
   onMakeStatic?: (lease: DhcpLease) => void;
 }
 
 /** Table listing DHCP leases with status badges, revoke, and make-static actions. */
-export function DhcpLeaseTable({ leases, onRevoke, onMakeStatic }: DhcpLeaseTableProps) {
-  const columns = createColumns(onRevoke, onMakeStatic);
+export function DhcpLeaseTable({ leases, devices, onRevoke, onMakeStatic }: DhcpLeaseTableProps) {
+  const deviceIndex = useMemo(() => buildDeviceIndex(devices), [devices]);
+  const columns = useMemo(
+    () => createColumns(deviceIndex, onRevoke, onMakeStatic),
+    [deviceIndex, onRevoke, onMakeStatic],
+  );
 
   if (leases.length === 0) {
     return (
       <DiscoveryPlaceholder
-        cols={6}
+        cols={5}
         message="Waiting for DHCP leases"
         hint="Leases will appear when devices receive addresses from the DHCP server."
       />

--- a/source/web-ui/src/components/compound/DhcpReservationTable.tsx
+++ b/source/web-ui/src/components/compound/DhcpReservationTable.tsx
@@ -1,29 +1,56 @@
+import { useMemo } from "react";
 import type { ColumnDef } from "@tanstack/react-table";
+import { Bookmark } from "lucide-react";
 import { Button } from "@/components/core/ui/button";
 import { DataTable } from "@/components/core/ui/data-table";
+import { DeviceIcon } from "@/components/compound/DeviceIcon";
 import { EmptyStatePlaceholder } from "@/components/compound/EmptyStatePlaceholder";
-import type { DhcpReservation } from "@wardnet/js";
+import { HostCell, buildDeviceIndex } from "@/components/compound/HostCell";
+import { cn } from "@/lib/utils";
+import type { Device, DhcpReservation } from "@wardnet/js";
 
-function createColumns(onDelete: (id: string) => void): ColumnDef<DhcpReservation>[] {
+function createColumns(
+  deviceIndex: Map<string, Device>,
+  onDelete: (id: string) => void,
+): ColumnDef<DhcpReservation>[] {
   return [
+    {
+      accessorKey: "host",
+      header: "Host",
+      cell: ({ row }) => {
+        const reservation = row.original;
+        const device = deviceIndex.get(reservation.mac_address.toLowerCase());
+        // Reservation hostname (admin-set, pushed to the client) is used as
+        // the primary identifier when no device record or description is
+        // available — better than falling all the way through to MAC.
+        const primary =
+          device?.name ??
+          reservation.description ??
+          reservation.hostname ??
+          device?.hostname ??
+          reservation.mac_address;
+        const secondary = primary === reservation.mac_address ? null : reservation.mac_address;
+        // Known devices reuse the device-table icon; truly unknown MACs
+        // (no device record yet) fall back to a generic reservation icon.
+        const icon = device ? (
+          <DeviceIcon type={device.device_type} />
+        ) : (
+          <Bookmark size={18} className={cn("text-muted-foreground")} />
+        );
+        return <HostCell primary={primary} secondary={secondary} icon={icon} />;
+      },
+    },
     {
       accessorKey: "ip_address",
       header: "IP",
       cell: ({ row }) => <span className="font-mono text-xs">{row.original.ip_address}</span>,
     },
     {
-      accessorKey: "mac_address",
-      header: "MAC",
-      cell: ({ row }) => (
-        <span className="font-mono text-xs text-muted-foreground">{row.original.mac_address}</span>
-      ),
-    },
-    {
       accessorKey: "description",
       header: "Description",
       meta: { className: "hidden md:table-cell" },
       cell: ({ row }) => (
-        <span className="text-muted-foreground">{row.original.description ?? "\u2014"}</span>
+        <span className="text-muted-foreground">{row.original.description ?? "—"}</span>
       ),
     },
     {
@@ -45,13 +72,20 @@ function createColumns(onDelete: (id: string) => void): ColumnDef<DhcpReservatio
 
 interface DhcpReservationTableProps {
   reservations: DhcpReservation[];
+  devices: Device[];
   onDelete: (id: string) => void;
   onAdd: () => void;
 }
 
 /** Table listing DHCP reservations with delete action and add button. */
-export function DhcpReservationTable({ reservations, onDelete, onAdd }: DhcpReservationTableProps) {
-  const columns = createColumns(onDelete);
+export function DhcpReservationTable({
+  reservations,
+  devices,
+  onDelete,
+  onAdd,
+}: DhcpReservationTableProps) {
+  const deviceIndex = useMemo(() => buildDeviceIndex(devices), [devices]);
+  const columns = useMemo(() => createColumns(deviceIndex, onDelete), [deviceIndex, onDelete]);
 
   if (reservations.length === 0) {
     return (

--- a/source/web-ui/src/components/compound/HostCell.tsx
+++ b/source/web-ui/src/components/compound/HostCell.tsx
@@ -1,0 +1,37 @@
+import type { Device } from "@wardnet/js";
+
+/**
+ * MAC-keyed lookup map for matching DHCP/lease records to known devices.
+ * Lower-cases on insert because MAC casing currently varies across the
+ * stack (see wardnet/wardnet#312).
+ */
+export function buildDeviceIndex(devices: Device[]): Map<string, Device> {
+  const map = new Map<string, Device>();
+  for (const d of devices) map.set(d.mac.toLowerCase(), d);
+  return map;
+}
+
+/**
+ * Two-line "Host" cell shared by Devices, DHCP leases, and reservations:
+ * an icon on the left, then a primary identifier with a smaller secondary
+ * line beneath. Keeps tabular layouts visually consistent.
+ */
+export function HostCell({
+  primary,
+  secondary,
+  icon,
+}: {
+  primary: string;
+  secondary: string | null;
+  icon: React.ReactNode;
+}) {
+  return (
+    <div className="flex items-center gap-3">
+      {icon}
+      <div className="flex flex-col">
+        <span className="font-medium">{primary}</span>
+        {secondary && <span className="text-xs text-muted-foreground">{secondary}</span>}
+      </div>
+    </div>
+  );
+}

--- a/source/web-ui/src/pages/Dhcp.tsx
+++ b/source/web-ui/src/pages/Dhcp.tsx
@@ -19,6 +19,7 @@ import {
   useRevokeLease,
   useDeleteReservation,
 } from "@/hooks/useDhcp";
+import { useDevices } from "@/hooks/useDevices";
 
 /** DHCP management page (admin only). */
 export default function Dhcp() {
@@ -26,6 +27,7 @@ export default function Dhcp() {
   const { data: configData } = useDhcpConfig();
   const { data: leaseData } = useDhcpLeases();
   const { data: reservationData } = useDhcpReservations();
+  const { data: deviceData } = useDevices();
 
   const toggleDhcp = useToggleDhcp();
   const revokeLease = useRevokeLease();
@@ -43,6 +45,7 @@ export default function Dhcp() {
   const config = configData?.config;
   const leases = leaseData?.leases ?? [];
   const reservations = reservationData?.reservations ?? [];
+  const devices = deviceData?.devices ?? [];
 
   const leaseToRevoke = leases.find((l) => l.id === revokeLeaseId);
   const reservationToDelete = reservations.find((r) => r.id === deleteReservationId);
@@ -78,6 +81,7 @@ export default function Dhcp() {
             <TabsContent value="leases" className="mt-4 flex min-h-0 flex-1 flex-col">
               <DhcpLeaseTable
                 leases={leases}
+                devices={devices}
                 onRevoke={setRevokeLeaseId}
                 onMakeStatic={(lease) =>
                   setReservationSheet({
@@ -94,6 +98,7 @@ export default function Dhcp() {
             <TabsContent value="reservations" className="mt-4 flex min-h-0 flex-1 flex-col">
               <DhcpReservationTable
                 reservations={reservations}
+                devices={devices}
                 onDelete={setDeleteReservationId}
                 onAdd={() => setReservationSheet({ open: true })}
               />


### PR DESCRIPTION
Closes #233. Closes #87.

## Summary

- Flip the device-registry hostname precedence from reverse-DNS-first to DHCP-option-12-first, with reverse DNS as the fallback (FR-022). Re-resolution fires whenever a lease is assigned or renewed with a new option-12 value, so client renames propagate without waiting for the next packet observation.
- New "Host" column on the DHCP **Leases** and **Reservations** tables: device-type icon for known MACs, generic `Clock`/`Bookmark` icon for unknown ones, hostname-over-MAC layout (mirrors the Devices grid).
- The latent `DhcpLeaseAssigned` / `DhcpLeaseRenewed` events in `WardnetEvent` are now actually published — the listener wiring is the fan-out point that drives re-resolution.

## Notable decisions (post-challenge, all explicit in #233's plan comment)

| Decision | Choice |
|---|---|
| Where does precedence live? | `DeviceDiscoveryServiceImpl` (`HostnameResolver` trait stays narrow) |
| Re-resolution trigger | Event-driven; new task in `DeviceDetector` |
| Cached-lease event noise | Suppressed unless the option-12 value actually changed |
| Empty/whitespace option-12 | Treated as absent (falls back to reverse DNS) |
| MAC casing | Normalised per-repo inside `resolve_hostname`; full canonicalisation tracked in #312 |
| Admin-assigned `Device.name` | Untouched at storage; precedence already handled at display time |

## Files of interest

- `wardnetd-services/src/device/discovery.rs` — `resolve_hostname(mac, ip)` with DHCP-first / reverse-DNS-fallback precedence and per-repo MAC normalisation.
- `wardnetd-services/src/dhcp/service.rs` — `renew_lease(mac, hostname)`, event publication on assign/renew, hostname propagation through the cached-lease and renew→assign fall-throughs.
- `wardnetd/src/device_detector.rs` — new `hostname_listener_task` driving re-resolution from lease events.
- `web-ui/src/components/compound/{HostCell.tsx,DhcpLeaseTable.tsx,DhcpReservationTable.tsx}` — shared Host cell + device-type-icon integration on both DHCP tables.

## Follow-up

- #312 — canonicalise MAC casing across the codebase so we can drop the per-repo normalisation added here.

## Test plan

- [x] `make check-daemon-container` (`cargo fmt --check`, `clippy --all-targets -- -D warnings`, `cargo test --workspace`) — green; 626 wardnetd-services tests, 180 wardnetd-mock, 170 wardnetd-api, 139 wardnetd-data, …
- [x] `yarn tsc --noEmit` and `yarn lint` on web-ui — 0 errors (pre-existing warnings unchanged aside from one matching the same pattern as `button.tsx` / `tabs.tsx`).
- [x] New unit tests cover: DHCP wins over reverse DNS; empty/whitespace option-12 falls back; no active lease falls back; race-tolerant when device not yet registered; MAC case mismatch path; event published on assign/renew with hostname; **no event** on cached-path retransmit when hostname unchanged.
- [ ] Manual smoke via `make run-dev`: assign a lease with hostname `living-room-tv` for an observed MAC, confirm Devices page shows that hostname; rename via re-DISCOVER, confirm device row updates; revoke lease, confirm hostname is preserved (no null-out).
- [ ] Manual UI check on `/dhcp`: known-device leases/reservations show the device's icon; unknown ones show the generic icon; first column reads as host-over-mac.

🤖 Generated with [Claude Code](https://claude.com/claude-code)