### PR TITLE
fix(daemon): reconcile tunnel iface presence in run_health_check

### DIFF
--- a/source/daemon/crates/wardnetd-services/src/tunnel/service.rs
+++ b/source/daemon/crates/wardnetd-services/src/tunnel/service.rs
@@ -276,6 +276,97 @@ impl TunnelServiceImpl {
         Ok(())
     }
 
+    /// Reconcile DB tunnel status against kernel reality. After a daemon
+    /// restart or external `modprobe -r wireguard` / `ip link delete`, the
+    /// DB can claim a tunnel is `Up`/`Connecting`/`Reconnecting` while the
+    /// kernel has no iface — every subsequent decision based on
+    /// `tunnel.status` is then wrong. Flip iface-missing tunnels to `Down`
+    /// here so the existing routing-path bring-up and `bring_up_core`'s
+    /// `Down` guard both work as designed.
+    ///
+    /// Returns the subset of tunnels whose iface is still present, ready
+    /// for the rest of the health-check pass.
+    async fn reconcile_iface_presence(
+        &self,
+        all_tunnels: Vec<Tunnel>,
+        now: chrono::DateTime<chrono::Utc>,
+    ) -> Result<Vec<Tunnel>, AppError> {
+        let live_ifaces: std::collections::HashSet<String> = self
+            .tunnel_interface
+            .list()
+            .await
+            .map_err(AppError::Internal)?
+            .into_iter()
+            .collect();
+
+        let mut surviving = Vec::new();
+        for tunnel in all_tunnels {
+            if tunnel.status == TunnelStatus::Down {
+                continue;
+            }
+            if live_ifaces.contains(&tunnel.interface_name) {
+                surviving.push(tunnel);
+                continue;
+            }
+            if let Err(e) = self
+                .tunnels
+                .update_status(&tunnel.id.to_string(), "down")
+                .await
+            {
+                tracing::error!(
+                    tunnel_id = %tunnel.id,
+                    error = %e,
+                    "health check: failed to mark iface-missing tunnel down for {}: {e}",
+                    tunnel.interface_name
+                );
+                continue;
+            }
+            tracing::warn!(
+                tunnel_id = %tunnel.id,
+                interface = %tunnel.interface_name,
+                previous_status = ?tunnel.status,
+                "health check: kernel interface is gone, marking tunnel down"
+            );
+            self.events.publish(WardnetEvent::TunnelDown {
+                tunnel_id: tunnel.id,
+                interface_name: tunnel.interface_name,
+                reason: "interface absent".to_owned(),
+                timestamp: now,
+            });
+        }
+        Ok(surviving)
+    }
+
+    /// Tear down + bring up each stuck tunnel sequentially. Errors are
+    /// logged and swallowed — one failure should not stop recovery for
+    /// the others.
+    async fn recreate_stuck_tunnels(&self, ids: Vec<Uuid>) {
+        for id in ids {
+            tracing::warn!(
+                tunnel_id = %id,
+                "health check: tunnel stuck in reconnecting, recreating"
+            );
+            if let Err(e) = self
+                .tear_down_core(id, "stuck in reconnecting, recreating")
+                .await
+            {
+                tracing::error!(
+                    tunnel_id = %id,
+                    error = %e,
+                    "health check: failed to tear down stuck tunnel: {e}"
+                );
+                continue;
+            }
+            if let Err(e) = self.bring_up_core(id).await {
+                tracing::error!(
+                    tunnel_id = %id,
+                    error = %e,
+                    "health check: failed to bring stuck tunnel back up: {e}"
+                );
+            }
+        }
+    }
+
     /// Core logic for tearing down a tunnel (no auth check).
     async fn tear_down_core(&self, id: Uuid, reason: &str) -> Result<(), AppError> {
         let tunnel = self.require_tunnel(id).await?;
@@ -561,14 +652,19 @@ impl TunnelService for TunnelServiceImpl {
 
     async fn run_health_check(&self) -> Result<(), AppError> {
         let stale_threshold = chrono::Duration::minutes(3);
+        // After this much time without a handshake while in `Reconnecting`,
+        // the iface is present but the peer hasn't replied — recreate to
+        // force fresh DNS resolution and a clean iface state. 5x the stale
+        // threshold gives the peer plenty of room to come back on its own.
+        let stuck_recovery_threshold = chrono::Duration::minutes(15);
         let now = chrono::Utc::now();
         let all_tunnels = self.tunnels.find_all().await.map_err(AppError::Internal)?;
-        // Health judgement applies to every tunnel whose iface is up.
-        // `collect_stats` has just refreshed `last_handshake` for these.
-        let active_tunnels: Vec<_> = all_tunnels
-            .into_iter()
-            .filter(|t| t.status != wardnet_common::tunnel::TunnelStatus::Down)
-            .collect();
+        let active_tunnels = self.reconcile_iface_presence(all_tunnels, now).await?;
+
+        // IDs of tunnels that are stuck in `Reconnecting` and need an active
+        // recreate after the per-tunnel match below has had its chance to
+        // flip them back to `Up`.
+        let mut to_recreate: Vec<Uuid> = Vec::new();
 
         for tunnel in active_tunnels {
             // A handshake is "fresh" if we have one and it's within the
@@ -639,11 +735,24 @@ impl TunnelService for TunnelServiceImpl {
                         timestamp: now,
                     });
                 }
-                // No-op: Up + fresh, Connecting + still no handshake,
-                // Reconnecting + still no handshake.
+                // Reconnecting and the peer still hasn't replied. If we've
+                // been stuck this long, the iface itself may be wedged or
+                // the peer DNS may have rotated — schedule a recreate.
+                (wardnet_common::tunnel::TunnelStatus::Reconnecting, false) => {
+                    let stuck = tunnel
+                        .last_handshake
+                        .is_none_or(|ts| (now - ts) > stuck_recovery_threshold);
+                    if stuck {
+                        to_recreate.push(tunnel.id);
+                    }
+                }
+                // No-op: Up + fresh, Connecting + still no handshake.
                 _ => {}
             }
         }
+
+        self.recreate_stuck_tunnels(to_recreate).await;
+
         Ok(())
     }
 }

--- a/source/daemon/crates/wardnetd-services/src/tunnel/tests/tunnel.rs
+++ b/source/daemon/crates/wardnetd-services/src/tunnel/tests/tunnel.rs
@@ -247,6 +247,9 @@ struct MockTunnelInterface {
     brought_up: Mutex<Vec<String>>,
     torn_down: Mutex<Vec<String>>,
     removed: Mutex<Vec<String>>,
+    /// Names of interfaces currently considered present in the kernel.
+    /// `create` adds, `remove` deletes — drives `list()`.
+    live: Mutex<std::collections::HashSet<String>>,
     stats_behavior: Mutex<StatsBehavior>,
 }
 
@@ -257,6 +260,7 @@ impl MockTunnelInterface {
             brought_up: Mutex::new(Vec::new()),
             torn_down: Mutex::new(Vec::new()),
             removed: Mutex::new(Vec::new()),
+            live: Mutex::new(std::collections::HashSet::new()),
             stats_behavior: Mutex::new(StatsBehavior::None),
         }
     }
@@ -268,11 +272,22 @@ impl MockTunnelInterface {
     fn set_stats_error(&self) {
         *self.stats_behavior.lock().unwrap() = StatsBehavior::Err;
     }
+
+    /// Simulate an external event that drops the kernel iface (kernel
+    /// reboot, `modprobe -r wireguard`, `ip link delete`) without going
+    /// through the service's tear-down path.
+    fn drop_iface(&self, name: &str) {
+        self.live.lock().unwrap().remove(name);
+    }
 }
 
 #[async_trait]
 impl TunnelInterface for MockTunnelInterface {
     async fn create(&self, params: CreateTunnelParams) -> anyhow::Result<()> {
+        self.live
+            .lock()
+            .unwrap()
+            .insert(params.interface_name.clone());
         self.created.lock().unwrap().push(params.interface_name);
         Ok(())
     }
@@ -294,6 +309,7 @@ impl TunnelInterface for MockTunnelInterface {
     }
 
     async fn remove(&self, interface_name: &str) -> anyhow::Result<()> {
+        self.live.lock().unwrap().remove(interface_name);
         self.removed.lock().unwrap().push(interface_name.to_owned());
         Ok(())
     }
@@ -307,7 +323,7 @@ impl TunnelInterface for MockTunnelInterface {
     }
 
     async fn list(&self) -> anyhow::Result<Vec<String>> {
-        Ok(Vec::new())
+        Ok(self.live.lock().unwrap().iter().cloned().collect())
     }
 }
 
@@ -1412,6 +1428,192 @@ async fn run_health_check_no_active_tunnels_is_noop() {
     let h = build_harness();
     // No tunnels brought up; run_health_check iterates over an empty list.
     h.svc.run_health_check().await.unwrap();
+}
+
+#[tokio::test]
+async fn run_health_check_iface_missing_flips_up_to_down() {
+    // Issue #311: after a daemon restart or `modprobe -r wireguard`, the DB
+    // still says `Up` while the kernel iface is gone. Health check must
+    // reconcile and flip to `Down` so on-demand bring-up can pick it back up.
+    let h = build_harness();
+    let resp = auth_context::with_context(admin_ctx(), h.svc.import_tunnel(sample_request()))
+        .await
+        .unwrap();
+    let id = resp.tunnel.id;
+
+    let fresh = chrono::Utc::now() - chrono::Duration::seconds(10);
+    bring_up_then_observe_handshake(&h, id, Some(fresh)).await;
+    h.svc.run_health_check().await.unwrap();
+    assert_eq!(
+        auth_context::with_context(admin_ctx(), h.svc.get_tunnel(id))
+            .await
+            .unwrap()
+            .status,
+        TunnelStatus::Up,
+    );
+
+    // Simulate an external event that drops the kernel iface without
+    // touching DB state — daemon restart, kernel module unload, etc.
+    h.tunnel_iface.drop_iface("wg_ward0");
+    h.events.events.lock().unwrap().clear();
+
+    h.svc.run_health_check().await.unwrap();
+
+    let tunnel = auth_context::with_context(admin_ctx(), h.svc.get_tunnel(id))
+        .await
+        .unwrap();
+    assert_eq!(tunnel.status, TunnelStatus::Down);
+
+    let events = h.events.published_events();
+    assert!(
+        events.iter().any(|e| matches!(
+            e,
+            WardnetEvent::TunnelDown { tunnel_id, reason, .. }
+                if *tunnel_id == id && reason == "interface absent"
+        )),
+        "expected TunnelDown event with 'interface absent' reason",
+    );
+}
+
+#[tokio::test]
+async fn run_health_check_iface_missing_flips_reconnecting_to_down() {
+    // Same scenario as the daemon-restart case but where status is already
+    // `Reconnecting` when the iface vanishes — the case in the original
+    // bug report.
+    let h = build_harness();
+    let resp = auth_context::with_context(admin_ctx(), h.svc.import_tunnel(sample_request()))
+        .await
+        .unwrap();
+    let id = resp.tunnel.id;
+
+    bring_up_then_observe_handshake(&h, id, None).await;
+    h.tunnels
+        .update_status(&id.to_string(), "reconnecting")
+        .await
+        .unwrap();
+
+    h.tunnel_iface.drop_iface("wg_ward0");
+    h.events.events.lock().unwrap().clear();
+
+    h.svc.run_health_check().await.unwrap();
+
+    assert_eq!(
+        auth_context::with_context(admin_ctx(), h.svc.get_tunnel(id))
+            .await
+            .unwrap()
+            .status,
+        TunnelStatus::Down,
+    );
+}
+
+#[tokio::test]
+async fn run_health_check_stuck_reconnecting_triggers_recreate() {
+    // When the iface is present but the peer hasn't replied for far longer
+    // than the stale threshold, the tunnel may be wedged or the peer DNS
+    // may have rotated. Health check must tear down + bring up to reset.
+    let h = build_harness();
+    let resp = auth_context::with_context(admin_ctx(), h.svc.import_tunnel(sample_request()))
+        .await
+        .unwrap();
+    let id = resp.tunnel.id;
+
+    bring_up_then_observe_handshake(&h, id, None).await;
+    h.tunnels
+        .update_status(&id.to_string(), "reconnecting")
+        .await
+        .unwrap();
+
+    // Persist a last_handshake well past the recovery threshold (15 min).
+    let very_stale = chrono::Utc::now() - chrono::Duration::minutes(30);
+    h.tunnels
+        .update_stats(&id.to_string(), 0, 0, Some(&very_stale.to_rfc3339()))
+        .await
+        .unwrap();
+    h.tunnel_iface.torn_down.lock().unwrap().clear();
+    h.tunnel_iface.removed.lock().unwrap().clear();
+    h.tunnel_iface.created.lock().unwrap().clear();
+    h.tunnel_iface.brought_up.lock().unwrap().clear();
+    h.events.events.lock().unwrap().clear();
+
+    h.svc.run_health_check().await.unwrap();
+
+    // Recreate path must have run: tear-down + remove + create + bring-up.
+    assert_eq!(
+        h.tunnel_iface.torn_down.lock().unwrap().len(),
+        1,
+        "expected exactly one tear_down call"
+    );
+    assert_eq!(
+        h.tunnel_iface.removed.lock().unwrap().len(),
+        1,
+        "expected exactly one remove call"
+    );
+    assert_eq!(
+        h.tunnel_iface.created.lock().unwrap().len(),
+        1,
+        "expected exactly one create call"
+    );
+    assert_eq!(
+        h.tunnel_iface.brought_up.lock().unwrap().len(),
+        1,
+        "expected exactly one bring_up call"
+    );
+
+    // Domain events must be published so subscribers (routing engine, web
+    // UI) react to the recreate.
+    let events = h.events.published_events();
+    assert!(
+        events.iter().any(|e| matches!(
+            e,
+            WardnetEvent::TunnelDown { tunnel_id, reason, .. }
+                if *tunnel_id == id && reason == "stuck in reconnecting, recreating"
+        )),
+        "expected TunnelDown event with stuck-reconnecting reason",
+    );
+    assert!(
+        events.iter().any(|e| matches!(
+            e,
+            WardnetEvent::TunnelConnecting { tunnel_id, .. } if *tunnel_id == id
+        )),
+        "expected TunnelConnecting event after recreate",
+    );
+}
+
+#[tokio::test]
+async fn run_health_check_reconnecting_within_threshold_no_recreate() {
+    // Reconnecting with a stale-but-recent handshake should NOT trigger a
+    // recreate yet — give the peer time to come back on its own.
+    let h = build_harness();
+    let resp = auth_context::with_context(admin_ctx(), h.svc.import_tunnel(sample_request()))
+        .await
+        .unwrap();
+    let id = resp.tunnel.id;
+
+    bring_up_then_observe_handshake(&h, id, None).await;
+    h.tunnels
+        .update_status(&id.to_string(), "reconnecting")
+        .await
+        .unwrap();
+
+    // 5 min old: past stale (3 min) but well below recovery (15 min).
+    let stale_recent = chrono::Utc::now() - chrono::Duration::minutes(5);
+    h.tunnels
+        .update_stats(&id.to_string(), 0, 0, Some(&stale_recent.to_rfc3339()))
+        .await
+        .unwrap();
+    h.tunnel_iface.torn_down.lock().unwrap().clear();
+    h.tunnel_iface.removed.lock().unwrap().clear();
+
+    h.svc.run_health_check().await.unwrap();
+
+    assert!(
+        h.tunnel_iface.torn_down.lock().unwrap().is_empty(),
+        "tear_down must not be called for a tunnel still within the recovery threshold"
+    );
+    assert!(
+        h.tunnel_iface.removed.lock().unwrap().is_empty(),
+        "remove must not be called for a tunnel still within the recovery threshold"
+    );
 }
 
 const SAMPLE_CONF_WITH_PRESHARED: &str = "\


### PR DESCRIPTION
Closes #311.

## Summary

- After a daemon restart or any event that drops a `wg_*` interface, tunnels stayed stuck in `Reconnecting` forever and routed devices silently fell through to direct. The new state machine from #301 reported the symptom but never acted on it.
- `run_health_check` now reconciles DB tunnel status against kernel reality: any non-`Down` tunnel whose iface is missing gets flipped to `Down` (with a `TunnelDown { reason: "interface absent" }` event), so the existing routing-path bring-up and `bring_up_core`'s `Down` guard both work as designed — no changes needed in `routing/service.rs`.
- Tunnels stuck in `Reconnecting` past 15 min (5× the stale threshold) are now actively torn-down + brought-up, so recovery no longer depends on routed-device traffic and DNS gets re-resolved for peer hostnames that may have rotated.

## Why this shape

The minimum-diff fix described in the issue (relax the `Down` guard at `routing/service.rs:559`) wouldn't have worked alone — `bring_up_core` *also* early-returns on `status != Down`, so the on-demand bring-up would have silently no-op'd for `Reconnecting`. Instead, this restores the "Down = no kernel iface" invariant upstream in `run_health_check`, which keeps the existing guards correct and adds a kernel-driven recovery path independent of routed traffic.

## Test plan

- [x] `make check-daemon` (fmt, clippy, 620 tests) passes
- [x] New test: daemon-restart-with-missing-iface flips `Up → Down` + emits `TunnelDown { reason: "interface absent" }`
- [x] New test: same flow flips `Reconnecting → Down`
- [x] New test: stuck-Reconnecting (>15 min) triggers tear-down + remove + create + bring-up, plus the matching domain events
- [x] New test: Reconnecting within threshold (5 min) does NOT trigger recreate

🤖 Generated with [Claude Code](https://claude.com/claude-code)