### PR TITLE
fix(ci): pin WARDNET_VERSION on tag pushes so releases aren't `-dirty`

### DIFF
--- a/.github/workflows/build-daemon.yml
+++ b/.github/workflows/build-daemon.yml
@@ -174,6 +174,26 @@ jobs:
         if: matrix.cross_apt_packages != ''
         run: sudo apt-get update && sudo apt-get install -y ${{ matrix.cross_apt_packages }}
 
+      - name: Pin WARDNET_VERSION for tagged release builds
+        # `build-web` (run upstream) overwrites the tracked
+        # source/web-ui/dist/index.html placeholder with Vite's hashed
+        # output. That dirties the worktree, so the `wardnetd-services`
+        # / `wardnetd` build scripts' `git describe --tags --dirty` ends
+        # up emitting `<calver>-dirty` for an otherwise-clean tag commit
+        # — which is what users see as "Current version" in the Updates
+        # card. Bypass git describe entirely on tag pushes by setting
+        # the documented WARDNET_VERSION_OVERRIDE escape hatch to the
+        # tag (sans `v`). For PR / push-to-main runs the override stays
+        # empty so binaries keep the `-dev.N+gHASH` commit identifier.
+        if: startsWith(github.ref, 'refs/tags/v')
+        env:
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          VERSION="${REF_NAME#v}"
+          echo "WARDNET_VERSION_OVERRIDE=${VERSION}" >> "${GITHUB_ENV}"
+          echo "Pinned WARDNET_VERSION_OVERRIDE=${VERSION}"
+
       - name: Build wardnetd
         env:
           TARGET: ${{ matrix.target }}


### PR DESCRIPTION
## Summary
- Closes #310. Tag-driven release builds were producing binaries that report their version as `<calver>-dirty` (visible as `Current version: 2026.05.01-dirty` in Settings → Updates).
- Root cause: the upstream `build-web` step in `build-daemon.yml` runs `yarn build`, which overwrites the tracked `source/web-ui/dist/index.html` placeholder. By the time the daemon's `build.rs` runs `git describe --tags --always --dirty`, the worktree is dirty, so the resolved `WARDNET_VERSION` carries `-dirty` even on a clean tag commit.
- Fix: on tag pushes, export the documented `WARDNET_VERSION_OVERRIDE` escape hatch with the tag (sans `v`) before any `cargo build` runs. The override is wired through both `wardnetd-services/build.rs` and `wardnetd/build.rs` already, so no Rust changes were needed. PR / push-to-main runs keep the `-dev.N+gHASH` suffix for diagnostics.
- Note: the issue claimed `release_version` in `/api/info` is also affected, but that field reads from `CALVER` directly and is unaffected. The visible bug is on `current_version` (sourced from `WARDNET_VERSION`).

## Test plan
- [ ] CI on this PR passes (non-tag run → override stays empty → `-dev.N+gHASH` version preserved).
- [ ] Cut the next `vYYYY.MM.DD` tag and verify `/api/info` `version` is the bare CalVer (no `-dirty`) and Settings → Updates shows `Current version: <calver>` matching `Latest`.
- [ ] Confirm `docs/openapi.json` doesn't drift (uses `RELEASE_VERSION` which was already correct).

🤖 Generated with [Claude Code](https://claude.com/claude-code)