### PR TITLE
fix(update): runner-mediated swap of /usr/local/bin/wardnetd

### DIFF
--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -294,12 +294,14 @@ if ! id wardnet &>/dev/null; then
     useradd --system --no-create-home --shell /usr/sbin/nologin wardnet
 fi
 
-# 2. Directory structure. `/var/lib/wardnet/updates` must share a filesystem
-#    with `/usr/local/bin/wardnetd` so the auto-update rename is atomic;
-#    `/var/lib` qualifies on a typical Debian/Ubuntu install. The secret
-#    store lives under `/var/lib/wardnet/secrets` (not `/etc`) because it
-#    holds runtime state — generated WireGuard keys, backup passphrases,
-#    destination credentials — not static operator configuration.
+# 2. Directory structure. `/var/lib/wardnet/updates` is wardnet-writable
+#    (the daemon stages the next release tarball here for the runner to
+#    pick up) and must share a filesystem with `/usr/local/bin/wardnetd`
+#    so the runner's final rename is atomic. `/var/lib` qualifies on a
+#    typical Debian/Ubuntu install. The secret store lives under
+#    `/var/lib/wardnet/secrets` (not `/etc`) because it holds runtime
+#    state — generated WireGuard keys, backup passphrases, destination
+#    credentials — not static operator configuration.
 install -d -o wardnet -g wardnet -m 750 /etc/wardnet
 install -d -o wardnet -g wardnet -m 750 /var/lib/wardnet
 install -d -o wardnet -g wardnet -m 700 /var/lib/wardnet/secrets
@@ -331,8 +333,11 @@ EOF
     chmod 640 /etc/wardnet/wardnet.toml
 fi
 
-# 4. Binary. Daemon-owned + 0755 so the auto-update runner can atomically
-#    rename a staged binary into place without setuid or a root helper.
+# 4. Binary. Owned by wardnet so the daemon process can read+exec it,
+#    but the parent /usr/local/bin/ stays root-owned. The atomic swap
+#    on auto-update is performed by `wardnet-postupgrade-runner` (root)
+#    not the daemon — see step 5 and source/daemon/crates/wardnet-
+#    postupgrade-runner/src/swap.rs for the trust anchor.
 install -o wardnet -g wardnet -m 0755 "$WORKDIR/wardnetd" /usr/local/bin/wardnetd
 
 # 5. Privileged post-upgrade migration framework. The runner is the trust

--- a/deploy/wardnetd.service
+++ b/deploy/wardnetd.service
@@ -41,10 +41,11 @@ RuntimeDirectoryMode=0755
 NoNewPrivileges=yes
 ProtectSystem=strict
 ProtectHome=yes
-# `/usr/local/bin` is writable so the auto-update runner can atomically
-# rename the staged binary into place. The daemon user owns the binary
-# (install.sh chowns it) so no root-only step is needed.
-ReadWritePaths=/var/lib/wardnet /var/log/wardnet /usr/local/bin
+# Auto-update stages the new tarball into /var/lib/wardnet/updates/;
+# the privileged `wardnet-postupgrade.service` performs the actual
+# /usr/local/bin/wardnetd swap on next start under root, so the
+# wardnet user no longer needs write access to /usr/local/bin.
+ReadWritePaths=/var/lib/wardnet /var/log/wardnet
 PrivateTmp=yes
 
 # Logging to journal

--- a/source/daemon/Cargo.lock
+++ b/source/daemon/Cargo.lock
@@ -5269,11 +5269,13 @@ version = "0.1.1"
 dependencies = [
  "anyhow",
  "chrono",
+ "flate2",
  "libc",
  "minisign",
  "minisign-verify",
  "serde",
  "serde_json",
+ "tar",
  "tempfile",
  "tracing",
  "tracing-subscriber",

--- a/source/daemon/crates/wardnet-postupgrade-runner/Cargo.toml
+++ b/source/daemon/crates/wardnet-postupgrade-runner/Cargo.toml
@@ -17,6 +17,8 @@ path = "src/main.rs"
 anyhow.workspace = true
 # https://crates.io/crates/chrono
 chrono.workspace = true
+# https://crates.io/crates/flate2
+flate2.workspace = true
 # https://crates.io/crates/libc
 libc.workspace = true
 # https://crates.io/crates/minisign-verify
@@ -25,6 +27,8 @@ minisign-verify.workspace = true
 serde.workspace = true
 # https://crates.io/crates/serde_json
 serde_json.workspace = true
+# https://crates.io/crates/tar
+tar.workspace = true
 # https://crates.io/crates/tracing
 tracing.workspace = true
 # https://crates.io/crates/tracing-subscriber

--- a/source/daemon/crates/wardnet-postupgrade-runner/src/lib.rs
+++ b/source/daemon/crates/wardnet-postupgrade-runner/src/lib.rs
@@ -103,18 +103,12 @@ impl Runner {
         match swap::run(&self.swap_paths, self.public_key) {
             swap::SwapOutcome::NoOp => {}
             swap::SwapOutcome::Swapped => {
-                tracing::info!(
-                    live = %self.swap_paths.live_binary.display(),
-                    "wardnetd binary swapped into place at {live}",
-                    live = self.swap_paths.live_binary.display(),
-                );
+                let live = self.swap_paths.live_binary.display().to_string();
+                tracing::info!(%live, "wardnetd binary swapped into place at {live}");
             }
             swap::SwapOutcome::RolledBack => {
-                tracing::info!(
-                    live = %self.swap_paths.live_binary.display(),
-                    "wardnetd rolled back to previous binary at {live}",
-                    live = self.swap_paths.live_binary.display(),
-                );
+                let live = self.swap_paths.live_binary.display().to_string();
+                tracing::info!(%live, "wardnetd rolled back to previous binary at {live}");
             }
             swap::SwapOutcome::Failed(e) => {
                 return RunOutcome::SwapFailed(e);
@@ -135,11 +129,11 @@ impl Runner {
             if let Err(state_err) =
                 state::record_verification_failure(&self.state_path, &format!("{e:#}"), now)
             {
+                let state = self.state_path.display().to_string();
                 tracing::warn!(
-                    error = %state_err,
-                    state = %self.state_path.display(),
+                    %state_err,
+                    %state,
                     "could not record verification failure to {state}: {state_err}",
-                    state = self.state_path.display(),
                 );
             }
             return RunOutcome::VerifyFailed(e);

--- a/source/daemon/crates/wardnet-postupgrade-runner/src/lib.rs
+++ b/source/daemon/crates/wardnet-postupgrade-runner/src/lib.rs
@@ -23,6 +23,7 @@
 
 pub mod exec;
 pub mod state;
+pub mod swap;
 pub mod verify;
 
 use std::path::PathBuf;
@@ -38,6 +39,10 @@ pub const DEFAULT_SIGNATURE_PATH: &str = "/var/lib/wardnet/postupgrade/wardnet-p
 /// cannot rewrite this file to mark a `Required` failure as `applied`
 /// and bypass the daemon-startup gate.
 pub const DEFAULT_STATE_PATH: &str = "/var/lib/wardnet-postupgrade/state.json";
+/// Default location of the live wardnetd binary swapped into place by
+/// the privileged swap step. Mirrors the daemon's
+/// `config.update.live_binary_path` default.
+pub const DEFAULT_LIVE_BINARY_PATH: &str = "/usr/local/bin/wardnetd";
 
 /// Inputs the runner needs to verify and exec a payload. Mostly fixed
 /// at compile time; `Runner::with_default_paths` wires the production
@@ -46,6 +51,7 @@ pub struct Runner {
     pub payload_path: PathBuf,
     pub signature_path: PathBuf,
     pub state_path: PathBuf,
+    pub swap_paths: swap::SwapPaths,
     pub public_key: &'static str,
 }
 
@@ -65,6 +71,11 @@ pub enum RunOutcome {
     /// the process and never returns this variant. Very rare in
     /// practice (kernel out of memory, seccomp policy mismatch).
     ExecFailed(anyhow::Error),
+    /// Privileged swap of `<live>` could not be completed (signature
+    /// failure, missing wardnetd entry, fs error). The runner exits
+    /// nonzero so systemd refuses to start `wardnetd.service` against
+    /// an unverified binary.
+    SwapFailed(anyhow::Error),
 }
 
 impl Runner {
@@ -76,6 +87,7 @@ impl Runner {
             payload_path: PathBuf::from(DEFAULT_PAYLOAD_PATH),
             signature_path: PathBuf::from(DEFAULT_SIGNATURE_PATH),
             state_path: PathBuf::from(DEFAULT_STATE_PATH),
+            swap_paths: swap::SwapPaths::with_defaults(PathBuf::from(DEFAULT_LIVE_BINARY_PATH)),
             public_key,
         }
     }
@@ -84,6 +96,31 @@ impl Runner {
     /// failure modes are mapped to [`RunOutcome`] variants. The caller
     /// (`main.rs`) translates the variant to a logger call + exit code.
     pub fn run(&self, args: &[std::ffi::CString]) -> RunOutcome {
+        // Privileged daemon swap runs first — the migration runner the
+        // exec branch invokes belongs to the new release, not the old
+        // one. A swap failure aborts boot rather than running migrations
+        // against a binary the trust anchor couldn't verify.
+        match swap::run(&self.swap_paths, self.public_key) {
+            swap::SwapOutcome::NoOp => {}
+            swap::SwapOutcome::Swapped => {
+                tracing::info!(
+                    live = %self.swap_paths.live_binary.display(),
+                    "wardnetd binary swapped into place at {live}",
+                    live = self.swap_paths.live_binary.display(),
+                );
+            }
+            swap::SwapOutcome::RolledBack => {
+                tracing::info!(
+                    live = %self.swap_paths.live_binary.display(),
+                    "wardnetd rolled back to previous binary at {live}",
+                    live = self.swap_paths.live_binary.display(),
+                );
+            }
+            swap::SwapOutcome::Failed(e) => {
+                return RunOutcome::SwapFailed(e);
+            }
+        }
+
         let Some((payload, signature)) =
             verify::read_artifacts(&self.payload_path, &self.signature_path)
         else {

--- a/source/daemon/crates/wardnet-postupgrade-runner/src/main.rs
+++ b/source/daemon/crates/wardnet-postupgrade-runner/src/main.rs
@@ -44,6 +44,16 @@ fn main() {
             );
             std::process::exit(2);
         }
+        RunOutcome::SwapFailed(e) => {
+            tracing::error!(
+                error = %format!("{e:#}"),
+                pending = %runner.swap_paths.pending_tarball.display(),
+                live = %runner.swap_paths.live_binary.display(),
+                "wardnetd swap failed; refusing to start the daemon: error={e:#}",
+                e = format!("{e:#}"),
+            );
+            std::process::exit(3);
+        }
     }
 }
 

--- a/source/daemon/crates/wardnet-postupgrade-runner/src/swap.rs
+++ b/source/daemon/crates/wardnet-postupgrade-runner/src/swap.rs
@@ -1,0 +1,265 @@
+//! Verify-and-swap of `wardnetd` from a wardnet-staged release tarball.
+//!
+//! The trust anchor: this module re-verifies the outer release tarball
+//! signature against the embedded public key before touching
+//! `/usr/local/bin/wardnetd`. The wardnet user can stage any bytes at
+//! the pending paths, but cannot bypass the signature check, so the
+//! escalation surface is bounded by the release signing key.
+//!
+//! Two reasons the runner — not the daemon — owns this step:
+//!   1. `/usr/local/bin/` is `root:root 0755`, so the unprivileged
+//!      wardnet user cannot rename anything into it (rename(2) needs
+//!      write+x on the destination directory). The runner is `User=root`.
+//!   2. Re-verification under root closes a TOCTOU window even within
+//!      the same trust domain — the wardnet user could replace the
+//!      pending tarball after the daemon's pre-stage verify; verifying
+//!      again here defeats that.
+//!
+//! On a successful swap the previously-live binary is preserved at
+//! `<live>.old` so `wardnetd-rollback.service` can restore it if the
+//! new daemon crash-loops.
+
+use std::io::Read;
+use std::path::{Path, PathBuf};
+
+use anyhow::Context;
+
+use crate::verify;
+
+/// Default location of the daemon-staged release tarball awaiting the
+/// privileged swap. Wardnet-writable; the runner re-verifies before
+/// trusting any byte of it.
+pub const DEFAULT_PENDING_TARBALL_PATH: &str = "/var/lib/wardnet/updates/wardnetd-pending.tar.gz";
+/// Default location of the detached minisign signature accompanying
+/// [`DEFAULT_PENDING_TARBALL_PATH`].
+pub const DEFAULT_PENDING_SIGNATURE_PATH: &str =
+    "/var/lib/wardnet/updates/wardnetd-pending.tar.gz.minisig";
+/// Default location of the rollback-request marker. Empty file written
+/// by the daemon when an operator requests a rollback; the runner
+/// performs the actual rename of `<live>.old → <live>` and removes
+/// the marker.
+pub const DEFAULT_ROLLBACK_REQUEST_PATH: &str =
+    "/var/lib/wardnet/updates/wardnetd-rollback.request";
+
+/// File name the swap pulls from inside the release tarball. Anything
+/// else in the archive is ignored — the postupgrade migration runner
+/// owns the rest of the payload.
+const ARCHIVE_NAME_DAEMON: &str = "wardnetd";
+
+/// Where to find a swap request and what to do on success. Mirrors the
+/// daemon-side [`FsBinaryApplier`] paths so production wires both ends
+/// to the same locations.
+pub struct SwapPaths {
+    pub pending_tarball: PathBuf,
+    pub pending_signature: PathBuf,
+    pub rollback_request: PathBuf,
+    pub live_binary: PathBuf,
+}
+
+impl SwapPaths {
+    /// Production paths. Tests construct `SwapPaths` directly inside a
+    /// tempdir.
+    #[must_use]
+    pub fn with_defaults(live_binary: PathBuf) -> Self {
+        Self {
+            pending_tarball: PathBuf::from(DEFAULT_PENDING_TARBALL_PATH),
+            pending_signature: PathBuf::from(DEFAULT_PENDING_SIGNATURE_PATH),
+            rollback_request: PathBuf::from(DEFAULT_ROLLBACK_REQUEST_PATH),
+            live_binary,
+        }
+    }
+
+    fn old_binary(&self) -> PathBuf {
+        let mut p = self.live_binary.clone();
+        let name = p.file_name().map_or_else(
+            || "wardnetd.old".to_owned(),
+            |n| format!("{}.old", n.to_string_lossy()),
+        );
+        p.set_file_name(name);
+        p
+    }
+}
+
+/// What the swap step did. The runner exits nonzero on `Failed` so
+/// systemd refuses to start `wardnetd.service` until an operator
+/// clears the failure — preserving the safety property that the
+/// daemon never runs against a binary the trust anchor couldn't
+/// verify.
+#[derive(Debug)]
+pub enum SwapOutcome {
+    /// No pending tarball and no rollback request; the runner moves on
+    /// to the migration step. The common boot path on a host that has
+    /// not run an auto-update since reboot.
+    NoOp,
+    /// `wardnetd-pending.tar.gz` was verified, `wardnetd` extracted, and
+    /// renamed into `<live>` with the previous binary preserved at
+    /// `<live>.old`.
+    Swapped,
+    /// `wardnetd-rollback.request` was honoured: `<live>.old` renamed
+    /// back over `<live>`. No-op (logged but successful) if no `.old`
+    /// is present — the operator may have requested rollback against
+    /// a fresh install.
+    RolledBack,
+    /// Something went wrong — signature verification failed, the tarball
+    /// did not contain a `wardnetd` entry, or a filesystem operation
+    /// errored. The error chain carries the failing path / reason.
+    Failed(anyhow::Error),
+}
+
+/// Run the verify-and-swap step. Called at the top of [`crate::Runner::run`].
+///
+/// Order of operations:
+///   1. If a rollback request marker is present, honour it and return
+///      (the operator wants the previous binary; ignoring a coincident
+///      pending tarball is the safe choice).
+///   2. If a pending tarball is staged, re-verify its signature and
+///      replace `<live>` with the embedded `wardnetd`.
+///   3. Otherwise no-op.
+#[must_use]
+pub fn run(paths: &SwapPaths, public_key: &str) -> SwapOutcome {
+    if paths.rollback_request.exists() {
+        return match perform_rollback(paths) {
+            Ok(()) => SwapOutcome::RolledBack,
+            Err(e) => SwapOutcome::Failed(e),
+        };
+    }
+
+    let Some((tarball, signature)) =
+        verify::read_artifacts(&paths.pending_tarball, &paths.pending_signature)
+    else {
+        return SwapOutcome::NoOp;
+    };
+
+    if let Err(e) = verify::verify(public_key, &tarball, &signature) {
+        return SwapOutcome::Failed(e.context("pending tarball signature verification failed"));
+    }
+
+    match perform_swap(paths, &tarball) {
+        Ok(()) => SwapOutcome::Swapped,
+        Err(e) => SwapOutcome::Failed(e),
+    }
+}
+
+fn perform_swap(paths: &SwapPaths, tarball: &[u8]) -> anyhow::Result<()> {
+    let bytes = pluck_wardnetd(tarball).context("extract wardnetd from pending tarball")?;
+
+    let parent = paths.live_binary.parent().ok_or_else(|| {
+        anyhow::anyhow!(
+            "live binary path has no parent: {}",
+            paths.live_binary.display()
+        )
+    })?;
+    // Same dir as <live> so the final rename is intra-filesystem and
+    // therefore atomic. Keeping it adjacent to <live> also means the
+    // root-owned parent dir's permissions gate writes — wardnet user
+    // can never poison this staging file post-verify.
+    let staged = parent.join("wardnetd.swap-staging");
+    write_executable(&staged, &bytes)?;
+
+    let old = paths.old_binary();
+    if paths.live_binary.exists() {
+        if old.exists() {
+            std::fs::remove_file(&old).with_context(|| format!("remove_file {}", old.display()))?;
+        }
+        std::fs::rename(&paths.live_binary, &old).with_context(|| {
+            format!(
+                "rename {} -> {}",
+                paths.live_binary.display(),
+                old.display()
+            )
+        })?;
+    }
+    std::fs::rename(&staged, &paths.live_binary).with_context(|| {
+        format!(
+            "rename {} -> {}",
+            staged.display(),
+            paths.live_binary.display()
+        )
+    })?;
+
+    // The swap succeeded; the daemon-side staged artefacts have served
+    // their purpose. Removing them prevents a stale apply on the next
+    // boot if something else triggers the runner before another
+    // auto-update writes a fresh pair.
+    let _ = std::fs::remove_file(&paths.pending_tarball);
+    let _ = std::fs::remove_file(&paths.pending_signature);
+
+    Ok(())
+}
+
+fn perform_rollback(paths: &SwapPaths) -> anyhow::Result<()> {
+    let old = paths.old_binary();
+    let result = if old.exists() {
+        if paths.live_binary.exists() {
+            std::fs::remove_file(&paths.live_binary)
+                .with_context(|| format!("remove_file {}", paths.live_binary.display()))?;
+        }
+        std::fs::rename(&old, &paths.live_binary).with_context(|| {
+            format!(
+                "rename {} -> {}",
+                old.display(),
+                paths.live_binary.display()
+            )
+        })
+    } else {
+        tracing::warn!(
+            old = %old.display(),
+            "rollback requested but no previous binary at {old}; clearing request and exiting clean",
+            old = old.display(),
+        );
+        Ok(())
+    };
+
+    // Clear the request regardless of outcome — leaving it in place
+    // would loop the runner on every boot. A failure here is logged
+    // but doesn't block subsequent retries (daemon would re-write
+    // the marker if the operator requests rollback again).
+    let _ = std::fs::remove_file(&paths.rollback_request);
+
+    result
+}
+
+/// Single pass over the gzip-tar tarball; returns the bytes of the
+/// `wardnetd` entry. Anything else is ignored.
+fn pluck_wardnetd(tarball: &[u8]) -> anyhow::Result<Vec<u8>> {
+    let decoder = flate2::read::GzDecoder::new(tarball);
+    let mut archive = tar::Archive::new(decoder);
+    for entry in archive.entries().context("read tarball entries")? {
+        let mut entry = entry.context("read tarball entry header")?;
+        let path = entry.path().context("entry path")?.into_owned();
+        let name = path
+            .file_name()
+            .and_then(|s| s.to_str())
+            .unwrap_or_default();
+        if name == ARCHIVE_NAME_DAEMON {
+            let mut buf = Vec::new();
+            entry
+                .read_to_end(&mut buf)
+                .context("read wardnetd entry body")?;
+            return Ok(buf);
+        }
+    }
+    Err(anyhow::anyhow!(
+        "tarball did not contain a `wardnetd` entry at any path"
+    ))
+}
+
+fn write_executable(path: &Path, bytes: &[u8]) -> anyhow::Result<()> {
+    use std::io::Write;
+    let mut out =
+        std::fs::File::create(path).with_context(|| format!("create {}", path.display()))?;
+    out.write_all(bytes)
+        .with_context(|| format!("write {}", path.display()))?;
+    drop(out);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mut perms = std::fs::metadata(path)
+            .with_context(|| format!("metadata {}", path.display()))?
+            .permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(path, perms)
+            .with_context(|| format!("set_permissions {}", path.display()))?;
+    }
+    Ok(())
+}

--- a/source/daemon/crates/wardnet-postupgrade-runner/src/swap.rs
+++ b/source/daemon/crates/wardnet-postupgrade-runner/src/swap.rs
@@ -202,10 +202,10 @@ fn perform_rollback(paths: &SwapPaths) -> anyhow::Result<()> {
             )
         })
     } else {
+        let old = old.display().to_string();
         tracing::warn!(
-            old = %old.display(),
+            %old,
             "rollback requested but no previous binary at {old}; clearing request and exiting clean",
-            old = old.display(),
         );
         Ok(())
     };

--- a/source/daemon/crates/wardnet-postupgrade-runner/src/tests/mod.rs
+++ b/source/daemon/crates/wardnet-postupgrade-runner/src/tests/mod.rs
@@ -5,4 +5,5 @@
 mod exec;
 mod runner;
 mod state;
+mod swap;
 mod verify;

--- a/source/daemon/crates/wardnet-postupgrade-runner/src/tests/runner.rs
+++ b/source/daemon/crates/wardnet-postupgrade-runner/src/tests/runner.rs
@@ -12,6 +12,8 @@
 use std::ffi::CString;
 use std::io::Cursor;
 
+use flate2::Compression;
+use flate2::write::GzEncoder;
 use minisign::{KeyPair, sign};
 use tempfile::TempDir;
 
@@ -164,6 +166,140 @@ fn with_default_paths_uses_production_constants() {
     assert_eq!(
         runner.swap_paths.pending_tarball,
         std::path::PathBuf::from(crate::swap::DEFAULT_PENDING_TARBALL_PATH)
+    );
+}
+
+/// Install a process-global tracing subscriber once for the test
+/// binary. Without an active subscriber the structured fields inside
+/// `tracing::info!` / `warn!` macros expand to no-ops, so coverage
+/// tools mark the success-log arms as unhit. We use a global default
+/// rather than a thread-local guard because each tracing callsite is
+/// registered at first-touch and the registration result sticks for
+/// the rest of the process — a guard installed inside one test is
+/// raced by the callsite register from another test running in
+/// parallel.
+fn ensure_global_subscriber() {
+    use std::sync::Once;
+    static ONCE: Once = Once::new();
+    ONCE.call_once(|| {
+        let subscriber = tracing_subscriber::fmt()
+            .with_max_level(tracing::Level::TRACE)
+            .with_test_writer()
+            .finish();
+        let _ = tracing::subscriber::set_global_default(subscriber);
+    });
+}
+
+fn make_tarball(entries: &[(&str, &[u8])]) -> Vec<u8> {
+    let mut gz = GzEncoder::new(Vec::new(), Compression::fast());
+    {
+        let mut tar = tar::Builder::new(&mut gz);
+        for (name, bytes) in entries {
+            let mut header = tar::Header::new_gnu();
+            header.set_size(bytes.len() as u64);
+            header.set_mode(0o755);
+            header.set_cksum();
+            tar.append_data(&mut header, name, *bytes).unwrap();
+        }
+        tar.finish().unwrap();
+    }
+    gz.finish().unwrap()
+}
+
+#[test]
+fn swap_succeeds_then_no_payload_returns_no_payload() {
+    // Drives the `SwapOutcome::Swapped` arm in `Runner::run`. The
+    // postupgrade payload is absent, so after the successful binary
+    // swap the run resolves to `NoPayload` — exercising the info-log
+    // arm without needing a real fexecve.
+    let dir = TempDir::new().unwrap();
+    let live = dir.path().join("wardnetd");
+    std::fs::write(&live, b"OLD wardnetd").unwrap();
+
+    let tarball = make_tarball(&[("wardnetd", b"NEW wardnetd")]);
+    let (pk, sig) = signed_pair(&tarball);
+    let pending_tarball = dir.path().join("pending.tar.gz");
+    let pending_sig = dir.path().join("pending.tar.gz.minisig");
+    std::fs::write(&pending_tarball, &tarball).unwrap();
+    std::fs::write(&pending_sig, sig).unwrap();
+
+    let mut runner = build_runner(dir.path(), leak(pk));
+    runner.swap_paths = SwapPaths {
+        pending_tarball,
+        pending_signature: pending_sig,
+        rollback_request: dir.path().join("rollback.request"),
+        live_binary: live.clone(),
+    };
+    let argv = [CString::new("p").unwrap()];
+    ensure_global_subscriber();
+    let outcome = runner.run(&argv);
+    // The swap succeeded; no postupgrade payload is staged, so the
+    // pipeline short-circuits to NoPayload.
+    assert!(
+        matches!(outcome, RunOutcome::NoPayload),
+        "expected NoPayload after successful swap, got {outcome:?}"
+    );
+    assert_eq!(std::fs::read(&live).unwrap(), b"NEW wardnetd");
+}
+
+#[test]
+fn rollback_request_then_no_payload_returns_no_payload() {
+    // Drives the `SwapOutcome::RolledBack` arm in `Runner::run`. A
+    // request marker is present, the runner clears it, and the rest
+    // of the pipeline resolves to `NoPayload`.
+    let dir = TempDir::new().unwrap();
+    let live = dir.path().join("wardnetd");
+    std::fs::write(&live, b"BAD wardnetd").unwrap();
+    std::fs::write(dir.path().join("wardnetd.old"), b"GOOD wardnetd").unwrap();
+    let rollback_request = dir.path().join("rollback.request");
+    std::fs::write(&rollback_request, b"").unwrap();
+
+    let mut runner = build_runner(dir.path(), "untrusted comment: x\nAAAA");
+    runner.swap_paths = SwapPaths {
+        pending_tarball: dir.path().join("pending.tar.gz"),
+        pending_signature: dir.path().join("pending.tar.gz.minisig"),
+        rollback_request: rollback_request.clone(),
+        live_binary: live.clone(),
+    };
+    let argv = [CString::new("p").unwrap()];
+    ensure_global_subscriber();
+    let outcome = runner.run(&argv);
+    assert!(
+        matches!(outcome, RunOutcome::NoPayload),
+        "expected NoPayload after rollback, got {outcome:?}"
+    );
+    assert_eq!(std::fs::read(&live).unwrap(), b"GOOD wardnetd");
+    assert!(!rollback_request.exists());
+}
+
+#[test]
+fn verify_failed_with_unwritable_state_path_still_returns_verify_failed() {
+    // Regression for the "best-effort" state recording in
+    // `Runner::run`: a state.json that lives under a non-existent
+    // parent directory makes `record_verification_failure` fail. The
+    // run must still return `VerifyFailed` and the warn arm must
+    // execute (otherwise the journal would lose the failure mode).
+    let dir = TempDir::new().unwrap();
+    let payload = b"some payload bytes";
+    let (pk_a, _) = signed_pair(payload);
+    let (_, sig_b) = signed_pair(payload);
+    std::fs::write(dir.path().join("postupgrade.bin"), payload).unwrap();
+    std::fs::write(dir.path().join("postupgrade.minisig"), sig_b).unwrap();
+
+    let mut runner = build_runner(dir.path(), leak(pk_a));
+    // Point state.json at a path whose parent component is a regular
+    // file — `record_verification_failure` calls `create_dir_all`
+    // which fails with ENOTDIR.
+    let blocker = dir.path().join("blocker");
+    std::fs::write(&blocker, b"not a dir").unwrap();
+    runner.state_path = blocker.join("state.json");
+
+    let argv = [CString::new("p").unwrap()];
+    ensure_global_subscriber();
+    let outcome = runner.run(&argv);
+    assert!(
+        matches!(outcome, RunOutcome::VerifyFailed(_)),
+        "expected VerifyFailed despite state-write failure, got {outcome:?}"
     );
 }
 

--- a/source/daemon/crates/wardnet-postupgrade-runner/src/tests/runner.rs
+++ b/source/daemon/crates/wardnet-postupgrade-runner/src/tests/runner.rs
@@ -15,6 +15,7 @@ use std::io::Cursor;
 use minisign::{KeyPair, sign};
 use tempfile::TempDir;
 
+use crate::swap::SwapPaths;
 use crate::{RunOutcome, Runner};
 
 /// `&'static str` is what `Runner::public_key` expects. Tests leak
@@ -44,6 +45,15 @@ fn build_runner(dir: &std::path::Path, public_key: &'static str) -> Runner {
         payload_path: dir.join("postupgrade.bin"),
         signature_path: dir.join("postupgrade.minisig"),
         state_path: dir.join("state.json"),
+        // Tests that don't exercise the swap step point swap paths
+        // into a sub-tempdir whose pending files don't exist; the swap
+        // module short-circuits to NoOp without touching live_binary.
+        swap_paths: SwapPaths {
+            pending_tarball: dir.join("swap-unused/pending.tar.gz"),
+            pending_signature: dir.join("swap-unused/pending.tar.gz.minisig"),
+            rollback_request: dir.join("swap-unused/rollback.request"),
+            live_binary: dir.join("swap-unused/wardnetd"),
+        },
         public_key,
     }
 }
@@ -146,5 +156,50 @@ fn with_default_paths_uses_production_constants() {
     assert_eq!(
         runner.state_path,
         std::path::PathBuf::from(crate::DEFAULT_STATE_PATH)
+    );
+    assert_eq!(
+        runner.swap_paths.live_binary,
+        std::path::PathBuf::from(crate::DEFAULT_LIVE_BINARY_PATH)
+    );
+    assert_eq!(
+        runner.swap_paths.pending_tarball,
+        std::path::PathBuf::from(crate::swap::DEFAULT_PENDING_TARBALL_PATH)
+    );
+}
+
+#[test]
+fn swap_failure_short_circuits_run() {
+    // When the pending tarball is present but its signature doesn't
+    // verify, `Runner::run` must return `SwapFailed` without touching
+    // the migration payload — gating wardnetd start on a clean swap.
+    let dir = TempDir::new().unwrap();
+    let pending = dir.path().join("pending.tar.gz");
+    let pending_sig = dir.path().join("pending.tar.gz.minisig");
+    let live = dir.path().join("wardnetd");
+    std::fs::write(&live, b"OLD wardnetd").unwrap();
+    let tarball = b"any tarball bytes";
+    let (pk_a, _) = signed_pair(tarball);
+    let (_, sig_b) = signed_pair(tarball);
+    std::fs::write(&pending, tarball).unwrap();
+    std::fs::write(&pending_sig, sig_b).unwrap();
+
+    let mut runner = build_runner(dir.path(), leak(pk_a));
+    runner.swap_paths = SwapPaths {
+        pending_tarball: pending,
+        pending_signature: pending_sig,
+        rollback_request: dir.path().join("rollback.request"),
+        live_binary: live.clone(),
+    };
+
+    let argv = [CString::new("p").unwrap()];
+    let outcome = runner.run(&argv);
+    assert!(
+        matches!(outcome, RunOutcome::SwapFailed(_)),
+        "expected SwapFailed, got {outcome:?}"
+    );
+    assert_eq!(
+        std::fs::read(&live).unwrap(),
+        b"OLD wardnetd",
+        "live binary must be untouched on swap failure",
     );
 }

--- a/source/daemon/crates/wardnet-postupgrade-runner/src/tests/swap.rs
+++ b/source/daemon/crates/wardnet-postupgrade-runner/src/tests/swap.rs
@@ -1,0 +1,230 @@
+//! Tests for the privileged swap step. Each test builds an in-memory
+//! gzip-tar release tarball, signs it with a freshly-generated minisign
+//! keypair, and exercises `swap::run` against tempdir paths.
+
+use std::io::Cursor;
+
+use flate2::Compression;
+use flate2::write::GzEncoder;
+use minisign::{KeyPair, sign};
+use tempfile::TempDir;
+
+use crate::swap::{self, SwapOutcome, SwapPaths};
+
+fn make_tarball(entries: &[(&str, &[u8])]) -> Vec<u8> {
+    let mut gz = GzEncoder::new(Vec::new(), Compression::fast());
+    {
+        let mut tar = tar::Builder::new(&mut gz);
+        for (name, bytes) in entries {
+            let mut header = tar::Header::new_gnu();
+            header.set_size(bytes.len() as u64);
+            header.set_mode(0o755);
+            header.set_cksum();
+            tar.append_data(&mut header, name, *bytes).unwrap();
+        }
+        tar.finish().unwrap();
+    }
+    gz.finish().unwrap()
+}
+
+fn signed_pair(payload: &[u8]) -> (String, String) {
+    let keypair = KeyPair::generate_unencrypted_keypair().expect("keypair");
+    let pk_text = keypair.pk.to_box().expect("pk box").into_string();
+    let mut reader = Cursor::new(payload);
+    let signature_box = sign(
+        None,
+        &keypair.sk,
+        &mut reader,
+        Some("test trusted"),
+        Some("test untrusted"),
+    )
+    .expect("sign");
+    (pk_text, signature_box.into_string())
+}
+
+fn paths(dir: &std::path::Path) -> SwapPaths {
+    SwapPaths {
+        pending_tarball: dir.join("pending.tar.gz"),
+        pending_signature: dir.join("pending.tar.gz.minisig"),
+        rollback_request: dir.join("rollback.request"),
+        live_binary: dir.join("wardnetd"),
+    }
+}
+
+#[test]
+fn no_pending_files_is_noop() {
+    let dir = TempDir::new().unwrap();
+    let p = paths(dir.path());
+    let outcome = swap::run(&p, "untrusted comment: x\nAAAA");
+    assert!(matches!(outcome, SwapOutcome::NoOp), "got {outcome:?}");
+}
+
+#[test]
+fn signature_mismatch_fails_and_preserves_live_binary() {
+    let dir = TempDir::new().unwrap();
+    let p = paths(dir.path());
+
+    std::fs::write(&p.live_binary, b"OLD wardnetd").unwrap();
+
+    let tarball = make_tarball(&[("wardnetd", b"NEW wardnetd")]);
+    let (pk_a, _) = signed_pair(&tarball);
+    // Sign with a *different* key; runner's embedded key is pk_a.
+    let (_, sig_b) = signed_pair(&tarball);
+    std::fs::write(&p.pending_tarball, &tarball).unwrap();
+    std::fs::write(&p.pending_signature, sig_b).unwrap();
+
+    let outcome = swap::run(&p, &pk_a);
+    let SwapOutcome::Failed(err) = outcome else {
+        panic!("expected Failed, got {outcome:?}");
+    };
+    let chain = format!("{err:#}");
+    assert!(
+        chain.contains("signature verification failed"),
+        "expected verify-failed message, got: {chain}"
+    );
+    assert_eq!(std::fs::read(&p.live_binary).unwrap(), b"OLD wardnetd");
+    // Pending files must NOT be cleared on failure — operator may want
+    // to inspect and the next boot's runner will retry only when a
+    // fresh pair lands, but right now we leave them so the failure is
+    // diagnosable.
+    assert!(p.pending_tarball.exists());
+    assert!(p.pending_signature.exists());
+}
+
+#[test]
+fn happy_path_swaps_and_preserves_old() {
+    let dir = TempDir::new().unwrap();
+    let p = paths(dir.path());
+
+    std::fs::write(&p.live_binary, b"OLD wardnetd").unwrap();
+
+    let tarball = make_tarball(&[
+        ("wardnetd", b"NEW wardnetd"),
+        ("wardnet-postupgrade-runner", b"runner ignored here"),
+    ]);
+    let (pk, sig) = signed_pair(&tarball);
+    std::fs::write(&p.pending_tarball, &tarball).unwrap();
+    std::fs::write(&p.pending_signature, sig).unwrap();
+
+    let outcome = swap::run(&p, &pk);
+    assert!(
+        matches!(outcome, SwapOutcome::Swapped),
+        "expected Swapped, got {outcome:?}"
+    );
+
+    assert_eq!(std::fs::read(&p.live_binary).unwrap(), b"NEW wardnetd");
+    let old = dir.path().join("wardnetd.old");
+    assert_eq!(std::fs::read(&old).unwrap(), b"OLD wardnetd");
+    // Pending files cleared on success.
+    assert!(!p.pending_tarball.exists());
+    assert!(!p.pending_signature.exists());
+}
+
+#[test]
+fn happy_path_with_no_existing_live_binary() {
+    // Fresh-install case: the runner can be run against a system that
+    // has never had wardnetd before. The swap creates the live binary
+    // and skips the .old preservation step.
+    let dir = TempDir::new().unwrap();
+    let p = paths(dir.path());
+
+    let tarball = make_tarball(&[("wardnetd", b"NEW wardnetd")]);
+    let (pk, sig) = signed_pair(&tarball);
+    std::fs::write(&p.pending_tarball, &tarball).unwrap();
+    std::fs::write(&p.pending_signature, sig).unwrap();
+
+    let outcome = swap::run(&p, &pk);
+    assert!(
+        matches!(outcome, SwapOutcome::Swapped),
+        "expected Swapped, got {outcome:?}"
+    );
+    assert_eq!(std::fs::read(&p.live_binary).unwrap(), b"NEW wardnetd");
+    assert!(!dir.path().join("wardnetd.old").exists());
+}
+
+#[test]
+fn tarball_without_wardnetd_entry_fails_with_path_in_chain() {
+    let dir = TempDir::new().unwrap();
+    let p = paths(dir.path());
+    std::fs::write(&p.live_binary, b"OLD wardnetd").unwrap();
+
+    let tarball = make_tarball(&[("README", b"unrelated")]);
+    let (pk, sig) = signed_pair(&tarball);
+    std::fs::write(&p.pending_tarball, &tarball).unwrap();
+    std::fs::write(&p.pending_signature, sig).unwrap();
+
+    let outcome = swap::run(&p, &pk);
+    let SwapOutcome::Failed(err) = outcome else {
+        panic!("expected Failed, got {outcome:?}");
+    };
+    assert!(
+        format!("{err:#}").contains("wardnetd"),
+        "expected wardnetd-missing message"
+    );
+    assert_eq!(std::fs::read(&p.live_binary).unwrap(), b"OLD wardnetd");
+}
+
+#[test]
+fn rollback_request_renames_old_back_into_place() {
+    let dir = TempDir::new().unwrap();
+    let p = paths(dir.path());
+
+    std::fs::write(&p.live_binary, b"BAD wardnetd").unwrap();
+    std::fs::write(dir.path().join("wardnetd.old"), b"GOOD wardnetd").unwrap();
+    std::fs::write(&p.rollback_request, b"").unwrap();
+
+    let outcome = swap::run(&p, "untrusted comment: x\nAAAA");
+    assert!(
+        matches!(outcome, SwapOutcome::RolledBack),
+        "expected RolledBack, got {outcome:?}"
+    );
+    assert_eq!(std::fs::read(&p.live_binary).unwrap(), b"GOOD wardnetd");
+    assert!(!dir.path().join("wardnetd.old").exists());
+    assert!(!p.rollback_request.exists(), "request marker cleared");
+}
+
+#[test]
+fn rollback_request_takes_precedence_over_pending_swap() {
+    // If both a pending swap and a rollback request are present, the
+    // rollback wins — operator intent overrides automation. Coincident
+    // state shouldn't happen but the runner is the only thing the
+    // operator can lean on if it does.
+    let dir = TempDir::new().unwrap();
+    let p = paths(dir.path());
+
+    std::fs::write(&p.live_binary, b"CURRENT wardnetd").unwrap();
+    std::fs::write(dir.path().join("wardnetd.old"), b"PREVIOUS wardnetd").unwrap();
+
+    let tarball = make_tarball(&[("wardnetd", b"NEW wardnetd")]);
+    let (pk, sig) = signed_pair(&tarball);
+    std::fs::write(&p.pending_tarball, &tarball).unwrap();
+    std::fs::write(&p.pending_signature, sig).unwrap();
+    std::fs::write(&p.rollback_request, b"").unwrap();
+
+    let outcome = swap::run(&p, &pk);
+    assert!(
+        matches!(outcome, SwapOutcome::RolledBack),
+        "expected RolledBack, got {outcome:?}"
+    );
+    assert_eq!(std::fs::read(&p.live_binary).unwrap(), b"PREVIOUS wardnetd");
+    // Pending tarball + sig left in place — the rollback path doesn't
+    // touch them. Operator can clear or another swap cycle will replace.
+    assert!(p.pending_tarball.exists());
+}
+
+#[test]
+fn rollback_without_old_binary_clears_request_and_succeeds() {
+    let dir = TempDir::new().unwrap();
+    let p = paths(dir.path());
+
+    std::fs::write(&p.live_binary, b"CURRENT wardnetd").unwrap();
+    std::fs::write(&p.rollback_request, b"").unwrap();
+
+    let outcome = swap::run(&p, "untrusted comment: x\nAAAA");
+    assert!(
+        matches!(outcome, SwapOutcome::RolledBack),
+        "expected RolledBack, got {outcome:?}"
+    );
+    assert_eq!(std::fs::read(&p.live_binary).unwrap(), b"CURRENT wardnetd");
+    assert!(!p.rollback_request.exists());
+}

--- a/source/daemon/crates/wardnet-postupgrade-runner/src/tests/swap.rs
+++ b/source/daemon/crates/wardnet-postupgrade-runner/src/tests/swap.rs
@@ -213,6 +213,62 @@ fn rollback_request_takes_precedence_over_pending_swap() {
 }
 
 #[test]
+fn fails_when_live_binary_path_has_no_parent() {
+    // `Path::new("/").parent()` is None; an empty path likewise. The
+    // `parent()` ok_or_else arm builds an anyhow describing the
+    // unusable live path so the operator gets a diagnostic instead of
+    // a silent no-op.
+    let dir = TempDir::new().unwrap();
+    let mut p = paths(dir.path());
+    p.live_binary = std::path::PathBuf::from("/");
+
+    let tarball = make_tarball(&[("wardnetd", b"NEW wardnetd")]);
+    let (pk, sig) = signed_pair(&tarball);
+    std::fs::write(&p.pending_tarball, &tarball).unwrap();
+    std::fs::write(&p.pending_signature, sig).unwrap();
+
+    let outcome = swap::run(&p, &pk);
+    let SwapOutcome::Failed(err) = outcome else {
+        panic!("expected Failed, got {outcome:?}");
+    };
+    assert!(
+        format!("{err:#}").contains("no parent"),
+        "expected no-parent message"
+    );
+}
+
+#[test]
+fn happy_path_removes_pre_existing_old_before_renaming() {
+    // A previous failed swap can leave `<live>.old` behind. The next
+    // successful swap must `remove_file` the stale .old before the
+    // rename, otherwise `rename(<live> -> <live>.old)` fails with
+    // EEXIST on Linux's strict-mode tmpfs and on file systems where
+    // overwrite semantics aren't guaranteed.
+    let dir = TempDir::new().unwrap();
+    let p = paths(dir.path());
+
+    std::fs::write(&p.live_binary, b"OLD wardnetd").unwrap();
+    std::fs::write(dir.path().join("wardnetd.old"), b"STALE old").unwrap();
+
+    let tarball = make_tarball(&[("wardnetd", b"NEW wardnetd")]);
+    let (pk, sig) = signed_pair(&tarball);
+    std::fs::write(&p.pending_tarball, &tarball).unwrap();
+    std::fs::write(&p.pending_signature, sig).unwrap();
+
+    let outcome = swap::run(&p, &pk);
+    assert!(
+        matches!(outcome, SwapOutcome::Swapped),
+        "expected Swapped, got {outcome:?}"
+    );
+    assert_eq!(std::fs::read(&p.live_binary).unwrap(), b"NEW wardnetd");
+    assert_eq!(
+        std::fs::read(dir.path().join("wardnetd.old")).unwrap(),
+        b"OLD wardnetd",
+        ".old should hold the just-replaced binary, not the stale one",
+    );
+}
+
+#[test]
 fn rollback_without_old_binary_clears_request_and_succeeds() {
     let dir = TempDir::new().unwrap();
     let p = paths(dir.path());

--- a/source/daemon/crates/wardnetd-services/src/tests/init.rs
+++ b/source/daemon/crates/wardnetd-services/src/tests/init.rs
@@ -215,7 +215,11 @@ impl crate::update::verifier::ReleaseVerifier for StubReleaseVerifier {
 struct StubBinaryApplier;
 #[async_trait]
 impl crate::update::applier::BinaryApplier for StubBinaryApplier {
-    async fn apply(&self, _tarball: &[u8]) -> anyhow::Result<crate::update::applier::SwapOutcome> {
+    async fn apply(
+        &self,
+        _tarball: &[u8],
+        _signature: &[u8],
+    ) -> anyhow::Result<crate::update::applier::SwapOutcome> {
         unimplemented!("init tests never apply a real tarball")
     }
     async fn rollback(&self) -> anyhow::Result<()> {

--- a/source/daemon/crates/wardnetd-services/src/update/applier.rs
+++ b/source/daemon/crates/wardnetd-services/src/update/applier.rs
@@ -1,33 +1,53 @@
-//! Binary apply step — extract, stage, atomically swap.
+//! Binary apply step — stage a verified release tarball for the
+//! privileged swap that `wardnet-postupgrade-runner` performs at the
+//! next daemon restart.
+//!
+//! The daemon runs as the unprivileged `wardnet` user and cannot
+//! rename a binary into `/usr/local/bin/` (the parent dir is
+//! `root:root 0755`). The swap therefore happens out-of-process: this
+//! trait stages the tarball + signature into a wardnet-writable
+//! directory and the runner re-verifies + renames as root before
+//! `wardnetd.service` starts. See the runner crate's `swap` module
+//! for the consuming side.
 
 use async_trait::async_trait;
 use std::path::PathBuf;
 
-/// Result of a successful swap — holds the path of the previous binary
-/// retained for rollback.
+/// Result of a successful staging step.
+///
+/// The actual filesystem swap has *not* happened yet when this is
+/// returned — only the staging step is in this trait's scope. The
+/// `previous_binary` path is the location where the runner will
+/// preserve the old binary on its next run, so the daemon can record
+/// it for the rollback API.
 #[derive(Debug, Clone)]
 pub struct SwapOutcome {
-    /// Where the previously-live binary was moved to (usually `<live>.old`).
+    /// Where the previously-live binary will be moved to (`<live>.old`)
+    /// once the runner performs the swap on the next daemon restart.
     pub previous_binary: PathBuf,
 }
 
-/// Applies a verified release tarball to the running binary path.
+/// Stages a verified release tarball and signals the runner to swap it.
 ///
-/// The real implementation extracts the tarball into a staging directory,
-/// renames the current live binary to `<live>.old`, then renames the
-/// extracted binary into place. All three paths must live on the same
-/// filesystem so the renames are atomic.
+/// `apply` writes the tarball + minisig to a wardnet-writable location;
+/// `rollback` writes a request marker the runner picks up on next boot.
+/// `rollback_available` checks whether `<live>.old` is present (the
+/// runner produced one on a previous successful swap).
 #[async_trait]
 pub trait BinaryApplier: Send + Sync {
-    /// Apply a verified tarball. On success, the running binary has been
-    /// replaced and a `<live>.old` copy retained for rollback. Callers are
-    /// expected to restart the daemon after this returns.
-    async fn apply(&self, tarball: &[u8]) -> anyhow::Result<SwapOutcome>;
+    /// Stage a verified tarball for the privileged swap. On success,
+    /// the daemon should request a restart so `wardnet-postupgrade.service`
+    /// runs the swap before `wardnetd.service` starts. `signature` is
+    /// the detached minisign signature of `tarball`; the runner will
+    /// re-verify it against the embedded public key.
+    async fn apply(&self, tarball: &[u8], signature: &[u8]) -> anyhow::Result<SwapOutcome>;
 
-    /// Roll back to the `<live>.old` binary, if one exists. Returns an error
-    /// if no rollback target is present.
+    /// Request a rollback to `<live>.old`. Returns an error if no
+    /// rollback target is present. Like `apply`, the actual rename is
+    /// performed by the runner on the next daemon restart.
     async fn rollback(&self) -> anyhow::Result<()>;
 
-    /// Whether a `<live>.old` binary is present that can be rolled back to.
+    /// Whether a `<live>.old` binary is present that can be rolled
+    /// back to.
     async fn rollback_available(&self) -> bool;
 }

--- a/source/daemon/crates/wardnetd-services/src/update/fs_applier.rs
+++ b/source/daemon/crates/wardnetd-services/src/update/fs_applier.rs
@@ -169,12 +169,12 @@ impl FsBinaryApplier {
         if let Some((cfg, bin, sig)) = postupgrade_pair
             && let Err(e) = self.swap_postupgrade(cfg, &bin, &sig)
         {
+            let dir = cfg.dir.display().to_string();
+            let error = format!("{e:#}");
             tracing::warn!(
-                error = %format!("{e:#}"),
-                dir = %cfg.dir.display(),
-                "postupgrade artifacts not swapped: dir={dir}, error={e}",
-                dir = cfg.dir.display(),
-                e = format!("{e:#}"),
+                %error,
+                %dir,
+                "postupgrade artifacts not swapped: dir={dir}, error={error}",
             );
         }
 

--- a/source/daemon/crates/wardnetd-services/src/update/fs_applier.rs
+++ b/source/daemon/crates/wardnetd-services/src/update/fs_applier.rs
@@ -1,19 +1,42 @@
-//! Filesystem [`BinaryApplier`] — extract, stage, rename-swap.
+//! Filesystem [`BinaryApplier`] — stage tarball + signature for the
+//! root-mediated swap performed by `wardnet-postupgrade-runner`.
+//!
+//! Why staged-not-direct: the daemon runs as the unprivileged
+//! `wardnet` user and cannot rename a binary into `/usr/local/bin/`
+//! (the parent dir is `root:root 0755` and `rename(2)` needs write+x
+//! on the destination directory). The previous version of this module
+//! attempted the rename in-process and hit `EACCES (os error 13)` on
+//! every Pi install — see issue #309 for the diagnosis.
+//!
+//! The current design keeps the daemon's responsibilities limited to
+//! what the wardnet user *can* do:
+//!
+//!   1. Verify the tarball signature against the embedded public key.
+//!   2. Pluck `wardnet-postupgrade.bin` / `.minisig` and swap them into
+//!      `/var/lib/wardnet/postupgrade/` — wardnet-writable, no privilege
+//!      step required.
+//!   3. Write the original tarball + signature to
+//!      `<staging>/wardnetd-pending.tar.gz{,.minisig}`. The runner picks
+//!      these up at the next daemon restart, re-verifies the signature
+//!      under root, and renames the extracted `wardnetd` into
+//!      `/usr/local/bin/`.
+//!
+//! `rollback()` writes a request marker the runner consumes the same
+//! way. The trust boundary survives because the runner re-verifies
+//! every time — the wardnet user can stage anything but cannot get a
+//! payload past the embedded public key.
 
 use std::io::Read;
 use std::path::PathBuf;
 
+use anyhow::Context;
 use async_trait::async_trait;
 use flate2::read::GzDecoder;
 use tokio::task;
 
 use crate::update::applier::{BinaryApplier, SwapOutcome};
 
-/// File names extracted from the release tarball. Anything else
-/// (`wardnet-postupgrade-runner`, `wardnet-postupgrade.service`,
-/// `LICENSE`, …) is silently ignored during auto-update — the runner
-/// is the trust anchor and may only be replaced by `install.sh`.
-const ARCHIVE_NAME_DAEMON: &str = "wardnetd";
+/// File names extracted from the release tarball.
 const ARCHIVE_NAME_POSTUPGRADE_BIN: &str = "wardnet-postupgrade.bin";
 const ARCHIVE_NAME_POSTUPGRADE_SIG: &str = "wardnet-postupgrade.minisig";
 
@@ -21,6 +44,15 @@ const ARCHIVE_NAME_POSTUPGRADE_SIG: &str = "wardnet-postupgrade.minisig";
 /// swap.
 const POSTUPGRADE_BIN_FILENAME: &str = "wardnet-postupgrade.bin";
 const POSTUPGRADE_SIG_FILENAME: &str = "wardnet-postupgrade.minisig";
+
+/// File names the runner reads from the staging dir.
+///
+/// MUST match `wardnet_postupgrade_runner::swap::DEFAULT_PENDING_*` —
+/// kept in sync manually because the daemon and the trust-anchor
+/// runner are intentionally separate compilation units.
+const PENDING_TARBALL_FILENAME: &str = "wardnetd-pending.tar.gz";
+const PENDING_SIGNATURE_FILENAME: &str = "wardnetd-pending.tar.gz.minisig";
+const ROLLBACK_REQUEST_FILENAME: &str = "wardnetd-rollback.request";
 
 /// Optional post-upgrade pipeline: where to place the wardnet-writable
 /// payload + signature, and which embedded public key to verify them
@@ -30,19 +62,12 @@ struct PostupgradeConfig {
     public_key: &'static str,
 }
 
-/// Write-then-rename applier bound to a live binary path and staging dir.
+/// Stages a release tarball for the runner-mediated swap.
 ///
-/// The live binary and the staging directory must live on the same
-/// filesystem so the final `rename(2)` is atomic. `apply()` leaves the
-/// previous binary at `<live>.old`, which is the target `rollback()`
-/// swaps back into place.
-///
-/// When configured via [`Self::with_postupgrade`], the applier also
-/// extracts `wardnet-postupgrade.bin` + `wardnet-postupgrade.minisig`
-/// from the tarball, **pre-flight verifies** the signature against
-/// the embedded key before any rename, then swaps them into the
-/// post-upgrade dir after `wardnetd`. A pre-flight verification
-/// failure aborts the entire apply (wardnetd is not touched).
+/// Holds the live binary path (used to compute the rollback target's
+/// expected `<live>.old` location), the staging directory (where the
+/// pending tarball + signature land), and an optional post-upgrade
+/// configuration for the migration framework's signed payload.
 pub struct FsBinaryApplier {
     live_path: PathBuf,
     staging_dir: PathBuf,
@@ -54,7 +79,6 @@ pub struct FsBinaryApplier {
 /// that will hit disk and a verification failure costs nothing.
 #[derive(Default)]
 struct Plucked {
-    wardnetd: Option<Vec<u8>>,
     postupgrade_bin: Option<Vec<u8>>,
     postupgrade_sig: Option<Vec<u8>>,
 }
@@ -92,20 +116,30 @@ impl FsBinaryApplier {
         p
     }
 
-    fn extract_and_swap(&self, tarball: &[u8]) -> anyhow::Result<SwapOutcome> {
-        std::fs::create_dir_all(&self.staging_dir)?;
-        let plucked = Self::pluck(tarball)?;
+    fn pending_tarball_path(&self) -> PathBuf {
+        self.staging_dir.join(PENDING_TARBALL_FILENAME)
+    }
 
-        let wardnetd_bytes = plucked.wardnetd.ok_or_else(|| {
-            anyhow::anyhow!("tarball did not contain a `wardnetd` entry at any path")
-        })?;
+    fn pending_signature_path(&self) -> PathBuf {
+        self.staging_dir.join(PENDING_SIGNATURE_FILENAME)
+    }
+
+    fn rollback_request_path(&self) -> PathBuf {
+        self.staging_dir.join(ROLLBACK_REQUEST_FILENAME)
+    }
+
+    fn stage_pending(&self, tarball: &[u8], signature: &[u8]) -> anyhow::Result<()> {
+        std::fs::create_dir_all(&self.staging_dir)
+            .with_context(|| format!("create_dir_all {}", self.staging_dir.display()))?;
+
+        let plucked = Self::pluck(tarball)?;
 
         // Pre-flight verify postupgrade artifacts (when configured AND
         // both files are present). A failed verify aborts the apply
         // before any rename. A missing pair is "lenient" — we leave
-        // the on-disk postupgrade alone and only swap wardnetd, which
-        // tolerates downgrades to pre-framework releases and CI
-        // regressions that briefly omit the artifacts.
+        // the on-disk postupgrade alone and only stage the wardnetd
+        // tarball, which tolerates downgrades to pre-framework releases
+        // and CI regressions that briefly omit the artifacts.
         let postupgrade_pair = match (
             self.postupgrade.as_ref(),
             plucked.postupgrade_bin,
@@ -118,45 +152,45 @@ impl FsBinaryApplier {
             _ => None,
         };
 
-        // Stage wardnetd (write to staging, set executable). All of
-        // this runs before any rename so a failure here also leaves
-        // the live tree untouched.
-        let staged_daemon = self.staging_dir.join("wardnetd.staged");
-        Self::write_file_executable(&staged_daemon, &wardnetd_bytes)?;
+        // Stage the runner-bound payload first: tarball + signature
+        // adjacent to each other, written atomically (tmp + rename) so
+        // a partial write can't be picked up by the runner. The runner
+        // re-verifies before swapping, so a torn write would fail
+        // verification rather than swap a bad binary.
+        Self::write_atomic(&self.pending_tarball_path(), tarball)?;
+        Self::write_atomic(&self.pending_signature_path(), signature)?;
 
-        // Swap wardnetd: move live → live.old, staged → live.
-        let old_path = self.old_path();
-        if self.live_path.exists() {
-            if old_path.exists() {
-                std::fs::remove_file(&old_path)?;
-            }
-            std::fs::rename(&self.live_path, &old_path)?;
-        }
-        std::fs::rename(&staged_daemon, &self.live_path)?;
-
-        // Swap postupgrade artifacts (best-effort: a rename failure
-        // here is logged but does not roll back wardnetd, since the
-        // existing on-disk postupgrade is still consistent with
-        // either the previous or new wardnetd — and OnFailure=
-        // wardnetd-rollback covers any downstream daemon crash).
+        // Postupgrade artifacts are wardnet-writable today, so the
+        // daemon swaps them itself — no runner round trip required.
+        // A rename failure here is logged but does not abort the
+        // pending stage above, since the stale on-disk postupgrade
+        // pair stays consistent with either the previous or new
+        // wardnetd.
         if let Some((cfg, bin, sig)) = postupgrade_pair
             && let Err(e) = self.swap_postupgrade(cfg, &bin, &sig)
         {
             tracing::warn!(
-                error = %e,
+                error = %format!("{e:#}"),
                 dir = %cfg.dir.display(),
                 "postupgrade artifacts not swapped: dir={dir}, error={e}",
                 dir = cfg.dir.display(),
+                e = format!("{e:#}"),
             );
         }
 
-        Ok(SwapOutcome {
-            previous_binary: old_path,
-        })
+        // A pending rollback request from a previous failed install
+        // would race the new pending tarball if both stayed on disk.
+        // Explicit precedence: a fresh install supersedes a stale
+        // rollback request.
+        let _ = std::fs::remove_file(self.rollback_request_path());
+
+        Ok(())
     }
 
-    /// Single pass over the tarball. Plucks the three known names into
-    /// memory; everything else is skipped.
+    /// Single pass over the tarball. Plucks the postupgrade pair into
+    /// memory; everything else is skipped. The wardnetd binary itself
+    /// is not extracted by the daemon — the runner does that under
+    /// root after re-verifying the tarball signature.
     fn pluck(tarball: &[u8]) -> anyhow::Result<Plucked> {
         let decoder = GzDecoder::new(tarball);
         let mut archive = tar::Archive::new(decoder);
@@ -170,7 +204,6 @@ impl FsBinaryApplier {
                 .and_then(|s| s.to_str())
                 .unwrap_or_default();
             let target: Option<&mut Option<Vec<u8>>> = match name {
-                ARCHIVE_NAME_DAEMON => Some(&mut out.wardnetd),
                 ARCHIVE_NAME_POSTUPGRADE_BIN => Some(&mut out.postupgrade_bin),
                 ARCHIVE_NAME_POSTUPGRADE_SIG => Some(&mut out.postupgrade_sig),
                 _ => None,
@@ -201,17 +234,17 @@ impl FsBinaryApplier {
         Ok(())
     }
 
-    fn write_file_executable(path: &std::path::Path, bytes: &[u8]) -> anyhow::Result<()> {
-        let mut out = std::fs::File::create(path)?;
-        std::io::Write::write_all(&mut out, bytes)?;
-        drop(out);
-        #[cfg(unix)]
-        {
-            use std::os::unix::fs::PermissionsExt;
-            let mut perms = std::fs::metadata(path)?.permissions();
-            perms.set_mode(0o755);
-            std::fs::set_permissions(path, perms)?;
-        }
+    /// Atomic write: tmp + rename. The runner only reads files at the
+    /// final names, so a crash mid-write leaves a `.tmp` alongside but
+    /// no half-written pending tarball.
+    fn write_atomic(path: &std::path::Path, bytes: &[u8]) -> anyhow::Result<()> {
+        let tmp = path.with_extension(format!(
+            "{}.tmp",
+            path.extension().and_then(|s| s.to_str()).unwrap_or("tmp")
+        ));
+        std::fs::write(&tmp, bytes).with_context(|| format!("write {}", tmp.display()))?;
+        std::fs::rename(&tmp, path)
+            .with_context(|| format!("rename {} -> {}", tmp.display(), path.display()))?;
         Ok(())
     }
 
@@ -221,12 +254,15 @@ impl FsBinaryApplier {
         bin: &[u8],
         sig: &[u8],
     ) -> anyhow::Result<()> {
-        std::fs::create_dir_all(&cfg.dir)?;
+        std::fs::create_dir_all(&cfg.dir)
+            .with_context(|| format!("create_dir_all {}", cfg.dir.display()))?;
 
         let staged_bin = self.staging_dir.join("wardnet-postupgrade.bin.staged");
         let staged_sig = self.staging_dir.join("wardnet-postupgrade.minisig.staged");
-        std::fs::write(&staged_bin, bin)?;
-        std::fs::write(&staged_sig, sig)?;
+        std::fs::write(&staged_bin, bin)
+            .with_context(|| format!("write {}", staged_bin.display()))?;
+        std::fs::write(&staged_sig, sig)
+            .with_context(|| format!("write {}", staged_sig.display()))?;
 
         // Rename the binary first, then the signature. If the second
         // rename fails after the first succeeds we are left with a
@@ -234,31 +270,42 @@ impl FsBinaryApplier {
         // previous) pair — the runner will reject that on the next
         // boot, blocking a malformed payload from running, which is
         // exactly the failure mode we want.
-        std::fs::rename(&staged_bin, cfg.dir.join(POSTUPGRADE_BIN_FILENAME))?;
-        std::fs::rename(&staged_sig, cfg.dir.join(POSTUPGRADE_SIG_FILENAME))?;
+        let final_bin = cfg.dir.join(POSTUPGRADE_BIN_FILENAME);
+        let final_sig = cfg.dir.join(POSTUPGRADE_SIG_FILENAME);
+        std::fs::rename(&staged_bin, &final_bin).with_context(|| {
+            format!("rename {} -> {}", staged_bin.display(), final_bin.display())
+        })?;
+        std::fs::rename(&staged_sig, &final_sig).with_context(|| {
+            format!("rename {} -> {}", staged_sig.display(), final_sig.display())
+        })?;
         Ok(())
     }
 }
 
 #[async_trait]
 impl BinaryApplier for FsBinaryApplier {
-    async fn apply(&self, tarball: &[u8]) -> anyhow::Result<SwapOutcome> {
+    async fn apply(&self, tarball: &[u8], signature: &[u8]) -> anyhow::Result<SwapOutcome> {
         let tarball = tarball.to_vec();
+        let signature = signature.to_vec();
         let live = self.live_path.clone();
         let staging = self.staging_dir.clone();
         let postupgrade = self.postupgrade.as_ref().map(|cfg| PostupgradeConfig {
             dir: cfg.dir.clone(),
             public_key: cfg.public_key,
         });
+        let outcome = SwapOutcome {
+            previous_binary: self.old_path(),
+        };
         task::spawn_blocking(move || {
             let applier = FsBinaryApplier {
                 live_path: live,
                 staging_dir: staging,
                 postupgrade,
             };
-            applier.extract_and_swap(&tarball)
+            applier.stage_pending(&tarball, &signature)
         })
-        .await?
+        .await??;
+        Ok(outcome)
     }
 
     async fn rollback(&self) -> anyhow::Result<()> {
@@ -269,15 +316,20 @@ impl BinaryApplier for FsBinaryApplier {
                 old.to_string_lossy()
             ));
         }
-        let live = self.live_path.clone();
+        let staging = self.staging_dir.clone();
+        let request = self.rollback_request_path();
         task::spawn_blocking(move || -> anyhow::Result<()> {
-            if live.exists() {
-                std::fs::remove_file(&live)?;
-            }
-            std::fs::rename(&old, &live)?;
+            std::fs::create_dir_all(&staging)
+                .with_context(|| format!("create_dir_all {}", staging.display()))?;
+            // Empty marker — the runner's swap step honours its
+            // presence; the body is unused. Atomic write so a
+            // mid-write crash doesn't leave an empty file the runner
+            // could misinterpret as a successful request.
+            FsBinaryApplier::write_atomic(&request, b"")?;
             Ok(())
         })
-        .await?
+        .await??;
+        Ok(())
     }
 
     async fn rollback_available(&self) -> bool {

--- a/source/daemon/crates/wardnetd-services/src/update/service.rs
+++ b/source/daemon/crates/wardnetd-services/src/update/service.rs
@@ -260,7 +260,10 @@ impl UpdateServiceImpl {
                 Ok(())
             }
             Err((phase, err)) => {
-                let msg = err.to_string();
+                // `{:#}` walks the anyhow chain so context wrapping (e.g.
+                // the path the applier tried to swap) reaches the history
+                // row and log line, not just the bare `io::Error`.
+                let msg = format!("{err:#}");
                 self.publish_progress(
                     &target,
                     InstallPhase::Failed {
@@ -345,26 +348,36 @@ impl UpdateServiceImpl {
             .await
             .map_err(|e| (InstallPhase::Verifying, AppError::Internal(e)))?;
 
-        if self.require_signature {
-            let minisig_url = release.minisig_url.clone().ok_or_else(|| {
-                (
-                    InstallPhase::Verifying,
-                    AppError::Internal(anyhow::anyhow!(
-                        "signature required but release has no minisig_url"
-                    )),
-                )
-            })?;
-            let sig_bytes = self
-                .release_source
+        // The detached signature is required for the runner-mediated
+        // swap regardless of `require_signature` — `wardnet-postupgrade-
+        // runner` re-verifies it under root before renaming the binary.
+        // `require_signature` only controls whether the daemon also
+        // verifies pre-stash; the trust anchor's check is unconditional.
+        let sig_bytes = if let Some(minisig_url) = release.minisig_url.clone() {
+            self.release_source
                 .fetch_asset(&minisig_url)
                 .await
-                .map_err(|e| (InstallPhase::Verifying, AppError::Internal(e)))?;
+                .map_err(|e| (InstallPhase::Verifying, AppError::Internal(e)))?
+        } else if self.require_signature {
+            return Err((
+                InstallPhase::Verifying,
+                AppError::Internal(anyhow::anyhow!(
+                    "signature required but release has no minisig_url"
+                )),
+            ));
+        } else {
+            tracing::warn!(
+                "signature verification disabled — staging without minisign \
+                 (runner will refuse to swap without one)"
+            );
+            Vec::new()
+        };
+
+        if self.require_signature {
             self.verifier
                 .verify_signature(&tarball, &sig_bytes)
                 .await
                 .map_err(|e| (InstallPhase::Verifying, AppError::Internal(e)))?;
-        } else {
-            tracing::warn!("signature verification disabled — proceeding without minisign");
         }
 
         self.publish_progress(&target, InstallPhase::Staging).await;
@@ -372,7 +385,7 @@ impl UpdateServiceImpl {
 
         let outcome = self
             .applier
-            .apply(&tarball)
+            .apply(&tarball, &sig_bytes)
             .await
             .map_err(|e| (InstallPhase::Swapping, AppError::Internal(e)))?;
 
@@ -617,7 +630,9 @@ impl UpdateService for UpdateServiceImpl {
             .await
             .map_err(AppError::Internal)?;
 
-        tracing::info!("rollback complete — daemon will be restarted by systemd");
+        tracing::info!(
+            "rollback request staged — runner will restore previous binary on next daemon restart",
+        );
         Ok(RollbackResponse {
             message: "rollback staged — daemon will restart".to_owned(),
         })

--- a/source/daemon/crates/wardnetd-services/src/update/service.rs
+++ b/source/daemon/crates/wardnetd-services/src/update/service.rs
@@ -215,7 +215,7 @@ impl UpdateServiceImpl {
         });
     }
 
-    async fn run_install(&self, release: Release) -> Result<(), AppError> {
+    pub(crate) async fn run_install(&self, release: Release) -> Result<(), AppError> {
         let target = release.version.clone();
         let history_id = self
             .history
@@ -301,7 +301,10 @@ impl UpdateServiceImpl {
     /// Run the download/verify/stage/swap pipeline. Emits progress events at
     /// each phase transition. On failure, returns the phase where the error
     /// occurred so history rows record a useful `phase` column.
-    async fn install_pipeline(&self, release: &Release) -> Result<(), (InstallPhase, AppError)> {
+    pub(crate) async fn install_pipeline(
+        &self,
+        release: &Release,
+    ) -> Result<(), (InstallPhase, AppError)> {
         let target = release.version.clone();
         let downloading = || InstallPhase::Downloading {
             bytes: 0,

--- a/source/daemon/crates/wardnetd-services/src/update/tests/fs_applier.rs
+++ b/source/daemon/crates/wardnetd-services/src/update/tests/fs_applier.rs
@@ -1,7 +1,9 @@
-//! Tests for `FsBinaryApplier`. Each test generates a fresh minisign
-//! keypair, builds an in-memory gzip-tar with the requested entries,
-//! and exercises the apply path in a tempdir. No fixtures committed
-//! to disk.
+//! Tests for `FsBinaryApplier` — the staging side of the runner-
+//! mediated swap. Each test generates a fresh minisign keypair, builds
+//! an in-memory gzip-tar with the requested entries, and exercises the
+//! stage path in a tempdir. The actual privileged rename happens in
+//! the runner crate's swap tests; here we only assert that the
+//! daemon stages the right artefacts in the right places.
 
 use std::io::Cursor;
 use std::path::Path;
@@ -14,8 +16,6 @@ use tempfile::TempDir;
 use crate::update::applier::BinaryApplier;
 use crate::update::fs_applier::FsBinaryApplier;
 
-/// Build a gzip-compressed tar archive in memory with the given
-/// `(name, bytes)` entries at the archive root.
 fn make_tarball(entries: &[(&str, &[u8])]) -> Vec<u8> {
     let mut gz = GzEncoder::new(Vec::new(), Compression::fast());
     {
@@ -32,8 +32,6 @@ fn make_tarball(entries: &[(&str, &[u8])]) -> Vec<u8> {
     gz.finish().unwrap()
 }
 
-/// Generate a minisign keypair and sign `payload`. Returns
-/// `(public_key_text, signature_text)`.
 fn signed_pair(payload: &[u8]) -> (String, String) {
     let keypair = KeyPair::generate_unencrypted_keypair().expect("keypair");
     let pk_text = keypair.pk.to_box().expect("pk box").into_string();
@@ -49,16 +47,40 @@ fn signed_pair(payload: &[u8]) -> (String, String) {
     (pk_text, signature_box.into_string())
 }
 
-/// `&'static str` is what `with_postupgrade` expects (the embedded
-/// public key has 'static lifetime in production). Tests work around
-/// the constraint by leaking each generated key — the leak is bounded
-/// by the test process's lifetime.
 fn leak(s: String) -> &'static str {
     Box::leak(s.into_boxed_str())
 }
 
 #[tokio::test]
-async fn valid_postupgrade_artifacts_swap_both() {
+async fn apply_stages_pending_tarball_and_signature() {
+    let dir = TempDir::new().unwrap();
+    let live_path = dir.path().join("wardnetd");
+    let staging = dir.path().join("staging");
+
+    let tarball = make_tarball(&[("wardnetd", b"new wardnetd bytes")]);
+    let outer_sig = b"outer tarball signature";
+
+    let applier = FsBinaryApplier::new(live_path.clone(), staging.clone());
+    let outcome = applier.apply(&tarball, outer_sig).await.expect("apply ok");
+
+    // Pending tarball + sig land at the runner's expected names.
+    assert_eq!(
+        std::fs::read(staging.join("wardnetd-pending.tar.gz")).unwrap(),
+        tarball,
+    );
+    assert_eq!(
+        std::fs::read(staging.join("wardnetd-pending.tar.gz.minisig")).unwrap(),
+        outer_sig,
+    );
+    // Daemon must NOT have touched the live binary — the runner does
+    // that under root on the next restart.
+    assert!(!live_path.exists());
+    // The previous-binary path the runner *will* produce on swap.
+    assert_eq!(outcome.previous_binary, dir.path().join("wardnetd.old"));
+}
+
+#[tokio::test]
+async fn apply_with_postupgrade_swaps_payload_and_stages_tarball() {
     let dir = TempDir::new().unwrap();
     let live_path = dir.path().join("wardnetd");
     let staging = dir.path().join("staging");
@@ -73,15 +95,16 @@ async fn valid_postupgrade_artifacts_swap_both() {
         ("wardnet-postupgrade.minisig", sig_text.as_bytes()),
     ]);
 
-    let applier = FsBinaryApplier::new(live_path.clone(), staging)
+    let applier = FsBinaryApplier::new(live_path.clone(), staging.clone())
         .with_postupgrade(postupgrade.clone(), leak(pk_text));
 
-    applier.apply(&tarball).await.expect("apply ok");
+    applier
+        .apply(&tarball, b"outer-sig")
+        .await
+        .expect("apply ok");
 
-    assert_eq!(
-        std::fs::read(&live_path).unwrap(),
-        b"the wardnetd binary bytes",
-    );
+    // Postupgrade artefacts swap into place (wardnet-writable, no
+    // runner round-trip needed).
     assert_eq!(
         std::fs::read(postupgrade.join("wardnet-postupgrade.bin")).unwrap(),
         postupgrade_bin,
@@ -90,6 +113,13 @@ async fn valid_postupgrade_artifacts_swap_both() {
         std::fs::read(postupgrade.join("wardnet-postupgrade.minisig")).unwrap(),
         sig_text.as_bytes(),
     );
+    // Pending tarball is staged verbatim (the runner will re-verify
+    // the OUTER signature, not the embedded postupgrade one).
+    assert_eq!(
+        std::fs::read(staging.join("wardnetd-pending.tar.gz")).unwrap(),
+        tarball,
+    );
+    assert!(!live_path.exists());
 }
 
 #[tokio::test]
@@ -100,14 +130,12 @@ async fn corrupted_postupgrade_signature_aborts_apply() {
     let postupgrade = dir.path().join("postupgrade");
 
     // Pre-existing files we expect untouched after the failed apply.
-    std::fs::write(&live_path, b"OLD wardnetd").unwrap();
     std::fs::create_dir_all(&postupgrade).unwrap();
     std::fs::write(
         postupgrade.join("wardnet-postupgrade.bin"),
         b"OLD postupgrade bin",
     )
     .unwrap();
-    std::fs::write(postupgrade.join("wardnet-postupgrade.minisig"), b"OLD sig").unwrap();
 
     let postupgrade_bin: &[u8] = b"the migration runner binary bytes";
     let (pk_text, sig_text) = signed_pair(postupgrade_bin);
@@ -121,38 +149,36 @@ async fn corrupted_postupgrade_signature_aborts_apply() {
         ("wardnet-postupgrade.minisig", &tampered),
     ]);
 
-    let applier = FsBinaryApplier::new(live_path.clone(), staging)
+    let applier = FsBinaryApplier::new(live_path.clone(), staging.clone())
         .with_postupgrade(postupgrade.clone(), leak(pk_text));
-    let err = applier.apply(&tarball).await.unwrap_err();
+    let err = applier.apply(&tarball, b"outer-sig").await.unwrap_err();
     let chain = format!("{err:#}");
     assert!(
         chain.contains("verification failed") || chain.contains("decode failed"),
         "expected verification failure, got: {chain}"
     );
 
-    // Live binary and on-disk postupgrade artifacts remain at their
-    // pre-apply state — no half-finished swap.
-    assert_eq!(std::fs::read(&live_path).unwrap(), b"OLD wardnetd");
+    // Pre-apply postupgrade payload + missing pending tarball — the
+    // failed pre-flight must not have written anything.
     assert_eq!(
         std::fs::read(postupgrade.join("wardnet-postupgrade.bin")).unwrap(),
         b"OLD postupgrade bin",
     );
-    assert_eq!(
-        std::fs::read(postupgrade.join("wardnet-postupgrade.minisig")).unwrap(),
-        b"OLD sig",
-    );
-    assert!(!exists(&dir.path().join("wardnetd.old")));
+    assert!(!staging.join("wardnetd-pending.tar.gz").exists());
 }
 
 #[tokio::test]
-async fn tarball_without_postupgrade_only_swaps_wardnetd() {
+async fn apply_without_postupgrade_pair_still_stages_tarball() {
+    // Lenient downgrade tolerance: a tarball that omits the
+    // postupgrade pair stages cleanly. The on-disk postupgrade files
+    // are left in place; the runner will swap the wardnetd binary on
+    // next boot and the existing payload stays consistent with the
+    // new daemon.
     let dir = TempDir::new().unwrap();
     let live_path = dir.path().join("wardnetd");
     let staging = dir.path().join("staging");
     let postupgrade = dir.path().join("postupgrade");
 
-    // Pre-place an existing postupgrade payload to confirm it is left
-    // untouched (lenient downgrade tolerance).
     std::fs::create_dir_all(&postupgrade).unwrap();
     std::fs::write(
         postupgrade.join("wardnet-postupgrade.bin"),
@@ -163,95 +189,113 @@ async fn tarball_without_postupgrade_only_swaps_wardnetd() {
     let (pk_text, _sig_text) = signed_pair(b"unused");
     let tarball = make_tarball(&[("wardnetd", b"NEW wardnetd")]);
 
-    let applier = FsBinaryApplier::new(live_path.clone(), staging)
+    let applier = FsBinaryApplier::new(live_path, staging.clone())
         .with_postupgrade(postupgrade.clone(), leak(pk_text));
-    applier.apply(&tarball).await.expect("apply ok");
+    applier
+        .apply(&tarball, b"outer-sig")
+        .await
+        .expect("apply ok");
 
-    assert_eq!(std::fs::read(&live_path).unwrap(), b"NEW wardnetd");
-    // Existing payload is preserved — applier never touched it.
     assert_eq!(
         std::fs::read(postupgrade.join("wardnet-postupgrade.bin")).unwrap(),
         b"existing payload",
     );
+    assert!(staging.join("wardnetd-pending.tar.gz").exists());
 }
 
 #[tokio::test]
-async fn tarball_missing_wardnetd_returns_err() {
+async fn apply_clears_stale_rollback_request() {
+    // A pending rollback request from a previous failed install must
+    // not race a new install — staging the next forward swap clears
+    // the marker so the runner doesn't roll back instead.
+    let dir = TempDir::new().unwrap();
+    let live_path = dir.path().join("wardnetd");
+    let staging = dir.path().join("staging");
+    std::fs::create_dir_all(&staging).unwrap();
+    std::fs::write(staging.join("wardnetd-rollback.request"), b"").unwrap();
+
+    let tarball = make_tarball(&[("wardnetd", b"NEW wardnetd")]);
+    let applier = FsBinaryApplier::new(live_path, staging.clone());
+    applier
+        .apply(&tarball, b"outer-sig")
+        .await
+        .expect("apply ok");
+
+    assert!(!staging.join("wardnetd-rollback.request").exists());
+    assert!(staging.join("wardnetd-pending.tar.gz").exists());
+}
+
+#[tokio::test]
+async fn rollback_writes_request_marker_when_old_binary_present() {
+    let dir = TempDir::new().unwrap();
+    let live_path = dir.path().join("wardnetd");
+    let staging = dir.path().join("staging");
+    let old_path = dir.path().join("wardnetd.old");
+
+    std::fs::write(&old_path, b"previous").unwrap();
+
+    let applier = FsBinaryApplier::new(live_path, staging.clone());
+    applier.rollback().await.expect("rollback request ok");
+
+    assert!(staging.join("wardnetd-rollback.request").exists());
+    // Request is empty (marker only, no body).
+    assert!(
+        std::fs::read(staging.join("wardnetd-rollback.request"))
+            .unwrap()
+            .is_empty(),
+    );
+}
+
+#[tokio::test]
+async fn rollback_without_old_binary_returns_err() {
     let dir = TempDir::new().unwrap();
     let live_path = dir.path().join("wardnetd");
     let staging = dir.path().join("staging");
 
-    let tarball = make_tarball(&[("README", b"unrelated entry")]);
+    let applier = FsBinaryApplier::new(live_path, staging);
+    let err = applier.rollback().await.unwrap_err();
+    assert!(
+        format!("{err:#}").contains("no previous binary"),
+        "expected no-previous-binary error"
+    );
+}
 
+#[tokio::test]
+async fn rollback_available_reflects_old_binary_existence() {
+    let dir = TempDir::new().unwrap();
+    let live_path = dir.path().join("wardnetd");
+    let staging = dir.path().join("staging");
     let applier = FsBinaryApplier::new(live_path.clone(), staging);
-    let err = applier.apply(&tarball).await.unwrap_err();
+
+    assert!(!applier.rollback_available().await);
+    std::fs::write(dir.path().join("wardnetd.old"), b"x").unwrap();
+    assert!(applier.rollback_available().await);
+}
+
+#[tokio::test]
+async fn fs_error_during_apply_carries_failing_path() {
+    // Issue #309 regression: a forced fs failure during staging must
+    // surface the offending PathBuf in the error chain so operators
+    // can diagnose without scraping kernel logs.
+    let dir = TempDir::new().unwrap();
+    let live_path = dir.path().join("wardnetd");
+    // Pre-create staging as a regular file so `create_dir_all` bails
+    // with ENOTDIR — a deterministic stand-in for the EACCES the user
+    // hit in production.
+    let staging = dir.path().join("staging-is-a-file");
+    std::fs::write(&staging, b"not a directory").unwrap();
+
+    let tarball = make_tarball(&[("wardnetd", b"daemon")]);
+    let applier = FsBinaryApplier::new(live_path, staging.clone());
+    let err = applier.apply(&tarball, b"outer-sig").await.unwrap_err();
     let chain = format!("{err:#}");
     assert!(
-        chain.contains("wardnetd"),
-        "expected wardnetd-missing error, got: {chain}"
+        chain.contains(staging.to_string_lossy().as_ref()),
+        "expected failing path in error chain, got: {chain}"
     );
-    assert!(!exists(&live_path));
 }
 
-#[tokio::test]
-async fn postupgrade_swap_failure_does_not_roll_back_wardnetd() {
-    // If the post-upgrade swap step fails AFTER wardnetd has been
-    // renamed (rare but possible: e.g. /var/lib/wardnet/postupgrade
-    // is a regular file, not a directory), the applier logs WARN and
-    // still returns Ok. The new wardnetd is in place; the existing
-    // on-disk postupgrade artifacts are consistent with either the
-    // previous or new wardnetd, and OnFailure=wardnetd-rollback.service
-    // catches any downstream daemon crash.
-    let dir = TempDir::new().unwrap();
-    let live_path = dir.path().join("wardnetd");
-    let staging = dir.path().join("staging");
-    let postupgrade_as_file = dir.path().join("postupgrade-is-a-file");
-    // Pre-create the postupgrade target as a regular file. The
-    // applier's `create_dir_all(&cfg.dir)` will fail because the
-    // path exists but isn't a directory.
-    std::fs::write(&postupgrade_as_file, b"not a directory").unwrap();
-
-    let postupgrade_bin: &[u8] = b"the migration runner binary bytes";
-    let (pk_text, sig_text) = signed_pair(postupgrade_bin);
-
-    let tarball = make_tarball(&[
-        ("wardnetd", b"NEW wardnetd"),
-        ("wardnet-postupgrade.bin", postupgrade_bin),
-        ("wardnet-postupgrade.minisig", sig_text.as_bytes()),
-    ]);
-
-    let applier = FsBinaryApplier::new(live_path.clone(), staging)
-        .with_postupgrade(postupgrade_as_file, leak(pk_text));
-    applier
-        .apply(&tarball)
-        .await
-        .expect("apply must succeed even when postupgrade swap can't proceed");
-
-    // wardnetd was still swapped. The postupgrade swap was skipped.
-    assert_eq!(std::fs::read(&live_path).unwrap(), b"NEW wardnetd");
-}
-
-#[tokio::test]
-async fn unconfigured_postupgrade_ignores_artifacts_in_tarball() {
-    // Backwards-compat: an applier built without `.with_postupgrade(...)`
-    // must skip the .bin/.minisig in the tarball entirely, even if
-    // they're present. Useful for legacy callers and the in-tree
-    // wardnetd-mock when run without a postupgrade fixture path.
-    let dir = TempDir::new().unwrap();
-    let live_path = dir.path().join("wardnetd");
-    let staging = dir.path().join("staging");
-
-    let tarball = make_tarball(&[
-        ("wardnetd", b"daemon"),
-        ("wardnet-postupgrade.bin", b"would-be-payload"),
-        ("wardnet-postupgrade.minisig", b"would-be-signature"),
-    ]);
-
-    let applier = FsBinaryApplier::new(live_path.clone(), staging);
-    applier.apply(&tarball).await.expect("apply ok");
-    assert_eq!(std::fs::read(&live_path).unwrap(), b"daemon");
-}
-
+#[allow(dead_code)]
 fn exists(p: &Path) -> bool {
     p.exists()
 }

--- a/source/daemon/crates/wardnetd-services/src/update/tests/fs_applier.rs
+++ b/source/daemon/crates/wardnetd-services/src/update/tests/fs_applier.rs
@@ -295,6 +295,51 @@ async fn fs_error_during_apply_carries_failing_path() {
     );
 }
 
+#[tokio::test]
+async fn apply_logs_warning_when_postupgrade_swap_fails() {
+    // The pre-flight verify of the postupgrade pair succeeds, but the
+    // subsequent rename into `cfg.dir` fails — `swap_postupgrade`
+    // returns Err and the apply path logs (rather than aborts) so the
+    // staged wardnetd tarball still reaches the runner.
+    let dir = TempDir::new().unwrap();
+    let live_path = dir.path().join("wardnetd");
+    let staging = dir.path().join("staging");
+    // Postupgrade dir resolves to a regular file -> create_dir_all
+    // inside swap_postupgrade returns ENOTDIR. Same shape of error the
+    // diagnose-by-path #309 fix surfaces, just for the postupgrade
+    // pipeline rather than the wardnetd swap.
+    let postupgrade = dir.path().join("postupgrade-is-a-file");
+    std::fs::write(&postupgrade, b"not a dir").unwrap();
+
+    let postupgrade_bin: &[u8] = b"the migration runner binary bytes";
+    let (pk_text, sig_text) = signed_pair(postupgrade_bin);
+
+    let tarball = make_tarball(&[
+        ("wardnetd", b"NEW wardnetd"),
+        ("wardnet-postupgrade.bin", postupgrade_bin),
+        ("wardnet-postupgrade.minisig", sig_text.as_bytes()),
+    ]);
+
+    let applier = FsBinaryApplier::new(live_path.clone(), staging.clone())
+        .with_postupgrade(postupgrade, leak(pk_text));
+
+    // The wardnetd tarball is still staged — only the postupgrade
+    // swap is best-effort. A subscriber is installed for the duration
+    // so the warn macro's structured fields actually evaluate;
+    // coverage tools treat field exprs inside disabled tracing macros
+    // as unhit.
+    let subscriber = tracing_subscriber::fmt()
+        .with_max_level(tracing::Level::TRACE)
+        .with_test_writer()
+        .finish();
+    let _guard = tracing::subscriber::set_default(subscriber);
+    applier
+        .apply(&tarball, b"outer-sig")
+        .await
+        .expect("apply ok despite postupgrade swap failure");
+    assert!(staging.join("wardnetd-pending.tar.gz").exists());
+}
+
 #[allow(dead_code)]
 fn exists(p: &Path) -> bool {
     p.exists()

--- a/source/daemon/crates/wardnetd-services/src/update/tests/service.rs
+++ b/source/daemon/crates/wardnetd-services/src/update/tests/service.rs
@@ -134,7 +134,7 @@ struct RecordingApplier {
 
 #[async_trait]
 impl BinaryApplier for RecordingApplier {
-    async fn apply(&self, _tarball: &[u8]) -> anyhow::Result<SwapOutcome> {
+    async fn apply(&self, _tarball: &[u8], _signature: &[u8]) -> anyhow::Result<SwapOutcome> {
         *self.apply_count.lock().unwrap() += 1;
         let prev = std::path::PathBuf::from("/tmp/fake.old");
         *self.rollback_target.lock().unwrap() = Some(prev.clone());

--- a/source/daemon/crates/wardnetd-services/src/update/tests/service.rs
+++ b/source/daemon/crates/wardnetd-services/src/update/tests/service.rs
@@ -130,11 +130,24 @@ struct RecordingApplier {
     apply_count: StdMutex<u32>,
     rolled_back: StdMutex<bool>,
     rollback_target: StdMutex<Option<std::path::PathBuf>>,
+    apply_signatures: StdMutex<Vec<Vec<u8>>>,
+    apply_should_fail: StdMutex<bool>,
 }
 
 #[async_trait]
 impl BinaryApplier for RecordingApplier {
-    async fn apply(&self, _tarball: &[u8], _signature: &[u8]) -> anyhow::Result<SwapOutcome> {
+    async fn apply(&self, _tarball: &[u8], signature: &[u8]) -> anyhow::Result<SwapOutcome> {
+        self.apply_signatures
+            .lock()
+            .unwrap()
+            .push(signature.to_vec());
+        if *self.apply_should_fail.lock().unwrap() {
+            // Chained context simulates an `io::Error` wrapped with a path —
+            // exercises the `format!("{err:#}")` branch in `run_install`.
+            return Err(
+                anyhow::anyhow!("EACCES (os error 13)").context("rename /usr/local/bin/wardnetd")
+            );
+        }
         *self.apply_count.lock().unwrap() += 1;
         let prev = std::path::PathBuf::from("/tmp/fake.old");
         *self.rollback_target.lock().unwrap() = Some(prev.clone());
@@ -165,19 +178,53 @@ fn build_service(
     Arc<RecordingApplier>,
     Arc<BroadcastEventBus>,
 ) {
+    build_service_full(release, false)
+}
+
+fn build_service_full(
+    release: Option<Release>,
+    require_signature: bool,
+) -> (
+    Arc<UpdateServiceImpl>,
+    Arc<RecordingApplier>,
+    Arc<BroadcastEventBus>,
+) {
     let applier = Arc::new(RecordingApplier::default());
     let events = Arc::new(BroadcastEventBus::new(32));
+    let history = Arc::new(MemoryHistory::default());
     let svc = Arc::new(UpdateServiceImpl::new(
         Arc::new(MemoryConfig::default()),
-        Arc::new(MemoryHistory::default()),
+        history,
         Arc::new(StubReleaseSource(release)),
         Arc::new(AlwaysOkVerifier),
         applier.clone(),
         events.clone(),
-        false,
+        require_signature,
         "0.1.0",
     ));
     (svc, applier, events)
+}
+
+fn test_release_with_minisig() -> Release {
+    Release {
+        version: "0.2.0".to_owned(),
+        tarball_url: "http://example/t.tar.gz".to_owned(),
+        sha256_url: "http://example/t.tar.gz.sha256".to_owned(),
+        minisig_url: Some("http://example/t.tar.gz.minisig".to_owned()),
+        published_at: None,
+        notes: None,
+    }
+}
+
+fn test_release_without_minisig() -> Release {
+    Release {
+        version: "0.2.0".to_owned(),
+        tarball_url: "http://example/t.tar.gz".to_owned(),
+        sha256_url: "http://example/t.tar.gz.sha256".to_owned(),
+        minisig_url: None,
+        published_at: None,
+        notes: None,
+    }
 }
 
 #[tokio::test]
@@ -286,4 +333,131 @@ async fn auto_install_skipped_when_disabled() {
         .await
         .unwrap();
     assert!(result.is_none());
+}
+
+#[tokio::test]
+async fn run_install_success_drives_pipeline_through_apply() {
+    // End-to-end install: drives `run_install` → `install_pipeline` →
+    // `applier.apply`. Covers the success path through the new
+    // `Some(minisig_url)` branch and the `apply(&tarball, &sig_bytes)`
+    // call introduced by the runner-mediated swap rework.
+    let release = test_release_with_minisig();
+    let (svc, applier, events) = build_service(Some(release.clone()));
+    let mut rx = events.subscribe();
+
+    auth_context::with_context(test_admin_ctx(), svc.run_install(release))
+        .await
+        .expect("install ok");
+
+    assert_eq!(*applier.apply_count.lock().unwrap(), 1);
+    let mut completed = false;
+    while let Ok(evt) = rx.try_recv() {
+        if matches!(
+            evt,
+            wardnet_common::event::WardnetEvent::UpdateCompleted { .. }
+        ) {
+            completed = true;
+        }
+    }
+    assert!(completed, "expected UpdateCompleted event");
+}
+
+#[tokio::test]
+async fn run_install_with_failing_apply_records_anyhow_chain() {
+    // Regression for #309: the failing PathBuf propagated through the
+    // anyhow chain must reach the history row's `error` column. The
+    // `format!("{err:#}")` rendering walks the full chain — the bare
+    // `to_string()` it replaced only produced the leaf message.
+    let release = test_release_with_minisig();
+    let (svc, applier, _events) = build_service(Some(release.clone()));
+    *applier.apply_should_fail.lock().unwrap() = true;
+
+    let err = auth_context::with_context(test_admin_ctx(), svc.run_install(release))
+        .await
+        .expect_err("expected install failure");
+
+    let rendered = format!("{err:#}");
+    assert!(
+        rendered.contains("rename /usr/local/bin/wardnetd"),
+        "expected outer context in chain, got: {rendered}",
+    );
+    assert!(
+        rendered.contains("EACCES"),
+        "expected inner cause in chain, got: {rendered}",
+    );
+}
+
+#[tokio::test]
+async fn install_pipeline_requires_minisig_when_signature_required() {
+    // `require_signature=true` + a release without `minisig_url` must
+    // bail in the Verifying phase. The runner-mediated swap also needs
+    // a signature, but that constraint lives in the runner; this gate
+    // is the daemon-side opt-in pre-stash check.
+    let release = test_release_without_minisig();
+    let (svc, _applier, _events) = build_service_full(Some(release.clone()), true);
+
+    let (phase, err) = svc
+        .install_pipeline(&release)
+        .await
+        .expect_err("expected err");
+    assert!(matches!(
+        phase,
+        wardnet_common::update::InstallPhase::Verifying
+    ));
+    let rendered = format!("{err}");
+    assert!(
+        rendered.contains("signature required"),
+        "expected signature-required message, got: {rendered}",
+    );
+}
+
+#[tokio::test]
+async fn install_pipeline_runs_signature_verifier_when_required() {
+    // `require_signature=true` + a release with `minisig_url=Some`
+    // drives the verifier's `verify_signature` method. Covers the
+    // post-fetch verifier branch that's gated behind both flags.
+    let release = test_release_with_minisig();
+    let (svc, _applier, _events) = build_service_full(Some(release.clone()), true);
+
+    svc.install_pipeline(&release)
+        .await
+        .expect("pipeline ok with require_signature + minisig_url");
+}
+
+#[tokio::test]
+async fn install_pipeline_warns_and_proceeds_without_minisig_when_optional() {
+    // `require_signature=false` + missing `minisig_url` must NOT abort:
+    // the daemon stages the tarball with an empty signature and the
+    // runner is the one that will refuse to swap (logged warning makes
+    // that explicit). Empty `sig_bytes` reaches the applier verbatim.
+    let release = test_release_without_minisig();
+    let (svc, applier, _events) = build_service_full(Some(release.clone()), false);
+
+    svc.install_pipeline(&release).await.expect("pipeline ok");
+
+    let signatures = applier.apply_signatures.lock().unwrap();
+    assert_eq!(signatures.len(), 1);
+    assert!(
+        signatures[0].is_empty(),
+        "expected empty signature passthrough"
+    );
+}
+
+#[tokio::test]
+async fn rollback_with_previous_records_history_and_emits_log() {
+    // Drives the success path of `rollback`: applier reports a
+    // rollback target available, so the request marker is staged and
+    // a `RolledBack` history row is recorded. Covers the rollback log
+    // line introduced by the runner-mediated swap rework.
+    let (svc, applier, _events) = build_service(None);
+    // Pre-seed a rollback target the way a successful prior install would.
+    *applier.rollback_target.lock().unwrap() = Some(std::path::PathBuf::from("/tmp/fake.old"));
+
+    let svc_trait: Arc<dyn UpdateService> = svc;
+    let resp = auth_context::with_context(test_admin_ctx(), svc_trait.rollback())
+        .await
+        .expect("rollback ok");
+
+    assert!(resp.message.contains("rollback staged"));
+    assert!(*applier.rolled_back.lock().unwrap());
 }


### PR DESCRIPTION
## Summary

Fixes the auto-update EACCES failure by moving the `/usr/local/bin/wardnetd` rename out of the daemon and into `wardnet-postupgrade-runner` (root, embedded public key).

The daemon (wardnet user) **cannot** rename into `/usr/local/bin/` — the parent dir is `root:root 0755` and `rename(2)` requires write+x on the destination directory regardless of file ownership. The previous in-process applier was structurally broken; `install.sh` has been the only thing actually replacing the binary on production hosts.

## What changed

- **Daemon (`FsBinaryApplier`)** now stages the verified tarball + signature at `/var/lib/wardnet/updates/wardnetd-pending.tar.gz{,.minisig}` and triggers a restart. The wardnet user can write there; that's the only access it needs. The `wardnet-postupgrade.bin` / `.minisig` swap stays in the daemon (its destination dir is wardnet-writable).
- **Runner (`wardnet-postupgrade-runner`)** gains a `swap` module that runs before the existing migration-exec step. It re-verifies the staged tarball against the embedded public key, extracts `wardnetd`, and atomically renames into `/usr/local/bin/wardnetd` (preserving `<live>.old` for rollback). On any failure it exits nonzero, gating `wardnetd.service` from starting against an unverified binary.
- **Rollback** follows the same trust path: the daemon writes a request marker, the runner performs the actual `<live>.old → <live>` rename under root.
- **`wardnetd.service`** drops `/usr/local/bin` from `ReadWritePaths=` (no longer needed by the daemon user).
- **`install.sh`** comments updated; install command unchanged.
- **Path-context propagation** through every `std::fs::*` call in the applier + render `{err:#}` in the update history row, so future fs failures land in the log with the path attached (the original ask in #309).

## Trust model

The runner is the trust anchor:
- Root-owned binary at `/usr/local/libexec/wardnet/runner/`, NOT in `wardnetd.service`'s `ReadWritePaths` so the wardnet user cannot replace it via auto-update.
- Embeds the release public key at compile time.
- Re-verifies the staged tarball's detached minisign signature on every run.

The wardnet user can stage arbitrary bytes at the pending paths but cannot get a payload past the embedded key. Re-verification under root also closes a TOCTOU window — the wardnet user could in principle replace the staged tarball after the daemon's pre-stage verify; the runner's re-verify defeats that.

## Migration / upgrade story

A 2026.05.00 or 2026.05.01 host running this PR's predecessor will hit the same EACCES on its first auto-update attempt — the running daemon predates this fix. After this lands as e.g. 2026.05.02, affected users need to run `install.sh --upgrade-only` once:

```sh
curl -sSL https://wardnet.network/install.sh | sudo bash -s -- --upgrade-only
```

After that one-time recovery, all future auto-updates go through the runner-mediated swap and don't need install.sh.

This requirement should land in the 2026.05.02 release notes.

## Test plan

- [x] `make check-daemon` passes (fmt + clippy `-D warnings` + workspace tests, 629 total — 18 new across applier and runner crates).
- [x] New unit tests exercise the swap module's happy path, signature mismatch, missing wardnetd entry, fresh-install (no existing live binary), rollback request, rollback precedence over a coincident pending swap, and rollback with no `<live>.old`.
- [x] New applier tests exercise pending-tarball staging, postupgrade swap-still-happens, stale rollback-request clearing, rollback marker writing, and fs error path propagation.
- [x] Verified empirically on a 2026.05.01 Pi that the daemon's wardnet user cannot write to `/usr/local/bin/` even under the unit's exact systemd settings (`User=wardnet`, `ProtectSystem=strict`, `ReadWritePaths=/usr/local/bin`) — confirms the bug is structural, not a state issue.
- [ ] Container-level N-1 → N e2e via `tests-e2e` is **not** in this PR. Worth a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)