### PR TITLE
feat: Safe Reboot / Safe Shutdown (closes #215)

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -7339,6 +7339,125 @@
         ]
       }
     },
+    "/api/system/reboot": {
+      "post": {
+        "tags": [
+          "system"
+        ],
+        "summary": "Reboot the host (Pi-level), not just the daemon.",
+        "description": "Reboot the host. Returns immediately; the reboot itself is queued via systemd-logind and runs once the response has flushed. The daemon will be unreachable for as long as the host takes to come back up — typically 30–60 s on a Raspberry Pi.",
+        "operationId": "reboot",
+        "responses": {
+          "204": {
+            "description": "Reboot scheduled"
+          },
+          "401": {
+            "description": "Unauthenticated — session cookie or API key missing/invalid",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "description": "Standard API error response.",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "detail": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "error": {
+                      "type": "string"
+                    },
+                    "request_id": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "description": "Request ID for correlation with server logs."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden — caller is not an admin",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "description": "Standard API error response.",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "detail": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "error": {
+                      "type": "string"
+                    },
+                    "request_id": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "description": "Request ID for correlation with server logs."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "description": "Standard API error response.",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "detail": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "error": {
+                      "type": "string"
+                    },
+                    "request_id": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "description": "Request ID for correlation with server logs."
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "session_cookie": []
+          },
+          {
+            "bearer_auth": []
+          }
+        ]
+      }
+    },
     "/api/system/restart": {
       "post": {
         "tags": [
@@ -7350,6 +7469,125 @@
         "responses": {
           "204": {
             "description": "Restart scheduled"
+          },
+          "401": {
+            "description": "Unauthenticated — session cookie or API key missing/invalid",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "description": "Standard API error response.",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "detail": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "error": {
+                      "type": "string"
+                    },
+                    "request_id": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "description": "Request ID for correlation with server logs."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden — caller is not an admin",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "description": "Standard API error response.",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "detail": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "error": {
+                      "type": "string"
+                    },
+                    "request_id": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "description": "Request ID for correlation with server logs."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "description": "Standard API error response.",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "detail": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "error": {
+                      "type": "string"
+                    },
+                    "request_id": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "description": "Request ID for correlation with server logs."
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "session_cookie": []
+          },
+          {
+            "bearer_auth": []
+          }
+        ]
+      }
+    },
+    "/api/system/shutdown": {
+      "post": {
+        "tags": [
+          "system"
+        ],
+        "summary": "Power off the host. Internet is unavailable until the operator\nphysically powers the Pi back on.",
+        "description": "Power the host off. Returns immediately; the poweroff itself is queued via systemd-logind and runs once the response has flushed. The daemon will not come back up until the operator turns the Pi on again.",
+        "operationId": "shutdown",
+        "responses": {
+          "204": {
+            "description": "Shutdown scheduled"
           },
           "401": {
             "description": "Unauthenticated — session cookie or API key missing/invalid",

--- a/source/daemon/Dockerfile.test
+++ b/source/daemon/Dockerfile.test
@@ -155,14 +155,17 @@ EOF
 FROM ghcr.io/wardnet/wardnet-base@sha256:ba478f4a8b6441af3ebe8b3b4918d44040905a4b92dcefaf0d150eede8aad53b
 
 # Test-only client tooling: dig (DNS probe), ping (reachability),
-# dhclient (lease renew). Not in wardnet-base because the prod image
-# doesn't need them; they only exist for the wardnet-test-agent client
-# subcommands that the end-to-end suite drives.
+# dhclient (lease renew). policykit-1 ships pkcheck + the polkitd
+# daemon, both required for the Safe Reboot / Safe Shutdown
+# end-to-end spec (#215). Not in wardnet-base because the prod image
+# doesn't need them; they only exist for the wardnet-test-agent
+# client subcommands that the end-to-end suite drives.
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         dnsutils \
         iputils-ping \
         isc-dhcp-client \
+        policykit-1 \
     && rm -rf /var/lib/apt/lists/*
 
 # install.sh + service units copied from the repo (online manifest
@@ -217,6 +220,36 @@ RUN chmod 0755 /usr/local/bin/wardnet-test-agent \
     && chmod 0644 /etc/systemd/system/wardnet-test-agent.service \
     && ln -s /etc/systemd/system/wardnet-test-agent.service \
         /etc/systemd/system/multi-user.target.wants/wardnet-test-agent.service
+
+# Shim for `systemctl` at /usr/sbin/systemctl that intercepts the
+# `reboot` / `poweroff` subcommands so the Safe Reboot / Safe
+# Shutdown end-to-end spec (#215) can assert the daemon's spawned
+# task actually invoked them — without literally rebooting CI.
+#
+# The daemon's production `ShellCommandExecutor` resolves the
+# program name through `/usr/sbin` and `/sbin` first (see
+# `source/daemon/crates/wardnetd/src/command.rs`), so a binary
+# named `systemctl` parked here is what wardnetd will exec when
+# `SystemctlPowerOps::reboot()` / `.poweroff()` runs. Other
+# systemctl callers (the test agent, install.sh, manual `docker
+# exec` debugging) keep using the real binary at `/usr/bin/systemctl`
+# — this shim only shadows for processes that resolve via sbin.
+#
+# The shim writes its argv to a marker file under /var/lib/wardnet
+# that the test-agent's `/power/systemctl-invocations` endpoint
+# surfaces back to the spec. Each invocation appends a line; the
+# spec reads the whole file and asserts the expected verbs landed.
+COPY <<"SHIM_EOF" /usr/sbin/systemctl
+#!/bin/sh
+# Test-only shim — see Dockerfile.test for context. Installed by
+# the wardnet test image so end-to-end specs can verify Safe
+# Reboot / Safe Shutdown without rebooting CI.
+mkdir -p /var/lib/wardnet
+echo "$@" >> /var/lib/wardnet/systemctl-invocations.log
+exit 0
+SHIM_EOF
+RUN chown root:root /usr/sbin/systemctl \
+    && chmod 0755 /usr/sbin/systemctl
 
 # wardnet-base already exposes 53/udp 53/tcp 67/udp 7411/tcp for the
 # daemon; the test-agent's HTTP probe API listens on 3001 (see

--- a/source/daemon/crates/wardnet-postupgrade/src/lib.rs
+++ b/source/daemon/crates/wardnet-postupgrade/src/lib.rs
@@ -19,6 +19,7 @@
 pub mod migrations;
 pub mod runner;
 pub mod state;
+pub mod up;
 
 pub use migrations::{Migration, Severity, migrations};
 pub use runner::{RunOutcome, RunReport, run};

--- a/source/daemon/crates/wardnet-postupgrade/src/migrations.rs
+++ b/source/daemon/crates/wardnet-postupgrade/src/migrations.rs
@@ -36,9 +36,21 @@ pub struct Migration {
 /// The migration list applied at every boot. Order matters: each
 /// migration may rely on the system state established by earlier
 /// applied migrations.
-///
-/// Empty until #215 lands `0001_polkit_power_rule`.
 #[must_use]
 pub fn migrations() -> &'static [Migration] {
-    &[]
+    &[Migration {
+        // Authorises the daemon (running as the unprivileged
+        // `wardnet` user) to call logind's reboot / power-off
+        // actions, which is what `systemctl reboot|poweroff
+        // --no-block` invokes under the hood. See #215.
+        //
+        // Severity::Optional: the daemon still starts without it.
+        // Only Safe Reboot / Safe Shutdown stop working — the rest
+        // of the system keeps functioning, so blocking startup
+        // would be the wrong trade-off (e.g. on a non-systemd
+        // container or a host where polkit is uninstalled).
+        id: "0001_polkit_power_rule",
+        severity: Severity::Optional,
+        up: crate::up::write_polkit_power_rule,
+    }]
 }

--- a/source/daemon/crates/wardnet-postupgrade/src/tests/migrations.rs
+++ b/source/daemon/crates/wardnet-postupgrade/src/tests/migrations.rs
@@ -3,14 +3,32 @@
 use crate::migrations::{Severity, migrations};
 
 #[test]
-fn empty_list_until_first_migration_lands() {
-    // The framework ships with no migrations — #215 (polkit power
-    // rule) is the first consumer. This test pins the empty state
-    // so an accidental insert here gets caught at PR time and the
-    // author goes through the proper migration-add review.
+fn lists_polkit_power_rule_migration() {
+    // Pins the first entry so an accidental edit to migration ids,
+    // severities, or ordering surfaces at PR time. Migration ids
+    // MUST NEVER change once shipped — operators have state files
+    // referencing them.
+    let list = migrations();
     assert!(
-        migrations().is_empty(),
-        "migration list must stay empty until a deliberate migration is added"
+        !list.is_empty(),
+        "migration list should contain at least 0001_polkit_power_rule"
+    );
+    let first = &list[0];
+    assert_eq!(first.id, "0001_polkit_power_rule");
+    assert_eq!(first.severity, Severity::Optional);
+}
+
+#[test]
+fn migration_ids_are_unique() {
+    let list = migrations();
+    let mut ids: Vec<&'static str> = list.iter().map(|m| m.id).collect();
+    ids.sort_unstable();
+    let len_before = ids.len();
+    ids.dedup();
+    assert_eq!(
+        ids.len(),
+        len_before,
+        "duplicate migration id detected in migrations()"
     );
 }
 

--- a/source/daemon/crates/wardnet-postupgrade/src/up/mod.rs
+++ b/source/daemon/crates/wardnet-postupgrade/src/up/mod.rs
@@ -1,0 +1,27 @@
+//! Migration `up` functions.
+//!
+//! Each function in this module corresponds to one entry in
+//! [`crate::migrations::migrations()`]. Functions are **idempotent
+//! reconcilers** — running the same migration twice must leave the
+//! system in the same state and must not flip the file's mtime if no
+//! content change is required.
+//!
+//! Functions exposed at this level take no arguments so they fit the
+//! `fn() -> anyhow::Result<()>` shape expected by [`crate::Migration`].
+//! The actual logic lives in submodules that accept a base-path
+//! argument so unit tests can drive them against a `tempfile::TempDir`.
+
+use std::path::Path;
+
+pub mod polkit;
+
+/// Migration `0001_polkit_power_rule` entry point.
+///
+/// Writes `/etc/polkit-1/rules.d/50-wardnet-power.rules` so the
+/// unprivileged `wardnet` user can call
+/// `org.freedesktop.login1.{Reboot,PowerOff}` (plus the
+/// `*-multiple-sessions` variants) — what `systemctl reboot` and
+/// `systemctl poweroff` actually invoke under the hood.
+pub fn write_polkit_power_rule() -> anyhow::Result<()> {
+    polkit::write_rule(Path::new(polkit::DEFAULT_RULES_DIR))
+}

--- a/source/daemon/crates/wardnet-postupgrade/src/up/polkit.rs
+++ b/source/daemon/crates/wardnet-postupgrade/src/up/polkit.rs
@@ -1,0 +1,189 @@
+//! Idempotent writer for the polkit rule that authorises Safe
+//! Reboot / Safe Shutdown for the `wardnet` user.
+
+use std::fs;
+use std::io::Write;
+use std::os::unix::fs::PermissionsExt;
+use std::path::Path;
+
+use anyhow::Context;
+
+/// Filename of the rule under `rules.d/`. The numeric prefix orders
+/// the rule in polkit's evaluation sequence; 50 puts it after most
+/// distro defaults but before any operator override at 60+.
+pub const RULE_FILENAME: &str = "50-wardnet-power.rules";
+
+/// Default base directory on a real Pi. Tests pass tempdir paths.
+pub const DEFAULT_RULES_DIR: &str = "/etc/polkit-1/rules.d";
+
+/// Embedded rule body. The trailing newline matters: polkit's parser
+/// is whitespace-tolerant but operators reading the file expect a
+/// final newline like every other config file.
+pub const RULE_BODY: &str = include_str!("polkit_power.rules.in");
+
+/// File mode applied to the rule file. Polkit reads it as root, so
+/// world-readable is fine and matches every other rule under
+/// `rules.d/`.
+const RULE_MODE: u32 = 0o644;
+
+/// Write the rule to `<base>/50-wardnet-power.rules`.
+///
+/// Idempotent: if a file with identical content already exists this
+/// returns `Ok(())` without rewriting. Otherwise it writes a sibling
+/// temp file, fsyncs it, renames into place, and fsyncs the parent
+/// directory so a power loss after the rename leaves the new content
+/// (rather than zeroes) on disk.
+///
+/// Polkitd `inotify`-watches `rules.d/` so no reload step is needed.
+pub fn write_rule(base: &Path) -> anyhow::Result<()> {
+    let target = base.join(RULE_FILENAME);
+
+    // Idempotent fast path: bytes already match. Don't touch mtime.
+    if let Ok(existing) = fs::read(&target)
+        && existing == RULE_BODY.as_bytes()
+    {
+        // Even on a no-op pass, make sure the mode is what we want.
+        // Operators sometimes hand-chmod files; reconciling here
+        // means a re-run after such a tweak puts mode back to 0644.
+        ensure_mode(&target)?;
+        return Ok(());
+    }
+
+    fs::create_dir_all(base)
+        .with_context(|| format!("creating polkit rules dir {}", base.display()))?;
+
+    // Sibling temp file so the rename is atomic on the same fs.
+    // Leading '.' keeps the partial file out of polkit's inotify
+    // attention until we rename it onto the final name.
+    let tmp = base.join(format!(".{RULE_FILENAME}.tmp"));
+
+    {
+        let mut file = fs::File::create(&tmp)
+            .with_context(|| format!("creating temp file {}", tmp.display()))?;
+        file.write_all(RULE_BODY.as_bytes())
+            .with_context(|| format!("writing temp file {}", tmp.display()))?;
+        file.sync_all()
+            .with_context(|| format!("fsync temp file {}", tmp.display()))?;
+        // Explicitly set permissions before the rename so polkitd
+        // never sees the file with default umask permissions.
+        fs::set_permissions(&tmp, fs::Permissions::from_mode(RULE_MODE))
+            .with_context(|| format!("chmod temp file {}", tmp.display()))?;
+    }
+
+    fs::rename(&tmp, &target)
+        .with_context(|| format!("rename {} -> {}", tmp.display(), target.display()))?;
+
+    // Fsync the parent so the rename hits disk before we return —
+    // otherwise a sudden power loss could replay an old metadata
+    // state where the rename hasn't been persisted.
+    fsync_dir(base)?;
+
+    Ok(())
+}
+
+/// Ensure the existing file is mode 0644. Returns Ok if already so.
+fn ensure_mode(path: &Path) -> anyhow::Result<()> {
+    let meta = fs::metadata(path).with_context(|| format!("stat {}", path.display()))?;
+    let current = meta.permissions().mode() & 0o777;
+    if current != RULE_MODE {
+        fs::set_permissions(path, fs::Permissions::from_mode(RULE_MODE))
+            .with_context(|| format!("chmod {}", path.display()))?;
+    }
+    Ok(())
+}
+
+/// Open the directory and call `fsync(2)` on it.
+fn fsync_dir(dir: &Path) -> anyhow::Result<()> {
+    let f = fs::File::open(dir).with_context(|| format!("open dir {}", dir.display()))?;
+    f.sync_all()
+        .with_context(|| format!("fsync dir {}", dir.display()))?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::os::unix::fs::PermissionsExt;
+    use tempfile::TempDir;
+
+    #[test]
+    fn writes_expected_content_and_mode() {
+        let dir = TempDir::new().unwrap();
+        write_rule(dir.path()).unwrap();
+
+        let file = dir.path().join(RULE_FILENAME);
+        let bytes = fs::read(&file).unwrap();
+        assert_eq!(bytes, RULE_BODY.as_bytes());
+
+        let mode = fs::metadata(&file).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o644, "expected 0644, got {mode:o}");
+    }
+
+    #[test]
+    fn rule_body_authorises_wardnet_user_for_login1_actions() {
+        // Spot-check the embedded rule body — guards against an
+        // accidental edit that no longer matches the four action ids
+        // the daemon needs.
+        assert!(RULE_BODY.contains("subject.user !== \"wardnet\""));
+        assert!(RULE_BODY.contains("org.freedesktop.login1.reboot"));
+        assert!(RULE_BODY.contains("org.freedesktop.login1.reboot-multiple-sessions"));
+        assert!(RULE_BODY.contains("org.freedesktop.login1.power-off"));
+        assert!(RULE_BODY.contains("org.freedesktop.login1.power-off-multiple-sessions"));
+        assert!(RULE_BODY.contains("polkit.Result.YES"));
+    }
+
+    #[test]
+    fn idempotent_rerun_preserves_mtime() {
+        let dir = TempDir::new().unwrap();
+        write_rule(dir.path()).unwrap();
+        let file = dir.path().join(RULE_FILENAME);
+        let mtime_before = fs::metadata(&file).unwrap().modified().unwrap();
+
+        // Sleep briefly so a rewrite would produce a different mtime
+        // even on filesystems with second-resolution timestamps.
+        std::thread::sleep(std::time::Duration::from_millis(1100));
+
+        write_rule(dir.path()).unwrap();
+        let mtime_after = fs::metadata(&file).unwrap().modified().unwrap();
+        assert_eq!(
+            mtime_before, mtime_after,
+            "second run rewrote the file even though content matched"
+        );
+    }
+
+    #[test]
+    fn mismatched_content_is_rewritten() {
+        let dir = TempDir::new().unwrap();
+        let file = dir.path().join(RULE_FILENAME);
+        fs::write(&file, b"// stale content from a hand edit\n").unwrap();
+
+        write_rule(dir.path()).unwrap();
+        let bytes = fs::read(&file).unwrap();
+        assert_eq!(bytes, RULE_BODY.as_bytes());
+    }
+
+    #[test]
+    fn idempotent_rerun_restores_mode_if_chmodded() {
+        let dir = TempDir::new().unwrap();
+        write_rule(dir.path()).unwrap();
+        let file = dir.path().join(RULE_FILENAME);
+
+        // Operator chmods to 0600 by mistake; re-running the
+        // migration should put it back to 0644 without rewriting
+        // the content.
+        fs::set_permissions(&file, fs::Permissions::from_mode(0o600)).unwrap();
+        write_rule(dir.path()).unwrap();
+
+        let mode = fs::metadata(&file).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o644);
+    }
+
+    #[test]
+    fn creates_base_directory_if_missing() {
+        let parent = TempDir::new().unwrap();
+        let base = parent.path().join("not-yet-created");
+        write_rule(&base).unwrap();
+
+        assert!(base.join(RULE_FILENAME).exists());
+    }
+}

--- a/source/daemon/crates/wardnet-postupgrade/src/up/polkit_power.rules.in
+++ b/source/daemon/crates/wardnet-postupgrade/src/up/polkit_power.rules.in
@@ -1,0 +1,14 @@
+// Authorise the unprivileged 'wardnet' daemon user to reboot and power
+// off the host. Managed by Wardnet's post-upgrade migration framework
+// (migration 0001_polkit_power_rule). Do not edit by hand.
+polkit.addRule(function(action, subject) {
+    if (subject.user !== "wardnet") {
+        return;
+    }
+    if (action.id === "org.freedesktop.login1.reboot" ||
+        action.id === "org.freedesktop.login1.reboot-multiple-sessions" ||
+        action.id === "org.freedesktop.login1.power-off" ||
+        action.id === "org.freedesktop.login1.power-off-multiple-sessions") {
+        return polkit.Result.YES;
+    }
+});

--- a/source/daemon/crates/wardnet-test-agent/src/server/handlers/mod.rs
+++ b/source/daemon/crates/wardnet-test-agent/src/server/handlers/mod.rs
@@ -5,3 +5,4 @@ pub mod fixtures;
 pub mod kernel;
 pub mod pid;
 pub mod postupgrade;
+pub mod power;

--- a/source/daemon/crates/wardnet-test-agent/src/server/handlers/power.rs
+++ b/source/daemon/crates/wardnet-test-agent/src/server/handlers/power.rs
@@ -1,0 +1,162 @@
+//! Read-only handlers for the Safe Reboot / Safe Shutdown e2e suite.
+//!
+//! Three concerns:
+//!
+//! 1. Surface the contents of the `systemctl` invocation log written
+//!    by the test image's shim, so the spec can assert that the
+//!    daemon's spawned task actually called `systemctl reboot
+//!    --no-block` / `systemctl poweroff --no-block`.
+//! 2. Surface the contents of the polkit rule file written by the
+//!    `0001_polkit_power_rule` migration, so the spec can verify the
+//!    install put it on disk with the expected payload.
+//! 3. Run `pkcheck` as the `wardnet` user — the closest we can get
+//!    to "polkit accepts the rule" without rebooting CI.
+//!
+//! All three only run inside the test image. Production daemons
+//! never ship the test agent.
+
+use axum::Json;
+use axum::extract::Query;
+use axum::http::StatusCode;
+use axum::response::IntoResponse;
+use serde::{Deserialize, Serialize};
+use tokio::process::Command;
+
+/// Path the test image's `systemctl` shim writes to. Matches the
+/// `Dockerfile.test` shim — keep in sync.
+const SYSTEMCTL_INVOCATIONS_LOG: &str = "/var/lib/wardnet/systemctl-invocations.log";
+
+/// Where the `0001_polkit_power_rule` migration drops the rule.
+const POLKIT_RULE_PATH: &str = "/etc/polkit-1/rules.d/50-wardnet-power.rules";
+
+#[derive(Debug, Serialize)]
+pub struct FileContentsResponse {
+    pub path: &'static str,
+    pub exists: bool,
+    pub contents: Option<String>,
+}
+
+/// `GET /power/systemctl-invocations` — returns each line written
+/// by the shim. Returns `exists: false` if the daemon never invoked
+/// the shim (i.e. before the first reboot/shutdown POST), so specs
+/// can poll deterministically without 404 noise.
+pub async fn get_systemctl_invocations() -> impl IntoResponse {
+    read_optional_file(SYSTEMCTL_INVOCATIONS_LOG).await
+}
+
+/// `GET /power/polkit-rule` — returns the on-disk rule content if
+/// the migration has run.
+pub async fn get_polkit_rule() -> impl IntoResponse {
+    read_optional_file(POLKIT_RULE_PATH).await
+}
+
+async fn read_optional_file(path: &'static str) -> impl IntoResponse {
+    match tokio::fs::read_to_string(path).await {
+        Ok(contents) => Json(FileContentsResponse {
+            path,
+            exists: true,
+            contents: Some(contents),
+        })
+        .into_response(),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Json(FileContentsResponse {
+            path,
+            exists: false,
+            contents: None,
+        })
+        .into_response(),
+        Err(e) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            format!("failed to read {path}: {e}"),
+        )
+            .into_response(),
+    }
+}
+
+#[derive(Debug, Deserialize)]
+pub struct PkcheckQuery {
+    pub action_id: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct PkcheckResponse {
+    pub action_id: String,
+    pub exit_code: i32,
+    pub stdout: String,
+    pub stderr: String,
+}
+
+/// `GET /power/pkcheck?action_id=...` — runs
+/// `pkcheck --action-id <id> --process $$ --allow-user-interaction`
+/// as the `wardnet` user. The spec asserts `exit_code == 0` for the
+/// four login1 actions the polkit rule grants.
+pub async fn get_pkcheck(Query(q): Query<PkcheckQuery>) -> impl IntoResponse {
+    // Reject obviously bogus inputs before invoking pkcheck. Action
+    // ids are dotted ASCII; anything else is almost certainly a
+    // typo or injection attempt.
+    if !is_valid_action_id(&q.action_id) {
+        return (
+            StatusCode::BAD_REQUEST,
+            format!("invalid action_id: {}", q.action_id),
+        )
+            .into_response();
+    }
+
+    // `runuser` keeps us in the same cgroup as the agent so the
+    // spawned pkcheck has a real UID context. `--allow-user-interaction`
+    // matches what a regular GUI consumer would pass; without it
+    // pkcheck refuses authorisation that requires admin auth, which
+    // would mask the polkit-rule grant we want to verify.
+    //
+    // `sh -c 'pkcheck --process $$'` resolves $$ inside the runuser
+    // shell so the subject is the just-spawned process — pkcheck
+    // then reads /proc/$$/status and confirms its uid is `wardnet`.
+    let output = match Command::new("runuser")
+        .args([
+            "-u",
+            "wardnet",
+            "--",
+            "sh",
+            "-c",
+            &format!(
+                "pkcheck --action-id {} --process $$ --allow-user-interaction",
+                shell_escape(&q.action_id)
+            ),
+        ])
+        .output()
+        .await
+    {
+        Ok(o) => o,
+        Err(e) => {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("failed to spawn pkcheck: {e}"),
+            )
+                .into_response();
+        }
+    };
+
+    Json(PkcheckResponse {
+        action_id: q.action_id,
+        exit_code: output.status.code().unwrap_or(-1),
+        stdout: String::from_utf8_lossy(&output.stdout).into_owned(),
+        stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
+    })
+    .into_response()
+}
+
+/// Allow only `[A-Za-z0-9._-]` action ids — covers every
+/// `org.freedesktop.login1.*` value polkit ships with.
+fn is_valid_action_id(id: &str) -> bool {
+    !id.is_empty()
+        && id.len() <= 128
+        && id
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '.' || c == '_' || c == '-')
+}
+
+/// Wrap a string in single quotes for shell consumption. Inputs are
+/// already validated by [`is_valid_action_id`] so this is belt-and-
+/// suspenders, but cheap to apply.
+fn shell_escape(s: &str) -> String {
+    format!("'{}'", s.replace('\'', r"'\''"))
+}

--- a/source/daemon/crates/wardnet-test-agent/src/server/mod.rs
+++ b/source/daemon/crates/wardnet-test-agent/src/server/mod.rs
@@ -63,6 +63,12 @@ fn build_router(state: Arc<AppState>) -> Router {
         )
         .route("/fixtures/{name}", get(handlers::fixtures::get_fixture))
         .route("/postupgrade/state", get(handlers::postupgrade::get_state))
+        .route(
+            "/power/systemctl-invocations",
+            get(handlers::power::get_systemctl_invocations),
+        )
+        .route("/power/polkit-rule", get(handlers::power::get_polkit_rule))
+        .route("/power/pkcheck", get(handlers::power::get_pkcheck))
         .with_state(state)
 }
 

--- a/source/daemon/crates/wardnetd-api/src/api/system.rs
+++ b/source/daemon/crates/wardnetd-api/src/api/system.rs
@@ -17,15 +17,17 @@ use wardnetd_services::error::AppError;
 use wardnetd_services::logging::error_notifier::ErrorEntry;
 
 /// Register system routes (status, log download, recent errors,
-/// restart) onto the given [`OpenApiRouter`]. The WebSocket log stream
-/// is registered separately in [`crate::api::router`] since it cannot
-/// be modeled in `OpenAPI`.
+/// restart, reboot, shutdown) onto the given [`OpenApiRouter`]. The
+/// WebSocket log stream is registered separately in
+/// [`crate::api::router`] since it cannot be modeled in `OpenAPI`.
 pub fn register(router: OpenApiRouter<AppState>) -> OpenApiRouter<AppState> {
     router
         .routes(routes!(status))
         .routes(routes!(recent_errors))
         .routes(routes!(download_logs))
         .routes(routes!(restart))
+        .routes(routes!(reboot))
+        .routes(routes!(shutdown))
 }
 
 #[utoipa::path(
@@ -114,6 +116,69 @@ pub async fn restart(
     _auth: AdminAuth,
 ) -> Result<axum::http::StatusCode, AppError> {
     state.system_service().request_restart().await?;
+    Ok(axum::http::StatusCode::NO_CONTENT)
+}
+
+/// Reboot the host (Pi-level), not just the daemon.
+///
+/// Returns `204 No Content` immediately; logind queues the reboot a
+/// few hundred ms later, after the response has flushed. systemd
+/// drives the actual shutdown sequence and SIGTERMs wardnetd as part
+/// of `shutdown.target`.
+#[utoipa::path(
+    post,
+    path = "/api/system/reboot",
+    tag = "system",
+    description = "Reboot the host. Returns immediately; the reboot \
+                   itself is queued via systemd-logind and runs once \
+                   the response has flushed. The daemon will be \
+                   unreachable for as long as the host takes to come \
+                   back up — typically 30–60 s on a Raspberry Pi.",
+    responses(
+        (status = 204, description = "Reboot scheduled"),
+        AuthErrors,
+    ),
+    security(
+        ("session_cookie" = []),
+        ("bearer_auth" = []),
+    ),
+)]
+pub async fn reboot(
+    State(state): State<AppState>,
+    _auth: AdminAuth,
+) -> Result<axum::http::StatusCode, AppError> {
+    state.system_service().request_reboot().await?;
+    Ok(axum::http::StatusCode::NO_CONTENT)
+}
+
+/// Power off the host. Internet is unavailable until the operator
+/// physically powers the Pi back on.
+///
+/// Returns `204 No Content` immediately; logind queues the poweroff
+/// a few hundred ms later, after the response has flushed.
+#[utoipa::path(
+    post,
+    path = "/api/system/shutdown",
+    tag = "system",
+    description = "Power the host off. Returns immediately; the \
+                   poweroff itself is queued via systemd-logind and \
+                   runs once the response has flushed. The daemon \
+                   will not come back up until the operator turns \
+                   the Pi on again.",
+    responses(
+        (status = 204, description = "Shutdown scheduled"),
+        AuthErrors,
+    ),
+    security(
+        ("session_cookie" = []),
+        ("bearer_auth" = []),
+    ),
+)]
+pub async fn shutdown(
+    State(state): State<AppState>,
+    _auth: AdminAuth,
+) -> Result<axum::http::StatusCode, AppError> {
+    state.system_service().request_shutdown().await?;
     Ok(axum::http::StatusCode::NO_CONTENT)
 }
 

--- a/source/daemon/crates/wardnetd-api/src/api/tests/system.rs
+++ b/source/daemon/crates/wardnetd-api/src/api/tests/system.rs
@@ -106,6 +106,12 @@ impl SystemService for MockSystemService {
     async fn request_restart(&self) -> Result<(), AppError> {
         Ok(())
     }
+    async fn request_reboot(&self) -> Result<(), AppError> {
+        Ok(())
+    }
+    async fn request_shutdown(&self) -> Result<(), AppError> {
+        Ok(())
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -150,6 +156,14 @@ fn system_app_full(state: AppState) -> Router {
         .route(
             "/api/system/restart",
             axum::routing::post(crate::api::system::restart),
+        )
+        .route(
+            "/api/system/reboot",
+            axum::routing::post(crate::api::system::reboot),
+        )
+        .route(
+            "/api/system/shutdown",
+            axum::routing::post(crate::api::system::shutdown),
         )
         .with_state(state)
 }
@@ -811,6 +825,12 @@ async fn restart_surfaces_service_error_as_500() {
         async fn request_restart(&self) -> Result<(), AppError> {
             Err(AppError::Internal(anyhow::anyhow!("shutdown not wired")))
         }
+        async fn request_reboot(&self) -> Result<(), AppError> {
+            Ok(())
+        }
+        async fn request_shutdown(&self) -> Result<(), AppError> {
+            Ok(())
+        }
     }
 
     let admin_id = Uuid::new_v4();
@@ -820,6 +840,184 @@ async fn restart_surfaces_service_error_as_500() {
     let req = Request::builder()
         .method("POST")
         .uri("/api/system/restart")
+        .header("Authorization", "Bearer k")
+        .extension(connect_info_ext())
+        .body(Body::empty())
+        .unwrap();
+
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::INTERNAL_SERVER_ERROR);
+}
+
+// ---------------------------------------------------------------------------
+// POST /api/system/reboot
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn reboot_returns_204_on_success() {
+    let admin_id = Uuid::new_v4();
+    let state = make_state(
+        AlwaysAuthService { admin_id },
+        MockSystemService {
+            response: Ok(default_status()),
+        },
+    );
+
+    let app = system_app_full(state);
+    let req = Request::builder()
+        .method("POST")
+        .uri("/api/system/reboot")
+        .header("Cookie", "wardnet_session=valid-token")
+        .extension(connect_info_ext())
+        .body(Body::empty())
+        .unwrap();
+
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::NO_CONTENT);
+}
+
+#[tokio::test]
+async fn reboot_requires_authentication() {
+    let state = make_state(
+        NeverAuthService,
+        MockSystemService {
+            response: Ok(default_status()),
+        },
+    );
+
+    let app = system_app_full(state);
+    let req = Request::builder()
+        .method("POST")
+        .uri("/api/system/reboot")
+        .extension(connect_info_ext())
+        .body(Body::empty())
+        .unwrap();
+
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn reboot_surfaces_service_error_as_500() {
+    struct FailingRebootService;
+    #[async_trait]
+    impl SystemService for FailingRebootService {
+        fn version(&self) -> &'static str {
+            "0.0.0"
+        }
+        fn uptime(&self) -> std::time::Duration {
+            std::time::Duration::ZERO
+        }
+        async fn status(&self) -> Result<SystemStatusResponse, AppError> {
+            unimplemented!()
+        }
+        async fn request_restart(&self) -> Result<(), AppError> {
+            Ok(())
+        }
+        async fn request_reboot(&self) -> Result<(), AppError> {
+            Err(AppError::Internal(anyhow::anyhow!("polkit denied")))
+        }
+        async fn request_shutdown(&self) -> Result<(), AppError> {
+            Ok(())
+        }
+    }
+
+    let admin_id = Uuid::new_v4();
+    let state = make_state(AlwaysAuthService { admin_id }, FailingRebootService);
+    let app = system_app_full(state);
+
+    let req = Request::builder()
+        .method("POST")
+        .uri("/api/system/reboot")
+        .header("Authorization", "Bearer k")
+        .extension(connect_info_ext())
+        .body(Body::empty())
+        .unwrap();
+
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::INTERNAL_SERVER_ERROR);
+}
+
+// ---------------------------------------------------------------------------
+// POST /api/system/shutdown
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn shutdown_returns_204_on_success() {
+    let admin_id = Uuid::new_v4();
+    let state = make_state(
+        AlwaysAuthService { admin_id },
+        MockSystemService {
+            response: Ok(default_status()),
+        },
+    );
+
+    let app = system_app_full(state);
+    let req = Request::builder()
+        .method("POST")
+        .uri("/api/system/shutdown")
+        .header("Cookie", "wardnet_session=valid-token")
+        .extension(connect_info_ext())
+        .body(Body::empty())
+        .unwrap();
+
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::NO_CONTENT);
+}
+
+#[tokio::test]
+async fn shutdown_requires_authentication() {
+    let state = make_state(
+        NeverAuthService,
+        MockSystemService {
+            response: Ok(default_status()),
+        },
+    );
+
+    let app = system_app_full(state);
+    let req = Request::builder()
+        .method("POST")
+        .uri("/api/system/shutdown")
+        .extension(connect_info_ext())
+        .body(Body::empty())
+        .unwrap();
+
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn shutdown_surfaces_service_error_as_500() {
+    struct FailingShutdownService;
+    #[async_trait]
+    impl SystemService for FailingShutdownService {
+        fn version(&self) -> &'static str {
+            "0.0.0"
+        }
+        fn uptime(&self) -> std::time::Duration {
+            std::time::Duration::ZERO
+        }
+        async fn status(&self) -> Result<SystemStatusResponse, AppError> {
+            unimplemented!()
+        }
+        async fn request_restart(&self) -> Result<(), AppError> {
+            Ok(())
+        }
+        async fn request_reboot(&self) -> Result<(), AppError> {
+            Ok(())
+        }
+        async fn request_shutdown(&self) -> Result<(), AppError> {
+            Err(AppError::Internal(anyhow::anyhow!("polkit denied")))
+        }
+    }
+
+    let admin_id = Uuid::new_v4();
+    let state = make_state(AlwaysAuthService { admin_id }, FailingShutdownService);
+    let app = system_app_full(state);
+
+    let req = Request::builder()
+        .method("POST")
+        .uri("/api/system/shutdown")
         .header("Authorization", "Bearer k")
         .extension(connect_info_ext())
         .body(Body::empty())

--- a/source/daemon/crates/wardnetd-api/src/tests/stubs.rs
+++ b/source/daemon/crates/wardnetd-api/src/tests/stubs.rs
@@ -402,6 +402,12 @@ impl SystemService for StubSystemService {
     async fn request_restart(&self) -> Result<(), AppError> {
         Ok(())
     }
+    async fn request_reboot(&self) -> Result<(), AppError> {
+        Ok(())
+    }
+    async fn request_shutdown(&self) -> Result<(), AppError> {
+        Ok(())
+    }
 }
 
 pub struct StubTunnelService;

--- a/source/daemon/crates/wardnetd-mock/src/backends/mod.rs
+++ b/source/daemon/crates/wardnetd-mock/src/backends/mod.rs
@@ -11,5 +11,6 @@
 pub mod noop_device;
 pub mod noop_dhcp;
 pub mod noop_dns;
+pub mod noop_power_ops;
 pub mod noop_routing;
 pub mod noop_tunnel;

--- a/source/daemon/crates/wardnetd-mock/src/backends/noop_power_ops.rs
+++ b/source/daemon/crates/wardnetd-mock/src/backends/noop_power_ops.rs
@@ -1,0 +1,26 @@
+//! No-op [`SystemPowerOps`] implementation for the mock server.
+//!
+//! Calling `reboot()` or `poweroff()` here logs a `WARN` and returns
+//! `Ok(())`. The dev daemon is **not** terminated — that would force
+//! the operator to relaunch the mock every time they exercise the
+//! Safe Reboot / Safe Shutdown UI.
+
+use async_trait::async_trait;
+use wardnetd_services::error::AppError;
+use wardnetd_services::system::SystemPowerOps;
+
+#[derive(Debug, Default, Clone)]
+pub struct NoopSystemPowerOps;
+
+#[async_trait]
+impl SystemPowerOps for NoopSystemPowerOps {
+    async fn reboot(&self) -> Result<(), AppError> {
+        tracing::warn!("mock power_ops reboot() called (no-op; dev daemon stays up)");
+        Ok(())
+    }
+
+    async fn poweroff(&self) -> Result<(), AppError> {
+        tracing::warn!("mock power_ops poweroff() called (no-op; dev daemon stays up)");
+        Ok(())
+    }
+}

--- a/source/daemon/crates/wardnetd-mock/src/main.rs
+++ b/source/daemon/crates/wardnetd-mock/src/main.rs
@@ -23,6 +23,7 @@ use wardnetd_data::create_repository_factory;
 use wardnetd_mock::backends::noop_device::{NoopHostnameResolver, NoopPacketCapture};
 use wardnetd_mock::backends::noop_dhcp::NoopDhcpServer;
 use wardnetd_mock::backends::noop_dns::NoopDnsServer;
+use wardnetd_mock::backends::noop_power_ops::NoopSystemPowerOps;
 use wardnetd_mock::backends::noop_routing::{NoopFirewallManager, NoopPolicyRouter};
 use wardnetd_mock::backends::noop_tunnel::NoopTunnelInterface;
 use wardnetd_mock::events::FakeEventEmitter;
@@ -222,6 +223,7 @@ async fn run(
         config_path: mock_config_path,
         host_id: "wardnetd-mock".to_owned(),
         shutdown_token: shutdown_token.clone(),
+        power_ops: Arc::new(NoopSystemPowerOps),
     };
 
     // A synthetic LAN IP that looks plausible in UI copy.

--- a/source/daemon/crates/wardnetd-services/src/lib.rs
+++ b/source/daemon/crates/wardnetd-services/src/lib.rs
@@ -87,6 +87,10 @@ pub struct Backends {
     /// shutdown path runs — axum drains connections, runners exit
     /// cleanly, Drop impls fire.
     pub shutdown_token: tokio_util::sync::CancellationToken,
+    /// Host-power operations. Production wires `SystemctlPowerOps`
+    /// (shells out to `systemctl reboot|poweroff --no-block`); the
+    /// mock wires a logging no-op so dev launches don't get killed.
+    pub power_ops: Arc<dyn system::SystemPowerOps>,
 }
 
 /// Auto-update backends, grouped so the three concerns (release discovery,
@@ -261,6 +265,7 @@ fn create_services(
         tunnel_repo.clone(),
         started_at,
         backends.shutdown_token.clone(),
+        backends.power_ops.clone(),
     ));
 
     let tunnel_service: Arc<dyn TunnelService> = Arc::new(TunnelServiceImpl::new(

--- a/source/daemon/crates/wardnetd-services/src/system/mod.rs
+++ b/source/daemon/crates/wardnetd-services/src/system/mod.rs
@@ -1,5 +1,7 @@
+pub mod power_ops;
 pub mod service;
 
+pub use power_ops::SystemPowerOps;
 pub use service::{SystemService, SystemServiceImpl};
 
 #[cfg(test)]

--- a/source/daemon/crates/wardnetd-services/src/system/power_ops.rs
+++ b/source/daemon/crates/wardnetd-services/src/system/power_ops.rs
@@ -1,0 +1,24 @@
+//! Host-power operations: reboot and poweroff.
+//!
+//! Behind a trait so the production binary can shell out to
+//! `systemctl reboot --no-block` / `systemctl poweroff --no-block`
+//! while the mock daemon and unit tests can plug in a no-op stub
+//! that does not actually reboot the developer's laptop.
+
+use async_trait::async_trait;
+
+use crate::error::AppError;
+
+/// Reboot or power off the host. Implementations are wired onto
+/// [`crate::Backends`] so the service layer never reaches for a
+/// concrete `systemctl` shell-out.
+#[async_trait]
+pub trait SystemPowerOps: Send + Sync {
+    /// Reboot the host. Implementations must return promptly —
+    /// `systemctl reboot --no-block` returns once logind has accepted
+    /// the request, before the actual shutdown sequence begins.
+    async fn reboot(&self) -> Result<(), AppError>;
+
+    /// Power off the host. Same semantics as [`Self::reboot`].
+    async fn poweroff(&self) -> Result<(), AppError>;
+}

--- a/source/daemon/crates/wardnetd-services/src/system/service.rs
+++ b/source/daemon/crates/wardnetd-services/src/system/service.rs
@@ -8,6 +8,7 @@ use wardnet_common::api::SystemStatusResponse;
 
 use crate::auth_context;
 use crate::error::AppError;
+use crate::system::SystemPowerOps;
 use wardnetd_data::repository::{SystemConfigRepository, TunnelRepository};
 
 /// How long the restart handler waits before cancelling the shutdown
@@ -16,6 +17,10 @@ use wardnetd_data::repository::{SystemConfigRepository, TunnelRepository};
 /// connections. Anything longer isn't needed; anything shorter
 /// occasionally cuts the response short on a busy connection.
 const RESTART_GRACE: Duration = Duration::from_millis(500);
+
+/// Same grace window for `request_reboot` / `request_shutdown` —
+/// lets the 204 flush before we ask logind to take the host down.
+const POWER_GRACE: Duration = Duration::from_millis(500);
 
 /// System-wide status and health information.
 ///
@@ -40,6 +45,19 @@ pub trait SystemService: Send + Sync {
     /// actual `exit(0)` after a short grace period so the HTTP
     /// response completes before the socket closes. Admin-only.
     async fn request_restart(&self) -> Result<(), AppError>;
+
+    /// Ask the host to reboot (Pi-level, not just the daemon).
+    ///
+    /// Symmetric with [`Self::request_restart`]: returns immediately,
+    /// then a spawned task waits ~500 ms for the response to flush
+    /// before invoking the wired [`SystemPowerOps::reboot`]. systemd
+    /// drives the actual shutdown sequence and SIGTERMs wardnetd as
+    /// part of `shutdown.target`. Admin-only.
+    async fn request_reboot(&self) -> Result<(), AppError>;
+
+    /// Ask the host to power off. Same shape as [`Self::request_reboot`]
+    /// but invokes [`SystemPowerOps::poweroff`]. Admin-only.
+    async fn request_shutdown(&self) -> Result<(), AppError>;
 }
 
 /// Default implementation of [`SystemService`] backed by [`SystemConfigRepository`].
@@ -61,6 +79,7 @@ pub struct SystemServiceImpl {
     started_at: Instant,
     sysinfo: tokio::sync::Mutex<System>,
     shutdown_token: CancellationToken,
+    power_ops: Arc<dyn SystemPowerOps>,
 }
 
 impl SystemServiceImpl {
@@ -69,6 +88,7 @@ impl SystemServiceImpl {
         tunnel_repo: Arc<dyn TunnelRepository>,
         started_at: Instant,
         shutdown_token: CancellationToken,
+        power_ops: Arc<dyn SystemPowerOps>,
     ) -> Self {
         Self {
             system_config,
@@ -76,6 +96,7 @@ impl SystemServiceImpl {
             started_at,
             sysinfo: tokio::sync::Mutex::new(System::new_all()),
             shutdown_token,
+            power_ops,
         }
     }
 }
@@ -163,6 +184,48 @@ impl SystemService for SystemServiceImpl {
             // back up on a Pi install; on the dev mock the process
             // exits cleanly and the operator re-runs `make run-dev`.
             token.cancel();
+        });
+        Ok(())
+    }
+
+    async fn request_reboot(&self) -> Result<(), AppError> {
+        auth_context::require_admin()?;
+        tracing::warn!(
+            action = "reboot",
+            grace_ms = POWER_GRACE.as_millis(),
+            "host reboot requested via API — invoking systemctl reboot in {grace_ms}ms",
+            grace_ms = POWER_GRACE.as_millis(),
+        );
+        let ops = self.power_ops.clone();
+        // systemd drives the rest of the shutdown sequence: it sends
+        // SIGTERM to wardnetd as part of `shutdown.target`, our
+        // existing `shutdown_signal` handler runs, and the unit stops
+        // before the host reboots. We never touch `shutdown_token`
+        // here — single source of truth for the actual shutdown is
+        // systemd, not the daemon.
+        tokio::spawn(async move {
+            tokio::time::sleep(POWER_GRACE).await;
+            if let Err(e) = ops.reboot().await {
+                tracing::error!(error = %e, "host reboot invocation failed: error={e}");
+            }
+        });
+        Ok(())
+    }
+
+    async fn request_shutdown(&self) -> Result<(), AppError> {
+        auth_context::require_admin()?;
+        tracing::warn!(
+            action = "shutdown",
+            grace_ms = POWER_GRACE.as_millis(),
+            "host shutdown requested via API — invoking systemctl poweroff in {grace_ms}ms",
+            grace_ms = POWER_GRACE.as_millis(),
+        );
+        let ops = self.power_ops.clone();
+        tokio::spawn(async move {
+            tokio::time::sleep(POWER_GRACE).await;
+            if let Err(e) = ops.poweroff().await {
+                tracing::error!(error = %e, "host poweroff invocation failed: error={e}");
+            }
         });
         Ok(())
     }

--- a/source/daemon/crates/wardnetd-services/src/system/tests/system.rs
+++ b/source/daemon/crates/wardnetd-services/src/system/tests/system.rs
@@ -1,4 +1,5 @@
 use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Instant;
 
 use async_trait::async_trait;
@@ -7,6 +8,7 @@ use wardnet_common::auth::AuthContext;
 
 use crate::auth_context;
 use crate::error::AppError;
+use crate::system::SystemPowerOps;
 use crate::{SystemService, SystemServiceImpl};
 use wardnet_common::tunnel::{Tunnel, TunnelConfig};
 use wardnetd_data::repository::tunnel::TunnelRow;
@@ -93,11 +95,48 @@ fn admin_ctx() -> AuthContext {
     }
 }
 
+/// Counts calls to `reboot()` / `poweroff()` so the request_*
+/// service tests can assert the spawned task fired exactly once
+/// after the grace window.
+#[derive(Default)]
+struct RecordingPowerOps {
+    reboot_calls: AtomicUsize,
+    poweroff_calls: AtomicUsize,
+}
+
+#[async_trait]
+impl SystemPowerOps for RecordingPowerOps {
+    async fn reboot(&self) -> Result<(), AppError> {
+        self.reboot_calls.fetch_add(1, Ordering::SeqCst);
+        Ok(())
+    }
+    async fn poweroff(&self) -> Result<(), AppError> {
+        self.poweroff_calls.fetch_add(1, Ordering::SeqCst);
+        Ok(())
+    }
+}
+
 fn build_service(
     devices: i64,
     tunnels: i64,
     active_tunnels: i64,
     db_size: u64,
+) -> SystemServiceImpl {
+    build_service_with_power_ops(
+        devices,
+        tunnels,
+        active_tunnels,
+        db_size,
+        Arc::new(RecordingPowerOps::default()),
+    )
+}
+
+fn build_service_with_power_ops(
+    devices: i64,
+    tunnels: i64,
+    active_tunnels: i64,
+    db_size: u64,
+    power_ops: Arc<dyn SystemPowerOps>,
 ) -> SystemServiceImpl {
     SystemServiceImpl::new(
         Arc::new(MockSystemConfigRepo {
@@ -110,6 +149,7 @@ fn build_service(
         }),
         Instant::now(),
         tokio_util::sync::CancellationToken::new(),
+        power_ops,
     )
 }
 
@@ -161,4 +201,115 @@ async fn status_device_forbidden() {
     };
     let result = auth_context::with_context(ctx, svc.status()).await;
     assert!(matches!(result, Err(AppError::Forbidden(_))));
+}
+
+// -- request_reboot / request_shutdown ------------------------------------
+
+#[tokio::test(start_paused = true)]
+async fn request_reboot_invokes_power_ops_after_grace() {
+    let ops = Arc::new(RecordingPowerOps::default());
+    let svc = build_service_with_power_ops(0, 0, 0, 0, ops.clone());
+
+    auth_context::with_context(admin_ctx(), svc.request_reboot())
+        .await
+        .unwrap();
+
+    // Yield so the spawned task gets polled and registers its sleep
+    // with the paused timer driver. Without this the timer driver
+    // never sees the sleep and `advance` has nothing to wake.
+    tokio::task::yield_now().await;
+    assert_eq!(ops.reboot_calls.load(Ordering::SeqCst), 0);
+
+    // Advance past the 500 ms grace window, then drive the runtime
+    // a few more times so the woken task runs to completion.
+    tokio::time::advance(std::time::Duration::from_millis(750)).await;
+    for _ in 0..20 {
+        tokio::task::yield_now().await;
+        tokio::time::advance(std::time::Duration::from_millis(10)).await;
+    }
+    assert_eq!(ops.reboot_calls.load(Ordering::SeqCst), 1);
+    assert_eq!(ops.poweroff_calls.load(Ordering::SeqCst), 0);
+}
+
+#[tokio::test(start_paused = true)]
+async fn request_shutdown_invokes_power_ops_after_grace() {
+    let ops = Arc::new(RecordingPowerOps::default());
+    let svc = build_service_with_power_ops(0, 0, 0, 0, ops.clone());
+
+    auth_context::with_context(admin_ctx(), svc.request_shutdown())
+        .await
+        .unwrap();
+
+    tokio::task::yield_now().await;
+    assert_eq!(ops.poweroff_calls.load(Ordering::SeqCst), 0);
+
+    tokio::time::advance(std::time::Duration::from_millis(750)).await;
+    for _ in 0..20 {
+        tokio::task::yield_now().await;
+        tokio::time::advance(std::time::Duration::from_millis(10)).await;
+    }
+    assert_eq!(ops.poweroff_calls.load(Ordering::SeqCst), 1);
+    assert_eq!(ops.reboot_calls.load(Ordering::SeqCst), 0);
+}
+
+#[tokio::test]
+async fn request_reboot_returns_immediately() {
+    // Without `start_paused`, real time progresses; the test just
+    // confirms the call returns long before the 500 ms grace would
+    // have elapsed (which means the response can flush before the
+    // power op fires).
+    let ops = Arc::new(RecordingPowerOps::default());
+    let svc = build_service_with_power_ops(0, 0, 0, 0, ops);
+
+    let started = std::time::Instant::now();
+    auth_context::with_context(admin_ctx(), svc.request_reboot())
+        .await
+        .unwrap();
+    assert!(
+        started.elapsed() < std::time::Duration::from_millis(100),
+        "request_reboot should return promptly, took {:?}",
+        started.elapsed()
+    );
+}
+
+#[tokio::test]
+async fn request_reboot_anonymous_forbidden() {
+    let ops = Arc::new(RecordingPowerOps::default());
+    let svc = build_service_with_power_ops(0, 0, 0, 0, ops.clone());
+    let result = auth_context::with_context(AuthContext::Anonymous, svc.request_reboot()).await;
+    assert!(matches!(result, Err(AppError::Forbidden(_))));
+    assert_eq!(ops.reboot_calls.load(Ordering::SeqCst), 0);
+}
+
+#[tokio::test]
+async fn request_shutdown_anonymous_forbidden() {
+    let ops = Arc::new(RecordingPowerOps::default());
+    let svc = build_service_with_power_ops(0, 0, 0, 0, ops.clone());
+    let result = auth_context::with_context(AuthContext::Anonymous, svc.request_shutdown()).await;
+    assert!(matches!(result, Err(AppError::Forbidden(_))));
+    assert_eq!(ops.poweroff_calls.load(Ordering::SeqCst), 0);
+}
+
+#[tokio::test]
+async fn request_reboot_device_forbidden() {
+    let ops = Arc::new(RecordingPowerOps::default());
+    let svc = build_service_with_power_ops(0, 0, 0, 0, ops.clone());
+    let ctx = AuthContext::Device {
+        mac: "AA:BB:CC:DD:EE:01".to_owned(),
+    };
+    let result = auth_context::with_context(ctx, svc.request_reboot()).await;
+    assert!(matches!(result, Err(AppError::Forbidden(_))));
+    assert_eq!(ops.reboot_calls.load(Ordering::SeqCst), 0);
+}
+
+#[tokio::test]
+async fn request_shutdown_device_forbidden() {
+    let ops = Arc::new(RecordingPowerOps::default());
+    let svc = build_service_with_power_ops(0, 0, 0, 0, ops.clone());
+    let ctx = AuthContext::Device {
+        mac: "AA:BB:CC:DD:EE:01".to_owned(),
+    };
+    let result = auth_context::with_context(ctx, svc.request_shutdown()).await;
+    assert!(matches!(result, Err(AppError::Forbidden(_))));
+    assert_eq!(ops.poweroff_calls.load(Ordering::SeqCst), 0);
 }

--- a/source/daemon/crates/wardnetd-services/src/tests/init.rs
+++ b/source/daemon/crates/wardnetd-services/src/tests/init.rs
@@ -18,9 +18,11 @@ use wardnetd_data::secret_store::SecretStore;
 use crate::Backends;
 use crate::device::hostname_resolver::HostnameResolver;
 use crate::device::packet_capture::{ObservedDevice, PacketCapture};
+use crate::error::AppError;
 use crate::logging::{ErrorNotifierService, LogService, LogServiceImpl, LogStreamService};
 use crate::routing::firewall::FirewallManager;
 use crate::routing::policy_router::PolicyRouter;
+use crate::system::SystemPowerOps;
 use crate::tunnel::interface::{CreateTunnelParams, TunnelInterface, TunnelStats};
 use crate::{init_services, init_services_with_factory};
 use wardnet_common::config::AdminConfig;
@@ -146,6 +148,17 @@ impl HostnameResolver for StubHostnameResolver {
     }
 }
 
+struct StubPowerOps;
+#[async_trait]
+impl SystemPowerOps for StubPowerOps {
+    async fn reboot(&self) -> Result<(), AppError> {
+        unimplemented!()
+    }
+    async fn poweroff(&self) -> Result<(), AppError> {
+        unimplemented!()
+    }
+}
+
 struct StubSecretStore;
 #[async_trait]
 impl SecretStore for StubSecretStore {
@@ -184,6 +197,7 @@ fn stub_backends() -> Backends {
         config_path: std::path::PathBuf::from("/tmp/wardnet-init-test.toml"),
         host_id: "init-test-host".to_owned(),
         shutdown_token: tokio_util::sync::CancellationToken::new(),
+        power_ops: Arc::new(StubPowerOps),
     }
 }
 

--- a/source/daemon/crates/wardnetd/src/lib.rs
+++ b/source/daemon/crates/wardnetd/src/lib.rs
@@ -13,6 +13,9 @@ pub mod tunnel_interface_wireguard;
 pub mod dhcp;
 pub mod dns;
 
+// Host-power operations (systemctl reboot/poweroff).
+pub mod system;
+
 // Background tasks.
 pub mod device_detector;
 pub mod metrics_collector;

--- a/source/daemon/crates/wardnetd/src/main.rs
+++ b/source/daemon/crates/wardnetd/src/main.rs
@@ -30,6 +30,7 @@ use wardnetd::policy_router_netlink::NetlinkPolicyRouter;
 use wardnetd::profiling::ProfilingAgent;
 use wardnetd::route_monitor::RouteMonitor;
 use wardnetd::routing_listener::RoutingListener;
+use wardnetd::system::SystemctlPowerOps;
 use wardnetd::tunnel_idle::IdleTunnelWatcher;
 use wardnetd::tunnel_interface_wireguard::WireGuardTunnelInterface;
 use wardnetd::tunnel_monitor::TunnelMonitor;
@@ -223,6 +224,7 @@ async fn run(
         config_path: config_path.clone(),
         host_id,
         shutdown_token: shutdown_token.clone(),
+        power_ops: Arc::new(SystemctlPowerOps::new(executor.clone())),
     };
 
     // Wire services (initialises repo factory, bootstraps admin, creates all services).

--- a/source/daemon/crates/wardnetd/src/system/mod.rs
+++ b/source/daemon/crates/wardnetd/src/system/mod.rs
@@ -1,0 +1,11 @@
+//! Real (Linux) implementations of host-power operations.
+//!
+//! The daemon shells out via the existing [`CommandExecutor`] so the
+//! same `/usr/sbin` resolution rules that apply to `ip`, `nft`, and
+//! `sysctl` apply here too.
+//!
+//! [`CommandExecutor`]: wardnetd_services::command::CommandExecutor
+
+pub mod systemctl_power_ops;
+
+pub use systemctl_power_ops::SystemctlPowerOps;

--- a/source/daemon/crates/wardnetd/src/system/systemctl_power_ops.rs
+++ b/source/daemon/crates/wardnetd/src/system/systemctl_power_ops.rs
@@ -1,0 +1,63 @@
+//! Production [`SystemPowerOps`] backed by `systemctl`.
+//!
+//! Both methods invoke `systemctl ... --no-block` so logind queues
+//! the action and returns immediately; the actual shutdown sequence
+//! runs asynchronously and SIGTERMs wardnetd as part of
+//! `shutdown.target`.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+
+use wardnetd_services::command::CommandExecutor;
+use wardnetd_services::error::AppError;
+use wardnetd_services::system::SystemPowerOps;
+
+/// Shells out to `systemctl reboot|poweroff --no-block`. Authorisation
+/// to do so as the unprivileged `wardnet` user is granted by the
+/// polkit rule installed by the `0001_polkit_power_rule` post-upgrade
+/// migration.
+#[derive(Debug)]
+pub struct SystemctlPowerOps {
+    executor: Arc<dyn CommandExecutor>,
+}
+
+impl SystemctlPowerOps {
+    #[must_use]
+    pub fn new(executor: Arc<dyn CommandExecutor>) -> Self {
+        Self { executor }
+    }
+
+    async fn run_systemctl(&self, verb: &str) -> Result<(), AppError> {
+        let output = self
+            .executor
+            .run("systemctl", &[verb, "--no-block"])
+            .await
+            .map_err(|e| {
+                AppError::Internal(anyhow::anyhow!("failed to spawn systemctl {verb}: {e}"))
+            })?;
+
+        if output.success {
+            return Ok(());
+        }
+
+        // logind refuses with a non-zero exit when the polkit rule is
+        // missing or denies the action. Surface the stderr verbatim so
+        // the UI can show a useful "did_not_fire" diagnostic.
+        Err(AppError::Internal(anyhow::anyhow!(
+            "systemctl {verb} --no-block failed: {}",
+            output.stderr.trim()
+        )))
+    }
+}
+
+#[async_trait]
+impl SystemPowerOps for SystemctlPowerOps {
+    async fn reboot(&self) -> Result<(), AppError> {
+        self.run_systemctl("reboot").await
+    }
+
+    async fn poweroff(&self) -> Result<(), AppError> {
+        self.run_systemctl("poweroff").await
+    }
+}

--- a/source/daemon/crates/wardnetd/src/tests/metrics_collector.rs
+++ b/source/daemon/crates/wardnetd/src/tests/metrics_collector.rs
@@ -37,6 +37,12 @@ impl SystemService for MockSystemService {
     async fn request_restart(&self) -> Result<(), AppError> {
         Ok(())
     }
+    async fn request_reboot(&self) -> Result<(), AppError> {
+        Ok(())
+    }
+    async fn request_shutdown(&self) -> Result<(), AppError> {
+        Ok(())
+    }
 }
 
 /// Mock system service that always returns an error.
@@ -56,6 +62,16 @@ impl SystemService for FailingSystemService {
         )))
     }
     async fn request_restart(&self) -> Result<(), AppError> {
+        Err(AppError::Internal(anyhow::anyhow!(
+            "simulated service failure"
+        )))
+    }
+    async fn request_reboot(&self) -> Result<(), AppError> {
+        Err(AppError::Internal(anyhow::anyhow!(
+            "simulated service failure"
+        )))
+    }
+    async fn request_shutdown(&self) -> Result<(), AppError> {
         Err(AppError::Internal(anyhow::anyhow!(
             "simulated service failure"
         )))

--- a/source/daemon/crates/wardnetd/src/tests/mod.rs
+++ b/source/daemon/crates/wardnetd/src/tests/mod.rs
@@ -7,6 +7,7 @@ mod pidfile;
 mod profiling;
 mod routing_listener;
 pub mod stubs;
+mod systemctl_power_ops;
 mod tunnel_idle;
 mod tunnel_interface_wireguard;
 mod tunnel_monitor;

--- a/source/daemon/crates/wardnetd/src/tests/stubs.rs
+++ b/source/daemon/crates/wardnetd/src/tests/stubs.rs
@@ -195,6 +195,12 @@ impl SystemService for StubSystemService {
     async fn request_restart(&self) -> Result<(), AppError> {
         unimplemented!()
     }
+    async fn request_reboot(&self) -> Result<(), AppError> {
+        unimplemented!()
+    }
+    async fn request_shutdown(&self) -> Result<(), AppError> {
+        unimplemented!()
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/source/daemon/crates/wardnetd/src/tests/systemctl_power_ops.rs
+++ b/source/daemon/crates/wardnetd/src/tests/systemctl_power_ops.rs
@@ -1,0 +1,169 @@
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use tokio::sync::Mutex;
+
+use crate::system::SystemctlPowerOps;
+use wardnetd_services::command::{CommandExecutor, CommandOutput};
+use wardnetd_services::error::AppError;
+use wardnetd_services::system::SystemPowerOps;
+
+/// Recorded invocation of the executor — same shape the firewall
+/// tests use, replicated locally so the two test suites can evolve
+/// independently.
+#[derive(Debug, Clone)]
+struct RecordedCall {
+    program: String,
+    args: Vec<String>,
+}
+
+#[derive(Debug)]
+struct MockExecutor {
+    calls: Arc<Mutex<Vec<RecordedCall>>>,
+    response: Mutex<CommandOutput>,
+    /// When set, `run` returns `Err(io::Error)` instead of `Ok(...)`.
+    spawn_error: Mutex<Option<std::io::ErrorKind>>,
+}
+
+impl MockExecutor {
+    fn new(response: CommandOutput) -> (Self, Arc<Mutex<Vec<RecordedCall>>>) {
+        let calls = Arc::new(Mutex::new(Vec::new()));
+        let mock = Self {
+            calls: Arc::clone(&calls),
+            response: Mutex::new(response),
+            spawn_error: Mutex::new(None),
+        };
+        (mock, calls)
+    }
+
+    fn with_spawn_error(kind: std::io::ErrorKind) -> (Self, Arc<Mutex<Vec<RecordedCall>>>) {
+        let calls = Arc::new(Mutex::new(Vec::new()));
+        let mock = Self {
+            calls: Arc::clone(&calls),
+            response: Mutex::new(success("")),
+            spawn_error: Mutex::new(Some(kind)),
+        };
+        (mock, calls)
+    }
+}
+
+fn success(stdout: &str) -> CommandOutput {
+    CommandOutput {
+        stdout: stdout.to_owned(),
+        stderr: String::new(),
+        success: true,
+    }
+}
+
+fn failure(stderr: &str) -> CommandOutput {
+    CommandOutput {
+        stdout: String::new(),
+        stderr: stderr.to_owned(),
+        success: false,
+    }
+}
+
+#[async_trait]
+impl CommandExecutor for MockExecutor {
+    async fn run(&self, program: &str, args: &[&str]) -> std::io::Result<CommandOutput> {
+        self.calls.lock().await.push(RecordedCall {
+            program: program.to_owned(),
+            args: args.iter().map(|s| (*s).to_owned()).collect(),
+        });
+
+        if let Some(kind) = *self.spawn_error.lock().await {
+            return Err(std::io::Error::new(kind, "mock spawn failure"));
+        }
+        Ok(self.response.lock().await.clone())
+    }
+
+    async fn run_with_stdin(
+        &self,
+        _program: &str,
+        _args: &[&str],
+        _stdin_data: &str,
+    ) -> std::io::Result<CommandOutput> {
+        unimplemented!("SystemctlPowerOps never invokes run_with_stdin")
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn reboot_invokes_systemctl_reboot_no_block() {
+    let (executor, calls) = MockExecutor::new(success(""));
+    let ops = SystemctlPowerOps::new(Arc::new(executor));
+
+    ops.reboot().await.unwrap();
+
+    let calls = calls.lock().await;
+    assert_eq!(calls.len(), 1);
+    assert_eq!(calls[0].program, "systemctl");
+    assert_eq!(calls[0].args, vec!["reboot", "--no-block"]);
+}
+
+#[tokio::test]
+async fn poweroff_invokes_systemctl_poweroff_no_block() {
+    let (executor, calls) = MockExecutor::new(success(""));
+    let ops = SystemctlPowerOps::new(Arc::new(executor));
+
+    ops.poweroff().await.unwrap();
+
+    let calls = calls.lock().await;
+    assert_eq!(calls.len(), 1);
+    assert_eq!(calls[0].program, "systemctl");
+    assert_eq!(calls[0].args, vec!["poweroff", "--no-block"]);
+}
+
+#[tokio::test]
+async fn reboot_propagates_nonzero_exit_as_internal_error() {
+    let (executor, _calls) =
+        MockExecutor::new(failure("Failed to reboot system via logind: Access denied"));
+    let ops = SystemctlPowerOps::new(Arc::new(executor));
+
+    let err = ops.reboot().await.expect_err("expected error on nonzero");
+    match err {
+        AppError::Internal(e) => {
+            let msg = format!("{e}");
+            assert!(msg.contains("systemctl reboot --no-block failed"));
+            assert!(msg.contains("Access denied"));
+        }
+        other => panic!("expected AppError::Internal, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn poweroff_propagates_nonzero_exit_as_internal_error() {
+    let (executor, _calls) = MockExecutor::new(failure("logind: not authorized"));
+    let ops = SystemctlPowerOps::new(Arc::new(executor));
+
+    let err = ops.poweroff().await.expect_err("expected error on nonzero");
+    match err {
+        AppError::Internal(e) => {
+            let msg = format!("{e}");
+            assert!(msg.contains("systemctl poweroff --no-block failed"));
+            assert!(msg.contains("not authorized"));
+        }
+        other => panic!("expected AppError::Internal, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn reboot_propagates_spawn_error_as_internal_error() {
+    let (executor, _calls) = MockExecutor::with_spawn_error(std::io::ErrorKind::NotFound);
+    let ops = SystemctlPowerOps::new(Arc::new(executor));
+
+    let err = ops
+        .reboot()
+        .await
+        .expect_err("expected error on spawn fail");
+    match err {
+        AppError::Internal(e) => {
+            let msg = format!("{e}");
+            assert!(msg.contains("failed to spawn systemctl reboot"));
+        }
+        other => panic!("expected AppError::Internal, got {other:?}"),
+    }
+}

--- a/source/end2end-tests/daemon/tests/postupgrade.spec.ts
+++ b/source/end2end-tests/daemon/tests/postupgrade.spec.ts
@@ -27,7 +27,7 @@ describe("post-upgrade migration framework", () => {
     await waitForReady(client);
   }, 120_000);
 
-  it("runs cleanly at boot and writes an empty state.json", async () => {
+  it("runs cleanly at boot and records every shipped migration as applied", async () => {
     // wardnet-postupgrade.service is `Type=oneshot` and runs before
     // wardnetd.service. By the time wardnetd is healthy, the runner
     // has already exited and the migration runner has written
@@ -53,11 +53,12 @@ describe("post-upgrade migration framework", () => {
       );
     }
 
-    // Empty migration list ships with this PR — no entries should
-    // have been applied or failed. last_verification_failure must
+    // No migrations may have failed. last_verification_failure must
     // not be set (the runner only writes that field when the
-    // signature on the in-image payload doesn't verify).
-    expect(state.applied).toEqual([]);
+    // signature on the in-image payload doesn't verify). The
+    // safe-power spec asserts `applied` contains the specific
+    // 0001_polkit_power_rule entry; here we just guard that the
+    // runner ran cleanly to completion.
     expect(state.failed).toEqual([]);
     expect(state.last_verification_failure ?? null).toBeNull();
   });

--- a/source/end2end-tests/daemon/tests/safe-power.spec.ts
+++ b/source/end2end-tests/daemon/tests/safe-power.spec.ts
@@ -1,0 +1,181 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import { SystemService, WardnetApiError, WardnetClient } from "@wardnet/js";
+
+import {
+  API_BASE_URL,
+  AuthedClient,
+  agentGet,
+  ensureAdminAndLogin,
+  waitForReady,
+} from "./helpers.js";
+
+// Test agent runs in the wardnetd container alongside the daemon and
+// exposes `:3001`. Compose DNS resolves `wardnetd` to that container
+// on the wardnet_mgmt bridge.
+const TEST_AGENT_URL = "http://wardnetd:3001";
+
+interface FileContentsResponse {
+  path: string;
+  exists: boolean;
+  contents: string | null;
+}
+
+interface PostupgradeState {
+  applied: Array<{ id: string; applied_at: string }>;
+  failed: Array<{ id: string; error: string; at: string }>;
+}
+
+interface PkcheckResponse {
+  action_id: string;
+  exit_code: number;
+  stdout: string;
+  stderr: string;
+}
+
+/**
+ * Poll `/power/systemctl-invocations` until the marker file exists
+ * and contains a line matching `expectedArgs` (e.g. `"reboot --no-block"`).
+ *
+ * We poll because the daemon's `request_reboot` / `request_shutdown`
+ * spawns a 500 ms-grace task; the 204 returns before the spawned
+ * task fires `systemctl`. ~3 s is plenty.
+ */
+async function waitForSystemctlInvocation(
+  expectedArgs: string,
+  timeoutMs = 5_000,
+): Promise<string> {
+  const deadline = Date.now() + timeoutMs;
+  let last: FileContentsResponse | undefined;
+  while (Date.now() < deadline) {
+    last = await agentGet<FileContentsResponse>(
+      TEST_AGENT_URL,
+      "/power/systemctl-invocations",
+    );
+    if (last.exists && last.contents?.includes(expectedArgs)) {
+      return last.contents;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 250));
+  }
+  throw new Error(
+    `systemctl was not invoked with ${JSON.stringify(expectedArgs)} within ${timeoutMs}ms; ` +
+      `last response: ${JSON.stringify(last)}`,
+  );
+}
+
+describe("Safe Reboot / Safe Shutdown", () => {
+  const client = new WardnetClient({ baseUrl: API_BASE_URL });
+  let admin: AuthedClient;
+
+  beforeAll(async () => {
+    await waitForReady(client);
+    admin = await ensureAdminAndLogin(client);
+  }, 120_000);
+
+  it("applies the 0001_polkit_power_rule migration on first boot", async () => {
+    const state = await agentGet<PostupgradeState>(
+      TEST_AGENT_URL,
+      "/postupgrade/state",
+    );
+    const ids = state.applied.map((e) => e.id);
+    expect(ids).toContain("0001_polkit_power_rule");
+    expect(state.failed).toEqual([]);
+  });
+
+  it("writes the polkit rule to the expected path with the expected content", async () => {
+    const file = await agentGet<FileContentsResponse>(
+      TEST_AGENT_URL,
+      "/power/polkit-rule",
+    );
+    expect(file.exists).toBe(true);
+    expect(file.contents).toContain('subject.user !== "wardnet"');
+    expect(file.contents).toContain("org.freedesktop.login1.reboot");
+    expect(file.contents).toContain(
+      "org.freedesktop.login1.reboot-multiple-sessions",
+    );
+    expect(file.contents).toContain("org.freedesktop.login1.power-off");
+    expect(file.contents).toContain(
+      "org.freedesktop.login1.power-off-multiple-sessions",
+    );
+    expect(file.contents).toContain("polkit.Result.YES");
+  });
+
+  it.each([
+    "org.freedesktop.login1.reboot",
+    "org.freedesktop.login1.reboot-multiple-sessions",
+    "org.freedesktop.login1.power-off",
+    "org.freedesktop.login1.power-off-multiple-sessions",
+  ])("polkit grants %s to the wardnet user", async (actionId) => {
+    const res = await agentGet<PkcheckResponse>(
+      TEST_AGENT_URL,
+      `/power/pkcheck?action_id=${encodeURIComponent(actionId)}`,
+    );
+    expect(res).toMatchObject({
+      action_id: actionId,
+      exit_code: 0,
+    });
+  });
+
+  it("POST /api/system/reboot returns 204 and invokes systemctl reboot --no-block", async () => {
+    // Endpoint contract: 204 on accept.
+    const res = await fetch(`${API_BASE_URL}/system/reboot`, {
+      method: "POST",
+      headers: { Authorization: `Bearer ${tokenOf(admin)}` },
+    });
+    expect(res.status).toBe(204);
+
+    // The spawned task fires after a ~500 ms grace; assert the shim
+    // captured it.
+    const log = await waitForSystemctlInvocation("reboot --no-block");
+    expect(log).toContain("reboot --no-block");
+  });
+
+  it("POST /api/system/shutdown returns 204 and invokes systemctl poweroff --no-block", async () => {
+    const res = await fetch(`${API_BASE_URL}/system/shutdown`, {
+      method: "POST",
+      headers: { Authorization: `Bearer ${tokenOf(admin)}` },
+    });
+    expect(res.status).toBe(204);
+
+    const log = await waitForSystemctlInvocation("poweroff --no-block");
+    expect(log).toContain("poweroff --no-block");
+  });
+
+  it("rejects unauthenticated POST /api/system/reboot with 401", async () => {
+    const res = await fetch(`${API_BASE_URL}/system/reboot`, {
+      method: "POST",
+    });
+    expect(res.status).toBe(401);
+  });
+
+  it("rejects unauthenticated POST /api/system/shutdown with 401", async () => {
+    const res = await fetch(`${API_BASE_URL}/system/shutdown`, {
+      method: "POST",
+    });
+    expect(res.status).toBe(401);
+  });
+
+  it("SDK SystemService.reboot/shutdown succeeds against the live API", async () => {
+    // Exercise the SDK code path rather than raw fetch — guards
+    // against SDK-level regressions in the `postNoContent` helper.
+    const system = new SystemService(admin);
+    await system.reboot();
+    await system.shutdown();
+    // No throws ⇒ both returned 204.
+  });
+
+  it("surfaces a structured WardnetApiError for unauthenticated SDK calls", async () => {
+    const anon = new SystemService(new WardnetClient({ baseUrl: API_BASE_URL }));
+    await expect(anon.reboot()).rejects.toBeInstanceOf(WardnetApiError);
+  });
+});
+
+/**
+ * Pull the bearer token off an [`AuthedClient`]. The class doesn't
+ * expose it publicly — the e2e helper is the only place that
+ * constructs one — but the test occasionally needs it for raw
+ * `fetch` calls that bypass `WardnetClient`. Cast keeps the
+ * intrusion local.
+ */
+function tokenOf(authed: AuthedClient): string {
+  return (authed as unknown as { token: string }).token;
+}

--- a/source/sdk/wardnet-js/src/client.ts
+++ b/source/sdk/wardnet-js/src/client.ts
@@ -36,7 +36,15 @@ export class WardnetClient {
     this.baseUrl = options?.baseUrl ?? "/api";
   }
 
-  /** Send a typed HTTP request to the daemon API. */
+  /** Send a typed HTTP request to the daemon API.
+   *
+   * Returns `undefined` (cast to `T`) on `204 No Content` so callers
+   * with `Promise<void>` can route through the same path as JSON-
+   * returning calls — important because subclasses (e.g. `AuthedClient`
+   * in the e2e harness) override `request` to attach an
+   * `Authorization` header. Bypassing `request` means bypassing
+   * those overrides; routing through it keeps the auth path uniform.
+   */
   async request<T>(path: string, init?: RequestInit): Promise<T> {
     const res = await fetch(`${this.baseUrl}${path}`, {
       headers: { "Content-Type": "application/json" },
@@ -50,6 +58,10 @@ export class WardnetClient {
         error: res.statusText,
       }))) as ApiError;
       throw new WardnetApiError(res.status, res.statusText, body, requestId);
+    }
+
+    if (res.status === 204) {
+      return undefined as T;
     }
 
     return (await res.json()) as T;

--- a/source/sdk/wardnet-js/src/services/system.ts
+++ b/source/sdk/wardnet-js/src/services/system.ts
@@ -24,7 +24,50 @@ export class SystemService {
    * `make run-dev`.
    */
   async restart(): Promise<void> {
-    const res = await fetch(`${this.client.baseUrl}/system/restart`, {
+    await this.postNoContent("/system/restart");
+  }
+
+  /**
+   * Ask the host (Pi) to reboot.
+   *
+   * Resolves once the server has accepted the request (HTTP 204);
+   * the actual reboot fires a few hundred milliseconds later via
+   * `systemctl reboot --no-block`. Callers should treat the daemon
+   * as unreachable for the next 30–60 seconds and surface an
+   * appropriate progress UI to the user.
+   *
+   * Throws [`WardnetApiError`] on a non-2xx response — for example
+   * if the request was not authenticated (401), the user is not an
+   * admin (403), or the polkit migration has not been applied so
+   * logind refused the action (500).
+   */
+  async reboot(): Promise<void> {
+    await this.postNoContent("/system/reboot");
+  }
+
+  /**
+   * Ask the host (Pi) to power off.
+   *
+   * Resolves once the server has accepted the request (HTTP 204);
+   * the actual poweroff fires a few hundred milliseconds later via
+   * `systemctl poweroff --no-block`. Internet for managed devices
+   * stays unavailable until the operator powers the Pi back on
+   * manually — there is no automatic recovery.
+   *
+   * Throws [`WardnetApiError`] on a non-2xx response.
+   */
+  async shutdown(): Promise<void> {
+    await this.postNoContent("/system/shutdown");
+  }
+
+  /**
+   * Shared POST helper for endpoints that return `204 No Content`.
+   * `WardnetClient.request` is JSON-only; rolling our own here keeps
+   * the same error-shape contract without forcing the client to
+   * tolerate an empty body.
+   */
+  private async postNoContent(path: string): Promise<void> {
+    const res = await fetch(`${this.client.baseUrl}${path}`, {
       method: "POST",
       credentials: "include",
     });

--- a/source/sdk/wardnet-js/src/services/system.ts
+++ b/source/sdk/wardnet-js/src/services/system.ts
@@ -1,5 +1,4 @@
-import { WardnetApiError, type WardnetClient } from "../client.js";
-import type { ApiError } from "../types/api.js";
+import { type WardnetClient } from "../client.js";
 import type { SystemStatusResponse } from "../types/system.js";
 
 /** System information service for the Wardnet daemon. */
@@ -62,19 +61,13 @@ export class SystemService {
 
   /**
    * Shared POST helper for endpoints that return `204 No Content`.
-   * `WardnetClient.request` is JSON-only; rolling our own here keeps
-   * the same error-shape contract without forcing the client to
-   * tolerate an empty body.
+   *
+   * Routes through `client.request<void>` so subclassed clients
+   * (e.g. `AuthedClient` in the e2e harness, which overrides
+   * `request` to attach a `Bearer` token) get a chance to inject
+   * their headers. The client handles the empty body for 204.
    */
   private async postNoContent(path: string): Promise<void> {
-    const res = await fetch(`${this.client.baseUrl}${path}`, {
-      method: "POST",
-      credentials: "include",
-    });
-    if (!res.ok) {
-      const requestId = res.headers.get("X-Request-Id") ?? undefined;
-      const body = (await res.json().catch(() => ({ error: res.statusText }))) as ApiError;
-      throw new WardnetApiError(res.status, res.statusText, body, requestId);
-    }
+    await this.client.request<void>(path, { method: "POST" });
   }
 }

--- a/source/web-ui/src/components/features/PowerCard.tsx
+++ b/source/web-ui/src/components/features/PowerCard.tsx
@@ -1,0 +1,183 @@
+import { useState } from "react";
+import { PowerIcon, RotateCcwIcon, RefreshCwIcon } from "lucide-react";
+import { Button } from "@/components/core/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/core/ui/card";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/core/ui/alert-dialog";
+
+interface Props {
+  /** Confirm dialog → fires `POST /api/system/reboot`. Primary action. */
+  onReboot: () => void;
+  /** Confirm dialog → fires `POST /api/system/shutdown`. Destructive action. */
+  onShutdown: () => void;
+  /** Confirm dialog → fires `POST /api/system/restart`. Advanced/secondary. */
+  onRestartDaemon: () => void;
+  /** Disable all three buttons while any of the lifecycles is mid-flight. */
+  busy: boolean;
+}
+
+/**
+ * Power controls card on the Settings page.
+ *
+ * Pure presentation: receives three callbacks and a `busy` flag, has
+ * no idea TanStack Query or the SDK exist. Confirmation dialogs are
+ * inlined here using `core/ui/alert-dialog` (per Decision 5 — don't
+ * speculatively extract a generic compound until a second feature
+ * needs the same shape).
+ *
+ * Visual hierarchy (top-to-bottom = most-to-least common usage):
+ *   1. Safe Reboot — primary button, default variant
+ *   2. Safe Shutdown — destructive (red) variant
+ *   3. Restart daemon — small/secondary, lower in the card
+ */
+export function PowerCard({ onReboot, onShutdown, onRestartDaemon, busy }: Props) {
+  // The two confirmation dialogs live as local state so we can keep
+  // the open/close logic right next to the corresponding button.
+  const [rebootOpen, setRebootOpen] = useState(false);
+  const [shutdownOpen, setShutdownOpen] = useState(false);
+  const [restartOpen, setRestartOpen] = useState(false);
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Power</CardTitle>
+      </CardHeader>
+      <CardContent className="flex flex-col gap-3">
+        {/* Safe Reboot — primary, default variant. */}
+        <div className="flex items-center justify-between border-b pb-3">
+          <div>
+            <div className="text-sm font-medium">Safe Reboot</div>
+            <div className="text-xs text-muted-foreground">
+              Reboot the Pi. Wardnet will be unavailable for ~30–60 seconds while it comes back up;
+              managed devices fall back to the upstream router during that gap.
+            </div>
+          </div>
+          <Button onClick={() => setRebootOpen(true)} disabled={busy} aria-label="Safe Reboot">
+            <RotateCcwIcon />
+            Reboot
+          </Button>
+        </div>
+
+        {/* Safe Shutdown — destructive variant. */}
+        <div className="flex items-center justify-between border-b pb-3">
+          <div>
+            <div className="text-sm font-medium">Safe Shutdown</div>
+            <div className="text-xs text-muted-foreground">
+              Power the Pi off. Internet for managed devices will go through your home router until
+              you turn the Pi back on manually.
+            </div>
+          </div>
+          <Button
+            variant="destructive"
+            onClick={() => setShutdownOpen(true)}
+            disabled={busy}
+            aria-label="Safe Shutdown"
+          >
+            <PowerIcon />
+            Shut down
+          </Button>
+        </div>
+
+        {/* Restart daemon — small / secondary, advanced. */}
+        <div className="flex items-center justify-between">
+          <div>
+            <div className="text-sm font-medium">Restart daemon (advanced)</div>
+            <div className="text-xs text-muted-foreground">
+              Restart only the wardnetd process. The Pi keeps running. Use this if support has asked
+              you to.
+            </div>
+          </div>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => setRestartOpen(true)}
+            disabled={busy}
+            aria-label="Restart daemon"
+          >
+            <RefreshCwIcon />
+            Restart daemon
+          </Button>
+        </div>
+      </CardContent>
+
+      <AlertDialog open={rebootOpen} onOpenChange={setRebootOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Reboot Wardnet?</AlertDialogTitle>
+            <AlertDialogDescription>
+              Wardnet will restart. Your network will be unavailable for ~30–60 seconds while it
+              comes back up.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={() => {
+                setRebootOpen(false);
+                onReboot();
+              }}
+            >
+              Reboot
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
+      <AlertDialog open={shutdownOpen} onOpenChange={setShutdownOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Shut Wardnet down?</AlertDialogTitle>
+            <AlertDialogDescription>
+              Wardnet will power off. Internet will be unavailable until you turn the Pi back on
+              manually.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              variant="destructive"
+              onClick={() => {
+                setShutdownOpen(false);
+                onShutdown();
+              }}
+            >
+              Shut down
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
+      <AlertDialog open={restartOpen} onOpenChange={setRestartOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Restart daemon?</AlertDialogTitle>
+            <AlertDialogDescription>
+              The wardnetd process will exit and the supervisor will bring it back up. The Pi itself
+              keeps running; the network stays online except for a few seconds while the daemon
+              comes back.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={() => {
+                setRestartOpen(false);
+                onRestartDaemon();
+              }}
+            >
+              Restart
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </Card>
+  );
+}

--- a/source/web-ui/src/components/features/PowerCard.tsx
+++ b/source/web-ui/src/components/features/PowerCard.tsx
@@ -33,10 +33,11 @@ interface Props {
  * speculatively extract a generic compound until a second feature
  * needs the same shape).
  *
- * Visual hierarchy (top-to-bottom = most-to-least common usage):
- *   1. Safe Reboot — primary button, default variant
- *   2. Safe Shutdown — destructive (red) variant
- *   3. Restart daemon — small/secondary, lower in the card
+ * Visual hierarchy: all three are secondary actions — none is a
+ * happy-path CTA, so they all use the `outline` variant. Shutdown
+ * keeps the destructive (red) styling because it's the only one
+ * that leaves the network without internet until the operator
+ * physically powers the Pi back on.
  */
 export function PowerCard({ onReboot, onShutdown, onRestartDaemon, busy }: Props) {
   // The two confirmation dialogs live as local state so we can keep
@@ -60,7 +61,12 @@ export function PowerCard({ onReboot, onShutdown, onRestartDaemon, busy }: Props
               managed devices fall back to the upstream router during that gap.
             </div>
           </div>
-          <Button onClick={() => setRebootOpen(true)} disabled={busy} aria-label="Safe Reboot">
+          <Button
+            variant="outline"
+            onClick={() => setRebootOpen(true)}
+            disabled={busy}
+            aria-label="Safe Reboot"
+          >
             <RotateCcwIcon />
             Reboot
           </Button>

--- a/source/web-ui/src/components/features/RestartProgressDialog.tsx
+++ b/source/web-ui/src/components/features/RestartProgressDialog.tsx
@@ -58,7 +58,11 @@ export function RestartProgressDialog({
   const elapsed = useElapsedSeconds(open ? startedAt : null);
 
   const terminal =
-    phase === "ready" || phase === "ready_signed_out" || phase === "timeout" || phase === "failed";
+    phase === "ready" ||
+    phase === "ready_signed_out" ||
+    phase === "timeout" ||
+    phase === "failed" ||
+    phase === "did_not_fire";
 
   return (
     <AlertDialog
@@ -92,7 +96,7 @@ export function RestartProgressDialog({
               Sign in again
             </AlertDialogAction>
           )}
-          {(phase === "timeout" || phase === "failed") && (
+          {(phase === "timeout" || phase === "failed" || phase === "did_not_fire") && (
             <AlertDialogCancel onClick={onDismiss}>Dismiss</AlertDialogCancel>
           )}
         </AlertDialogFooter>
@@ -112,6 +116,7 @@ function PhaseIcon({ phase }: { phase: RestartPhase }) {
       return <LogInIcon className="h-5 w-5 text-amber-600" />;
     case "timeout":
     case "failed":
+    case "did_not_fire":
       return <AlertTriangleIcon className="h-5 w-5 text-destructive" />;
     default:
       return null;
@@ -132,6 +137,8 @@ function titleFor(phase: RestartPhase): string {
       return "Daemon didn't come back";
     case "failed":
       return "Restart request failed";
+    case "did_not_fire":
+      return "Restart didn't fire";
     default:
       return "Restart";
   }
@@ -151,6 +158,8 @@ function descriptionFor(phase: RestartPhase, errorMessage: string | null): strin
       return "The daemon didn't come back within 45 seconds. This usually means the supervisor (systemd) needs attention.";
     case "failed":
       return errorMessage ?? "The restart request itself was rejected.";
+    case "did_not_fire":
+      return "Wardnet didn't restart. The privileged migration may not have run — try Settings → Updates, or re-run install.sh.";
     default:
       return "";
   }

--- a/source/web-ui/src/components/features/ShutdownProgressDialog.tsx
+++ b/source/web-ui/src/components/features/ShutdownProgressDialog.tsx
@@ -1,0 +1,143 @@
+import { useEffect, useState } from "react";
+import { Loader2Icon, AlertTriangleIcon, PowerOffIcon } from "lucide-react";
+import {
+  AlertDialog,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/core/ui/alert-dialog";
+import type { ShutdownPhase } from "@/hooks/useShutdown";
+
+interface Props {
+  /** Whether to render the dialog at all — mirrors `useShutdown().isOpen`. */
+  open: boolean;
+  /** Current lifecycle phase. */
+  phase: ShutdownPhase;
+  /** UTC ms timestamp the shutdown was initiated, for elapsed display. */
+  startedAt: number | null;
+  /** Error message to show in the `failed` phase. */
+  errorMessage: string | null;
+  /** Called when the operator dismisses the modal (only valid in terminal phases). */
+  onDismiss: () => void;
+}
+
+/**
+ * Full-screen-overlay progress modal for a host shutdown.
+ *
+ * Differs from [`RestartProgressDialog`] in that the terminal `off`
+ * state is **definitive**: there is no recovery spinner, no retry,
+ * and no comeback poll. The operator must physically power the Pi
+ * back on. Copy is from the issue's Decision 1.
+ *
+ * | Phase           | Icon       | Message                                            |
+ * | --------------- | ---------- | -------------------------------------------------- |
+ * | scheduled       | spinner    | "Waiting for the daemon to exit…"                  |
+ * | down            | spinner    | "Daemon went offline. Confirming the host is off…" |
+ * | off             | poweroff   | "Wardnet is now off." + Dismiss                    |
+ * | did_not_fire    | warning    | "Wardnet didn't shut down." + Dismiss              |
+ * | timeout         | warning    | "Couldn't confirm the host went off." + Dismiss    |
+ * | failed          | warning    | request never accepted — show error + Dismiss      |
+ */
+export function ShutdownProgressDialog({ open, phase, startedAt, errorMessage, onDismiss }: Props) {
+  const elapsed = useElapsedSeconds(open ? startedAt : null);
+
+  const terminal =
+    phase === "off" || phase === "did_not_fire" || phase === "timeout" || phase === "failed";
+
+  return (
+    <AlertDialog
+      open={open}
+      onOpenChange={(next) => {
+        if (!next && terminal) onDismiss();
+      }}
+    >
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle className="flex items-center gap-2">
+            <PhaseIcon phase={phase} />
+            {titleFor(phase)}
+          </AlertDialogTitle>
+          <AlertDialogDescription>{descriptionFor(phase, errorMessage)}</AlertDialogDescription>
+        </AlertDialogHeader>
+
+        {!terminal && (
+          <div className="text-xs text-muted-foreground">
+            Elapsed: {elapsed}s (times out at 45s).
+          </div>
+        )}
+
+        <AlertDialogFooter>
+          {terminal && <AlertDialogCancel onClick={onDismiss}>Dismiss</AlertDialogCancel>}
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}
+
+function PhaseIcon({ phase }: { phase: ShutdownPhase }) {
+  switch (phase) {
+    case "scheduled":
+    case "down":
+      return <Loader2Icon className="h-5 w-5 animate-spin text-muted-foreground" />;
+    case "off":
+      return <PowerOffIcon className="h-5 w-5 text-muted-foreground" />;
+    case "did_not_fire":
+    case "timeout":
+    case "failed":
+      return <AlertTriangleIcon className="h-5 w-5 text-destructive" />;
+    default:
+      return null;
+  }
+}
+
+function titleFor(phase: ShutdownPhase): string {
+  switch (phase) {
+    case "scheduled":
+      return "Shutting down Wardnet";
+    case "down":
+      return "Confirming Wardnet is off";
+    case "off":
+      return "Wardnet is now off";
+    case "did_not_fire":
+      return "Shutdown didn't fire";
+    case "timeout":
+      return "Couldn't confirm Wardnet went off";
+    case "failed":
+      return "Shutdown request failed";
+    default:
+      return "Shutdown";
+  }
+}
+
+function descriptionFor(phase: ShutdownPhase, errorMessage: string | null): string {
+  switch (phase) {
+    case "scheduled":
+      return "Waiting for the daemon to exit.";
+    case "down":
+      return "Daemon went offline. Confirming the host is fully off.";
+    case "off":
+      return "Wardnet is now off. Internet for managed devices will go through your home router. To bring Wardnet back, power your Pi on and refresh this page.";
+    case "did_not_fire":
+      return "Wardnet didn't shut down. The privileged migration may not have run — try Settings → Updates, or re-run install.sh.";
+    case "timeout":
+      return "The daemon went offline but came back before we could confirm the host had powered off. Try again.";
+    case "failed":
+      return errorMessage ?? "The shutdown request itself was rejected.";
+    default:
+      return "";
+  }
+}
+
+/** Live-updating elapsed-seconds counter, paused while `startedAt` is null. */
+function useElapsedSeconds(startedAt: number | null): number {
+  const [now, setNow] = useState(() => Date.now());
+  useEffect(() => {
+    if (startedAt === null) return;
+    const id = setInterval(() => setNow(Date.now()), 500);
+    return () => clearInterval(id);
+  }, [startedAt]);
+  return startedAt === null ? 0 : Math.max(0, Math.floor((now - startedAt) / 1000));
+}

--- a/source/web-ui/src/hooks/useDaemonReachability.ts
+++ b/source/web-ui/src/hooks/useDaemonReachability.ts
@@ -1,0 +1,217 @@
+import { useCallback, useRef, useState } from "react";
+import { WardnetApiError } from "@wardnet/js";
+import { systemService } from "@/lib/sdk";
+
+/**
+ * Observable state of an in-flight power lifecycle.
+ *
+ * Shared across `useRestart`, `useReboot`, and `useShutdown`. Each
+ * caller maps the terminal phases to its own copy:
+ *
+ * - `idle` — no power op in progress; the dialog is closed.
+ * - `scheduled` — request accepted (HTTP 204). The daemon should
+ *   exit shortly. We poll `/api/info` (unauthenticated). While the
+ *   process is still alive the probe succeeds, so we stay in this
+ *   phase until the first failure.
+ * - `down` — one or more consecutive probes failed; the daemon is
+ *   either exiting or not yet back up.
+ * - `ready` — probe succeeded again *and* the admin cookie still
+ *   resolves a valid session. Restart's "all good, continue" state.
+ * - `ready_signed_out` — probe succeeded but the session probe
+ *   returned 401; the cookie was invalidated by the restart (e.g.
+ *   in-memory session store). Operator needs to sign in again.
+ * - `off` — daemon went down and stayed down for `OFF_CONFIRM_MS`.
+ *   Shutdown's terminal "host is powered off, no recovery" state.
+ *   Reboot never resolves to `off` (it's expected to come back).
+ * - `did_not_fire` — request returned 204 but the daemon is *still*
+ *   reachable `DID_NOT_FIRE_MS` later. Means the spawned task
+ *   succeeded the 204 but logind refused — almost always because
+ *   the polkit migration hasn't been applied. Surface actionable
+ *   copy pointing at Settings → Updates.
+ * - `timeout` — the lifecycle didn't reach a definitive terminal
+ *   state within `TIMEOUT_MS`. On the dev mock this is the
+ *   expected path for restart/reboot (no supervisor brings the
+ *   daemon back); on a Pi this means something is wrong.
+ * - `failed` — the initial POST itself failed; nothing further.
+ */
+export type DaemonReachabilityPhase =
+  | "idle"
+  | "scheduled"
+  | "down"
+  | "ready"
+  | "ready_signed_out"
+  | "off"
+  | "did_not_fire"
+  | "timeout"
+  | "failed";
+
+/** Which kind of power op is being observed — controls how the
+ *  state machine resolves. */
+export type ReachabilityMode =
+  | { kind: "restart" } // expects daemon back, validates session
+  | { kind: "reboot" } // expects daemon back (host comes back up)
+  | { kind: "shutdown" }; // expects daemon to stay down ⇒ `off`
+
+/** Upper bound on the whole lifecycle before we give up. Matches
+ *  the existing `useRestart` value so the UX doesn't drift. */
+const TIMEOUT_MS = 45_000;
+/** Probe interval while waiting for the daemon to come back. */
+const POLL_INTERVAL_MS = 800;
+/** If the daemon is still reachable this long after a request, we
+ *  conclude the spawned task never fired (almost always missing
+ *  polkit rule). 8 s = the 500 ms grace window plus a comfortable
+ *  margin for systemctl + logind round-trips. */
+const DID_NOT_FIRE_MS = 8_000;
+/** Shutdown only: number of consecutive-down probes required to
+ *  confirm the host is off rather than mid-reboot. ~3 s of silence
+ *  is enough to distinguish a true poweroff from a brief socket
+ *  blip. */
+const OFF_CONFIRM_DOWN_PROBES = 4;
+
+/**
+ * Lifecycle state machine for "the daemon is about to go away".
+ *
+ * Owns the poll loop. Consumers fire the appropriate POST, then
+ * call `start()` to enter `scheduled` and let the hook drive the
+ * rest of the state machine. `mode` determines how the terminal
+ * phases resolve:
+ *
+ * | Mode        | Daemon reachable post-grace | Came back, session OK | Came back, session 401 | Down for ≥ N probes |
+ * | ----------- | --------------------------- | --------------------- | ---------------------- | ------------------- |
+ * | `restart`   | did_not_fire                | ready                 | ready_signed_out       | (keeps polling)     |
+ * | `reboot`    | did_not_fire                | ready                 | ready_signed_out       | (keeps polling)     |
+ * | `shutdown`  | did_not_fire                | (treats as bounce)    | (treats as bounce)     | off                 |
+ *
+ * The hook does not write to TanStack Query caches.
+ */
+export function useDaemonReachability() {
+  const [phase, setPhase] = useState<DaemonReachabilityPhase>("idle");
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [startedAt, setStartedAt] = useState<number | null>(null);
+
+  const cancelRef = useRef<(() => void) | null>(null);
+
+  const startPolling = useCallback((mode: ReachabilityMode) => {
+    let cancelled = false;
+    let seenDown = false;
+    let downStreak = 0;
+    const startedAtLocal = Date.now();
+    const timeoutAt = startedAtLocal + TIMEOUT_MS;
+    const didNotFireAt = startedAtLocal + DID_NOT_FIRE_MS;
+
+    cancelRef.current = () => {
+      cancelled = true;
+    };
+
+    const tick = async () => {
+      while (!cancelled) {
+        const now = Date.now();
+        if (now > timeoutAt) {
+          if (!cancelled) setPhase("timeout");
+          return;
+        }
+
+        let probeOk;
+        try {
+          const res = await fetch("/api/info", { cache: "no-store" });
+          probeOk = res.ok;
+        } catch {
+          probeOk = false;
+        }
+
+        if (!probeOk) {
+          seenDown = true;
+          downStreak += 1;
+          if (mode.kind === "shutdown" && downStreak >= OFF_CONFIRM_DOWN_PROBES) {
+            // Daemon has been silent long enough — host is off.
+            if (!cancelled) setPhase("off");
+            return;
+          }
+          if (!cancelled) setPhase("down");
+        } else {
+          downStreak = 0;
+          if (seenDown) {
+            // Daemon is back. For shutdown, this is unexpected (the
+            // host came back up on its own?) — treat the same as a
+            // restart bounce: recheck session.
+            try {
+              await systemService.getStatus();
+              if (!cancelled) setPhase("ready");
+            } catch (err) {
+              if (err instanceof WardnetApiError && err.status === 401) {
+                if (!cancelled) setPhase("ready_signed_out");
+              } else {
+                // Non-auth error (network blip, 5xx). Treat as ready
+                // and let the rest of the app surface any real issue.
+                if (!cancelled) setPhase("ready");
+              }
+            }
+            return;
+          }
+          // Still reachable, never went down. If we've blown past
+          // the did-not-fire window we conclude logind never accepted
+          // the request — most often a missing polkit rule.
+          if (now > didNotFireAt) {
+            if (!cancelled) setPhase("did_not_fire");
+            return;
+          }
+          // Otherwise stay in `scheduled` and keep polling.
+        }
+
+        await new Promise((r) => setTimeout(r, POLL_INTERVAL_MS));
+      }
+    };
+
+    void tick();
+  }, []);
+
+  /** Move into `scheduled` and start polling for the given mode. */
+  const start = useCallback(
+    (mode: ReachabilityMode) => {
+      setErrorMessage(null);
+      setPhase("scheduled");
+      setStartedAt(Date.now());
+      startPolling(mode);
+    },
+    [startPolling],
+  );
+
+  /** Move directly into `failed` with an error message. Used when
+   *  the initial POST itself rejects. Tears down any active poll. */
+  const fail = useCallback((message: string) => {
+    if (cancelRef.current) cancelRef.current();
+    cancelRef.current = null;
+    setErrorMessage(message);
+    setPhase("failed");
+  }, []);
+
+  /** Move into `scheduled` *without* starting the poll loop. Used by
+   *  callers that prefer to fire the POST first and only start
+   *  polling on a 204 — keeps a 4xx/5xx out of the poll budget. */
+  const markScheduled = useCallback(() => {
+    setErrorMessage(null);
+    setPhase("scheduled");
+    setStartedAt(Date.now());
+  }, []);
+
+  /** Tear down any in-flight poll and reset to `idle`. */
+  const reset = useCallback(() => {
+    if (cancelRef.current) cancelRef.current();
+    cancelRef.current = null;
+    setPhase("idle");
+    setStartedAt(null);
+    setErrorMessage(null);
+  }, []);
+
+  return {
+    phase,
+    errorMessage,
+    startedAt,
+    start,
+    markScheduled,
+    fail,
+    reset,
+    /** `true` whenever the dialog should be open (any non-idle phase). */
+    isOpen: phase !== "idle",
+  };
+}

--- a/source/web-ui/src/hooks/useReboot.ts
+++ b/source/web-ui/src/hooks/useReboot.ts
@@ -3,9 +3,9 @@ import { WardnetApiError } from "@wardnet/js";
 import { systemService } from "@/lib/sdk";
 import { useDaemonReachability } from "./useDaemonReachability";
 
-/** Phases the restart flow may surface. Subset of
- *  [`DaemonReachabilityPhase`] — restart never resolves to `off`. */
-export type RestartPhase =
+/** Phases the reboot flow may surface. Same as
+ *  [`useRestart`](./useRestart.ts) — both expect the daemon back. */
+export type RebootPhase =
   | "idle"
   | "scheduled"
   | "down"
@@ -16,25 +16,24 @@ export type RestartPhase =
   | "failed";
 
 /**
- * Lifecycle manager for a daemon restart from the web UI.
+ * Lifecycle manager for a host reboot from the web UI.
  *
- * Thin wrapper over [`useDaemonReachability`] that fires
- * `POST /api/system/restart` and starts the shared poll loop in
- * "restart" mode once the server has accepted the request.
- *
- * Public surface mirrors the previous (pre-#215) implementation —
- * existing callers (Settings page, post-restore prompt) keep
- * working without changes.
+ * Fires `POST /api/system/reboot`, then runs the shared
+ * [`useDaemonReachability`] state machine in "reboot" mode. The
+ * lifecycle is the same shape as `useRestart` (the daemon is
+ * expected to come back); the difference is the trigger endpoint
+ * and the on-the-wire effect — see #213's GARP failover, which
+ * uses this endpoint as its e2e trigger.
  */
-export function useRestart() {
+export function useReboot() {
   const reach = useDaemonReachability();
 
   const start = useCallback(() => {
     reach.markScheduled();
     systemService
-      .restart()
+      .reboot()
       .then(() => {
-        reach.start({ kind: "restart" });
+        reach.start({ kind: "reboot" });
       })
       .catch((err: unknown) => {
         const msg =
@@ -42,13 +41,13 @@ export function useRestart() {
             ? (err.body.detail ?? err.body.error)
             : err instanceof Error
               ? err.message
-              : "Failed to restart";
+              : "Failed to reboot";
         reach.fail(msg);
       });
   }, [reach]);
 
   return {
-    phase: reach.phase as RestartPhase,
+    phase: reach.phase as RebootPhase,
     errorMessage: reach.errorMessage,
     startedAt: reach.startedAt,
     isOpen: reach.isOpen,

--- a/source/web-ui/src/hooks/useShutdown.ts
+++ b/source/web-ui/src/hooks/useShutdown.ts
@@ -3,38 +3,37 @@ import { WardnetApiError } from "@wardnet/js";
 import { systemService } from "@/lib/sdk";
 import { useDaemonReachability } from "./useDaemonReachability";
 
-/** Phases the restart flow may surface. Subset of
- *  [`DaemonReachabilityPhase`] — restart never resolves to `off`. */
-export type RestartPhase =
+/** Phases the shutdown flow may surface. Resolves to `off` (the
+ *  host is powered down) instead of `ready`/`ready_signed_out`. */
+export type ShutdownPhase =
   | "idle"
   | "scheduled"
   | "down"
-  | "ready"
-  | "ready_signed_out"
+  | "off"
   | "did_not_fire"
   | "timeout"
   | "failed";
 
 /**
- * Lifecycle manager for a daemon restart from the web UI.
+ * Lifecycle manager for a host shutdown from the web UI.
  *
- * Thin wrapper over [`useDaemonReachability`] that fires
- * `POST /api/system/restart` and starts the shared poll loop in
- * "restart" mode once the server has accepted the request.
- *
- * Public surface mirrors the previous (pre-#215) implementation —
- * existing callers (Settings page, post-restore prompt) keep
- * working without changes.
+ * Fires `POST /api/system/shutdown`, then runs the shared
+ * [`useDaemonReachability`] state machine in "shutdown" mode. The
+ * difference vs reboot/restart: the lifecycle resolves to a
+ * **terminal** `off` once the daemon has been silent for a few
+ * consecutive probes — the operator must manually power the Pi
+ * back on, so there is no comeback poll and the dialog copy says
+ * exactly that.
  */
-export function useRestart() {
+export function useShutdown() {
   const reach = useDaemonReachability();
 
   const start = useCallback(() => {
     reach.markScheduled();
     systemService
-      .restart()
+      .shutdown()
       .then(() => {
-        reach.start({ kind: "restart" });
+        reach.start({ kind: "shutdown" });
       })
       .catch((err: unknown) => {
         const msg =
@@ -42,13 +41,13 @@ export function useRestart() {
             ? (err.body.detail ?? err.body.error)
             : err instanceof Error
               ? err.message
-              : "Failed to restart";
+              : "Failed to shut down";
         reach.fail(msg);
       });
   }, [reach]);
 
   return {
-    phase: reach.phase as RestartPhase,
+    phase: reach.phase as ShutdownPhase,
     errorMessage: reach.errorMessage,
     startedAt: reach.startedAt,
     isOpen: reach.isOpen,

--- a/source/web-ui/src/pages/Settings.tsx
+++ b/source/web-ui/src/pages/Settings.tsx
@@ -1,14 +1,17 @@
 import { useState } from "react";
 import { useNavigate } from "react-router";
 import type { RestorePreviewResponse } from "@wardnet/js";
-import { Button } from "@/components/core/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/core/ui/card";
 import { PageHeader } from "@/components/compound/PageHeader";
 import { BackupCard } from "@/components/features/BackupCard";
+import { PowerCard } from "@/components/features/PowerCard";
 import { RestartProgressDialog } from "@/components/features/RestartProgressDialog";
+import { ShutdownProgressDialog } from "@/components/features/ShutdownProgressDialog";
 import { UpdateCard } from "@/components/features/UpdateCard";
 import { useApplyImport, useExportBackup, usePreviewImport } from "@/hooks/useBackup";
+import { useReboot } from "@/hooks/useReboot";
 import { useRestart } from "@/hooks/useRestart";
+import { useShutdown } from "@/hooks/useShutdown";
 import { useSystemStatus } from "@/hooks/useSystemStatus";
 import {
   useCheckForUpdates,
@@ -19,7 +22,6 @@ import {
 } from "@/hooks/useUpdate";
 import { useAuthStore } from "@/stores/authStore";
 import { formatBytes, formatUptime } from "@/lib/utils";
-import { RotateCcwIcon } from "lucide-react";
 
 /** Settings page for system configuration (admin only). */
 export default function Settings() {
@@ -40,11 +42,13 @@ export default function Settings() {
   const previewImport = usePreviewImport();
   const applyImport = useApplyImport();
 
-  // Restart lifecycle — shared between the explicit "Restart daemon"
-  // button and the post-restore prompt. The hook owns the poll loop
-  // and exposes a phase state machine; the dialog renders phase-
-  // specific copy.
+  // Power lifecycles — three independent hooks, one shared poll
+  // implementation under the hood (see `useDaemonReachability`).
   const restart = useRestart();
+  const reboot = useReboot();
+  const shutdown = useShutdown();
+
+  const anyPowerOpInFlight = restart.isOpen || reboot.isOpen || shutdown.isOpen;
 
   const onRestartReady = () => {
     restart.reset();
@@ -54,6 +58,15 @@ export default function Settings() {
     // session store). Clear local admin flag and route to login.
     logout();
     restart.reset();
+    void navigate("/login");
+  };
+
+  const onRebootReady = () => {
+    reboot.reset();
+  };
+  const onRebootSignIn = () => {
+    logout();
+    reboot.reset();
     void navigate("/login");
   };
 
@@ -96,25 +109,15 @@ export default function Settings() {
             ) : (
               <p className="text-sm text-muted-foreground">Unable to connect to daemon.</p>
             )}
-
-            <div className="mt-6 flex items-center justify-between border-t pt-4">
-              <div>
-                <div className="text-sm font-medium">Restart daemon</div>
-                <div className="text-xs text-muted-foreground">
-                  The daemon will be unreachable for a few seconds while it restarts.
-                </div>
-              </div>
-              <Button
-                variant="destructive"
-                onClick={() => restart.start()}
-                disabled={restart.isOpen}
-              >
-                <RotateCcwIcon />
-                Restart
-              </Button>
-            </div>
           </CardContent>
         </Card>
+
+        <PowerCard
+          onReboot={() => reboot.start()}
+          onShutdown={() => shutdown.start()}
+          onRestartDaemon={() => restart.start()}
+          busy={anyPowerOpInFlight}
+        />
 
         <UpdateCard
           status={updateStatus?.status ?? null}
@@ -169,6 +172,7 @@ export default function Settings() {
         </Card>
       </div>
 
+      {/* Restart-daemon flow. Same dialog the post-restore prompt uses. */}
       <RestartProgressDialog
         open={restart.isOpen}
         phase={restart.phase}
@@ -176,6 +180,29 @@ export default function Settings() {
         errorMessage={restart.errorMessage}
         onDismiss={onRestartReady}
         onSignIn={onRestartSignIn}
+      />
+
+      {/* Safe-Reboot flow — lifecycle is the same shape as restart
+          (the daemon is expected to come back), so we re-use the
+          same progress dialog. The copy is generic enough to fit
+          both. */}
+      <RestartProgressDialog
+        open={reboot.isOpen}
+        phase={reboot.phase}
+        startedAt={reboot.startedAt}
+        errorMessage={reboot.errorMessage}
+        onDismiss={onRebootReady}
+        onSignIn={onRebootSignIn}
+      />
+
+      {/* Safe-Shutdown flow — distinct dialog because the terminal
+          state is "host is off, no recovery" rather than "back up". */}
+      <ShutdownProgressDialog
+        open={shutdown.isOpen}
+        phase={shutdown.phase}
+        startedAt={shutdown.startedAt}
+        errorMessage={shutdown.errorMessage}
+        onDismiss={() => shutdown.reset()}
       />
     </>
   );


### PR DESCRIPTION
## Summary

Closes #215.

Adds host-level reboot/poweroff to the daemon, the matching SDK + Web UI surface, and the e2e harness. Three commits intentionally aligned with the planning addendum's three-PR slice in case we want to split before merge — combined here per the issue's "combine if each piece stays under ~600 lines diff" guidance (largest chunk is daemon at ~932 lines, but it's tightly coupled).

- **`feat(daemon)`** — `SystemPowerOps` trait + `SystemctlPowerOps` (real, shells out to `systemctl reboot|poweroff --no-block`) + `NoopSystemPowerOps` (mock). `Backends` DI carries it. `SystemService::request_reboot`/`request_shutdown` are admin-only, return immediately, then a 500 ms-grace task fires the wired ops so the 204 flushes before logind queues the action. systemd drives the actual shutdown; we never touch `shutdown_token`. New endpoints `POST /api/system/reboot` and `/shutdown`. Migration `0001_polkit_power_rule` (Severity::Optional) drops `/etc/polkit-1/rules.d/50-wardnet-power.rules` authorising the `wardnet` user for the four `org.freedesktop.login1.{reboot,reboot-multiple-sessions,power-off,power-off-multiple-sessions}` actions, idempotent (read → compare → write-temp + parent fsync only on diff, also reconciles mode 0644 if hand-chmodded).
- **`feat(sdk,web-ui)`** — SDK `SystemService.reboot()`/`.shutdown()` mirror the existing `restart()` shape. New `useDaemonReachability` hook owns the single poll loop with `idle | scheduled | down | ready | ready_signed_out | off | did_not_fire | timeout | failed` phases; `useReboot`, `useShutdown`, and refactored `useRestart` are thin wrappers. `did_not_fire` surfaces if the daemon stays reachable 8 s after the 204 — copy points the operator at Settings → Updates / `install.sh`. `PowerCard` is pure presentation (callbacks + `busy` flag, no SDK), `ShutdownProgressDialog` mirrors `RestartProgressDialog`'s props-driven shape with a definitive `off` terminal state. Settings page wires the three hooks. Per UX feedback during validation, all three buttons use the `outline` variant — none of these are happy-path CTAs — with Shutdown keeping the destructive (red) tint.
- **`test(e2e)`** — `Dockerfile.test` adds `policykit-1` and a `/usr/sbin/systemctl` shim that captures argv to a marker file (the daemon's `ShellCommandExecutor` resolves sbin first, so wardnetd execs the shim while real systemctl callers stay on `/usr/bin/systemctl`). New `/power/{systemctl-invocations,polkit-rule,pkcheck}` endpoints on the test agent. `safe-power.spec.ts` covers Decision 8's full e2e tier: migration applied, polkit rule on disk, `pkcheck` succeeds for each of the four actions as `wardnet`, 204 + shim invocation for both endpoints, 401 unauth, SDK round-trip.

### Decisions noted in commit messages

- **Web-UI vitest tests deferred** — the planning addendum lists per-component vitest tests, but the web-ui has no vitest harness in the repo (no dep, no config, no script). Setting one up wasn't part of the locked plan and is deferred to a follow-up. Service-level + API-level + e2e coverage already exercises the same behaviour end-to-end.
- **Signed-payload sequencing** — source-only PR per Decision 3. The next `release-daemon.yml` run rebuilds `wardnet-postupgrade` with the new migration baked in, signs with `WARDNET_MINISIGN_KEY`, and bundles into the release tarball.

## Test plan

- [x] `make check-daemon` (Linux container) — fmt + clippy `-D warnings` + workspace `cargo test` — 691 tests green
- [x] Web UI `yarn type-check` + `yarn lint` clean
- [x] SDK `yarn type-check` clean
- [x] E2E `yarn type-check` clean
- [x] Local `make run-dev` smoke — Settings page renders the new card; styling validated by reviewer
- [ ] CI green
- [ ] `make e2e-daemon` (CI tests-e2e workflow) — `safe-power.spec.ts` runs against the real test image with the polkit rule + systemctl shim

🤖 Generated with [Claude Code](https://claude.com/claude-code)