### PR TITLE
fix(ci): grant id-token + attestations write to release-daemon caller

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -216,6 +216,12 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/v')
     permissions:
       contents: write
+      # SLSA build-provenance attestation in release-daemon.yml needs both.
+      # A reusable workflow's job permissions cannot exceed what the caller
+      # grants, so they have to be declared here too — not just in the
+      # callee.
+      id-token: write
+      attestations: write
     uses: ./.github/workflows/release-daemon.yml
     with:
       version: ${{ needs.resolve.outputs.version }}


### PR DESCRIPTION
## Summary

Fixes the `startup_failure` that hit the v2026.05.02 tag push ([run](https://github.com/wardnet/wardnet/actions/runs/25479777446)). The orchestrator never executed any job — it failed at validation in 1 s.

### Root cause

PR #328 added `id-token: write` and `attestations: write` to the `publish` job inside `release-daemon.yml` so `actions/attest-build-provenance` could mint a Sigstore identity. But a reusable workflow's job-level permissions cannot exceed what the calling job has granted, and `release.yml`'s `release-daemon` call only declared:

```yaml
permissions:
  contents: write
```

When the tag actually triggered the workflow, GitHub validated the permission graph, saw the callee asking for `id-token: write` / `attestations: write` that the caller hadn't granted, and rejected the run before any job ran.

### Why CI didn't catch this on #328

`release-daemon` is gated on `if: startsWith(github.ref, 'refs/tags/v')`. PR runs and `workflow_dispatch` on `main` both fail that predicate, skip the job, and never exercise the permission graph. The first time the path is evaluated is when an actual `v*.*.*` tag is pushed — which is exactly what happened on `v2026.05.02`.

### Fix

Mirror the SLSA permissions into the orchestrator's `release-daemon` call so the caller's grant covers what the callee asks for.

### Recovery for `v2026.05.02`

After this lands, I'll force-push `v2026.05.02` to the merge commit. No GitHub Release was created for v2026.05.02 by the failed run (`gh release view v2026.05.02` → `release not found`), no tarballs were uploaded, no auto-update manifest was refreshed, and no client has seen the tag — so the force-push is safe in this specific case (the skill's "don't reuse a CalVer slot" warning is about clobbering a published release, which doesn't apply here).

## Test plan

- [ ] CI green on this PR (orthogonal — this PR doesn't push a tag, so the orchestrator's tag-only path won't actually run; the YAML still has to parse cleanly)
- [ ] After merge + retag, the `v2026.05.02` workflow run reaches `release-daemon` instead of failing at startup