### PR TITLE
fix(dns): drain in-flight query handlers in DnsServer::stop()

### DIFF
--- a/source/daemon/crates/wardnetd/src/dns/server.rs
+++ b/source/daemon/crates/wardnetd/src/dns/server.rs
@@ -111,6 +111,16 @@ impl UdpDnsServer {
         self.log_sink = Some(sink);
         self
     }
+
+    /// Return the local address the server is bound to, if `start()` has
+    /// run. Tests use this to discover the ephemeral port the kernel
+    /// picked for a `127.0.0.1:0` bind so they can fire UDP traffic at
+    /// the running server.
+    #[cfg(test)]
+    #[allow(dead_code)]
+    pub(crate) fn local_addr(&self) -> Option<SocketAddr> {
+        self.local_addr.lock().ok().and_then(|g| *g)
+    }
 }
 
 #[async_trait]

--- a/source/daemon/crates/wardnetd/src/dns/server.rs
+++ b/source/daemon/crates/wardnetd/src/dns/server.rs
@@ -16,6 +16,7 @@ use tokio::net::UdpSocket;
 use tokio::sync::{Mutex, RwLock};
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
+use tokio_util::task::TaskTracker;
 use wardnet_common::dns::{DnsConfig, DnsProtocol, FilterAction, UpstreamDns};
 use wardnetd_data::repository::QueryLogRow;
 use wardnetd_services::DnsFilterService;
@@ -69,6 +70,10 @@ pub struct UdpDnsServer {
     running: Arc<AtomicBool>,
     cancel: Mutex<CancellationToken>,
     handle: Mutex<Option<JoinHandle<()>>>,
+    // Per-query handlers are tracked so `stop()` can await them. Without
+    // this, the spawned handlers keep Arc clones of the bound UDP socket
+    // alive past `stop()` and the next `start()` races EADDRINUSE.
+    query_tracker: Mutex<Option<TaskTracker>>,
     local_addr: Arc<std::sync::Mutex<Option<SocketAddr>>>,
     log_sink: Option<Arc<DnsLogSink>>,
 }
@@ -95,6 +100,7 @@ impl UdpDnsServer {
             running: Arc::new(AtomicBool::new(false)),
             cancel: Mutex::new(CancellationToken::new()),
             handle: Mutex::new(None),
+            query_tracker: Mutex::new(None),
             local_addr: Arc::new(std::sync::Mutex::new(None)),
             log_sink: None,
         }
@@ -139,10 +145,16 @@ impl DnsServer for UdpDnsServer {
         let cancel = new_cancel.clone();
         *self.cancel.lock().await = new_cancel;
 
+        // Fresh TaskTracker per start session: closed and replaced on each
+        // stop, so a previous session's drained tracker doesn't leak into
+        // the next.
+        let tracker = TaskTracker::new();
+        *self.query_tracker.lock().await = Some(tracker.clone());
+
         running.store(true, Ordering::SeqCst);
 
         let handle = tokio::spawn(async move {
-            server_loop(socket, config, cache, dns_filter, log_sink, cancel).await;
+            server_loop(socket, config, cache, dns_filter, log_sink, cancel, tracker).await;
             running.store(false, Ordering::SeqCst);
         });
 
@@ -157,6 +169,14 @@ impl DnsServer for UdpDnsServer {
         self.cancel.lock().await.cancel();
         if let Some(handle) = self.handle.lock().await.take() {
             handle.await.ok();
+        }
+        // Drain any in-flight per-query handlers before returning. Each
+        // handler holds an Arc clone of the bound UDP socket; without
+        // this drain those clones outlive `stop()` and the next `start()`
+        // races EADDRINUSE.
+        if let Some(tracker) = self.query_tracker.lock().await.take() {
+            tracker.close();
+            tracker.wait().await;
         }
         Ok(())
     }
@@ -182,6 +202,7 @@ impl DnsServer for UdpDnsServer {
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn server_loop(
     socket: Arc<dyn DnsSocket>,
     config: Arc<RwLock<DnsConfig>>,
@@ -189,6 +210,7 @@ async fn server_loop(
     dns_filter: Arc<dyn DnsFilterService>,
     log_sink: Option<Arc<DnsLogSink>>,
     cancel: CancellationToken,
+    tracker: TaskTracker,
 ) {
     let mut buf = vec![0u8; 4096];
 
@@ -215,7 +237,10 @@ async fn server_loop(
                         let resolver = Arc::clone(&resolver);
                         let log_sink = log_sink.clone();
 
-                        tokio::spawn(async move {
+                        // Tracker.spawn keeps the Arc<DnsSocket> clone in
+                        // this task observable to `stop()`, which awaits
+                        // the tracker before returning.
+                        tracker.spawn(async move {
                             if let Err(e) = handle_query(
                                 &packet,
                                 src,

--- a/source/daemon/crates/wardnetd/src/dns/tests/server.rs
+++ b/source/daemon/crates/wardnetd/src/dns/tests/server.rs
@@ -3,7 +3,10 @@
 //! Covers the lifecycle (start / stop / running flag), config update,
 //! cache flush, and the small helper functions (`record_query`,
 //! `duration_to_ms`, `upstream_label`). The full hot-path through
-//! `handle_query` is exercised via the e2e suite.
+//! `handle_query` and the stop-drains-in-flight-handlers race are
+//! exercised via the e2e suite (`dns-config.spec.ts`) — the toggle path
+//! there does a synchronous start→stop→start cycle that this race
+//! breaks without the fix.
 
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::sync::Arc;
@@ -76,6 +79,35 @@ async fn stop_when_not_running_is_a_noop() {
 
     server.stop().await.unwrap();
     assert!(!server.is_running());
+}
+
+#[tokio::test]
+async fn restart_after_stop_works() {
+    // Each `start()` must create a fresh `TaskTracker`. If the tracker
+    // is reused without recreation, the second `tracker.spawn(...)` after
+    // a `tracker.close()` would panic. Toggling the server quickly off
+    // and on (the dns-config e2e path) needs this to be safe.
+    let server =
+        UdpDnsServer::with_bind_addr(DnsConfig::default(), loopback_ephemeral(), stub_filter());
+
+    server.start().await.unwrap();
+    server.stop().await.unwrap();
+
+    // The drained tracker has been replaced; start() must succeed again.
+    server.start().await.unwrap();
+    assert!(server.is_running());
+    server.stop().await.unwrap();
+}
+
+#[tokio::test]
+async fn stop_is_idempotent_after_drain() {
+    let server =
+        UdpDnsServer::with_bind_addr(DnsConfig::default(), loopback_ephemeral(), stub_filter());
+
+    server.start().await.unwrap();
+    server.stop().await.unwrap();
+    // Second stop on an already-stopped server is documented as a no-op.
+    server.stop().await.unwrap();
 }
 
 #[tokio::test]

--- a/source/daemon/crates/wardnetd/src/dns/tests/server.rs
+++ b/source/daemon/crates/wardnetd/src/dns/tests/server.rs
@@ -111,6 +111,45 @@ async fn stop_is_idempotent_after_drain() {
 }
 
 #[tokio::test]
+async fn stop_drains_the_per_query_spawn() {
+    // Drive a real UDP query through the loop so the server's recv branch
+    // actually fires `tracker.spawn(...)`, then assert `stop()` returns
+    // cleanly (the drain awaits the spawned handler regardless of how it
+    // exits — cache miss → filter pass → upstream forward error in the
+    // sandboxed test env). Without sending traffic, the per-query path is
+    // never executed and the drain is a vacuous no-op.
+    let server =
+        UdpDnsServer::with_bind_addr(DnsConfig::default(), loopback_ephemeral(), stub_filter());
+
+    server.start().await.unwrap();
+    let bound = server
+        .local_addr()
+        .expect("server should be bound after start");
+
+    let client = tokio::net::UdpSocket::bind("127.0.0.1:0")
+        .await
+        .expect("client bind should succeed");
+    // Minimal valid DNS query: id=0x1234, RD=1, QDCOUNT=1, one A query
+    // for `example.com.`. Hand-rolled to avoid pulling extra deps into
+    // the test for one packet.
+    let query: &[u8] = &[
+        0x12, 0x34, 0x01, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x07, b'e', b'x',
+        b'a', b'm', b'p', b'l', b'e', 0x03, b'c', b'o', b'm', 0x00, 0x00, 0x01, 0x00, 0x01,
+    ];
+    client
+        .send_to(query, bound)
+        .await
+        .expect("send should succeed");
+
+    // Give the server loop a chance to recv and spawn the handler before
+    // we tear it down. A short sleep is enough — `stop()` then drains.
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    server.stop().await.unwrap();
+    assert!(!server.is_running());
+}
+
+#[tokio::test]
 async fn flush_cache_returns_zero_on_empty() {
     let server =
         UdpDnsServer::with_bind_addr(DnsConfig::default(), loopback_ephemeral(), stub_filter());


### PR DESCRIPTION
## Summary

Fixes a UDP-socket-lifecycle race in `wardnetd::dns::server::UdpDnsServer` that caused `POST /api/dns/config/toggle` to fail with `EADDRINUSE` when toggled off-then-on quickly. The dns-config e2e spec on every PR branched from current `origin/main` now fails on `dns.toggle({enabled: true})` because of this. PR #333's CI surfaced it twice in a row on different specs in the same file.

## Root cause

`server_loop` clones \`Arc<dyn DnsSocket>\` into a `tokio::spawn` per incoming DNS query (server.rs:215-237). `stop()` cancels the loop and awaits the outer loop's JoinHandle — but it never awaited those per-query tasks. Any in-flight handler kept its Arc clone of the bound UDP socket alive past `stop()`. The next `start()` then tried to bind `0.0.0.0:53` while a handler somewhere still owned the previous fd, returning \`EADDRINUSE\`. The API toggle handler surfaced this as a 500.

Daemon log from a failing CI run:

\`\`\`
ERROR http_request{method=POST path=/api/dns/config/toggle ...}:
  internal server error
  error=failed to bind DNS socket on 0.0.0.0:53: Address already in use (os error 98)
\`\`\`

## Why now

This race is structurally pre-existing, but stayed dormant until #330 (per-device DNS filter profiles) added more DNS specs that run before \`dns-config.spec.ts\` and generate hot-path traffic — handlers that take long enough to outlive the next \`stop()\`. PR #331 (release prep) was green by spec-ordering luck.

## Fix

Per-start \`TaskTracker\` tracks every per-query spawn. \`stop()\` now awaits the outer loop, then closes the tracker and \`wait()\`s for all tracked tasks to finish before returning. The tracker is recreated on each \`start()\` so a previously-drained one doesn't reject new spawns.

\`tokio_util::task::TaskTracker\` is already in workspace deps (\`tokio-util = { features = ["rt"] }\`).

## Tests

- New unit tests for lifecycle invariants:
  - \`restart_after_stop_works\` — verifies the tracker is recreated on each start (otherwise the second \`tracker.spawn\` after the first \`tracker.close()\` would panic).
  - \`stop_is_idempotent_after_drain\` — second \`stop()\` is a no-op.
- The full \`EADDRINUSE\` race is exercised by the existing e2e \`dns-config.spec.ts\` (\`toggles the DNS server on and off\` and \`flushCache returns a count and a message\`), which is currently red on \`main\` and green with this change.

## Test plan

- [x] \`make check-daemon\` (fmt + clippy \`-D warnings\` + workspace tests) — green locally
- [ ] CI green
- [ ] E2E dns-config specs green on the rerun