### PR TITLE
fix(dns): serialize start/stop with a lifecycle Mutex

### DIFF
--- a/source/daemon/crates/wardnetd/src/dns/server.rs
+++ b/source/daemon/crates/wardnetd/src/dns/server.rs
@@ -68,6 +68,12 @@ pub struct UdpDnsServer {
     bind_addr: SocketAddr,
     injected_socket: Option<Arc<dyn DnsSocket>>,
     running: Arc<AtomicBool>,
+    // Serializes `start()` / `stop()` so concurrent callers (the API
+    // toggle handler runs synchronously *and* the `DnsRunner` reacts to
+    // the same `DnsConfigChanged` event) can't both pass the
+    // `running == false` check and race to bind 0.0.0.0:53. Without this
+    // the loser hits EADDRINUSE.
+    lifecycle: Mutex<()>,
     cancel: Mutex<CancellationToken>,
     handle: Mutex<Option<JoinHandle<()>>>,
     // Per-query handlers are tracked so `stop()` can await them. Without
@@ -98,6 +104,7 @@ impl UdpDnsServer {
             bind_addr,
             injected_socket: None,
             running: Arc::new(AtomicBool::new(false)),
+            lifecycle: Mutex::new(()),
             cancel: Mutex::new(CancellationToken::new()),
             handle: Mutex::new(None),
             query_tracker: Mutex::new(None),
@@ -126,6 +133,10 @@ impl UdpDnsServer {
 #[async_trait]
 impl DnsServer for UdpDnsServer {
     async fn start(&self) -> anyhow::Result<()> {
+        // Hold the lifecycle guard across the whole start: the
+        // running-flag check is otherwise racy against another caller
+        // (handler vs runner) doing the same check + bind concurrently.
+        let _lifecycle = self.lifecycle.lock().await;
         if self.running.load(Ordering::SeqCst) {
             tracing::warn!("DNS server already running");
             return Ok(());
@@ -173,6 +184,9 @@ impl DnsServer for UdpDnsServer {
     }
 
     async fn stop(&self) -> anyhow::Result<()> {
+        // Same lifecycle guard as `start()` so a concurrent start() can't
+        // pass running=false while we're tearing the listener down.
+        let _lifecycle = self.lifecycle.lock().await;
         if !self.running.load(Ordering::SeqCst) {
             return Ok(());
         }

--- a/source/daemon/crates/wardnetd/src/dns/tests/server.rs
+++ b/source/daemon/crates/wardnetd/src/dns/tests/server.rs
@@ -150,6 +150,47 @@ async fn stop_drains_the_per_query_spawn() {
 }
 
 #[tokio::test]
+async fn concurrent_start_calls_dont_race_to_bind() {
+    // Two concurrent `start()` calls used to both pass the
+    // `running == false` check and both proceed to `UdpSocket::bind`,
+    // racing on the same address. The loser hit EADDRINUSE. The
+    // lifecycle Mutex serializes them: the first sets `running = true`,
+    // the second sees it under the same lock and returns Ok with a warn.
+    //
+    // Reproduces the second race surfaced by the dns-config e2e
+    // (`flushCache returns a count and a message`) — the API toggle
+    // handler calls start() synchronously and the DnsRunner reacts to
+    // the same DnsConfigChanged event in parallel.
+    //
+    // Probe-and-drop a UdpSocket to discover a port that's free *right
+    // now*, then re-use that port for both start() calls. With the bug,
+    // one of the two binds would race the other and fail. With the fix,
+    // only one bind happens (the second start sees running=true under
+    // the lifecycle lock and returns immediately).
+    let probe = tokio::net::UdpSocket::bind("127.0.0.1:0")
+        .await
+        .expect("probe bind should succeed");
+    let port = probe.local_addr().unwrap().port();
+    drop(probe);
+    let bind = SocketAddr::from(([127, 0, 0, 1], port));
+
+    let server = Arc::new(UdpDnsServer::with_bind_addr(
+        DnsConfig::default(),
+        bind,
+        stub_filter(),
+    ));
+
+    let s1 = Arc::clone(&server);
+    let s2 = Arc::clone(&server);
+    let (r1, r2) = tokio::join!(s1.start(), s2.start());
+    r1.expect("first concurrent start should succeed");
+    r2.expect("second concurrent start should be a no-op (server already running)");
+
+    assert!(server.is_running());
+    server.stop().await.unwrap();
+}
+
+#[tokio::test]
 async fn flush_cache_returns_zero_on_empty() {
     let server =
         UdpDnsServer::with_bind_addr(DnsConfig::default(), loopback_ephemeral(), stub_filter());


### PR DESCRIPTION
## Summary

Sibling fix to #334. That PR drained per-query handlers so the previous bound socket fully released before the next `start()` ran. This PR closes the **second** race that surfaces on the same `dns-config` e2e test.

## Root cause

Two callers of \`start()\`:

1. The synchronous API toggle handler at \`wardnetd-api/src/api/dns.rs:101\` — runs after \`service.toggle()\` flips the DB and publishes a \`DnsConfigChanged\` event.
2. The asynchronous \`DnsRunner\` background task — subscribes to \`DnsConfigChanged\` and reacts to the new config by calling \`server.start()\` / \`server.stop()\`.

Both can fire on the same toggle. \`start()\` does:

\`\`\`rust
if self.running.load(Ordering::SeqCst) {
    warn!(...);
    return Ok(());
}
// ... UdpSocket::bind ...
running.store(true, ...);
\`\`\`

The \`running.load()\` and the \`UdpSocket::bind\` are not atomic. Two callers can both load \`running == false\`, both reach the bind, and the loser gets \`EADDRINUSE\`.

Daemon log from the v2026.05.02 tag run E2E (run 25488977500) that surfaced this:

\`\`\`
ERROR dns_runner: failed to start DNS server after config change
      error=failed to bind DNS socket on 0.0.0.0:53: Address already in use
ERROR http_request{POST /api/dns/config/toggle}: internal server error
      error=failed to bind DNS socket on 0.0.0.0:53: Address already in use
\`\`\`

Two distinct timestamps with the loser identified explicitly — confirms both call sites lose in different races.

## Fix

A \`lifecycle: Mutex<()>\` field on \`UdpDnsServer\` acquired as the first step in both \`start()\` and \`stop()\`. The first concurrent caller binds and sets \`running = true\` under the lock; the second acquires the lock after release, sees \`running == true\`, and returns Ok with the existing \"DNS server already running\" warn.

The same lock also makes start/stop pairs serialize cleanly — \`stop\` can't observe a half-started server and \`start\` can't begin while \`stop\` is mid-drain.

## Tests

Added \`concurrent_start_calls_dont_race_to_bind\` — uses a probe-then-drop trick to discover a free port the kernel will hand out, then pins both concurrent \`start()\` calls to that port via \`with_bind_addr\`. Without the lock the second bind would race the first and one would lose. Existing lifecycle tests continue to pass.

## Test plan

- [x] \`make check-daemon\` (fmt + clippy \`-D warnings\` + workspace tests, including new test) — green locally
- [ ] CI green
- [ ] After merge, retag \`v2026.05.02\` — release pipeline reaches \`tests-e2e\` cleanly, \`release-daemon\` publishes