### PR TITLE
feat: detect unclean shutdown + dashboard banner (closes #216)

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -10483,6 +10483,125 @@
         ]
       }
     },
+    "/api/system/shutdown/acknowledge": {
+      "post": {
+        "tags": [
+          "system"
+        ],
+        "summary": "Dismiss the dashboard's unclean-shutdown banner.",
+        "description": "Acknowledge the most recent unclean-shutdown event so the dashboard banner is dismissed. Idempotent — repeated calls just refresh the timestamp. The banner reappears automatically on the next unclean shutdown. Admin only.",
+        "operationId": "acknowledge_shutdown",
+        "responses": {
+          "204": {
+            "description": "Acknowledgement recorded"
+          },
+          "401": {
+            "description": "Unauthenticated — session cookie or API key missing/invalid",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "description": "Standard API error response.",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "detail": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "error": {
+                      "type": "string"
+                    },
+                    "request_id": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "description": "Request ID for correlation with server logs."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden — caller is not an admin",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "description": "Standard API error response.",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "detail": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "error": {
+                      "type": "string"
+                    },
+                    "request_id": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "description": "Request ID for correlation with server logs."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "description": "Standard API error response.",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "detail": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "error": {
+                      "type": "string"
+                    },
+                    "request_id": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "description": "Request ID for correlation with server logs."
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "session_cookie": []
+          },
+          {
+            "bearer_auth": []
+          }
+        ]
+      }
+    },
     "/api/system/status": {
       "get": {
         "tags": [
@@ -14367,6 +14486,41 @@
           "TERMINATED_WITH_ERRORS"
         ]
       },
+      "LastShutdownState": {
+        "type": "string",
+        "description": "How the previous daemon shutdown ended.",
+        "enum": [
+          "unknown",
+          "graceful",
+          "unclean"
+        ]
+      },
+      "LastShutdownStatus": {
+        "type": "object",
+        "description": "Classification of the previous daemon shutdown.\n\n`at` is the timestamp the previous run last touched the database\n(graceful exit time, or last heartbeat for unclean events). It is\n`None` only for `unknown` (first-ever boot). `acknowledged_at` is\nset by `POST /api/system/shutdown/acknowledge`; the banner is\nconsidered dismissed iff `acknowledged_at >= at`.",
+        "required": [
+          "state"
+        ],
+        "properties": {
+          "acknowledged_at": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "date-time"
+          },
+          "at": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "date-time"
+          },
+          "state": {
+            "$ref": "#/components/schemas/LastShutdownState"
+          }
+        }
+      },
       "ListAllowlistResponse": {
         "type": "object",
         "description": "Response for GET /api/dns/allowlist.",
@@ -15301,7 +15455,8 @@
           "db_size_bytes",
           "cpu_usage_percent",
           "memory_used_bytes",
-          "memory_total_bytes"
+          "memory_total_bytes",
+          "last_shutdown"
         ],
         "properties": {
           "cpu_usage_percent": {
@@ -15317,6 +15472,10 @@
             "type": "integer",
             "format": "int64",
             "minimum": 0
+          },
+          "last_shutdown": {
+            "$ref": "#/components/schemas/LastShutdownStatus",
+            "description": "Classification of the previous daemon shutdown plus its\nacknowledgement timestamp. The web UI uses this to surface a\npersistent banner after an unclean shutdown until an admin\ndismisses it."
           },
           "memory_total_bytes": {
             "type": "integer",

--- a/source/daemon/crates/wardnet-common/src/api.rs
+++ b/source/daemon/crates/wardnet-common/src/api.rs
@@ -1,3 +1,4 @@
+use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
 use crate::backup::{BackupStatus, BundleManifest, LocalSnapshot};
@@ -94,6 +95,38 @@ pub struct SystemStatusResponse {
     pub cpu_usage_percent: f32,
     pub memory_used_bytes: u64,
     pub memory_total_bytes: u64,
+    /// Classification of the previous daemon shutdown plus its
+    /// acknowledgement timestamp. The web UI uses this to surface a
+    /// persistent banner after an unclean shutdown until an admin
+    /// dismisses it.
+    pub last_shutdown: LastShutdownStatus,
+}
+
+/// How the previous daemon shutdown ended.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, utoipa::ToSchema)]
+#[serde(rename_all = "lowercase")]
+pub enum LastShutdownState {
+    /// No prior shutdown has been recorded — first-ever boot.
+    Unknown,
+    /// Daemon recorded a graceful shutdown marker before exit.
+    Graceful,
+    /// Daemon was interrupted (crash, power loss, SIGKILL); the
+    /// "running" marker survived into the next boot.
+    Unclean,
+}
+
+/// Classification of the previous daemon shutdown.
+///
+/// `at` is the timestamp the previous run last touched the database
+/// (graceful exit time, or last heartbeat for unclean events). It is
+/// `None` only for `unknown` (first-ever boot). `acknowledged_at` is
+/// set by `POST /api/system/shutdown/acknowledge`; the banner is
+/// considered dismissed iff `acknowledged_at >= at`.
+#[derive(Debug, Clone, Serialize, utoipa::ToSchema)]
+pub struct LastShutdownStatus {
+    pub state: LastShutdownState,
+    pub at: Option<DateTime<Utc>>,
+    pub acknowledged_at: Option<DateTime<Utc>>,
 }
 
 /// Response from the public info endpoint.

--- a/source/daemon/crates/wardnetd-api/src/api/system.rs
+++ b/source/daemon/crates/wardnetd-api/src/api/system.rs
@@ -31,6 +31,7 @@ pub fn register(router: OpenApiRouter<AppState>) -> OpenApiRouter<AppState> {
         .routes(routes!(reboot))
         .routes(routes!(shutdown))
         .routes(routes!(get_default_policy, set_default_policy))
+        .routes(routes!(acknowledge_shutdown))
 }
 
 #[utoipa::path(
@@ -243,6 +244,39 @@ pub async fn set_default_policy(
     Ok(Json(SetDefaultPolicyResponse {
         policy: body.policy,
     }))
+}
+
+/// Dismiss the dashboard's unclean-shutdown banner.
+///
+/// Records `last_shutdown_acknowledged_at = NOW`. The banner predicate
+/// (`acknowledged_at >= last_shutdown.at`) hides the banner from the
+/// next status response. A future unclean event automatically restores
+/// the banner because the new event timestamp is newer than the stored
+/// ack — no explicit "reset on event" coupling.
+#[utoipa::path(
+    post,
+    path = "/api/system/shutdown/acknowledge",
+    tag = "system",
+    description = "Acknowledge the most recent unclean-shutdown event \
+                   so the dashboard banner is dismissed. Idempotent — \
+                   repeated calls just refresh the timestamp. The \
+                   banner reappears automatically on the next unclean \
+                   shutdown. Admin only.",
+    responses(
+        (status = 204, description = "Acknowledgement recorded"),
+        AuthErrors,
+    ),
+    security(
+        ("session_cookie" = []),
+        ("bearer_auth" = []),
+    ),
+)]
+pub async fn acknowledge_shutdown(
+    State(state): State<AppState>,
+    _auth: AdminAuth,
+) -> Result<axum::http::StatusCode, AppError> {
+    state.system_service().acknowledge_last_shutdown().await?;
+    Ok(axum::http::StatusCode::NO_CONTENT)
 }
 
 /// API-layer mirror of [`wardnetd_services::logging::error_notifier::ErrorEntry`] that

--- a/source/daemon/crates/wardnetd-api/src/api/tests/network.rs
+++ b/source/daemon/crates/wardnetd-api/src/api/tests/network.rs
@@ -206,6 +206,15 @@ impl SystemService for MockSystemService {
             Err(e) => Err(clone_app_error(e)),
         }
     }
+    async fn record_heartbeat(&self) -> Result<(), AppError> {
+        unimplemented!()
+    }
+    async fn record_graceful_shutdown(&self) -> Result<(), AppError> {
+        unimplemented!()
+    }
+    async fn acknowledge_last_shutdown(&self) -> Result<(), AppError> {
+        unimplemented!()
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/source/daemon/crates/wardnetd-api/src/api/tests/system.rs
+++ b/source/daemon/crates/wardnetd-api/src/api/tests/system.rs
@@ -11,7 +11,9 @@ use axum::http::{Request, StatusCode};
 use axum::routing::get;
 use tower::ServiceExt;
 use uuid::Uuid;
-use wardnet_common::api::{SetDefaultPolicyRequest, SystemStatusResponse};
+use wardnet_common::api::{
+    LastShutdownState, LastShutdownStatus, SetDefaultPolicyRequest, SystemStatusResponse,
+};
 
 use crate::state::AppState;
 use crate::tests::stubs::{
@@ -125,6 +127,7 @@ impl SystemService for MockSystemService {
                 cpu_usage_percent: r.cpu_usage_percent,
                 memory_used_bytes: r.memory_used_bytes,
                 memory_total_bytes: r.memory_total_bytes,
+                last_shutdown: r.last_shutdown.clone(),
             }),
             Err(_) => Err(AppError::Internal(anyhow::anyhow!("mock error"))),
         }
@@ -151,6 +154,15 @@ impl SystemService for MockSystemService {
         &self,
     ) -> Result<wardnet_common::api::DhcpSelfProbeResponse, AppError> {
         unimplemented!()
+    }
+    async fn record_heartbeat(&self) -> Result<(), AppError> {
+        Ok(())
+    }
+    async fn record_graceful_shutdown(&self) -> Result<(), AppError> {
+        Ok(())
+    }
+    async fn acknowledge_last_shutdown(&self) -> Result<(), AppError> {
+        Ok(())
     }
 }
 
@@ -332,7 +344,19 @@ fn system_app_full(state: AppState) -> Router {
             "/api/system/default-policy",
             get(crate::api::system::get_default_policy).put(crate::api::system::set_default_policy),
         )
+        .route(
+            "/api/system/shutdown/acknowledge",
+            axum::routing::post(crate::api::system::acknowledge_shutdown),
+        )
         .with_state(state)
+}
+
+fn default_last_shutdown() -> LastShutdownStatus {
+    LastShutdownStatus {
+        state: LastShutdownState::Unknown,
+        at: None,
+        acknowledged_at: None,
+    }
 }
 
 fn default_status() -> SystemStatusResponse {
@@ -347,6 +371,7 @@ fn default_status() -> SystemStatusResponse {
         cpu_usage_percent: 0.0,
         memory_used_bytes: 0,
         memory_total_bytes: 0,
+        last_shutdown: default_last_shutdown(),
     }
 }
 
@@ -375,6 +400,7 @@ async fn status_returns_200_with_correct_json() {
                 cpu_usage_percent: 25.5,
                 memory_used_bytes: 1_073_741_824,
                 memory_total_bytes: 4_294_967_296,
+                last_shutdown: default_last_shutdown(),
             }),
         },
     );
@@ -419,6 +445,7 @@ async fn status_requires_authentication() {
                 cpu_usage_percent: 0.0,
                 memory_used_bytes: 0,
                 memory_total_bytes: 0,
+                last_shutdown: default_last_shutdown(),
             }),
         },
     );
@@ -1019,6 +1046,15 @@ async fn restart_surfaces_service_error_as_500() {
         ) -> Result<wardnet_common::api::DhcpSelfProbeResponse, AppError> {
             unimplemented!()
         }
+        async fn record_heartbeat(&self) -> Result<(), AppError> {
+            Ok(())
+        }
+        async fn record_graceful_shutdown(&self) -> Result<(), AppError> {
+            Ok(())
+        }
+        async fn acknowledge_last_shutdown(&self) -> Result<(), AppError> {
+            Ok(())
+        }
     }
 
     let admin_id = Uuid::new_v4();
@@ -1123,6 +1159,15 @@ async fn reboot_surfaces_service_error_as_500() {
             &self,
         ) -> Result<wardnet_common::api::DhcpSelfProbeResponse, AppError> {
             unimplemented!()
+        }
+        async fn record_heartbeat(&self) -> Result<(), AppError> {
+            Ok(())
+        }
+        async fn record_graceful_shutdown(&self) -> Result<(), AppError> {
+            Ok(())
+        }
+        async fn acknowledge_last_shutdown(&self) -> Result<(), AppError> {
+            Ok(())
         }
     }
 
@@ -1229,6 +1274,15 @@ async fn shutdown_surfaces_service_error_as_500() {
         ) -> Result<wardnet_common::api::DhcpSelfProbeResponse, AppError> {
             unimplemented!()
         }
+        async fn record_heartbeat(&self) -> Result<(), AppError> {
+            Ok(())
+        }
+        async fn record_graceful_shutdown(&self) -> Result<(), AppError> {
+            Ok(())
+        }
+        async fn acknowledge_last_shutdown(&self) -> Result<(), AppError> {
+            Ok(())
+        }
     }
 
     let admin_id = Uuid::new_v4();
@@ -1245,6 +1299,167 @@ async fn shutdown_surfaces_service_error_as_500() {
 
     let resp = app.oneshot(req).await.unwrap();
     assert_eq!(resp.status(), StatusCode::INTERNAL_SERVER_ERROR);
+}
+
+// ---------------------------------------------------------------------------
+// POST /api/system/shutdown/acknowledge
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn acknowledge_shutdown_returns_204_on_success() {
+    let admin_id = Uuid::new_v4();
+    let state = make_state(
+        AlwaysAuthService { admin_id },
+        MockSystemService {
+            response: Ok(default_status()),
+        },
+    );
+
+    let app = system_app_full(state);
+    let req = Request::builder()
+        .method("POST")
+        .uri("/api/system/shutdown/acknowledge")
+        .header("Cookie", "wardnet_session=valid-token")
+        .extension(connect_info_ext())
+        .body(Body::empty())
+        .unwrap();
+
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::NO_CONTENT);
+}
+
+#[tokio::test]
+async fn acknowledge_shutdown_requires_authentication() {
+    let state = make_state(
+        NeverAuthService,
+        MockSystemService {
+            response: Ok(default_status()),
+        },
+    );
+
+    let app = system_app_full(state);
+    let req = Request::builder()
+        .method("POST")
+        .uri("/api/system/shutdown/acknowledge")
+        .extension(connect_info_ext())
+        .body(Body::empty())
+        .unwrap();
+
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn acknowledge_shutdown_surfaces_service_error_as_500() {
+    struct FailingAckService;
+    #[async_trait]
+    impl SystemService for FailingAckService {
+        fn version(&self) -> &'static str {
+            "0.0.0"
+        }
+        fn uptime(&self) -> std::time::Duration {
+            std::time::Duration::ZERO
+        }
+        async fn status(&self) -> Result<SystemStatusResponse, AppError> {
+            unimplemented!()
+        }
+        async fn request_restart(&self) -> Result<(), AppError> {
+            Ok(())
+        }
+        async fn request_reboot(&self) -> Result<(), AppError> {
+            Ok(())
+        }
+        async fn request_shutdown(&self) -> Result<(), AppError> {
+            Ok(())
+        }
+        async fn network_status(
+            &self,
+        ) -> Result<wardnet_common::api::NetworkStatusResponse, AppError> {
+            unimplemented!()
+        }
+        async fn discover_gateway_mac(
+            &self,
+            _request: wardnet_common::api::DiscoverGatewayMacRequest,
+        ) -> Result<wardnet_common::api::DiscoverGatewayMacResponse, AppError> {
+            unimplemented!()
+        }
+        async fn dhcp_self_probe(
+            &self,
+        ) -> Result<wardnet_common::api::DhcpSelfProbeResponse, AppError> {
+            unimplemented!()
+        }
+        async fn record_heartbeat(&self) -> Result<(), AppError> {
+            Ok(())
+        }
+        async fn record_graceful_shutdown(&self) -> Result<(), AppError> {
+            Ok(())
+        }
+        async fn acknowledge_last_shutdown(&self) -> Result<(), AppError> {
+            Err(AppError::Internal(anyhow::anyhow!("db locked")))
+        }
+    }
+
+    let admin_id = Uuid::new_v4();
+    let state = make_state(AlwaysAuthService { admin_id }, FailingAckService);
+    let app = system_app_full(state);
+
+    let req = Request::builder()
+        .method("POST")
+        .uri("/api/system/shutdown/acknowledge")
+        .header("Authorization", "Bearer k")
+        .extension(connect_info_ext())
+        .body(Body::empty())
+        .unwrap();
+
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::INTERNAL_SERVER_ERROR);
+}
+
+#[tokio::test]
+async fn status_includes_last_shutdown_payload() {
+    use chrono::{TimeZone, Utc};
+
+    let at = Utc.with_ymd_and_hms(2026, 5, 7, 12, 0, 0).unwrap();
+    let admin_id = Uuid::new_v4();
+    let state = make_state(
+        AlwaysAuthService { admin_id },
+        MockSystemService {
+            response: Ok(SystemStatusResponse {
+                version: "1.0.0".to_owned(),
+                release_version: "1.0.0".to_owned(),
+                uptime_seconds: 0,
+                device_count: 0,
+                tunnel_count: 0,
+                tunnel_active_count: 0,
+                db_size_bytes: 0,
+                cpu_usage_percent: 0.0,
+                memory_used_bytes: 0,
+                memory_total_bytes: 0,
+                last_shutdown: LastShutdownStatus {
+                    state: LastShutdownState::Unclean,
+                    at: Some(at),
+                    acknowledged_at: None,
+                },
+            }),
+        },
+    );
+
+    let app = system_app(state);
+    let req = Request::builder()
+        .uri("/api/system/status")
+        .header("Cookie", "wardnet_session=valid-token")
+        .extension(connect_info_ext())
+        .body(Body::empty())
+        .unwrap();
+
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    let body = axum::body::to_bytes(resp.into_body(), 4096).await.unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(json["last_shutdown"]["state"], "unclean");
+    assert!(json["last_shutdown"]["at"].is_string());
+    assert!(json["last_shutdown"]["acknowledged_at"].is_null());
 }
 
 #[tokio::test]
@@ -1264,6 +1479,7 @@ async fn status_authenticates_via_bearer_token() {
                 cpu_usage_percent: 0.0,
                 memory_used_bytes: 0,
                 memory_total_bytes: 0,
+                last_shutdown: default_last_shutdown(),
             }),
         },
     );

--- a/source/daemon/crates/wardnetd-api/src/tests/stubs.rs
+++ b/source/daemon/crates/wardnetd-api/src/tests/stubs.rs
@@ -521,6 +521,11 @@ impl SystemService for StubSystemService {
             cpu_usage_percent: 0.0,
             memory_used_bytes: 0,
             memory_total_bytes: 0,
+            last_shutdown: LastShutdownStatus {
+                state: LastShutdownState::Unknown,
+                at: None,
+                acknowledged_at: None,
+            },
         })
     }
     async fn request_restart(&self) -> Result<(), AppError> {
@@ -545,6 +550,15 @@ impl SystemService for StubSystemService {
         &self,
     ) -> Result<wardnet_common::api::DhcpSelfProbeResponse, AppError> {
         unimplemented!()
+    }
+    async fn record_heartbeat(&self) -> Result<(), AppError> {
+        Ok(())
+    }
+    async fn record_graceful_shutdown(&self) -> Result<(), AppError> {
+        Ok(())
+    }
+    async fn acknowledge_last_shutdown(&self) -> Result<(), AppError> {
+        Ok(())
     }
 }
 

--- a/source/daemon/crates/wardnetd-data/src/repository/mod.rs
+++ b/source/daemon/crates/wardnetd-data/src/repository/mod.rs
@@ -30,7 +30,7 @@ pub use sqlite::{
     SqliteSystemConfigRepository, SqliteTunnelMetricsRepository, SqliteTunnelRepository,
     SqliteUpdateRepository,
 };
-pub use system_config::SystemConfigRepository;
+pub use system_config::{LastShutdownInfo, SystemConfigRepository};
 pub use tunnel::{TunnelRepository, TunnelRow};
 pub use tunnel_metrics::{DailyMetricRow, IntradayMetricRow, TunnelMetricsRepository};
 pub use update::{UpdateHistoryRow, UpdateRepository};

--- a/source/daemon/crates/wardnetd-data/src/repository/sqlite/system_config.rs
+++ b/source/daemon/crates/wardnetd-data/src/repository/sqlite/system_config.rs
@@ -1,7 +1,82 @@
 use async_trait::async_trait;
+use chrono::{DateTime, NaiveDateTime, TimeZone, Utc};
 use sqlx::SqlitePool;
+use sqlx::sqlite::SqliteConnection;
+use wardnet_common::api::LastShutdownState;
 
-use super::super::SystemConfigRepository;
+use super::super::{LastShutdownInfo, SystemConfigRepository};
+
+const TS_FMT: &str = "%Y-%m-%dT%H:%M:%SZ";
+
+// Markers for the *current* run, updated on boot (`running`) and on
+// graceful exit (`graceful`).
+const KEY_LAST_SHUTDOWN_STATE: &str = "last_shutdown_state";
+const KEY_LAST_SHUTDOWN_AT: &str = "last_shutdown_at";
+// Heartbeat — the most recent moment the previous run was alive.
+const KEY_LAST_SEEN_AT: &str = "last_seen_at";
+// Ack for the most recent unclean event; banner predicate compares
+// this against `KEY_PREV_SHUTDOWN_AT`.
+const KEY_LAST_SHUTDOWN_ACK: &str = "last_shutdown_acknowledged_at";
+
+// Persisted classification of the *previous* run, written once by
+// `detect_previous_shutdown` so the read path can surface it without
+// re-deriving it from the live "running" marker.
+const KEY_PREV_SHUTDOWN_STATE: &str = "prev_shutdown_state";
+const KEY_PREV_SHUTDOWN_AT: &str = "prev_shutdown_at";
+
+const STATE_RUNNING: &str = "running";
+const STATE_GRACEFUL: &str = "graceful";
+const STATE_UNCLEAN: &str = "unclean";
+const STATE_UNKNOWN: &str = "unknown";
+
+fn now_iso() -> String {
+    Utc::now().format(TS_FMT).to_string()
+}
+
+fn parse_ts(value: &str) -> anyhow::Result<DateTime<Utc>> {
+    let naive = NaiveDateTime::parse_from_str(value, TS_FMT)?;
+    Ok(Utc.from_utc_datetime(&naive))
+}
+
+fn parse_ts_opt(value: Option<&str>) -> anyhow::Result<Option<DateTime<Utc>>> {
+    value.map(parse_ts).transpose()
+}
+
+async fn get_value(conn: &mut SqliteConnection, key: &str) -> anyhow::Result<Option<String>> {
+    let v = sqlx::query_scalar::<_, String>("SELECT value FROM system_config WHERE key = ?")
+        .bind(key)
+        .fetch_optional(conn)
+        .await?;
+    Ok(v)
+}
+
+async fn upsert_value(conn: &mut SqliteConnection, key: &str, value: &str) -> anyhow::Result<()> {
+    sqlx::query(
+        "INSERT INTO system_config (key, value) VALUES (?, ?) \
+         ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+    )
+    .bind(key)
+    .bind(value)
+    .execute(conn)
+    .await?;
+    Ok(())
+}
+
+fn state_to_str(state: LastShutdownState) -> &'static str {
+    match state {
+        LastShutdownState::Graceful => STATE_GRACEFUL,
+        LastShutdownState::Unclean => STATE_UNCLEAN,
+        LastShutdownState::Unknown => STATE_UNKNOWN,
+    }
+}
+
+fn parse_prev_state(value: Option<&str>) -> LastShutdownState {
+    match value {
+        Some(STATE_GRACEFUL) => LastShutdownState::Graceful,
+        Some(STATE_UNCLEAN) => LastShutdownState::Unclean,
+        _ => LastShutdownState::Unknown,
+    }
+}
 
 /// SQLite-backed implementation of [`SystemConfigRepository`].
 pub struct SqliteSystemConfigRepository {
@@ -59,5 +134,96 @@ impl SystemConfigRepository for SqliteSystemConfigRepository {
         .fetch_one(&self.pool)
         .await?;
         Ok(u64::try_from(size).unwrap_or(0))
+    }
+
+    async fn detect_previous_shutdown(&self) -> anyhow::Result<LastShutdownInfo> {
+        let mut tx = self.pool.begin().await?;
+
+        let prev_state = get_value(&mut tx, KEY_LAST_SHUTDOWN_STATE).await?;
+        let prev_at = parse_ts_opt(get_value(&mut tx, KEY_LAST_SHUTDOWN_AT).await?.as_deref())?;
+        let prev_seen = parse_ts_opt(get_value(&mut tx, KEY_LAST_SEEN_AT).await?.as_deref())?;
+        let acknowledged_at =
+            parse_ts_opt(get_value(&mut tx, KEY_LAST_SHUTDOWN_ACK).await?.as_deref())?;
+
+        let info = match prev_state.as_deref() {
+            Some(STATE_GRACEFUL) => LastShutdownInfo {
+                state: LastShutdownState::Graceful,
+                at: prev_at,
+                acknowledged_at,
+            },
+            Some(STATE_RUNNING) => LastShutdownInfo {
+                state: LastShutdownState::Unclean,
+                // Pick the later of the two timestamps. `last_seen_at`
+                // can be a stale heartbeat from an earlier run that
+                // wasn't reset before the prior run armed its marker
+                // and crashed; in that case `last_shutdown_at` (the
+                // prior run's boot time) is the more accurate floor.
+                at: [prev_seen, prev_at].into_iter().flatten().max(),
+                acknowledged_at,
+            },
+            // None → first-ever boot. Some(legacy/corrupt) → fail safe.
+            // Both surface as `Unknown` with no timestamp.
+            _ => LastShutdownInfo {
+                state: LastShutdownState::Unknown,
+                at: None,
+                acknowledged_at,
+            },
+        };
+
+        // Persist the classification so the API can surface it later.
+        upsert_value(&mut tx, KEY_PREV_SHUTDOWN_STATE, state_to_str(info.state)).await?;
+        match info.at {
+            Some(at) => {
+                upsert_value(
+                    &mut tx,
+                    KEY_PREV_SHUTDOWN_AT,
+                    &at.format(TS_FMT).to_string(),
+                )
+                .await?;
+            }
+            None => {
+                sqlx::query("DELETE FROM system_config WHERE key = ?")
+                    .bind(KEY_PREV_SHUTDOWN_AT)
+                    .execute(&mut *tx)
+                    .await?;
+            }
+        }
+
+        // Arm the marker for *this* run.
+        let now = now_iso();
+        upsert_value(&mut tx, KEY_LAST_SHUTDOWN_STATE, STATE_RUNNING).await?;
+        upsert_value(&mut tx, KEY_LAST_SHUTDOWN_AT, &now).await?;
+
+        tx.commit().await?;
+        Ok(info)
+    }
+
+    async fn record_graceful_shutdown(&self) -> anyhow::Result<()> {
+        let now = now_iso();
+        let mut tx = self.pool.begin().await?;
+        upsert_value(&mut tx, KEY_LAST_SHUTDOWN_STATE, STATE_GRACEFUL).await?;
+        upsert_value(&mut tx, KEY_LAST_SHUTDOWN_AT, &now).await?;
+        tx.commit().await?;
+        Ok(())
+    }
+
+    async fn record_heartbeat(&self) -> anyhow::Result<()> {
+        self.set(KEY_LAST_SEEN_AT, &now_iso()).await
+    }
+
+    async fn read_last_shutdown(&self) -> anyhow::Result<LastShutdownInfo> {
+        let prev_state = self.get(KEY_PREV_SHUTDOWN_STATE).await?;
+        let prev_at = parse_ts_opt(self.get(KEY_PREV_SHUTDOWN_AT).await?.as_deref())?;
+        let acknowledged_at = parse_ts_opt(self.get(KEY_LAST_SHUTDOWN_ACK).await?.as_deref())?;
+
+        Ok(LastShutdownInfo {
+            state: parse_prev_state(prev_state.as_deref()),
+            at: prev_at,
+            acknowledged_at,
+        })
+    }
+
+    async fn acknowledge_last_shutdown(&self) -> anyhow::Result<()> {
+        self.set(KEY_LAST_SHUTDOWN_ACK, &now_iso()).await
     }
 }

--- a/source/daemon/crates/wardnetd-data/src/repository/system_config.rs
+++ b/source/daemon/crates/wardnetd-data/src/repository/system_config.rs
@@ -1,10 +1,28 @@
 use async_trait::async_trait;
+use chrono::{DateTime, Utc};
+use wardnet_common::api::LastShutdownState;
+
+/// Snapshot of the previous daemon shutdown.
+///
+/// Returned both by [`SystemConfigRepository::detect_previous_shutdown`]
+/// (which classifies the prior run and writes a fresh `running` marker
+/// in a single transaction) and by [`SystemConfigRepository::read_last_shutdown`]
+/// (which performs a read-only lookup for the API).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LastShutdownInfo {
+    pub state: LastShutdownState,
+    pub at: Option<DateTime<Utc>>,
+    pub acknowledged_at: Option<DateTime<Utc>>,
+}
 
 /// Data access for the key-value `system_config` table and aggregate counts.
 ///
-/// Provides simple get/set for configuration values and count queries for
-/// devices and tunnels. Used by [`SystemService`](crate::service::SystemService)
-/// to build status responses.
+/// Provides simple get/set for configuration values, count queries for
+/// devices and tunnels, and the unclean-shutdown detection key set
+/// (`last_shutdown_state`, `last_shutdown_at`, `last_shutdown_acknowledged_at`,
+/// `last_seen_at`). Used by [`SystemService`](crate::service::SystemService)
+/// to build status responses and by the daemon entrypoint to classify
+/// the previous shutdown on boot.
 #[async_trait]
 pub trait SystemConfigRepository: Send + Sync {
     /// Retrieve a config value by key.
@@ -21,6 +39,75 @@ pub trait SystemConfigRepository: Send + Sync {
 
     /// Return the database file size in bytes.
     async fn db_size_bytes(&self) -> anyhow::Result<u64>;
+
+    /// Classify the previous shutdown and atomically arm the next-boot
+    /// marker.
+    ///
+    /// Reads `last_shutdown_state`, `last_shutdown_at`, `last_seen_at`,
+    /// and `last_shutdown_acknowledged_at`, then UPSERTs
+    /// `last_shutdown_state="running"` and `last_shutdown_at=NOW` in
+    /// the same transaction. Must be called exactly once per boot,
+    /// before the heartbeat runner starts.
+    ///
+    /// Classification:
+    /// - row absent → `Unknown`, `at = None`
+    /// - prior `graceful` → `Graceful`, `at = last_shutdown_at`
+    /// - prior `running` → `Unclean`, `at = last_seen_at` (falling back
+    ///   to `last_shutdown_at` if the heartbeat never fired before the
+    ///   crash)
+    ///
+    /// `acknowledged_at` is intentionally untouched by this method —
+    /// the timestamp-comparison ack model (`acknowledged_at >= at`)
+    /// handles the reset implicitly when a fresh unclean event writes
+    /// a newer `last_shutdown_at`.
+    async fn detect_previous_shutdown(&self) -> anyhow::Result<LastShutdownInfo> {
+        Ok(LastShutdownInfo {
+            state: LastShutdownState::Unknown,
+            at: None,
+            acknowledged_at: None,
+        })
+    }
+
+    /// Record a graceful shutdown.
+    ///
+    /// Writes `last_shutdown_state="graceful"` and
+    /// `last_shutdown_at=NOW`. Called from `main.rs` after the runner
+    /// shutdown sequence and before the process exits.
+    async fn record_graceful_shutdown(&self) -> anyhow::Result<()> {
+        Ok(())
+    }
+
+    /// Update the heartbeat timestamp.
+    ///
+    /// Writes `last_seen_at=NOW`. The heartbeat runner calls this on
+    /// a 60s cadence so an unclean shutdown's `at` timestamp is
+    /// accurate to within the heartbeat interval.
+    async fn record_heartbeat(&self) -> anyhow::Result<()> {
+        Ok(())
+    }
+
+    /// Read the current shutdown classification without modifying it.
+    ///
+    /// Used by `SystemService::status()` to embed the result in the
+    /// dashboard's status response. Returns the same shape as
+    /// [`Self::detect_previous_shutdown`] but is read-only.
+    async fn read_last_shutdown(&self) -> anyhow::Result<LastShutdownInfo> {
+        Ok(LastShutdownInfo {
+            state: LastShutdownState::Unknown,
+            at: None,
+            acknowledged_at: None,
+        })
+    }
+
+    /// Acknowledge the most recent unclean shutdown.
+    ///
+    /// Writes `last_shutdown_acknowledged_at=NOW`. Idempotent —
+    /// repeated calls just refresh the timestamp. The banner predicate
+    /// is `acknowledged_at < at`, so a future unclean event with a
+    /// newer `last_shutdown_at` automatically makes this stale.
+    async fn acknowledge_last_shutdown(&self) -> anyhow::Result<()> {
+        Ok(())
+    }
 
     /// Check whether the initial setup wizard has been completed.
     ///

--- a/source/daemon/crates/wardnetd-data/src/repository/tests/system_config.rs
+++ b/source/daemon/crates/wardnetd-data/src/repository/tests/system_config.rs
@@ -1,5 +1,6 @@
 use super::test_pool;
 use crate::repository::{SqliteSystemConfigRepository, SystemConfigRepository};
+use wardnet_common::api::LastShutdownState;
 
 #[tokio::test]
 async fn get_seeded_value() {
@@ -96,6 +97,198 @@ async fn set_setup_completed_updates_value() {
 
     repo.set_setup_completed(true).await.unwrap();
     assert!(repo.is_setup_completed().await.unwrap());
+}
+
+#[tokio::test]
+async fn detect_first_ever_boot_returns_unknown() {
+    let pool = test_pool().await;
+    let repo = SqliteSystemConfigRepository::new(pool);
+
+    let info = repo.detect_previous_shutdown().await.unwrap();
+    assert_eq!(info.state, LastShutdownState::Unknown);
+    assert!(info.at.is_none());
+    assert!(info.acknowledged_at.is_none());
+
+    // After detection, read_last_shutdown surfaces the persisted
+    // classification of the prior run (still `Unknown`).
+    let read = repo.read_last_shutdown().await.unwrap();
+    assert_eq!(read.state, LastShutdownState::Unknown);
+    assert!(read.at.is_none());
+}
+
+#[tokio::test]
+async fn detect_after_graceful_returns_graceful() {
+    let pool = test_pool().await;
+    let repo = SqliteSystemConfigRepository::new(pool);
+
+    // First boot — arms the running marker.
+    repo.detect_previous_shutdown().await.unwrap();
+    // Graceful exit recorded.
+    repo.record_graceful_shutdown().await.unwrap();
+
+    // Next boot — classifies the prior run.
+    let info = repo.detect_previous_shutdown().await.unwrap();
+    assert_eq!(info.state, LastShutdownState::Graceful);
+    assert!(info.at.is_some());
+
+    let read = repo.read_last_shutdown().await.unwrap();
+    assert_eq!(read.state, LastShutdownState::Graceful);
+    assert_eq!(read.at, info.at);
+}
+
+#[tokio::test]
+async fn detect_after_running_marker_returns_unclean() {
+    let pool = test_pool().await;
+    let repo = SqliteSystemConfigRepository::new(pool);
+
+    // First boot — arms running, never records graceful.
+    repo.detect_previous_shutdown().await.unwrap();
+    // Heartbeat fires while the daemon is alive.
+    repo.record_heartbeat().await.unwrap();
+
+    // Crash → next boot.
+    let info = repo.detect_previous_shutdown().await.unwrap();
+    assert_eq!(info.state, LastShutdownState::Unclean);
+    // `at` resolves to the heartbeat timestamp.
+    assert!(info.at.is_some());
+
+    let read = repo.read_last_shutdown().await.unwrap();
+    assert_eq!(read.state, LastShutdownState::Unclean);
+    assert_eq!(read.at, info.at);
+}
+
+#[tokio::test]
+async fn detect_unclean_falls_back_to_last_shutdown_at_when_heartbeat_missing() {
+    let pool = test_pool().await;
+    let repo = SqliteSystemConfigRepository::new(pool);
+
+    // First boot — arms running. No heartbeat fires.
+    repo.detect_previous_shutdown().await.unwrap();
+
+    // Crash → next boot.
+    let info = repo.detect_previous_shutdown().await.unwrap();
+    assert_eq!(info.state, LastShutdownState::Unclean);
+    // No heartbeat ever ran, so `at` falls back to the previous
+    // run's `last_shutdown_at` (the boot time of the prior run).
+    assert!(info.at.is_some());
+}
+
+#[tokio::test]
+async fn detect_unclean_ignores_heartbeat_older_than_last_boot() {
+    // Regression: a stale `last_seen_at` written by an *earlier* run
+    // (before that run's graceful exit + a subsequent boot that
+    // crashed before its first heartbeat) must not be returned as the
+    // unclean event timestamp. The boot marker (`last_shutdown_at`)
+    // is newer and is the correct fallback.
+    let pool = test_pool().await;
+    let repo = SqliteSystemConfigRepository::new(pool);
+
+    // Boot 1 → heartbeat fires → graceful exit.
+    repo.detect_previous_shutdown().await.unwrap();
+    repo.record_heartbeat().await.unwrap();
+    repo.record_graceful_shutdown().await.unwrap();
+
+    // Sleep so the next boot's `last_shutdown_at` is strictly newer
+    // than Boot 1's heartbeat.
+    tokio::time::sleep(std::time::Duration::from_millis(1100)).await;
+
+    // Boot 2 → arms running. Crashes before its own heartbeat fires;
+    // the stale `last_seen_at` is still Boot 1's value.
+    let boot2 = repo.detect_previous_shutdown().await.unwrap();
+    assert_eq!(boot2.state, LastShutdownState::Graceful);
+    let boot2_at = boot2.at.expect("graceful at recorded");
+
+    // Boot 3 → must classify Boot 2's crash with `at >= boot2_at`,
+    // i.e. the boot marker, not the stale heartbeat from Boot 1.
+    let boot3 = repo.detect_previous_shutdown().await.unwrap();
+    assert_eq!(boot3.state, LastShutdownState::Unclean);
+    let boot3_at = boot3.at.expect("unclean at recorded");
+    assert!(
+        boot3_at >= boot2_at,
+        "unclean `at` ({boot3_at}) must not predate Boot 2's start ({boot2_at})",
+    );
+}
+
+#[tokio::test]
+async fn acknowledge_records_timestamp() {
+    let pool = test_pool().await;
+    let repo = SqliteSystemConfigRepository::new(pool);
+
+    repo.detect_previous_shutdown().await.unwrap();
+    repo.record_heartbeat().await.unwrap();
+    repo.detect_previous_shutdown().await.unwrap();
+
+    let before = repo.read_last_shutdown().await.unwrap();
+    assert!(before.acknowledged_at.is_none());
+
+    repo.acknowledge_last_shutdown().await.unwrap();
+
+    let after = repo.read_last_shutdown().await.unwrap();
+    let ack = after.acknowledged_at.expect("ack written");
+    let at = after.at.expect("at present");
+    // The banner predicate hides the banner when ack >= at.
+    assert!(ack >= at);
+}
+
+#[tokio::test]
+async fn new_unclean_event_makes_older_ack_stale() {
+    let pool = test_pool().await;
+    let repo = SqliteSystemConfigRepository::new(pool);
+
+    // Boot 1 → unclean event 1.
+    repo.detect_previous_shutdown().await.unwrap();
+    repo.record_heartbeat().await.unwrap();
+    repo.detect_previous_shutdown().await.unwrap();
+    repo.acknowledge_last_shutdown().await.unwrap();
+    let acked = repo.read_last_shutdown().await.unwrap();
+    let ack_ts = acked.acknowledged_at.expect("ack present");
+    let event1_at = acked.at.expect("event 1 at");
+    assert!(ack_ts >= event1_at);
+
+    // Sleep one second so timestamps (1s precision) advance.
+    tokio::time::sleep(std::time::Duration::from_millis(1100)).await;
+
+    // Heartbeat continues in the new run.
+    repo.record_heartbeat().await.unwrap();
+
+    tokio::time::sleep(std::time::Duration::from_millis(1100)).await;
+
+    // Crash → unclean event 2 (no graceful in between).
+    let event2 = repo.detect_previous_shutdown().await.unwrap();
+    assert_eq!(event2.state, LastShutdownState::Unclean);
+
+    let read = repo.read_last_shutdown().await.unwrap();
+    let event2_at = read.at.expect("event 2 at");
+    let still_acked = read.acknowledged_at.expect("ack persisted");
+    // The old ack must now be older than the new event timestamp,
+    // restoring the banner.
+    assert!(still_acked < event2_at);
+}
+
+#[tokio::test]
+async fn detect_arms_running_marker_for_next_boot() {
+    let pool = test_pool().await;
+    let repo = SqliteSystemConfigRepository::new(pool);
+
+    repo.detect_previous_shutdown().await.unwrap();
+
+    let state = repo.get("last_shutdown_state").await.unwrap();
+    assert_eq!(state.as_deref(), Some("running"));
+    let at = repo.get("last_shutdown_at").await.unwrap();
+    assert!(at.is_some());
+}
+
+#[tokio::test]
+async fn record_heartbeat_writes_last_seen_at() {
+    let pool = test_pool().await;
+    let repo = SqliteSystemConfigRepository::new(pool);
+
+    assert!(repo.get("last_seen_at").await.unwrap().is_none());
+
+    repo.record_heartbeat().await.unwrap();
+
+    let seen = repo.get("last_seen_at").await.unwrap();
+    assert!(seen.is_some());
 }
 
 #[tokio::test]

--- a/source/daemon/crates/wardnetd-services/src/lib.rs
+++ b/source/daemon/crates/wardnetd-services/src/lib.rs
@@ -180,6 +180,13 @@ pub async fn init_services(
         .await?
         .unwrap_or_else(|| config.network.default_policy.clone());
 
+    // Classify the previous shutdown and arm the running marker for
+    // this run. Runs once per boot, before any other component
+    // touches `system_config`. Its result is logged here; the API
+    // surfaces it on every `/api/system/status` call by reading the
+    // persisted classification back from the repository.
+    classify_previous_shutdown(repo_factory.as_ref()).await;
+
     // Wire services.
     Ok(create_services(
         repo_factory.as_ref(),
@@ -226,6 +233,10 @@ pub async fn init_services_with_factory(
         .await?
         .unwrap_or_else(|| config.network.default_policy.clone());
 
+    // Classify the previous shutdown and arm the running marker for
+    // this run. See `init_services` for context.
+    classify_previous_shutdown(repo_factory).await;
+
     Ok(create_services(
         repo_factory,
         backends,
@@ -235,6 +246,46 @@ pub async fn init_services_with_factory(
         log_service,
         initial_default_policy,
     ))
+}
+
+/// Run [`SystemConfigRepository::detect_previous_shutdown`] once at
+/// startup and log the outcome.
+///
+/// Called from [`init_services`] / [`init_services_with_factory`] so
+/// the classification persists into `prev_shutdown_*` keys before any
+/// service reads them. Failure here is logged but never fatal — a
+/// transient `SQLite` error must not prevent the daemon from booting.
+async fn classify_previous_shutdown(repo_factory: &dyn RepositoryFactory) {
+    let repo = repo_factory.system_config();
+    match repo.detect_previous_shutdown().await {
+        Ok(info) => match info.state {
+            wardnet_common::api::LastShutdownState::Unclean => {
+                tracing::warn!(
+                    at = ?info.at,
+                    "previous daemon shutdown was unclean (crash or power loss): at={at:?}",
+                    at = info.at,
+                );
+            }
+            wardnet_common::api::LastShutdownState::Graceful => {
+                tracing::info!(
+                    at = ?info.at,
+                    "previous daemon shutdown was graceful: at={at:?}",
+                    at = info.at,
+                );
+            }
+            wardnet_common::api::LastShutdownState::Unknown => {
+                tracing::info!(
+                    "no prior shutdown record found (first-ever boot or fresh database)"
+                );
+            }
+        },
+        Err(e) => {
+            tracing::warn!(
+                error = %e,
+                "failed to classify previous shutdown — skipping detection: {e}",
+            );
+        }
+    }
 }
 
 /// Creates services from a [`RepositoryFactory`] + [`Backends`] + config.

--- a/source/daemon/crates/wardnetd-services/src/system/service.rs
+++ b/source/daemon/crates/wardnetd-services/src/system/service.rs
@@ -6,7 +6,7 @@ use sysinfo::System;
 use tokio_util::sync::CancellationToken;
 use wardnet_common::api::{
     DhcpSelfProbeResponse, DiscoverGatewayMacRequest, DiscoverGatewayMacResponse,
-    NetworkStatusResponse, RouterMacSource, SystemStatusResponse,
+    LastShutdownStatus, NetworkStatusResponse, RouterMacSource, SystemStatusResponse,
 };
 
 use crate::auth_context;
@@ -113,6 +113,27 @@ pub trait SystemService: Send + Sync {
     /// Ask the host to power off. Same shape as [`Self::request_reboot`]
     /// but invokes [`SystemPowerOps::poweroff`]. Admin-only.
     async fn request_shutdown(&self) -> Result<(), AppError>;
+
+    /// Update the heartbeat marker so a future unclean-shutdown
+    /// classification has a recent `last_seen_at` to surface.
+    ///
+    /// Called by the background `HeartbeatRunner` on a 60-second
+    /// cadence. Admin-only — the runner wraps the call in
+    /// `auth_context::with_context(AuthContext::Admin { admin_id: Uuid::nil() })`.
+    async fn record_heartbeat(&self) -> Result<(), AppError>;
+
+    /// Record that the daemon is exiting gracefully so the next boot
+    /// classifies the prior run as `Graceful` (not `Unclean`).
+    ///
+    /// Called from `main.rs` after the runner-shutdown sequence
+    /// completes and before the process exits. Admin-only — invoked
+    /// from the shutdown path inside an `auth_context::with_context`
+    /// wrapper.
+    async fn record_graceful_shutdown(&self) -> Result<(), AppError>;
+
+    /// Acknowledge the most recent unclean shutdown so the dashboard
+    /// banner is dismissed. Idempotent. Admin-only.
+    async fn acknowledge_last_shutdown(&self) -> Result<(), AppError>;
 }
 
 /// Default implementation of [`SystemService`] backed by [`SystemConfigRepository`].
@@ -196,6 +217,17 @@ impl SystemService for SystemServiceImpl {
             .await
             .map_err(AppError::Internal)?;
 
+        let last_shutdown_info = self
+            .system_config
+            .read_last_shutdown()
+            .await
+            .map_err(AppError::Internal)?;
+        let last_shutdown = LastShutdownStatus {
+            state: last_shutdown_info.state,
+            at: last_shutdown_info.at,
+            acknowledged_at: last_shutdown_info.acknowledged_at,
+        };
+
         // Refresh CPU and memory readings from the persistent sysinfo instance.
         let (cpu_usage_percent, memory_used_bytes, memory_total_bytes) = {
             let mut sys = self.sysinfo.lock().await;
@@ -225,6 +257,7 @@ impl SystemService for SystemServiceImpl {
             cpu_usage_percent,
             memory_used_bytes,
             memory_total_bytes,
+            last_shutdown,
         })
     }
 
@@ -419,6 +452,33 @@ impl SystemService for SystemServiceImpl {
                 tracing::error!(error = %e, "host poweroff invocation failed: error={e}");
             }
         });
+        Ok(())
+    }
+
+    async fn record_heartbeat(&self) -> Result<(), AppError> {
+        auth_context::require_admin()?;
+        self.system_config
+            .record_heartbeat()
+            .await
+            .map_err(AppError::Internal)?;
+        Ok(())
+    }
+
+    async fn record_graceful_shutdown(&self) -> Result<(), AppError> {
+        auth_context::require_admin()?;
+        self.system_config
+            .record_graceful_shutdown()
+            .await
+            .map_err(AppError::Internal)?;
+        Ok(())
+    }
+
+    async fn acknowledge_last_shutdown(&self) -> Result<(), AppError> {
+        auth_context::require_admin()?;
+        self.system_config
+            .acknowledge_last_shutdown()
+            .await
+            .map_err(AppError::Internal)?;
         Ok(())
     }
 }

--- a/source/daemon/crates/wardnetd-services/src/system/tests/system.rs
+++ b/source/daemon/crates/wardnetd-services/src/system/tests/system.rs
@@ -1,9 +1,12 @@
 use std::sync::Arc;
+use std::sync::Mutex;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Instant;
 
 use async_trait::async_trait;
+use chrono::{DateTime, Utc};
 use uuid::Uuid;
+use wardnet_common::api::LastShutdownState;
 use wardnet_common::auth::AuthContext;
 
 use crate::auth_context;
@@ -13,11 +16,10 @@ use crate::system::{
 };
 use crate::{SystemService, SystemServiceImpl};
 use std::net::Ipv4Addr;
-use std::sync::Mutex;
 use wardnet_common::api::DhcpSource;
 use wardnet_common::tunnel::{Tunnel, TunnelConfig};
 use wardnetd_data::repository::tunnel::TunnelRow;
-use wardnetd_data::repository::{SystemConfigRepository, TunnelRepository};
+use wardnetd_data::repository::{LastShutdownInfo, SystemConfigRepository, TunnelRepository};
 
 // -- Mock repositories ----------------------------------------------------
 
@@ -26,6 +28,31 @@ struct MockSystemConfigRepo {
     devices: i64,
     tunnels: i64,
     db_size: u64,
+    last_shutdown: Mutex<LastShutdownInfo>,
+    graceful_calls: AtomicUsize,
+    ack_calls: AtomicUsize,
+}
+
+impl MockSystemConfigRepo {
+    fn new(devices: i64, tunnels: i64, db_size: u64) -> Self {
+        Self {
+            devices,
+            tunnels,
+            db_size,
+            last_shutdown: Mutex::new(LastShutdownInfo {
+                state: LastShutdownState::Unknown,
+                at: None,
+                acknowledged_at: None,
+            }),
+            graceful_calls: AtomicUsize::new(0),
+            ack_calls: AtomicUsize::new(0),
+        }
+    }
+
+    fn with_last_shutdown(self, info: LastShutdownInfo) -> Self {
+        *self.last_shutdown.lock().unwrap() = info;
+        self
+    }
 }
 
 #[async_trait]
@@ -44,6 +71,25 @@ impl SystemConfigRepository for MockSystemConfigRepo {
     }
     async fn db_size_bytes(&self) -> anyhow::Result<u64> {
         Ok(self.db_size)
+    }
+    async fn detect_previous_shutdown(&self) -> anyhow::Result<LastShutdownInfo> {
+        Ok(self.last_shutdown.lock().unwrap().clone())
+    }
+    async fn record_graceful_shutdown(&self) -> anyhow::Result<()> {
+        self.graceful_calls.fetch_add(1, Ordering::SeqCst);
+        Ok(())
+    }
+    async fn record_heartbeat(&self) -> anyhow::Result<()> {
+        Ok(())
+    }
+    async fn read_last_shutdown(&self) -> anyhow::Result<LastShutdownInfo> {
+        Ok(self.last_shutdown.lock().unwrap().clone())
+    }
+    async fn acknowledge_last_shutdown(&self) -> anyhow::Result<()> {
+        self.ack_calls.fetch_add(1, Ordering::SeqCst);
+        let mut info = self.last_shutdown.lock().unwrap();
+        info.acknowledged_at = Some(Utc::now());
+        Ok(())
     }
 }
 
@@ -144,17 +190,30 @@ fn build_service_with_power_ops(
     power_ops: Arc<dyn SystemPowerOps>,
 ) -> SystemServiceImpl {
     SystemServiceImpl::new(
-        Arc::new(MockSystemConfigRepo {
-            devices,
-            tunnels,
-            db_size,
-        }),
+        Arc::new(MockSystemConfigRepo::new(devices, tunnels, db_size)),
         Arc::new(MockTunnelRepo {
             active: active_tunnels,
         }),
         Instant::now(),
         tokio_util::sync::CancellationToken::new(),
         power_ops,
+        Arc::new(StaticNetworkInspector),
+        Arc::new(StaticNetworkProbe::default()),
+    )
+}
+
+fn build_service_with_repo(
+    repo: Arc<MockSystemConfigRepo>,
+    active_tunnels: i64,
+) -> SystemServiceImpl {
+    SystemServiceImpl::new(
+        repo,
+        Arc::new(MockTunnelRepo {
+            active: active_tunnels,
+        }),
+        Instant::now(),
+        tokio_util::sync::CancellationToken::new(),
+        Arc::new(RecordingPowerOps::default()),
         Arc::new(StaticNetworkInspector),
         Arc::new(StaticNetworkProbe::default()),
     )
@@ -690,5 +749,100 @@ async fn discover_gateway_mac_anonymous_forbidden() {
             target_ip: None,
         })
         .await;
+    assert!(matches!(result, Err(AppError::Forbidden(_))));
+}
+
+// -- last_shutdown / record_graceful / acknowledge ------------------------
+
+#[tokio::test]
+async fn status_includes_last_shutdown_unknown() {
+    let svc = build_service(0, 0, 0, 0);
+    let resp = auth_context::with_context(admin_ctx(), svc.status())
+        .await
+        .unwrap();
+    assert_eq!(resp.last_shutdown.state, LastShutdownState::Unknown);
+    assert!(resp.last_shutdown.at.is_none());
+    assert!(resp.last_shutdown.acknowledged_at.is_none());
+}
+
+#[tokio::test]
+async fn status_includes_last_shutdown_unclean() {
+    let at: DateTime<Utc> = Utc::now();
+    let repo = Arc::new(
+        MockSystemConfigRepo::new(0, 0, 0).with_last_shutdown(LastShutdownInfo {
+            state: LastShutdownState::Unclean,
+            at: Some(at),
+            acknowledged_at: None,
+        }),
+    );
+    let svc = build_service_with_repo(repo, 0);
+
+    let resp = auth_context::with_context(admin_ctx(), svc.status())
+        .await
+        .unwrap();
+    assert_eq!(resp.last_shutdown.state, LastShutdownState::Unclean);
+    assert_eq!(resp.last_shutdown.at, Some(at));
+}
+
+#[tokio::test]
+async fn record_graceful_shutdown_calls_repo() {
+    let repo = Arc::new(MockSystemConfigRepo::new(0, 0, 0));
+    let svc = build_service_with_repo(repo.clone(), 0);
+
+    auth_context::with_context(admin_ctx(), svc.record_graceful_shutdown())
+        .await
+        .unwrap();
+    assert_eq!(repo.graceful_calls.load(Ordering::SeqCst), 1);
+}
+
+#[tokio::test]
+async fn record_graceful_shutdown_anonymous_forbidden() {
+    let repo = Arc::new(MockSystemConfigRepo::new(0, 0, 0));
+    let svc = build_service_with_repo(repo.clone(), 0);
+
+    let result =
+        auth_context::with_context(AuthContext::Anonymous, svc.record_graceful_shutdown()).await;
+    assert!(matches!(result, Err(AppError::Forbidden(_))));
+    assert_eq!(repo.graceful_calls.load(Ordering::SeqCst), 0);
+}
+
+#[tokio::test]
+async fn acknowledge_last_shutdown_calls_repo() {
+    let repo = Arc::new(MockSystemConfigRepo::new(0, 0, 0));
+    let svc = build_service_with_repo(repo.clone(), 0);
+
+    auth_context::with_context(admin_ctx(), svc.acknowledge_last_shutdown())
+        .await
+        .unwrap();
+    assert_eq!(repo.ack_calls.load(Ordering::SeqCst), 1);
+}
+
+#[tokio::test]
+async fn acknowledge_last_shutdown_anonymous_forbidden() {
+    let repo = Arc::new(MockSystemConfigRepo::new(0, 0, 0));
+    let svc = build_service_with_repo(repo.clone(), 0);
+
+    let result =
+        auth_context::with_context(AuthContext::Anonymous, svc.acknowledge_last_shutdown()).await;
+    assert!(matches!(result, Err(AppError::Forbidden(_))));
+    assert_eq!(repo.ack_calls.load(Ordering::SeqCst), 0);
+}
+
+#[tokio::test]
+async fn record_heartbeat_admin_succeeds() {
+    let repo = Arc::new(MockSystemConfigRepo::new(0, 0, 0));
+    let svc = build_service_with_repo(repo, 0);
+
+    auth_context::with_context(admin_ctx(), svc.record_heartbeat())
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn record_heartbeat_anonymous_forbidden() {
+    let repo = Arc::new(MockSystemConfigRepo::new(0, 0, 0));
+    let svc = build_service_with_repo(repo, 0);
+
+    let result = auth_context::with_context(AuthContext::Anonymous, svc.record_heartbeat()).await;
     assert!(matches!(result, Err(AppError::Forbidden(_))));
 }

--- a/source/daemon/crates/wardnetd/src/heartbeat.rs
+++ b/source/daemon/crates/wardnetd/src/heartbeat.rs
@@ -1,0 +1,93 @@
+use std::sync::Arc;
+use std::time::Duration;
+
+use tokio::time::interval;
+use tokio_util::sync::CancellationToken;
+use tracing::Instrument;
+use uuid::Uuid;
+use wardnet_common::auth::AuthContext;
+
+use wardnetd_services::auth_context;
+use wardnetd_services::system::SystemService;
+
+/// Cadence between heartbeat writes. Sets the worst-case error of
+/// the `last_seen_at` timestamp surfaced for an unclean shutdown.
+pub const HEARTBEAT_INTERVAL: Duration = Duration::from_mins(1);
+
+/// Background task that refreshes `last_seen_at` in `system_config`.
+///
+/// On boot, [`wardnetd_data::repository::SystemConfigRepository::detect_previous_shutdown`]
+/// classifies the prior run by inspecting `last_shutdown_state` and
+/// `last_seen_at`. The heartbeat runner is what keeps `last_seen_at`
+/// current while the daemon is alive — without it, an unclean
+/// shutdown's reported timestamp would only ever be the boot time,
+/// not the moment the daemon was actually killed.
+///
+/// Failures are logged and never escalate: a transient `SQLite` write
+/// error must not bring the daemon down. The runner retries on the
+/// next tick.
+pub struct HeartbeatRunner {
+    cancel: CancellationToken,
+    handle: tokio::task::JoinHandle<()>,
+}
+
+impl HeartbeatRunner {
+    /// Start the runner. Logs land under a child of `parent` named
+    /// `heartbeat`, matching the span hierarchy described in
+    /// `.agents/observability.md`.
+    pub fn start(system: Arc<dyn SystemService>, parent: &tracing::Span) -> Self {
+        Self::start_with_interval(system, HEARTBEAT_INTERVAL, parent)
+    }
+
+    /// Start with a custom interval — used by tests to drive the loop
+    /// faster than once a minute.
+    pub fn start_with_interval(
+        system: Arc<dyn SystemService>,
+        tick: Duration,
+        parent: &tracing::Span,
+    ) -> Self {
+        let cancel = CancellationToken::new();
+        let span = tracing::info_span!(parent: parent, "heartbeat");
+
+        let handle = tokio::spawn(heartbeat_loop(system, tick, cancel.clone()).instrument(span));
+
+        Self { cancel, handle }
+    }
+
+    /// Cancel the loop and wait for the task to exit.
+    pub async fn shutdown(self) {
+        self.cancel.cancel();
+        let _ = self.handle.await;
+        tracing::info!("heartbeat runner shut down");
+    }
+}
+
+async fn heartbeat_loop(system: Arc<dyn SystemService>, tick: Duration, cancel: CancellationToken) {
+    let admin_ctx = AuthContext::Admin {
+        admin_id: Uuid::nil(),
+    };
+
+    // Fire one heartbeat immediately on startup so the initial
+    // `last_seen_at` is no older than the boot moment.
+    if let Err(e) = auth_context::with_context(admin_ctx.clone(), system.record_heartbeat()).await {
+        tracing::warn!(error = %e, "initial heartbeat write failed: {e}");
+    }
+
+    let mut ticker = interval(tick);
+    // Skip the immediate-fire built into `interval` since we already
+    // wrote one above.
+    ticker.tick().await;
+
+    loop {
+        tokio::select! {
+            () = cancel.cancelled() => break,
+            _ = ticker.tick() => {}
+        }
+
+        if let Err(e) =
+            auth_context::with_context(admin_ctx.clone(), system.record_heartbeat()).await
+        {
+            tracing::warn!(error = %e, "heartbeat write failed: {e}");
+        }
+    }
+}

--- a/source/daemon/crates/wardnetd/src/lib.rs
+++ b/source/daemon/crates/wardnetd/src/lib.rs
@@ -18,6 +18,7 @@ pub mod system;
 
 // Background tasks.
 pub mod device_detector;
+pub mod heartbeat;
 pub mod metrics_collector;
 pub mod profiling;
 pub mod route_monitor;

--- a/source/daemon/crates/wardnetd/src/main.rs
+++ b/source/daemon/crates/wardnetd/src/main.rs
@@ -23,6 +23,7 @@ use wardnet_common::auth::AuthContext;
 use wardnet_common::config::{ApplicationConfiguration, LogFormat, LogRotation, OtelConfig};
 use wardnetd::device_detector::DeviceDetector;
 use wardnetd::firewall_nftables::NftablesFirewallManager;
+use wardnetd::heartbeat::HeartbeatRunner;
 use wardnetd::hostname_resolver::SystemHostnameResolver;
 use wardnetd::metrics_collector::MetricsCollector;
 use wardnetd::packet_capture_pnet::PnetCapture;
@@ -284,6 +285,11 @@ async fn run(
     let route_monitor = RouteMonitor::start(services.event_publisher.clone(), &root_span)
         .map_err(|e| anyhow::anyhow!("failed to start route monitor: {e}"))?;
 
+    // Heartbeat: refreshes `last_seen_at` in `system_config` every
+    // 60 seconds so an unclean shutdown's reported timestamp is
+    // accurate to within the heartbeat window.
+    let heartbeat_runner = HeartbeatRunner::start(services.system.clone(), &root_span);
+
     // Start device detector (conditionally).
     let device_detector = if config.detection.enabled {
         Some(DeviceDetector::start(
@@ -505,6 +511,7 @@ async fn run(
     update_runner.shutdown().await;
     backup_cleanup_runner.shutdown().await;
     tunnel_metrics_runner.shutdown().await;
+    heartbeat_runner.shutdown().await;
     if let Some(detector) = device_detector {
         detector.shutdown().await;
     }
@@ -513,6 +520,22 @@ async fn run(
     }
     if let Some(agent) = profiling_agent {
         agent.shutdown();
+    }
+
+    // Mark this shutdown as graceful so the next boot's
+    // `detect_previous_shutdown` classifies the run as `Graceful` and
+    // the dashboard does not surface an unclean-shutdown banner.
+    // Wrapped in `auth_context::with_context` because the call lives
+    // outside the HTTP middleware chain. Failure here is logged but
+    // never escalated — the worst-case is a benign false-positive
+    // banner on the next boot.
+    let admin_ctx = AuthContext::Admin {
+        admin_id: uuid::Uuid::nil(),
+    };
+    if let Err(e) =
+        auth_context::with_context(admin_ctx, services.system.record_graceful_shutdown()).await
+    {
+        tracing::warn!(error = %e, "failed to record graceful shutdown marker: {e}");
     }
 
     Ok(())

--- a/source/daemon/crates/wardnetd/src/tests/heartbeat.rs
+++ b/source/daemon/crates/wardnetd/src/tests/heartbeat.rs
@@ -1,0 +1,154 @@
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
+use std::time::Duration;
+
+use async_trait::async_trait;
+use wardnet_common::api::{
+    DhcpSelfProbeResponse, DiscoverGatewayMacRequest, DiscoverGatewayMacResponse,
+    NetworkStatusResponse, SystemStatusResponse,
+};
+use wardnetd_services::auth_context;
+use wardnetd_services::error::AppError;
+use wardnetd_services::system::SystemService;
+
+use crate::heartbeat::HeartbeatRunner;
+
+/// Mock system service that counts `record_heartbeat` calls and
+/// optionally returns an error so the runner's failure-swallowing
+/// branch is exercised.
+struct MockSystemService {
+    heartbeat_count: AtomicU32,
+    fail: AtomicBool,
+}
+
+impl MockSystemService {
+    fn new() -> Self {
+        Self {
+            heartbeat_count: AtomicU32::new(0),
+            fail: AtomicBool::new(false),
+        }
+    }
+
+    fn failing() -> Self {
+        let svc = Self::new();
+        svc.fail.store(true, Ordering::SeqCst);
+        svc
+    }
+}
+
+#[async_trait]
+impl SystemService for MockSystemService {
+    fn version(&self) -> &'static str {
+        "0.0.0-test"
+    }
+    fn uptime(&self) -> Duration {
+        Duration::ZERO
+    }
+    async fn status(&self) -> Result<SystemStatusResponse, AppError> {
+        unimplemented!()
+    }
+    async fn network_status(&self) -> Result<NetworkStatusResponse, AppError> {
+        unimplemented!()
+    }
+    async fn discover_gateway_mac(
+        &self,
+        _request: DiscoverGatewayMacRequest,
+    ) -> Result<DiscoverGatewayMacResponse, AppError> {
+        unimplemented!()
+    }
+    async fn dhcp_self_probe(&self) -> Result<DhcpSelfProbeResponse, AppError> {
+        unimplemented!()
+    }
+    async fn request_restart(&self) -> Result<(), AppError> {
+        unimplemented!()
+    }
+    async fn request_reboot(&self) -> Result<(), AppError> {
+        unimplemented!()
+    }
+    async fn request_shutdown(&self) -> Result<(), AppError> {
+        unimplemented!()
+    }
+    async fn record_heartbeat(&self) -> Result<(), AppError> {
+        // Heartbeat goes through `auth_context::with_context`, so the
+        // service-layer admin guard must see an Admin context here.
+        auth_context::require_admin()?;
+        self.heartbeat_count.fetch_add(1, Ordering::SeqCst);
+        if self.fail.load(Ordering::SeqCst) {
+            return Err(AppError::Internal(anyhow::anyhow!("simulated db error")));
+        }
+        Ok(())
+    }
+    async fn record_graceful_shutdown(&self) -> Result<(), AppError> {
+        unimplemented!()
+    }
+    async fn acknowledge_last_shutdown(&self) -> Result<(), AppError> {
+        unimplemented!()
+    }
+}
+
+#[tokio::test]
+async fn fires_initial_heartbeat_on_start() {
+    let svc = Arc::new(MockSystemService::new());
+    let parent = tracing::info_span!("test");
+    let runner = HeartbeatRunner::start_with_interval(svc.clone(), Duration::from_mins(1), &parent);
+
+    // The runner fires once immediately on startup. Yield + a small
+    // sleep so the spawned task has a chance to run.
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    runner.shutdown().await;
+
+    assert!(
+        svc.heartbeat_count.load(Ordering::SeqCst) >= 1,
+        "expected at least one heartbeat fire on startup",
+    );
+}
+
+#[tokio::test]
+async fn ticks_periodically() {
+    let svc = Arc::new(MockSystemService::new());
+    let parent = tracing::info_span!("test");
+    let runner =
+        HeartbeatRunner::start_with_interval(svc.clone(), Duration::from_millis(50), &parent);
+
+    // Wait long enough for two or three ticks past the initial fire.
+    tokio::time::sleep(Duration::from_millis(220)).await;
+    runner.shutdown().await;
+
+    assert!(
+        svc.heartbeat_count.load(Ordering::SeqCst) >= 2,
+        "expected periodic ticks beyond the initial fire, got {}",
+        svc.heartbeat_count.load(Ordering::SeqCst)
+    );
+}
+
+#[tokio::test]
+async fn swallows_repository_errors() {
+    let svc = Arc::new(MockSystemService::failing());
+    let parent = tracing::info_span!("test");
+    let runner =
+        HeartbeatRunner::start_with_interval(svc.clone(), Duration::from_millis(50), &parent);
+
+    tokio::time::sleep(Duration::from_millis(180)).await;
+    runner.shutdown().await;
+
+    // Initial fire + at least one tick — both surfaced errors and
+    // neither brought the runner down.
+    assert!(svc.heartbeat_count.load(Ordering::SeqCst) >= 2);
+}
+
+#[tokio::test]
+async fn shutdown_stops_loop_promptly() {
+    let svc = Arc::new(MockSystemService::new());
+    let parent = tracing::info_span!("test");
+    let runner = HeartbeatRunner::start_with_interval(svc, Duration::from_hours(1), &parent);
+
+    // Even with a 1-hour tick, shutdown returns within the cancellation
+    // poll window because the loop selects on `cancel.cancelled()`.
+    let started = std::time::Instant::now();
+    runner.shutdown().await;
+    assert!(
+        started.elapsed() < Duration::from_secs(2),
+        "shutdown should not wait on the next tick: took {:?}",
+        started.elapsed()
+    );
+}

--- a/source/daemon/crates/wardnetd/src/tests/metrics_collector.rs
+++ b/source/daemon/crates/wardnetd/src/tests/metrics_collector.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use async_trait::async_trait;
-use wardnet_common::api::SystemStatusResponse;
+use wardnet_common::api::{LastShutdownState, LastShutdownStatus, SystemStatusResponse};
 
 use crate::metrics_collector::MetricsCollector;
 use wardnet_common::config::OtelMetricsConfig;
@@ -32,6 +32,11 @@ impl SystemService for MockSystemService {
             cpu_usage_percent: 10.0,
             memory_used_bytes: 500_000_000,
             memory_total_bytes: 1_000_000_000,
+            last_shutdown: LastShutdownStatus {
+                state: LastShutdownState::Unknown,
+                at: None,
+                acknowledged_at: None,
+            },
         })
     }
     async fn request_restart(&self) -> Result<(), AppError> {
@@ -56,6 +61,15 @@ impl SystemService for MockSystemService {
         &self,
     ) -> Result<wardnet_common::api::DhcpSelfProbeResponse, AppError> {
         unimplemented!()
+    }
+    async fn record_heartbeat(&self) -> Result<(), AppError> {
+        Ok(())
+    }
+    async fn record_graceful_shutdown(&self) -> Result<(), AppError> {
+        Ok(())
+    }
+    async fn acknowledge_last_shutdown(&self) -> Result<(), AppError> {
+        Ok(())
     }
 }
 
@@ -103,6 +117,21 @@ impl SystemService for FailingSystemService {
         &self,
     ) -> Result<wardnet_common::api::DhcpSelfProbeResponse, AppError> {
         unimplemented!()
+    }
+    async fn record_heartbeat(&self) -> Result<(), AppError> {
+        Err(AppError::Internal(anyhow::anyhow!(
+            "simulated service failure"
+        )))
+    }
+    async fn record_graceful_shutdown(&self) -> Result<(), AppError> {
+        Err(AppError::Internal(anyhow::anyhow!(
+            "simulated service failure"
+        )))
+    }
+    async fn acknowledge_last_shutdown(&self) -> Result<(), AppError> {
+        Err(AppError::Internal(anyhow::anyhow!(
+            "simulated service failure"
+        )))
     }
 }
 

--- a/source/daemon/crates/wardnetd/src/tests/mod.rs
+++ b/source/daemon/crates/wardnetd/src/tests/mod.rs
@@ -1,5 +1,6 @@
 mod device_detector;
 mod firewall_nftables;
+mod heartbeat;
 mod hostname_resolver;
 mod metrics_collector;
 mod packet_capture;

--- a/source/daemon/crates/wardnetd/src/tests/stubs.rs
+++ b/source/daemon/crates/wardnetd/src/tests/stubs.rs
@@ -229,6 +229,15 @@ impl SystemService for StubSystemService {
     ) -> Result<wardnet_common::api::DhcpSelfProbeResponse, AppError> {
         unimplemented!()
     }
+    async fn record_heartbeat(&self) -> Result<(), AppError> {
+        unimplemented!()
+    }
+    async fn record_graceful_shutdown(&self) -> Result<(), AppError> {
+        unimplemented!()
+    }
+    async fn acknowledge_last_shutdown(&self) -> Result<(), AppError> {
+        unimplemented!()
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/source/sdk/wardnet-js/src/index.ts
+++ b/source/sdk/wardnet-js/src/index.ts
@@ -48,6 +48,8 @@ export type { LoginRequest, LoginResponse } from "./types/auth.js";
 
 // Types — system
 export type {
+  LastShutdownState,
+  LastShutdownStatus,
   SetDefaultPolicyRequest,
   SetDefaultPolicyResponse,
   SystemStatusResponse,

--- a/source/sdk/wardnet-js/src/services/system.ts
+++ b/source/sdk/wardnet-js/src/services/system.ts
@@ -82,6 +82,21 @@ export class SystemService {
   }
 
   /**
+   * Acknowledge the most recent unclean-shutdown event so the
+   * dashboard banner is dismissed.
+   *
+   * Idempotent — repeated calls just refresh the timestamp. The
+   * banner reappears automatically on the next unclean shutdown
+   * because the new event timestamp is newer than the stored
+   * acknowledgement.
+   *
+   * Throws [`WardnetApiError`] on a non-2xx response.
+   */
+  async acknowledgeShutdown(): Promise<void> {
+    await this.postNoContent("/system/shutdown/acknowledge");
+  }
+
+  /**
    * Shared POST helper for endpoints that return `204 No Content`.
    *
    * Routes through `client.request<void>` so subclassed clients

--- a/source/sdk/wardnet-js/src/types/system.ts
+++ b/source/sdk/wardnet-js/src/types/system.ts
@@ -1,3 +1,27 @@
+/**
+ * Classification of the previous daemon shutdown:
+ * - `unknown` — no prior shutdown record (first-ever boot or fresh DB).
+ * - `graceful` — daemon recorded a graceful exit before the previous run ended.
+ * - `unclean` — the previous run was interrupted by a crash, kill -9, or power loss.
+ */
+export type LastShutdownState = "unknown" | "graceful" | "unclean";
+
+/**
+ * Status of the previous daemon shutdown.
+ *
+ * `at` is the timestamp the previous run last touched the database
+ * (graceful exit time, or last heartbeat for unclean events). `at` is
+ * `null` only for `unknown`. `acknowledged_at` is set when an admin
+ * dismisses the unclean-shutdown banner via
+ * `POST /api/system/shutdown/acknowledge`. The banner is hidden iff
+ * `acknowledged_at >= at`.
+ */
+export interface LastShutdownStatus {
+  state: LastShutdownState;
+  at: string | null;
+  acknowledged_at: string | null;
+}
+
 /** Response for GET /api/system/status. */
 export interface SystemStatusResponse {
   /** Diagnostic git-derived version. See `InfoResponse.version`. */
@@ -11,6 +35,8 @@ export interface SystemStatusResponse {
   cpu_usage_percent: number;
   memory_used_bytes: number;
   memory_total_bytes: number;
+  /** Classification of the previous daemon shutdown plus its acknowledgement. */
+  last_shutdown: LastShutdownStatus;
 }
 
 /**

--- a/source/web-ui/src/components/compound/UncleanShutdownBanner.tsx
+++ b/source/web-ui/src/components/compound/UncleanShutdownBanner.tsx
@@ -1,0 +1,62 @@
+import { CircleAlertIcon, X } from "lucide-react";
+import { Button } from "@/components/core/ui/button";
+import { useAcknowledgeShutdown, useSystemStatus } from "@/hooks/useSystemStatus";
+import { timeAgo } from "@/lib/utils";
+
+/**
+ * Full-width banner that calls out the previous unclean daemon
+ * shutdown.
+ *
+ * Visible iff the most recent shutdown classification is `unclean`
+ * AND there is no acknowledgement timestamp at-or-after the event
+ * timestamp. Dismissing the banner posts to
+ * `/api/system/shutdown/acknowledge`, which records `acknowledged_at`.
+ * A future unclean event automatically resurfaces the banner because
+ * the new event timestamp is newer than the stored ack — no explicit
+ * "reset on event" coupling is required.
+ *
+ * Styling mirrors the destructive tone of `ApiErrorAlert` but renders
+ * full-width above the page content (à la `ConnectionBanner`) so the
+ * operator notices it on every authenticated route until they
+ * acknowledge it.
+ */
+export function UncleanShutdownBanner() {
+  const { data: status } = useSystemStatus();
+  const ack = useAcknowledgeShutdown();
+
+  if (!status) return null;
+
+  const { last_shutdown: shutdown } = status;
+  if (shutdown.state !== "unclean" || !shutdown.at) return null;
+
+  // Banner predicate: hide once the ack is at-or-after the event.
+  if (shutdown.acknowledged_at && shutdown.acknowledged_at >= shutdown.at) {
+    return null;
+  }
+
+  return (
+    <div
+      role="alert"
+      className="flex items-center gap-3 border-b border-destructive/30 bg-destructive/10 px-4 py-2.5 text-sm text-destructive"
+    >
+      <CircleAlertIcon className="size-4 shrink-0" />
+      <div className="flex-1">
+        <span className="font-medium">Wardnet did not shut down cleanly</span>
+        <span className="ml-2 text-destructive/80">
+          Last seen {timeAgo(shutdown.at)} — likely a crash or power loss.
+        </span>
+      </div>
+      <Button
+        size="sm"
+        variant="ghost"
+        className="h-7 px-2 text-destructive hover:bg-destructive/20 hover:text-destructive"
+        onClick={() => ack.mutate()}
+        disabled={ack.isPending}
+        aria-label="Dismiss unclean shutdown banner"
+      >
+        <X className="mr-1 size-3.5" />
+        Dismiss
+      </Button>
+    </div>
+  );
+}

--- a/source/web-ui/src/components/layouts/AppLayout.tsx
+++ b/source/web-ui/src/components/layouts/AppLayout.tsx
@@ -3,6 +3,7 @@ import { Sidebar } from "@/components/compound/Sidebar";
 import { MobileMenu } from "@/components/compound/MobileMenu";
 import { Logo } from "@/components/compound/Logo";
 import { ConnectionBanner } from "@/components/compound/ConnectionBanner";
+import { UncleanShutdownBanner } from "@/components/compound/UncleanShutdownBanner";
 import { useAuth } from "@/hooks/useAuth";
 
 /**
@@ -33,6 +34,7 @@ export function AppLayout() {
         </header>
 
         <ConnectionBanner />
+        {isAdmin && <UncleanShutdownBanner />}
 
         <main className="flex min-h-0 flex-1 flex-col overflow-y-auto p-4 md:p-6">
           <Outlet />

--- a/source/web-ui/src/hooks/useSystemStatus.ts
+++ b/source/web-ui/src/hooks/useSystemStatus.ts
@@ -1,4 +1,4 @@
-import { useQuery } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { systemService, client } from "@/lib/sdk";
 
 export function useSystemStatus() {
@@ -6,6 +6,23 @@ export function useSystemStatus() {
     queryKey: ["system", "status"],
     queryFn: () => systemService.getStatus(),
     refetchInterval: 30_000,
+  });
+}
+
+/**
+ * Mutation that dismisses the unclean-shutdown banner.
+ *
+ * On success, invalidates the `["system","status"]` query so the
+ * banner predicate (`acknowledged_at >= last_shutdown.at`) re-evaluates
+ * with the freshly persisted timestamp and the banner disappears.
+ */
+export function useAcknowledgeShutdown() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: () => systemService.acknowledgeShutdown(),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ["system", "status"] });
+    },
   });
 }
 


### PR DESCRIPTION
## Summary

Tracks whether the previous daemon run ended gracefully or was
interrupted (crash, kill -9, power loss) and surfaces unclean
shutdowns as a persistent banner with timestamp until an admin
dismisses it. Implements the FR-071 / FR-075 operator-visibility
requirement called out in the issue.

- **DB-only detection** using the existing `system_config` key/value
  table — no flag file (`/run/wardnetd` is `RuntimeDirectory=` tmpfs
  and can't distinguish graceful daemon shutdown from host power loss).
- **Transactional classification** runs once per boot in
  `init_services` before any other component touches the DB; persists
  the result to `prev_shutdown_*` keys so the API read path is
  stateless.
- **60 s heartbeat** (`HeartbeatRunner`, child of root tracing span)
  keeps `last_seen_at` current so an unclean shutdown's reported
  timestamp is accurate to within the heartbeat window.
- **Explicit graceful marker** written from `main.rs` after the
  runner-shutdown sequence and before `Ok(())`. Panics deliberately
  bypass this and correctly classify as unclean.
- **Timestamp-comparison ack** — banner shown iff
  `state == "unclean" && acknowledged_at < at`. A future unclean event
  writes a newer `at`, automatically making any older ack stale; no
  explicit "reset on event" coupling.
- **App-shell-wide banner** (admin-only) renders full-width above the
  page content with destructive-tone styling matching `ApiErrorAlert`.

## Test plan

Daemon (1485 tests pass under `make check-daemon`):
- [ ] First-ever boot → `state="unknown"` in `/api/system/status`.
- [ ] Run + `kill -9` the daemon → next boot reports `state="unclean"`
      with `at` ≈ last heartbeat; banner appears in the UI.
- [ ] Run + Safe Restart from the dashboard → next boot reports
      `state="graceful"`; no banner.
- [ ] Click Dismiss → banner clears; refresh → still dismissed
      (`acknowledged_at` persisted).
- [ ] After dismissing, kill -9 again → banner reappears on next boot
      because the new event's `at` is newer than the old ack.

Coverage:
- `wardnet-common/src/api.rs`: 100%
- `wardnetd-api/src/api/system.rs`: 100%
- `wardnetd-data/src/repository/sqlite/system_config.rs`: 93.83%
- `wardnetd/src/heartbeat.rs`: 90.48%

## Notable design notes

- `prev_shutdown_state` / `prev_shutdown_at` — extra persisted keys so
  `read_last_shutdown` doesn't need to cache the boot-time
  classification on the service struct.
- Classification picks `max(last_seen_at, last_shutdown_at)` rather
  than `last_seen_at.or(last_shutdown_at)` to ignore a stale heartbeat
  from an earlier run that didn't get reset before a subsequent boot
  crashed pre-heartbeat. Regression test:
  `detect_unclean_ignores_heartbeat_older_than_last_boot`.

Closes #216

🤖 Generated with [Claude Code](https://claude.com/claude-code)