### PR TITLE
feat(tunnels): add exit-IP/country test endpoint (#238)

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -70,7 +70,7 @@ jobs:
             --workspace \
             --profile ci \
             --lcov --output-path ../../coverage/daemon-lcov.info \
-            --ignore-filename-regex '(main\.rs|noop_.*\.rs|db\.rs|web\.rs|api/mod\.rs|auth_context\.rs|command\.rs|policy_router_netlink\.rs|route_monitor\.rs|wardnet-test-agent/.*|wardnetd-mock/src/events\.rs|wardnetd-data/src/lib\.rs)'
+            --ignore-filename-regex '(main\.rs|noop_.*\.rs|db\.rs|web\.rs|api/mod\.rs|auth_context\.rs|command\.rs|policy_router_netlink\.rs|route_monitor\.rs|tunnel_exit_probe\.rs|wardnet-test-agent/.*|wardnetd-mock/src/events\.rs|wardnetd-data/src/lib\.rs)'
           cp target/nextest/ci/junit.xml ../../coverage/daemon-junit.xml
 
       - name: Upload daemon coverage artifact

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ LINUX_TARGET := $(CURDIR)/.target-linux
 
 # Coverage: files excluded from cargo-llvm-cov.  Single source of truth —
 # CI calls `make coverage-daemon` with COV_FMT overridden for LCOV output.
-COV_IGNORE := (main\.rs|noop_.*\.rs|db\.rs|web\.rs|api/mod\.rs|auth_context\.rs|command\.rs|policy_router_netlink\.rs|route_monitor\.rs|pnet_network_probe\.rs|wardnet-test-agent/.*|wardnetd-mock/src/events\.rs|wardnetd-data/src/lib\.rs)
+COV_IGNORE := (main\.rs|noop_.*\.rs|db\.rs|web\.rs|api/mod\.rs|auth_context\.rs|command\.rs|policy_router_netlink\.rs|route_monitor\.rs|pnet_network_probe\.rs|tunnel_exit_probe\.rs|wardnet-test-agent/.*|wardnetd-mock/src/events\.rs|wardnetd-data/src/lib\.rs)
 # Default: human-readable summary.  CI overrides:
 #   make coverage-daemon COV_FMT="--lcov --output-path ../../coverage/daemon-lcov.info"
 COV_FMT    ?= --summary-only

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -11588,6 +11588,239 @@
         ]
       }
     },
+    "/api/tunnels/{id}/test": {
+      "post": {
+        "tags": [
+          "tunnels"
+        ],
+        "description": "Run an exit-IP / country probe through this tunnel. The daemon brings the tunnel up if needed, waits for a fresh handshake, sends one HTTP probe through the tunnel interface, and reports the exit IP, ISO-3166 alpha-2 country code, and probe latency. Restores the prior up/down state when finished. Admin only.",
+        "operationId": "test_tunnel",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Tunnel ID",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Tunnel test result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TunnelTestResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthenticated — session cookie or API key missing/invalid",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "description": "Standard API error response.",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "detail": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "error": {
+                      "type": "string"
+                    },
+                    "request_id": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "description": "Request ID for correlation with server logs."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden — caller is not an admin",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "description": "Standard API error response.",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "detail": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "error": {
+                      "type": "string"
+                    },
+                    "request_id": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "description": "Request ID for correlation with server logs."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Resource not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "description": "Standard API error response.",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "detail": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "error": {
+                      "type": "string"
+                    },
+                    "request_id": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "description": "Request ID for correlation with server logs."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflicting concurrent operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "description": "Standard API error response.",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "detail": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "error": {
+                      "type": "string"
+                    },
+                    "request_id": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "description": "Request ID for correlation with server logs."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "description": "Standard API error response.",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "detail": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "error": {
+                      "type": "string"
+                    },
+                    "request_id": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "description": "Request ID for correlation with server logs."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "502": {
+            "description": "Upstream service unavailable or unreachable",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "description": "Standard API error response.",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "detail": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "error": {
+                      "type": "string"
+                    },
+                    "request_id": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "description": "Request ID for correlation with server logs."
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "session_cookie": []
+          },
+          {
+            "bearer_auth": []
+          }
+        ]
+      }
+    },
     "/api/update/check": {
       "post": {
         "tags": [
@@ -15608,6 +15841,48 @@
           },
           "label": {
             "type": "string"
+          }
+        }
+      },
+      "TunnelTestResponse": {
+        "type": "object",
+        "description": "Response envelope for `POST /api/tunnels/{id}/test`.",
+        "required": [
+          "result"
+        ],
+        "properties": {
+          "result": {
+            "$ref": "#/components/schemas/TunnelTestResult"
+          }
+        }
+      },
+      "TunnelTestResult": {
+        "type": "object",
+        "description": "Result payload of `POST /api/tunnels/{id}/test`.\n\nThe daemon brings the tunnel up if needed, sends a single HTTP probe\nthrough the tunnel interface, and reports the exit IP, ISO-3166 alpha-2\ncountry code, and round-trip latency in milliseconds.",
+        "required": [
+          "tunnel_id",
+          "exit_ip",
+          "country_code",
+          "latency_ms"
+        ],
+        "properties": {
+          "country_code": {
+            "type": "string",
+            "description": "ISO-3166 alpha-2 country code reported by the probe service."
+          },
+          "exit_ip": {
+            "type": "string",
+            "description": "Public IP observed at the tunnel exit."
+          },
+          "latency_ms": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Round-trip latency of the probe call, in milliseconds.",
+            "minimum": 0
+          },
+          "tunnel_id": {
+            "type": "string",
+            "format": "uuid"
           }
         }
       },

--- a/source/daemon/Cargo.lock
+++ b/source/daemon/Cargo.lock
@@ -5588,7 +5588,6 @@ dependencies = [
  "serde_json",
  "tabled",
  "tokio",
- "wardnet-common",
 ]
 
 [[package]]

--- a/source/daemon/Cargo.lock
+++ b/source/daemon/Cargo.lock
@@ -5588,6 +5588,7 @@ dependencies = [
  "serde_json",
  "tabled",
  "tokio",
+ "wardnet-common",
 ]
 
 [[package]]

--- a/source/daemon/crates/wardnet-common/src/api.rs
+++ b/source/daemon/crates/wardnet-common/src/api.rs
@@ -222,6 +222,28 @@ pub struct TunnelDevicesResponse {
     pub devices: Vec<Device>,
 }
 
+/// Result payload of `POST /api/tunnels/{id}/test`.
+///
+/// The daemon brings the tunnel up if needed, sends a single HTTP probe
+/// through the tunnel interface, and reports the exit IP, ISO-3166 alpha-2
+/// country code, and round-trip latency in milliseconds.
+#[derive(Debug, Clone, Serialize, Deserialize, utoipa::ToSchema)]
+pub struct TunnelTestResult {
+    pub tunnel_id: Uuid,
+    /// Public IP observed at the tunnel exit.
+    pub exit_ip: String,
+    /// ISO-3166 alpha-2 country code reported by the probe service.
+    pub country_code: String,
+    /// Round-trip latency of the probe call, in milliseconds.
+    pub latency_ms: u64,
+}
+
+/// Response envelope for `POST /api/tunnels/{id}/test`.
+#[derive(Debug, Clone, Serialize, Deserialize, utoipa::ToSchema)]
+pub struct TunnelTestResponse {
+    pub result: TunnelTestResult,
+}
+
 /// A device enriched with its DHCP status for API responses.
 ///
 /// Uses `#[serde(flatten)]` so the JSON output includes all `Device` fields

--- a/source/daemon/crates/wardnet-common/src/config.rs
+++ b/source/daemon/crates/wardnet-common/src/config.rs
@@ -282,6 +282,11 @@ pub struct TunnelConfig {
     /// `tunnel_metrics_intraday`. The 5-second poll loop decimates to
     /// this interval, accumulating the delta.
     pub metrics_sample_interval_secs: u64,
+    /// URL probed by the tunnel test endpoint to determine the exit IP and
+    /// country. The default is Cloudflare's `cdn-cgi/trace`, which returns a
+    /// `key=value` document including `ip=` and `loc=`. Overriding this
+    /// requires the same response shape.
+    pub test_probe_url: String,
 }
 
 impl Default for TunnelConfig {
@@ -291,6 +296,7 @@ impl Default for TunnelConfig {
             health_check_interval_secs: 10,
             stats_interval_secs: 5,
             metrics_sample_interval_secs: 300,
+            test_probe_url: "https://1.1.1.1/cdn-cgi/trace".to_owned(),
         }
     }
 }

--- a/source/daemon/crates/wardnetd-api/src/api/responses.rs
+++ b/source/daemon/crates/wardnetd-api/src/api/responses.rs
@@ -44,3 +44,24 @@ pub enum BadRequest {
     #[response(status = 400, description = "Malformed or invalid request body")]
     BadRequest(#[to_schema] ApiError),
 }
+
+/// 409 — use on endpoints that may collide with concurrent state.
+#[derive(IntoResponses)]
+#[allow(dead_code)]
+pub enum Conflict {
+    /// Another operation conflicts with this request.
+    #[response(status = 409, description = "Conflicting concurrent operation")]
+    Conflict(#[to_schema] ApiError),
+}
+
+/// 502 — use on endpoints that depend on an external service.
+#[derive(IntoResponses)]
+#[allow(dead_code)]
+pub enum UpstreamUnavailable {
+    /// Upstream service was unreachable or returned an unexpected response.
+    #[response(
+        status = 502,
+        description = "Upstream service unavailable or unreachable"
+    )]
+    UpstreamUnavailable(#[to_schema] ApiError),
+}

--- a/source/daemon/crates/wardnetd-api/src/api/tests/tunnels.rs
+++ b/source/daemon/crates/wardnetd-api/src/api/tests/tunnels.rs
@@ -13,6 +13,7 @@ use tower::ServiceExt;
 use uuid::Uuid;
 use wardnet_common::api::{
     CreateTunnelRequest, CreateTunnelResponse, DeleteTunnelResponse, ListTunnelsResponse,
+    TunnelTestResult,
 };
 use wardnet_common::tunnel::{Tunnel, TunnelStatus};
 
@@ -72,15 +73,31 @@ impl AuthService for MockAuthService {
 /// Mock `TunnelService` with configurable tunnel list.
 struct MockTunnelService {
     tunnels: Vec<Tunnel>,
+    /// Optional one-shot override for `test_tunnel`. Used by the API tests
+    /// to drive the 200 / 404 / 409 / 502 path mappings deterministically.
+    /// The response is taken on the first call; later calls fall back to
+    /// the default behaviour (404).
+    test_response: std::sync::Mutex<Option<Result<TunnelTestResult, AppError>>>,
 }
 
 impl MockTunnelService {
     fn with_tunnels(tunnels: Vec<Tunnel>) -> Self {
-        Self { tunnels }
+        Self {
+            tunnels,
+            test_response: std::sync::Mutex::new(None),
+        }
     }
 
     fn empty() -> Self {
-        Self { tunnels: vec![] }
+        Self {
+            tunnels: vec![],
+            test_response: std::sync::Mutex::new(None),
+        }
+    }
+
+    fn with_test_response(self, response: Result<TunnelTestResult, AppError>) -> Self {
+        *self.test_response.lock().unwrap() = Some(response);
+        self
     }
 }
 
@@ -158,6 +175,21 @@ impl TunnelService for MockTunnelService {
 
     async fn tear_down_internal(&self, _id: Uuid, _reason: &str) -> Result<(), AppError> {
         Ok(())
+    }
+
+    async fn test_tunnel(&self, id: Uuid) -> Result<TunnelTestResult, AppError> {
+        if let Some(response) = self.test_response.lock().unwrap().take() {
+            return response;
+        }
+        if !self.tunnels.iter().any(|t| t.id == id) {
+            return Err(AppError::NotFound(format!("tunnel {id} not found")));
+        }
+        Ok(TunnelTestResult {
+            tunnel_id: id,
+            exit_ip: "203.0.113.7".to_owned(),
+            country_code: "DE".to_owned(),
+            latency_ms: 42,
+        })
     }
 
     async fn delete_tunnel(&self, id: Uuid) -> Result<DeleteTunnelResponse, AppError> {
@@ -248,6 +280,10 @@ fn tunnel_router(state: AppState) -> Router {
         .route(
             "/api/tunnels/{id}/devices",
             get(crate::api::tunnels::list_tunnel_devices),
+        )
+        .route(
+            "/api/tunnels/{id}/test",
+            axum::routing::post(crate::api::tunnels::test_tunnel),
         )
         .with_state(state)
 }
@@ -674,6 +710,118 @@ async fn list_tunnel_devices_unauthorized_without_session() {
         .oneshot(
             Request::builder()
                 .uri("/api/tunnels/00000000-0000-0000-0000-000000000010/devices")
+                .extension(connect_info())
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+}
+
+// ---------------------------------------------------------------------------
+// POST /api/tunnels/:id/test
+// ---------------------------------------------------------------------------
+
+/// Send an authenticated empty-body POST request.
+async fn post_empty(app: Router, uri: &str) -> (StatusCode, serde_json::Value) {
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(uri)
+                .header("Cookie", "wardnet_session=valid-token")
+                .extension(connect_info())
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    let status = resp.status();
+    let body = axum::body::to_bytes(resp.into_body(), 16384).await.unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap_or(serde_json::Value::Null);
+    (status, json)
+}
+
+#[tokio::test]
+async fn test_tunnel_returns_result() {
+    let tunnel = sample_tunnel();
+    let state = build_state(MockTunnelService::with_tunnels(vec![tunnel]));
+    let app = tunnel_router(state);
+
+    let (status, json) = post_empty(
+        app,
+        "/api/tunnels/00000000-0000-0000-0000-000000000010/test",
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(
+        json["result"]["tunnel_id"],
+        "00000000-0000-0000-0000-000000000010"
+    );
+    assert_eq!(json["result"]["exit_ip"], "203.0.113.7");
+    assert_eq!(json["result"]["country_code"], "DE");
+    assert_eq!(json["result"]["latency_ms"], 42);
+}
+
+#[tokio::test]
+async fn test_tunnel_not_found() {
+    let state = build_state(MockTunnelService::empty());
+    let app = tunnel_router(state);
+
+    let (status, json) = post_empty(
+        app,
+        "/api/tunnels/00000000-0000-0000-0000-000000000099/test",
+    )
+    .await;
+    assert_eq!(status, StatusCode::NOT_FOUND);
+    assert_eq!(json["error"], "not found");
+}
+
+#[tokio::test]
+async fn test_tunnel_conflict_when_in_flight() {
+    let state = build_state(MockTunnelService::empty().with_test_response(Err(
+        AppError::Conflict("test already in progress".to_owned()),
+    )));
+    let app = tunnel_router(state);
+
+    let (status, json) = post_empty(
+        app,
+        "/api/tunnels/00000000-0000-0000-0000-000000000010/test",
+    )
+    .await;
+    assert_eq!(status, StatusCode::CONFLICT);
+    assert_eq!(json["error"], "conflict");
+}
+
+#[tokio::test]
+async fn test_tunnel_upstream_unavailable() {
+    let state = build_state(MockTunnelService::empty().with_test_response(Err(
+        AppError::UpstreamUnavailable("probe connect failed".to_owned()),
+    )));
+    let app = tunnel_router(state);
+
+    let (status, json) = post_empty(
+        app,
+        "/api/tunnels/00000000-0000-0000-0000-000000000010/test",
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_GATEWAY);
+    assert_eq!(json["error"], "upstream unavailable");
+}
+
+#[tokio::test]
+async fn test_tunnel_unauthorized_without_session() {
+    let state = build_state(MockTunnelService::empty());
+    let app = tunnel_router(state);
+
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/tunnels/00000000-0000-0000-0000-000000000010/test")
                 .extension(connect_info())
                 .body(Body::empty())
                 .unwrap(),

--- a/source/daemon/crates/wardnetd-api/src/api/tunnels.rs
+++ b/source/daemon/crates/wardnetd-api/src/api/tunnels.rs
@@ -8,10 +8,11 @@ use uuid::Uuid;
 use wardnet_common::api::{
     CreateTunnelRequest, CreateTunnelResponse, DeleteTunnelResponse, ListTunnelsResponse,
     TunnelDetailResponse, TunnelDevicesResponse, TunnelMetricsRange, TunnelMetricsResponse,
+    TunnelTestResponse,
 };
 
 use crate::api::middleware::AdminAuth;
-use crate::api::responses::{AuthErrors, BadRequest, NotFound};
+use crate::api::responses::{AuthErrors, BadRequest, Conflict, NotFound, UpstreamUnavailable};
 use crate::state::AppState;
 use wardnetd_services::error::AppError;
 
@@ -22,6 +23,7 @@ pub fn register(router: OpenApiRouter<AppState>) -> OpenApiRouter<AppState> {
         .routes(routes!(get_tunnel, delete_tunnel))
         .routes(routes!(get_tunnel_metrics))
         .routes(routes!(list_tunnel_devices))
+        .routes(routes!(test_tunnel))
 }
 
 #[utoipa::path(
@@ -193,4 +195,35 @@ pub async fn delete_tunnel(
 ) -> Result<Json<DeleteTunnelResponse>, AppError> {
     let response = state.tunnel_service().delete_tunnel(id).await?;
     Ok(Json(response))
+}
+
+#[utoipa::path(
+    post,
+    path = "/api/tunnels/{id}/test",
+    tag = "tunnels",
+    description = "Run an exit-IP / country probe through this tunnel. The daemon \
+                   brings the tunnel up if needed, waits for a fresh handshake, sends \
+                   one HTTP probe through the tunnel interface, and reports the exit \
+                   IP, ISO-3166 alpha-2 country code, and probe latency. Restores \
+                   the prior up/down state when finished. Admin only.",
+    params(("id" = Uuid, Path, description = "Tunnel ID")),
+    responses(
+        (status = 200, description = "Tunnel test result", body = TunnelTestResponse),
+        AuthErrors,
+        NotFound,
+        Conflict,
+        UpstreamUnavailable,
+    ),
+    security(
+        ("session_cookie" = []),
+        ("bearer_auth" = []),
+    ),
+)]
+pub async fn test_tunnel(
+    State(state): State<AppState>,
+    _auth: AdminAuth,
+    Path(id): Path<Uuid>,
+) -> Result<Json<TunnelTestResponse>, AppError> {
+    let result = state.tunnel_service().test_tunnel(id).await?;
+    Ok(Json(TunnelTestResponse { result }))
 }

--- a/source/daemon/crates/wardnetd-api/src/tests/stubs.rs
+++ b/source/daemon/crates/wardnetd-api/src/tests/stubs.rs
@@ -563,6 +563,12 @@ impl TunnelService for StubTunnelService {
     async fn get_tunnel(&self, _id: Uuid) -> Result<Tunnel, AppError> {
         unimplemented!()
     }
+    async fn test_tunnel(
+        &self,
+        _id: Uuid,
+    ) -> Result<wardnet_common::api::TunnelTestResult, AppError> {
+        unimplemented!()
+    }
     async fn get_metrics(
         &self,
         _id: Uuid,

--- a/source/daemon/crates/wardnetd-mock/src/backends/mock_exit_probe.rs
+++ b/source/daemon/crates/wardnetd-mock/src/backends/mock_exit_probe.rs
@@ -1,0 +1,86 @@
+//! Deterministic [`TunnelExitProbe`] implementation for the mock server.
+//!
+//! Looks up the tunnel by interface name in the in-memory tunnel repo
+//! and returns a synthetic exit IP plus the tunnel's stored country
+//! code, so a developer running `make run-dev` can exercise the
+//! tunnel-test flow without any real network egress.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use async_trait::async_trait;
+
+use wardnetd_data::repository::TunnelRepository;
+use wardnetd_services::tunnel::exit_probe::{ExitInfo, ProbeError, TunnelExitProbe};
+
+/// Synthetic-IP / country probe for the mock daemon.
+pub struct MockExitProbe {
+    tunnels: Arc<dyn TunnelRepository>,
+}
+
+impl MockExitProbe {
+    #[must_use]
+    pub fn new(tunnels: Arc<dyn TunnelRepository>) -> Self {
+        Self { tunnels }
+    }
+}
+
+#[async_trait]
+impl TunnelExitProbe for MockExitProbe {
+    async fn probe(&self, interface: &str) -> Result<ExitInfo, ProbeError> {
+        // 75 ms to mimic a real DC handshake + probe round trip without
+        // making `make run-dev` feel sluggish.
+        tokio::time::sleep(Duration::from_millis(75)).await;
+
+        let tunnels = self
+            .tunnels
+            .find_all()
+            .await
+            .map_err(|e| ProbeError::Connect(format!("mock probe repo lookup failed: {e}")))?;
+        let tunnel = tunnels
+            .into_iter()
+            .find(|t| t.interface_name == interface)
+            .ok_or_else(|| {
+                ProbeError::Connect(format!(
+                    "mock probe: no tunnel registered for interface '{interface}'"
+                ))
+            })?;
+
+        Ok(ExitInfo {
+            ip: synthetic_ip(&tunnel.id),
+            country_code: tunnel.country_code,
+        })
+    }
+}
+
+/// Map a tunnel id to a stable address inside the TEST-NET-2 documentation
+/// range (`198.51.100.0/24`). The `198.51.100.<n>` last octet stays in
+/// `1..=254` so it never collides with `.0` (network) or `.255`
+/// (broadcast).
+fn synthetic_ip(tunnel_id: &uuid::Uuid) -> String {
+    let bytes = tunnel_id.as_bytes();
+    let last_octet = (u32::from(bytes[15]) % 254) + 1;
+    format!("198.51.100.{last_octet}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn synthetic_ip_is_in_test_net_2_range() {
+        for _ in 0..32 {
+            let id = uuid::Uuid::new_v4();
+            let ip = synthetic_ip(&id);
+            assert!(ip.starts_with("198.51.100."));
+            let last: u32 = ip.rsplit('.').next().unwrap().parse().unwrap();
+            assert!((1..=254).contains(&last));
+        }
+    }
+
+    #[test]
+    fn synthetic_ip_is_deterministic_per_id() {
+        let id = uuid::Uuid::new_v4();
+        assert_eq!(synthetic_ip(&id), synthetic_ip(&id));
+    }
+}

--- a/source/daemon/crates/wardnetd-mock/src/backends/mod.rs
+++ b/source/daemon/crates/wardnetd-mock/src/backends/mod.rs
@@ -8,10 +8,10 @@
 //! Filenames are intentionally prefixed `noop_` to match the workspace
 //! coverage-ignore regex (see top-level `Makefile`).
 
-pub mod mock_exit_probe;
 pub mod noop_device;
 pub mod noop_dhcp;
 pub mod noop_dns;
+pub mod noop_exit_probe;
 pub mod noop_network_inspector;
 pub mod noop_network_probe;
 pub mod noop_power_ops;

--- a/source/daemon/crates/wardnetd-mock/src/backends/mod.rs
+++ b/source/daemon/crates/wardnetd-mock/src/backends/mod.rs
@@ -8,6 +8,7 @@
 //! Filenames are intentionally prefixed `noop_` to match the workspace
 //! coverage-ignore regex (see top-level `Makefile`).
 
+pub mod mock_exit_probe;
 pub mod noop_device;
 pub mod noop_dhcp;
 pub mod noop_dns;

--- a/source/daemon/crates/wardnetd-mock/src/backends/noop_exit_probe.rs
+++ b/source/daemon/crates/wardnetd-mock/src/backends/noop_exit_probe.rs
@@ -14,11 +14,11 @@ use wardnetd_data::repository::TunnelRepository;
 use wardnetd_services::tunnel::exit_probe::{ExitInfo, ProbeError, TunnelExitProbe};
 
 /// Synthetic-IP / country probe for the mock daemon.
-pub struct MockExitProbe {
+pub struct NoopExitProbe {
     tunnels: Arc<dyn TunnelRepository>,
 }
 
-impl MockExitProbe {
+impl NoopExitProbe {
     #[must_use]
     pub fn new(tunnels: Arc<dyn TunnelRepository>) -> Self {
         Self { tunnels }
@@ -26,7 +26,7 @@ impl MockExitProbe {
 }
 
 #[async_trait]
-impl TunnelExitProbe for MockExitProbe {
+impl TunnelExitProbe for NoopExitProbe {
     async fn probe(&self, interface: &str) -> Result<ExitInfo, ProbeError> {
         // 75 ms to mimic a real DC handshake + probe round trip without
         // making `make run-dev` feel sluggish.

--- a/source/daemon/crates/wardnetd-mock/src/backends/noop_tunnel.rs
+++ b/source/daemon/crates/wardnetd-mock/src/backends/noop_tunnel.rs
@@ -51,10 +51,14 @@ impl TunnelInterface for NoopTunnelInterface {
             interface = interface_name,
             "mock tunnel get_stats: interface={interface_name}",
         );
+        // Return `Some(now)` for `last_handshake` so the tunnel-test
+        // flow's handshake-readiness gate clears immediately under the
+        // mock daemon — there is no real kernel to confirm the
+        // handshake, so we simulate the success path.
         Ok(Some(TunnelStats {
             bytes_tx: 0,
             bytes_rx: 0,
-            last_handshake: None,
+            last_handshake: Some(chrono::Utc::now()),
         }))
     }
 

--- a/source/daemon/crates/wardnetd-mock/src/main.rs
+++ b/source/daemon/crates/wardnetd-mock/src/main.rs
@@ -20,10 +20,10 @@ use tracing_subscriber::util::SubscriberInitExt;
 use wardnet_common::config::ApplicationConfiguration;
 use wardnetd_api::state::AppState;
 use wardnetd_data::create_repository_factory;
-use wardnetd_mock::backends::mock_exit_probe::MockExitProbe;
 use wardnetd_mock::backends::noop_device::{NoopHostnameResolver, NoopPacketCapture};
 use wardnetd_mock::backends::noop_dhcp::NoopDhcpServer;
 use wardnetd_mock::backends::noop_dns::NoopDnsServer;
+use wardnetd_mock::backends::noop_exit_probe::NoopExitProbe;
 use wardnetd_mock::backends::noop_network_inspector::NoopNetworkInspector;
 use wardnetd_mock::backends::noop_network_probe::NoopNetworkProbe;
 use wardnetd_mock::backends::noop_power_ops::NoopSystemPowerOps;
@@ -220,7 +220,7 @@ async fn run(
 
     let backends = Backends {
         tunnel_interface: Arc::new(NoopTunnelInterface),
-        tunnel_exit_probe: Arc::new(MockExitProbe::new(factory.tunnel())),
+        tunnel_exit_probe: Arc::new(NoopExitProbe::new(factory.tunnel())),
         policy_router: Arc::new(NoopPolicyRouter),
         firewall: Arc::new(NoopFirewallManager),
         packet_capture: Arc::new(NoopPacketCapture),

--- a/source/daemon/crates/wardnetd-mock/src/main.rs
+++ b/source/daemon/crates/wardnetd-mock/src/main.rs
@@ -20,6 +20,7 @@ use tracing_subscriber::util::SubscriberInitExt;
 use wardnet_common::config::ApplicationConfiguration;
 use wardnetd_api::state::AppState;
 use wardnetd_data::create_repository_factory;
+use wardnetd_mock::backends::mock_exit_probe::MockExitProbe;
 use wardnetd_mock::backends::noop_device::{NoopHostnameResolver, NoopPacketCapture};
 use wardnetd_mock::backends::noop_dhcp::NoopDhcpServer;
 use wardnetd_mock::backends::noop_dns::NoopDnsServer;
@@ -219,6 +220,7 @@ async fn run(
 
     let backends = Backends {
         tunnel_interface: Arc::new(NoopTunnelInterface),
+        tunnel_exit_probe: Arc::new(MockExitProbe::new(factory.tunnel())),
         policy_router: Arc::new(NoopPolicyRouter),
         firewall: Arc::new(NoopFirewallManager),
         packet_capture: Arc::new(NoopPacketCapture),

--- a/source/daemon/crates/wardnetd-services/src/lib.rs
+++ b/source/daemon/crates/wardnetd-services/src/lib.rs
@@ -69,6 +69,11 @@ pub use crate::vpn::VpnProviderService;
 /// the mock server passes no-op stubs.
 pub struct Backends {
     pub tunnel_interface: Arc<dyn tunnel::TunnelInterface>,
+    /// Sends a single HTTP probe through a tunnel interface to learn the
+    /// public IP and country at the tunnel exit. Wired to a real reqwest
+    /// implementation in production and to a deterministic mock in
+    /// `wardnetd-mock`.
+    pub tunnel_exit_probe: Arc<dyn tunnel::TunnelExitProbe>,
     pub policy_router: Arc<dyn routing::PolicyRouter>,
     pub firewall: Arc<dyn routing::FirewallManager>,
     pub packet_capture: Arc<dyn device::PacketCapture>,
@@ -327,6 +332,7 @@ fn create_services(
         tunnel_metrics_repo.clone(),
         device_repo.clone(),
         backends.tunnel_interface.clone(),
+        backends.tunnel_exit_probe.clone(),
         backends.secret_store.clone(),
         event_publisher.clone(),
         config.tunnel.metrics_sample_interval_secs,

--- a/source/daemon/crates/wardnetd-services/src/routing/tests/routing.rs
+++ b/source/daemon/crates/wardnetd-services/src/routing/tests/routing.rs
@@ -267,6 +267,13 @@ impl TunnelService for MockTunnelService {
             .ok_or_else(|| AppError::NotFound("tunnel not found".to_owned()))
     }
 
+    async fn test_tunnel(
+        &self,
+        _id: Uuid,
+    ) -> Result<wardnet_common::api::TunnelTestResult, AppError> {
+        unimplemented!("not used in routing tests")
+    }
+
     async fn get_metrics(
         &self,
         _id: Uuid,

--- a/source/daemon/crates/wardnetd-services/src/tests/init.rs
+++ b/source/daemon/crates/wardnetd-services/src/tests/init.rs
@@ -23,6 +23,7 @@ use crate::logging::{ErrorNotifierService, LogService, LogServiceImpl, LogStream
 use crate::routing::firewall::FirewallManager;
 use crate::routing::policy_router::PolicyRouter;
 use crate::system::SystemPowerOps;
+use crate::tunnel::exit_probe::{ExitInfo, ProbeError, TunnelExitProbe};
 use crate::tunnel::interface::{CreateTunnelParams, TunnelInterface, TunnelStats};
 use crate::{init_services, init_services_with_factory};
 use wardnet_common::config::AdminConfig;
@@ -51,6 +52,16 @@ impl TunnelInterface for StubTunnelInterface {
     }
     async fn list(&self) -> anyhow::Result<Vec<String>> {
         unimplemented!()
+    }
+}
+
+struct StubTunnelExitProbe;
+#[async_trait]
+impl TunnelExitProbe for StubTunnelExitProbe {
+    async fn probe(&self, _interface: &str) -> Result<ExitInfo, ProbeError> {
+        Err(ProbeError::Unsupported(
+            "stub probe in init test".to_owned(),
+        ))
     }
 }
 
@@ -183,6 +194,7 @@ impl SecretStore for StubSecretStore {
 fn stub_backends() -> Backends {
     Backends {
         tunnel_interface: Arc::new(StubTunnelInterface),
+        tunnel_exit_probe: Arc::new(StubTunnelExitProbe),
         policy_router: Arc::new(StubPolicyRouter),
         firewall: Arc::new(StubFirewall),
         packet_capture: Arc::new(StubPacketCapture),

--- a/source/daemon/crates/wardnetd-services/src/tunnel/exit_probe.rs
+++ b/source/daemon/crates/wardnetd-services/src/tunnel/exit_probe.rs
@@ -1,0 +1,42 @@
+use async_trait::async_trait;
+
+/// Result of probing the public side of a tunnel.
+#[derive(Debug, Clone)]
+pub struct ExitInfo {
+    /// Public IP observed at the tunnel exit.
+    pub ip: String,
+    /// ISO-3166 alpha-2 country code reported by the probe service.
+    pub country_code: String,
+}
+
+/// Failure modes for [`TunnelExitProbe::probe`].
+#[derive(Debug, thiserror::Error)]
+pub enum ProbeError {
+    /// The probe could not establish a connection through the tunnel
+    /// interface (DNS, TCP, TLS, or routing failure).
+    #[error("probe could not connect: {0}")]
+    Connect(String),
+
+    /// The probe completed but the response could not be parsed into an
+    /// [`ExitInfo`].
+    #[error("probe response could not be parsed: {0}")]
+    Parse(String),
+
+    /// The probe exceeded its allotted time budget.
+    #[error("probe timed out after {0} ms")]
+    Timeout(u64),
+
+    /// The probe is not implemented for this build/platform.
+    #[error("probe unsupported on this platform: {0}")]
+    Unsupported(String),
+}
+
+/// Sends a single HTTP probe through a specific network interface to learn
+/// the public IP and country at the tunnel's exit.
+///
+/// Implementations must bind the outbound socket to the interface so the
+/// probe traverses the tunnel and not the default route.
+#[async_trait]
+pub trait TunnelExitProbe: Send + Sync {
+    async fn probe(&self, interface: &str) -> Result<ExitInfo, ProbeError>;
+}

--- a/source/daemon/crates/wardnetd-services/src/tunnel/mod.rs
+++ b/source/daemon/crates/wardnetd-services/src/tunnel/mod.rs
@@ -1,8 +1,10 @@
+pub mod exit_probe;
 pub mod interface;
 pub mod key_store;
 pub mod metrics_runner;
 pub mod service;
 
+pub use exit_probe::{ExitInfo, ProbeError, TunnelExitProbe};
 pub use interface::{CreateTunnelParams, TunnelConfig, TunnelInterface, TunnelStats};
 pub use key_store::{KeyStore, KeyStoreAdapter};
 pub use metrics_runner::{DEFAULT_ROLLUP_INTERVAL, TunnelMetricsRunner};

--- a/source/daemon/crates/wardnetd-services/src/tunnel/service.rs
+++ b/source/daemon/crates/wardnetd-services/src/tunnel/service.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
 use async_trait::async_trait;
@@ -9,6 +9,7 @@ use uuid::Uuid;
 use wardnet_common::api::{
     CreateTunnelRequest, CreateTunnelResponse, DeleteTunnelResponse, ListTunnelsResponse,
     TunnelDevicesResponse, TunnelMetricsPoint, TunnelMetricsRange, TunnelMetricsResponse,
+    TunnelTestResult,
 };
 use wardnet_common::event::WardnetEvent;
 use wardnet_common::tunnel::{Tunnel, TunnelStatus};
@@ -17,6 +18,7 @@ use wardnet_common::wireguard_config;
 use crate::auth_context;
 use crate::error::AppError;
 use crate::event::EventPublisher;
+use crate::tunnel::exit_probe::{ProbeError, TunnelExitProbe};
 use crate::tunnel::interface::{
     CreateTunnelParams, TunnelConfig as TiTunnelConfig, TunnelInterface,
 };
@@ -56,6 +58,18 @@ pub trait TunnelService: Send + Sync {
 
     /// Get a single tunnel by ID.
     async fn get_tunnel(&self, id: Uuid) -> Result<Tunnel, AppError>;
+
+    /// Run an exit-IP/country probe through the tunnel.
+    ///
+    /// Brings the tunnel up if it was `Down`, waits for a fresh
+    /// handshake, sends a single HTTP probe through the tunnel
+    /// interface, then restores the prior up/down state. Returns the
+    /// observed exit IP, ISO-3166 alpha-2 country code, and probe
+    /// latency.
+    ///
+    /// Returns `AppError::Conflict` if a test is already in flight for
+    /// the same tunnel id.
+    async fn test_tunnel(&self, id: Uuid) -> Result<TunnelTestResult, AppError>;
 
     /// Get throughput history for a tunnel over the requested range.
     ///
@@ -123,12 +137,18 @@ pub struct TunnelServiceImpl {
     metrics: Arc<dyn TunnelMetricsRepository>,
     devices: Arc<dyn wardnetd_data::repository::DeviceRepository>,
     tunnel_interface: Arc<dyn TunnelInterface>,
+    exit_probe: Arc<dyn TunnelExitProbe>,
     keys: Arc<dyn KeyStore>,
     events: Arc<dyn EventPublisher>,
     /// In-memory tracking of the last counter snapshot and write
     /// time per tunnel. Used to decimate the 5-second poll into one
     /// `tunnel_metrics_intraday` row per `metrics_sample_interval_secs`.
     last_intraday_sample: Mutex<HashMap<Uuid, LastSample>>,
+    /// Tunnel ids with a `test_tunnel` call in progress. Each id is
+    /// inserted on entry and removed via the [`InFlightGuard`] RAII
+    /// guard. Concurrent calls for the same id return
+    /// `AppError::Conflict`.
+    tests_in_flight: Arc<std::sync::Mutex<HashSet<Uuid>>>,
     metrics_sample_interval_secs: u64,
 }
 
@@ -139,11 +159,13 @@ impl TunnelServiceImpl {
     /// built internally — callers outside this crate only need to hand
     /// in a secret store; the key-store facade never escapes the tunnel
     /// module.
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         tunnels: Arc<dyn TunnelRepository>,
         metrics: Arc<dyn TunnelMetricsRepository>,
         devices: Arc<dyn wardnetd_data::repository::DeviceRepository>,
         tunnel_interface: Arc<dyn TunnelInterface>,
+        exit_probe: Arc<dyn TunnelExitProbe>,
         secret_store: Arc<dyn SecretStore>,
         events: Arc<dyn EventPublisher>,
         metrics_sample_interval_secs: u64,
@@ -154,9 +176,11 @@ impl TunnelServiceImpl {
             metrics,
             devices,
             tunnel_interface,
+            exit_probe,
             keys,
             events,
             last_intraday_sample: Mutex::new(HashMap::new()),
+            tests_in_flight: Arc::new(std::sync::Mutex::new(HashSet::new())),
             metrics_sample_interval_secs,
         }
     }
@@ -167,11 +191,13 @@ impl TunnelServiceImpl {
     /// depend on the narrower interface — production code must go
     /// through [`Self::new`] with a [`SecretStore`].
     #[cfg(test)]
+    #[allow(clippy::too_many_arguments)]
     pub(crate) fn with_key_store(
         tunnels: Arc<dyn TunnelRepository>,
         metrics: Arc<dyn TunnelMetricsRepository>,
         devices: Arc<dyn wardnetd_data::repository::DeviceRepository>,
         tunnel_interface: Arc<dyn TunnelInterface>,
+        exit_probe: Arc<dyn TunnelExitProbe>,
         keys: Arc<dyn KeyStore>,
         events: Arc<dyn EventPublisher>,
         metrics_sample_interval_secs: u64,
@@ -181,9 +207,11 @@ impl TunnelServiceImpl {
             metrics,
             devices,
             tunnel_interface,
+            exit_probe,
             keys,
             events,
             last_intraday_sample: Mutex::new(HashMap::new()),
+            tests_in_flight: Arc::new(std::sync::Mutex::new(HashSet::new())),
             metrics_sample_interval_secs,
         }
     }
@@ -513,6 +541,102 @@ impl TunnelServiceImpl {
         );
     }
 
+    /// Try to claim the in-flight slot for this tunnel id. Returns
+    /// `None` and sets up `AppError::Conflict` for the caller when a
+    /// test is already in flight.
+    fn acquire_in_flight(&self, id: Uuid) -> Result<InFlightGuard, AppError> {
+        let mut guard = self
+            .tests_in_flight
+            .lock()
+            .map_err(|_| AppError::Internal(anyhow::anyhow!("tests_in_flight mutex poisoned")))?;
+        if !guard.insert(id) {
+            return Err(AppError::Conflict(format!(
+                "test already in progress for tunnel {id}"
+            )));
+        }
+        Ok(InFlightGuard {
+            set: self.tests_in_flight.clone(),
+            id,
+        })
+    }
+
+    /// Wait for a fresh handshake, then send a single exit probe.
+    ///
+    /// Returns the [`crate::tunnel::ExitInfo`] together with the
+    /// measured probe latency in milliseconds. Errors map to
+    /// [`AppError::UpstreamUnavailable`] for handshake/probe failures
+    /// (the user can retry) and [`AppError::Internal`] for unexpected
+    /// failures.
+    async fn run_test_probe(
+        &self,
+        interface_name: &str,
+    ) -> Result<(crate::tunnel::ExitInfo, u64), AppError> {
+        self.await_fresh_handshake(interface_name, std::time::Duration::from_millis(3500))
+            .await?;
+
+        let started = std::time::Instant::now();
+        let info = self
+            .exit_probe
+            .probe(interface_name)
+            .await
+            .map_err(|e| match e {
+                ProbeError::Timeout(ms) => {
+                    AppError::UpstreamUnavailable(format!("probe timed out after {ms} ms"))
+                }
+                ProbeError::Connect(msg) => {
+                    AppError::UpstreamUnavailable(format!("probe connect failed: {msg}"))
+                }
+                ProbeError::Parse(msg) => {
+                    AppError::UpstreamUnavailable(format!("probe parse failed: {msg}"))
+                }
+                ProbeError::Unsupported(msg) => {
+                    AppError::Internal(anyhow::anyhow!("probe unsupported: {msg}"))
+                }
+            })?;
+        let latency_ms = u64::try_from(started.elapsed().as_millis()).unwrap_or(u64::MAX);
+        Ok((info, latency_ms))
+    }
+
+    /// Block until the tunnel reports a recent handshake or `budget`
+    /// elapses. Polls `tunnel_interface.get_stats` every 100 ms and
+    /// considers a handshake "fresh" when its timestamp is within the
+    /// last 5 seconds — long enough to forgive small clock drift but
+    /// short enough that a stale value from a previous session won't
+    /// pass.
+    async fn await_fresh_handshake(
+        &self,
+        interface_name: &str,
+        budget: std::time::Duration,
+    ) -> Result<(), AppError> {
+        let deadline = tokio::time::Instant::now() + budget;
+        let freshness = chrono::Duration::seconds(5);
+        loop {
+            match self.tunnel_interface.get_stats(interface_name).await {
+                Ok(Some(stats)) => {
+                    if let Some(ts) = stats.last_handshake
+                        && (chrono::Utc::now() - ts) <= freshness
+                    {
+                        return Ok(());
+                    }
+                }
+                Ok(None) => {}
+                Err(e) => {
+                    return Err(AppError::Internal(anyhow::anyhow!(
+                        "failed to read tunnel stats while waiting for handshake: {e}"
+                    )));
+                }
+            }
+
+            if tokio::time::Instant::now() >= deadline {
+                return Err(AppError::UpstreamUnavailable(format!(
+                    "tunnel handshake did not complete within {} ms",
+                    budget.as_millis(),
+                )));
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+        }
+    }
+
     /// Core logic for tearing down a tunnel (no auth check).
     async fn tear_down_core(&self, id: Uuid, reason: &str) -> Result<(), AppError> {
         let tunnel = self.require_tunnel(id).await?;
@@ -547,6 +671,23 @@ impl TunnelServiceImpl {
         });
 
         Ok(())
+    }
+}
+
+/// RAII guard that releases the tunnel id from `tests_in_flight` when
+/// dropped. Constructed by [`TunnelServiceImpl::acquire_in_flight`]
+/// only when the slot was successfully claimed, so `Drop` can always
+/// remove unconditionally.
+struct InFlightGuard {
+    set: Arc<std::sync::Mutex<HashSet<Uuid>>>,
+    id: Uuid,
+}
+
+impl Drop for InFlightGuard {
+    fn drop(&mut self) {
+        if let Ok(mut guard) = self.set.lock() {
+            guard.remove(&self.id);
+        }
     }
 }
 
@@ -646,6 +787,50 @@ impl TunnelService for TunnelServiceImpl {
         auth_context::require_admin()?;
 
         self.require_tunnel(id).await
+    }
+
+    async fn test_tunnel(&self, id: Uuid) -> Result<TunnelTestResult, AppError> {
+        auth_context::require_admin()?;
+
+        // Claim the in-flight slot before any state changes so a
+        // double-click is rejected with 409 instead of starting a
+        // second concurrent bring-up.
+        let _guard = self.acquire_in_flight(id)?;
+
+        let tunnel = self.require_tunnel(id).await?;
+        let was_up_before = matches!(
+            tunnel.status,
+            TunnelStatus::Up | TunnelStatus::Connecting | TunnelStatus::Reconnecting,
+        );
+        let interface_name = tunnel.interface_name.clone();
+
+        // Bring the tunnel up if needed. `bring_up_core` is idempotent
+        // for the non-`Down` cases.
+        if !was_up_before {
+            self.bring_up_core(id).await?;
+        }
+
+        // Drive the probe to completion, capturing the result so we
+        // always tear down before returning when we brought the tunnel
+        // up ourselves.
+        let probe_outcome = self.run_test_probe(&interface_name).await;
+
+        if !was_up_before && let Err(e) = self.tear_down_core(id, "test completed").await {
+            tracing::warn!(
+                tunnel_id = %id,
+                error = %e,
+                "tunnel test: failed to tear down tunnel after probe; leaving best-effort"
+            );
+        }
+
+        let (exit_info, latency_ms) = probe_outcome?;
+
+        Ok(TunnelTestResult {
+            tunnel_id: id,
+            exit_ip: exit_info.ip,
+            country_code: exit_info.country_code,
+            latency_ms,
+        })
     }
 
     async fn list_tunnel_devices(&self, id: Uuid) -> Result<TunnelDevicesResponse, AppError> {

--- a/source/daemon/crates/wardnetd-services/src/tunnel/tests/metrics_runner.rs
+++ b/source/daemon/crates/wardnetd-services/src/tunnel/tests/metrics_runner.rs
@@ -13,7 +13,7 @@ use async_trait::async_trait;
 use uuid::Uuid;
 use wardnet_common::api::{
     CreateTunnelRequest, CreateTunnelResponse, DeleteTunnelResponse, ListTunnelsResponse,
-    TunnelDevicesResponse, TunnelMetricsRange, TunnelMetricsResponse,
+    TunnelDevicesResponse, TunnelMetricsRange, TunnelMetricsResponse, TunnelTestResult,
 };
 use wardnet_common::tunnel::Tunnel;
 
@@ -47,6 +47,9 @@ impl TunnelService for CountingTunnelService {
         unimplemented!()
     }
     async fn get_tunnel(&self, _id: Uuid) -> Result<Tunnel, AppError> {
+        unimplemented!()
+    }
+    async fn test_tunnel(&self, _id: Uuid) -> Result<TunnelTestResult, AppError> {
         unimplemented!()
     }
     async fn get_metrics(
@@ -148,6 +151,9 @@ async fn runner_swallows_maintenance_errors() {
             unimplemented!()
         }
         async fn get_tunnel(&self, _id: Uuid) -> Result<Tunnel, AppError> {
+            unimplemented!()
+        }
+        async fn test_tunnel(&self, _id: Uuid) -> Result<TunnelTestResult, AppError> {
             unimplemented!()
         }
         async fn get_metrics(

--- a/source/daemon/crates/wardnetd-services/src/tunnel/tests/tunnel.rs
+++ b/source/daemon/crates/wardnetd-services/src/tunnel/tests/tunnel.rs
@@ -2242,3 +2242,66 @@ async fn test_tunnel_probe_connect_error_maps_to_upstream_unavailable() {
     let result = auth_context::with_context(admin_ctx(), h.svc.test_tunnel(id)).await;
     assert!(matches!(result, Err(AppError::UpstreamUnavailable(_))));
 }
+
+#[tokio::test]
+async fn test_tunnel_probe_timeout_maps_to_upstream_unavailable() {
+    let h = build_harness();
+    let id = imported_tunnel_id(&h).await;
+    h.exit_probe.set_err(ProbeError::Timeout(1500));
+    h.tunnel_iface.set_stats(TunnelStats {
+        bytes_tx: 0,
+        bytes_rx: 0,
+        last_handshake: Some(chrono::Utc::now()),
+    });
+
+    let result = auth_context::with_context(admin_ctx(), h.svc.test_tunnel(id)).await;
+    assert!(matches!(result, Err(AppError::UpstreamUnavailable(_))));
+}
+
+#[tokio::test]
+async fn test_tunnel_probe_parse_error_maps_to_upstream_unavailable() {
+    let h = build_harness();
+    let id = imported_tunnel_id(&h).await;
+    h.exit_probe
+        .set_err(ProbeError::Parse("missing ip= field".to_owned()));
+    h.tunnel_iface.set_stats(TunnelStats {
+        bytes_tx: 0,
+        bytes_rx: 0,
+        last_handshake: Some(chrono::Utc::now()),
+    });
+
+    let result = auth_context::with_context(admin_ctx(), h.svc.test_tunnel(id)).await;
+    assert!(matches!(result, Err(AppError::UpstreamUnavailable(_))));
+}
+
+#[tokio::test]
+async fn test_tunnel_probe_unsupported_maps_to_internal() {
+    let h = build_harness();
+    let id = imported_tunnel_id(&h).await;
+    h.exit_probe
+        .set_err(ProbeError::Unsupported("not on linux".to_owned()));
+    h.tunnel_iface.set_stats(TunnelStats {
+        bytes_tx: 0,
+        bytes_rx: 0,
+        last_handshake: Some(chrono::Utc::now()),
+    });
+
+    let result = auth_context::with_context(admin_ctx(), h.svc.test_tunnel(id)).await;
+    assert!(matches!(result, Err(AppError::Internal(_))));
+}
+
+#[tokio::test]
+async fn test_tunnel_get_stats_error_maps_to_internal() {
+    let h = build_harness();
+    let id = imported_tunnel_id(&h).await;
+    // `set_stats_error` makes `get_stats` return `Err`, which the
+    // handshake-readiness loop must surface as `Internal` rather than
+    // looping forever or falling through as a timeout.
+    h.tunnel_iface.set_stats_error();
+
+    let result = auth_context::with_context(admin_ctx(), h.svc.test_tunnel(id)).await;
+    assert!(
+        matches!(result, Err(AppError::Internal(_))),
+        "expected Internal on stats Err, got {result:?}"
+    );
+}

--- a/source/daemon/crates/wardnetd-services/src/tunnel/tests/tunnel.rs
+++ b/source/daemon/crates/wardnetd-services/src/tunnel/tests/tunnel.rs
@@ -16,6 +16,7 @@ use wardnet_common::routing::RoutingRule;
 use crate::auth_context;
 use crate::error::AppError;
 use crate::event::EventPublisher;
+use crate::tunnel::exit_probe::{ExitInfo, ProbeError, TunnelExitProbe};
 use crate::tunnel::interface::{CreateTunnelParams, TunnelInterface, TunnelStats};
 use crate::tunnel::key_store::KeyStore;
 use crate::{TunnelService, TunnelServiceImpl};
@@ -410,6 +411,71 @@ impl TunnelInterface for MockTunnelInterface {
     }
 }
 
+// -- Mock TunnelExitProbe -------------------------------------------------
+
+enum ProbeBehavior {
+    Ok(ExitInfo),
+    Err(ProbeError),
+}
+
+struct MockTunnelExitProbe {
+    behavior: Mutex<ProbeBehavior>,
+    calls: Mutex<Vec<String>>,
+    delay_ms: std::sync::atomic::AtomicU64,
+}
+
+impl MockTunnelExitProbe {
+    fn new() -> Self {
+        Self {
+            behavior: Mutex::new(ProbeBehavior::Ok(ExitInfo {
+                ip: "198.51.100.7".to_owned(),
+                country_code: "SE".to_owned(),
+            })),
+            calls: Mutex::new(Vec::new()),
+            delay_ms: std::sync::atomic::AtomicU64::new(0),
+        }
+    }
+
+    fn set_ok(&self, ip: &str, country_code: &str) {
+        *self.behavior.lock().unwrap() = ProbeBehavior::Ok(ExitInfo {
+            ip: ip.to_owned(),
+            country_code: country_code.to_owned(),
+        });
+    }
+
+    fn set_err(&self, err: ProbeError) {
+        *self.behavior.lock().unwrap() = ProbeBehavior::Err(err);
+    }
+
+    fn set_delay(&self, ms: u64) {
+        self.delay_ms.store(ms, std::sync::atomic::Ordering::SeqCst);
+    }
+
+    fn call_count(&self) -> usize {
+        self.calls.lock().unwrap().len()
+    }
+}
+
+#[async_trait]
+impl TunnelExitProbe for MockTunnelExitProbe {
+    async fn probe(&self, interface: &str) -> Result<ExitInfo, ProbeError> {
+        self.calls.lock().unwrap().push(interface.to_owned());
+        let delay_ms = self.delay_ms.load(std::sync::atomic::Ordering::SeqCst);
+        if delay_ms > 0 {
+            tokio::time::sleep(std::time::Duration::from_millis(delay_ms)).await;
+        }
+        match &*self.behavior.lock().unwrap() {
+            ProbeBehavior::Ok(info) => Ok(info.clone()),
+            ProbeBehavior::Err(ProbeError::Connect(m)) => Err(ProbeError::Connect(m.clone())),
+            ProbeBehavior::Err(ProbeError::Parse(m)) => Err(ProbeError::Parse(m.clone())),
+            ProbeBehavior::Err(ProbeError::Timeout(ms)) => Err(ProbeError::Timeout(*ms)),
+            ProbeBehavior::Err(ProbeError::Unsupported(m)) => {
+                Err(ProbeError::Unsupported(m.clone()))
+            }
+        }
+    }
+}
+
 // -- Mock EventPublisher --------------------------------------------------
 
 /// Records published events for assertion.
@@ -594,6 +660,7 @@ struct TestHarness {
     events: Arc<MockEventPublisher>,
     keys: Arc<MockKeyStore>,
     metrics: Arc<MockMetricsRepo>,
+    exit_probe: Arc<MockTunnelExitProbe>,
 }
 
 fn build_harness() -> TestHarness {
@@ -604,12 +671,14 @@ fn build_harness() -> TestHarness {
     let tunnel_iface = Arc::new(MockTunnelInterface::new());
     let keys = Arc::new(MockKeyStore::new());
     let events = Arc::new(MockEventPublisher::new());
+    let exit_probe = Arc::new(MockTunnelExitProbe::new());
 
     let svc = TunnelServiceImpl::with_key_store(
         repo.clone(),
         metrics_dyn,
         device_repo,
         tunnel_iface.clone(),
+        exit_probe.clone(),
         keys.clone(),
         events.clone(),
         300,
@@ -622,6 +691,7 @@ fn build_harness() -> TestHarness {
         events,
         keys,
         metrics,
+        exit_probe,
     }
 }
 
@@ -632,12 +702,14 @@ fn build_harness_with_device_repo(device_repo: Arc<dyn DeviceRepository>) -> Tes
     let tunnel_iface = Arc::new(MockTunnelInterface::new());
     let keys = Arc::new(MockKeyStore::new());
     let events = Arc::new(MockEventPublisher::new());
+    let exit_probe = Arc::new(MockTunnelExitProbe::new());
 
     let svc = TunnelServiceImpl::with_key_store(
         repo.clone(),
         metrics_dyn,
         device_repo,
         tunnel_iface.clone(),
+        exit_probe.clone(),
         keys.clone(),
         events.clone(),
         300,
@@ -650,6 +722,7 @@ fn build_harness_with_device_repo(device_repo: Arc<dyn DeviceRepository>) -> Tes
         events,
         keys,
         metrics,
+        exit_probe,
     }
 }
 
@@ -2006,4 +2079,166 @@ async fn run_metrics_maintenance_is_noop_with_empty_repo() {
     // relying on real data.
     let h = build_harness();
     h.svc.run_metrics_maintenance().await.unwrap();
+}
+
+// -- test_tunnel ----------------------------------------------------------
+
+/// Helper: import a tunnel and return its id.
+async fn imported_tunnel_id(h: &TestHarness) -> Uuid {
+    let resp = auth_context::with_context(admin_ctx(), h.svc.import_tunnel(sample_request()))
+        .await
+        .unwrap();
+    resp.tunnel.id
+}
+
+#[tokio::test]
+async fn test_tunnel_returns_result() {
+    let h = build_harness();
+    let id = imported_tunnel_id(&h).await;
+    h.exit_probe.set_ok("203.0.113.7", "DE");
+    // `bring_up_internal` flips status to `connecting`; for the test we
+    // need `get_stats` to report a fresh handshake so the readiness gate
+    // clears immediately.
+    h.tunnel_iface.set_stats(TunnelStats {
+        bytes_tx: 0,
+        bytes_rx: 0,
+        last_handshake: Some(chrono::Utc::now()),
+    });
+
+    let result = auth_context::with_context(admin_ctx(), h.svc.test_tunnel(id))
+        .await
+        .expect("test_tunnel should succeed");
+    assert_eq!(result.tunnel_id, id);
+    assert_eq!(result.exit_ip, "203.0.113.7");
+    assert_eq!(result.country_code, "DE");
+    assert_eq!(h.exit_probe.call_count(), 1);
+}
+
+#[tokio::test]
+async fn test_tunnel_tears_down_when_was_down() {
+    let h = build_harness();
+    let id = imported_tunnel_id(&h).await;
+    h.tunnel_iface.set_stats(TunnelStats {
+        bytes_tx: 0,
+        bytes_rx: 0,
+        last_handshake: Some(chrono::Utc::now()),
+    });
+
+    auth_context::with_context(admin_ctx(), h.svc.test_tunnel(id))
+        .await
+        .unwrap();
+
+    let torn_down = h.tunnel_iface.torn_down.lock().unwrap();
+    assert!(
+        !torn_down.is_empty(),
+        "expected tear_down call when starting from Down"
+    );
+}
+
+#[tokio::test]
+async fn test_tunnel_leaves_up_when_was_up() {
+    let h = build_harness();
+    let id = imported_tunnel_id(&h).await;
+    // Pre-mark the tunnel `up` so test_tunnel skips bring_up + tear_down.
+    h.tunnels
+        .update_status(&id.to_string(), "up")
+        .await
+        .unwrap();
+    h.tunnel_iface.set_stats(TunnelStats {
+        bytes_tx: 0,
+        bytes_rx: 0,
+        last_handshake: Some(chrono::Utc::now()),
+    });
+
+    auth_context::with_context(admin_ctx(), h.svc.test_tunnel(id))
+        .await
+        .unwrap();
+
+    let torn_down = h.tunnel_iface.torn_down.lock().unwrap();
+    assert!(
+        torn_down.is_empty(),
+        "expected no tear_down when tunnel was already up"
+    );
+    let brought_up = h.tunnel_iface.brought_up.lock().unwrap();
+    assert!(
+        brought_up.is_empty(),
+        "expected no bring_up when tunnel was already up"
+    );
+}
+
+#[tokio::test]
+async fn test_tunnel_returns_conflict_when_test_in_flight() {
+    let h = Arc::new(build_harness());
+    let id = imported_tunnel_id(&h).await;
+    h.tunnel_iface.set_stats(TunnelStats {
+        bytes_tx: 0,
+        bytes_rx: 0,
+        last_handshake: Some(chrono::Utc::now()),
+    });
+    // Hold the first probe open long enough to overlap with the second.
+    h.exit_probe.set_delay(300);
+
+    // Spawn one in-flight call; before it finishes, kick off a second.
+    let h1 = h.clone();
+    let first = tokio::spawn(async move {
+        auth_context::with_context(admin_ctx(), h1.svc.test_tunnel(id)).await
+    });
+
+    // Yield long enough that the first call is past `acquire_in_flight`.
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+    let second = auth_context::with_context(admin_ctx(), h.svc.test_tunnel(id)).await;
+    assert!(
+        matches!(second, Err(AppError::Conflict(_))),
+        "expected Conflict on second concurrent call, got {second:?}"
+    );
+
+    // Drain the first call so the test doesn't leak a task.
+    first.await.unwrap().unwrap();
+}
+
+#[tokio::test]
+async fn test_tunnel_handshake_timeout_returns_upstream_unavailable() {
+    let h = build_harness();
+    let id = imported_tunnel_id(&h).await;
+    // Default `MockTunnelInterface::get_stats` returns `Ok(None)`, which
+    // never satisfies the freshness check — the readiness gate must time
+    // out within its budget.
+    let started = std::time::Instant::now();
+    let result = auth_context::with_context(admin_ctx(), h.svc.test_tunnel(id)).await;
+    let elapsed = started.elapsed();
+    assert!(
+        matches!(result, Err(AppError::UpstreamUnavailable(_))),
+        "expected UpstreamUnavailable on handshake timeout, got {result:?}"
+    );
+    // The poll budget is 3.5 s; allow generous slack so a slow CI host
+    // doesn't fail the assertion while still catching a runaway sleep.
+    assert!(
+        elapsed < std::time::Duration::from_secs(6),
+        "handshake timeout should not take more than ~3.5 s, took {elapsed:?}"
+    );
+}
+
+#[tokio::test]
+async fn test_tunnel_anonymous_forbidden() {
+    let h = build_harness();
+    let id = imported_tunnel_id(&h).await;
+    let result = auth_context::with_context(AuthContext::Anonymous, h.svc.test_tunnel(id)).await;
+    assert!(matches!(result, Err(AppError::Forbidden(_))));
+}
+
+#[tokio::test]
+async fn test_tunnel_probe_connect_error_maps_to_upstream_unavailable() {
+    let h = build_harness();
+    let id = imported_tunnel_id(&h).await;
+    h.exit_probe
+        .set_err(ProbeError::Connect("dns failed".to_owned()));
+    h.tunnel_iface.set_stats(TunnelStats {
+        bytes_tx: 0,
+        bytes_rx: 0,
+        last_handshake: Some(chrono::Utc::now()),
+    });
+
+    let result = auth_context::with_context(admin_ctx(), h.svc.test_tunnel(id)).await;
+    assert!(matches!(result, Err(AppError::UpstreamUnavailable(_))));
 }

--- a/source/daemon/crates/wardnetd-services/src/vpn/tests/provider.rs
+++ b/source/daemon/crates/wardnetd-services/src/vpn/tests/provider.rs
@@ -4,7 +4,7 @@ use async_trait::async_trait;
 use uuid::Uuid;
 use wardnet_common::api::{
     CreateTunnelRequest, CreateTunnelResponse, DeleteTunnelResponse, ListServersRequest,
-    ListTunnelsResponse, SetupProviderRequest, ValidateCredentialsRequest,
+    ListTunnelsResponse, SetupProviderRequest, TunnelTestResult, ValidateCredentialsRequest,
 };
 use wardnet_common::tunnel::{Tunnel, TunnelStatus};
 use wardnet_common::vpn_provider::{
@@ -187,6 +187,10 @@ impl TunnelService for MockTunnelService {
     }
 
     async fn get_tunnel(&self, _id: Uuid) -> Result<Tunnel, AppError> {
+        Err(AppError::NotFound("not implemented in mock".to_owned()))
+    }
+
+    async fn test_tunnel(&self, _id: Uuid) -> Result<TunnelTestResult, AppError> {
         Err(AppError::NotFound("not implemented in mock".to_owned()))
     }
 

--- a/source/daemon/crates/wardnetd/src/lib.rs
+++ b/source/daemon/crates/wardnetd/src/lib.rs
@@ -7,6 +7,7 @@ pub mod firewall_nftables;
 pub mod hostname_resolver;
 pub mod packet_capture_pnet;
 pub mod policy_router_netlink;
+pub mod tunnel_exit_probe;
 pub mod tunnel_interface_wireguard;
 
 // DHCP/DNS server implementations.

--- a/source/daemon/crates/wardnetd/src/main.rs
+++ b/source/daemon/crates/wardnetd/src/main.rs
@@ -31,6 +31,7 @@ use wardnetd::profiling::ProfilingAgent;
 use wardnetd::route_monitor::RouteMonitor;
 use wardnetd::routing_listener::RoutingListener;
 use wardnetd::system::{PnetNetworkProbe, ProcNetNetworkInspector, SystemctlPowerOps};
+use wardnetd::tunnel_exit_probe::ReqwestTunnelExitProbe;
 use wardnetd::tunnel_idle::IdleTunnelWatcher;
 use wardnetd::tunnel_interface_wireguard::WireGuardTunnelInterface;
 use wardnetd::tunnel_monitor::TunnelMonitor;
@@ -211,6 +212,9 @@ async fn run(
 
     let backends = Backends {
         tunnel_interface: Arc::new(WireGuardTunnelInterface),
+        tunnel_exit_probe: Arc::new(ReqwestTunnelExitProbe::new(
+            config.tunnel.test_probe_url.clone(),
+        )),
         policy_router: Arc::new(
             NetlinkPolicyRouter::new(executor.clone())
                 .expect("failed to initialise netlink policy router"),

--- a/source/daemon/crates/wardnetd/src/tests/stubs.rs
+++ b/source/daemon/crates/wardnetd/src/tests/stubs.rs
@@ -17,7 +17,7 @@ use wardnet_common::api::{
     ListCountriesResponse, ListProvidersResponse, ListServersRequest, ListServersResponse,
     ListTunnelsResponse, SetMyRuleResponse, SetupProviderRequest, SetupProviderResponse,
     SystemStatusResponse, TunnelDevicesResponse, TunnelMetricsRange, TunnelMetricsResponse,
-    ValidateCredentialsRequest, ValidateCredentialsResponse,
+    TunnelTestResult, ValidateCredentialsRequest, ValidateCredentialsResponse,
 };
 use wardnet_common::device::{Device, DeviceType};
 use wardnet_common::event::WardnetEvent;
@@ -288,6 +288,9 @@ impl TunnelService for StubTunnelService {
         Ok(ListTunnelsResponse { tunnels: vec![] })
     }
     async fn get_tunnel(&self, _id: Uuid) -> Result<Tunnel, AppError> {
+        unimplemented!()
+    }
+    async fn test_tunnel(&self, _id: Uuid) -> Result<TunnelTestResult, AppError> {
         unimplemented!()
     }
     async fn get_metrics(

--- a/source/daemon/crates/wardnetd/src/tests/tunnel_idle.rs
+++ b/source/daemon/crates/wardnetd/src/tests/tunnel_idle.rs
@@ -53,6 +53,13 @@ impl TunnelService for MockTunnelService {
         Err(AppError::NotFound("not found".to_owned()))
     }
 
+    async fn test_tunnel(
+        &self,
+        _id: Uuid,
+    ) -> Result<wardnet_common::api::TunnelTestResult, AppError> {
+        unimplemented!("not needed for idle watcher tests")
+    }
+
     async fn get_metrics(
         &self,
         _id: Uuid,

--- a/source/daemon/crates/wardnetd/src/tests/tunnel_monitor.rs
+++ b/source/daemon/crates/wardnetd/src/tests/tunnel_monitor.rs
@@ -60,6 +60,12 @@ impl TunnelService for MockTunnelService {
     async fn get_tunnel(&self, _id: Uuid) -> Result<Tunnel, AppError> {
         unimplemented!()
     }
+    async fn test_tunnel(
+        &self,
+        _id: Uuid,
+    ) -> Result<wardnet_common::api::TunnelTestResult, AppError> {
+        unimplemented!()
+    }
     async fn get_metrics(
         &self,
         _id: Uuid,

--- a/source/daemon/crates/wardnetd/src/tunnel_exit_probe.rs
+++ b/source/daemon/crates/wardnetd/src/tunnel_exit_probe.rs
@@ -1,0 +1,132 @@
+//! Real `TunnelExitProbe` impl: HTTP probe through a specific interface.
+//!
+//! Linux uses `SO_BINDTODEVICE` (via `reqwest::ClientBuilder::interface`) to
+//! force the outbound socket onto the tunnel interface, so the probe
+//! traverses the tunnel rather than the default route. Other platforms
+//! return [`ProbeError::Unsupported`] — the production daemon only runs on
+//! Linux; macOS/Windows builds reach the mock backend instead.
+
+use std::time::Duration;
+
+use async_trait::async_trait;
+
+use wardnetd_services::tunnel::exit_probe::{ExitInfo, ProbeError, TunnelExitProbe};
+
+/// 1.5 s probe budget — chosen so the daemon endpoint stays under its 5 s
+/// overall timeout once the 3.5 s handshake budget is spent.
+const PROBE_TIMEOUT: Duration = Duration::from_millis(1500);
+
+/// HTTP probe for tunnel exit IP / country, configurable via
+/// `tunnel.test_probe_url`.
+///
+/// The default endpoint is Cloudflare's `https://1.1.1.1/cdn-cgi/trace`,
+/// which returns a `key=value` document including `ip=` and `loc=` (an
+/// ISO-3166 alpha-2 code). Operators that want a different probe must
+/// pick one with the same response shape.
+pub struct ReqwestTunnelExitProbe {
+    probe_url: String,
+}
+
+impl ReqwestTunnelExitProbe {
+    #[must_use]
+    pub fn new(probe_url: String) -> Self {
+        Self { probe_url }
+    }
+}
+
+#[async_trait]
+impl TunnelExitProbe for ReqwestTunnelExitProbe {
+    #[cfg(target_os = "linux")]
+    async fn probe(&self, interface: &str) -> Result<ExitInfo, ProbeError> {
+        let client = reqwest::Client::builder()
+            .timeout(PROBE_TIMEOUT)
+            .interface(interface)
+            .build()
+            .map_err(|e| ProbeError::Connect(format!("client build failed: {e}")))?;
+
+        let resp = client.get(&self.probe_url).send().await.map_err(|e| {
+            if e.is_timeout() {
+                ProbeError::Timeout(u64::try_from(PROBE_TIMEOUT.as_millis()).unwrap_or(u64::MAX))
+            } else {
+                ProbeError::Connect(e.to_string())
+            }
+        })?;
+
+        if !resp.status().is_success() {
+            return Err(ProbeError::Connect(format!(
+                "probe returned HTTP {}",
+                resp.status()
+            )));
+        }
+
+        let body = resp
+            .text()
+            .await
+            .map_err(|e| ProbeError::Connect(format!("read body failed: {e}")))?;
+
+        parse_trace_body(&body)
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    async fn probe(&self, _interface: &str) -> Result<ExitInfo, ProbeError> {
+        Err(ProbeError::Unsupported(
+            "SO_BINDTODEVICE is Linux-only; tunnel test endpoint requires Linux".to_owned(),
+        ))
+    }
+}
+
+/// Parse Cloudflare's `cdn-cgi/trace` response into [`ExitInfo`].
+///
+/// The body is a sequence of `key=value` lines; `ip=` and `loc=` are
+/// the two we need. Missing fields fail with [`ProbeError::Parse`] so
+/// the user sees a precise error rather than a generic "probe failed".
+fn parse_trace_body(body: &str) -> Result<ExitInfo, ProbeError> {
+    let mut ip: Option<String> = None;
+    let mut country: Option<String> = None;
+
+    for line in body.lines() {
+        if let Some(rest) = line.strip_prefix("ip=") {
+            ip = Some(rest.trim().to_owned());
+        } else if let Some(rest) = line.strip_prefix("loc=") {
+            country = Some(rest.trim().to_owned());
+        }
+    }
+
+    let ip = ip.ok_or_else(|| ProbeError::Parse("response missing 'ip=' field".to_owned()))?;
+    let country_code =
+        country.ok_or_else(|| ProbeError::Parse("response missing 'loc=' field".to_owned()))?;
+
+    if ip.is_empty() {
+        return Err(ProbeError::Parse("'ip=' was empty".to_owned()));
+    }
+    if country_code.is_empty() {
+        return Err(ProbeError::Parse("'loc=' was empty".to_owned()));
+    }
+
+    Ok(ExitInfo { ip, country_code })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_trace_body_extracts_ip_and_loc() {
+        let body = "fl=53f1\nh=1.1.1.1\nip=203.0.113.42\nts=1714000000.0\nvisit_scheme=https\nuag=test\ncolo=AMS\nsliver=none\nhttp=http/2\nloc=NL\ntls=TLSv1.3\nsni=plaintext\nwarp=off\ngateway=off\nrbi=off\nkex=X25519\n";
+        let info = parse_trace_body(body).expect("parse ok");
+        assert_eq!(info.ip, "203.0.113.42");
+        assert_eq!(info.country_code, "NL");
+    }
+
+    #[test]
+    fn parse_trace_body_missing_ip_errors() {
+        let body = "loc=DE\n";
+        assert!(matches!(parse_trace_body(body), Err(ProbeError::Parse(_))));
+    }
+
+    #[test]
+    fn parse_trace_body_missing_loc_errors() {
+        let body = "ip=203.0.113.1\n";
+        assert!(matches!(parse_trace_body(body), Err(ProbeError::Parse(_))));
+    }
+}

--- a/source/daemon/crates/wctl/Cargo.toml
+++ b/source/daemon/crates/wctl/Cargo.toml
@@ -23,4 +23,3 @@ tokio.workspace = true
 tabled.workspace = true
 # https://crates.io/crates/anyhow
 anyhow.workspace = true
-wardnet-common = { path = "../wardnet-common" }

--- a/source/daemon/crates/wctl/Cargo.toml
+++ b/source/daemon/crates/wctl/Cargo.toml
@@ -23,3 +23,4 @@ tokio.workspace = true
 tabled.workspace = true
 # https://crates.io/crates/anyhow
 anyhow.workspace = true
+wardnet-common = { path = "../wardnet-common" }

--- a/source/daemon/crates/wctl/src/main.rs
+++ b/source/daemon/crates/wctl/src/main.rs
@@ -1,4 +1,10 @@
+use std::path::PathBuf;
+use std::time::Duration;
+
+use anyhow::{Context, Result, anyhow};
 use clap::{Parser, Subcommand};
+use wardnet_common::api::TunnelTestResponse;
+use wardnet_common::config::ApplicationConfiguration;
 
 #[derive(Parser)]
 #[command(name = "wctl", about = "Wardnet CLI", version = env!("WARDNET_VERSION"))]
@@ -120,23 +126,44 @@ enum TunnelsCommand {
         /// Tunnel ID
         id: String,
     },
+    /// Probe a tunnel for its exit IP, country, and latency.
+    Test {
+        /// Tunnel ID
+        id: String,
+    },
 }
 
-fn main() {
+#[tokio::main]
+async fn main() -> std::process::ExitCode {
     let cli = Cli::parse();
+    let json = cli.json;
 
     match cli.command {
-        Commands::Status => println!("status: not yet implemented"),
-        Commands::Devices(cmd) => match cmd {
-            DevicesCommand::List => println!("devices list: not yet implemented"),
-            DevicesCommand::Show { id } => println!("devices show {id}: not yet implemented"),
-            DevicesCommand::SetRule { id, target } => {
-                println!("devices set-rule {id} {target}: not yet implemented");
+        Commands::Status => {
+            println!("status: not yet implemented");
+            std::process::ExitCode::SUCCESS
+        }
+        Commands::Devices(cmd) => {
+            match cmd {
+                DevicesCommand::List => println!("devices list: not yet implemented"),
+                DevicesCommand::Show { id } => {
+                    println!("devices show {id}: not yet implemented");
+                }
+                DevicesCommand::SetRule { id, target } => {
+                    println!("devices set-rule {id} {target}: not yet implemented");
+                }
             }
-        },
+            std::process::ExitCode::SUCCESS
+        }
         Commands::Tunnels(cmd) => match cmd {
-            TunnelsCommand::List => println!("tunnels list: not yet implemented"),
-            TunnelsCommand::Show { id } => println!("tunnels show {id}: not yet implemented"),
+            TunnelsCommand::List => {
+                println!("tunnels list: not yet implemented");
+                std::process::ExitCode::SUCCESS
+            }
+            TunnelsCommand::Show { id } => {
+                println!("tunnels show {id}: not yet implemented");
+                std::process::ExitCode::SUCCESS
+            }
             TunnelsCommand::Add {
                 label,
                 country,
@@ -145,43 +172,126 @@ fn main() {
                 println!(
                     "tunnels add --label {label} --country {country} --interface {interface}: not yet implemented"
                 );
+                std::process::ExitCode::SUCCESS
             }
             TunnelsCommand::Remove { id } => {
                 println!("tunnels remove {id}: not yet implemented");
+                std::process::ExitCode::SUCCESS
             }
-        },
-        Commands::Update(cmd) => match cmd {
-            UpdateCommand::Status => println!("update status: not yet implemented"),
-            UpdateCommand::Check => println!("update check: not yet implemented"),
-            UpdateCommand::Install { version } => match version {
-                Some(v) => println!("update install --version {v}: not yet implemented"),
-                None => println!("update install: not yet implemented"),
-            },
-            UpdateCommand::Rollback => println!("update rollback: not yet implemented"),
-        },
-        Commands::Backup(cmd) => match cmd {
-            BackupCommand::Status => println!("backup status: not yet implemented"),
-            BackupCommand::Export {
-                out,
-                passphrase_file,
-            } => match passphrase_file {
-                Some(p) => {
-                    println!(
-                        "backup export --out {out} --passphrase-file {p}: not yet implemented"
-                    );
+            TunnelsCommand::Test { id } => match run_tunnel_test(&cli.config, &id, json).await {
+                Ok(()) => std::process::ExitCode::SUCCESS,
+                Err(e) => {
+                    if json {
+                        let payload = serde_json::json!({
+                            "status": "error",
+                            "message": e.to_string(),
+                        });
+                        println!("{payload}");
+                    } else {
+                        eprintln!("tunnel test failed: {e}");
+                    }
+                    std::process::ExitCode::from(1)
                 }
-                None => println!("backup export --out {out}: not yet implemented"),
             },
-            BackupCommand::Import {
-                bundle,
-                passphrase_file,
-            } => match passphrase_file {
-                Some(p) => {
-                    println!("backup import {bundle} --passphrase-file {p}: not yet implemented");
-                }
-                None => println!("backup import {bundle}: not yet implemented"),
-            },
-            BackupCommand::Snapshots => println!("backup snapshots: not yet implemented"),
         },
+        Commands::Update(cmd) => {
+            match cmd {
+                UpdateCommand::Status => println!("update status: not yet implemented"),
+                UpdateCommand::Check => println!("update check: not yet implemented"),
+                UpdateCommand::Install { version } => match version {
+                    Some(v) => println!("update install --version {v}: not yet implemented"),
+                    None => println!("update install: not yet implemented"),
+                },
+                UpdateCommand::Rollback => println!("update rollback: not yet implemented"),
+            }
+            std::process::ExitCode::SUCCESS
+        }
+        Commands::Backup(cmd) => {
+            match cmd {
+                BackupCommand::Status => println!("backup status: not yet implemented"),
+                BackupCommand::Export {
+                    out,
+                    passphrase_file,
+                } => match passphrase_file {
+                    Some(p) => {
+                        println!(
+                            "backup export --out {out} --passphrase-file {p}: not yet implemented"
+                        );
+                    }
+                    None => println!("backup export --out {out}: not yet implemented"),
+                },
+                BackupCommand::Import {
+                    bundle,
+                    passphrase_file,
+                } => match passphrase_file {
+                    Some(p) => {
+                        println!(
+                            "backup import {bundle} --passphrase-file {p}: not yet implemented"
+                        );
+                    }
+                    None => println!("backup import {bundle}: not yet implemented"),
+                },
+                BackupCommand::Snapshots => println!("backup snapshots: not yet implemented"),
+            }
+            std::process::ExitCode::SUCCESS
+        }
     }
+}
+
+/// Read the daemon URL from `config_path` (falls back to a 127.0.0.1
+/// default when the file is absent), POST to `/api/tunnels/{id}/test`,
+/// and render the result either as `key: value` lines (default) or raw
+/// JSON (`--json`).
+async fn run_tunnel_test(config_path: &str, id: &str, json: bool) -> Result<()> {
+    let config = ApplicationConfiguration::load(&PathBuf::from(config_path))
+        .with_context(|| format!("failed to load config at {config_path}"))?;
+
+    let scheme = "http";
+    let host = if config.server.host == "0.0.0.0" {
+        "127.0.0.1"
+    } else {
+        config.server.host.as_str()
+    };
+    let url = format!(
+        "{scheme}://{host}:{port}/api/tunnels/{id}/test",
+        port = config.server.port
+    );
+
+    // Daemon timeout is 5 s; give the SDK / CLI a slightly larger
+    // budget so a healthy probe never gets clipped at the client.
+    let mut req = reqwest::Client::builder()
+        .timeout(Duration::from_secs(8))
+        .build()
+        .context("failed to build http client")?
+        .post(&url);
+
+    if let Ok(token) = std::env::var("WARDNET_API_KEY") {
+        req = req.bearer_auth(token);
+    }
+
+    let resp = req.send().await.context("failed to call daemon")?;
+    let status = resp.status();
+    let body = resp.text().await.context("failed to read response body")?;
+
+    if !status.is_success() {
+        return Err(anyhow!(
+            "daemon returned HTTP {status}: {body}",
+            body = body.trim()
+        ));
+    }
+
+    let parsed: TunnelTestResponse =
+        serde_json::from_str(&body).context("failed to parse daemon response")?;
+
+    if json {
+        println!("{body}");
+    } else {
+        println!("Tunnel:  {}", parsed.result.tunnel_id);
+        println!("Status:  ok");
+        println!("Exit IP: {}", parsed.result.exit_ip);
+        println!("Country: {}", parsed.result.country_code);
+        println!("Latency: {} ms", parsed.result.latency_ms);
+    }
+
+    Ok(())
 }

--- a/source/daemon/crates/wctl/src/main.rs
+++ b/source/daemon/crates/wctl/src/main.rs
@@ -1,10 +1,4 @@
-use std::path::PathBuf;
-use std::time::Duration;
-
-use anyhow::{Context, Result, anyhow};
 use clap::{Parser, Subcommand};
-use wardnet_common::api::TunnelTestResponse;
-use wardnet_common::config::ApplicationConfiguration;
 
 #[derive(Parser)]
 #[command(name = "wctl", about = "Wardnet CLI", version = env!("WARDNET_VERSION"))]
@@ -133,37 +127,21 @@ enum TunnelsCommand {
     },
 }
 
-#[tokio::main]
-async fn main() -> std::process::ExitCode {
+fn main() {
     let cli = Cli::parse();
-    let json = cli.json;
 
     match cli.command {
-        Commands::Status => {
-            println!("status: not yet implemented");
-            std::process::ExitCode::SUCCESS
-        }
-        Commands::Devices(cmd) => {
-            match cmd {
-                DevicesCommand::List => println!("devices list: not yet implemented"),
-                DevicesCommand::Show { id } => {
-                    println!("devices show {id}: not yet implemented");
-                }
-                DevicesCommand::SetRule { id, target } => {
-                    println!("devices set-rule {id} {target}: not yet implemented");
-                }
+        Commands::Status => println!("status: not yet implemented"),
+        Commands::Devices(cmd) => match cmd {
+            DevicesCommand::List => println!("devices list: not yet implemented"),
+            DevicesCommand::Show { id } => println!("devices show {id}: not yet implemented"),
+            DevicesCommand::SetRule { id, target } => {
+                println!("devices set-rule {id} {target}: not yet implemented");
             }
-            std::process::ExitCode::SUCCESS
-        }
+        },
         Commands::Tunnels(cmd) => match cmd {
-            TunnelsCommand::List => {
-                println!("tunnels list: not yet implemented");
-                std::process::ExitCode::SUCCESS
-            }
-            TunnelsCommand::Show { id } => {
-                println!("tunnels show {id}: not yet implemented");
-                std::process::ExitCode::SUCCESS
-            }
+            TunnelsCommand::List => println!("tunnels list: not yet implemented"),
+            TunnelsCommand::Show { id } => println!("tunnels show {id}: not yet implemented"),
             TunnelsCommand::Add {
                 label,
                 country,
@@ -172,126 +150,46 @@ async fn main() -> std::process::ExitCode {
                 println!(
                     "tunnels add --label {label} --country {country} --interface {interface}: not yet implemented"
                 );
-                std::process::ExitCode::SUCCESS
             }
             TunnelsCommand::Remove { id } => {
                 println!("tunnels remove {id}: not yet implemented");
-                std::process::ExitCode::SUCCESS
             }
-            TunnelsCommand::Test { id } => match run_tunnel_test(&cli.config, &id, json).await {
-                Ok(()) => std::process::ExitCode::SUCCESS,
-                Err(e) => {
-                    if json {
-                        let payload = serde_json::json!({
-                            "status": "error",
-                            "message": e.to_string(),
-                        });
-                        println!("{payload}");
-                    } else {
-                        eprintln!("tunnel test failed: {e}");
-                    }
-                    std::process::ExitCode::from(1)
-                }
-            },
+            TunnelsCommand::Test { id } => {
+                println!("tunnels test {id}: not yet implemented");
+            }
         },
-        Commands::Update(cmd) => {
-            match cmd {
-                UpdateCommand::Status => println!("update status: not yet implemented"),
-                UpdateCommand::Check => println!("update check: not yet implemented"),
-                UpdateCommand::Install { version } => match version {
-                    Some(v) => println!("update install --version {v}: not yet implemented"),
-                    None => println!("update install: not yet implemented"),
-                },
-                UpdateCommand::Rollback => println!("update rollback: not yet implemented"),
-            }
-            std::process::ExitCode::SUCCESS
-        }
-        Commands::Backup(cmd) => {
-            match cmd {
-                BackupCommand::Status => println!("backup status: not yet implemented"),
-                BackupCommand::Export {
-                    out,
-                    passphrase_file,
-                } => match passphrase_file {
-                    Some(p) => {
-                        println!(
-                            "backup export --out {out} --passphrase-file {p}: not yet implemented"
-                        );
-                    }
-                    None => println!("backup export --out {out}: not yet implemented"),
-                },
-                BackupCommand::Import {
-                    bundle,
-                    passphrase_file,
-                } => match passphrase_file {
-                    Some(p) => {
-                        println!(
-                            "backup import {bundle} --passphrase-file {p}: not yet implemented"
-                        );
-                    }
-                    None => println!("backup import {bundle}: not yet implemented"),
-                },
-                BackupCommand::Snapshots => println!("backup snapshots: not yet implemented"),
-            }
-            std::process::ExitCode::SUCCESS
-        }
+        Commands::Update(cmd) => match cmd {
+            UpdateCommand::Status => println!("update status: not yet implemented"),
+            UpdateCommand::Check => println!("update check: not yet implemented"),
+            UpdateCommand::Install { version } => match version {
+                Some(v) => println!("update install --version {v}: not yet implemented"),
+                None => println!("update install: not yet implemented"),
+            },
+            UpdateCommand::Rollback => println!("update rollback: not yet implemented"),
+        },
+        Commands::Backup(cmd) => match cmd {
+            BackupCommand::Status => println!("backup status: not yet implemented"),
+            BackupCommand::Export {
+                out,
+                passphrase_file,
+            } => match passphrase_file {
+                Some(p) => {
+                    println!(
+                        "backup export --out {out} --passphrase-file {p}: not yet implemented"
+                    );
+                }
+                None => println!("backup export --out {out}: not yet implemented"),
+            },
+            BackupCommand::Import {
+                bundle,
+                passphrase_file,
+            } => match passphrase_file {
+                Some(p) => {
+                    println!("backup import {bundle} --passphrase-file {p}: not yet implemented");
+                }
+                None => println!("backup import {bundle}: not yet implemented"),
+            },
+            BackupCommand::Snapshots => println!("backup snapshots: not yet implemented"),
+        },
     }
-}
-
-/// Read the daemon URL from `config_path` (falls back to a 127.0.0.1
-/// default when the file is absent), POST to `/api/tunnels/{id}/test`,
-/// and render the result either as `key: value` lines (default) or raw
-/// JSON (`--json`).
-async fn run_tunnel_test(config_path: &str, id: &str, json: bool) -> Result<()> {
-    let config = ApplicationConfiguration::load(&PathBuf::from(config_path))
-        .with_context(|| format!("failed to load config at {config_path}"))?;
-
-    let scheme = "http";
-    let host = if config.server.host == "0.0.0.0" {
-        "127.0.0.1"
-    } else {
-        config.server.host.as_str()
-    };
-    let url = format!(
-        "{scheme}://{host}:{port}/api/tunnels/{id}/test",
-        port = config.server.port
-    );
-
-    // Daemon timeout is 5 s; give the SDK / CLI a slightly larger
-    // budget so a healthy probe never gets clipped at the client.
-    let mut req = reqwest::Client::builder()
-        .timeout(Duration::from_secs(8))
-        .build()
-        .context("failed to build http client")?
-        .post(&url);
-
-    if let Ok(token) = std::env::var("WARDNET_API_KEY") {
-        req = req.bearer_auth(token);
-    }
-
-    let resp = req.send().await.context("failed to call daemon")?;
-    let status = resp.status();
-    let body = resp.text().await.context("failed to read response body")?;
-
-    if !status.is_success() {
-        return Err(anyhow!(
-            "daemon returned HTTP {status}: {body}",
-            body = body.trim()
-        ));
-    }
-
-    let parsed: TunnelTestResponse =
-        serde_json::from_str(&body).context("failed to parse daemon response")?;
-
-    if json {
-        println!("{body}");
-    } else {
-        println!("Tunnel:  {}", parsed.result.tunnel_id);
-        println!("Status:  ok");
-        println!("Exit IP: {}", parsed.result.exit_ip);
-        println!("Country: {}", parsed.result.country_code);
-        println!("Latency: {} ms", parsed.result.latency_ms);
-    }
-
-    Ok(())
 }

--- a/source/sdk/wardnet-js/src/index.ts
+++ b/source/sdk/wardnet-js/src/index.ts
@@ -113,6 +113,8 @@ export type {
   TunnelMetricsRange,
   TunnelMetricsPoint,
   TunnelMetricsResponse,
+  TunnelTestResult,
+  TunnelTestResponse,
   ListProvidersResponse,
   ValidateCredentialsRequest,
   ValidateCredentialsResponse,

--- a/source/sdk/wardnet-js/src/services/tunnels.ts
+++ b/source/sdk/wardnet-js/src/services/tunnels.ts
@@ -8,6 +8,7 @@ import type {
   TunnelDevicesResponse,
   TunnelMetricsRange,
   TunnelMetricsResponse,
+  TunnelTestResponse,
 } from "../types/api.js";
 
 /** Tunnel management service for the Wardnet daemon. */
@@ -48,6 +49,17 @@ export class TunnelService {
   async delete(id: string): Promise<DeleteTunnelResponse> {
     return this.client.request<DeleteTunnelResponse>(`/tunnels/${id}`, {
       method: "DELETE",
+    });
+  }
+
+  /**
+   * Probe the tunnel for its exit IP, country, and latency (admin only).
+   * The daemon brings the tunnel up if needed, runs a single HTTP probe
+   * through the tunnel, then restores the prior up/down state.
+   */
+  async test(id: string): Promise<TunnelTestResponse> {
+    return this.client.request<TunnelTestResponse>(`/tunnels/${id}/test`, {
+      method: "POST",
     });
   }
 }

--- a/source/sdk/wardnet-js/src/types/api.ts
+++ b/source/sdk/wardnet-js/src/types/api.ts
@@ -113,6 +113,22 @@ export interface TunnelDevicesResponse {
   devices: Device[];
 }
 
+/** Result payload of POST /api/tunnels/:id/test. */
+export interface TunnelTestResult {
+  tunnel_id: string;
+  /** Public IP observed at the tunnel exit. */
+  exit_ip: string;
+  /** ISO-3166 alpha-2 country code reported by the probe service. */
+  country_code: string;
+  /** Round-trip latency of the probe call, in milliseconds. */
+  latency_ms: number;
+}
+
+/** Response envelope for POST /api/tunnels/:id/test. */
+export interface TunnelTestResponse {
+  result: TunnelTestResult;
+}
+
 /** Response for GET /api/providers. */
 export interface ListProvidersResponse {
   providers: ProviderInfo[];

--- a/source/web-ui/src/components/compound/TunnelCard.tsx
+++ b/source/web-ui/src/components/compound/TunnelCard.tsx
@@ -1,11 +1,13 @@
-import { ArrowDown, ArrowUp } from "lucide-react";
+import { ArrowDown, ArrowUp, Loader2 } from "lucide-react";
+import { useState } from "react";
 import { Link } from "react-router";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/core/ui/card";
 import { Button } from "@/components/core/ui/button";
 import { StatusBadge } from "./StatusBadge";
 import { formatBytes, timeAgo } from "@/lib/utils";
 import { countryFlag } from "@/lib/country";
-import type { Tunnel, TunnelStatus, ProviderInfo } from "@wardnet/js";
+import { useTestTunnel } from "@/hooks/useTunnels";
+import type { Tunnel, TunnelStatus, ProviderInfo, TunnelTestResult } from "@wardnet/js";
 
 function statusTone(status: TunnelStatus): "success" | "neutral" | "danger" {
   switch (status) {
@@ -75,6 +77,29 @@ export function TunnelCard({ tunnel, providers, onDelete }: TunnelCardProps) {
   const provider = providers.find((p) => p.id === tunnel.provider);
   const flag = tunnel.country_code ? countryFlag(tunnel.country_code) : "";
 
+  const testTunnel = useTestTunnel();
+  const [testResult, setTestResult] = useState<TunnelTestResult | null>(null);
+  const [testError, setTestError] = useState<string | null>(null);
+  const [testedAt, setTestedAt] = useState<string | null>(null);
+
+  const onTestClick = (e: React.MouseEvent) => {
+    // Card is wrapped in <Link>; don't navigate when clicking Test.
+    e.preventDefault();
+    e.stopPropagation();
+    testTunnel.mutate(tunnel.id, {
+      onSuccess: (data) => {
+        setTestResult(data.result);
+        setTestError(null);
+        setTestedAt(new Date().toISOString());
+      },
+      onError: (err) => {
+        setTestResult(null);
+        setTestError(err instanceof Error ? err.message : "Tunnel test failed");
+        setTestedAt(new Date().toISOString());
+      },
+    });
+  };
+
   return (
     <Card className="transition-colors hover:bg-accent/30">
       <Link
@@ -133,7 +158,35 @@ export function TunnelCard({ tunnel, providers, onDelete }: TunnelCardProps) {
         </CardContent>
       </Link>
       <CardContent className="pt-0">
-        <div className="flex justify-end">
+        {testResult && (
+          <div className="mb-3 rounded-md border bg-muted/40 px-3 py-2 text-xs">
+            <div className="flex items-center gap-2">
+              <span aria-hidden>{countryFlag(testResult.country_code)}</span>
+              <span className="font-medium">{testResult.country_code.toUpperCase()}</span>
+              <span className="text-muted-foreground">·</span>
+              <span className="font-mono">{testResult.exit_ip}</span>
+              <span className="text-muted-foreground">·</span>
+              <span>{testResult.latency_ms} ms</span>
+            </div>
+            {testedAt && <p className="mt-0.5 text-muted-foreground">tested {timeAgo(testedAt)}</p>}
+          </div>
+        )}
+        {testError && !testResult && (
+          <div className="mb-3 rounded-md border border-destructive/50 bg-destructive/10 px-3 py-2 text-xs text-destructive">
+            {testError}
+          </div>
+        )}
+        <div className="flex justify-end gap-2">
+          <Button variant="outline" disabled={testTunnel.isPending} onClick={onTestClick}>
+            {testTunnel.isPending ? (
+              <>
+                <Loader2 className="mr-1 size-3 animate-spin" aria-hidden />
+                Testing
+              </>
+            ) : (
+              "Test"
+            )}
+          </Button>
           <Button
             variant="destructive"
             onClick={(e) => {

--- a/source/web-ui/src/hooks/useTunnels.ts
+++ b/source/web-ui/src/hooks/useTunnels.ts
@@ -62,3 +62,20 @@ export function useDeleteTunnel() {
     onError: () => toast.error("Failed to delete tunnel"),
   });
 }
+
+export function useTestTunnel() {
+  return useMutation({
+    mutationFn: (id: string) => tunnelService.test(id),
+    onError: (error) => {
+      const message = error instanceof Error ? error.message : "Tunnel test failed";
+      // 409 surfaces as "conflict" / "test already in progress" — show a
+      // dedicated toast so a rapid double-click is obviously rate-limited
+      // rather than a generic failure.
+      if (/already|conflict/i.test(message)) {
+        toast.error("Test already in progress");
+      } else {
+        toast.error(message);
+      }
+    },
+  });
+}

--- a/source/web-ui/src/pages/setup/Step4RouterMac.tsx
+++ b/source/web-ui/src/pages/setup/Step4RouterMac.tsx
@@ -86,7 +86,7 @@ export default function Step4RouterMac() {
 
       <Button
         onClick={handleContinue}
-        disabled={advance.isPending || (!probedMac && !probeFailed)}
+        disabled={advance.isPending}
         className="h-12 w-full"
       >
         {advance.isPending ? "Saving…" : probedMac ? "Continue" : "Skip"}


### PR DESCRIPTION
## Summary

Closes #238. Adds `POST /api/tunnels/{id}/test`: brings a tunnel up if needed, sends one HTTP probe through the tunnel interface, and returns `{exit_ip, country_code, latency_ms}`. Surfaced via:

- New JS SDK method `TunnelService.test(id)` and `TunnelTestResult` / `TunnelTestResponse` types.
- A **Test** button on each `TunnelCard` with inline result row, spinner, and 409 toast on rapid double-click.
- Daemon-side `TunnelExitProbe` trait, real `reqwest`-based impl using `SO_BINDTODEVICE` (Linux), and a deterministic mock that returns a TEST-NET-2 IP plus the seeded tunnel's country code so `make run-dev` exercises the full flow offline.
- Probe URL configurable via `tunnel.test_probe_url` (default Cloudflare `cdn-cgi/trace`).
- 409 Conflict on concurrent calls (in-flight set keyed by tunnel id, RAII guard).
- Restores prior up/down state — only tears down if `test_tunnel` brought the tunnel up itself.

Also includes a small UX fix: the wizard's Step 4 (router MAC) Skip button stayed disabled while the ARP probe was in flight, which trapped operators when the probe hangs. Skip is now enabled from mount.

\`wctl tunnels test <id>\` is deliberately left as a placeholder — wctl is meant to drive the future Rust SDK (paired with the JS one) and support remote daemons; rather than introduce a one-off direct-HTTP implementation, the subcommand matches the rest of wctl's stubs. See [issue comment](https://github.com/wardnet/wardnet/issues/238#issuecomment-4404552185).

## Test plan

- [ ] \`make check-daemon\` (fmt + clippy + tests) green
- [ ] \`make openapi-check\` clean
- [ ] SDK + web-ui \`type-check\`, \`lint\`, \`format:check\` clean
- [ ] Manual e2e against \`make run-dev\`: click Test on a seeded tunnel → result row shows flag + ISO-2 + 198.51.100.x IP + small latency
- [ ] Rapid double-click → second click shows "Test already in progress" toast
- [ ] Wizard Step 4 Skip is clickable as soon as the page renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)