### PR TITLE
feat(dns): support multiple default DNS filter profiles

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -13593,7 +13593,7 @@
       },
       "DeviceDnsFilterSettings": {
         "type": "object",
-        "description": "Per-device DNS filtering settings.\n\n`enabled = false` is the kill switch; the device's queries skip filtering\nentirely. When `enabled = true` and `profile_ids` is empty, the device\ninherits the global default profile from [`DnsFilterConfig`].",
+        "description": "Per-device DNS filtering settings.\n\n`enabled = false` is the kill switch; the device's queries skip filtering\nentirely. When `enabled = true` and `profile_ids` is empty, the device\ninherits the global default profiles from [`DnsFilterConfig`].",
         "required": [
           "device_id",
           "enabled",
@@ -13614,7 +13614,7 @@
               "type": "string",
               "format": "uuid"
             },
-            "description": "Explicit profile assignments. Empty means \"follow the default profile\"."
+            "description": "Explicit profile assignments. Empty means \"follow the default profiles\"."
           },
           "updated_at": {
             "type": "string",
@@ -14079,16 +14079,17 @@
         "type": "object",
         "description": "Global DNS filtering configuration.",
         "required": [
-          "enabled"
+          "enabled",
+          "default_profile_ids"
         ],
         "properties": {
-          "default_profile_id": {
-            "type": [
-              "string",
-              "null"
-            ],
-            "format": "uuid",
-            "description": "Profile applied to devices with no explicit assignment. `None` means\nunassigned devices skip filtering."
+          "default_profile_ids": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "description": "Profiles applied to devices with no explicit assignment. Empty means\nunassigned devices skip filtering. Multiple profiles stack — a domain\nblocked in any of them is blocked. Treat as a set: the order across\nthe get/set roundtrip is not preserved."
           },
           "enabled": {
             "type": "boolean",
@@ -16347,14 +16348,17 @@
       },
       "UpdateDnsFilterConfigRequest": {
         "type": "object",
-        "description": "Request body for PUT /api/dns/filter/config.\n\n`default_profile_id` uses double-`Option` semantics: omitted from JSON =\nno change, `null` = clear the default, `\"<uuid>\"` = set.",
+        "description": "Request body for PUT /api/dns/filter/config.\n\nBoth fields are partial-update: omitted from JSON = no change. For\n`default_profile_ids`, an empty list clears the default (unassigned\ndevices stop being filtered) and a non-empty list replaces the entire\nset.",
         "properties": {
-          "default_profile_id": {
+          "default_profile_ids": {
             "type": [
-              "string",
+              "array",
               "null"
             ],
-            "format": "uuid"
+            "items": {
+              "type": "string",
+              "format": "uuid"
+            }
           },
           "enabled": {
             "type": [

--- a/source/daemon/crates/wardnet-common/src/api.rs
+++ b/source/daemon/crates/wardnet-common/src/api.rs
@@ -1043,14 +1043,16 @@ pub struct DnsFilterConfigResponse {
 
 /// Request body for PUT /api/dns/filter/config.
 ///
-/// `default_profile_id` uses double-`Option` semantics: omitted from JSON =
-/// no change, `null` = clear the default, `"<uuid>"` = set.
+/// Both fields are partial-update: omitted from JSON = no change. For
+/// `default_profile_ids`, an empty list clears the default (unassigned
+/// devices stop being filtered) and a non-empty list replaces the entire
+/// set.
 #[derive(Debug, Clone, Default, Serialize, Deserialize, utoipa::ToSchema)]
 pub struct UpdateDnsFilterConfigRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub enabled: Option<bool>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub default_profile_id: Option<Option<Uuid>>,
+    pub default_profile_ids: Option<Vec<Uuid>>,
 }
 
 // ---------------------------------------------------------------------------

--- a/source/daemon/crates/wardnet-common/src/dns_filter.rs
+++ b/source/daemon/crates/wardnet-common/src/dns_filter.rs
@@ -2,8 +2,8 @@
 //!
 //! A **DNS Filter Profile** groups blocklists, an allowlist, and custom
 //! filter rules under a single name. Devices opt into one or more profiles;
-//! when a device has no explicit profiles the global default profile
-//! applies. Three profiles are seeded as `builtin`: "Ad Blocking",
+//! when a device has no explicit profiles the global default profiles
+//! apply. Three profiles are seeded as `builtin`: "Ad Blocking",
 //! "Parental Controls", and "Malware & Phishing".
 //!
 //! See `.agents/architecture.md` for the layered design and
@@ -30,12 +30,12 @@ pub struct DnsFilterProfile {
 ///
 /// `enabled = false` is the kill switch; the device's queries skip filtering
 /// entirely. When `enabled = true` and `profile_ids` is empty, the device
-/// inherits the global default profile from [`DnsFilterConfig`].
+/// inherits the global default profiles from [`DnsFilterConfig`].
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, utoipa::ToSchema)]
 pub struct DeviceDnsFilterSettings {
     pub device_id: Uuid,
     pub enabled: bool,
-    /// Explicit profile assignments. Empty means "follow the default profile".
+    /// Explicit profile assignments. Empty means "follow the default profiles".
     pub profile_ids: Vec<Uuid>,
     pub updated_at: DateTime<Utc>,
 }
@@ -60,16 +60,18 @@ pub struct DnsFilterConfig {
     /// Global emergency stop. When `false`, every query short-circuits to
     /// `Pass` regardless of profile state.
     pub enabled: bool,
-    /// Profile applied to devices with no explicit assignment. `None` means
-    /// unassigned devices skip filtering.
-    pub default_profile_id: Option<Uuid>,
+    /// Profiles applied to devices with no explicit assignment. Empty means
+    /// unassigned devices skip filtering. Multiple profiles stack — a domain
+    /// blocked in any of them is blocked. Treat as a set: the order across
+    /// the get/set roundtrip is not preserved.
+    pub default_profile_ids: Vec<Uuid>,
 }
 
 impl Default for DnsFilterConfig {
     fn default() -> Self {
         Self {
             enabled: true,
-            default_profile_id: None,
+            default_profile_ids: Vec::new(),
         }
     }
 }

--- a/source/daemon/crates/wardnet-common/src/tests/dns_filter.rs
+++ b/source/daemon/crates/wardnet-common/src/tests/dns_filter.rs
@@ -29,14 +29,14 @@ fn device_dns_filter_settings_default_for() {
 fn dns_filter_config_default() {
     let cfg = DnsFilterConfig::default();
     assert!(cfg.enabled);
-    assert!(cfg.default_profile_id.is_none());
+    assert!(cfg.default_profile_ids.is_empty());
 }
 
 #[test]
 fn dns_filter_config_round_trip() {
     let cfg = DnsFilterConfig {
         enabled: false,
-        default_profile_id: Some(Uuid::new_v4()),
+        default_profile_ids: vec![Uuid::new_v4(), Uuid::new_v4()],
     };
     let json = serde_json::to_string(&cfg).unwrap();
     let back: DnsFilterConfig = serde_json::from_str(&json).unwrap();

--- a/source/daemon/crates/wardnetd-api/src/api/tests/dns_filter.rs
+++ b/source/daemon/crates/wardnetd-api/src/api/tests/dns_filter.rs
@@ -94,6 +94,7 @@ impl AuthService for MockAuthService {
 // ---------------------------------------------------------------------------
 
 const PROFILE_ID: Uuid = Uuid::from_u128(0x100);
+const PROFILE_ID_B: Uuid = Uuid::from_u128(0x101);
 const BLOCKLIST_ID: Uuid = Uuid::from_u128(0x200);
 const RULE_ID: Uuid = Uuid::from_u128(0x300);
 const ENTRY_ID: Uuid = Uuid::from_u128(0x400);
@@ -345,7 +346,7 @@ impl DnsFilterService for MockDnsFilterService {
         Ok(DnsFilterConfigResponse {
             config: DnsFilterConfig {
                 enabled: true,
-                default_profile_id: Some(PROFILE_ID),
+                default_profile_ids: vec![PROFILE_ID],
             },
         })
     }
@@ -356,7 +357,7 @@ impl DnsFilterService for MockDnsFilterService {
         Ok(DnsFilterConfigResponse {
             config: DnsFilterConfig {
                 enabled: true,
-                default_profile_id: Some(PROFILE_ID),
+                default_profile_ids: vec![PROFILE_ID],
             },
         })
     }
@@ -807,12 +808,35 @@ async fn get_config_returns_ok() {
     let (status, json) = get_json(app, "/api/dns/filter/config").await;
     assert_eq!(status, StatusCode::OK);
     assert!(json["config"]["enabled"].as_bool().unwrap());
+    let ids = json["config"]["default_profile_ids"].as_array().unwrap();
+    assert_eq!(ids.len(), 1);
+    assert_eq!(ids[0].as_str().unwrap(), PROFILE_ID.to_string());
 }
 
 #[tokio::test]
 async fn update_config_returns_ok() {
     let app = router(build_state());
     let (status, _) = put_json(app, "/api/dns/filter/config", r#"{"enabled":false}"#).await;
+    assert_eq!(status, StatusCode::OK);
+}
+
+#[tokio::test]
+async fn update_config_accepts_multi_default_ids() {
+    let app = router(build_state());
+    let body = format!(r#"{{"default_profile_ids":["{PROFILE_ID}","{PROFILE_ID_B}"]}}"#);
+    let (status, _) = put_json(app, "/api/dns/filter/config", &body).await;
+    assert_eq!(status, StatusCode::OK);
+}
+
+#[tokio::test]
+async fn update_config_accepts_empty_default_ids() {
+    let app = router(build_state());
+    let (status, _) = put_json(
+        app,
+        "/api/dns/filter/config",
+        r#"{"default_profile_ids":[]}"#,
+    )
+    .await;
     assert_eq!(status, StatusCode::OK);
 }
 

--- a/source/daemon/crates/wardnetd-data/migrations/20260508000000_dns_filter_multi_default.sql
+++ b/source/daemon/crates/wardnetd-data/migrations/20260508000000_dns_filter_multi_default.sql
@@ -1,0 +1,22 @@
+-- Stage 8: support setting multiple DNS filter profiles as default.
+-- The per-device side already accepts N profiles via dns_filter_device_profile;
+-- this widens the global default fallback to match. The single-value
+-- system_config row `dns_default_filter_profile_id` is replaced by a join
+-- table mirroring dns_filter_device_profile.
+
+CREATE TABLE IF NOT EXISTS dns_filter_default_profile (
+    profile_id TEXT PRIMARY KEY NOT NULL
+        REFERENCES dns_filter_profiles(id) ON DELETE CASCADE,
+    created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
+);
+
+-- Carry the existing single default forward, if it points at a real profile.
+-- The JOIN against dns_filter_profiles is what filters out empty/invalid
+-- values — a malformed `sc.value` (including '') won't match any profile id.
+INSERT OR IGNORE INTO dns_filter_default_profile (profile_id)
+    SELECT sc.value
+      FROM system_config sc
+      JOIN dns_filter_profiles p ON p.id = sc.value
+     WHERE sc.key = 'dns_default_filter_profile_id';
+
+DELETE FROM system_config WHERE key = 'dns_default_filter_profile_id';

--- a/source/daemon/crates/wardnetd-data/src/repository/dns_filter.rs
+++ b/source/daemon/crates/wardnetd-data/src/repository/dns_filter.rs
@@ -166,12 +166,14 @@ pub trait DnsFilterRepository: Send + Sync {
 
     // ── Global filter config ────────────────────────────────────────────
 
-    /// Read `dns_filtering_enabled` + `dns_default_filter_profile_id` from
-    /// `system_config`.
+    /// Read `dns_filtering_enabled` from `system_config` and the membership
+    /// of `dns_filter_default_profile`.
     async fn get_dns_filter_config(&self) -> anyhow::Result<DnsFilterConfig>;
 
-    /// Persist both fields. `default_profile_id = None` writes an empty
-    /// string to `system_config`, preserving the "unset" semantic.
+    /// Persist both fields. `default_profile_ids` is replace-set semantics:
+    /// the prior membership of `dns_filter_default_profile` is wiped and
+    /// rewritten to the supplied list. An empty list leaves the table empty,
+    /// which the service treats as "unassigned devices skip filtering".
     async fn set_dns_filter_config(&self, config: &DnsFilterConfig) -> anyhow::Result<()>;
 }
 

--- a/source/daemon/crates/wardnetd-data/src/repository/sqlite/dns_filter.rs
+++ b/source/daemon/crates/wardnetd-data/src/repository/sqlite/dns_filter.rs
@@ -15,7 +15,6 @@ use crate::repository::dns_filter::{
 
 const TS_FMT: &str = "%Y-%m-%dT%H:%M:%SZ";
 const KEY_DNS_FILTERING_ENABLED: &str = "dns_filtering_enabled";
-const KEY_DEFAULT_PROFILE_ID: &str = "dns_default_filter_profile_id";
 
 fn now_iso() -> String {
     Utc::now().format(TS_FMT).to_string()
@@ -731,20 +730,23 @@ impl DnsFilterRepository for SqliteDnsFilterRepository {
                 .bind(KEY_DNS_FILTERING_ENABLED)
                 .fetch_optional(&self.pool)
                 .await?;
-        let default_id: Option<String> =
-            sqlx::query_scalar("SELECT value FROM system_config WHERE key = ?")
-                .bind(KEY_DEFAULT_PROFILE_ID)
-                .fetch_optional(&self.pool)
-                .await?;
+
+        let default_profile_ids: Vec<String> = sqlx::query_scalar(
+            "SELECT profile_id FROM dns_filter_default_profile \
+             ORDER BY created_at, profile_id",
+        )
+        .fetch_all(&self.pool)
+        .await?;
 
         let enabled = enabled.as_deref() != Some("false");
-        let default_profile_id = default_id
-            .filter(|s| !s.is_empty())
-            .and_then(|s| s.parse().ok());
+        let default_profile_ids: Vec<Uuid> = default_profile_ids
+            .into_iter()
+            .filter_map(|s| s.parse().ok())
+            .collect();
 
         Ok(DnsFilterConfig {
             enabled,
-            default_profile_id,
+            default_profile_ids,
         })
     }
 
@@ -759,18 +761,15 @@ impl DnsFilterRepository for SqliteDnsFilterRepository {
         .execute(&mut *tx)
         .await?;
 
-        let default_value = config
-            .default_profile_id
-            .map(|u| u.to_string())
-            .unwrap_or_default();
-        sqlx::query(
-            "INSERT INTO system_config (key, value) VALUES (?, ?) \
-             ON CONFLICT(key) DO UPDATE SET value = excluded.value",
-        )
-        .bind(KEY_DEFAULT_PROFILE_ID)
-        .bind(&default_value)
-        .execute(&mut *tx)
-        .await?;
+        sqlx::query("DELETE FROM dns_filter_default_profile")
+            .execute(&mut *tx)
+            .await?;
+        for pid in &config.default_profile_ids {
+            sqlx::query("INSERT INTO dns_filter_default_profile (profile_id) VALUES (?)")
+                .bind(pid.to_string())
+                .execute(&mut *tx)
+                .await?;
+        }
 
         tx.commit().await?;
         Ok(())

--- a/source/daemon/crates/wardnetd-data/src/repository/tests/dns_filter.rs
+++ b/source/daemon/crates/wardnetd-data/src/repository/tests/dns_filter.rs
@@ -90,8 +90,9 @@ async fn migration_sets_default_profile_to_ad_blocking() {
 
     let cfg = repo.get_dns_filter_config().await.unwrap();
     assert!(cfg.enabled, "kill switch on by default");
+    assert_eq!(cfg.default_profile_ids.len(), 1);
     assert_eq!(
-        cfg.default_profile_id.unwrap().to_string().to_lowercase(),
+        cfg.default_profile_ids[0].to_string().to_lowercase(),
         AD_BLOCKING
     );
 }
@@ -499,35 +500,92 @@ async fn set_dns_filter_config_round_trip() {
     let pool = test_pool().await;
     let repo = SqliteDnsFilterRepository::new(pool);
 
-    let new_default = Uuid::new_v4();
-    repo.create_profile(new_default, "Default-ish")
-        .await
-        .unwrap();
+    let a = Uuid::new_v4();
+    let b = Uuid::new_v4();
+    repo.create_profile(a, "First").await.unwrap();
+    repo.create_profile(b, "Second").await.unwrap();
 
     repo.set_dns_filter_config(&DnsFilterConfig {
         enabled: false,
-        default_profile_id: Some(new_default),
+        default_profile_ids: vec![a, b],
     })
     .await
     .unwrap();
 
     let cfg = repo.get_dns_filter_config().await.unwrap();
     assert!(!cfg.enabled);
-    assert_eq!(cfg.default_profile_id, Some(new_default));
+    let mut got = cfg.default_profile_ids.clone();
+    let mut want = vec![a, b];
+    got.sort();
+    want.sort();
+    assert_eq!(got, want);
 }
 
 #[tokio::test]
-async fn set_dns_filter_config_clears_default_with_none() {
+async fn set_dns_filter_config_replaces_default_set() {
     let pool = test_pool().await;
     let repo = SqliteDnsFilterRepository::new(pool);
 
+    let a = Uuid::new_v4();
+    let b = Uuid::new_v4();
+    repo.create_profile(a, "A").await.unwrap();
+    repo.create_profile(b, "B").await.unwrap();
+
+    // Seed a multi-profile default, then replace it with a single id.
     repo.set_dns_filter_config(&DnsFilterConfig {
         enabled: true,
-        default_profile_id: None,
+        default_profile_ids: vec![a, b],
+    })
+    .await
+    .unwrap();
+
+    repo.set_dns_filter_config(&DnsFilterConfig {
+        enabled: true,
+        default_profile_ids: vec![b],
     })
     .await
     .unwrap();
 
     let cfg = repo.get_dns_filter_config().await.unwrap();
-    assert!(cfg.default_profile_id.is_none());
+    assert_eq!(cfg.default_profile_ids, vec![b]);
+}
+
+#[tokio::test]
+async fn set_dns_filter_config_clears_default_with_empty_vec() {
+    let pool = test_pool().await;
+    let repo = SqliteDnsFilterRepository::new(pool);
+
+    repo.set_dns_filter_config(&DnsFilterConfig {
+        enabled: true,
+        default_profile_ids: Vec::new(),
+    })
+    .await
+    .unwrap();
+
+    let cfg = repo.get_dns_filter_config().await.unwrap();
+    assert!(cfg.default_profile_ids.is_empty());
+}
+
+#[tokio::test]
+async fn deleting_profile_cascades_default_membership() {
+    let pool = test_pool().await;
+    let repo = SqliteDnsFilterRepository::new(pool);
+
+    let p = Uuid::new_v4();
+    repo.create_profile(p, "Doomed").await.unwrap();
+
+    repo.set_dns_filter_config(&DnsFilterConfig {
+        enabled: true,
+        default_profile_ids: vec![p],
+    })
+    .await
+    .unwrap();
+
+    repo.delete_profile(p).await.unwrap();
+
+    let cfg = repo.get_dns_filter_config().await.unwrap();
+    assert!(
+        !cfg.default_profile_ids.contains(&p),
+        "ON DELETE CASCADE should drop default-membership"
+    );
 }

--- a/source/daemon/crates/wardnetd-services/src/dns_filter/service.rs
+++ b/source/daemon/crates/wardnetd-services/src/dns_filter/service.rs
@@ -523,16 +523,34 @@ impl DnsFilterServiceImpl {
 
     async fn rebuild_default_context_inner(&self) -> Result<(), AppError> {
         let cfg = self.config.load_full();
-        let new_ctx = match cfg.default_profile_id {
-            Some(pid) => {
-                let map = self.profiles.read().await;
-                let profiles = map.get(&pid).cloned().into_iter().collect();
+        let new_ctx = if cfg.default_profile_ids.is_empty() {
+            DeviceFilterContext::unfiltered()
+        } else {
+            let map = self.profiles.read().await;
+            let profiles: Vec<_> = cfg
+                .default_profile_ids
+                .iter()
+                .filter_map(|id| {
+                    let resolved = map.get(id).cloned();
+                    if resolved.is_none() {
+                        // Survives FK CASCADE so should be unreachable in
+                        // practice; surface it if a race ever lets it through.
+                        tracing::warn!(profile_id = %id, "default profile not found in cache");
+                    }
+                    resolved
+                })
+                .collect();
+            // Converge the empty-after-resolve case with the explicit-empty
+            // case — "filtering on with zero rules" is observationally
+            // identical to unfiltered but reports differently.
+            if profiles.is_empty() {
+                DeviceFilterContext::unfiltered()
+            } else {
                 DeviceFilterContext {
                     enabled: true,
                     profiles,
                 }
             }
-            None => DeviceFilterContext::unfiltered(),
         };
         self.default_context.store(Arc::new(new_ctx));
         Ok(())
@@ -1139,17 +1157,28 @@ impl DnsFilterService for DnsFilterServiceImpl {
             changed_global = current.enabled != enabled;
             current.enabled = enabled;
         }
-        if let Some(default) = req.default_profile_id {
-            if let Some(pid) = default {
-                self.ensure_profile_exists(pid).await?;
+        if let Some(mut ids) = req.default_profile_ids {
+            // Storage has profile_id as PK — duplicates would abort the
+            // replace-set tx. Sort+dedup also doubles as the canonical
+            // form for the change-detection compare below.
+            ids.sort();
+            ids.dedup();
+            for pid in &ids {
+                self.ensure_profile_exists(*pid).await?;
             }
-            changed_default = current.default_profile_id != default;
-            current.default_profile_id = default;
+            let mut current_sorted = current.default_profile_ids.clone();
+            current_sorted.sort();
+            changed_default = current_sorted != ids;
+            current.default_profile_ids = ids;
         }
         self.repo
             .set_dns_filter_config(&current)
             .await
             .map_err(AppError::Internal)?;
+        // Refresh the in-memory Arc immediately so synchronous readers
+        // (e.g. the kill-switch short-circuit in `check()`) don't run
+        // against the stale config until the runner picks up the event.
+        self.config.store(Arc::new(current.clone()));
         if changed_default {
             self.publish(DnsFilterChange::DefaultProfile);
         }
@@ -1191,7 +1220,7 @@ impl DnsFilterService for DnsFilterServiceImpl {
 
         // Default-context might point at this profile; refresh it.
         let cfg = self.config.load_full();
-        if cfg.default_profile_id == Some(profile_id) {
+        if cfg.default_profile_ids.contains(&profile_id) {
             self.rebuild_default_context_inner().await?;
         }
 

--- a/source/daemon/crates/wardnetd-services/src/dns_filter/tests/service.rs
+++ b/source/daemon/crates/wardnetd-services/src/dns_filter/tests/service.rs
@@ -668,42 +668,93 @@ async fn get_filter_config_returns_seed_default() {
     as_admin(async {
         let cfg = h.service.get_filter_config().await.unwrap();
         assert!(cfg.config.enabled);
-        // Seed sets default to Ad Blocking profile.
-        assert_eq!(
-            cfg.config.default_profile_id.unwrap().to_string(),
-            AD_BLOCKING
-        );
+        // Seed sets default to a single Ad Blocking profile.
+        assert_eq!(cfg.config.default_profile_ids.len(), 1);
+        assert_eq!(cfg.config.default_profile_ids[0].to_string(), AD_BLOCKING);
     })
     .await;
 }
 
 #[tokio::test]
-async fn update_filter_config_double_option_semantics() {
+async fn update_filter_config_partial_update_semantics() {
     let h = build().await;
     as_admin(async {
-        // Outer Some, inner None = explicit clear.
+        // Some(empty vec) = explicit clear.
         let resp = h
             .service
             .update_filter_config(UpdateDnsFilterConfigRequest {
                 enabled: Some(false),
-                default_profile_id: Some(None),
+                default_profile_ids: Some(Vec::new()),
             })
             .await
             .unwrap();
         assert!(!resp.config.enabled);
-        assert!(resp.config.default_profile_id.is_none());
+        assert!(resp.config.default_profile_ids.is_empty());
 
-        // Outer None = leave alone — re-set enabled but don't touch default.
+        // None = leave alone — re-set enabled but don't touch default.
         let resp = h
             .service
             .update_filter_config(UpdateDnsFilterConfigRequest {
                 enabled: Some(true),
-                default_profile_id: None,
+                default_profile_ids: None,
             })
             .await
             .unwrap();
         assert!(resp.config.enabled);
-        assert!(resp.config.default_profile_id.is_none());
+        assert!(resp.config.default_profile_ids.is_empty());
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn update_filter_config_accepts_multi_default() {
+    let h = build().await;
+    as_admin(async {
+        let parental: Uuid = "00000000-0000-0000-0000-000000000101".parse().unwrap();
+        let malware: Uuid = "00000000-0000-0000-0000-000000000102".parse().unwrap();
+
+        let resp = h
+            .service
+            .update_filter_config(UpdateDnsFilterConfigRequest {
+                enabled: None,
+                default_profile_ids: Some(vec![parental, malware]),
+            })
+            .await
+            .unwrap();
+        let mut got = resp.config.default_profile_ids.clone();
+        got.sort();
+        let mut want = vec![parental, malware];
+        want.sort();
+        assert_eq!(got, want);
+
+        // Round-trip via get_filter_config to confirm persistence (not just
+        // a happy echo of the request body).
+        let fetched = h.service.get_filter_config().await.unwrap();
+        let mut got = fetched.config.default_profile_ids.clone();
+        got.sort();
+        assert_eq!(got, want);
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn update_filter_config_dedupes_duplicate_default_ids() {
+    // The repo has profile_id as PK on dns_filter_default_profile, so
+    // duplicates would abort the replace-set transaction. The service is
+    // expected to dedupe before persisting.
+    let h = build().await;
+    as_admin(async {
+        let parental: Uuid = "00000000-0000-0000-0000-000000000101".parse().unwrap();
+
+        let resp = h
+            .service
+            .update_filter_config(UpdateDnsFilterConfigRequest {
+                enabled: None,
+                default_profile_ids: Some(vec![parental, parental, parental]),
+            })
+            .await
+            .unwrap();
+        assert_eq!(resp.config.default_profile_ids, vec![parental]);
     })
     .await;
 }
@@ -928,7 +979,7 @@ async fn create_blocklist_under_unknown_profile_returns_not_found() {
 
 #[tokio::test]
 async fn update_filter_config_with_unknown_default_profile_returns_not_found() {
-    // Setting default_profile_id to a profile that doesn't exist should
+    // Setting default_profile_ids to a list containing an unknown id should
     // reject; otherwise unassigned devices would silently filter against
     // a missing profile.
     let h = build().await;
@@ -937,7 +988,7 @@ async fn update_filter_config_with_unknown_default_profile_returns_not_found() {
             .service
             .update_filter_config(UpdateDnsFilterConfigRequest {
                 enabled: None,
-                default_profile_id: Some(Some(Uuid::new_v4())),
+                default_profile_ids: Some(vec![Uuid::new_v4()]),
             })
             .await
             .unwrap_err();
@@ -1092,7 +1143,7 @@ async fn check_passes_when_global_emergency_stop_off() {
         h.service
             .update_filter_config(UpdateDnsFilterConfigRequest {
                 enabled: Some(false),
-                default_profile_id: None,
+                default_profile_ids: None,
             })
             .await
             .unwrap();

--- a/source/end2end-tests/daemon/tests/dns-filter-default-profile.spec.ts
+++ b/source/end2end-tests/daemon/tests/dns-filter-default-profile.spec.ts
@@ -25,7 +25,14 @@ const BLOCKLIST_NAME = "e2e-dns-filter-default-profile";
 const ALT_DEFAULT_NAME = "e2e-alt-default";
 const CRON_NEVER = "0 0 1 1 *";
 
-const BLOCKED_DOMAIN = "www.iana.org";
+// Two distinct canaries, each blocked by a *different* profile. They make
+// the stacking test meaningful: under [Ad] only, BLOCKED_BY_AD blocks but
+// BLOCKED_BY_ALT resolves; under [alt] only, the inverse; under [Ad, alt]
+// both block. If the daemon silently dropped one id from the default set,
+// one of the assertions would fail.
+const BLOCKED_BY_AD = "www.iana.org";
+const BLOCKED_BY_ALT = "www.example.com";
+const ALT_RULE = `||${BLOCKED_BY_ALT}^`;
 
 describe("dns filter — global default profile", () => {
   let authed: AuthedClient;
@@ -34,7 +41,7 @@ describe("dns filter — global default profile", () => {
   let jobs: JobsService;
   let blocklistId: string | undefined;
   let altDefaultId: string | undefined;
-  let originalDefaultId: string | null = null;
+  let originalDefaultIds: string[] = [];
   let deviceVisible = false;
 
   beforeAll(async () => {
@@ -47,10 +54,10 @@ describe("dns filter — global default profile", () => {
 
     await ensureDnsEnabled(authed);
 
-    // Snapshot the pre-spec default so afterAll can restore it,
-    // even if some previous test changed it.
+    // Snapshot the pre-spec defaults so afterAll can restore them,
+    // even if some previous test changed them.
     const config = await dnsFilter.getConfig();
-    originalDefaultId = config.config.default_profile_id;
+    originalDefaultIds = config.config.default_profile_ids;
 
     // Drop leftover state from a prior failed run.
     const existingLists = await dnsFilter.listBlocklists(AD_BLOCKING_PROFILE_ID);
@@ -92,22 +99,26 @@ describe("dns filter — global default profile", () => {
     const job = await waitForJob(jobs, dispatched.job_id, 30_000);
     expect(job.status, `job error: ${job.error ?? "(none)"}`).toBe("SUCCEED");
 
-    // Empty alternative profile — when the global default points at
-    // it, an unassigned device sees no rules and resolves freely.
+    // Alternative profile with a single custom rule blocking BLOCKED_BY_ALT
+    // (a *different* canary from BLOCKED_BY_AD). The two profiles each
+    // block exactly one canary, which lets the stacking test prove union
+    // semantics rather than reproducing single-profile behaviour.
     const profile = await dnsFilter.createProfile({ name: ALT_DEFAULT_NAME });
     altDefaultId = profile.profile.id;
+    await dnsFilter.createFilterRule(altDefaultId, {
+      rule_text: ALT_RULE,
+      enabled: true,
+    });
   }, 180_000);
 
   afterAll(async () => {
-    // Restore the pre-spec default first so the deleteProfile below
-    // doesn't fail (`ON DELETE SET NULL` would silently drop the
-    // pointer, but explicit restoration is clearer in failure logs).
-    if (originalDefaultId !== null) {
-      try {
-        await dnsFilter.updateConfig({ default_profile_id: originalDefaultId });
-      } catch {
-        // ignore
-      }
+    // Restore the pre-spec defaults first so the deleteProfile below
+    // doesn't fail (`ON DELETE CASCADE` would silently drop default
+    // membership, but explicit restoration is clearer in failure logs).
+    try {
+      await dnsFilter.updateConfig({ default_profile_ids: originalDefaultIds });
+    } catch {
+      // ignore
     }
     if (altDefaultId) {
       try {
@@ -139,11 +150,11 @@ describe("dns filter — global default profile", () => {
     expect(altDefaultId).toBeDefined();
 
     // Phase 1: default = Ad Blocking → canary blocks.
-    await dnsFilter.updateConfig({ default_profile_id: AD_BLOCKING_PROFILE_ID });
+    await dnsFilter.updateConfig({ default_profile_ids: [AD_BLOCKING_PROFILE_ID] });
     await dns.flushCache();
     await expect
       .poll(
-        async () => (await resolveViaAgent(TEST_DEBIAN_AGENT, BLOCKED_DOMAIN)).addrs.length,
+        async () => (await resolveViaAgent(TEST_DEBIAN_AGENT, BLOCKED_BY_AD)).addrs.length,
         { interval: 250, timeout: 10_000 },
       )
       .toBe(0);
@@ -151,24 +162,90 @@ describe("dns filter — global default profile", () => {
     // Phase 2: switch the global default to the empty profile. The
     // hot-path "default context" should rebuild and the unassigned
     // device should no longer see the Ad Blocking blocklist.
-    const swapped = await dnsFilter.updateConfig({ default_profile_id: altDefaultId! });
-    expect(swapped.config.default_profile_id).toBe(altDefaultId);
+    const swapped = await dnsFilter.updateConfig({ default_profile_ids: [altDefaultId!] });
+    expect(swapped.config.default_profile_ids).toEqual([altDefaultId]);
     await dns.flushCache();
     await expect
       .poll(
-        async () => (await resolveViaAgent(TEST_DEBIAN_AGENT, BLOCKED_DOMAIN)).addrs.length,
+        async () => (await resolveViaAgent(TEST_DEBIAN_AGENT, BLOCKED_BY_AD)).addrs.length,
         { interval: 500, timeout: 15_000 },
       )
       .toBeGreaterThan(0);
 
     // Phase 3: flip back. Blocking resumes.
-    await dnsFilter.updateConfig({ default_profile_id: AD_BLOCKING_PROFILE_ID });
+    await dnsFilter.updateConfig({ default_profile_ids: [AD_BLOCKING_PROFILE_ID] });
     await dns.flushCache();
     await expect
       .poll(
-        async () => (await resolveViaAgent(TEST_DEBIAN_AGENT, BLOCKED_DOMAIN)).addrs.length,
+        async () => (await resolveViaAgent(TEST_DEBIAN_AGENT, BLOCKED_BY_AD)).addrs.length,
         { interval: 250, timeout: 10_000 },
       )
       .toBe(0);
+  });
+
+  it("stacks multiple default profiles for unassigned devices", async (ctx) => {
+    if (!deviceVisible) {
+      return ctx.skip();
+    }
+    expect(altDefaultId).toBeDefined();
+
+    // Phase 1: stack BOTH profiles. Each canary is blocked by exactly one
+    // profile, so a union is the only configuration where both get blocked.
+    // If the daemon dropped one id from the default set, exactly one of
+    // these assertions would fail.
+    const stacked = await dnsFilter.updateConfig({
+      default_profile_ids: [AD_BLOCKING_PROFILE_ID, altDefaultId!],
+    });
+    expect(stacked.config.default_profile_ids.slice().sort()).toEqual(
+      [AD_BLOCKING_PROFILE_ID, altDefaultId!].sort(),
+    );
+    await dns.flushCache();
+    await expect
+      .poll(
+        async () => (await resolveViaAgent(TEST_DEBIAN_AGENT, BLOCKED_BY_AD)).addrs.length,
+        { interval: 250, timeout: 10_000 },
+      )
+      .toBe(0);
+    await expect
+      .poll(
+        async () => (await resolveViaAgent(TEST_DEBIAN_AGENT, BLOCKED_BY_ALT)).addrs.length,
+        { interval: 250, timeout: 10_000 },
+      )
+      .toBe(0);
+
+    // Phase 2: drop Ad Blocking from the default set. Now BLOCKED_BY_AD
+    // should resolve (proof Ad Blocking was contributing to the stack)
+    // while BLOCKED_BY_ALT keeps blocking (alt is still in the set).
+    await dnsFilter.updateConfig({ default_profile_ids: [altDefaultId!] });
+    await dns.flushCache();
+    await expect
+      .poll(
+        async () => (await resolveViaAgent(TEST_DEBIAN_AGENT, BLOCKED_BY_AD)).addrs.length,
+        { interval: 500, timeout: 15_000 },
+      )
+      .toBeGreaterThan(0);
+    await expect
+      .poll(
+        async () => (await resolveViaAgent(TEST_DEBIAN_AGENT, BLOCKED_BY_ALT)).addrs.length,
+        { interval: 250, timeout: 10_000 },
+      )
+      .toBe(0);
+
+    // Phase 3: clear the default entirely. Both canaries resolve.
+    const cleared = await dnsFilter.updateConfig({ default_profile_ids: [] });
+    expect(cleared.config.default_profile_ids).toEqual([]);
+    await dns.flushCache();
+    await expect
+      .poll(
+        async () => (await resolveViaAgent(TEST_DEBIAN_AGENT, BLOCKED_BY_AD)).addrs.length,
+        { interval: 500, timeout: 15_000 },
+      )
+      .toBeGreaterThan(0);
+    await expect
+      .poll(
+        async () => (await resolveViaAgent(TEST_DEBIAN_AGENT, BLOCKED_BY_ALT)).addrs.length,
+        { interval: 500, timeout: 15_000 },
+      )
+      .toBeGreaterThan(0);
   });
 });

--- a/source/sdk/wardnet-js/src/types/dns-filter.ts
+++ b/source/sdk/wardnet-js/src/types/dns-filter.ts
@@ -26,12 +26,17 @@ export interface DeviceDnsFilterSettings {
   updated_at: string;
 }
 
-/** Global DNS filtering configuration (emergency stop + default profile). */
+/** Global DNS filtering configuration (emergency stop + default profiles). */
 export interface DnsFilterConfig {
   /** Global emergency stop. When `false`, every query short-circuits to `Pass`. */
   enabled: boolean;
-  /** Profile applied to devices with no explicit assignment. `null` = unfiltered. */
-  default_profile_id: string | null;
+  /**
+   * Profiles applied to devices with no explicit assignment. Empty array =
+   * unassigned devices skip filtering. Multiple profiles stack — a domain
+   * blocked in any of them is blocked. Treat as a set: the order across
+   * the get/set roundtrip is not preserved.
+   */
+  default_profile_ids: string[];
 }
 
 /** A URL-sourced domain blocklist scoped to a DNS filter profile. */
@@ -226,10 +231,12 @@ export interface DnsFilterConfigResponse {
 /**
  * Request body for PUT /api/dns/filter/config.
  *
- * `default_profile_id` honors three states: omitted = no change, `null` =
- * clear the default, `"<uuid>"` = set.
+ * Both fields are partial-update: omitted from JSON = no change. For
+ * `default_profile_ids`, an empty array clears the default (unassigned
+ * devices stop being filtered) and a non-empty array replaces the entire
+ * set.
  */
 export interface UpdateDnsFilterConfigRequest {
   enabled?: boolean;
-  default_profile_id?: string | null;
+  default_profile_ids?: string[];
 }

--- a/source/web-ui/src/components/compound/ProfileToggleList.tsx
+++ b/source/web-ui/src/components/compound/ProfileToggleList.tsx
@@ -1,0 +1,87 @@
+import { Badge } from "@/components/core/ui/badge";
+import { Switch } from "@/components/core/ui/switch";
+import type { DnsFilterProfile } from "@wardnet/js";
+
+interface ProfileToggleListProps {
+  /** Catalog of profiles to render rows for. */
+  profiles: DnsFilterProfile[];
+  /** Currently-selected profile ids. Ids that aren't in `profiles` are
+   *  preserved through `onChange` (i.e. orphans aren't dropped on toggle)
+   *  but render no row — the caller usually wants to await their resolution. */
+  selectedIds: string[];
+  /** Called with the new full set when a row toggles. */
+  onChange: (ids: string[]) => void;
+  /** Disables every row's switch (e.g. when an upstream kill switch is off). */
+  disabled?: boolean;
+  /** Replaces the empty-state copy when `profiles` is empty. */
+  emptyMessage?: string;
+  /** Id of the external `<Label>` that names this group, for screen-reader
+   *  group association. Pairs with `role="group"` on the container. */
+  ariaLabelledBy?: string;
+}
+
+/** Toggle list of DNS filter profiles. Each row is a labeled `Switch`; the
+ *  callback is fired with the resulting full id list (add or remove). The
+ *  caller owns the surrounding label and any explanatory hint. */
+export function ProfileToggleList({
+  profiles,
+  selectedIds,
+  onChange,
+  disabled = false,
+  emptyMessage = "No profiles defined.",
+  ariaLabelledBy,
+}: ProfileToggleListProps) {
+  function toggle(profileId: string, checked: boolean) {
+    onChange(
+      checked
+        ? Array.from(new Set([...selectedIds, profileId]))
+        : selectedIds.filter((p) => p !== profileId),
+    );
+  }
+
+  if (profiles.length === 0) {
+    return <p className="text-sm text-muted-foreground">{emptyMessage}</p>;
+  }
+
+  return (
+    <div role="group" aria-labelledby={ariaLabelledBy} className="flex flex-col gap-2">
+      {profiles.map((profile) => (
+        <ProfileToggleRow
+          key={profile.id}
+          profile={profile}
+          checked={selectedIds.includes(profile.id)}
+          disabled={disabled}
+          onChange={(c) => toggle(profile.id, c)}
+        />
+      ))}
+    </div>
+  );
+}
+
+interface ProfileToggleRowProps {
+  profile: DnsFilterProfile;
+  checked: boolean;
+  disabled: boolean;
+  onChange: (checked: boolean) => void;
+}
+
+function ProfileToggleRow({ profile, checked, disabled, onChange }: ProfileToggleRowProps) {
+  return (
+    <div className="flex items-center justify-between rounded-md border border-border px-3 py-2">
+      <div className="flex items-center gap-2">
+        <span className="text-sm">{profile.name}</span>
+        {profile.builtin && (
+          <Badge variant="outline" className="text-xs">
+            Builtin
+          </Badge>
+        )}
+      </div>
+      <Switch
+        checked={checked}
+        onCheckedChange={onChange}
+        disabled={disabled}
+        aria-label={profile.name}
+      />
+    </div>
+  );
+}

--- a/source/web-ui/src/components/features/DeviceDnsFilterCard.tsx
+++ b/source/web-ui/src/components/features/DeviceDnsFilterCard.tsx
@@ -10,8 +10,8 @@ import {
 } from "@/components/core/ui/card";
 import { Label } from "@/components/core/ui/label";
 import { Switch } from "@/components/core/ui/switch";
-import { Badge } from "@/components/core/ui/badge";
 import { ApiErrorAlert } from "@/components/compound/ApiErrorAlert";
+import { ProfileToggleList } from "@/components/compound/ProfileToggleList";
 import {
   useDeviceFilterSettings,
   useDnsFilterConfig,
@@ -24,19 +24,18 @@ interface DeviceDnsFilterCardProps {
   device: Device;
 }
 
+const PROFILES_LABEL_ID = "device-dns-filter-profiles-label";
+
 /** Editable DNS filter settings card for the device detail page. */
 export function DeviceDnsFilterCard({ device }: DeviceDnsFilterCardProps) {
   const { data: settingsData, isLoading: settingsLoading } = useDeviceFilterSettings(device.id);
-  const { data: profilesData } = useDnsFilterProfiles();
-  const { data: configData } = useDnsFilterConfig();
+  const { data: profilesData, isLoading: profilesLoading } = useDnsFilterProfiles();
+  const { data: configData, isLoading: configLoading } = useDnsFilterConfig();
   const update = useUpdateDeviceFilterSettings();
 
-  const profiles = profilesData?.profiles ?? [];
+  const profiles = profilesData?.profiles;
   const settings = settingsData?.settings;
-  const defaultProfileId = configData?.config.default_profile_id ?? null;
-  const defaultProfile = defaultProfileId
-    ? (profiles.find((p) => p.id === defaultProfileId) ?? null)
-    : null;
+  const config = configData?.config;
 
   const [editing, setEditing] = useState(false);
   const [enabled, setEnabled] = useState(true);
@@ -63,13 +62,13 @@ export function DeviceDnsFilterCard({ device }: DeviceDnsFilterCardProps) {
     setEditing(false);
   }
 
-  function toggleProfile(profileId: string, checked: boolean) {
-    setProfileIds((prev) =>
-      checked ? Array.from(new Set([...prev, profileId])) : prev.filter((p) => p !== profileId),
-    );
-  }
+  // All three queries must settle before rendering — otherwise the
+  // read-only summary line resolves `defaultProfiles`/`assignedProfiles`
+  // against an empty profiles cache and falsely reports "None".
+  const ready =
+    !settingsLoading && !profilesLoading && !configLoading && settings && profiles && config;
 
-  if (settingsLoading || !settings) {
+  if (!ready) {
     return (
       <Card>
         <CardHeader>
@@ -81,6 +80,8 @@ export function DeviceDnsFilterCard({ device }: DeviceDnsFilterCardProps) {
       </Card>
     );
   }
+
+  const defaultProfiles = profiles.filter((p) => config.default_profile_ids.includes(p.id));
 
   const assignedProfiles = profiles.filter((p) => settings.profile_ids.includes(p.id));
 
@@ -112,27 +113,19 @@ export function DeviceDnsFilterCard({ device }: DeviceDnsFilterCardProps) {
             </div>
 
             <div className="flex flex-col gap-2">
-              <Label>Profiles</Label>
+              <Label id={PROFILES_LABEL_ID}>Profiles</Label>
               <DefaultProfileHint
                 enabled={enabled}
                 hasExplicit={profileIds.length > 0}
-                defaultProfile={defaultProfile}
+                defaultProfiles={defaultProfiles}
               />
-              <div className="flex flex-col gap-2">
-                {profiles.length === 0 ? (
-                  <p className="text-sm text-muted-foreground">No profiles defined.</p>
-                ) : (
-                  profiles.map((profile) => (
-                    <ProfileToggleRow
-                      key={profile.id}
-                      profile={profile}
-                      checked={profileIds.includes(profile.id)}
-                      disabled={!enabled}
-                      onChange={(c) => toggleProfile(profile.id, c)}
-                    />
-                  ))
-                )}
-              </div>
+              <ProfileToggleList
+                profiles={profiles}
+                selectedIds={profileIds}
+                onChange={setProfileIds}
+                disabled={!enabled}
+                ariaLabelledBy={PROFILES_LABEL_ID}
+              />
             </div>
 
             {update.isError && (
@@ -160,8 +153,8 @@ export function DeviceDnsFilterCard({ device }: DeviceDnsFilterCardProps) {
               {!settings.enabled
                 ? "—"
                 : assignedProfiles.length === 0
-                  ? defaultProfile
-                    ? `${defaultProfile.name} (default)`
+                  ? defaultProfiles.length > 0
+                    ? `${defaultProfiles.map((p) => p.name).join(", ")} (default)`
                     : "None (no default profile set)"
                   : assignedProfiles.map((p) => p.name).join(", ")}
             </span>
@@ -177,16 +170,16 @@ interface DefaultProfileHintProps {
   enabled: boolean;
   /** Whether the user has any profile checked in the form. */
   hasExplicit: boolean;
-  /** Currently configured global default profile, if any. Looked up from
-   *  `dns_config.default_profile_id`. */
-  defaultProfile: DnsFilterProfile | null;
+  /** Currently configured global default profiles (resolved from the config's
+   *  `default_profile_ids`). */
+  defaultProfiles: DnsFilterProfile[];
 }
 
 /** Helper text under the Profiles label that explains exactly what the
  *  device will be filtered against given the current form state. Spells
- *  out the default profile by name so the user isn't left guessing what
- *  "the default" means in this household's setup. */
-function DefaultProfileHint({ enabled, hasExplicit, defaultProfile }: DefaultProfileHintProps) {
+ *  out the default profiles by name so the user isn't left guessing what
+ *  "the defaults" mean in this household's setup. */
+function DefaultProfileHint({ enabled, hasExplicit, defaultProfiles }: DefaultProfileHintProps) {
   if (!enabled) {
     return (
       <p className="text-xs text-muted-foreground">
@@ -201,11 +194,15 @@ function DefaultProfileHint({ enabled, hasExplicit, defaultProfile }: DefaultPro
       </p>
     );
   }
-  if (defaultProfile) {
+  if (defaultProfiles.length > 0) {
+    const noun = defaultProfiles.length === 1 ? "profile" : "profiles";
     return (
       <p className="text-xs text-muted-foreground">
-        No profile selected — this device follows the global default profile{" "}
-        <span className="font-medium text-foreground">{defaultProfile.name}</span>.
+        No profile selected — this device follows the global default {noun}{" "}
+        <span className="font-medium text-foreground">
+          {defaultProfiles.map((p) => p.name).join(", ")}
+        </span>
+        .
       </p>
     );
   }
@@ -213,28 +210,5 @@ function DefaultProfileHint({ enabled, hasExplicit, defaultProfile }: DefaultPro
     <p className="text-xs text-muted-foreground">
       No profile selected and no global default is set — this device's traffic isn't filtered.
     </p>
-  );
-}
-
-interface ProfileToggleRowProps {
-  profile: DnsFilterProfile;
-  checked: boolean;
-  disabled: boolean;
-  onChange: (checked: boolean) => void;
-}
-
-function ProfileToggleRow({ profile, checked, disabled, onChange }: ProfileToggleRowProps) {
-  return (
-    <div className="flex items-center justify-between rounded-md border border-border px-3 py-2">
-      <div className="flex items-center gap-2">
-        <span className="text-sm">{profile.name}</span>
-        {profile.builtin && (
-          <Badge variant="outline" className="text-xs">
-            Builtin
-          </Badge>
-        )}
-      </div>
-      <Switch checked={checked} onCheckedChange={onChange} disabled={disabled} />
-    </div>
   );
 }

--- a/source/web-ui/src/components/features/DnsFilterSettingsCard.tsx
+++ b/source/web-ui/src/components/features/DnsFilterSettingsCard.tsx
@@ -1,29 +1,28 @@
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/core/ui/card";
 import { Label } from "@/components/core/ui/label";
 import { Switch } from "@/components/core/ui/switch";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/core/ui/select";
+import { ProfileToggleList } from "@/components/compound/ProfileToggleList";
 import {
   useDnsFilterConfig,
   useDnsFilterProfiles,
   useUpdateDnsFilterConfig,
 } from "@/hooks/useDnsFilter";
 
-const NONE_VALUE = "__none__";
+const DEFAULT_PROFILES_LABEL_ID = "dns-filter-default-profiles-label";
 
-/** Settings-page card for the global DNS filter config (kill switch + default profile). */
+/** Settings-page card for the global DNS filter config (kill switch + default profiles). */
 export function DnsFilterSettingsCard() {
-  const { data: configData, isLoading } = useDnsFilterConfig();
-  const { data: profilesData } = useDnsFilterProfiles();
+  const { data: configData, isLoading: configLoading } = useDnsFilterConfig();
+  const { data: profilesData, isLoading: profilesLoading } = useDnsFilterProfiles();
   const update = useUpdateDnsFilterConfig();
 
   const config = configData?.config;
-  const profiles = profilesData?.profiles ?? [];
+  const profiles = profilesData?.profiles;
+
+  // Both queries must be settled before rendering the picker — otherwise the
+  // composite renders "No profiles defined." in the brief window before
+  // profiles arrive.
+  const ready = !configLoading && !profilesLoading && config && profiles;
 
   return (
     <Card>
@@ -31,7 +30,7 @@ export function DnsFilterSettingsCard() {
         <CardTitle>DNS filtering</CardTitle>
       </CardHeader>
       <CardContent className="flex flex-col gap-5">
-        {isLoading || !config ? (
+        {!ready ? (
           <p className="text-sm text-muted-foreground">Loading…</p>
         ) : (
           <>
@@ -51,31 +50,23 @@ export function DnsFilterSettingsCard() {
               />
             </div>
 
-            <div className="flex flex-col gap-2">
-              <Label htmlFor="default-profile">Default profile</Label>
-              <p className="text-xs text-muted-foreground">
-                Applied to devices that have no explicit profile assignment. Choose "None" to leave
-                unassigned devices unfiltered.
-              </p>
-              <Select
-                value={config.default_profile_id ?? NONE_VALUE}
-                onValueChange={(v) =>
-                  update.mutate({ default_profile_id: v === NONE_VALUE ? null : v })
-                }
-              >
-                <SelectTrigger id="default-profile" className="max-w-sm">
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value={NONE_VALUE}>None (unfiltered)</SelectItem>
-                  {profiles.map((p) => (
-                    <SelectItem key={p.id} value={p.id}>
-                      {p.name}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            </div>
+            {config.enabled && (
+              <div className="flex flex-col gap-2">
+                <Label id={DEFAULT_PROFILES_LABEL_ID}>Default profiles</Label>
+                <p className="text-xs text-muted-foreground">
+                  Applied to devices that have no explicit profile assignment. Multiple profiles
+                  stack — a domain blocked in any one of them is blocked. Leave empty to leave
+                  unassigned devices unfiltered.
+                </p>
+                <ProfileToggleList
+                  profiles={profiles}
+                  selectedIds={config.default_profile_ids}
+                  onChange={(ids) => update.mutate({ default_profile_ids: ids })}
+                  disabled={update.isPending}
+                  ariaLabelledBy={DEFAULT_PROFILES_LABEL_ID}
+                />
+              </div>
+            )}
           </>
         )}
       </CardContent>


### PR DESCRIPTION
## Summary
- Widens the global "default profile" fallback from `Option<Uuid>` to `Vec<Uuid>`, mirroring the per-device side which already accepts N profiles. Empty list = unassigned devices skip filtering. Multiple profiles stack — a domain blocked in any of them is blocked.
- New migration `dns_filter_default_profile(profile_id PK FK CASCADE, created_at)` carries the existing single value forward and replaces the `system_config.dns_default_filter_profile_id` row.
- Web UI: extracted a reusable `ProfileToggleList` composite from `DeviceDnsFilterCard.tsx` and use it in both the device card and the new multi-toggle Default-profiles section on the settings page (replacing the prior `<Select>`).
- Migration carry-forward: existing single default is preserved on upgrade. Clean rename — no compat shim for the old `default_profile_id` field, by user direction. SDK + OpenAPI bumped in tree.

## Implementation notes
- Service-layer `update_filter_config` sorts and dedupes incoming ids before validation/persistence (`profile_id` is PK on the join table, duplicates would otherwise abort the replace-set tx).
- `self.config` Arc is refreshed synchronously after the repo write so `check()` readers don't run against the stale config until the runner picks up the event.
- `rebuild_default_context_inner` converges the empty-after-resolve case with the explicit-empty case (both → `unfiltered()`).
- `DnsFilterSettingsCard` hides the Default-profiles section when the kill switch is off.
- `DefaultProfileHint` on the device card renders one-or-many default profile names.

## Test plan
- [x] `cargo fmt --check` ✅
- [x] `cargo clippy --all-targets -- -D warnings` ✅
- [x] `cargo test --workspace` — all crates green (707 service / 229 daemon / 206 services / 173 data / 117 api / etc., 0 failed)
- [x] `yarn type-check` (web-ui, sdk, e2e) ✅
- [x] `yarn lint` (web-ui) — only pre-existing warning in `Step4RouterMac.tsx` from main, not in this diff
- [x] OpenAPI regenerated via the daemon's `dump_openapi` bin
- [x] Manual smoke on the running mock + Vite dev UI (mock daemon on `:7411`, web on `:7412`): kill-switch toggle, multi-default toggle, empty-default → unfiltered, conditional render of Default-profiles section
- [ ] E2E `dns-filter-default-profile.spec.ts` will run in CI — the new "stacks multiple default profiles" case uses two distinct canaries (`www.iana.org` blocked by Ad Blocking's blocklist, `www.example.com` blocked by a custom rule on the alt profile) so a daemon that silently dropped one id from the default set would fail it
