### PR TITLE
feat(dns): invalidate cache on filter source updates (#341)

### DIFF
--- a/source/daemon/crates/wardnet-common/src/event.rs
+++ b/source/daemon/crates/wardnet-common/src/event.rs
@@ -134,6 +134,19 @@ pub enum WardnetEvent {
         change: DnsFilterChange,
         timestamp: DateTime<Utc>,
     },
+    /// A DNS filter source was rebuilt and the new compiled filter is now
+    /// live (i.e. the `ArcSwap` swap has happened). Emitted by
+    /// `DnsFilterServiceImpl` after each mutating rebuild. Subscribers
+    /// such as `UdpDnsServer` use this to invalidate caches that were
+    /// populated against the previous filter — without invalidation,
+    /// already-forwarded answers stay served until cache TTL expiry,
+    /// so newly-blocked domains keep returning their cached `Pass`
+    /// responses (issue #341). Payload is intentionally just
+    /// `timestamp`: the flush is coarse (whole cache) so the
+    /// subscriber doesn't need to know which filter changed.
+    DnsFilterRebuilt {
+        timestamp: DateTime<Utc>,
+    },
     UpdateAvailable {
         current_version: String,
         latest_version: String,

--- a/source/daemon/crates/wardnetd-services/src/dns_filter/service.rs
+++ b/source/daemon/crates/wardnetd-services/src/dns_filter/service.rs
@@ -250,6 +250,18 @@ impl DnsFilterServiceImpl {
         });
     }
 
+    /// Announce that a compiled filter has just been swapped in. Emitted
+    /// from each mutating `rebuild_*_inner` immediately after the swap,
+    /// so `UdpDnsServer` (and any other cache holder) can invalidate
+    /// answers that were forwarded under the previous filter (issue
+    /// #341). Coarse by design — subscribers wanting fine-grained
+    /// behaviour can listen to `DnsFilterChanged` instead.
+    fn publish_rebuilt(&self) {
+        self.events.publish(WardnetEvent::DnsFilterRebuilt {
+            timestamp: Utc::now(),
+        });
+    }
+
     fn validate_domain(domain: &str) -> Result<(), AppError> {
         if domain.is_empty() {
             return Err(AppError::BadRequest("domain must not be empty".to_owned()));
@@ -384,6 +396,8 @@ impl DnsFilterServiceImpl {
         } else {
             filters.insert(blocklist_id, Arc::new(ArcSwap::from_pointee(new_filter)));
         }
+        drop(filters);
+        self.publish_rebuilt();
         Ok(())
     }
 
@@ -460,6 +474,8 @@ impl DnsFilterServiceImpl {
         } else {
             profiles.insert(profile_id, Arc::new(ArcSwap::from_pointee(runtime)));
         }
+        drop(profiles);
+        self.publish_rebuilt();
         Ok(())
     }
 
@@ -490,6 +506,8 @@ impl DnsFilterServiceImpl {
         if let Some(ip) = new_ip {
             by_ip.insert(ip, context);
         }
+        drop(by_ip);
+        self.publish_rebuilt();
         Ok(())
     }
 
@@ -553,6 +571,7 @@ impl DnsFilterServiceImpl {
             }
         };
         self.default_context.store(Arc::new(new_ctx));
+        self.publish_rebuilt();
         Ok(())
     }
 

--- a/source/daemon/crates/wardnetd-services/src/dns_filter/service.rs
+++ b/source/daemon/crates/wardnetd-services/src/dns_filter/service.rs
@@ -369,7 +369,14 @@ impl DnsFilterServiceImpl {
             .await
             .map_err(AppError::Internal)?;
         let Some(bl) = bl else {
-            // Removed — drop the cache entry.
+            // Removed — drop the cache entry. We deliberately do NOT
+            // publish `DnsFilterRebuilt` on this path: the response
+            // cache only ever holds `Pass` answers (the Block/Rewrite
+            // branches in `UdpDnsServer::handle_query` skip caching),
+            // and removing a blocklist can only un-block, never
+            // un-pass. Anything currently cached is still a valid
+            // answer. If a future change starts caching Block answers
+            // this invariant is gone and this path must publish.
             self.blocklist_filters.write().await.remove(&blocklist_id);
             return Ok(());
         };
@@ -410,6 +417,11 @@ impl DnsFilterServiceImpl {
             .await
             .map_err(AppError::Internal)?
         else {
+            // Profile gone — drop its in-memory entries. No
+            // `DnsFilterRebuilt` for the same reason as the
+            // blocklist-removed path above: cached answers are all
+            // `Pass`, and removing a profile can only un-block, never
+            // un-pass.
             self.profiles.write().await.remove(&profile_id);
             self.profile_aux_filters.write().await.remove(&profile_id);
             return Ok(());

--- a/source/daemon/crates/wardnetd/src/dns/server.rs
+++ b/source/daemon/crates/wardnetd/src/dns/server.rs
@@ -909,11 +909,14 @@ pub(crate) fn upstream_label(upstreams: &[UpstreamDns]) -> Option<String> {
 /// listener comes back. Flush on an empty cache is a no-op, so the
 /// always-on cost is nil. Exits cleanly on cancellation (Drop) or when
 /// the broadcast bus closes.
-fn spawn_cache_invalidator(
+///
+/// `pub(crate)` so the per-branch unit tests in `dns::tests::server`
+/// can drive it directly without standing up a full `UdpDnsServer`.
+pub(crate) fn spawn_cache_invalidator(
     cache: Arc<RwLock<DnsCache>>,
     mut event_rx: broadcast::Receiver<WardnetEvent>,
     cancel: CancellationToken,
-) {
+) -> tokio::task::JoinHandle<()> {
     tokio::spawn(async move {
         loop {
             tokio::select! {
@@ -951,7 +954,7 @@ fn spawn_cache_invalidator(
                 }
             }
         }
-    });
+    })
 }
 
 type TokioResolver = Resolver<TokioRuntimeProvider>;

--- a/source/daemon/crates/wardnetd/src/dns/server.rs
+++ b/source/daemon/crates/wardnetd/src/dns/server.rs
@@ -15,18 +15,20 @@ use hickory_resolver::config::{
 use hickory_resolver::lookup::Lookup;
 use hickory_resolver::net::runtime::TokioRuntimeProvider;
 use tokio::net::UdpSocket;
-use tokio::sync::{Mutex, RwLock};
+use tokio::sync::{Mutex, RwLock, broadcast};
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 use tokio_util::task::TaskTracker;
 use uuid::Uuid;
 use wardnet_common::dns::{DnsConfig, DnsProtocol, FilterAction, UpstreamDns, UpstreamId};
+use wardnet_common::event::WardnetEvent;
 use wardnetd_data::repository::QueryLogRow;
 use wardnetd_data::repository::TunnelRepository;
 use wardnetd_services::DnsFilterService;
 use wardnetd_services::dns::DnsLogSink;
 use wardnetd_services::dns::cache::DnsCache;
 use wardnetd_services::dns::server::{DnsServer, DnsSocket};
+use wardnetd_services::event::EventPublisher;
 
 // ---------------------------------------------------------------------------
 // UdpDnsSocket — production socket impl
@@ -102,6 +104,25 @@ pub struct UdpDnsServer {
     /// upstream the snapshot points at, not the forwarder behaviour
     /// itself, and unused entries quietly age out at process restart.
     tunnel_forwarders: Arc<RwLock<HashMap<Uuid, Arc<TunnelForwarderInfo>>>>,
+    /// Cancellation token for the background cache-invalidation
+    /// subscriber spawned in `new`/`with_bind_addr`. The subscriber
+    /// flushes the response cache on every `WardnetEvent::DnsFilterRebuilt`
+    /// (issue #341) so a freshly-published filter rebuild takes effect on
+    /// the next query rather than after cache TTL expiry. Lives for the
+    /// whole process — independent of the DNS `enabled` toggle — so
+    /// rebuild events that fire while DNS is disabled don't leave stale
+    /// entries when DNS is re-enabled. Cancelled in `Drop`.
+    cache_invalidator_cancel: CancellationToken,
+}
+
+impl Drop for UdpDnsServer {
+    fn drop(&mut self) {
+        // Signal the cache-invalidation subscriber to exit. The task
+        // observes the token and breaks out of its `select!`. Drop
+        // doesn't await the join — the bus has already been closed by
+        // its publisher (or soon will be) and the task self-terminates.
+        self.cache_invalidator_cancel.cancel();
+    }
 }
 
 /// Cached metadata required to forward a query to a specific tunnel's
@@ -121,6 +142,7 @@ impl UdpDnsServer {
         dns_filter: Arc<dyn DnsFilterService>,
         routing_snapshot: Arc<ArcSwap<HashMap<IpAddr, UpstreamId>>>,
         tunnel_repo: Arc<dyn TunnelRepository>,
+        events: Arc<dyn EventPublisher>,
     ) -> Self {
         Self::with_bind_addr(
             config,
@@ -128,9 +150,14 @@ impl UdpDnsServer {
             dns_filter,
             routing_snapshot,
             tunnel_repo,
+            events,
         )
     }
 
+    // `events` is consumed (subscribed once, then dropped) — keeping the
+    // by-value signature mirrors the other Arc params and lets call
+    // sites read like a plain construction.
+    #[allow(clippy::needless_pass_by_value)]
     #[must_use]
     pub fn with_bind_addr(
         config: DnsConfig,
@@ -138,11 +165,25 @@ impl UdpDnsServer {
         dns_filter: Arc<dyn DnsFilterService>,
         routing_snapshot: Arc<ArcSwap<HashMap<IpAddr, UpstreamId>>>,
         tunnel_repo: Arc<dyn TunnelRepository>,
+        events: Arc<dyn EventPublisher>,
     ) -> Self {
         let cache_capacity = config.cache_size as usize;
+        let cache = Arc::new(RwLock::new(DnsCache::new(cache_capacity)));
+        let cache_invalidator_cancel = CancellationToken::new();
+        // Subscribe BEFORE spawning so any event published between
+        // construction and the task running is buffered into this
+        // receiver — `broadcast::Receiver` only drops messages older
+        // than its position, not future ones. Subscribing in the spawn
+        // body would race rebuild events that land in the same tick.
+        let event_rx = events.subscribe();
+        spawn_cache_invalidator(
+            Arc::clone(&cache),
+            event_rx,
+            cache_invalidator_cancel.clone(),
+        );
         Self {
             config: Arc::new(RwLock::new(config)),
-            cache: Arc::new(RwLock::new(DnsCache::new(cache_capacity))),
+            cache,
             dns_filter,
             bind_addr,
             injected_socket: None,
@@ -156,6 +197,7 @@ impl UdpDnsServer {
             routing_snapshot,
             tunnel_repo,
             tunnel_forwarders: Arc::new(RwLock::new(HashMap::new())),
+            cache_invalidator_cancel,
         }
     }
 
@@ -856,6 +898,60 @@ pub(crate) fn duration_to_ms(d: std::time::Duration) -> f64 {
 
 pub(crate) fn upstream_label(upstreams: &[UpstreamDns]) -> Option<String> {
     upstreams.first().map(|u| u.address.clone())
+}
+
+/// Long-lived background task: subscribe to the event bus and flush the
+/// response cache on every `WardnetEvent::DnsFilterRebuilt` (issue #341).
+///
+/// Lives for the whole `UdpDnsServer` instance — independent of the
+/// `enabled` toggle that controls the listener — so a rebuild that
+/// fires while DNS is paused doesn't leave the cache stale when the
+/// listener comes back. Flush on an empty cache is a no-op, so the
+/// always-on cost is nil. Exits cleanly on cancellation (Drop) or when
+/// the broadcast bus closes.
+fn spawn_cache_invalidator(
+    cache: Arc<RwLock<DnsCache>>,
+    mut event_rx: broadcast::Receiver<WardnetEvent>,
+    cancel: CancellationToken,
+) {
+    tokio::spawn(async move {
+        loop {
+            tokio::select! {
+                () = cancel.cancelled() => {
+                    tracing::debug!("DNS cache invalidator cancelled");
+                    break;
+                }
+                result = event_rx.recv() => {
+                    match result {
+                        Ok(WardnetEvent::DnsFilterRebuilt { .. }) => {
+                            let removed = cache.write().await.flush();
+                            if removed > 0 {
+                                tracing::debug!(
+                                    removed,
+                                    "flushed DNS cache after filter rebuild"
+                                );
+                            }
+                        }
+                        Ok(_) => {}
+                        Err(broadcast::error::RecvError::Lagged(n)) => {
+                            // We may have skipped a rebuild event. Flush
+                            // defensively — a stale cache is the bug we're
+                            // here to prevent.
+                            tracing::warn!(
+                                skipped = n,
+                                "DNS cache invalidator lagged behind event bus; flushing defensively"
+                            );
+                            cache.write().await.flush();
+                        }
+                        Err(broadcast::error::RecvError::Closed) => {
+                            tracing::info!("DNS cache invalidator: event bus closed");
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+    });
 }
 
 type TokioResolver = Resolver<TokioRuntimeProvider>;

--- a/source/daemon/crates/wardnetd/src/dns/tests/server.rs
+++ b/source/daemon/crates/wardnetd/src/dns/tests/server.rs
@@ -21,11 +21,13 @@ use hickory_proto::rr::RecordType;
 use tokio::sync::RwLock;
 use uuid::Uuid;
 use wardnet_common::dns::{DnsConfig, DnsProtocol, UpstreamDns, UpstreamId};
+use wardnet_common::event::WardnetEvent;
 use wardnet_common::tunnel::{Tunnel, TunnelConfig, TunnelStatus};
 use wardnet_common::wireguard_config::WgPeerConfig;
 use wardnetd_data::repository::TunnelRepository;
 use wardnetd_data::repository::tunnel::TunnelRow;
 use wardnetd_services::dns::server::DnsServer;
+use wardnetd_services::event::{BroadcastEventBus, EventPublisher};
 
 use crate::dns::server::{
     TunnelForwarderInfo, UdpDnsServer, duration_to_ms, get_or_build_tunnel_forwarder,
@@ -39,6 +41,10 @@ fn loopback_ephemeral() -> SocketAddr {
 
 fn stub_filter() -> Arc<dyn wardnetd_services::DnsFilterService> {
     Arc::new(StubDnsFilterService)
+}
+
+fn stub_events() -> Arc<dyn EventPublisher> {
+    Arc::new(BroadcastEventBus::new(16))
 }
 
 fn empty_routing_snapshot() -> Arc<ArcSwap<HashMap<IpAddr, UpstreamId>>> {
@@ -320,6 +326,7 @@ fn build_test_server(config: DnsConfig, bind_addr: SocketAddr) -> UdpDnsServer {
         stub_filter(),
         empty_routing_snapshot(),
         stub_tunnel_repo(),
+        stub_events(),
     )
 }
 
@@ -659,6 +666,7 @@ async fn server_records_query_after_handling_it() {
         stub_filter(),
         empty_routing_snapshot(),
         stub_tunnel_repo(),
+        stub_events(),
     )
     .with_log_sink(Arc::clone(&sink));
 
@@ -917,6 +925,7 @@ fn build_with_filter(
         filter,
         empty_routing_snapshot(),
         stub_tunnel_repo(),
+        stub_events(),
     )
     .with_log_sink(sink)
 }
@@ -1036,6 +1045,7 @@ async fn handle_query_tunnel_branch_records_upstream_error_when_forward_fails() 
         filter,
         snapshot,
         tunnel_repo,
+        stub_events(),
     )
     .with_log_sink(Arc::clone(&sink));
 
@@ -1124,4 +1134,394 @@ fn build_resolver_skips_invalid_ip_addresses() {
         port: None,
     }];
     let _ = crate::dns::server::build_resolver(&upstreams);
+}
+
+// ---------------------------------------------------------------------------
+// Cache invalidation on DnsFilterRebuilt (issue #341).
+//
+// The server subscribes to the event bus at construction and flushes its
+// response cache whenever a filter rebuild is announced. Without this, a
+// domain that was previously forwarded and cached keeps serving the cached
+// "Pass" answer even after a blocklist update added it — until cache TTL
+// expiry, which is up to `dns_cache_ttl_max_secs` (one day default).
+// ---------------------------------------------------------------------------
+
+/// Filter that flips between Pass and Block under a shared lock so the
+/// test can simulate a blocklist update *before* publishing the
+/// invalidation event — i.e. the same ordering the real
+/// `DnsFilterServiceImpl` enforces (swap, then announce).
+struct SwitchableFilter {
+    action: tokio::sync::RwLock<wardnet_common::dns::FilterAction>,
+}
+
+impl SwitchableFilter {
+    fn new(initial: wardnet_common::dns::FilterAction) -> Self {
+        Self {
+            action: tokio::sync::RwLock::new(initial),
+        }
+    }
+    async fn set(&self, action: wardnet_common::dns::FilterAction) {
+        *self.action.write().await = action;
+    }
+}
+
+#[async_trait]
+impl wardnetd_services::DnsFilterService for SwitchableFilter {
+    async fn check(
+        &self,
+        _domain: &str,
+        _qtype: hickory_proto::rr::RecordType,
+        _client: std::net::IpAddr,
+    ) -> wardnetd_services::dns_filter::service::CheckOutcome {
+        wardnetd_services::dns_filter::service::CheckOutcome {
+            action: *self.action.read().await,
+            would_have_blocked: false,
+        }
+    }
+    async fn rebuild_all(&self) -> Result<(), wardnetd_services::error::AppError> {
+        Ok(())
+    }
+    async fn list_profiles(
+        &self,
+    ) -> Result<wardnet_common::api::ListProfilesResponse, wardnetd_services::error::AppError> {
+        unimplemented!()
+    }
+    async fn get_profile(
+        &self,
+        _id: Uuid,
+    ) -> Result<wardnet_common::api::GetProfileResponse, wardnetd_services::error::AppError> {
+        unimplemented!()
+    }
+    async fn create_profile(
+        &self,
+        _r: wardnet_common::api::CreateProfileRequest,
+    ) -> Result<wardnet_common::api::CreateProfileResponse, wardnetd_services::error::AppError>
+    {
+        unimplemented!()
+    }
+    async fn update_profile(
+        &self,
+        _id: Uuid,
+        _r: wardnet_common::api::UpdateProfileRequest,
+    ) -> Result<wardnet_common::api::UpdateProfileResponse, wardnetd_services::error::AppError>
+    {
+        unimplemented!()
+    }
+    async fn delete_profile(
+        &self,
+        _id: Uuid,
+    ) -> Result<wardnet_common::api::DeleteProfileResponse, wardnetd_services::error::AppError>
+    {
+        unimplemented!()
+    }
+    async fn list_blocklists(
+        &self,
+        _profile_id: Uuid,
+    ) -> Result<wardnet_common::api::ListBlocklistsResponse, wardnetd_services::error::AppError>
+    {
+        unimplemented!()
+    }
+    async fn create_blocklist(
+        &self,
+        _profile_id: Uuid,
+        _r: wardnet_common::api::CreateBlocklistRequest,
+    ) -> Result<wardnet_common::api::CreateBlocklistResponse, wardnetd_services::error::AppError>
+    {
+        unimplemented!()
+    }
+    async fn update_blocklist(
+        &self,
+        _profile_id: Uuid,
+        _id: Uuid,
+        _r: wardnet_common::api::UpdateBlocklistRequest,
+    ) -> Result<wardnet_common::api::UpdateBlocklistResponse, wardnetd_services::error::AppError>
+    {
+        unimplemented!()
+    }
+    async fn delete_blocklist(
+        &self,
+        _profile_id: Uuid,
+        _id: Uuid,
+    ) -> Result<wardnet_common::api::DeleteBlocklistResponse, wardnetd_services::error::AppError>
+    {
+        unimplemented!()
+    }
+    async fn refresh_blocklist(
+        &self,
+        _profile_id: Uuid,
+        _id: Uuid,
+    ) -> Result<wardnet_common::jobs::JobDispatchedResponse, wardnetd_services::error::AppError>
+    {
+        unimplemented!()
+    }
+    async fn list_allowlist(
+        &self,
+        _profile_id: Uuid,
+    ) -> Result<wardnet_common::api::ListAllowlistResponse, wardnetd_services::error::AppError>
+    {
+        unimplemented!()
+    }
+    async fn create_allowlist_entry(
+        &self,
+        _profile_id: Uuid,
+        _r: wardnet_common::api::CreateAllowlistRequest,
+    ) -> Result<wardnet_common::api::CreateAllowlistResponse, wardnetd_services::error::AppError>
+    {
+        unimplemented!()
+    }
+    async fn delete_allowlist_entry(
+        &self,
+        _profile_id: Uuid,
+        _id: Uuid,
+    ) -> Result<wardnet_common::api::DeleteAllowlistResponse, wardnetd_services::error::AppError>
+    {
+        unimplemented!()
+    }
+    async fn list_custom_rules(
+        &self,
+        _profile_id: Uuid,
+    ) -> Result<wardnet_common::api::ListFilterRulesResponse, wardnetd_services::error::AppError>
+    {
+        unimplemented!()
+    }
+    async fn create_custom_rule(
+        &self,
+        _profile_id: Uuid,
+        _r: wardnet_common::api::CreateFilterRuleRequest,
+    ) -> Result<wardnet_common::api::CreateFilterRuleResponse, wardnetd_services::error::AppError>
+    {
+        unimplemented!()
+    }
+    async fn update_custom_rule(
+        &self,
+        _profile_id: Uuid,
+        _id: Uuid,
+        _r: wardnet_common::api::UpdateFilterRuleRequest,
+    ) -> Result<wardnet_common::api::UpdateFilterRuleResponse, wardnetd_services::error::AppError>
+    {
+        unimplemented!()
+    }
+    async fn delete_custom_rule(
+        &self,
+        _profile_id: Uuid,
+        _id: Uuid,
+    ) -> Result<wardnet_common::api::DeleteFilterRuleResponse, wardnetd_services::error::AppError>
+    {
+        unimplemented!()
+    }
+    async fn list_device_settings(
+        &self,
+        _params: wardnet_common::api::ListDeviceFilterSettingsParams,
+    ) -> Result<
+        wardnet_common::api::ListDeviceFilterSettingsResponse,
+        wardnetd_services::error::AppError,
+    > {
+        unimplemented!()
+    }
+    async fn get_device_settings(
+        &self,
+        _device_id: Uuid,
+    ) -> Result<
+        wardnet_common::api::GetDeviceFilterSettingsResponse,
+        wardnetd_services::error::AppError,
+    > {
+        unimplemented!()
+    }
+    async fn update_device_settings(
+        &self,
+        _device_id: Uuid,
+        _r: wardnet_common::api::UpdateDeviceFilterSettingsRequest,
+    ) -> Result<
+        wardnet_common::api::UpdateDeviceFilterSettingsResponse,
+        wardnetd_services::error::AppError,
+    > {
+        unimplemented!()
+    }
+    async fn get_filter_config(
+        &self,
+    ) -> Result<wardnet_common::api::DnsFilterConfigResponse, wardnetd_services::error::AppError>
+    {
+        unimplemented!()
+    }
+    async fn update_filter_config(
+        &self,
+        _r: wardnet_common::api::UpdateDnsFilterConfigRequest,
+    ) -> Result<wardnet_common::api::DnsFilterConfigResponse, wardnetd_services::error::AppError>
+    {
+        unimplemented!()
+    }
+    async fn rebuild_blocklist_filter(
+        &self,
+        _id: Uuid,
+    ) -> Result<(), wardnetd_services::error::AppError> {
+        Ok(())
+    }
+    async fn rebuild_profile(&self, _id: Uuid) -> Result<(), wardnetd_services::error::AppError> {
+        Ok(())
+    }
+    async fn rebuild_device(&self, _id: Uuid) -> Result<(), wardnetd_services::error::AppError> {
+        Ok(())
+    }
+    async fn rebuild_default_context(&self) -> Result<(), wardnetd_services::error::AppError> {
+        Ok(())
+    }
+    async fn handle_device_ip_changed(
+        &self,
+        _device_id: Uuid,
+        _old_ip: &str,
+        _new_ip: &str,
+    ) -> Result<(), wardnetd_services::error::AppError> {
+        Ok(())
+    }
+}
+
+/// Spawn a tiny UDP responder that answers every query with a single A
+/// record (`93.184.216.34`, TTL 60). Returns the bound address. Lives
+/// for the test's duration — the spawned task self-terminates when its
+/// socket is dropped (which happens when the test exits and the
+/// runtime tears down).
+async fn spawn_stub_upstream() -> SocketAddr {
+    use hickory_proto::op::{Message, OpCode};
+    use hickory_proto::rr::{Name, RData, Record, rdata::A};
+    use hickory_proto::serialize::binary::{BinDecodable, BinEncodable};
+
+    let socket = tokio::net::UdpSocket::bind("127.0.0.1:0")
+        .await
+        .expect("stub upstream bind");
+    let addr = socket.local_addr().expect("stub upstream local_addr");
+    tokio::spawn(async move {
+        let mut buf = vec![0u8; 4096];
+        loop {
+            let Ok((n, src)) = socket.recv_from(&mut buf).await else {
+                break;
+            };
+            let Ok(request) = Message::from_bytes(&buf[..n]) else {
+                continue;
+            };
+            let id = request.metadata.id;
+            let mut response = Message::response(id, OpCode::Query);
+            response.metadata.recursion_desired = true;
+            response.metadata.recursion_available = true;
+            response.add_queries(request.queries.clone());
+            for q in &request.queries {
+                if q.query_type() == RecordType::A {
+                    let name = Name::from_str_relaxed(q.name().to_string())
+                        .unwrap_or_else(|_| q.name().clone());
+                    let record =
+                        Record::from_rdata(name, 60, RData::A(A(Ipv4Addr::new(93, 184, 216, 34))));
+                    response.add_answer(record);
+                }
+            }
+            if let Ok(bytes) = response.to_bytes() {
+                let _ = socket.send_to(&bytes, src).await;
+            }
+        }
+    });
+    addr
+}
+
+/// Send a hand-rolled A query for `foo.com.` (id=0xCAFE) and read the
+/// reply from a fresh client socket. Returns the parsed response so the
+/// test can check `response_code`.
+async fn query_foo_com(target: SocketAddr) -> hickory_proto::op::Message {
+    use hickory_proto::op::Message;
+    use hickory_proto::serialize::binary::BinDecodable;
+
+    let client = tokio::net::UdpSocket::bind("127.0.0.1:0")
+        .await
+        .expect("client bind");
+    // DNS query: id=0xCAFE, RD=1, 1 question for foo.com A IN.
+    let query: &[u8] = &[
+        0xCA, 0xFE, 0x01, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x03, b'f', b'o',
+        b'o', 0x03, b'c', b'o', b'm', 0x00, 0x00, 0x01, 0x00, 0x01,
+    ];
+    client.send_to(query, target).await.expect("send");
+    let mut buf = vec![0u8; 4096];
+    let (n, _) = tokio::time::timeout(Duration::from_secs(5), client.recv_from(&mut buf))
+        .await
+        .expect("client recv timeout")
+        .expect("client recv");
+    Message::from_bytes(&buf[..n]).expect("parse response")
+}
+
+#[tokio::test]
+async fn dns_filter_rebuilt_event_flushes_response_cache() {
+    use hickory_proto::op::ResponseCode;
+
+    // 1. Stand up a controlled upstream so cache fills deterministically.
+    let upstream_addr = spawn_stub_upstream().await;
+
+    // 2. Switchable filter starts in Pass — cache fills on the first query.
+    let filter = Arc::new(SwitchableFilter::new(
+        wardnet_common::dns::FilterAction::Pass,
+    ));
+    let bus: Arc<dyn EventPublisher> = Arc::new(BroadcastEventBus::new(16));
+
+    let cfg = DnsConfig {
+        upstream_servers: vec![UpstreamDns {
+            name: "stub".into(),
+            address: upstream_addr.ip().to_string(),
+            protocol: DnsProtocol::Udp,
+            port: Some(upstream_addr.port()),
+        }],
+        ..DnsConfig::default()
+    };
+    let server = UdpDnsServer::with_bind_addr(
+        cfg,
+        loopback_ephemeral(),
+        filter.clone() as Arc<dyn wardnetd_services::DnsFilterService>,
+        empty_routing_snapshot(),
+        stub_tunnel_repo(),
+        bus.clone(),
+    );
+    server.start().await.unwrap();
+    let bound = server.local_addr().expect("server bound");
+
+    // 3. First query — Pass + forward, response gets cached.
+    let resp = query_foo_com(bound).await;
+    assert_eq!(
+        resp.metadata.response_code,
+        ResponseCode::NoError,
+        "stub upstream should answer NoError"
+    );
+    assert!(
+        server.cache_size().await > 0,
+        "forwarded answer should populate the cache"
+    );
+
+    // 4. Simulate the service swap: flip the filter to Block, *then*
+    //    publish DnsFilterRebuilt — same ordering as the real service
+    //    (swap, then announce). The subscriber spawned in
+    //    `with_bind_addr` should observe the event and flush.
+    filter.set(wardnet_common::dns::FilterAction::Block).await;
+    bus.publish(WardnetEvent::DnsFilterRebuilt {
+        timestamp: Utc::now(),
+    });
+
+    // 5. Wait for the flush. Poll briefly — the subscriber runs on the
+    //    tokio runtime and the broadcast hop is sub-millisecond, but
+    //    the write lock still needs a scheduler tick.
+    let mut flushed = false;
+    for _ in 0..50 {
+        if server.cache_size().await == 0 {
+            flushed = true;
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+    assert!(
+        flushed,
+        "cache was not flushed within 1s of DnsFilterRebuilt"
+    );
+
+    // 6. Re-query foo.com — must NOT serve the (now flushed) cached
+    //    answer. The new filter blocks, so we expect NXDOMAIN.
+    let resp = query_foo_com(bound).await;
+    assert_eq!(
+        resp.metadata.response_code,
+        ResponseCode::NXDomain,
+        "post-flush query should hit the new Block filter, not the stale cache"
+    );
+
+    server.stop().await.unwrap();
 }

--- a/source/daemon/crates/wardnetd/src/dns/tests/server.rs
+++ b/source/daemon/crates/wardnetd/src/dns/tests/server.rs
@@ -31,7 +31,7 @@ use wardnetd_services::event::{BroadcastEventBus, EventPublisher};
 
 use crate::dns::server::{
     TunnelForwarderInfo, UdpDnsServer, duration_to_ms, get_or_build_tunnel_forwarder,
-    upstream_label,
+    spawn_cache_invalidator, upstream_label,
 };
 use crate::tests::stubs::StubDnsFilterService;
 
@@ -1524,4 +1524,150 @@ async fn dns_filter_rebuilt_event_flushes_response_cache() {
     );
 
     server.stop().await.unwrap();
+}
+
+// ---------------------------------------------------------------------------
+// `spawn_cache_invalidator` per-branch unit tests.
+//
+// The integration test above covers the happy path (subscribe → receive
+// `DnsFilterRebuilt` → flush). The branches below are harder to exercise
+// through a full `UdpDnsServer` so we drive the task directly: the
+// function is `pub(crate)` for exactly this reason.
+// ---------------------------------------------------------------------------
+
+/// Build a primed cache + a fresh task. Returns the cache handle (so the
+/// test can observe flushes), the bus (so the test can publish), the
+/// cancellation token, and the spawned task's handle (so the test can
+/// await clean exit).
+async fn spawn_invalidator_for_test(
+    capacity: usize,
+) -> (
+    Arc<RwLock<wardnetd_services::dns::cache::DnsCache>>,
+    Arc<BroadcastEventBus>,
+    tokio_util::sync::CancellationToken,
+    tokio::task::JoinHandle<()>,
+) {
+    use wardnetd_services::dns::cache::DnsCache;
+    let cache = Arc::new(RwLock::new(DnsCache::new(16)));
+    seed_cache(&cache).await;
+    let bus = Arc::new(BroadcastEventBus::new(capacity));
+    let cancel = tokio_util::sync::CancellationToken::new();
+    let handle = spawn_cache_invalidator(Arc::clone(&cache), bus.subscribe(), cancel.clone());
+    (cache, bus, cancel, handle)
+}
+
+/// Insert a single sentinel entry so `cache.len() == 1` and a flush is
+/// observable. Re-uses the cache's own `insert` path with a synthetic
+/// `Pass` answer keyed on `Default`.
+async fn seed_cache(cache: &Arc<RwLock<wardnetd_services::dns::cache::DnsCache>>) {
+    use hickory_proto::op::{Message, OpCode};
+    let mut answer = Message::response(0, OpCode::Query);
+    answer.metadata.recursion_desired = true;
+    answer.metadata.recursion_available = true;
+    cache.write().await.insert(
+        UpstreamId::Default,
+        "seed.example.",
+        RecordType::A,
+        answer,
+        60,
+        1,
+        60,
+    );
+    assert_eq!(cache.read().await.len(), 1, "seed must populate cache");
+}
+
+#[tokio::test]
+async fn cache_invalidator_ignores_non_rebuild_events() {
+    // The `Ok(_) => {}` arm: events other than `DnsFilterRebuilt` are
+    // observed and discarded without touching the cache.
+    let (cache, bus, cancel, handle) = spawn_invalidator_for_test(16).await;
+
+    bus.publish(WardnetEvent::DnsServerStarted {
+        timestamp: Utc::now(),
+    });
+
+    // Give the task a tick to consume the event.
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    assert_eq!(
+        cache.read().await.len(),
+        1,
+        "non-rebuild events must NOT flush the cache"
+    );
+
+    cancel.cancel();
+    handle.await.expect("task joins after cancel");
+}
+
+#[tokio::test]
+async fn cache_invalidator_exits_on_cancel() {
+    // The `cancel.cancelled()` arm: cancelling the token (the path
+    // `Drop` takes) makes the task return promptly. We assert via
+    // `handle.await` completing within a small budget.
+    let (_cache, _bus, cancel, handle) = spawn_invalidator_for_test(16).await;
+
+    cancel.cancel();
+    tokio::time::timeout(Duration::from_secs(1), handle)
+        .await
+        .expect("task must exit within 1s of cancel")
+        .expect("task joins cleanly (no panic)");
+}
+
+#[tokio::test]
+async fn cache_invalidator_exits_on_bus_close() {
+    // The `RecvError::Closed` arm: when every sender drops, the
+    // receiver returns Closed and the task breaks out. The
+    // `BroadcastEventBus` owns the sender, so dropping the sole Arc
+    // closes the channel.
+    let (_cache, bus, _cancel, handle) = spawn_invalidator_for_test(16).await;
+
+    drop(bus);
+    tokio::time::timeout(Duration::from_secs(1), handle)
+        .await
+        .expect("task must exit within 1s of bus close")
+        .expect("task joins cleanly (no panic)");
+}
+
+#[tokio::test]
+async fn cache_invalidator_flushes_defensively_on_lagged() {
+    // The `RecvError::Lagged` arm: if we publish more than `capacity`
+    // events before the task drains them, the broadcast receiver
+    // surfaces `Lagged(n)` on its next `recv()`. The subscriber
+    // flushes anyway because we may have skipped a real
+    // `DnsFilterRebuilt`.
+    //
+    // Capacity 2 and 5 publishes before any scheduler tick guarantees
+    // the lag — even on a single-threaded runtime the publishes are
+    // synchronous and the subscriber hasn't been polled yet.
+    let (cache, bus, cancel, handle) = spawn_invalidator_for_test(2).await;
+
+    for _ in 0..5 {
+        bus.publish(WardnetEvent::DnsServerStarted {
+            timestamp: Utc::now(),
+        });
+    }
+
+    let mut flushed = false;
+    for _ in 0..50 {
+        if cache.read().await.is_empty() {
+            flushed = true;
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+    assert!(flushed, "Lagged path must trigger a defensive flush");
+
+    cancel.cancel();
+    handle.await.expect("task joins after cancel");
+}
+
+#[tokio::test]
+async fn drop_cancels_cache_invalidator() {
+    // `UdpDnsServer::Drop` fires the cancellation token. We can't
+    // reach into the spawned task from here, but constructing then
+    // immediately dropping a server ensures the Drop body runs (and
+    // therefore is counted by coverage), and the test must not hang —
+    // a leaked task wouldn't block this test, but a panic in Drop
+    // would surface here.
+    let server = build_test_server(DnsConfig::default(), loopback_ephemeral());
+    drop(server);
 }

--- a/source/daemon/crates/wardnetd/src/main.rs
+++ b/source/daemon/crates/wardnetd/src/main.rs
@@ -378,6 +378,7 @@ async fn run(
             services.dns_filter.clone(),
             services.routing.dns_upstream_snapshot(),
             services.tunnel_repo.clone(),
+            services.event_publisher.clone(),
         )
         .with_log_sink(services.dns_log_sink.clone()),
     );

--- a/source/daemon/crates/wardnetd/src/routing_listener.rs
+++ b/source/daemon/crates/wardnetd/src/routing_listener.rs
@@ -212,6 +212,7 @@ async fn handle_event(event: WardnetEvent, routing: &dyn RoutingService) {
         | WardnetEvent::DnsConfigChanged { .. }
         | WardnetEvent::DnsFilterBlocklistUpdated { .. }
         | WardnetEvent::DnsFilterChanged { .. }
+        | WardnetEvent::DnsFilterRebuilt { .. }
         | WardnetEvent::UpdateAvailable { .. }
         | WardnetEvent::UpdateProgress { .. }
         | WardnetEvent::UpdateCompleted { .. }


### PR DESCRIPTION
Closes #341.

## Summary

- Cached DNS answers (TTL ≤ `dns_cache_ttl_max_secs`, default 1 day) survived filter changes — newly-blocked domains kept returning cached `Pass` answers until TTL expiry. From the user's perspective, blocklist edits did nothing.
- Add `WardnetEvent::DnsFilterRebuilt { timestamp }`. `DnsFilterServiceImpl` publishes it immediately after `ArcSwap.store(new)` in the four mutating rebuild paths — `rebuild_blocklist_inner`, `rebuild_profile_inner`, `rebuild_device_inner`, `rebuild_default_context_inner`. `rebuild_all` (bootstrap, cache empty) and `handle_device_ip_changed` (DHCP churn doesn't change `UpstreamId`) are skipped per the design.
- `UdpDnsServer::new` / `with_bind_addr` now take `Arc<dyn EventPublisher>` and spawn a long-lived background subscriber that flushes the response cache on every `DnsFilterRebuilt`. The task lives for the whole process — independent of the DNS `enabled` toggle — so rebuilds that fire while DNS is paused don't leave the cache stale when it resumes. Cancelled in `Drop`.
- Order is **flush after swap, never before**: flushing before would let an in-flight query miss cache, run the old filter, forward, and re-insert a stale `Pass` that survives the swap until TTL.

## Test plan

- [x] Unit tests pass (`make check-daemon`) — including a new integration test `dns_filter_rebuilt_event_flushes_response_cache` that spins up a stub UDP upstream, fills the cache via a real query, publishes `DnsFilterRebuilt` after flipping a switchable filter to Block, awaits the flush, and asserts the next query returns NXDOMAIN (covers the AC's recipe).
- [x] All four targeted rebuild paths emit the event — verified by code inspection; the new shared `publish_rebuilt()` helper is called from each.
- [x] Subscriber is cancelled cleanly on shutdown — explicit `Drop` impl on `UdpDnsServer` cancels the token; the spawned task observes `cancel.cancelled()` in its `select!` and exits.
- [x] `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test --workspace` all green.