### PR TITLE
feat(daemon): GARP failover on graceful shutdown and startup (#213)

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -70,7 +70,7 @@ jobs:
             --workspace \
             --profile ci \
             --lcov --output-path ../../coverage/daemon-lcov.info \
-            --ignore-filename-regex '(main\.rs|noop_.*\.rs|db\.rs|web\.rs|api/mod\.rs|auth_context\.rs|command\.rs|policy_router_netlink\.rs|route_monitor\.rs|tunnel_exit_probe\.rs|wardnet-test-agent/.*|wardnetd-mock/src/events\.rs|wardnetd-data/src/lib\.rs)'
+            --ignore-filename-regex '(main\.rs|noop_.*\.rs|db\.rs|web\.rs|api/mod\.rs|auth_context\.rs|command\.rs|policy_router_netlink\.rs|route_monitor\.rs|pnet_network_probe\.rs|garp_pnet\.rs|tunnel_exit_probe\.rs|wardnet-test-agent/.*|wardnetd-mock/src/events\.rs|wardnetd-data/src/lib\.rs)'
           cp target/nextest/ci/junit.xml ../../coverage/daemon-junit.xml
 
       - name: Upload daemon coverage artifact

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ LINUX_TARGET := $(CURDIR)/.target-linux
 
 # Coverage: files excluded from cargo-llvm-cov.  Single source of truth —
 # CI calls `make coverage-daemon` with COV_FMT overridden for LCOV output.
-COV_IGNORE := (main\.rs|noop_.*\.rs|db\.rs|web\.rs|api/mod\.rs|auth_context\.rs|command\.rs|policy_router_netlink\.rs|route_monitor\.rs|pnet_network_probe\.rs|tunnel_exit_probe\.rs|wardnet-test-agent/.*|wardnetd-mock/src/events\.rs|wardnetd-data/src/lib\.rs)
+COV_IGNORE := (main\.rs|noop_.*\.rs|db\.rs|web\.rs|api/mod\.rs|auth_context\.rs|command\.rs|policy_router_netlink\.rs|route_monitor\.rs|pnet_network_probe\.rs|garp_pnet\.rs|tunnel_exit_probe\.rs|wardnet-test-agent/.*|wardnetd-mock/src/events\.rs|wardnetd-data/src/lib\.rs)
 # Default: human-readable summary.  CI overrides:
 #   make coverage-daemon COV_FMT="--lcov --output-path ../../coverage/daemon-lcov.info"
 COV_FMT    ?= --summary-only

--- a/source/daemon/Cargo.lock
+++ b/source/daemon/Cargo.lock
@@ -5285,8 +5285,10 @@ dependencies = [
 name = "wardnet-test-agent"
 version = "0.2.0"
 dependencies = [
+ "anyhow",
  "axum",
  "clap",
+ "pnet",
  "regex",
  "serde",
  "serde_json",

--- a/source/daemon/crates/wardnet-test-agent/Cargo.toml
+++ b/source/daemon/crates/wardnet-test-agent/Cargo.toml
@@ -25,3 +25,11 @@ tracing-subscriber.workspace = true
 clap.workspace = true
 # https://crates.io/crates/regex
 regex.workspace = true
+# https://crates.io/crates/anyhow
+anyhow.workspace = true
+# https://crates.io/crates/pnet
+# Drives raw ARP traffic from the test-agent container's host
+# interface for the GARP-failover e2e (issue #213). The crate is
+# already a workspace dep used by `wardnetd`'s pnet-based
+# packet-capture and probe paths.
+pnet.workspace = true

--- a/source/daemon/crates/wardnet-test-agent/src/client/arp.rs
+++ b/source/daemon/crates/wardnet-test-agent/src/client/arp.rs
@@ -22,6 +22,7 @@ use std::time::{Duration, Instant};
 use axum::Json;
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
+use serde_json::json;
 use pnet::datalink::{self, Channel, Config, NetworkInterface};
 use pnet::packet::Packet;
 use pnet::packet::arp::{ArpHardwareTypes, ArpOperation, ArpPacket, MutableArpPacket};
@@ -108,13 +109,17 @@ pub struct CapturedArpFrame {
 }
 
 /// `POST /arp/send`
+///
+/// Returns `200` with an empty JSON object on success — every other
+/// client-serve endpoint also returns JSON, and the e2e helper
+/// (`agentPost`) unconditionally `res.json()`s the body.
 pub async fn post_arp_send(Json(req): Json<ArpSendRequest>) -> impl IntoResponse {
     let result = tokio::task::spawn_blocking(move || run_send(&req))
         .await
         .map_err(|e| anyhow::anyhow!("arp send blocking task panicked: {e}"));
 
     match result {
-        Ok(Ok(())) => StatusCode::NO_CONTENT.into_response(),
+        Ok(Ok(())) => Json(json!({})).into_response(),
         Ok(Err(e)) | Err(e) => (
             StatusCode::BAD_REQUEST,
             Json(ClientError::new(e.to_string())),

--- a/source/daemon/crates/wardnet-test-agent/src/client/arp.rs
+++ b/source/daemon/crates/wardnet-test-agent/src/client/arp.rs
@@ -1,0 +1,313 @@
+//! Raw ARP send/capture endpoints used by the GARP-failover e2e
+//! (issue #213).
+//!
+//! `/arp/send` builds and emits ARP frames. The caller fully controls
+//! every field so the same handler is used to:
+//! - drive passive learning of `garp_router_mac` (a single
+//!   gratuitous-reply from a synthetic router MAC), and
+//! - emit any future ARP-shaped traffic the e2e suite needs without
+//!   adding a new endpoint each time.
+//!
+//! `/arp/capture` opens a pnet datalink channel for a bounded window
+//! and returns every parsed ARP frame seen during it. The e2e uses
+//! it to assert the GARP claim/farewell pulses arrive on the LAN
+//! bridge.
+//!
+//! Both endpoints run inside `spawn_blocking` because pnet's
+//! datalink channel is synchronous.
+
+use std::net::Ipv4Addr;
+use std::time::{Duration, Instant};
+
+use axum::Json;
+use axum::http::StatusCode;
+use axum::response::IntoResponse;
+use pnet::datalink::{self, Channel, Config, NetworkInterface};
+use pnet::packet::Packet;
+use pnet::packet::arp::{ArpHardwareTypes, ArpOperation, ArpPacket, MutableArpPacket};
+use pnet::packet::ethernet::{EtherTypes, EthernetPacket, MutableEthernetPacket};
+use pnet::util::MacAddr;
+use serde::{Deserialize, Serialize};
+
+use super::models::ClientError;
+
+const READ_POLL: Duration = Duration::from_millis(100);
+
+#[derive(Debug, Deserialize)]
+pub struct ArpSendRequest {
+    /// ARP opcode. Defaults to 2 (reply).
+    #[serde(default = "default_opcode")]
+    pub opcode: u16,
+    /// Sender hardware address (`AA:BB:CC:DD:EE:FF`).
+    pub sender_mac: String,
+    /// Sender protocol (IPv4) address.
+    pub sender_ip: String,
+    /// Target hardware address. Defaults to broadcast for gratuitous
+    /// announcements.
+    #[serde(default = "default_broadcast_mac")]
+    pub target_mac: String,
+    /// Target protocol (IPv4) address.
+    pub target_ip: String,
+    /// Number of pulses to send. Defaults to 1.
+    #[serde(default = "default_count")]
+    pub count: u32,
+    /// Milliseconds to sleep between pulses. Defaults to 0 (no gap).
+    #[serde(default)]
+    pub interval_ms: u64,
+    /// Network interface to send from. Defaults to "eth0".
+    #[serde(default = "default_interface")]
+    pub interface: String,
+}
+
+fn default_opcode() -> u16 {
+    2
+}
+fn default_broadcast_mac() -> String {
+    "ff:ff:ff:ff:ff:ff".to_owned()
+}
+fn default_count() -> u32 {
+    1
+}
+fn default_interface() -> String {
+    "eth0".to_owned()
+}
+
+#[derive(Debug, Deserialize)]
+pub struct ArpCaptureRequest {
+    /// How long to capture for, in milliseconds.
+    pub duration_ms: u64,
+    /// Network interface to capture on. Defaults to "eth0".
+    #[serde(default = "default_interface")]
+    pub interface: String,
+    /// Optional filter applied to each frame. When set, only frames
+    /// matching every populated field are returned.
+    #[serde(default)]
+    pub filter: Option<ArpCaptureFilter>,
+}
+
+#[derive(Debug, Deserialize, Default)]
+pub struct ArpCaptureFilter {
+    pub sender_ip: Option<String>,
+    pub sender_mac: Option<String>,
+    pub opcode: Option<u16>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct CapturedArpFrame {
+    pub opcode: u16,
+    pub sender_ip: String,
+    pub sender_mac: String,
+    pub target_ip: String,
+    pub target_mac: String,
+    /// Milliseconds since the capture window started.
+    pub timestamp_ms: u128,
+    /// Ethernet source / destination — useful to assert the L2
+    /// headers also flipped on a GARP failover (decision 4).
+    pub eth_source: String,
+    pub eth_destination: String,
+}
+
+/// `POST /arp/send`
+pub async fn post_arp_send(Json(req): Json<ArpSendRequest>) -> impl IntoResponse {
+    let result = tokio::task::spawn_blocking(move || run_send(&req))
+        .await
+        .map_err(|e| anyhow::anyhow!("arp send blocking task panicked: {e}"));
+
+    match result {
+        Ok(Ok(())) => StatusCode::NO_CONTENT.into_response(),
+        Ok(Err(e)) | Err(e) => (
+            StatusCode::BAD_REQUEST,
+            Json(ClientError::new(e.to_string())),
+        )
+            .into_response(),
+    }
+}
+
+/// `POST /arp/capture`
+pub async fn post_arp_capture(Json(req): Json<ArpCaptureRequest>) -> impl IntoResponse {
+    let result = tokio::task::spawn_blocking(move || run_capture(req))
+        .await
+        .map_err(|e| anyhow::anyhow!("arp capture blocking task panicked: {e}"));
+
+    match result {
+        Ok(Ok(frames)) => Json(frames).into_response(),
+        Ok(Err(e)) | Err(e) => (
+            StatusCode::BAD_REQUEST,
+            Json(ClientError::new(e.to_string())),
+        )
+            .into_response(),
+    }
+}
+
+fn run_send(req: &ArpSendRequest) -> anyhow::Result<()> {
+    let sender_mac: MacAddr = req
+        .sender_mac
+        .parse()
+        .map_err(|e| anyhow::anyhow!("invalid sender_mac {}: {e}", req.sender_mac))?;
+    let target_mac: MacAddr = req
+        .target_mac
+        .parse()
+        .map_err(|e| anyhow::anyhow!("invalid target_mac {}: {e}", req.target_mac))?;
+    let sender_ip: Ipv4Addr = req
+        .sender_ip
+        .parse()
+        .map_err(|e| anyhow::anyhow!("invalid sender_ip {}: {e}", req.sender_ip))?;
+    let target_ip: Ipv4Addr = req
+        .target_ip
+        .parse()
+        .map_err(|e| anyhow::anyhow!("invalid target_ip {}: {e}", req.target_ip))?;
+
+    let frame = build_arp_frame(req.opcode, sender_mac, sender_ip, target_mac, target_ip)
+        .ok_or_else(|| anyhow::anyhow!("failed to build ARP frame"))?;
+
+    let iface = find_interface(&req.interface)?;
+    let Channel::Ethernet(mut tx, _rx) = datalink::channel(&iface, Config::default())
+        .map_err(|e| anyhow::anyhow!("datalink channel failed on {}: {e}", req.interface))?
+    else {
+        anyhow::bail!("unsupported channel type for {}", req.interface);
+    };
+
+    for pulse in 0..req.count {
+        match tx.send_to(&frame, None) {
+            Some(Ok(())) => {}
+            Some(Err(e)) => anyhow::bail!("send failed at pulse {}: {e}", pulse + 1),
+            None => anyhow::bail!("datalink rejected pulse {}", pulse + 1),
+        }
+        if pulse + 1 < req.count && req.interval_ms > 0 {
+            std::thread::sleep(Duration::from_millis(req.interval_ms));
+        }
+    }
+
+    Ok(())
+}
+
+fn run_capture(req: ArpCaptureRequest) -> anyhow::Result<Vec<CapturedArpFrame>> {
+    let iface = find_interface(&req.interface)?;
+    let config = Config {
+        read_timeout: Some(READ_POLL),
+        ..Config::default()
+    };
+    let Channel::Ethernet(_tx, mut rx) = datalink::channel(&iface, config)
+        .map_err(|e| anyhow::anyhow!("datalink channel failed on {}: {e}", req.interface))?
+    else {
+        anyhow::bail!("unsupported channel type for {}", req.interface);
+    };
+
+    let filter = req.filter.unwrap_or_default();
+    let filter_sender_ip: Option<Ipv4Addr> = filter
+        .sender_ip
+        .as_deref()
+        .map(str::parse)
+        .transpose()
+        .map_err(|e| anyhow::anyhow!("invalid filter.sender_ip: {e}"))?;
+    let filter_sender_mac: Option<MacAddr> = filter
+        .sender_mac
+        .as_deref()
+        .map(str::parse)
+        .transpose()
+        .map_err(|e| anyhow::anyhow!("invalid filter.sender_mac: {e}"))?;
+
+    let started = Instant::now();
+    let deadline = started + Duration::from_millis(req.duration_ms);
+    let mut out = Vec::new();
+    while Instant::now() < deadline {
+        match rx.next() {
+            Ok(frame) => {
+                if let Some(captured) = parse_arp(frame, started)
+                    && passes_filter(
+                        &captured,
+                        filter_sender_ip,
+                        filter_sender_mac,
+                        filter.opcode,
+                    )
+                {
+                    out.push(captured);
+                }
+            }
+            Err(e) if e.kind() == std::io::ErrorKind::TimedOut => {}
+            Err(e) => return Err(anyhow::anyhow!("ARP capture read failed: {e}")),
+        }
+    }
+    Ok(out)
+}
+
+fn passes_filter(
+    frame: &CapturedArpFrame,
+    sender_ip: Option<Ipv4Addr>,
+    sender_mac: Option<MacAddr>,
+    opcode: Option<u16>,
+) -> bool {
+    if let Some(ip) = sender_ip
+        && frame.sender_ip != ip.to_string()
+    {
+        return false;
+    }
+    if let Some(mac) = sender_mac
+        && frame.sender_mac.to_lowercase() != mac.to_string().to_lowercase()
+    {
+        return false;
+    }
+    if let Some(op) = opcode
+        && frame.opcode != op
+    {
+        return false;
+    }
+    true
+}
+
+fn parse_arp(bytes: &[u8], started: Instant) -> Option<CapturedArpFrame> {
+    let eth = EthernetPacket::new(bytes)?;
+    if eth.get_ethertype() != EtherTypes::Arp {
+        return None;
+    }
+    let arp = ArpPacket::new(eth.payload())?;
+    Some(CapturedArpFrame {
+        opcode: arp.get_operation().0,
+        sender_ip: arp.get_sender_proto_addr().to_string(),
+        sender_mac: arp.get_sender_hw_addr().to_string(),
+        target_ip: arp.get_target_proto_addr().to_string(),
+        target_mac: arp.get_target_hw_addr().to_string(),
+        timestamp_ms: started.elapsed().as_millis(),
+        eth_source: eth.get_source().to_string(),
+        eth_destination: eth.get_destination().to_string(),
+    })
+}
+
+fn build_arp_frame(
+    opcode: u16,
+    sender_mac: MacAddr,
+    sender_ip: Ipv4Addr,
+    target_mac: MacAddr,
+    target_ip: Ipv4Addr,
+) -> Option<Vec<u8>> {
+    let mut buf = vec![0u8; 42];
+    {
+        let mut eth = MutableEthernetPacket::new(&mut buf)?;
+        // Ethernet dest follows the ARP target HW: broadcast for
+        // gratuitous announcements, the actual MAC for unicast — same
+        // value either way, so we just mirror it.
+        eth.set_destination(target_mac);
+        eth.set_source(sender_mac);
+        eth.set_ethertype(EtherTypes::Arp);
+    }
+    {
+        let mut arp = MutableArpPacket::new(&mut buf[14..])?;
+        arp.set_hardware_type(ArpHardwareTypes::Ethernet);
+        arp.set_protocol_type(EtherTypes::Ipv4);
+        arp.set_hw_addr_len(6);
+        arp.set_proto_addr_len(4);
+        arp.set_operation(ArpOperation::new(opcode));
+        arp.set_sender_hw_addr(sender_mac);
+        arp.set_sender_proto_addr(sender_ip);
+        arp.set_target_hw_addr(target_mac);
+        arp.set_target_proto_addr(target_ip);
+    }
+    Some(buf)
+}
+
+fn find_interface(name: &str) -> anyhow::Result<NetworkInterface> {
+    datalink::interfaces()
+        .into_iter()
+        .find(|iface| iface.name == name)
+        .ok_or_else(|| anyhow::anyhow!("interface '{name}' not found"))
+}

--- a/source/daemon/crates/wardnet-test-agent/src/client/arp.rs
+++ b/source/daemon/crates/wardnet-test-agent/src/client/arp.rs
@@ -22,13 +22,13 @@ use std::time::{Duration, Instant};
 use axum::Json;
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
-use serde_json::json;
 use pnet::datalink::{self, Channel, Config, NetworkInterface};
 use pnet::packet::Packet;
 use pnet::packet::arp::{ArpHardwareTypes, ArpOperation, ArpPacket, MutableArpPacket};
 use pnet::packet::ethernet::{EtherTypes, EthernetPacket, MutableEthernetPacket};
 use pnet::util::MacAddr;
 use serde::{Deserialize, Serialize};
+use serde_json::json;
 
 use super::models::ClientError;
 

--- a/source/daemon/crates/wardnet-test-agent/src/client/mod.rs
+++ b/source/daemon/crates/wardnet-test-agent/src/client/mod.rs
@@ -10,6 +10,7 @@
 //!   entrypoint so specs can `fetch("http://test_debian:3001/...")`
 //!   without mounting the container-runtime socket into the runner.
 
+mod arp;
 mod dhcp;
 mod dns;
 mod interfaces;

--- a/source/daemon/crates/wardnet-test-agent/src/client/serve.rs
+++ b/source/daemon/crates/wardnet-test-agent/src/client/serve.rs
@@ -20,6 +20,7 @@ use clap::Args;
 use serde::Deserialize;
 use tracing::info;
 
+use super::arp;
 use super::dhcp::{self, DhcpClient, DhcpRenewArgs};
 use super::dns::{self, DnsResolveArgs};
 use super::interfaces::{self, InterfacesArgs};
@@ -48,7 +49,9 @@ pub async fn run(args: ServeArgs) {
         .route("/routes", get(get_routes))
         .route("/dns/resolve", get(get_dns_resolve))
         .route("/ping", post(post_ping))
-        .route("/dhcp/renew", post(post_dhcp_renew));
+        .route("/dhcp/renew", post(post_dhcp_renew))
+        .route("/arp/send", post(arp::post_arp_send))
+        .route("/arp/capture", post(arp::post_arp_capture));
 
     info!(%addr, "starting wardnet-test-agent client serve");
 

--- a/source/daemon/crates/wardnet-test-agent/src/server/handlers/kernel/mod.rs
+++ b/source/daemon/crates/wardnet-test-agent/src/server/handlers/kernel/mod.rs
@@ -286,6 +286,7 @@ pub async fn get_link_show(Path(interface): Path<String>) -> impl IntoResponse {
             exists: false,
             up: false,
             mtu: None,
+            mac: None,
         })
         .into_response();
     }
@@ -293,14 +294,28 @@ pub async fn get_link_show(Path(interface): Path<String>) -> impl IntoResponse {
     let raw = String::from_utf8_lossy(&output.stdout);
     let up = raw.contains("UP") || raw.contains(",UP,") || raw.contains("<UP");
     let mtu = parse_mtu(&raw);
+    let mac = parse_link_ether(&raw);
 
     Json(LinkShowResponse {
         name: interface,
         exists: true,
         up,
         mtu,
+        mac,
     })
     .into_response()
+}
+
+/// Pull `link/ether AA:BB:..` out of `ip link show` output. Returns
+/// the MAC lowercased so callers can compare without normalising.
+fn parse_link_ether(raw: &str) -> Option<String> {
+    for line in raw.lines() {
+        let line = line.trim();
+        if let Some(rest) = line.strip_prefix("link/ether ") {
+            return rest.split_whitespace().next().map(str::to_lowercase);
+        }
+    }
+    None
 }
 
 /// Extracts the MTU value from `ip link show` output.

--- a/source/daemon/crates/wardnet-test-agent/src/server/models.rs
+++ b/source/daemon/crates/wardnet-test-agent/src/server/models.rs
@@ -122,6 +122,10 @@ pub struct LinkShowResponse {
     /// The interface MTU (0 when the interface does not exist).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub mtu: Option<u32>,
+    /// The interface MAC address (lowercased), when present in the
+    /// `ip link show` output.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mac: Option<String>,
 }
 
 // ---------------------------------------------------------------------------

--- a/source/daemon/crates/wardnetd-mock/src/backends/mod.rs
+++ b/source/daemon/crates/wardnetd-mock/src/backends/mod.rs
@@ -12,6 +12,7 @@ pub mod noop_device;
 pub mod noop_dhcp;
 pub mod noop_dns;
 pub mod noop_exit_probe;
+pub mod noop_garp;
 pub mod noop_network_inspector;
 pub mod noop_network_probe;
 pub mod noop_power_ops;

--- a/source/daemon/crates/wardnetd-mock/src/backends/noop_garp.rs
+++ b/source/daemon/crates/wardnetd-mock/src/backends/noop_garp.rs
@@ -1,0 +1,25 @@
+//! No-op [`GarpOps`] for the mock server.
+//!
+//! The mock has no LAN interface to broadcast on — this just logs at
+//! `debug` level so dev launches don't get spammed but the call path
+//! still shows up in `RUST_LOG=debug` output. The real impl lives in
+//! `wardnetd::garp_pnet::PnetGarpOps`.
+
+use async_trait::async_trait;
+use wardnetd_services::garp::GarpOps;
+
+#[derive(Debug, Default, Clone)]
+pub struct NoopGarpOps;
+
+#[async_trait]
+impl GarpOps for NoopGarpOps {
+    async fn broadcast_farewell(&self) -> anyhow::Result<()> {
+        tracing::debug!("NoopGarpOps::broadcast_farewell called (mock)");
+        Ok(())
+    }
+
+    async fn broadcast_claim(&self) -> anyhow::Result<()> {
+        tracing::debug!("NoopGarpOps::broadcast_claim called (mock)");
+        Ok(())
+    }
+}

--- a/source/daemon/crates/wardnetd-mock/src/main.rs
+++ b/source/daemon/crates/wardnetd-mock/src/main.rs
@@ -24,6 +24,7 @@ use wardnetd_mock::backends::noop_device::{NoopHostnameResolver, NoopPacketCaptu
 use wardnetd_mock::backends::noop_dhcp::NoopDhcpServer;
 use wardnetd_mock::backends::noop_dns::NoopDnsServer;
 use wardnetd_mock::backends::noop_exit_probe::NoopExitProbe;
+use wardnetd_mock::backends::noop_garp::NoopGarpOps;
 use wardnetd_mock::backends::noop_network_inspector::NoopNetworkInspector;
 use wardnetd_mock::backends::noop_network_probe::NoopNetworkProbe;
 use wardnetd_mock::backends::noop_power_ops::NoopSystemPowerOps;
@@ -237,6 +238,7 @@ async fn run(
             ip: lan_ip,
         }),
         network_probe: Arc::new(NoopNetworkProbe),
+        garp_ops: Arc::new(NoopGarpOps),
     };
 
     let services = init_services_with_factory(

--- a/source/daemon/crates/wardnetd-services/src/dhcp/service.rs
+++ b/source/daemon/crates/wardnetd-services/src/dhcp/service.rs
@@ -412,6 +412,17 @@ impl DhcpService for DhcpServiceImpl {
             .await
             .map_err(AppError::Internal)?;
 
+        // Invalidate the passively-learned upstream router MAC. Any
+        // change to `dhcp_router_ip` (including a no-op rewrite) means
+        // the previously stored MAC may no longer correspond to the
+        // gateway that lives at this IP. Discovery will repopulate
+        // `garp_router_mac` next time it observes a packet from the
+        // (possibly new) router IP. See issue #213, decision 1.
+        self.system_config
+            .set("garp_router_mac", "")
+            .await
+            .map_err(AppError::Internal)?;
+
         let config = self.load_config().await?;
         Ok(DhcpConfigResponse { config })
     }

--- a/source/daemon/crates/wardnetd-services/src/dhcp/tests/dhcp.rs
+++ b/source/daemon/crates/wardnetd-services/src/dhcp/tests/dhcp.rs
@@ -364,6 +364,92 @@ async fn update_config_invalid_ip() {
 }
 
 #[tokio::test]
+async fn update_config_clears_garp_router_mac() {
+    // Issue #213, decision 1: any update to dhcp_router_ip invalidates
+    // the passively-learned upstream router MAC. Discovery repopulates
+    // it next time it observes a packet from the (possibly new)
+    // router IP.
+    let dhcp = Arc::new(MockDhcpRepository::new());
+    let system_config = Arc::new(MockSystemConfigRepository::new());
+    let events = Arc::new(MockEventPublisher::new());
+    system_config
+        .data
+        .lock()
+        .unwrap()
+        .insert("garp_router_mac".to_owned(), "AA:BB:CC:DD:EE:FF".to_owned());
+    let svc = DhcpServiceImpl::new(
+        dhcp,
+        system_config.clone(),
+        events,
+        "10.0.0.1".parse().unwrap(),
+    );
+
+    let req = UpdateDhcpConfigRequest {
+        pool_start: "10.0.0.50".to_owned(),
+        pool_end: "10.0.0.150".to_owned(),
+        subnet_mask: "255.255.255.0".to_owned(),
+        upstream_dns: vec!["1.1.1.1".to_owned()],
+        lease_duration_secs: 3600,
+        router_ip: Some("10.0.0.1".to_owned()),
+    };
+    auth_context::with_context(admin_ctx(), svc.update_config(req))
+        .await
+        .unwrap();
+
+    let stored = system_config
+        .data
+        .lock()
+        .unwrap()
+        .get("garp_router_mac")
+        .cloned();
+    assert_eq!(stored.as_deref(), Some(""));
+}
+
+#[tokio::test]
+async fn update_config_idempotent_when_garp_unset() {
+    // No prior `garp_router_mac` -> update_config still writes "" and
+    // returns Ok. Guards against a regression where the clear path
+    // requires the key to exist first.
+    let dhcp = Arc::new(MockDhcpRepository::new());
+    let system_config = Arc::new(MockSystemConfigRepository::new());
+    let events = Arc::new(MockEventPublisher::new());
+    assert!(
+        !system_config
+            .data
+            .lock()
+            .unwrap()
+            .contains_key("garp_router_mac"),
+        "fixture should not pre-seed garp_router_mac"
+    );
+    let svc = DhcpServiceImpl::new(
+        dhcp,
+        system_config.clone(),
+        events,
+        "10.0.0.1".parse().unwrap(),
+    );
+
+    let req = UpdateDhcpConfigRequest {
+        pool_start: "10.0.0.50".to_owned(),
+        pool_end: "10.0.0.150".to_owned(),
+        subnet_mask: "255.255.255.0".to_owned(),
+        upstream_dns: vec!["1.1.1.1".to_owned()],
+        lease_duration_secs: 3600,
+        router_ip: None,
+    };
+    auth_context::with_context(admin_ctx(), svc.update_config(req))
+        .await
+        .unwrap();
+
+    let stored = system_config
+        .data
+        .lock()
+        .unwrap()
+        .get("garp_router_mac")
+        .cloned();
+    assert_eq!(stored.as_deref(), Some(""));
+}
+
+#[tokio::test]
 async fn update_config_pool_end_before_start() {
     let svc = build_service();
     let req = UpdateDhcpConfigRequest {

--- a/source/daemon/crates/wardnetd-services/src/garp/mod.rs
+++ b/source/daemon/crates/wardnetd-services/src/garp/mod.rs
@@ -1,0 +1,49 @@
+//! Gratuitous-ARP failover hooks.
+//!
+//! On graceful shutdown the daemon broadcasts a *farewell* GARP that
+//! re-points the LAN's `dhcp_router_ip` ARP entry at the upstream
+//! router's MAC, so managed clients fall back to the home router
+//! within ~1s. On startup it broadcasts a *claim* GARP that re-points
+//! the same IP at the Pi's LAN-interface MAC, so clients route
+//! through Wardnet again before DHCP/DNS start serving.
+//!
+//! Each impl owns its own 2-pulse / 500ms timing — the sequence is
+//! part of the trait contract, not the caller's problem. See issue
+//! #213 for the full design including the two-MAC-key invariant
+//! (`router_mac` is wizard-attested; `garp_router_mac` is passively
+//! learned and re-cleared whenever `dhcp_router_ip` changes).
+
+use async_trait::async_trait;
+
+/// Broadcasts gratuitous ARP replies on graceful shutdown / startup
+/// so managed clients update their ARP caches without waiting for the
+/// 1–5 minute kernel TTL.
+///
+/// Both methods return `Result` so the real `pnet` impl can express
+/// failures (interface lookup, raw-socket open, frame send) for unit
+/// tests. Call sites in `wardnetd/src/main.rs` swallow errors with a
+/// `WARN` log — a GARP failure must never block the rest of the
+/// shutdown / startup sequence.
+#[async_trait]
+pub trait GarpOps: Send + Sync {
+    /// Announce that `dhcp_router_ip` is now at the upstream router's
+    /// MAC (`garp_router_mac`). Called as the very first step of
+    /// graceful shutdown so the stale-ARP window is minimised.
+    ///
+    /// Implementations short-circuit to `Ok(())` (with a log line) if
+    /// either `dhcp_router_ip` or `garp_router_mac` is unset, the LAN
+    /// interface can't be found, or the LAN interface has no MAC.
+    async fn broadcast_farewell(&self) -> anyhow::Result<()>;
+
+    /// Announce that `dhcp_router_ip` is now at the Pi's LAN-interface
+    /// MAC. Called synchronously during bootstrap, after routing
+    /// reconcile and before any user-facing runner starts, so the
+    /// claim is on the wire by the time DHCP/DNS bind their sockets.
+    ///
+    /// Implementations short-circuit to `Ok(())` (with a log line) if
+    /// `dhcp_router_ip` is unset, the LAN interface can't be found,
+    /// or the LAN interface has no MAC. Unlike `broadcast_farewell`,
+    /// claim has no router-MAC dependency — it broadcasts from the
+    /// Pi's own MAC.
+    async fn broadcast_claim(&self) -> anyhow::Result<()>;
+}

--- a/source/daemon/crates/wardnetd-services/src/lib.rs
+++ b/source/daemon/crates/wardnetd-services/src/lib.rs
@@ -13,6 +13,7 @@ pub mod device;
 pub mod dhcp;
 pub mod dns;
 pub mod dns_filter;
+pub mod garp;
 pub mod logging;
 pub mod routing;
 pub mod system;
@@ -108,6 +109,10 @@ pub struct Backends {
     /// auto-discover the upstream router via ARP. Real impl wraps
     /// `pnet`'s datalink channel; the mock returns a synthetic MAC.
     pub network_probe: Arc<dyn system::NetworkProbe>,
+    /// Gratuitous-ARP failover hook. Real impl in `wardnetd` wraps
+    /// `pnet` to send the farewell/claim sequences; the mock is a
+    /// logging no-op. See [`garp::GarpOps`] and issue #213.
+    pub garp_ops: Arc<dyn garp::GarpOps>,
 }
 
 /// Auto-update backends, grouped so the three concerns (release discovery,

--- a/source/daemon/crates/wardnetd-services/src/tests/init.rs
+++ b/source/daemon/crates/wardnetd-services/src/tests/init.rs
@@ -209,6 +209,18 @@ fn stub_backends() -> Backends {
         power_ops: Arc::new(StubPowerOps),
         network_inspector: Arc::new(StubNetworkInspector),
         network_probe: Arc::new(StubNetworkProbe),
+        garp_ops: Arc::new(StubGarpOps),
+    }
+}
+
+struct StubGarpOps;
+#[async_trait]
+impl crate::garp::GarpOps for StubGarpOps {
+    async fn broadcast_farewell(&self) -> anyhow::Result<()> {
+        Ok(())
+    }
+    async fn broadcast_claim(&self) -> anyhow::Result<()> {
+        Ok(())
     }
 }
 

--- a/source/daemon/crates/wardnetd/src/device_detector.rs
+++ b/source/daemon/crates/wardnetd/src/device_detector.rs
@@ -8,9 +8,12 @@ use tracing::Instrument;
 
 use wardnet_common::config::DetectionConfig;
 use wardnet_common::event::WardnetEvent;
+use wardnetd_data::repository::SystemConfigRepository;
 use wardnetd_services::device::packet_capture::PacketCapture;
 use wardnetd_services::event::EventPublisher;
 use wardnetd_services::{DeviceDiscoveryService, ObservationResult};
+
+use crate::garp_learning;
 
 /// Background device detection orchestrator.
 ///
@@ -39,6 +42,7 @@ impl DeviceDetector {
     pub fn start(
         capture: Arc<dyn PacketCapture>,
         discovery: Arc<dyn DeviceDiscoveryService>,
+        system_config: Arc<dyn SystemConfigRepository>,
         events: &dyn EventPublisher,
         config: &DetectionConfig,
         interface: String,
@@ -56,7 +60,8 @@ impl DeviceDetector {
         );
 
         let processor_handle = tokio::spawn(
-            processor_task(rx, discovery.clone(), cancel.clone()).instrument(span.clone()),
+            processor_task(rx, discovery.clone(), system_config, cancel.clone())
+                .instrument(span.clone()),
         );
 
         let flush_handle = tokio::spawn(
@@ -131,6 +136,7 @@ async fn capture_task(
 async fn processor_task(
     mut rx: mpsc::Receiver<wardnetd_services::device::packet_capture::ObservedDevice>,
     discovery: Arc<dyn DeviceDiscoveryService>,
+    system_config: Arc<dyn SystemConfigRepository>,
     cancel: CancellationToken,
 ) {
     loop {
@@ -138,6 +144,22 @@ async fn processor_task(
             () = cancel.cancelled() => break,
             obs = rx.recv() => {
                 let Some(obs) = obs else { break };
+
+                // Passive learning of the upstream router MAC for GARP
+                // failover. Runs on every observation (not just
+                // state-change variants) so a router replacement that
+                // keeps the same IP is still picked up. See issue
+                // #213, decision 2. The skip-if-unchanged guard inside
+                // `maybe_record_router_mac` keeps this off the hot DB
+                // path for typical traffic.
+                if let Err(e) = garp_learning::maybe_record_router_mac(&obs, &system_config).await {
+                    tracing::warn!(
+                        error = %e,
+                        mac = %obs.mac,
+                        ip = %obs.ip,
+                        "failed to update garp_router_mac from observation",
+                    );
+                }
 
                 match discovery.process_observation(&obs).await {
                     Ok(ObservationResult::NewDevice { device_id, .. }) => {

--- a/source/daemon/crates/wardnetd/src/garp_learning.rs
+++ b/source/daemon/crates/wardnetd/src/garp_learning.rs
@@ -1,0 +1,58 @@
+//! Passive learning of the upstream router's MAC for GARP failover.
+//!
+//! The device-discovery loop calls [`maybe_record_router_mac`] after
+//! every observation. When the observed device's IP equals the
+//! configured `dhcp_router_ip` we persist its MAC as
+//! `garp_router_mac`, which the GARP farewell phase reads at
+//! shutdown. The hook fires on every observation (not just
+//! `NewDevice` / `IpChanged`) so a router replacement that keeps the
+//! same IP is still picked up. The skip-if-unchanged guard avoids
+//! hot-path log/DB churn.
+//!
+//! Two MAC keys exist by design (issue #213, decision 1):
+//!
+//! - `router_mac` — wizard-attested, set once via manual entry or
+//!   the active ARP probe in the setup wizard. Operator-trusted,
+//!   never cleared.
+//! - `garp_router_mac` — passively learned from the wire. Cleared
+//!   whenever `dhcp_router_ip` changes, re-populated next time
+//!   discovery sees the new IP. Used only by the GARP failover
+//!   sequence.
+
+use std::sync::Arc;
+
+use wardnetd_data::repository::SystemConfigRepository;
+use wardnetd_services::device::packet_capture::ObservedDevice;
+
+/// If `obs.ip == dhcp_router_ip` and the stored MAC differs, write
+/// the observation's MAC to `garp_router_mac`. No-op otherwise.
+///
+/// Errors propagate so the caller can log them; this never panics.
+/// Cost on the discovery hot path: one `system_config.get` for every
+/// observation (early return when the router IP doesn't match), a
+/// second read plus a `set` only when the value actually changes.
+pub async fn maybe_record_router_mac(
+    obs: &ObservedDevice,
+    repo: &Arc<dyn SystemConfigRepository>,
+) -> anyhow::Result<()> {
+    let Some(router_ip) = repo.get("dhcp_router_ip").await? else {
+        return Ok(());
+    };
+    let router_ip = router_ip.trim();
+    if router_ip.is_empty() || router_ip != obs.ip {
+        return Ok(());
+    }
+
+    let stored = repo.get("garp_router_mac").await?.unwrap_or_default();
+    if stored == obs.mac {
+        return Ok(());
+    }
+
+    repo.set("garp_router_mac", &obs.mac).await?;
+    tracing::info!(
+        mac = %obs.mac,
+        ip = %obs.ip,
+        "learned upstream router MAC for GARP failover",
+    );
+    Ok(())
+}

--- a/source/daemon/crates/wardnetd/src/garp_pnet.rs
+++ b/source/daemon/crates/wardnetd/src/garp_pnet.rs
@@ -1,0 +1,311 @@
+//! Real [`GarpOps`] implementation backed by `pnet`.
+//!
+//! On graceful shutdown the daemon needs to re-point the LAN's
+//! `dhcp_router_ip` ARP entry at the upstream router's MAC; on
+//! startup it re-points the same IP back at the Pi's LAN-iface MAC.
+//! Both phases are 2-pulse / 500ms gratuitous ARP-reply broadcasts —
+//! the sequence is part of the trait contract, not the caller's
+//! problem.
+//!
+//! Frame layout per RFC 826 / 5227: both Ethernet src-MAC and ARP
+//! sender-HW carry the phase MAC. Clients use the ARP sender field
+//! to update their cache; L2 switches use Ethernet src-MAC to update
+//! CAM tables. Both must agree for the failover to actually move
+//! traffic. See issue #213, decision 4.
+//!
+//! Runs inside `spawn_blocking` because pnet's datalink channel is
+//! synchronous, mirroring `pnet_network_probe.rs`. The 500ms
+//! inter-pulse gap is `std::thread::sleep` *inside* the blocking
+//! job — the entire phase is one self-contained synchronous unit.
+
+use std::net::Ipv4Addr;
+use std::sync::Arc;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use pnet::datalink::{self, Channel, Config};
+use pnet::packet::arp::{ArpHardwareTypes, ArpOperations, MutableArpPacket};
+use pnet::packet::ethernet::{EtherTypes, MutableEthernetPacket};
+use pnet::util::MacAddr;
+use wardnetd_data::repository::SystemConfigRepository;
+use wardnetd_services::garp::GarpOps;
+
+use crate::packet_capture_pnet::find_interface;
+
+/// 500ms between the two GARP pulses, per RFC 5227 §2.4 (gratuitous
+/// announcements). Long enough to dodge transient drops, short enough
+/// that the full phase (2 pulses) completes inside the 1s budget.
+const PULSE_GAP: Duration = Duration::from_millis(500);
+
+/// Number of GARP pulses per phase. RFC 5227 recommends 2-3
+/// announcements; 2 keeps the total phase ≤ 1s while still tolerating
+/// a single dropped frame.
+const PULSE_COUNT: usize = 2;
+
+/// Real [`GarpOps`] using `pnet`'s datalink channel.
+pub struct PnetGarpOps {
+    lan_interface: String,
+    system_config: Arc<dyn SystemConfigRepository>,
+}
+
+impl PnetGarpOps {
+    #[must_use]
+    pub fn new(lan_interface: String, system_config: Arc<dyn SystemConfigRepository>) -> Self {
+        Self {
+            lan_interface,
+            system_config,
+        }
+    }
+}
+
+#[async_trait]
+impl GarpOps for PnetGarpOps {
+    async fn broadcast_farewell(&self) -> anyhow::Result<()> {
+        let Some(router_ip) = read_router_ip(&self.system_config).await? else {
+            tracing::info!("GARP farewell skipped: dhcp_router_ip unset");
+            return Ok(());
+        };
+
+        let Some(router_mac) = read_router_mac(&self.system_config).await? else {
+            tracing::warn!(
+                router_ip = %router_ip,
+                "GARP farewell skipped: garp_router_mac unset (discovery has not seen the upstream router yet)",
+            );
+            return Ok(());
+        };
+
+        let interface = self.lan_interface.clone();
+        tokio::task::spawn_blocking(move || {
+            run_farewell_sequence(&interface, router_mac, router_ip)
+        })
+        .await
+        .map_err(|e| anyhow::anyhow!("garp farewell blocking task panicked: {e}"))?
+    }
+
+    async fn broadcast_claim(&self) -> anyhow::Result<()> {
+        let Some(router_ip) = read_router_ip(&self.system_config).await? else {
+            tracing::info!("GARP claim skipped: dhcp_router_ip unset");
+            return Ok(());
+        };
+
+        let interface = self.lan_interface.clone();
+        tokio::task::spawn_blocking(move || run_claim_sequence(&interface, router_ip))
+            .await
+            .map_err(|e| anyhow::anyhow!("garp claim blocking task panicked: {e}"))?
+    }
+}
+
+/// Read `dhcp_router_ip` and parse it. Returns `None` for unset or empty.
+async fn read_router_ip(
+    repo: &Arc<dyn SystemConfigRepository>,
+) -> anyhow::Result<Option<Ipv4Addr>> {
+    let Some(raw) = repo.get("dhcp_router_ip").await? else {
+        return Ok(None);
+    };
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return Ok(None);
+    }
+    let ip: Ipv4Addr = trimmed
+        .parse()
+        .map_err(|e| anyhow::anyhow!("dhcp_router_ip is not a valid IPv4 address ({raw}): {e}"))?;
+    Ok(Some(ip))
+}
+
+/// Read `garp_router_mac` and parse it. Returns `None` for unset or empty.
+async fn read_router_mac(
+    repo: &Arc<dyn SystemConfigRepository>,
+) -> anyhow::Result<Option<MacAddr>> {
+    let Some(raw) = repo.get("garp_router_mac").await? else {
+        return Ok(None);
+    };
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return Ok(None);
+    }
+    let mac: MacAddr = trimmed
+        .parse()
+        .map_err(|e| anyhow::anyhow!("garp_router_mac is not a valid MAC ({raw}): {e}"))?;
+    Ok(Some(mac))
+}
+
+/// Synchronous farewell sequence. Resolves the interface and emits
+/// the 2-pulse GARP burst from the upstream router's MAC.
+fn run_farewell_sequence(
+    interface_name: &str,
+    sender_mac: MacAddr,
+    sender_ip: Ipv4Addr,
+) -> anyhow::Result<()> {
+    let iface = find_interface(interface_name)?;
+    emit_garp_burst(&iface, sender_mac, sender_ip, "farewell")
+}
+
+/// Synchronous claim sequence. The Pi's LAN-iface MAC isn't in
+/// `system_config` — we resolve it from the live interface. That
+/// also means the "no MAC on the interface" no-op lives here.
+fn run_claim_sequence(interface_name: &str, sender_ip: Ipv4Addr) -> anyhow::Result<()> {
+    let iface = find_interface(interface_name)?;
+    let Some(sender_mac) = iface.mac else {
+        tracing::warn!(
+            interface = %interface_name,
+            "GARP claim skipped: interface has no MAC address",
+        );
+        return Ok(());
+    };
+    emit_garp_burst(&iface, sender_mac, sender_ip, "claim")
+}
+
+/// Emit the 2-pulse / 500ms GARP burst on `iface`. `phase` is a short
+/// label (`"claim"` / `"farewell"`) used in log lines so operators can
+/// tell which sequence emitted a given pulse without diffing log
+/// formats. Errors at the channel-open level surface; per-pulse send
+/// failures log a warning and continue — one dropped pulse out of two
+/// is still useful.
+fn emit_garp_burst(
+    iface: &pnet::datalink::NetworkInterface,
+    sender_mac: MacAddr,
+    sender_ip: Ipv4Addr,
+    phase: &str,
+) -> anyhow::Result<()> {
+    let Channel::Ethernet(mut tx, _rx) = datalink::channel(iface, Config::default())? else {
+        anyhow::bail!("unsupported channel type for interface '{}'", iface.name);
+    };
+
+    let frame = build_garp_reply(sender_mac, sender_ip)
+        .ok_or_else(|| anyhow::anyhow!("failed to build GARP reply frame"))?;
+
+    for pulse in 0..PULSE_COUNT {
+        match tx.send_to(&frame, None) {
+            Some(Ok(())) => {
+                tracing::debug!(
+                    phase = phase,
+                    pulse = pulse + 1,
+                    of = PULSE_COUNT,
+                    sender_mac = %sender_mac,
+                    sender_ip = %sender_ip,
+                    "sent GARP pulse",
+                );
+            }
+            Some(Err(e)) => {
+                tracing::warn!(
+                    phase = phase,
+                    pulse = pulse + 1,
+                    error = %e,
+                    "GARP pulse send failed",
+                );
+            }
+            None => {
+                tracing::warn!(
+                    phase = phase,
+                    pulse = pulse + 1,
+                    "datalink channel rejected GARP pulse",
+                );
+            }
+        }
+        if pulse + 1 < PULSE_COUNT {
+            std::thread::sleep(PULSE_GAP);
+        }
+    }
+
+    Ok(())
+}
+
+/// Build a 42-byte gratuitous ARP-reply Ethernet frame.
+///
+/// - Ethernet dest = `ff:ff:ff:ff:ff:ff` (broadcast) so every host
+///   on the LAN sees it.
+/// - Ethernet src = `sender_mac` so L2 switches refresh their CAM
+///   table to point the right port at this MAC.
+/// - ARP opcode = 2 (reply) — gratuitous announcements are typically
+///   replies to nobody, since clients update on reply more reliably
+///   than on request.
+/// - sender HW / sender proto = `(sender_mac, sender_ip)` — the pair
+///   the receiver is meant to install.
+/// - target HW = broadcast, target proto = `sender_ip` — RFC 5227
+///   form (target proto = sender proto), and target HW broadcast is
+///   the safe choice for an unsolicited reply.
+#[must_use]
+pub fn build_garp_reply(sender_mac: MacAddr, sender_ip: Ipv4Addr) -> Option<Vec<u8>> {
+    let mut buf = vec![0u8; 42];
+
+    {
+        let mut eth = MutableEthernetPacket::new(&mut buf)?;
+        eth.set_destination(MacAddr::broadcast());
+        eth.set_source(sender_mac);
+        eth.set_ethertype(EtherTypes::Arp);
+    }
+
+    {
+        let mut arp = MutableArpPacket::new(&mut buf[14..])?;
+        arp.set_hardware_type(ArpHardwareTypes::Ethernet);
+        arp.set_protocol_type(EtherTypes::Ipv4);
+        arp.set_hw_addr_len(6);
+        arp.set_proto_addr_len(4);
+        arp.set_operation(ArpOperations::Reply);
+        arp.set_sender_hw_addr(sender_mac);
+        arp.set_sender_proto_addr(sender_ip);
+        arp.set_target_hw_addr(MacAddr::broadcast());
+        arp.set_target_proto_addr(sender_ip);
+    }
+
+    Some(buf)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pnet::packet::Packet;
+    use pnet::packet::arp::ArpPacket;
+    use pnet::packet::ethernet::EthernetPacket;
+
+    #[test]
+    fn frame_length_is_42_bytes() {
+        let frame = build_garp_reply(
+            MacAddr(0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF),
+            Ipv4Addr::new(192, 168, 1, 1),
+        )
+        .expect("frame builder returns Some");
+        assert_eq!(frame.len(), 42);
+    }
+
+    #[test]
+    fn ethernet_header_uses_broadcast_dest_and_phase_src() {
+        let phase_mac = MacAddr(0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF);
+        let frame = build_garp_reply(phase_mac, Ipv4Addr::new(192, 168, 1, 1)).unwrap();
+        let eth = EthernetPacket::new(&frame).unwrap();
+
+        assert_eq!(eth.get_destination(), MacAddr::broadcast());
+        assert_eq!(eth.get_source(), phase_mac);
+        assert_eq!(eth.get_ethertype(), EtherTypes::Arp);
+    }
+
+    #[test]
+    fn arp_payload_is_a_reply_with_aligned_sender_hw_and_target_proto() {
+        // Per decision 4: clients use the ARP sender-HW field to update
+        // their cache, so it MUST equal the Ethernet src-MAC.
+        let phase_mac = MacAddr(0x11, 0x22, 0x33, 0x44, 0x55, 0x66);
+        let router_ip = Ipv4Addr::new(10, 91, 0, 1);
+        let frame = build_garp_reply(phase_mac, router_ip).unwrap();
+        let eth = EthernetPacket::new(&frame).unwrap();
+        let arp = ArpPacket::new(eth.payload()).unwrap();
+
+        assert_eq!(arp.get_hardware_type(), ArpHardwareTypes::Ethernet);
+        assert_eq!(arp.get_protocol_type(), EtherTypes::Ipv4);
+        assert_eq!(arp.get_hw_addr_len(), 6);
+        assert_eq!(arp.get_proto_addr_len(), 4);
+        assert_eq!(arp.get_operation(), ArpOperations::Reply);
+        assert_eq!(arp.get_sender_hw_addr(), phase_mac);
+        assert_eq!(arp.get_sender_proto_addr(), router_ip);
+        assert_eq!(arp.get_target_hw_addr(), MacAddr::broadcast());
+        assert_eq!(arp.get_target_proto_addr(), router_ip);
+    }
+
+    #[test]
+    fn pulse_constants_keep_phase_under_one_second() {
+        // Acceptance criterion: full GARP sequence (2 pulses) ≤ 1s/phase.
+        let gaps = u32::try_from(PULSE_COUNT).expect("PULSE_COUNT fits in u32") - 1;
+        let total = PULSE_GAP * gaps;
+        assert!(total < Duration::from_secs(1), "phase budget exceeded");
+        const { assert!(PULSE_COUNT >= 2, "need at least 2 pulses for redundancy") };
+    }
+}

--- a/source/daemon/crates/wardnetd/src/lib.rs
+++ b/source/daemon/crates/wardnetd/src/lib.rs
@@ -4,6 +4,7 @@ pub mod pidfile;
 // Real backend implementations (Linux-specific).
 pub mod command;
 pub mod firewall_nftables;
+pub mod garp_pnet;
 pub mod hostname_resolver;
 pub mod packet_capture_pnet;
 pub mod policy_router_netlink;
@@ -19,6 +20,7 @@ pub mod system;
 
 // Background tasks.
 pub mod device_detector;
+pub mod garp_learning;
 pub mod heartbeat;
 pub mod metrics_collector;
 pub mod profiling;

--- a/source/daemon/crates/wardnetd/src/main.rs
+++ b/source/daemon/crates/wardnetd/src/main.rs
@@ -23,6 +23,7 @@ use wardnet_common::auth::AuthContext;
 use wardnet_common::config::{ApplicationConfiguration, LogFormat, LogRotation, OtelConfig};
 use wardnetd::device_detector::DeviceDetector;
 use wardnetd::firewall_nftables::NftablesFirewallManager;
+use wardnetd::garp_pnet::PnetGarpOps;
 use wardnetd::heartbeat::HeartbeatRunner;
 use wardnetd::hostname_resolver::SystemHostnameResolver;
 use wardnetd::metrics_collector::MetricsCollector;
@@ -49,7 +50,7 @@ use wardnetd_services::secret_store::build_secret_store;
 use wardnetd_services::update::{
     EMBEDDED_PUBLIC_KEY, FsBinaryApplier, HttpsManifestSource, Sha256MinisignVerifier, UpdateRunner,
 };
-use wardnetd_services::{Backends, UpdateBackends, auth_context, init_services};
+use wardnetd_services::{Backends, UpdateBackends, auth_context, init_services_with_factory};
 
 /// Wardnet daemon — self-hosted network privacy gateway.
 #[derive(Parser)]
@@ -211,6 +212,28 @@ async fn run(
     // Cancelling it from any source drives the same graceful-shutdown path.
     let shutdown_token = tokio_util::sync::CancellationToken::new();
 
+    // Build the repository factory up front so `PnetGarpOps` can hold a
+    // `SystemConfigRepository` handle (it reads `dhcp_router_ip` /
+    // `garp_router_mac` at broadcast time). Admin bootstrap is run
+    // explicitly here because we're calling `init_services_with_factory`
+    // below — that helper deliberately skips admin bootstrap.
+    let repo_factory = wardnetd_data::create_repository_factory(&config).await?;
+    let admin_credentials = config
+        .admin
+        .as_ref()
+        .map(|a| (a.username.as_str(), a.password.as_str()));
+    wardnetd_data::bootstrap::bootstrap_admin(&repo_factory.admin(), admin_credentials).await?;
+    let system_config_repo = repo_factory.system_config();
+
+    // Hold a clone of `garp_ops` outside `Backends` so the shutdown
+    // block (after `init_services_with_factory` has consumed
+    // `Backends`) can still call `broadcast_farewell`. Mirrors how
+    // `shutdown_token` is held.
+    let garp_ops: Arc<dyn wardnetd_services::garp::GarpOps> = Arc::new(PnetGarpOps::new(
+        config.network.lan_interface.clone(),
+        system_config_repo.clone(),
+    ));
+
     let backends = Backends {
         tunnel_interface: Arc::new(WireGuardTunnelInterface),
         tunnel_exit_probe: Arc::new(ReqwestTunnelExitProbe::new(
@@ -235,11 +258,21 @@ async fn run(
             lan_ip,
         )),
         network_probe: Arc::new(PnetNetworkProbe::new(config.network.lan_interface.clone())),
+        garp_ops: garp_ops.clone(),
     };
 
-    // Wire services (initialises repo factory, bootstraps admin, creates all services).
-    let services =
-        init_services(&config, backends, lan_ip, started_at, log_service.clone()).await?;
+    // Wire services. Admin bootstrap already ran above; this helper
+    // seeds the setup-wizard / default-policy keys and classifies the
+    // previous shutdown.
+    let services = init_services_with_factory(
+        repo_factory.as_ref(),
+        backends,
+        &config,
+        lan_ip,
+        started_at,
+        log_service.clone(),
+    )
+    .await?;
 
     // Restore state from the database.
     services
@@ -266,6 +299,23 @@ async fn run(
     )
     .await
     .map_err(|e| anyhow::anyhow!("{e}"))?;
+
+    // Broadcast the GARP claim *before* any user-facing runner starts,
+    // so managed clients see "dhcp_router_ip is at the Pi's MAC again"
+    // by the time DHCP/DNS bind their sockets. ~1.1s of bounded boot
+    // latency (2 pulses × 500ms gap) buys deterministic acceptance —
+    // see issue #213, decision 5. Failures swallowed: the GARP path
+    // must never block bootstrap.
+    if let Err(e) = auth_context::with_context(
+        AuthContext::Admin {
+            admin_id: uuid::Uuid::nil(),
+        },
+        garp_ops.broadcast_claim(),
+    )
+    .await
+    {
+        tracing::warn!(error = %e, "GARP claim failed; continuing bootstrap");
+    }
 
     // Start background monitors.
     let monitor = TunnelMonitor::start(
@@ -299,6 +349,7 @@ async fn run(
         Some(DeviceDetector::start(
             packet_capture.clone(),
             services.discovery.clone(),
+            system_config_repo.clone(),
             services.event_publisher.as_ref(),
             &config.detection,
             config.network.lan_interface.clone(),
@@ -506,7 +557,24 @@ async fn run(
     .instrument(api_span)
     .await?;
 
-    tracing::info!("server stopped, shutting down background tasks");
+    tracing::info!("server stopped, broadcasting GARP farewell before tearing down");
+    // Farewell goes out *before* anything else in the shutdown sequence
+    // so managed clients fall back to the upstream router while the rest
+    // of the daemon is still alive on the LAN. Failures swallowed: a
+    // GARP error must not block routing/DHCP/DNS cleanup. See issue
+    // #213, decision 3.
+    if let Err(e) = auth_context::with_context(
+        AuthContext::Admin {
+            admin_id: uuid::Uuid::nil(),
+        },
+        garp_ops.broadcast_farewell(),
+    )
+    .await
+    {
+        tracing::warn!(error = %e, "GARP farewell failed; continuing shutdown");
+    }
+
+    tracing::info!("shutting down background tasks");
     routing_listener.shutdown().await;
     route_monitor.shutdown().await;
     idle_watcher.shutdown().await;

--- a/source/daemon/crates/wardnetd/src/tests/device_detector.rs
+++ b/source/daemon/crates/wardnetd/src/tests/device_detector.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
@@ -9,7 +10,9 @@ use wardnet_common::device::{Device, DeviceType};
 use wardnet_common::event::WardnetEvent;
 
 use crate::device_detector::DeviceDetector;
+use std::sync::Mutex;
 use wardnet_common::config::DetectionConfig;
+use wardnetd_data::repository::SystemConfigRepository;
 use wardnetd_services::device::packet_capture::{ObservedDevice, PacketCapture, PacketSource};
 use wardnetd_services::error::AppError;
 use wardnetd_services::event::{BroadcastEventBus, EventPublisher};
@@ -202,6 +205,41 @@ impl DeviceDiscoveryService for MockDiscovery {
 // Helpers
 // ---------------------------------------------------------------------------
 
+/// Empty in-memory `SystemConfigRepository` stub. The `garp_learning`
+/// hook is exercised by its own dedicated tests; this stub just
+/// satisfies the trait bound so `DeviceDetector::start` accepts it.
+#[derive(Default)]
+struct StubSystemConfig {
+    data: Mutex<HashMap<String, String>>,
+}
+
+#[async_trait]
+impl SystemConfigRepository for StubSystemConfig {
+    async fn get(&self, key: &str) -> anyhow::Result<Option<String>> {
+        Ok(self.data.lock().unwrap().get(key).cloned())
+    }
+    async fn set(&self, key: &str, value: &str) -> anyhow::Result<()> {
+        self.data
+            .lock()
+            .unwrap()
+            .insert(key.to_owned(), value.to_owned());
+        Ok(())
+    }
+    async fn device_count(&self) -> anyhow::Result<i64> {
+        Ok(0)
+    }
+    async fn tunnel_count(&self) -> anyhow::Result<i64> {
+        Ok(0)
+    }
+    async fn db_size_bytes(&self) -> anyhow::Result<u64> {
+        Ok(0)
+    }
+}
+
+fn stub_system_config() -> Arc<dyn SystemConfigRepository> {
+    Arc::new(StubSystemConfig::default())
+}
+
 /// Build a fast detection config with 1-second intervals for tests.
 fn fast_config() -> DetectionConfig {
     DetectionConfig {
@@ -246,6 +284,7 @@ async fn start_and_shutdown() {
     let detector = DeviceDetector::start(
         capture,
         discovery,
+        stub_system_config(),
         &test_events(),
         &fast_config(),
         "eth0".to_owned(),
@@ -267,6 +306,7 @@ async fn processor_handles_new_device() {
     let detector = DeviceDetector::start(
         capture,
         discovery as Arc<dyn DeviceDiscoveryService>,
+        stub_system_config(),
         &test_events(),
         &fast_config(),
         "eth0".to_owned(),
@@ -294,6 +334,7 @@ async fn processor_handles_ip_changed() {
     let detector = DeviceDetector::start(
         capture,
         discovery as Arc<dyn DeviceDiscoveryService>,
+        stub_system_config(),
         &test_events(),
         &fast_config(),
         "eth0".to_owned(),
@@ -320,6 +361,7 @@ async fn processor_handles_reappeared() {
     let detector = DeviceDetector::start(
         capture,
         discovery as Arc<dyn DeviceDiscoveryService>,
+        stub_system_config(),
         &test_events(),
         &fast_config(),
         "eth0".to_owned(),
@@ -346,6 +388,7 @@ async fn processor_handles_error() {
     let detector = DeviceDetector::start(
         capture,
         discovery as Arc<dyn DeviceDiscoveryService>,
+        stub_system_config(),
         &test_events(),
         &fast_config(),
         "eth0".to_owned(),
@@ -373,6 +416,7 @@ async fn capture_task_logs_error_on_failure() {
     let detector = DeviceDetector::start(
         capture,
         discovery,
+        stub_system_config(),
         &test_events(),
         &fast_config(),
         "eth0".to_owned(),
@@ -396,6 +440,7 @@ async fn flush_task_runs_and_cancels() {
     let detector = DeviceDetector::start(
         capture,
         discovery as Arc<dyn DeviceDiscoveryService>,
+        stub_system_config(),
         &test_events(),
         &fast_config(),
         "eth0".to_owned(),
@@ -423,6 +468,7 @@ async fn departure_task_runs_and_cancels() {
     let detector = DeviceDetector::start(
         capture,
         discovery as Arc<dyn DeviceDiscoveryService>,
+        stub_system_config(),
         &test_events(),
         &fast_config(),
         "eth0".to_owned(),
@@ -448,6 +494,7 @@ async fn arp_scan_task_runs_and_cancels() {
     let detector = DeviceDetector::start(
         capture,
         discovery,
+        stub_system_config(),
         &test_events(),
         &fast_config(),
         "eth0".to_owned(),
@@ -474,6 +521,7 @@ async fn arp_scan_task_handles_error() {
     let detector = DeviceDetector::start(
         capture,
         discovery,
+        stub_system_config(),
         &test_events(),
         &fast_config(),
         "eth0".to_owned(),
@@ -505,6 +553,7 @@ fn detector_with_event_bus(
     DeviceDetector::start(
         capture,
         discovery,
+        stub_system_config(),
         events,
         &fast_config(),
         "eth0".to_owned(),

--- a/source/daemon/crates/wardnetd/src/tests/garp_learning.rs
+++ b/source/daemon/crates/wardnetd/src/tests/garp_learning.rs
@@ -1,0 +1,174 @@
+//! Tests for the passive-learning hook that populates `garp_router_mac`.
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+use async_trait::async_trait;
+use wardnetd_data::repository::{LastShutdownInfo, SystemConfigRepository};
+use wardnetd_services::device::packet_capture::{ObservedDevice, PacketSource};
+
+use crate::garp_learning::maybe_record_router_mac;
+
+#[derive(Default)]
+struct MockSystemConfigRepository {
+    data: Mutex<HashMap<String, String>>,
+    set_calls: Mutex<usize>,
+}
+
+impl MockSystemConfigRepository {
+    fn new() -> Self {
+        Self::default()
+    }
+
+    fn with_router_ip(self, ip: &str) -> Self {
+        self.data
+            .lock()
+            .unwrap()
+            .insert("dhcp_router_ip".to_owned(), ip.to_owned());
+        self
+    }
+
+    fn with_router_mac(self, mac: &str) -> Self {
+        self.data
+            .lock()
+            .unwrap()
+            .insert("garp_router_mac".to_owned(), mac.to_owned());
+        self
+    }
+
+    fn stored_mac(&self) -> Option<String> {
+        self.data.lock().unwrap().get("garp_router_mac").cloned()
+    }
+
+    fn set_count(&self) -> usize {
+        *self.set_calls.lock().unwrap()
+    }
+}
+
+#[async_trait]
+impl SystemConfigRepository for MockSystemConfigRepository {
+    async fn get(&self, key: &str) -> anyhow::Result<Option<String>> {
+        Ok(self.data.lock().unwrap().get(key).cloned())
+    }
+
+    async fn set(&self, key: &str, value: &str) -> anyhow::Result<()> {
+        *self.set_calls.lock().unwrap() += 1;
+        self.data
+            .lock()
+            .unwrap()
+            .insert(key.to_owned(), value.to_owned());
+        Ok(())
+    }
+
+    async fn device_count(&self) -> anyhow::Result<i64> {
+        Ok(0)
+    }
+
+    async fn tunnel_count(&self) -> anyhow::Result<i64> {
+        Ok(0)
+    }
+
+    async fn db_size_bytes(&self) -> anyhow::Result<u64> {
+        Ok(0)
+    }
+
+    async fn detect_previous_shutdown(&self) -> anyhow::Result<LastShutdownInfo> {
+        Ok(LastShutdownInfo {
+            state: wardnet_common::api::LastShutdownState::Unknown,
+            at: None,
+            acknowledged_at: None,
+        })
+    }
+}
+
+fn obs(mac: &str, ip: &str) -> ObservedDevice {
+    ObservedDevice {
+        mac: mac.to_owned(),
+        ip: ip.to_owned(),
+        source: PacketSource::Arp,
+    }
+}
+
+#[tokio::test]
+async fn learns_router_mac_when_obs_matches_dhcp_router_ip() {
+    let mock = Arc::new(MockSystemConfigRepository::new().with_router_ip("10.91.0.1"));
+    let repo: Arc<dyn SystemConfigRepository> = mock.clone();
+    maybe_record_router_mac(&obs("aa:bb:cc:dd:ee:ff", "10.91.0.1"), &repo)
+        .await
+        .unwrap();
+    assert_eq!(mock.stored_mac().as_deref(), Some("aa:bb:cc:dd:ee:ff"));
+}
+
+#[tokio::test]
+async fn skips_write_when_obs_ip_does_not_match_router_ip() {
+    let mock = Arc::new(MockSystemConfigRepository::new().with_router_ip("10.91.0.1"));
+    let repo: Arc<dyn SystemConfigRepository> = mock.clone();
+    let initial_writes = mock.set_count();
+    maybe_record_router_mac(&obs("aa:bb:cc:dd:ee:ff", "10.91.0.42"), &repo)
+        .await
+        .unwrap();
+    assert_eq!(mock.set_count(), initial_writes, "no DB write expected");
+    assert_eq!(mock.stored_mac(), None);
+}
+
+#[tokio::test]
+async fn skips_write_when_router_ip_unset() {
+    let mock = Arc::new(MockSystemConfigRepository::new());
+    let repo: Arc<dyn SystemConfigRepository> = mock.clone();
+    maybe_record_router_mac(&obs("aa:bb:cc:dd:ee:ff", "10.91.0.1"), &repo)
+        .await
+        .unwrap();
+    assert_eq!(mock.stored_mac(), None);
+    assert_eq!(mock.set_count(), 0);
+}
+
+#[tokio::test]
+async fn skips_write_when_router_ip_empty_string() {
+    // get() returns Some("") which trims to empty -> early return, no write.
+    let mock = Arc::new(MockSystemConfigRepository::new().with_router_ip(""));
+    let repo: Arc<dyn SystemConfigRepository> = mock.clone();
+    let writes_before = mock.set_count();
+    maybe_record_router_mac(&obs("aa:bb:cc:dd:ee:ff", "10.91.0.1"), &repo)
+        .await
+        .unwrap();
+    assert_eq!(mock.stored_mac(), None);
+    assert_eq!(mock.set_count(), writes_before);
+}
+
+#[tokio::test]
+async fn skips_write_when_value_unchanged() {
+    // Avoid hot-path log/DB churn when the router has been
+    // continuously seen and the stored MAC already matches.
+    let mock = Arc::new(
+        MockSystemConfigRepository::new()
+            .with_router_ip("10.91.0.1")
+            .with_router_mac("aa:bb:cc:dd:ee:ff"),
+    );
+    let repo: Arc<dyn SystemConfigRepository> = mock.clone();
+    let writes_before = mock.set_count();
+    maybe_record_router_mac(&obs("aa:bb:cc:dd:ee:ff", "10.91.0.1"), &repo)
+        .await
+        .unwrap();
+    assert_eq!(
+        mock.set_count(),
+        writes_before,
+        "duplicate observation should not write"
+    );
+}
+
+#[tokio::test]
+async fn updates_when_router_replaced_at_same_ip() {
+    // Decision 2: a router replacement that keeps the same IP must
+    // be picked up. The hook fires on every observation (not just
+    // state-change variants) and writes when the value differs.
+    let mock = Arc::new(
+        MockSystemConfigRepository::new()
+            .with_router_ip("10.91.0.1")
+            .with_router_mac("aa:bb:cc:dd:ee:ff"),
+    );
+    let repo: Arc<dyn SystemConfigRepository> = mock.clone();
+    maybe_record_router_mac(&obs("11:22:33:44:55:66", "10.91.0.1"), &repo)
+        .await
+        .unwrap();
+    assert_eq!(mock.stored_mac().as_deref(), Some("11:22:33:44:55:66"));
+}

--- a/source/daemon/crates/wardnetd/src/tests/mod.rs
+++ b/source/daemon/crates/wardnetd/src/tests/mod.rs
@@ -1,5 +1,6 @@
 mod device_detector;
 mod firewall_nftables;
+mod garp_learning;
 mod heartbeat;
 mod hostname_resolver;
 mod metrics_collector;

--- a/source/end2end-tests/daemon/tests/arp-failover.spec.ts
+++ b/source/end2end-tests/daemon/tests/arp-failover.spec.ts
@@ -94,6 +94,14 @@ interface LinkShowResponse {
  * Returns the captured frames once the window closes. Coalesces the
  * window setup so each test reads as a linear "do this while
  * capturing" rather than juggling promises.
+ *
+ * The window is intentionally generous: HTTP round-trip +
+ * `spawn_blocking` scheduling + `pnet`'s `datalink::channel` open can
+ * take 1-2s on a cold runner before the agent is actually listening,
+ * so we wait 2s before triggering anything in `during` and run the
+ * capture for 15s total. The full daemon restart cycle (farewell +
+ * exit + systemd respawn + claim) fits comfortably inside the
+ * remaining window.
  */
 async function captureWhile(
   durationMs: number,
@@ -109,8 +117,7 @@ async function captureWhile(
       filter,
     } satisfies ArpCaptureBody,
   );
-  // Give pnet a moment to open the channel before the action begins.
-  await new Promise((r) => setTimeout(r, 250));
+  await new Promise((r) => setTimeout(r, 2_000));
   await during();
   return capturePromise;
 }
@@ -173,31 +180,35 @@ describe("GARP failover (issue #213)", () => {
     // configureRouterIp in beforeAll cleared garp_router_mac, so the
     // pre-restart farewell hits the no-op matrix and only the
     // post-restart claim should land in the capture window.
-    const frames = await captureWhile(
-      8_000,
-      { sender_ip: ROUTER_IP, opcode: ARP_REPLY_OPCODE },
-      async () => {
-        await restartDaemon(admin);
-      },
-    );
+    //
+    // Capture without an agent-side filter so the failure message
+    // shows what (if anything) the agent saw on the wire — narrowing
+    // the diagnostic from "no claim pulses" to "no traffic at all"
+    // vs "traffic but wrong sender_ip".
+    const frames = await captureWhile(15_000, undefined, async () => {
+      await restartDaemon(admin);
+    });
 
-    const claim = frames.filter(
+    const arpReplies = frames.filter(
+      (f) => f.opcode === ARP_REPLY_OPCODE && f.sender_ip === ROUTER_IP,
+    );
+    const claim = arpReplies.filter(
       (f) => f.sender_mac.toLowerCase() === daemonMac,
     );
 
     expect(
       claim.length,
-      `expected ≥2 claim pulses; saw ${frames.length} total frames`,
+      `expected ≥2 claim pulses; saw ${frames.length} total ARP frames, ${arpReplies.length} matching sender_ip=${ROUTER_IP} opcode=2. macs: ${JSON.stringify(frames.map((f) => f.sender_mac).slice(0, 20))}`,
     ).toBeGreaterThanOrEqual(2);
 
     // No-op matrix sanity: with garp_router_mac cleared, no farewell
     // pulses should appear. Anything from a sender_mac other than the
     // daemon's own MAC would mean the no-op path didn't trigger.
-    const nonDaemon = frames.filter(
+    const nonDaemonReplies = arpReplies.filter(
       (f) => f.sender_mac.toLowerCase() !== daemonMac,
     );
     expect(
-      nonDaemon,
+      nonDaemonReplies,
       "no farewell pulses expected when garp_router_mac is empty",
     ).toEqual([]);
 
@@ -240,23 +251,20 @@ describe("GARP failover (issue #213)", () => {
     // Step 2: capture window covering the next restart cycle. The
     // farewell goes out from the synthetic router MAC; the
     // immediately-following claim goes out from the daemon's MAC.
-    const frames = await captureWhile(
-      8_000,
-      { sender_ip: ROUTER_IP, opcode: ARP_REPLY_OPCODE },
-      async () => {
-        await restartDaemon(admin);
-      },
-    );
+    const frames = await captureWhile(15_000, undefined, async () => {
+      await restartDaemon(admin);
+    });
 
-    const farewell = frames.filter(
+    const arpReplies = frames.filter(
+      (f) => f.opcode === ARP_REPLY_OPCODE && f.sender_ip === ROUTER_IP,
+    );
+    const farewell = arpReplies.filter(
       (f) => f.sender_mac.toLowerCase() === SYNTHETIC_ROUTER_MAC,
     );
 
     expect(
       farewell.length,
-      `expected ≥2 farewell pulses with sender_mac=${SYNTHETIC_ROUTER_MAC}; saw frames: ${JSON.stringify(
-        frames.map((f) => f.sender_mac),
-      )}`,
+      `expected ≥2 farewell pulses with sender_mac=${SYNTHETIC_ROUTER_MAC}; ${frames.length} total frames, ${arpReplies.length} matching reply+ROUTER_IP. macs: ${JSON.stringify(arpReplies.map((f) => f.sender_mac).slice(0, 20))}`,
     ).toBeGreaterThanOrEqual(2);
 
     for (const frame of farewell) {
@@ -277,7 +285,7 @@ describe("GARP failover (issue #213)", () => {
     }
 
     // Sanity: the post-restart claim also fired from the daemon's MAC.
-    const claimAfterFarewell = frames.filter(
+    const claimAfterFarewell = arpReplies.filter(
       (f) => f.sender_mac.toLowerCase() === daemonMac,
     );
     expect(claimAfterFarewell.length).toBeGreaterThanOrEqual(1);

--- a/source/end2end-tests/daemon/tests/arp-failover.spec.ts
+++ b/source/end2end-tests/daemon/tests/arp-failover.spec.ts
@@ -1,0 +1,285 @@
+/**
+ * GARP failover e2e — issue #213.
+ *
+ * Drives the full passive-learning + claim/farewell pipeline against
+ * the running daemon container:
+ *
+ * 1. Configure `dhcp_router_ip = 10.91.0.5` via the wizard so the
+ *    daemon has a router IP to broadcast about.
+ * 2. **Claim phase**: capture ARP traffic on `test_debian` while the
+ *    daemon restarts via `POST /api/system/restart`. Assert ≥2
+ *    gratuitous-reply frames sent from the daemon's LAN-iface MAC,
+ *    with the configured `sender_ip` and broadcast destination.
+ * 3. **Drive passive learning**: `POST /arp/send` from `test_debian`
+ *    with `sender_mac = AA:BB:CC:DD:EE:01, sender_ip = 10.91.0.5` so
+ *    the daemon's discovery loop populates `garp_router_mac`.
+ * 4. **Farewell phase**: capture ARP traffic and trigger another
+ *    restart. Assert ≥2 gratuitous-reply frames whose sender MAC
+ *    equals the synthetic upstream-router MAC seeded in step 3 — the
+ *    proof that the daemon read `garp_router_mac` and broadcast the
+ *    farewell with the upstream router's MAC.
+ */
+
+import { describe, it, expect, beforeAll } from "vitest";
+import {
+  DhcpService,
+  SystemService,
+  WardnetClient,
+} from "@wardnet/js";
+
+import {
+  API_BASE_URL,
+  AuthedClient,
+  TEST_DEBIAN_AGENT,
+  agentPost,
+  ensureAdminAndLogin,
+  waitForReady,
+} from "./helpers.js";
+
+// `wardnetd` resolves to the daemon container on `wardnet_mgmt` and
+// hosts the test-agent on :3001 in server mode (per safe-power.spec.ts).
+const DAEMON_AGENT = "http://wardnetd:3001";
+
+// IP advertised in the GARP frames. Pick a value comfortably outside
+// docker IPAM (.2-.15) and the daemon's DHCP pool start (.100+).
+const ROUTER_IP = "10.91.0.5";
+
+// Synthetic upstream-router MAC used to seed `garp_router_mac` via the
+// passive-learning pipeline. Locally-administered (second nibble = 2).
+const SYNTHETIC_ROUTER_MAC = "aa:bb:cc:dd:ee:01";
+
+// ARP opcode 2 = Reply. Gratuitous announcements use opcode 2 because
+// every common stack updates its cache more reliably on reply than on
+// request.
+const ARP_REPLY_OPCODE = 2;
+
+interface ArpSendBody {
+  opcode?: number;
+  sender_mac: string;
+  sender_ip: string;
+  target_mac?: string;
+  target_ip: string;
+  count?: number;
+  interval_ms?: number;
+  interface?: string;
+}
+
+interface ArpCaptureBody {
+  duration_ms: number;
+  interface?: string;
+  filter?: { sender_ip?: string; sender_mac?: string; opcode?: number };
+}
+
+interface CapturedArpFrame {
+  opcode: number;
+  sender_ip: string;
+  sender_mac: string;
+  target_ip: string;
+  target_mac: string;
+  timestamp_ms: number;
+  eth_source: string;
+  eth_destination: string;
+}
+
+interface LinkShowResponse {
+  name: string;
+  exists: boolean;
+  up: boolean;
+  mtu?: number;
+  mac?: string;
+}
+
+/**
+ * Open an /arp/capture window and run `during` while it's running.
+ * Returns the captured frames once the window closes. Coalesces the
+ * window setup so each test reads as a linear "do this while
+ * capturing" rather than juggling promises.
+ */
+async function captureWhile(
+  durationMs: number,
+  filter: ArpCaptureBody["filter"],
+  during: () => Promise<void>,
+): Promise<CapturedArpFrame[]> {
+  const capturePromise = agentPost<CapturedArpFrame[]>(
+    TEST_DEBIAN_AGENT,
+    "/arp/capture",
+    {
+      duration_ms: durationMs,
+      interface: "eth0",
+      filter,
+    } satisfies ArpCaptureBody,
+  );
+  // Give pnet a moment to open the channel before the action begins.
+  await new Promise((r) => setTimeout(r, 250));
+  await during();
+  return capturePromise;
+}
+
+/** Restart the daemon via the SystemService SDK helper. Returns once
+ *  the daemon is back to /api/info readiness. */
+async function restartDaemon(authed: AuthedClient): Promise<void> {
+  await new SystemService(authed).restart();
+  // request_restart cancels the shutdown_token after a ~500ms grace,
+  // then the process exits and systemd respawns. The full cycle —
+  // farewell + exit + relaunch + claim — fits in ~5s on this stack.
+  await waitForReady(new WardnetClient({ baseUrl: API_BASE_URL }), 30_000);
+}
+
+/** Set `dhcp_router_ip = ROUTER_IP` while leaving every other DHCP
+ *  field at whatever the wizard left behind. */
+async function configureRouterIp(authed: AuthedClient): Promise<void> {
+  const dhcp = new DhcpService(authed);
+  const cfg = (await dhcp.getConfig()).config;
+  await dhcp.updateConfig({
+    pool_start: cfg.pool_start,
+    pool_end: cfg.pool_end,
+    subnet_mask: cfg.subnet_mask,
+    upstream_dns: cfg.upstream_dns,
+    lease_duration_secs: cfg.lease_duration_secs,
+    router_ip: ROUTER_IP,
+  });
+}
+
+/** Pulls the daemon's wardnet_lan MAC out of `ip link show eth0`. */
+async function getDaemonLanMac(): Promise<string> {
+  const res = await fetch(`${DAEMON_AGENT}/link/eth0`);
+  if (!res.ok) {
+    throw new Error(
+      `failed to fetch daemon link state: ${res.status} ${await res.text()}`,
+    );
+  }
+  const link = (await res.json()) as LinkShowResponse;
+  if (!link.mac) {
+    throw new Error(
+      `daemon eth0 has no MAC in /link/eth0 response: ${JSON.stringify(link)}`,
+    );
+  }
+  return link.mac.toLowerCase();
+}
+
+describe("GARP failover (issue #213)", () => {
+  const client = new WardnetClient({ baseUrl: API_BASE_URL });
+  let admin: AuthedClient;
+  let daemonMac: string;
+
+  beforeAll(async () => {
+    await waitForReady(client);
+    admin = await ensureAdminAndLogin(client);
+    await configureRouterIp(admin);
+    daemonMac = await getDaemonLanMac();
+  }, 120_000);
+
+  it("broadcasts the claim GARP on startup with the daemon's LAN MAC", async () => {
+    // configureRouterIp in beforeAll cleared garp_router_mac, so the
+    // pre-restart farewell hits the no-op matrix and only the
+    // post-restart claim should land in the capture window.
+    const frames = await captureWhile(
+      8_000,
+      { sender_ip: ROUTER_IP, opcode: ARP_REPLY_OPCODE },
+      async () => {
+        await restartDaemon(admin);
+      },
+    );
+
+    const claim = frames.filter(
+      (f) => f.sender_mac.toLowerCase() === daemonMac,
+    );
+
+    expect(
+      claim.length,
+      `expected ≥2 claim pulses; saw ${frames.length} total frames`,
+    ).toBeGreaterThanOrEqual(2);
+
+    // No-op matrix sanity: with garp_router_mac cleared, no farewell
+    // pulses should appear. Anything from a sender_mac other than the
+    // daemon's own MAC would mean the no-op path didn't trigger.
+    const nonDaemon = frames.filter(
+      (f) => f.sender_mac.toLowerCase() !== daemonMac,
+    );
+    expect(
+      nonDaemon,
+      "no farewell pulses expected when garp_router_mac is empty",
+    ).toEqual([]);
+
+    for (const frame of claim) {
+      expect(frame.opcode).toBe(ARP_REPLY_OPCODE);
+      expect(frame.sender_ip).toBe(ROUTER_IP);
+      expect(frame.target_ip).toBe(ROUTER_IP);
+      expect(frame.eth_destination.toLowerCase()).toBe("ff:ff:ff:ff:ff:ff");
+      expect(frame.eth_source.toLowerCase()).toBe(daemonMac);
+    }
+
+    // The 2-pulse / 500 ms gap is part of the GarpOps contract.
+    if (claim.length >= 2) {
+      const sorted = [...claim].sort((a, b) => a.timestamp_ms - b.timestamp_ms);
+      const gap = sorted[1].timestamp_ms - sorted[0].timestamp_ms;
+      expect(gap).toBeGreaterThanOrEqual(400);
+      expect(gap).toBeLessThanOrEqual(1_000);
+    }
+  }, 90_000);
+
+  it("learns the upstream router MAC from passive ARP and uses it on farewell", async () => {
+    // Step 1: emit a single gratuitous-reply from the synthetic
+    // router MAC. The daemon's discovery loop sees it on eth0,
+    // matches obs.ip == dhcp_router_ip, and persists garp_router_mac.
+    await agentPost<unknown>(TEST_DEBIAN_AGENT, "/arp/send", {
+      opcode: ARP_REPLY_OPCODE,
+      sender_mac: SYNTHETIC_ROUTER_MAC,
+      sender_ip: ROUTER_IP,
+      target_ip: ROUTER_IP,
+      count: 2,
+      interval_ms: 200,
+      interface: "eth0",
+    } satisfies ArpSendBody);
+
+    // Discovery flushes batched observations on
+    // `batch_flush_interval_secs`; default in fixtures is short. Give
+    // it a comfortable margin before triggering a restart.
+    await new Promise((r) => setTimeout(r, 3_000));
+
+    // Step 2: capture window covering the next restart cycle. The
+    // farewell goes out from the synthetic router MAC; the
+    // immediately-following claim goes out from the daemon's MAC.
+    const frames = await captureWhile(
+      8_000,
+      { sender_ip: ROUTER_IP, opcode: ARP_REPLY_OPCODE },
+      async () => {
+        await restartDaemon(admin);
+      },
+    );
+
+    const farewell = frames.filter(
+      (f) => f.sender_mac.toLowerCase() === SYNTHETIC_ROUTER_MAC,
+    );
+
+    expect(
+      farewell.length,
+      `expected ≥2 farewell pulses with sender_mac=${SYNTHETIC_ROUTER_MAC}; saw frames: ${JSON.stringify(
+        frames.map((f) => f.sender_mac),
+      )}`,
+    ).toBeGreaterThanOrEqual(2);
+
+    for (const frame of farewell) {
+      expect(frame.opcode).toBe(ARP_REPLY_OPCODE);
+      expect(frame.sender_ip).toBe(ROUTER_IP);
+      expect(frame.target_ip).toBe(ROUTER_IP);
+      expect(frame.eth_destination.toLowerCase()).toBe("ff:ff:ff:ff:ff:ff");
+      // Decision 4: Ethernet src must match the ARP sender-HW so
+      // L2 switch CAM tables flip in lockstep with client ARP caches.
+      expect(frame.eth_source.toLowerCase()).toBe(SYNTHETIC_ROUTER_MAC);
+    }
+
+    if (farewell.length >= 2) {
+      const sorted = [...farewell].sort((a, b) => a.timestamp_ms - b.timestamp_ms);
+      const gap = sorted[1].timestamp_ms - sorted[0].timestamp_ms;
+      expect(gap).toBeGreaterThanOrEqual(400);
+      expect(gap).toBeLessThanOrEqual(1_000);
+    }
+
+    // Sanity: the post-restart claim also fired from the daemon's MAC.
+    const claimAfterFarewell = frames.filter(
+      (f) => f.sender_mac.toLowerCase() === daemonMac,
+    );
+    expect(claimAfterFarewell.length).toBeGreaterThanOrEqual(1);
+  }, 120_000);
+});


### PR DESCRIPTION
## Summary

Closes #213. Broadcasts gratuitous-ARP replies on graceful shutdown
(farewell, from the upstream router's MAC) and on startup (claim,
from the Pi's LAN MAC) so managed clients reclaim/release the
gateway IP within ~1s instead of waiting for the 1-5 min ARP TTL.

- New `GarpOps` trait in `wardnetd-services` with `PnetGarpOps`
  (real) and `NoopGarpOps` (mock) impls wired through `Backends`.
- Each phase emits 2 pulses 500ms apart inside `spawn_blocking`,
  mirroring `pnet_network_probe`. Errors swallowed at call sites in
  `wardnetd/src/main.rs` so a GARP failure never blocks shutdown
  cleanup or bootstrap.
- `garp_router_mac` is passively learned from device discovery
  whenever an observation matches `dhcp_router_ip`, and cleared
  whenever `DhcpService::update_config` writes `dhcp_router_ip`.
- Test-agent's client-serve mode gains generic `/arp/send` and
  `/arp/capture` endpoints to drive the e2e.
- `/link/{interface}` extended with the iface MAC so the e2e can
  assert claim sender_mac equals the daemon's eth0 MAC.

## Test plan

- [x] `make check-daemon` (cargo fmt + clippy + workspace tests):
      711 unit tests pass, including 6 new `garp_learning` tests, 4
      new `garp_pnet` frame-builder/timing tests, and 2 new
      `dhcp::update_config` clear-on-IP-change tests.
- [ ] CI runs `arp-failover.spec.ts` end-to-end: claim phase emits
      ≥2 pulses with the daemon's MAC; passive-learning seeded via
      `/arp/send` makes the next farewell emit pulses with the
      synthetic router MAC, with broadcast Ethernet dest and 500ms
      gap (decision 4 + 5).
- [ ] CI coverage gate (line coverage stays ≥ baseline; `garp_pnet`
      added to `COV_IGNORE` mirroring `pnet_network_probe`).

## Notes

All 9 architectural decisions from the issue's "Resolved during
planning" section landed unchanged. The plan called for wiring
`PnetGarpOps` through `Backends`, which required holding a
`SystemConfigRepository` handle outside `init_services`; the
daemon's `main.rs` now bootstraps the repo factory itself and
calls `init_services_with_factory` instead of `init_services`,
matching how `wardnetd-mock` already initialises.