### PR TITLE
chore(daemon): canonicalise MAC addresses to lowercase

### DIFF
--- a/source/daemon/crates/wardnet-common/src/dhcp.rs
+++ b/source/daemon/crates/wardnet-common/src/dhcp.rs
@@ -70,10 +70,15 @@ pub struct DhcpReservation {
 }
 
 /// A DHCP lease audit log entry.
+///
+/// `mac_address` is denormalised onto every row (issue #312) so the
+/// audit trail stays queryable without a JOIN to `dhcp_leases` — the
+/// table is the long-lived source of truth, leases come and go.
 #[derive(Debug, Clone, Serialize, Deserialize, utoipa::ToSchema)]
 pub struct DhcpLeaseLog {
     pub id: i64,
     pub lease_id: Uuid,
+    pub mac_address: String,
     pub event_type: DhcpLeaseEventType,
     pub details: Option<String>,
     pub created_at: DateTime<Utc>,

--- a/source/daemon/crates/wardnet-common/src/tests/dhcp.rs
+++ b/source/daemon/crates/wardnet-common/src/tests/dhcp.rs
@@ -135,6 +135,7 @@ fn dhcp_lease_log_round_trip() {
     let log = DhcpLeaseLog {
         id: 1,
         lease_id: Uuid::parse_str("00000000-0000-0000-0000-000000000001").unwrap(),
+        mac_address: "aa:bb:cc:dd:ee:01".to_owned(),
         event_type: DhcpLeaseEventType::Assigned,
         details: Some("Initial assignment".to_owned()),
         created_at: "2026-03-07T00:00:00Z".parse().unwrap(),
@@ -143,5 +144,6 @@ fn dhcp_lease_log_round_trip() {
     let back: DhcpLeaseLog = serde_json::from_str(&json).unwrap();
     assert_eq!(log.id, back.id);
     assert_eq!(log.lease_id, back.lease_id);
+    assert_eq!(log.mac_address, back.mac_address);
     assert_eq!(log.event_type, back.event_type);
 }

--- a/source/daemon/crates/wardnetd-api/src/api/devices.rs
+++ b/source/daemon/crates/wardnetd-api/src/api/devices.rs
@@ -113,6 +113,9 @@ pub async fn set_my_rule(
 ///
 /// Reservations take precedence: if a MAC has both a reservation and an
 /// active lease the status is [`DhcpStatus::Reservation`].
+///
+/// MAC casing is canonical (lowercase) across the data layer (issue #312),
+/// so map keys and lookups don't need per-call normalisation.
 async fn build_dhcp_status_map(state: &AppState) -> Result<HashMap<String, DhcpStatus>, AppError> {
     let leases = state.dhcp_service().list_leases().await?;
     let reservations = state.dhcp_service().list_reservations().await?;
@@ -120,12 +123,12 @@ async fn build_dhcp_status_map(state: &AppState) -> Result<HashMap<String, DhcpS
     let mut map = HashMap::new();
 
     for lease in &leases.leases {
-        map.insert(lease.mac_address.to_lowercase(), DhcpStatus::Lease);
+        map.insert(lease.mac_address.clone(), DhcpStatus::Lease);
     }
 
     // Reservations override leases.
     for res in &reservations.reservations {
-        map.insert(res.mac_address.to_lowercase(), DhcpStatus::Reservation);
+        map.insert(res.mac_address.clone(), DhcpStatus::Reservation);
     }
 
     Ok(map)
@@ -137,7 +140,7 @@ fn enrich_device(
     dhcp_map: &HashMap<String, DhcpStatus>,
 ) -> DeviceWithStatus {
     let status = dhcp_map
-        .get(&device.mac.to_lowercase())
+        .get(&device.mac)
         .copied()
         .unwrap_or(DhcpStatus::External);
     DeviceWithStatus {

--- a/source/daemon/crates/wardnetd-api/src/api/tests/devices.rs
+++ b/source/daemon/crates/wardnetd-api/src/api/tests/devices.rs
@@ -294,7 +294,7 @@ impl DeviceDiscoveryService for MockDiscoveryService {
 fn sample_device() -> Device {
     Device {
         id: Uuid::parse_str("00000000-0000-0000-0000-000000000001").unwrap(),
-        mac: "AA:BB:CC:DD:EE:01".to_owned(),
+        mac: "aa:bb:cc:dd:ee:01".to_owned(),
         name: Some("My Phone".to_owned()),
         hostname: None,
         manufacturer: Some("Apple".to_owned()),
@@ -418,7 +418,7 @@ async fn get_me_returns_device_when_found() {
 
     let (status, json) = get_json(app, "/api/devices/me").await;
     assert_eq!(status, StatusCode::OK);
-    assert_eq!(json["device"]["mac"], "AA:BB:CC:DD:EE:01");
+    assert_eq!(json["device"]["mac"], "aa:bb:cc:dd:ee:01");
     assert_eq!(json["current_rule"]["type"], "direct");
     assert_eq!(json["admin_locked"], false);
 }
@@ -562,7 +562,7 @@ async fn list_devices_returns_all() {
     let (status, json) = get_json(app, "/api/devices").await;
     assert_eq!(status, StatusCode::OK);
     assert_eq!(json["devices"].as_array().unwrap().len(), 1);
-    assert_eq!(json["devices"][0]["mac"], "AA:BB:CC:DD:EE:01");
+    assert_eq!(json["devices"][0]["mac"], "aa:bb:cc:dd:ee:01");
     // No lease or reservation for this device, so dhcp_status should be "external".
     assert_eq!(json["devices"][0]["dhcp_status"], "external");
 }
@@ -624,7 +624,7 @@ async fn get_device_by_id_success() {
     assert_eq!(status, StatusCode::OK);
     // DeviceDetailResponse is { device, current_rule } — device fields are
     // nested, current_rule sits at the top level.
-    assert_eq!(json["device"]["mac"], "AA:BB:CC:DD:EE:01");
+    assert_eq!(json["device"]["mac"], "aa:bb:cc:dd:ee:01");
     assert_eq!(json["current_rule"]["type"], "direct");
     assert_eq!(json["device"]["dhcp_status"], "external");
 }
@@ -793,7 +793,7 @@ async fn list_devices_with_dhcp_lease_shows_lease_status() {
     let device = sample_device();
     let lease = wardnet_common::dhcp::DhcpLease {
         id: Uuid::new_v4(),
-        mac_address: "AA:BB:CC:DD:EE:01".to_owned(),
+        mac_address: "aa:bb:cc:dd:ee:01".to_owned(),
         ip_address: "192.168.1.10".parse().unwrap(),
         hostname: None,
         lease_start: "2026-04-13T00:00:00Z".parse().unwrap(),
@@ -828,7 +828,7 @@ async fn list_devices_with_dhcp_reservation_shows_reservation_status() {
     let device = sample_device();
     let reservation = wardnet_common::dhcp::DhcpReservation {
         id: Uuid::new_v4(),
-        mac_address: "AA:BB:CC:DD:EE:01".to_owned(),
+        mac_address: "aa:bb:cc:dd:ee:01".to_owned(),
         ip_address: "192.168.1.10".parse().unwrap(),
         hostname: None,
         description: None,
@@ -860,7 +860,7 @@ async fn list_devices_reservation_overrides_lease() {
     let device = sample_device();
     let lease = wardnet_common::dhcp::DhcpLease {
         id: Uuid::new_v4(),
-        mac_address: "AA:BB:CC:DD:EE:01".to_owned(),
+        mac_address: "aa:bb:cc:dd:ee:01".to_owned(),
         ip_address: "192.168.1.10".parse().unwrap(),
         hostname: None,
         lease_start: "2026-04-13T00:00:00Z".parse().unwrap(),
@@ -872,7 +872,7 @@ async fn list_devices_reservation_overrides_lease() {
     };
     let reservation = wardnet_common::dhcp::DhcpReservation {
         id: Uuid::new_v4(),
-        mac_address: "AA:BB:CC:DD:EE:01".to_owned(),
+        mac_address: "aa:bb:cc:dd:ee:01".to_owned(),
         ip_address: "192.168.1.10".parse().unwrap(),
         hostname: None,
         description: None,
@@ -908,7 +908,7 @@ async fn get_device_by_id_includes_dhcp_status() {
     let device = sample_device();
     let lease = wardnet_common::dhcp::DhcpLease {
         id: Uuid::new_v4(),
-        mac_address: "aa:bb:cc:dd:ee:01".to_owned(), // lowercase MAC
+        mac_address: "aa:bb:cc:dd:ee:01".to_owned(),
         ip_address: "192.168.1.10".parse().unwrap(),
         hostname: None,
         lease_start: "2026-04-13T00:00:00Z".parse().unwrap(),

--- a/source/daemon/crates/wardnetd-data/migrations/20260510000000_canonicalise_mac_lowercase.sql
+++ b/source/daemon/crates/wardnetd-data/migrations/20260510000000_canonicalise_mac_lowercase.sql
@@ -1,0 +1,38 @@
+-- Canonicalise MAC addresses to lowercase across every table that stores
+-- one (issue #312). Two casings co-existed historically: packet-capture
+-- emitted uppercase (`AA:BB:…`), DHCP service emitted lowercase
+-- (`aa:bb:…`), and equality lookups (`*_by_mac`) are case-sensitive in
+-- SQLite, so cross-source joins silently failed. Repository writers and
+-- readers now lowercase defensively; this migration brings existing rows
+-- into the same form.
+--
+-- Also lowers the two MAC keys in `system_config` (`router_mac`,
+-- `garp_router_mac`) for consistency. Both feed log lines, not equality
+-- joins, so the only practical effect is uniform display.
+
+UPDATE devices            SET mac         = LOWER(mac);
+UPDATE dhcp_leases        SET mac_address = LOWER(mac_address);
+UPDATE dhcp_reservations  SET mac_address = LOWER(mac_address);
+
+UPDATE system_config
+   SET value = LOWER(value)
+ WHERE key IN ('router_mac', 'garp_router_mac')
+   AND value <> '';
+
+-- Denormalise MAC onto the lease audit log so the trail stays queryable
+-- after the parent lease row is rotated (released, expired, replaced by
+-- a re-DISCOVER with the same MAC, etc.). Pre-existing rows backfill
+-- from `dhcp_leases` where the lease still exists; orphaned rows fall
+-- back to '' so the NOT NULL constraint holds. New writes always carry
+-- the MAC explicitly (see `DhcpServiceImpl::*_lease`).
+ALTER TABLE dhcp_lease_log ADD COLUMN mac_address TEXT NOT NULL DEFAULT '';
+
+UPDATE dhcp_lease_log
+   SET mac_address = COALESCE(
+       (SELECT LOWER(l.mac_address) FROM dhcp_leases l WHERE l.id = dhcp_lease_log.lease_id),
+       ''
+   )
+ WHERE mac_address = '';
+
+CREATE INDEX IF NOT EXISTS idx_dhcp_lease_log_mac
+    ON dhcp_lease_log(mac_address);

--- a/source/daemon/crates/wardnetd-data/src/oui.rs
+++ b/source/daemon/crates/wardnetd-data/src/oui.rs
@@ -18,7 +18,8 @@ pub(crate) static OUI_MAP: LazyLock<HashMap<[u8; 3], &'static str>> = LazyLock::
 
 /// Look up the manufacturer for a MAC address by its OUI prefix (first 3 bytes).
 ///
-/// MAC must be in normalized format "AA:BB:CC:DD:EE:FF".
+/// MAC must be in normalised format "aa:bb:cc:dd:ee:ff" (issue #312).
+/// Casing of the input is irrelevant — `from_str_radix` is case-insensitive.
 /// Returns the manufacturer name if the OUI prefix is known.
 ///
 /// If the MAC has the locally-administered bit set (bit 1 of the first byte),

--- a/source/daemon/crates/wardnetd-data/src/repository/dhcp.rs
+++ b/source/daemon/crates/wardnetd-data/src/repository/dhcp.rs
@@ -42,6 +42,9 @@ pub struct DhcpReservationRow {
 pub struct DhcpLeaseLogRow {
     /// The lease this event belongs to.
     pub lease_id: String,
+    /// Client MAC address — denormalised so the audit trail survives
+    /// the lease row being rotated or deleted (issue #312).
+    pub mac_address: String,
     /// Event type string (`"assigned"`, `"renewed"`, `"released"`, `"expired"`, `"conflict"`).
     pub event_type: String,
     /// Optional free-form details about the event.
@@ -109,4 +112,11 @@ pub trait DhcpRepository: Send + Sync {
 
     /// Return all log entries for a given lease, ordered by creation time.
     async fn find_lease_logs(&self, lease_id: &str) -> anyhow::Result<Vec<DhcpLeaseLog>>;
+
+    /// Return all log entries for a MAC address, ordered by creation time.
+    ///
+    /// MAC-keyed access lets the audit trail outlive any individual
+    /// lease record — released or expired leases can be deleted while
+    /// the per-device history stays intact (issue #312).
+    async fn find_lease_logs_by_mac(&self, mac: &str) -> anyhow::Result<Vec<DhcpLeaseLog>>;
 }

--- a/source/daemon/crates/wardnetd-data/src/repository/sqlite/device.rs
+++ b/source/daemon/crates/wardnetd-data/src/repository/sqlite/device.rs
@@ -84,9 +84,13 @@ impl DeviceRepository for SqliteDeviceRepository {
     }
 
     async fn find_by_mac(&self, mac: &str) -> anyhow::Result<Option<Device>> {
+        // Defensive lowercase: MAC is stored lowercase across the codebase
+        // (issue #312). Inputs from older callers or external probes may
+        // arrive uppercase — normalise here so the WHERE-clause hits the
+        // canonical row regardless.
         let query = format!("SELECT {SELECT_COLS} FROM devices WHERE mac = ?");
         let row = sqlx::query_as::<_, DeviceRow>(&query)
-            .bind(mac)
+            .bind(mac.to_lowercase())
             .fetch_optional(&self.pool)
             .await?;
         row.map(DeviceRow::into_device).transpose()
@@ -106,7 +110,7 @@ impl DeviceRepository for SqliteDeviceRepository {
              VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
         )
         .bind(&device.id)
-        .bind(&device.mac)
+        .bind(device.mac.to_lowercase())
         .bind(&device.hostname)
         .bind(&device.manufacturer)
         .bind(&device.device_type)

--- a/source/daemon/crates/wardnetd-data/src/repository/sqlite/dhcp.rs
+++ b/source/daemon/crates/wardnetd-data/src/repository/sqlite/dhcp.rs
@@ -96,6 +96,7 @@ impl DbReservationRow {
 struct DbLeaseLogRow {
     id: i64,
     lease_id: String,
+    mac_address: String,
     event_type: String,
     details: Option<String>,
     created_at: String,
@@ -116,6 +117,7 @@ impl DbLeaseLogRow {
         Ok(DhcpLeaseLog {
             id: self.id,
             lease_id: self.lease_id.parse()?,
+            mac_address: self.mac_address,
             event_type,
             details: self.details,
             created_at: self.created_at.parse()?,
@@ -136,7 +138,7 @@ impl DhcpRepository for SqliteDhcpRepository {
              VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
         )
         .bind(&row.id)
-        .bind(&row.mac_address)
+        .bind(row.mac_address.to_lowercase())
         .bind(&row.ip_address)
         .bind(&row.hostname)
         .bind(&row.lease_start)
@@ -162,12 +164,14 @@ impl DhcpRepository for SqliteDhcpRepository {
     }
 
     async fn find_active_lease_by_mac(&self, mac: &str) -> anyhow::Result<Option<DhcpLease>> {
+        // MAC is stored lowercase (issue #312); normalise inputs defensively
+        // so an uppercase caller still hits the canonical row.
         let row = sqlx::query_as::<_, DbLeaseRow>(
             "SELECT id, mac_address, ip_address, hostname, lease_start, lease_end, \
              status, device_id, created_at, updated_at \
              FROM dhcp_leases WHERE mac_address = ? AND status = 'active'",
         )
-        .bind(mac)
+        .bind(mac.to_lowercase())
         .fetch_optional(&self.pool)
         .await?;
 
@@ -254,7 +258,7 @@ impl DhcpRepository for SqliteDhcpRepository {
              VALUES (?, ?, ?, ?, ?)",
         )
         .bind(&row.id)
-        .bind(&row.mac_address)
+        .bind(row.mac_address.to_lowercase())
         .bind(&row.ip_address)
         .bind(&row.hostname)
         .bind(&row.description)
@@ -285,11 +289,12 @@ impl DhcpRepository for SqliteDhcpRepository {
     }
 
     async fn find_reservation_by_mac(&self, mac: &str) -> anyhow::Result<Option<DhcpReservation>> {
+        // MAC is stored lowercase (issue #312); normalise inputs defensively.
         let row = sqlx::query_as::<_, DbReservationRow>(
             "SELECT id, mac_address, ip_address, hostname, description, created_at, updated_at \
              FROM dhcp_reservations WHERE mac_address = ?",
         )
-        .bind(mac)
+        .bind(mac.to_lowercase())
         .fetch_optional(&self.pool)
         .await?;
 
@@ -311,11 +316,13 @@ impl DhcpRepository for SqliteDhcpRepository {
     // ── Lease log ───────────────────────────────────────────────────
 
     async fn insert_lease_log(&self, row: &DhcpLeaseLogRow) -> anyhow::Result<()> {
+        // MAC stored canonical lowercase (issue #312).
         sqlx::query(
-            "INSERT INTO dhcp_lease_log (lease_id, event_type, details) \
-             VALUES (?, ?, ?)",
+            "INSERT INTO dhcp_lease_log (lease_id, mac_address, event_type, details) \
+             VALUES (?, ?, ?, ?)",
         )
         .bind(&row.lease_id)
+        .bind(row.mac_address.to_lowercase())
         .bind(&row.event_type)
         .bind(&row.details)
         .execute(&self.pool)
@@ -325,10 +332,22 @@ impl DhcpRepository for SqliteDhcpRepository {
 
     async fn find_lease_logs(&self, lease_id: &str) -> anyhow::Result<Vec<DhcpLeaseLog>> {
         let rows = sqlx::query_as::<_, DbLeaseLogRow>(
-            "SELECT id, lease_id, event_type, details, created_at \
+            "SELECT id, lease_id, mac_address, event_type, details, created_at \
              FROM dhcp_lease_log WHERE lease_id = ? ORDER BY created_at",
         )
         .bind(lease_id)
+        .fetch_all(&self.pool)
+        .await?;
+
+        rows.into_iter().map(DbLeaseLogRow::into_log).collect()
+    }
+
+    async fn find_lease_logs_by_mac(&self, mac: &str) -> anyhow::Result<Vec<DhcpLeaseLog>> {
+        let rows = sqlx::query_as::<_, DbLeaseLogRow>(
+            "SELECT id, lease_id, mac_address, event_type, details, created_at \
+             FROM dhcp_lease_log WHERE mac_address = ? ORDER BY created_at",
+        )
+        .bind(mac.to_lowercase())
         .fetch_all(&self.pool)
         .await?;
 

--- a/source/daemon/crates/wardnetd-data/src/repository/tests/device.rs
+++ b/source/daemon/crates/wardnetd-data/src/repository/tests/device.rs
@@ -40,12 +40,12 @@ async fn insert_device(pool: &sqlx::SqlitePool, id: &str, mac: &str, ip: &str) {
 #[tokio::test]
 async fn find_by_ip_found() {
     let pool = test_pool().await;
-    insert_device(&pool, DEV1, "AA:BB:CC:DD:EE:01", "192.168.1.10").await;
+    insert_device(&pool, DEV1, "aa:bb:cc:dd:ee:01", "192.168.1.10").await;
     let repo = SqliteDeviceRepository::new(pool);
 
     let device = repo.find_by_ip("192.168.1.10").await.unwrap().unwrap();
     assert_eq!(device.id.to_string(), DEV1);
-    assert_eq!(device.mac, "AA:BB:CC:DD:EE:01");
+    assert_eq!(device.mac, "aa:bb:cc:dd:ee:01");
     assert_eq!(device.last_ip, "192.168.1.10");
     assert_eq!(device.device_type, DeviceType::Unknown);
     assert!(!device.admin_locked);
@@ -63,21 +63,21 @@ async fn find_by_ip_not_found() {
 #[tokio::test]
 async fn find_by_id_found() {
     let pool = test_pool().await;
-    insert_device(&pool, DEV1, "AA:BB:CC:DD:EE:01", "192.168.1.10").await;
+    insert_device(&pool, DEV1, "aa:bb:cc:dd:ee:01", "192.168.1.10").await;
     let repo = SqliteDeviceRepository::new(pool);
 
     let device = repo.find_by_id(DEV1).await.unwrap().unwrap();
-    assert_eq!(device.mac, "AA:BB:CC:DD:EE:01");
+    assert_eq!(device.mac, "aa:bb:cc:dd:ee:01");
 }
 
 #[tokio::test]
 async fn find_by_mac_found() {
     let pool = test_pool().await;
-    insert_device(&pool, DEV1, "AA:BB:CC:DD:EE:01", "192.168.1.10").await;
+    insert_device(&pool, DEV1, "aa:bb:cc:dd:ee:01", "192.168.1.10").await;
     let repo = SqliteDeviceRepository::new(pool);
 
     let device = repo
-        .find_by_mac("AA:BB:CC:DD:EE:01")
+        .find_by_mac("aa:bb:cc:dd:ee:01")
         .await
         .unwrap()
         .unwrap();
@@ -89,8 +89,38 @@ async fn find_by_mac_not_found() {
     let pool = test_pool().await;
     let repo = SqliteDeviceRepository::new(pool);
 
-    let result = repo.find_by_mac("FF:FF:FF:FF:FF:FF").await.unwrap();
+    let result = repo.find_by_mac("ff:ff:ff:ff:ff:ff").await.unwrap();
     assert!(result.is_none());
+}
+
+/// Cross-case equality acceptance test for issue #312: an uppercase MAC
+/// inserted via the repo must be findable with a lowercase MAC argument
+/// (and the row must come back in canonical lowercase form). This pins
+/// the contract that `SqliteDeviceRepository` lowercases on both write
+/// and `_by_mac` lookup, so callers can stop normalising per-call.
+#[tokio::test]
+async fn insert_uppercase_mac_is_findable_by_lowercase() {
+    let pool = test_pool().await;
+    let repo = SqliteDeviceRepository::new(pool);
+
+    let row = sample_device_row(DEV1, "AA:BB:CC:DD:EE:01", "192.168.1.10");
+    repo.insert(&row).await.unwrap();
+
+    let device = repo
+        .find_by_mac("aa:bb:cc:dd:ee:01")
+        .await
+        .unwrap()
+        .expect("lowercase lookup must hit the row inserted with uppercase MAC");
+    assert_eq!(device.mac, "aa:bb:cc:dd:ee:01");
+
+    // Reverse direction also works: uppercase argument resolves the
+    // (now-lowercase) stored row.
+    let again = repo
+        .find_by_mac("AA:BB:CC:DD:EE:01")
+        .await
+        .unwrap()
+        .expect("uppercase lookup must hit the same canonical row");
+    assert_eq!(again.id, device.id);
 }
 
 #[tokio::test]
@@ -98,11 +128,11 @@ async fn insert_new_device() {
     let pool = test_pool().await;
     let repo = SqliteDeviceRepository::new(pool);
 
-    let row = sample_device_row(DEV1, "AA:BB:CC:DD:EE:01", "192.168.1.10");
+    let row = sample_device_row(DEV1, "aa:bb:cc:dd:ee:01", "192.168.1.10");
     repo.insert(&row).await.unwrap();
 
     let device = repo.find_by_id(DEV1).await.unwrap().unwrap();
-    assert_eq!(device.mac, "AA:BB:CC:DD:EE:01");
+    assert_eq!(device.mac, "aa:bb:cc:dd:ee:01");
     assert_eq!(device.hostname, Some("my-host".to_owned()));
     assert_eq!(device.manufacturer, Some("Apple".to_owned()));
     assert_eq!(device.device_type, DeviceType::Phone);
@@ -114,7 +144,7 @@ async fn update_last_seen_and_ip() {
     let pool = test_pool().await;
     let repo = SqliteDeviceRepository::new(pool);
 
-    let row = sample_device_row(DEV1, "AA:BB:CC:DD:EE:01", "192.168.1.10");
+    let row = sample_device_row(DEV1, "aa:bb:cc:dd:ee:01", "192.168.1.10");
     repo.insert(&row).await.unwrap();
 
     repo.update_last_seen_and_ip(DEV1, "192.168.1.20", "2026-03-07T12:00:00Z")
@@ -133,14 +163,14 @@ async fn update_last_seen_batch_multiple() {
 
     repo.insert(&sample_device_row(
         DEV1,
-        "AA:BB:CC:DD:EE:01",
+        "aa:bb:cc:dd:ee:01",
         "192.168.1.10",
     ))
     .await
     .unwrap();
     repo.insert(&sample_device_row(
         DEV2,
-        "AA:BB:CC:DD:EE:02",
+        "aa:bb:cc:dd:ee:02",
         "192.168.1.11",
     ))
     .await
@@ -165,7 +195,7 @@ async fn update_hostname() {
 
     repo.insert(&sample_device_row(
         DEV1,
-        "AA:BB:CC:DD:EE:01",
+        "aa:bb:cc:dd:ee:01",
         "192.168.1.10",
     ))
     .await
@@ -184,7 +214,7 @@ async fn update_name_and_type() {
 
     repo.insert(&sample_device_row(
         DEV1,
-        "AA:BB:CC:DD:EE:01",
+        "aa:bb:cc:dd:ee:01",
         "192.168.1.10",
     ))
     .await
@@ -205,12 +235,12 @@ async fn find_stale_returns_old_devices() {
     let repo = SqliteDeviceRepository::new(pool);
 
     // Device 1: old last_seen.
-    let mut row1 = sample_device_row(DEV1, "AA:BB:CC:DD:EE:01", "192.168.1.10");
+    let mut row1 = sample_device_row(DEV1, "aa:bb:cc:dd:ee:01", "192.168.1.10");
     row1.last_seen = "2026-03-06T00:00:00Z".to_owned();
     repo.insert(&row1).await.unwrap();
 
     // Device 2: recent last_seen.
-    let mut row2 = sample_device_row(DEV2, "AA:BB:CC:DD:EE:02", "192.168.1.11");
+    let mut row2 = sample_device_row(DEV2, "aa:bb:cc:dd:ee:02", "192.168.1.11");
     row2.last_seen = "2026-03-07T12:00:00Z".to_owned();
     repo.insert(&row2).await.unwrap();
 
@@ -226,21 +256,21 @@ async fn find_all_returns_all_devices() {
 
     repo.insert(&sample_device_row(
         DEV1,
-        "AA:BB:CC:DD:EE:01",
+        "aa:bb:cc:dd:ee:01",
         "192.168.1.10",
     ))
     .await
     .unwrap();
     repo.insert(&sample_device_row(
         DEV2,
-        "AA:BB:CC:DD:EE:02",
+        "aa:bb:cc:dd:ee:02",
         "192.168.1.11",
     ))
     .await
     .unwrap();
     repo.insert(&sample_device_row(
         DEV3,
-        "AA:BB:CC:DD:EE:03",
+        "aa:bb:cc:dd:ee:03",
         "192.168.1.12",
     ))
     .await
@@ -253,7 +283,7 @@ async fn find_all_returns_all_devices() {
 #[tokio::test]
 async fn find_rule_for_device_found() {
     let pool = test_pool().await;
-    insert_device(&pool, DEV1, "AA:BB:CC:DD:EE:01", "192.168.1.10").await;
+    insert_device(&pool, DEV1, "aa:bb:cc:dd:ee:01", "192.168.1.10").await;
     sqlx::query(
         "INSERT INTO routing_rules (id, device_id, target_json, created_by) \
          VALUES ('r1', ?, '{\"type\":\"direct\"}', 'user')",
@@ -272,7 +302,7 @@ async fn find_rule_for_device_found() {
 #[tokio::test]
 async fn find_rule_not_found() {
     let pool = test_pool().await;
-    insert_device(&pool, DEV1, "AA:BB:CC:DD:EE:01", "192.168.1.10").await;
+    insert_device(&pool, DEV1, "aa:bb:cc:dd:ee:01", "192.168.1.10").await;
     let repo = SqliteDeviceRepository::new(pool);
 
     let result = repo.find_rule_for_device(DEV1).await.unwrap();
@@ -282,7 +312,7 @@ async fn find_rule_not_found() {
 #[tokio::test]
 async fn upsert_user_rule_insert_and_update() {
     let pool = test_pool().await;
-    insert_device(&pool, DEV1, "AA:BB:CC:DD:EE:01", "192.168.1.10").await;
+    insert_device(&pool, DEV1, "aa:bb:cc:dd:ee:01", "192.168.1.10").await;
     let repo = SqliteDeviceRepository::new(pool);
 
     // Insert.
@@ -307,7 +337,7 @@ async fn update_admin_locked_sets_flag() {
 
     repo.insert(&sample_device_row(
         DEV1,
-        "AA:BB:CC:DD:EE:01",
+        "aa:bb:cc:dd:ee:01",
         "192.168.1.10",
     ))
     .await
@@ -331,9 +361,9 @@ async fn update_admin_locked_sets_flag() {
 #[tokio::test]
 async fn count_devices() {
     let pool = test_pool().await;
-    insert_device(&pool, DEV1, "AA:BB:CC:DD:EE:01", "192.168.1.10").await;
-    insert_device(&pool, DEV2, "AA:BB:CC:DD:EE:02", "192.168.1.11").await;
-    insert_device(&pool, DEV3, "AA:BB:CC:DD:EE:03", "192.168.1.12").await;
+    insert_device(&pool, DEV1, "aa:bb:cc:dd:ee:01", "192.168.1.10").await;
+    insert_device(&pool, DEV2, "aa:bb:cc:dd:ee:02", "192.168.1.11").await;
+    insert_device(&pool, DEV3, "aa:bb:cc:dd:ee:03", "192.168.1.12").await;
     let repo = SqliteDeviceRepository::new(pool);
 
     assert_eq!(repo.count().await.unwrap(), 3);

--- a/source/daemon/crates/wardnetd-data/src/repository/tests/dhcp.rs
+++ b/source/daemon/crates/wardnetd-data/src/repository/tests/dhcp.rs
@@ -35,13 +35,13 @@ async fn insert_and_find_lease_by_id() {
     let repo = SqliteDhcpRepository::new(pool);
     let id = "00000000-0000-0000-0000-000000000001";
 
-    repo.insert_lease(&sample_lease_row(id, "AA:BB:CC:DD:EE:01", "192.168.1.100"))
+    repo.insert_lease(&sample_lease_row(id, "aa:bb:cc:dd:ee:01", "192.168.1.100"))
         .await
         .unwrap();
 
     let lease = repo.find_lease_by_id(id).await.unwrap().unwrap();
     assert_eq!(lease.id.to_string(), id);
-    assert_eq!(lease.mac_address, "AA:BB:CC:DD:EE:01");
+    assert_eq!(lease.mac_address, "aa:bb:cc:dd:ee:01");
     assert_eq!(lease.ip_address.to_string(), "192.168.1.100");
     assert_eq!(lease.hostname, Some("test-host".to_owned()));
     assert_eq!(lease.status, DhcpLeaseStatus::Active);
@@ -67,6 +67,39 @@ async fn find_active_lease_by_mac() {
 
     repo.insert_lease(&sample_lease_row(
         "00000000-0000-0000-0000-000000000001",
+        "aa:bb:cc:dd:ee:01",
+        "192.168.1.100",
+    ))
+    .await
+    .unwrap();
+
+    let lease = repo
+        .find_active_lease_by_mac("aa:bb:cc:dd:ee:01")
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(lease.mac_address, "aa:bb:cc:dd:ee:01");
+
+    // Non-existent MAC returns None.
+    let missing = repo
+        .find_active_lease_by_mac("ff:ff:ff:ff:ff:ff")
+        .await
+        .unwrap();
+    assert!(missing.is_none());
+}
+
+/// Cross-case equality acceptance test for issue #312: an uppercase MAC
+/// inserted into a lease must be findable with a lowercase argument and
+/// vice versa, with the canonical (lowercase) form coming back from the
+/// row. Pinning this contract is what lets `DhcpService` and
+/// `DeviceDiscoveryService` stop normalising MAC casing per call.
+#[tokio::test]
+async fn lease_uppercase_mac_is_findable_by_lowercase() {
+    let pool = test_pool().await;
+    let repo = SqliteDhcpRepository::new(pool);
+
+    repo.insert_lease(&sample_lease_row(
+        "00000000-0000-0000-0000-000000000001",
         "AA:BB:CC:DD:EE:01",
         "192.168.1.100",
     ))
@@ -74,18 +107,39 @@ async fn find_active_lease_by_mac() {
     .unwrap();
 
     let lease = repo
+        .find_active_lease_by_mac("aa:bb:cc:dd:ee:01")
+        .await
+        .unwrap()
+        .expect("lowercase lookup must hit the lease inserted with uppercase MAC");
+    assert_eq!(lease.mac_address, "aa:bb:cc:dd:ee:01");
+
+    let again = repo
         .find_active_lease_by_mac("AA:BB:CC:DD:EE:01")
         .await
         .unwrap()
-        .unwrap();
-    assert_eq!(lease.mac_address, "AA:BB:CC:DD:EE:01");
+        .expect("uppercase lookup must hit the same canonical lease");
+    assert_eq!(again.id, lease.id);
+}
 
-    // Non-existent MAC returns None.
-    let missing = repo
-        .find_active_lease_by_mac("FF:FF:FF:FF:FF:FF")
+#[tokio::test]
+async fn reservation_uppercase_mac_is_findable_by_lowercase() {
+    let pool = test_pool().await;
+    let repo = SqliteDhcpRepository::new(pool);
+
+    repo.insert_reservation(&sample_reservation_row(
+        "00000000-0000-0000-0000-000000000001",
+        "AA:BB:CC:DD:EE:01",
+        "192.168.1.50",
+    ))
+    .await
+    .unwrap();
+
+    let res = repo
+        .find_reservation_by_mac("aa:bb:cc:dd:ee:01")
         .await
-        .unwrap();
-    assert!(missing.is_none());
+        .unwrap()
+        .expect("lowercase lookup must hit the reservation inserted with uppercase MAC");
+    assert_eq!(res.mac_address, "aa:bb:cc:dd:ee:01");
 }
 
 #[tokio::test]
@@ -95,7 +149,7 @@ async fn find_active_lease_by_ip() {
 
     repo.insert_lease(&sample_lease_row(
         "00000000-0000-0000-0000-000000000001",
-        "AA:BB:CC:DD:EE:01",
+        "aa:bb:cc:dd:ee:01",
         "192.168.1.100",
     ))
     .await
@@ -120,14 +174,14 @@ async fn list_active_leases() {
 
     repo.insert_lease(&sample_lease_row(
         "00000000-0000-0000-0000-000000000001",
-        "AA:BB:CC:DD:EE:01",
+        "aa:bb:cc:dd:ee:01",
         "192.168.1.100",
     ))
     .await
     .unwrap();
     repo.insert_lease(&sample_lease_row(
         "00000000-0000-0000-0000-000000000002",
-        "AA:BB:CC:DD:EE:02",
+        "aa:bb:cc:dd:ee:02",
         "192.168.1.101",
     ))
     .await
@@ -140,7 +194,7 @@ async fn list_active_leases() {
 
     let active = repo.list_active_leases().await.unwrap();
     assert_eq!(active.len(), 1);
-    assert_eq!(active[0].mac_address, "AA:BB:CC:DD:EE:01");
+    assert_eq!(active[0].mac_address, "aa:bb:cc:dd:ee:01");
 }
 
 #[tokio::test]
@@ -149,7 +203,7 @@ async fn update_lease_status() {
     let repo = SqliteDhcpRepository::new(pool);
     let id = "00000000-0000-0000-0000-000000000001";
 
-    repo.insert_lease(&sample_lease_row(id, "AA:BB:CC:DD:EE:01", "192.168.1.100"))
+    repo.insert_lease(&sample_lease_row(id, "aa:bb:cc:dd:ee:01", "192.168.1.100"))
         .await
         .unwrap();
     repo.update_lease_status(id, "released").await.unwrap();
@@ -164,7 +218,7 @@ async fn renew_lease() {
     let repo = SqliteDhcpRepository::new(pool);
     let id = "00000000-0000-0000-0000-000000000001";
 
-    repo.insert_lease(&sample_lease_row(id, "AA:BB:CC:DD:EE:01", "192.168.1.100"))
+    repo.insert_lease(&sample_lease_row(id, "aa:bb:cc:dd:ee:01", "192.168.1.100"))
         .await
         .unwrap();
 
@@ -209,7 +263,7 @@ async fn expire_stale_leases() {
     // Insert a lease that already expired (lease_end in the past).
     let mut stale = sample_lease_row(
         "00000000-0000-0000-0000-000000000001",
-        "AA:BB:CC:DD:EE:01",
+        "aa:bb:cc:dd:ee:01",
         "192.168.1.100",
     );
     stale.lease_end = "2020-01-01T00:00:00Z".to_owned();
@@ -217,7 +271,7 @@ async fn expire_stale_leases() {
     // Insert a lease that is still active (lease_end far in the future).
     let fresh = sample_lease_row(
         "00000000-0000-0000-0000-000000000002",
-        "AA:BB:CC:DD:EE:02",
+        "aa:bb:cc:dd:ee:02",
         "192.168.1.101",
     );
 
@@ -251,14 +305,14 @@ async fn insert_and_list_reservations() {
 
     repo.insert_reservation(&sample_reservation_row(
         "00000000-0000-0000-0000-000000000001",
-        "AA:BB:CC:DD:EE:01",
+        "aa:bb:cc:dd:ee:01",
         "192.168.1.50",
     ))
     .await
     .unwrap();
     repo.insert_reservation(&sample_reservation_row(
         "00000000-0000-0000-0000-000000000002",
-        "AA:BB:CC:DD:EE:02",
+        "aa:bb:cc:dd:ee:02",
         "192.168.1.51",
     ))
     .await
@@ -276,7 +330,7 @@ async fn delete_reservation() {
 
     repo.insert_reservation(&sample_reservation_row(
         id,
-        "AA:BB:CC:DD:EE:01",
+        "aa:bb:cc:dd:ee:01",
         "192.168.1.50",
     ))
     .await
@@ -294,25 +348,25 @@ async fn find_reservation_by_mac() {
 
     repo.insert_reservation(&sample_reservation_row(
         "00000000-0000-0000-0000-000000000001",
-        "AA:BB:CC:DD:EE:01",
+        "aa:bb:cc:dd:ee:01",
         "192.168.1.50",
     ))
     .await
     .unwrap();
 
     let res = repo
-        .find_reservation_by_mac("AA:BB:CC:DD:EE:01")
+        .find_reservation_by_mac("aa:bb:cc:dd:ee:01")
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(res.mac_address, "AA:BB:CC:DD:EE:01");
+    assert_eq!(res.mac_address, "aa:bb:cc:dd:ee:01");
     assert_eq!(res.ip_address.to_string(), "192.168.1.50");
     assert_eq!(res.hostname, Some("reserved-host".to_owned()));
     assert_eq!(res.description, Some("Test reservation".to_owned()));
 
     // Non-existent MAC returns None.
     let missing = repo
-        .find_reservation_by_mac("FF:FF:FF:FF:FF:FF")
+        .find_reservation_by_mac("ff:ff:ff:ff:ff:ff")
         .await
         .unwrap();
     assert!(missing.is_none());
@@ -325,7 +379,7 @@ async fn find_reservation_by_ip() {
 
     repo.insert_reservation(&sample_reservation_row(
         "00000000-0000-0000-0000-000000000001",
-        "AA:BB:CC:DD:EE:01",
+        "aa:bb:cc:dd:ee:01",
         "192.168.1.50",
     ))
     .await
@@ -337,7 +391,7 @@ async fn find_reservation_by_ip() {
         .unwrap()
         .unwrap();
     assert_eq!(res.ip_address.to_string(), "192.168.1.50");
-    assert_eq!(res.mac_address, "AA:BB:CC:DD:EE:01");
+    assert_eq!(res.mac_address, "aa:bb:cc:dd:ee:01");
 
     // Non-existent IP returns None.
     let missing = repo.find_reservation_by_ip("10.0.0.1").await.unwrap();
@@ -353,7 +407,7 @@ async fn insert_and_find_lease_logs() {
     // Insert a lease first (the log references it by ID).
     repo.insert_lease(&sample_lease_row(
         lease_id,
-        "AA:BB:CC:DD:EE:01",
+        "aa:bb:cc:dd:ee:01",
         "192.168.1.100",
     ))
     .await
@@ -361,6 +415,7 @@ async fn insert_and_find_lease_logs() {
 
     repo.insert_lease_log(&DhcpLeaseLogRow {
         lease_id: lease_id.to_owned(),
+        mac_address: "aa:bb:cc:dd:ee:01".to_owned(),
         event_type: "assigned".to_owned(),
         details: Some("Initial assignment".to_owned()),
     })
@@ -369,6 +424,7 @@ async fn insert_and_find_lease_logs() {
 
     repo.insert_lease_log(&DhcpLeaseLogRow {
         lease_id: lease_id.to_owned(),
+        mac_address: "aa:bb:cc:dd:ee:01".to_owned(),
         event_type: "renewed".to_owned(),
         details: None,
     })
@@ -377,10 +433,69 @@ async fn insert_and_find_lease_logs() {
 
     let logs = repo.find_lease_logs(lease_id).await.unwrap();
     assert_eq!(logs.len(), 2);
+    assert_eq!(logs[0].mac_address, "aa:bb:cc:dd:ee:01");
     assert_eq!(logs[0].event_type, DhcpLeaseEventType::Assigned);
     assert_eq!(logs[0].details, Some("Initial assignment".to_owned()));
     assert_eq!(logs[1].event_type, DhcpLeaseEventType::Renewed);
     assert!(logs[1].details.is_none());
+}
+
+/// MAC-keyed lookup for the audit log: events for a given MAC remain
+/// queryable independently of the parent lease row, so a released or
+/// expired lease can be deleted without losing the per-device history
+/// (issue #312). Also pins the case-insensitivity contract.
+#[tokio::test]
+async fn find_lease_logs_by_mac_returns_all_events_for_mac() {
+    let pool = test_pool().await;
+    let repo = SqliteDhcpRepository::new(pool);
+
+    repo.insert_lease(&sample_lease_row(
+        "00000000-0000-0000-0000-000000000001",
+        "aa:bb:cc:dd:ee:01",
+        "192.168.1.100",
+    ))
+    .await
+    .unwrap();
+
+    // Two events for the target MAC, plus one for an unrelated MAC.
+    repo.insert_lease_log(&DhcpLeaseLogRow {
+        lease_id: "00000000-0000-0000-0000-000000000001".to_owned(),
+        mac_address: "AA:BB:CC:DD:EE:01".to_owned(),
+        event_type: "assigned".to_owned(),
+        details: None,
+    })
+    .await
+    .unwrap();
+    repo.insert_lease_log(&DhcpLeaseLogRow {
+        lease_id: "00000000-0000-0000-0000-000000000001".to_owned(),
+        mac_address: "aa:bb:cc:dd:ee:01".to_owned(),
+        event_type: "renewed".to_owned(),
+        details: None,
+    })
+    .await
+    .unwrap();
+    repo.insert_lease_log(&DhcpLeaseLogRow {
+        lease_id: "00000000-0000-0000-0000-000000000002".to_owned(),
+        mac_address: "aa:bb:cc:dd:ee:99".to_owned(),
+        event_type: "assigned".to_owned(),
+        details: None,
+    })
+    .await
+    .unwrap();
+
+    let logs = repo
+        .find_lease_logs_by_mac("aa:bb:cc:dd:ee:01")
+        .await
+        .unwrap();
+    assert_eq!(logs.len(), 2);
+    assert!(logs.iter().all(|l| l.mac_address == "aa:bb:cc:dd:ee:01"));
+
+    // Uppercase argument hits the same canonical rows.
+    let logs_upper = repo
+        .find_lease_logs_by_mac("AA:BB:CC:DD:EE:01")
+        .await
+        .unwrap();
+    assert_eq!(logs_upper.len(), 2);
 }
 
 #[tokio::test]
@@ -389,7 +504,7 @@ async fn find_lease_by_id_released_status() {
     let repo = SqliteDhcpRepository::new(pool);
     let id = "00000000-0000-0000-0000-000000000003";
 
-    let mut row = sample_lease_row(id, "AA:BB:CC:DD:EE:03", "192.168.1.103");
+    let mut row = sample_lease_row(id, "aa:bb:cc:dd:ee:03", "192.168.1.103");
     row.status = "released".to_owned();
     repo.insert_lease(&row).await.unwrap();
 
@@ -403,7 +518,7 @@ async fn find_lease_by_id_expired_status() {
     let repo = SqliteDhcpRepository::new(pool);
     let id = "00000000-0000-0000-0000-000000000004";
 
-    let mut row = sample_lease_row(id, "AA:BB:CC:DD:EE:04", "192.168.1.104");
+    let mut row = sample_lease_row(id, "aa:bb:cc:dd:ee:04", "192.168.1.104");
     row.status = "expired".to_owned();
     repo.insert_lease(&row).await.unwrap();
 
@@ -419,7 +534,7 @@ async fn insert_and_find_lease_log_all_event_types() {
 
     repo.insert_lease(&sample_lease_row(
         lease_id,
-        "AA:BB:CC:DD:EE:10",
+        "aa:bb:cc:dd:ee:10",
         "192.168.1.110",
     ))
     .await
@@ -429,6 +544,7 @@ async fn insert_and_find_lease_log_all_event_types() {
     for event_type in &["assigned", "renewed", "released", "expired", "conflict"] {
         repo.insert_lease_log(&DhcpLeaseLogRow {
             lease_id: lease_id.to_owned(),
+            mac_address: "aa:bb:cc:dd:ee:10".to_owned(),
             event_type: (*event_type).to_owned(),
             details: Some(format!("test {event_type}")),
         })
@@ -465,7 +581,7 @@ async fn expire_stale_leases_none_to_expire() {
     // Insert only a fresh lease.
     repo.insert_lease(&sample_lease_row(
         "00000000-0000-0000-0000-000000000005",
-        "AA:BB:CC:DD:EE:05",
+        "aa:bb:cc:dd:ee:05",
         "192.168.1.105",
     ))
     .await
@@ -497,7 +613,7 @@ async fn reservation_without_optional_fields() {
 
     let row = DhcpReservationRow {
         id: id.to_owned(),
-        mac_address: "AA:BB:CC:DD:EE:06".to_owned(),
+        mac_address: "aa:bb:cc:dd:ee:06".to_owned(),
         ip_address: "192.168.1.60".to_owned(),
         hostname: None,
         description: None,
@@ -505,7 +621,7 @@ async fn reservation_without_optional_fields() {
     repo.insert_reservation(&row).await.unwrap();
 
     let res = repo
-        .find_reservation_by_mac("AA:BB:CC:DD:EE:06")
+        .find_reservation_by_mac("aa:bb:cc:dd:ee:06")
         .await
         .unwrap()
         .unwrap();

--- a/source/daemon/crates/wardnetd-data/src/repository/tests/dns_filter.rs
+++ b/source/daemon/crates/wardnetd-data/src/repository/tests/dns_filter.rs
@@ -25,7 +25,7 @@ async fn insert_device(pool: &sqlx::SqlitePool, id: &str, ip: &str) {
     )
     .bind(id)
     .bind(format!(
-        "AA:BB:CC:DD:EE:{:02x}",
+        "aa:bb:cc:dd:ee:{:02x}",
         u32::from(id.as_bytes()[35]) & 0xff
     ))
     .bind(ip)

--- a/source/daemon/crates/wardnetd-data/src/repository/tests/system_config.rs
+++ b/source/daemon/crates/wardnetd-data/src/repository/tests/system_config.rs
@@ -68,7 +68,7 @@ async fn device_count_with_data() {
              VALUES (?, ?, ?, 'unknown', ?, ?)",
         )
         .bind(format!("00000000-0000-0000-0000-00000000000{i}"))
-        .bind(format!("AA:BB:CC:DD:EE:{i:02X}"))
+        .bind(format!("aa:bb:cc:dd:ee:{i:02x}"))
         .bind(format!("192.168.1.{}", 10 + i))
         .bind(now)
         .bind(now)
@@ -363,9 +363,9 @@ async fn router_mac_round_trip() {
 
     assert!(repo.get_router_mac().await.unwrap().is_none());
 
-    repo.set_router_mac("AA:BB:CC:DD:EE:FF").await.unwrap();
+    repo.set_router_mac("aa:bb:cc:dd:ee:ff").await.unwrap();
     assert_eq!(
         repo.get_router_mac().await.unwrap().as_deref(),
-        Some("AA:BB:CC:DD:EE:FF")
+        Some("aa:bb:cc:dd:ee:ff")
     );
 }

--- a/source/daemon/crates/wardnetd-services/src/device/discovery.rs
+++ b/source/daemon/crates/wardnetd-services/src/device/discovery.rs
@@ -438,22 +438,17 @@ impl DeviceDiscoveryService for DeviceDiscoveryServiceImpl {
     }
 
     async fn resolve_hostname(&self, mac: &str, ip: &str) -> Result<(), AppError> {
-        // MAC casing is currently inconsistent across the codebase: the
-        // device registry stores uppercase (set by `format_mac` in the
-        // packet-capture layer), the DHCP service stores lowercase
-        // (`mac.to_lowercase()` before insert/lookup). Until #312
-        // canonicalises this we normalise per-repo here so cross-source
-        // lookups succeed regardless of the caller's casing.
-        let mac_for_devices = mac.to_uppercase();
-        let mac_for_dhcp = mac.to_lowercase();
-
         // The MAC may belong to a device the registry hasn't seen yet (e.g.
         // a lease event arriving before packet capture observes the device).
         // Treat that as a no-op rather than an error; the next observation
         // will trigger another resolution attempt.
+        //
+        // Casing is canonicalised at the repository boundary (issue #312),
+        // so a single MAC string is fed to both repos regardless of the
+        // caller's source.
         let Some(device) = self
             .devices
-            .find_by_mac(&mac_for_devices)
+            .find_by_mac(mac)
             .await
             .map_err(AppError::Internal)?
         else {
@@ -465,7 +460,7 @@ impl DeviceDiscoveryService for DeviceDiscoveryServiceImpl {
         // says it's the primary source. Fall back to reverse DNS otherwise.
         let dhcp_hostname = self
             .dhcp
-            .find_active_lease_by_mac(&mac_for_dhcp)
+            .find_active_lease_by_mac(mac)
             .await
             .map_err(AppError::Internal)?
             .and_then(|l| l.hostname)

--- a/source/daemon/crates/wardnetd-services/src/device/tests/discovery.rs
+++ b/source/daemon/crates/wardnetd-services/src/device/tests/discovery.rs
@@ -53,6 +53,15 @@ struct MockDeviceRepo {
 
 impl MockDeviceRepo {
     fn with_devices(devices: Vec<Device>) -> Self {
+        // Mirror the SQLite repo: stored MAC is always canonical lowercase
+        // (#312), so seed fixtures get the same treatment.
+        let devices = devices
+            .into_iter()
+            .map(|mut d| {
+                d.mac = d.mac.to_lowercase();
+                d
+            })
+            .collect();
         Self {
             devices: Mutex::new(devices),
             inserted: Mutex::new(Vec::new()),
@@ -77,6 +86,8 @@ impl DeviceRepository for MockDeviceRepo {
     }
 
     async fn find_by_mac(&self, mac: &str) -> anyhow::Result<Option<Device>> {
+        // Mirror the SQLite repo: MAC is stored canonical lowercase (#312).
+        let mac = mac.to_lowercase();
         let devices = self.devices.lock().unwrap();
         Ok(devices.iter().find(|d| d.mac == mac).cloned())
     }
@@ -86,10 +97,12 @@ impl DeviceRepository for MockDeviceRepo {
     }
 
     async fn insert(&self, device: &DeviceRow) -> anyhow::Result<()> {
+        // Mirror the SQLite repo: MAC stored canonical lowercase (#312).
+        let mac = device.mac.to_lowercase();
         let mut inserted = self.inserted.lock().unwrap();
         inserted.push(DeviceRow {
             id: device.id.clone(),
-            mac: device.mac.clone(),
+            mac: mac.clone(),
             hostname: device.hostname.clone(),
             manufacturer: device.manufacturer.clone(),
             device_type: device.device_type.clone(),
@@ -102,7 +115,7 @@ impl DeviceRepository for MockDeviceRepo {
         let mut devices = self.devices.lock().unwrap();
         devices.push(Device {
             id: device.id.parse().unwrap(),
-            mac: device.mac.clone(),
+            mac: mac.clone(),
             name: None,
             hostname: device.hostname.clone(),
             manufacturer: device.manufacturer.clone(),
@@ -282,9 +295,11 @@ impl MockDhcpRepository {
     }
 
     fn with_lease_hostnames(entries: Vec<(&str, Option<&str>)>) -> Self {
+        // Mirror the SQLite repo: keys are stored canonical lowercase
+        // (#312) so that a lookup with mixed-case input still hits.
         let mut leases_by_mac = HashMap::new();
         for (mac, hostname) in entries {
-            leases_by_mac.insert(mac.to_owned(), hostname.map(ToOwned::to_owned));
+            leases_by_mac.insert(mac.to_lowercase(), hostname.map(ToOwned::to_owned));
         }
         Self { leases_by_mac }
     }
@@ -299,9 +314,10 @@ impl DhcpRepository for MockDhcpRepository {
         unreachable!()
     }
     async fn find_active_lease_by_mac(&self, mac: &str) -> anyhow::Result<Option<DhcpLease>> {
-        Ok(self.leases_by_mac.get(mac).map(|hostname| DhcpLease {
+        let mac = mac.to_lowercase();
+        Ok(self.leases_by_mac.get(&mac).map(|hostname| DhcpLease {
             id: Uuid::nil(),
-            mac_address: mac.to_owned(),
+            mac_address: mac.clone(),
             ip_address: Ipv4Addr::new(192, 168, 1, 10),
             hostname: hostname.clone(),
             lease_start: Utc::now(),
@@ -353,6 +369,9 @@ impl DhcpRepository for MockDhcpRepository {
         unreachable!()
     }
     async fn find_lease_logs(&self, _lease_id: &str) -> anyhow::Result<Vec<DhcpLeaseLog>> {
+        unreachable!()
+    }
+    async fn find_lease_logs_by_mac(&self, _mac: &str) -> anyhow::Result<Vec<DhcpLeaseLog>> {
         unreachable!()
     }
 }
@@ -439,7 +458,7 @@ fn build_harness_with_resolver_and_dhcp(
 #[tokio::test]
 async fn process_observation_new_device() {
     let h = build_harness();
-    let obs = sample_observation("AA:BB:CC:DD:EE:01", "192.168.1.10");
+    let obs = sample_observation("aa:bb:cc:dd:ee:01", "192.168.1.10");
 
     let result = h.svc.process_observation(&obs).await.unwrap();
     assert!(
@@ -450,7 +469,7 @@ async fn process_observation_new_device() {
     // Verify device was inserted.
     let inserted = h.repo.inserted.lock().unwrap();
     assert_eq!(inserted.len(), 1);
-    assert_eq!(inserted[0].mac, "AA:BB:CC:DD:EE:01");
+    assert_eq!(inserted[0].mac, "aa:bb:cc:dd:ee:01");
     assert_eq!(inserted[0].last_ip, "192.168.1.10");
 
     // Verify DeviceDiscovered event was emitted.
@@ -460,14 +479,14 @@ async fn process_observation_new_device() {
         &events[0],
         WardnetEvent::DeviceDiscovered {
             mac, ip, ..
-        } if mac == "AA:BB:CC:DD:EE:01" && ip == "192.168.1.10"
+        } if mac == "aa:bb:cc:dd:ee:01" && ip == "192.168.1.10"
     ));
 }
 
 #[tokio::test]
 async fn process_observation_known_device_same_ip() {
     let h = build_harness();
-    let obs = sample_observation("AA:BB:CC:DD:EE:01", "192.168.1.10");
+    let obs = sample_observation("aa:bb:cc:dd:ee:01", "192.168.1.10");
 
     // First observation registers the device.
     h.svc.process_observation(&obs).await.unwrap();
@@ -490,14 +509,14 @@ async fn process_observation_known_device_same_ip() {
 #[tokio::test]
 async fn process_observation_known_device_different_ip() {
     let h = build_harness();
-    let obs1 = sample_observation("AA:BB:CC:DD:EE:01", "192.168.1.10");
+    let obs1 = sample_observation("aa:bb:cc:dd:ee:01", "192.168.1.10");
     h.svc.process_observation(&obs1).await.unwrap();
 
     // Clear events.
     h.events.events.lock().unwrap().clear();
 
     // Second observation with same MAC but different IP.
-    let obs2 = sample_observation("AA:BB:CC:DD:EE:01", "192.168.1.20");
+    let obs2 = sample_observation("aa:bb:cc:dd:ee:01", "192.168.1.20");
     let result = h.svc.process_observation(&obs2).await.unwrap();
     assert!(
         matches!(
@@ -526,7 +545,7 @@ async fn process_observation_known_device_different_ip() {
 #[tokio::test]
 async fn process_observation_gone_device_returns() {
     let h = build_harness();
-    let obs = sample_observation("AA:BB:CC:DD:EE:01", "192.168.1.10");
+    let obs = sample_observation("aa:bb:cc:dd:ee:01", "192.168.1.10");
 
     // Register device.
     h.svc.process_observation(&obs).await.unwrap();
@@ -556,7 +575,7 @@ async fn process_observation_gone_device_returns() {
 #[tokio::test]
 async fn flush_last_seen_updates_batch() {
     let h = build_harness();
-    let obs = sample_observation("AA:BB:CC:DD:EE:01", "192.168.1.10");
+    let obs = sample_observation("aa:bb:cc:dd:ee:01", "192.168.1.10");
     h.svc.process_observation(&obs).await.unwrap();
 
     let count = h.svc.flush_last_seen().await.unwrap();
@@ -569,7 +588,7 @@ async fn flush_last_seen_updates_batch() {
 #[tokio::test]
 async fn scan_departures_emits_device_gone() {
     let h = build_harness();
-    let obs = sample_observation("AA:BB:CC:DD:EE:01", "192.168.1.10");
+    let obs = sample_observation("aa:bb:cc:dd:ee:01", "192.168.1.10");
     h.svc.process_observation(&obs).await.unwrap();
 
     // Clear events from registration.
@@ -587,14 +606,14 @@ async fn scan_departures_emits_device_gone() {
         &events[0],
         WardnetEvent::DeviceGone {
             mac, last_ip, ..
-        } if mac == "AA:BB:CC:DD:EE:01" && last_ip == "192.168.1.10"
+        } if mac == "aa:bb:cc:dd:ee:01" && last_ip == "192.168.1.10"
     ));
 }
 
 #[tokio::test]
 async fn scan_departures_ignores_recent() {
     let h = build_harness();
-    let obs = sample_observation("AA:BB:CC:DD:EE:01", "192.168.1.10");
+    let obs = sample_observation("aa:bb:cc:dd:ee:01", "192.168.1.10");
     h.svc.process_observation(&obs).await.unwrap();
 
     // Clear events.
@@ -613,7 +632,7 @@ async fn scan_departures_ignores_recent() {
 async fn get_all_devices_as_admin() {
     let device = sample_device(
         "00000000-0000-0000-0000-000000000001",
-        "AA:BB:CC:DD:EE:01",
+        "aa:bb:cc:dd:ee:01",
         "192.168.1.10",
     );
     let h = build_harness_with_devices(vec![device]);
@@ -622,29 +641,29 @@ async fn get_all_devices_as_admin() {
         .await
         .unwrap();
     assert_eq!(devices.len(), 1);
-    assert_eq!(devices[0].mac, "AA:BB:CC:DD:EE:01");
+    assert_eq!(devices[0].mac, "aa:bb:cc:dd:ee:01");
 }
 
 #[tokio::test]
 async fn get_all_devices_as_device_returns_own_only() {
     let dev_a = sample_device(
         "00000000-0000-0000-0000-000000000001",
-        "AA:BB:CC:DD:EE:01",
+        "aa:bb:cc:dd:ee:01",
         "192.168.1.10",
     );
     let dev_b = sample_device(
         "00000000-0000-0000-0000-000000000002",
-        "AA:BB:CC:DD:EE:02",
+        "aa:bb:cc:dd:ee:02",
         "192.168.1.11",
     );
     let h = build_harness_with_devices(vec![dev_a, dev_b]);
 
     let found =
-        auth_context::with_context(device_ctx("AA:BB:CC:DD:EE:01"), h.svc.get_all_devices())
+        auth_context::with_context(device_ctx("aa:bb:cc:dd:ee:01"), h.svc.get_all_devices())
             .await
             .unwrap();
     assert_eq!(found.len(), 1);
-    assert_eq!(found[0].mac, "AA:BB:CC:DD:EE:01");
+    assert_eq!(found[0].mac, "aa:bb:cc:dd:ee:01");
 }
 
 #[tokio::test]
@@ -678,31 +697,31 @@ async fn get_device_by_id_anonymous_forbidden() {
 async fn get_device_by_id_device_can_view_own() {
     let device = sample_device(
         "00000000-0000-0000-0000-000000000001",
-        "AA:BB:CC:DD:EE:01",
+        "aa:bb:cc:dd:ee:01",
         "192.168.1.10",
     );
     let id = device.id;
     let h = build_harness_with_devices(vec![device]);
 
     let result =
-        auth_context::with_context(device_ctx("AA:BB:CC:DD:EE:01"), h.svc.get_device_by_id(id))
+        auth_context::with_context(device_ctx("aa:bb:cc:dd:ee:01"), h.svc.get_device_by_id(id))
             .await;
     assert!(result.is_ok());
-    assert_eq!(result.unwrap().mac, "AA:BB:CC:DD:EE:01");
+    assert_eq!(result.unwrap().mac, "aa:bb:cc:dd:ee:01");
 }
 
 #[tokio::test]
 async fn get_device_by_id_device_cannot_view_other() {
     let device = sample_device(
         "00000000-0000-0000-0000-000000000001",
-        "AA:BB:CC:DD:EE:01",
+        "aa:bb:cc:dd:ee:01",
         "192.168.1.10",
     );
     let id = device.id;
     let h = build_harness_with_devices(vec![device]);
 
     let result =
-        auth_context::with_context(device_ctx("AA:BB:CC:DD:EE:99"), h.svc.get_device_by_id(id))
+        auth_context::with_context(device_ctx("aa:bb:cc:dd:ee:99"), h.svc.get_device_by_id(id))
             .await;
     assert!(matches!(result, Err(AppError::Forbidden(_))));
 }
@@ -711,7 +730,7 @@ async fn get_device_by_id_device_cannot_view_other() {
 async fn update_device_sets_name_and_type_as_admin() {
     let device = sample_device(
         "00000000-0000-0000-0000-000000000001",
-        "AA:BB:CC:DD:EE:01",
+        "aa:bb:cc:dd:ee:01",
         "192.168.1.10",
     );
     let id = device.id;
@@ -738,7 +757,7 @@ async fn update_device_sets_name_and_type_as_admin() {
 async fn update_device_anonymous_forbidden() {
     let device = sample_device(
         "00000000-0000-0000-0000-000000000001",
-        "AA:BB:CC:DD:EE:01",
+        "aa:bb:cc:dd:ee:01",
         "192.168.1.10",
     );
     let id = device.id;
@@ -756,14 +775,14 @@ async fn update_device_anonymous_forbidden() {
 async fn update_device_as_device_own_allowed() {
     let device = sample_device(
         "00000000-0000-0000-0000-000000000001",
-        "AA:BB:CC:DD:EE:01",
+        "aa:bb:cc:dd:ee:01",
         "192.168.1.10",
     );
     let id = device.id;
     let h = build_harness_with_devices(vec![device]);
 
     let result = auth_context::with_context(
-        device_ctx("AA:BB:CC:DD:EE:01"),
+        device_ctx("aa:bb:cc:dd:ee:01"),
         h.svc.update_device(id, Some("My Phone"), None),
     )
     .await;
@@ -775,14 +794,14 @@ async fn update_device_as_device_own_allowed() {
 async fn update_device_as_device_other_forbidden() {
     let device = sample_device(
         "00000000-0000-0000-0000-000000000001",
-        "AA:BB:CC:DD:EE:01",
+        "aa:bb:cc:dd:ee:01",
         "192.168.1.10",
     );
     let id = device.id;
     let h = build_harness_with_devices(vec![device]);
 
     let result = auth_context::with_context(
-        device_ctx("AA:BB:CC:DD:EE:99"),
+        device_ctx("aa:bb:cc:dd:ee:99"),
         h.svc.update_device(id, Some("name"), None),
     )
     .await;
@@ -793,7 +812,7 @@ async fn update_device_as_device_other_forbidden() {
 async fn update_device_as_device_admin_locked_forbidden() {
     let mut device = sample_device(
         "00000000-0000-0000-0000-000000000001",
-        "AA:BB:CC:DD:EE:01",
+        "aa:bb:cc:dd:ee:01",
         "192.168.1.10",
     );
     device.admin_locked = true;
@@ -801,7 +820,7 @@ async fn update_device_as_device_admin_locked_forbidden() {
     let h = build_harness_with_devices(vec![device]);
 
     let result = auth_context::with_context(
-        device_ctx("AA:BB:CC:DD:EE:01"),
+        device_ctx("aa:bb:cc:dd:ee:01"),
         h.svc.update_device(id, Some("name"), None),
     )
     .await;
@@ -812,7 +831,7 @@ async fn update_device_as_device_admin_locked_forbidden() {
 async fn resolve_hostname_falls_back_to_reverse_dns() {
     let device = sample_device(
         "00000000-0000-0000-0000-000000000001",
-        "AA:BB:CC:DD:EE:01",
+        "aa:bb:cc:dd:ee:01",
         "192.168.1.10",
     );
     let id = device.id;
@@ -821,7 +840,7 @@ async fn resolve_hostname_falls_back_to_reverse_dns() {
     let h = build_harness_with_resolver(vec![device], mappings);
 
     h.svc
-        .resolve_hostname("AA:BB:CC:DD:EE:01", "192.168.1.10")
+        .resolve_hostname("aa:bb:cc:dd:ee:01", "192.168.1.10")
         .await
         .unwrap();
 
@@ -835,14 +854,14 @@ async fn resolve_hostname_falls_back_to_reverse_dns() {
 async fn resolve_hostname_no_result_does_not_update_db() {
     let device = sample_device(
         "00000000-0000-0000-0000-000000000001",
-        "AA:BB:CC:DD:EE:01",
+        "aa:bb:cc:dd:ee:01",
         "192.168.1.10",
     );
     // Empty resolver and no DHCP lease: nothing to write.
     let h = build_harness_with_resolver(vec![device], HashMap::new());
 
     h.svc
-        .resolve_hostname("AA:BB:CC:DD:EE:01", "192.168.1.10")
+        .resolve_hostname("aa:bb:cc:dd:ee:01", "192.168.1.10")
         .await
         .unwrap();
 
@@ -857,7 +876,7 @@ async fn resolve_hostname_no_result_does_not_update_db() {
 async fn resolve_hostname_prefers_dhcp_over_reverse_dns() {
     let device = sample_device(
         "00000000-0000-0000-0000-000000000001",
-        "AA:BB:CC:DD:EE:01",
+        "aa:bb:cc:dd:ee:01",
         "192.168.1.10",
     );
     let id = device.id;
@@ -875,7 +894,7 @@ async fn resolve_hostname_prefers_dhcp_over_reverse_dns() {
     let h = build_harness_with_resolver_and_dhcp(vec![device], mappings, dhcp);
 
     h.svc
-        .resolve_hostname("AA:BB:CC:DD:EE:01", "192.168.1.10")
+        .resolve_hostname("aa:bb:cc:dd:ee:01", "192.168.1.10")
         .await
         .unwrap();
 
@@ -889,7 +908,7 @@ async fn resolve_hostname_prefers_dhcp_over_reverse_dns() {
 async fn resolve_hostname_falls_back_when_dhcp_value_empty() {
     let device = sample_device(
         "00000000-0000-0000-0000-000000000001",
-        "AA:BB:CC:DD:EE:01",
+        "aa:bb:cc:dd:ee:01",
         "192.168.1.10",
     );
 
@@ -900,7 +919,7 @@ async fn resolve_hostname_falls_back_when_dhcp_value_empty() {
     let h = build_harness_with_resolver_and_dhcp(vec![device], mappings, dhcp);
 
     h.svc
-        .resolve_hostname("AA:BB:CC:DD:EE:01", "192.168.1.10")
+        .resolve_hostname("aa:bb:cc:dd:ee:01", "192.168.1.10")
         .await
         .unwrap();
 
@@ -913,7 +932,7 @@ async fn resolve_hostname_falls_back_when_dhcp_value_empty() {
 async fn resolve_hostname_falls_back_when_no_active_lease() {
     let device = sample_device(
         "00000000-0000-0000-0000-000000000001",
-        "AA:BB:CC:DD:EE:01",
+        "aa:bb:cc:dd:ee:01",
         "192.168.1.10",
     );
 
@@ -924,7 +943,7 @@ async fn resolve_hostname_falls_back_when_no_active_lease() {
         build_harness_with_resolver_and_dhcp(vec![device], mappings, MockDhcpRepository::empty());
 
     h.svc
-        .resolve_hostname("AA:BB:CC:DD:EE:01", "192.168.1.10")
+        .resolve_hostname("aa:bb:cc:dd:ee:01", "192.168.1.10")
         .await
         .unwrap();
 
@@ -941,7 +960,7 @@ async fn resolve_hostname_no_op_when_device_not_registered() {
     let h = build_harness_with_resolver_and_dhcp(vec![], HashMap::new(), dhcp);
 
     h.svc
-        .resolve_hostname("AA:BB:CC:DD:EE:99", "192.168.1.99")
+        .resolve_hostname("aa:bb:cc:dd:ee:99", "192.168.1.99")
         .await
         .unwrap();
 
@@ -950,15 +969,16 @@ async fn resolve_hostname_no_op_when_device_not_registered() {
 }
 
 #[tokio::test]
-async fn resolve_hostname_normalises_mac_case_across_sources() {
-    // Reproduces the production split: packet capture stores devices with
-    // uppercase MACs, DHCP service stores leases with lowercase. The
-    // lease-event listener calls resolve_hostname with the lowercase form.
-    // Both lookups must succeed regardless. Tracked for canonicalisation
-    // in wardnet/wardnet#312.
+async fn resolve_hostname_tolerates_mixed_case_caller() {
+    // Even though MAC is canonicalised to lowercase across the data
+    // layer post-#312, callers (and historical event payloads) may
+    // arrive with mixed case. The repository layer normalises at the
+    // boundary, so a single uppercase MAC fed to `resolve_hostname`
+    // must still match the lowercase rows in both the device registry
+    // and the DHCP repository.
     let device = sample_device(
         "00000000-0000-0000-0000-000000000001",
-        "AA:BB:CC:DD:EE:01",
+        "aa:bb:cc:dd:ee:01",
         "192.168.1.10",
     );
     let id = device.id;
@@ -969,9 +989,9 @@ async fn resolve_hostname_normalises_mac_case_across_sources() {
     )]);
     let h = build_harness_with_resolver_and_dhcp(vec![device], HashMap::new(), dhcp);
 
-    // Listener-driven call: lowercase MAC (matches the event payload).
+    // Caller uses uppercase; both lookups must still hit.
     h.svc
-        .resolve_hostname("aa:bb:cc:dd:ee:01", "192.168.1.10")
+        .resolve_hostname("AA:BB:CC:DD:EE:01", "192.168.1.10")
         .await
         .unwrap();
 
@@ -985,7 +1005,7 @@ async fn resolve_hostname_normalises_mac_case_across_sources() {
 async fn restore_devices_populates_in_memory_state() {
     let device = sample_device(
         "00000000-0000-0000-0000-000000000001",
-        "AA:BB:CC:DD:EE:01",
+        "aa:bb:cc:dd:ee:01",
         "192.168.1.10",
     );
     let h = build_harness_with_devices(vec![device]);
@@ -994,7 +1014,7 @@ async fn restore_devices_populates_in_memory_state() {
 
     // After restore, processing the same MAC should not create a new device
     // because restore marks devices as gone; re-observing should reappear them.
-    let obs = sample_observation("AA:BB:CC:DD:EE:01", "192.168.1.10");
+    let obs = sample_observation("aa:bb:cc:dd:ee:01", "192.168.1.10");
     let result = h.svc.process_observation(&obs).await.unwrap();
     assert!(
         matches!(result, ObservationResult::Reappeared(_)),
@@ -1018,7 +1038,7 @@ async fn restore_devices_empty_repo() {
 async fn update_device_without_device_type_preserves_existing() {
     let device = sample_device(
         "00000000-0000-0000-0000-000000000001",
-        "AA:BB:CC:DD:EE:01",
+        "aa:bb:cc:dd:ee:01",
         "192.168.1.10",
     );
     let id = device.id;
@@ -1053,7 +1073,7 @@ async fn update_device_not_found() {
 async fn get_device_by_id_success() {
     let device = sample_device(
         "00000000-0000-0000-0000-000000000001",
-        "AA:BB:CC:DD:EE:01",
+        "aa:bb:cc:dd:ee:01",
         "192.168.1.10",
     );
     let id = device.id;
@@ -1063,13 +1083,13 @@ async fn get_device_by_id_success() {
         .await
         .unwrap();
     assert_eq!(result.id, id);
-    assert_eq!(result.mac, "AA:BB:CC:DD:EE:01");
+    assert_eq!(result.mac, "aa:bb:cc:dd:ee:01");
 }
 
 #[tokio::test]
 async fn flush_last_seen_with_gone_devices_skips_them() {
     let h = build_harness();
-    let obs = sample_observation("AA:BB:CC:DD:EE:01", "192.168.1.10");
+    let obs = sample_observation("aa:bb:cc:dd:ee:01", "192.168.1.10");
     h.svc.process_observation(&obs).await.unwrap();
 
     // Mark device as departed.
@@ -1086,14 +1106,14 @@ async fn process_observation_reappear_from_db_not_memory() {
     // Device exists in DB (from a previous daemon run) but not in memory.
     let device = sample_device(
         "00000000-0000-0000-0000-000000000001",
-        "AA:BB:CC:DD:EE:01",
+        "aa:bb:cc:dd:ee:01",
         "192.168.1.10",
     );
     let h = build_harness_with_devices(vec![device]);
 
     // Do NOT call restore_devices, so the in-memory map is empty.
     // Observing should find the device in the DB and reappear it.
-    let obs = sample_observation("AA:BB:CC:DD:EE:01", "192.168.1.20");
+    let obs = sample_observation("aa:bb:cc:dd:ee:01", "192.168.1.20");
     let result = h.svc.process_observation(&obs).await.unwrap();
     assert!(
         matches!(result, ObservationResult::Reappeared(_)),

--- a/source/daemon/crates/wardnetd-services/src/dhcp/service.rs
+++ b/source/daemon/crates/wardnetd-services/src/dhcp/service.rs
@@ -326,6 +326,7 @@ impl DhcpServiceImpl {
         self.dhcp
             .insert_lease_log(&DhcpLeaseLogRow {
                 lease_id: existing.id.to_string(),
+                mac_address: existing.mac_address.clone(),
                 event_type: "expired".to_owned(),
                 details: Some(detail),
             })
@@ -471,6 +472,7 @@ impl DhcpService for DhcpServiceImpl {
         self.dhcp
             .insert_lease_log(&DhcpLeaseLogRow {
                 lease_id: id.to_string(),
+                mac_address: lease.mac_address.clone(),
                 event_type: "released".to_owned(),
                 details: Some("admin revoked".to_owned()),
             })
@@ -498,8 +500,9 @@ impl DhcpService for DhcpServiceImpl {
     ) -> Result<CreateDhcpReservationResponse, AppError> {
         auth_context::require_admin()?;
 
-        // Normalize MAC to lowercase for consistent lookups.
-        let mac = req.mac_address.to_lowercase();
+        // Casing is canonicalised at the repository boundary (issue #312);
+        // use the request value as-is.
+        let mac = req.mac_address.as_str();
 
         // Validate IP.
         let _: Ipv4Addr = req
@@ -510,7 +513,7 @@ impl DhcpService for DhcpServiceImpl {
         // Check for duplicate MAC.
         if self
             .dhcp
-            .find_reservation_by_mac(&mac)
+            .find_reservation_by_mac(mac)
             .await
             .map_err(AppError::Internal)?
             .is_some()
@@ -537,7 +540,7 @@ impl DhcpService for DhcpServiceImpl {
         let id = Uuid::new_v4();
         let row = DhcpReservationRow {
             id: id.to_string(),
-            mac_address: mac.clone(),
+            mac_address: mac.to_owned(),
             ip_address: req.ip_address.clone(),
             hostname: req.hostname.clone(),
             description: req.description.clone(),
@@ -550,7 +553,7 @@ impl DhcpService for DhcpServiceImpl {
 
         let reservation = self
             .dhcp
-            .find_reservation_by_mac(&mac)
+            .find_reservation_by_mac(mac)
             .await
             .map_err(AppError::Internal)?
             .ok_or_else(|| {
@@ -625,8 +628,8 @@ impl DhcpService for DhcpServiceImpl {
 
     async fn assign_lease(&self, mac: &str, hostname: Option<&str>) -> Result<DhcpLease, AppError> {
         auth_context::require_admin()?;
-        let mac = mac.to_lowercase();
-        let mac = mac.as_str();
+        // Casing is canonicalised at the repository boundary (issue #312);
+        // pass the runtime-supplied MAC through verbatim.
         let hostname = Self::normalised_hostname(hostname);
 
         let config = self.load_config().await?;
@@ -655,6 +658,7 @@ impl DhcpService for DhcpServiceImpl {
                 self.dhcp
                     .insert_lease_log(&DhcpLeaseLogRow {
                         lease_id: existing.id.to_string(),
+                        mac_address: mac.to_owned(),
                         event_type: "assigned".to_owned(),
                         details: Some(format!(
                             "hostname updated: {} -> {new_h}",
@@ -727,6 +731,7 @@ impl DhcpService for DhcpServiceImpl {
         self.dhcp
             .insert_lease_log(&DhcpLeaseLogRow {
                 lease_id: id.to_string(),
+                mac_address: mac.to_owned(),
                 event_type: "assigned".to_owned(),
                 details: hostname.map(|h| format!("hostname: {h}")),
             })
@@ -753,8 +758,7 @@ impl DhcpService for DhcpServiceImpl {
 
     async fn renew_lease(&self, mac: &str, hostname: Option<&str>) -> Result<DhcpLease, AppError> {
         auth_context::require_admin()?;
-        let mac = mac.to_lowercase();
-        let mac = mac.as_str();
+        // Casing is canonicalised at the repository boundary (issue #312).
         let hostname = Self::normalised_hostname(hostname);
 
         let config = self.load_config().await?;
@@ -809,6 +813,7 @@ impl DhcpService for DhcpServiceImpl {
             self.dhcp
                 .insert_lease_log(&DhcpLeaseLogRow {
                     lease_id: existing.id.to_string(),
+                    mac_address: mac.to_owned(),
                     event_type: "renewed".to_owned(),
                     details: renewal_details,
                 })
@@ -842,8 +847,7 @@ impl DhcpService for DhcpServiceImpl {
 
     async fn release_lease(&self, mac: &str) -> Result<(), AppError> {
         auth_context::require_admin()?;
-        let mac = mac.to_lowercase();
-        let mac = mac.as_str();
+        // Casing is canonicalised at the repository boundary (issue #312).
 
         let lease = self
             .dhcp
@@ -860,6 +864,7 @@ impl DhcpService for DhcpServiceImpl {
             self.dhcp
                 .insert_lease_log(&DhcpLeaseLogRow {
                     lease_id: lease.id.to_string(),
+                    mac_address: lease.mac_address.clone(),
                     event_type: "released".to_owned(),
                     details: Some("client DHCPRELEASE".to_owned()),
                 })

--- a/source/daemon/crates/wardnetd-services/src/dhcp/tests/dhcp.rs
+++ b/source/daemon/crates/wardnetd-services/src/dhcp/tests/dhcp.rs
@@ -44,7 +44,10 @@ impl MockDhcpRepository {
 #[async_trait]
 impl DhcpRepository for MockDhcpRepository {
     async fn insert_lease(&self, row: &DhcpLeaseRow) -> anyhow::Result<()> {
-        self.leases.lock().unwrap().push(row.clone());
+        // Mirror the SQLite repo: MAC stored canonical lowercase (#312).
+        let mut row = row.clone();
+        row.mac_address = row.mac_address.to_lowercase();
+        self.leases.lock().unwrap().push(row);
         Ok(())
     }
 
@@ -55,6 +58,7 @@ impl DhcpRepository for MockDhcpRepository {
     }
 
     async fn find_active_lease_by_mac(&self, mac: &str) -> anyhow::Result<Option<DhcpLease>> {
+        let mac = mac.to_lowercase();
         let rows = self.leases.lock().unwrap();
         let row = rows
             .iter()
@@ -119,7 +123,10 @@ impl DhcpRepository for MockDhcpRepository {
     }
 
     async fn insert_reservation(&self, row: &DhcpReservationRow) -> anyhow::Result<()> {
-        self.reservations.lock().unwrap().push(row.clone());
+        // Mirror the SQLite repo: MAC stored canonical lowercase (#312).
+        let mut row = row.clone();
+        row.mac_address = row.mac_address.to_lowercase();
+        self.reservations.lock().unwrap().push(row);
         Ok(())
     }
 
@@ -134,6 +141,7 @@ impl DhcpRepository for MockDhcpRepository {
     }
 
     async fn find_reservation_by_mac(&self, mac: &str) -> anyhow::Result<Option<DhcpReservation>> {
+        let mac = mac.to_lowercase();
         let rows = self.reservations.lock().unwrap();
         let row = rows.iter().find(|r| r.mac_address == mac);
         Ok(row.map(row_to_reservation).transpose()?)
@@ -146,7 +154,10 @@ impl DhcpRepository for MockDhcpRepository {
     }
 
     async fn insert_lease_log(&self, row: &DhcpLeaseLogRow) -> anyhow::Result<()> {
-        self.logs.lock().unwrap().push(row.clone());
+        // Mirror the SQLite repo: MAC stored canonical lowercase (#312).
+        let mut row = row.clone();
+        row.mac_address = row.mac_address.to_lowercase();
+        self.logs.lock().unwrap().push(row);
         Ok(())
     }
 
@@ -155,20 +166,35 @@ impl DhcpRepository for MockDhcpRepository {
         Ok(rows
             .iter()
             .filter(|r| r.lease_id == lease_id)
-            .map(|r| DhcpLeaseLog {
-                id: 0,
-                lease_id: r.lease_id.parse().unwrap(),
-                event_type: match r.event_type.as_str() {
-                    "assigned" => wardnet_common::dhcp::DhcpLeaseEventType::Assigned,
-                    "renewed" => wardnet_common::dhcp::DhcpLeaseEventType::Renewed,
-                    "released" => wardnet_common::dhcp::DhcpLeaseEventType::Released,
-                    "expired" => wardnet_common::dhcp::DhcpLeaseEventType::Expired,
-                    _ => wardnet_common::dhcp::DhcpLeaseEventType::Conflict,
-                },
-                details: r.details.clone(),
-                created_at: Utc::now(),
-            })
+            .map(row_to_log)
             .collect())
+    }
+
+    async fn find_lease_logs_by_mac(&self, mac: &str) -> anyhow::Result<Vec<DhcpLeaseLog>> {
+        let mac = mac.to_lowercase();
+        let rows = self.logs.lock().unwrap();
+        Ok(rows
+            .iter()
+            .filter(|r| r.mac_address == mac)
+            .map(row_to_log)
+            .collect())
+    }
+}
+
+fn row_to_log(r: &DhcpLeaseLogRow) -> DhcpLeaseLog {
+    DhcpLeaseLog {
+        id: 0,
+        lease_id: r.lease_id.parse().unwrap(),
+        mac_address: r.mac_address.clone(),
+        event_type: match r.event_type.as_str() {
+            "assigned" => wardnet_common::dhcp::DhcpLeaseEventType::Assigned,
+            "renewed" => wardnet_common::dhcp::DhcpLeaseEventType::Renewed,
+            "released" => wardnet_common::dhcp::DhcpLeaseEventType::Released,
+            "expired" => wardnet_common::dhcp::DhcpLeaseEventType::Expired,
+            _ => wardnet_common::dhcp::DhcpLeaseEventType::Conflict,
+        },
+        details: r.details.clone(),
+        created_at: Utc::now(),
     }
 }
 

--- a/source/daemon/crates/wardnetd-services/src/system/service.rs
+++ b/source/daemon/crates/wardnetd-services/src/system/service.rs
@@ -14,8 +14,9 @@ use crate::error::AppError;
 use crate::system::{NetworkInspector, NetworkProbe, SystemPowerOps};
 use wardnetd_data::repository::{SystemConfigRepository, TunnelRepository};
 
-/// Loose colon-separated 6-octet MAC validator (e.g. `AA:BB:CC:DD:EE:FF`).
-/// Accepts upper or lower case; canonicalises to upper for storage.
+/// Loose colon-separated 6-octet MAC validator (e.g. `aa:bb:cc:dd:ee:ff`).
+/// Accepts upper or lower case; canonicalises to lowercase for storage
+/// per the project-wide MAC convention (issue #312).
 fn normalise_mac(input: &str) -> Option<String> {
     let trimmed = input.trim();
     let bytes: Vec<&str> = trimmed.split(':').collect();
@@ -30,7 +31,7 @@ fn normalise_mac(input: &str) -> Option<String> {
         if i > 0 {
             out.push(':');
         }
-        out.push_str(&byte.to_uppercase());
+        out.push_str(&byte.to_lowercase());
     }
     Some(out)
 }

--- a/source/daemon/crates/wardnetd-services/src/system/tests/system.rs
+++ b/source/daemon/crates/wardnetd-services/src/system/tests/system.rs
@@ -247,7 +247,7 @@ struct StaticNetworkProbe {
 impl Default for StaticNetworkProbe {
     fn default() -> Self {
         Self {
-            response: Some("AA:BB:CC:DD:EE:FF".to_owned()),
+            response: Some("aa:bb:cc:dd:ee:ff".to_owned()),
             targets: Mutex::new(Vec::new()),
             dhcp_responders: Vec::new(),
         }
@@ -580,15 +580,15 @@ async fn discover_gateway_mac_manual_path_persists_normalised_mac() {
     )
     .await
     .unwrap();
-    // Normalised to upper-case for storage.
-    assert_eq!(resp.mac, "AA:BB:CC:DD:EE:FF");
+    // Normalised to lowercase for storage (issue #312).
+    assert_eq!(resp.mac, "aa:bb:cc:dd:ee:ff");
     assert_eq!(resp.source, wardnet_common::api::RouterMacSource::Manual);
     // No ARP probe should have been issued on the manual path.
     assert!(fx.probe.arp_targets.lock().unwrap().is_empty());
     // Persisted under `router_mac`.
     assert_eq!(
         fx.system_config.get("router_mac").await.unwrap().as_deref(),
-        Some("AA:BB:CC:DD:EE:FF")
+        Some("aa:bb:cc:dd:ee:ff")
     );
 }
 

--- a/source/daemon/crates/wardnetd/src/packet_capture_pnet.rs
+++ b/source/daemon/crates/wardnetd/src/packet_capture_pnet.rs
@@ -129,10 +129,16 @@ pub async fn wait_for_interface_ipv4(
     }
 }
 
-/// Format a `pnet` `MacAddr` as uppercase colon-separated "AA:BB:CC:DD:EE:FF".
+/// Format a `pnet` `MacAddr` as lowercase colon-separated "aa:bb:cc:dd:ee:ff".
+///
+/// Lowercase is the project-wide canonical form (issue #312). Every
+/// MAC string downstream — device registry, lease events, GARP-learned
+/// router MAC — flows from this function, so emitting lowercase here
+/// keeps cross-source lookups (devices ↔ DHCP) string-equal without
+/// per-call normalisation.
 pub(crate) fn format_mac(mac: MacAddr) -> String {
     format!(
-        "{:02X}:{:02X}:{:02X}:{:02X}:{:02X}:{:02X}",
+        "{:02x}:{:02x}:{:02x}:{:02x}:{:02x}:{:02x}",
         mac.0, mac.1, mac.2, mac.3, mac.4, mac.5
     )
 }

--- a/source/daemon/crates/wardnetd/src/tests/packet_capture.rs
+++ b/source/daemon/crates/wardnetd/src/tests/packet_capture.rs
@@ -26,21 +26,20 @@ fn format_mac_all_zeros() {
 fn format_mac_all_ff() {
     assert_eq!(
         format_mac(MacAddr::new(0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF)),
-        "FF:FF:FF:FF:FF:FF"
+        "ff:ff:ff:ff:ff:ff"
     );
 }
 
 #[test]
 fn format_mac_typical() {
     let mac = MacAddr::new(0xAA, 0xBB, 0xCC, 0x01, 0x02, 0x03);
-    assert_eq!(format_mac(mac), "AA:BB:CC:01:02:03");
+    assert_eq!(format_mac(mac), "aa:bb:cc:01:02:03");
 }
 
 #[test]
-fn format_mac_lowercase_hex_digits_uppercased() {
-    // Ensure digits a-f come out uppercase.
+fn format_mac_emits_lowercase_hex_digits() {
     let mac = MacAddr::new(0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f);
-    assert_eq!(format_mac(mac), "0A:0B:0C:0D:0E:0F");
+    assert_eq!(format_mac(mac), "0a:0b:0c:0d:0e:0f");
 }
 
 // ---------------------------------------------------------------------------
@@ -227,7 +226,7 @@ fn parse_frame_arp_valid() {
     let frame = make_arp_frame(sender_mac, sender_ip);
     let obs = parse_frame(&frame, own_mac).expect("should parse ARP frame");
 
-    assert_eq!(obs.mac, "AA:BB:CC:11:22:33");
+    assert_eq!(obs.mac, "aa:bb:cc:11:22:33");
     assert_eq!(obs.ip, "192.168.1.50");
     assert_eq!(obs.source, PacketSource::Arp);
 }
@@ -268,7 +267,7 @@ fn parse_frame_ipv4_valid() {
     let frame = make_ipv4_frame(src_mac, src_ip);
     let obs = parse_frame(&frame, own_mac).expect("should parse IPv4 frame");
 
-    assert_eq!(obs.mac, "00:1A:2B:3C:4D:5E");
+    assert_eq!(obs.mac, "00:1a:2b:3c:4d:5e");
     assert_eq!(obs.ip, "10.0.0.42");
     assert_eq!(obs.source, PacketSource::Ip);
 }

--- a/source/end2end-tests/daemon/tests/arp-failover.spec.ts
+++ b/source/end2end-tests/daemon/tests/arp-failover.spec.ts
@@ -23,6 +23,7 @@
 import { describe, it, expect, beforeAll } from "vitest";
 import {
   DhcpService,
+  NetworkService,
   SystemService,
   WardnetClient,
 } from "@wardnet/js";
@@ -147,18 +148,26 @@ async function configureRouterIp(authed: AuthedClient): Promise<void> {
   });
 }
 
-/** Pulls the daemon's wardnet_lan MAC out of `ip link show eth0`. */
-async function getDaemonLanMac(): Promise<string> {
-  const res = await fetch(`${DAEMON_AGENT}/link/eth0`);
+/** Resolves the daemon's wardnet_lan MAC.
+ *
+ * Asks the daemon which interface holds the LAN IP (Docker doesn't
+ * guarantee a stable eth0/eth1/eth2 mapping when the container
+ * attaches to multiple networks — the compose entrypoint already
+ * pins the daemon's `lan_interface` to whichever NIC carries
+ * 10.91.0.1; this lookup mirrors that), then pulls the MAC for
+ * that interface from the daemon's test-agent. */
+async function getDaemonLanMac(authed: AuthedClient): Promise<string> {
+  const status = await new NetworkService(authed).getStatus();
+  const res = await fetch(`${DAEMON_AGENT}/link/${status.interface}`);
   if (!res.ok) {
     throw new Error(
-      `failed to fetch daemon link state: ${res.status} ${await res.text()}`,
+      `failed to fetch daemon link state for ${status.interface}: ${res.status} ${await res.text()}`,
     );
   }
   const link = (await res.json()) as LinkShowResponse;
   if (!link.mac) {
     throw new Error(
-      `daemon eth0 has no MAC in /link/eth0 response: ${JSON.stringify(link)}`,
+      `daemon ${status.interface} has no MAC in /link response: ${JSON.stringify(link)}`,
     );
   }
   return link.mac.toLowerCase();
@@ -173,7 +182,7 @@ describe("GARP failover (issue #213)", () => {
     await waitForReady(client);
     admin = await ensureAdminAndLogin(client);
     await configureRouterIp(admin);
-    daemonMac = await getDaemonLanMac();
+    daemonMac = await getDaemonLanMac(admin);
   }, 120_000);
 
   it("broadcasts the claim GARP on startup with the daemon's LAN MAC", async () => {

--- a/source/end2end-tests/daemon/tests/arp-failover.spec.ts
+++ b/source/end2end-tests/daemon/tests/arp-failover.spec.ts
@@ -11,7 +11,7 @@
  *    gratuitous-reply frames sent from the daemon's LAN-iface MAC,
  *    with the configured `sender_ip` and broadcast destination.
  * 3. **Drive passive learning**: `POST /arp/send` from `test_debian`
- *    with `sender_mac = AA:BB:CC:DD:EE:01, sender_ip = 10.91.0.5` so
+ *    with `sender_mac = aa:bb:cc:dd:ee:01, sender_ip = 10.91.0.5` so
  *    the daemon's discovery loop populates `garp_router_mac`.
  * 4. **Farewell phase**: capture ARP traffic and trigger another
  *    restart. Assert ≥2 gratuitous-reply frames whose sender MAC

--- a/source/web-ui/src/components/compound/DhcpLeaseTable.tsx
+++ b/source/web-ui/src/components/compound/DhcpLeaseTable.tsx
@@ -29,7 +29,7 @@ function createColumns(
       header: "Host",
       cell: ({ row }) => {
         const lease = row.original;
-        const device = deviceIndex.get(lease.mac_address.toLowerCase());
+        const device = deviceIndex.get(lease.mac_address);
         const primary = device?.name ?? lease.hostname ?? device?.hostname ?? lease.mac_address;
         const secondary = primary === lease.mac_address ? null : lease.mac_address;
         // Known devices reuse the device-table icon for visual consistency;

--- a/source/web-ui/src/components/compound/DhcpReservationTable.tsx
+++ b/source/web-ui/src/components/compound/DhcpReservationTable.tsx
@@ -19,7 +19,7 @@ function createColumns(
       header: "Host",
       cell: ({ row }) => {
         const reservation = row.original;
-        const device = deviceIndex.get(reservation.mac_address.toLowerCase());
+        const device = deviceIndex.get(reservation.mac_address);
         // Reservation hostname (admin-set, pushed to the client) is used as
         // the primary identifier when no device record or description is
         // available — better than falling all the way through to MAC.

--- a/source/web-ui/src/components/compound/HostCell.tsx
+++ b/source/web-ui/src/components/compound/HostCell.tsx
@@ -2,12 +2,12 @@ import type { Device } from "@wardnet/js";
 
 /**
  * MAC-keyed lookup map for matching DHCP/lease records to known devices.
- * Lower-cases on insert because MAC casing currently varies across the
- * stack (see wardnet/wardnet#312).
+ * MAC casing is canonical (lowercase) on the server (issue #312), so no
+ * per-key normalisation is needed.
  */
 export function buildDeviceIndex(devices: Device[]): Map<string, Device> {
   const map = new Map<string, Device>();
-  for (const d of devices) map.set(d.mac.toLowerCase(), d);
+  for (const d of devices) map.set(d.mac, d);
   return map;
 }
 

--- a/source/web-ui/src/components/features/DeviceNetworkCard.tsx
+++ b/source/web-ui/src/components/features/DeviceNetworkCard.tsx
@@ -34,8 +34,9 @@ function findReservation(
   reservations: DhcpReservation[] | undefined,
   mac: string,
 ): DhcpReservation | undefined {
-  const target = mac.toLowerCase();
-  return reservations?.find((r) => r.mac_address.toLowerCase() === target);
+  // MAC is canonical lowercase server-side (issue #312); both sides are
+  // already in the same form.
+  return reservations?.find((r) => r.mac_address === mac);
 }
 
 /** Editable network card: current IP, DHCP status, reservation create/update/remove. */


### PR DESCRIPTION
Closes #312.

## Summary

- Pick **lowercase** as the canonical MAC form. `packet_capture_pnet::format_mac` and `system::service::normalise_mac` now emit lowercase; the DHCP server's `format_mac` was already lowercase.
- **SQLite repositories** (`devices`, `dhcp_leases`, `dhcp_reservations`, `dhcp_lease_log`) lowercase MAC defensively on insert and on every `*_by_mac` lookup. The trait contract is "MAC may arrive any case; storage is canonical lowercase."
- **Migration** `20260510000000_canonicalise_mac_lowercase.sql` lowers existing rows across those tables and the `router_mac` / `garp_router_mac` keys in `system_config`.
- **Drop per-call workarounds**: `DeviceDiscoveryService::resolve_hostname` no longer dual-cases for the two repos (the temporary fix from #233 is gone); `DhcpServiceImpl::{create_reservation, assign_lease, renew_lease, release_lease}` and `wardnetd-api::api::devices::{build_dhcp_status_map, enrich_device}` no longer normalise locally. Web-UI client comparisons drop `.toLowerCase()` in `HostCell.buildDeviceIndex`, `DhcpLeaseTable`, `DhcpReservationTable`, and `DeviceNetworkCard.findReservation`.
- **`dhcp_lease_log` is now usable.** Denormalised `mac_address` onto every audit row plus a new `find_lease_logs_by_mac(mac)` query — the table previously had no MAC column and only a `lease_id` lookup that nothing called, making it effectively dead data. Backfill in the same migration draws the MAC from `dhcp_leases`; orphans (lease already deleted) get `''`.

## Acceptance

- ✅ No MAC-related `to_lowercase` / `to_uppercase` left in production logic outside the SQLite layer (and `system::service::normalise_mac`, the documented canonicalisation entry point for router MAC).
- ✅ New tests:
  - `repository::tests::device::insert_uppercase_mac_is_findable_by_lowercase`
  - `repository::tests::dhcp::lease_uppercase_mac_is_findable_by_lowercase`
  - `repository::tests::dhcp::reservation_uppercase_mac_is_findable_by_lowercase`
  - `repository::tests::dhcp::find_lease_logs_by_mac_returns_all_events_for_mac` (covers the new audit-log query, isolation, and case-insensitivity)
  - `device::tests::discovery::resolve_hostname_tolerates_mixed_case_caller` (renamed from the old per-call test, now feeds an uppercase MAC into the service to verify the repo-layer contract)
- ✅ Existing tests still pass.

## Test plan

- [x] `make check` (SDK + web UI + site + daemon: format, lint, typecheck, clippy, tests)
- [x] `make check-openapi` (no schema drift)
- [ ] Smoke: install on a host with pre-existing mixed-case rows → confirm migration lowers everything and existing devices keep matching their leases.