### PR TITLE
fix(deps): bump dhcproto 0.14 → 0.15 to drop vulnerable hickory-proto 0.25.2

### DIFF
--- a/source/daemon/Cargo.lock
+++ b/source/daemon/Cargo.lock
@@ -145,7 +145,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -156,7 +156,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -908,14 +908,14 @@ dependencies = [
 
 [[package]]
 name = "dhcproto"
-version = "0.14.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "425ab19f6a915beac79cac8ec2810c1311b502ae14d7f294682081cf5ae4c5bb"
+checksum = "c278d2f17dbcb7332f3b31788be67f76017096c5eedc293e1259f2d48b0f891f"
 dependencies = [
  "dhcproto-macros",
- "hickory-proto 0.25.2",
+ "hickory-proto",
  "ipnet",
- "rand 0.9.2",
+ "rand 0.10.1",
  "thiserror 2.0.18",
 ]
 
@@ -1014,18 +1014,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "enum-as-inner"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1e6a265c649f3f5979b601d26f1d05ada116434c87741c9493cb56218f76cbc"
-dependencies = [
- "heck",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "equator"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1058,7 +1046,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1523,7 +1511,7 @@ dependencies = [
  "futures-channel",
  "futures-io",
  "futures-util",
- "hickory-proto 0.26.1",
+ "hickory-proto",
  "idna",
  "ipnet",
  "jni 0.22.4",
@@ -1531,28 +1519,6 @@ dependencies = [
  "thiserror 2.0.18",
  "tinyvec",
  "tokio",
- "tracing",
- "url",
-]
-
-[[package]]
-name = "hickory-proto"
-version = "0.25.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8a6fe56c0038198998a6f217ca4e7ef3a5e51f46163bd6dd60b5c71ca6c6502"
-dependencies = [
- "async-trait",
- "cfg-if",
- "data-encoding",
- "enum-as-inner",
- "futures-channel",
- "futures-util",
- "idna",
- "ipnet",
- "once_cell",
- "rand 0.9.2",
- "thiserror 2.0.18",
- "tinyvec",
  "tracing",
  "url",
 ]
@@ -1586,7 +1552,7 @@ dependencies = [
  "cfg-if",
  "futures-util",
  "hickory-net",
- "hickory-proto 0.26.1",
+ "hickory-proto",
  "ipconfig",
  "ipnet",
  "jni 0.22.4",
@@ -2679,7 +2645,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3854,7 +3820,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3912,7 +3878,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4250,7 +4216,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4650,10 +4616,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5388,7 +5354,7 @@ dependencies = [
  "cron",
  "dhcproto",
  "futures",
- "hickory-proto 0.26.1",
+ "hickory-proto",
  "hickory-resolver",
  "ipnetwork",
  "mdns-sd",
@@ -5434,7 +5400,7 @@ dependencies = [
  "axum",
  "axum-extra",
  "chrono",
- "hickory-proto 0.26.1",
+ "hickory-proto",
  "mime_guess",
  "rust-embed",
  "serde",
@@ -5511,7 +5477,7 @@ dependencies = [
  "cron",
  "flate2",
  "hex",
- "hickory-proto 0.26.1",
+ "hickory-proto",
  "ipnetwork",
  "minisign",
  "minisign-verify",
@@ -5750,7 +5716,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/source/daemon/Cargo.toml
+++ b/source/daemon/Cargo.toml
@@ -115,7 +115,7 @@ pnet = "0.35"
 # https://crates.io/crates/sysinfo
 sysinfo = "0.39"
 # https://crates.io/crates/dhcproto
-dhcproto = "0.14"
+dhcproto = "0.15"
 
 # https://crates.io/crates/regex
 regex = "1"


### PR DESCRIPTION
## Summary

- Bumps `dhcproto` from `0.14` to `0.15` in `source/daemon/Cargo.toml`
- `dhcproto 0.15.0` updates its hickory-proto requirement from `^0.25.2` to `^0.26.1`, which removes the only copy of `hickory-proto 0.25.2` from the lock file
- Also drops the now-unused transitive dep `enum-as-inner 0.6.1`

Fixes [Dependabot alert #38](https://github.com/wardnet/wardnet/security/dependabot/38) — **GHSA-3v94-mw7p-v465** (high): `hickory-proto` NSEC3 closest-encloser proof validation enters unbounded loop on cross-zone responses, causing OOM on release builds.

No source changes required — `dhcproto 0.15.0` is API-compatible with `0.14.0` for the DHCPv4 types we use (`Message`, `Decodable`, `Encodable`, `DhcpOption`, `OptionCode`, etc.).

## Test plan

- [ ] CI passes (the build targets Linux/aarch64 so local `cargo check` on macOS shows pre-existing `netlink-sys` errors unrelated to this change)
- [ ] `hickory-proto 0.25.2` absent from the lock file (`grep hickory-proto source/daemon/Cargo.lock` returns only `0.26.1`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)