### PR TITLE
fix(api): tie static-file cache headers to daemon build version

### DIFF
--- a/source/daemon/crates/wardnetd-api/src/web.rs
+++ b/source/daemon/crates/wardnetd-api/src/web.rs
@@ -21,7 +21,7 @@ struct Assets;
 ///   A matching `If-None-Match` yields a 304 Not Modified.
 pub async fn static_handler(uri: Uri, req_headers: HeaderMap) -> Response {
     let path = uri.path().trim_start_matches('/');
-    let etag = format!("\"{}\"", RELEASE_VERSION);
+    let etag = format!("\"{RELEASE_VERSION}\"");
 
     // 304 shortcut: skip the body when the client already has this build.
     if req_headers

--- a/source/daemon/crates/wardnetd-api/src/web.rs
+++ b/source/daemon/crates/wardnetd-api/src/web.rs
@@ -1,6 +1,7 @@
-use axum::http::{StatusCode, Uri, header};
-use axum::response::{Html, IntoResponse, Response};
+use axum::http::{HeaderMap, StatusCode, Uri, header};
+use axum::response::{IntoResponse, Response};
 use rust_embed::Embed;
+use wardnetd_services::version::RELEASE_VERSION;
 
 /// Embedded web UI assets compiled into the binary.
 ///
@@ -10,27 +11,61 @@ use rust_embed::Embed;
 #[folder = "../../../admin-app/web/dist"]
 struct Assets;
 
-/// Fallback handler that serves embedded static files.
+/// Fallback handler that serves embedded static files with appropriate cache headers.
 ///
-/// Serves the requested file if it exists, otherwise falls back to
-/// `index.html` for client-side SPA routing.
-pub async fn static_handler(uri: Uri) -> Response {
+/// - Content-hashed assets under `/assets/` get `Cache-Control: immutable` (safe to
+///   cache indefinitely because a new build produces new filenames).
+/// - `index.html` and any other top-level path get `Cache-Control: no-cache` so the
+///   browser always revalidates after a daemon upgrade.
+/// - Every response includes an `ETag` tied to the daemon's `RELEASE_VERSION`.
+///   A matching `If-None-Match` yields a 304 Not Modified.
+pub async fn static_handler(uri: Uri, req_headers: HeaderMap) -> Response {
     let path = uri.path().trim_start_matches('/');
+    let etag = format!("\"{}\"", RELEASE_VERSION);
 
-    // Try the exact path first.
+    // 304 shortcut: skip the body when the client already has this build.
+    if req_headers
+        .get(header::IF_NONE_MATCH)
+        .and_then(|v| v.to_str().ok())
+        .is_some_and(|v| v == etag)
+    {
+        return (StatusCode::NOT_MODIFIED, [(header::ETAG, etag.as_str())]).into_response();
+    }
+
+    // Content-hashed assets under /assets/ are immutable at a given URL;
+    // everything else must revalidate so upgrades take effect without a hard-refresh.
+    let cache_ctrl = if path.starts_with("assets/") {
+        "public, max-age=31536000, immutable"
+    } else {
+        "no-cache"
+    };
+
     if let Some(file) = Assets::get(path) {
         let mime = mime_guess::from_path(path).first_or_octet_stream();
         return (
             StatusCode::OK,
-            [(header::CONTENT_TYPE, mime.as_ref())],
+            [
+                (header::CONTENT_TYPE, mime.as_ref()),
+                (header::CACHE_CONTROL, cache_ctrl),
+                (header::ETAG, etag.as_str()),
+            ],
             file.data,
         )
             .into_response();
     }
 
-    // Fall back to index.html for SPA routing.
+    // SPA fallback: serve index.html for all unmatched client-side routes.
     match Assets::get("index.html") {
-        Some(file) => Html(file.data).into_response(),
+        Some(file) => (
+            StatusCode::OK,
+            [
+                (header::CONTENT_TYPE, "text/html; charset=utf-8"),
+                (header::CACHE_CONTROL, "no-cache"),
+                (header::ETAG, etag.as_str()),
+            ],
+            file.data,
+        )
+            .into_response(),
         None => (StatusCode::NOT_FOUND, "not found").into_response(),
     }
 }


### PR DESCRIPTION
## Summary

- Content-hashed assets under `/assets/` get `Cache-Control: public, max-age=31536000, immutable` — safe to cache indefinitely since a new build produces new filenames
- `index.html` and other top-level files get `Cache-Control: no-cache` so browsers always revalidate after an upgrade
- Every response includes an `ETag` derived from `RELEASE_VERSION`; a matching `If-None-Match` returns `304 Not Modified` to skip retransmitting unchanged bodies

Closes #373

## Test plan

- [ ] `curl -I /` shows `cache-control: no-cache` and an `etag` header
- [ ] `curl -I /assets/index-<hash>.js` shows `cache-control: public, max-age=31536000, immutable`
- [ ] `curl -I -H 'If-None-Match: "<current-etag>"' /` returns `304 Not Modified`
- [ ] After a daemon upgrade the browser picks up the new `index.html` without a hard-refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)