### PR TITLE
fix(dns): unify query-log result classification (issue #336)

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -7374,9 +7374,13 @@
             "in": "query",
             "required": false,
             "schema": {
-              "type": [
-                "string",
-                "null"
+              "oneOf": [
+                {
+                  "type": "null"
+                },
+                {
+                  "$ref": "#/components/schemas/DnsQueryResult"
+                }
               ]
             }
           }
@@ -14389,14 +14393,15 @@
       },
       "DnsQueryResult": {
         "type": "string",
-        "description": "Result classification for a DNS query.",
+        "description": "Result classification for a DNS query.\n\nEach variant's `snake_case` serialisation exactly matches the string the DNS\nresolver writes to the `dns_query_log.result` column, so no translation is\nneeded between the DB and the API.",
         "enum": [
           "forwarded",
-          "cached",
+          "cache_hit",
           "blocked",
           "blocked_skipped",
-          "local",
+          "rewritten",
           "recursive",
+          "upstream_error",
           "error"
         ]
       },

--- a/source/admin-app/web/src/pages/DnsLogs.tsx
+++ b/source/admin-app/web/src/pages/DnsLogs.tsx
@@ -19,7 +19,7 @@ import { useDevices } from "@/hooks/useDevices";
 import { useDnsQueryLog } from "@/hooks/useDnsLogs";
 import { useDnsLogStore } from "@/stores/dnsLogStore";
 import { formatTime } from "@/lib/utils";
-import type { DnsQueryLogEntry, QueryLogEvent } from "@wardnet/js";
+import type { DnsQueryLogEntry, DnsQueryResult, QueryLogEvent } from "@wardnet/js";
 
 interface RowShape {
   timestamp: string;
@@ -38,10 +38,9 @@ const RESULT_BADGE: Record<string, "ok" | "warn" | "down" | "info" | "ghost"> = 
   upstream_error: "down",
   forwarded: "ghost",
   cache_hit: "ghost",
-  cached: "ghost",
   rewritten: "info",
-  local: "info",
   recursive: "info",
+  error: "warn",
 };
 
 const RESULT_LABEL: Record<string, string> = {
@@ -107,7 +106,7 @@ export default function DnsLogs() {
       offset: page * PAGE_SIZE,
       domain: domain || undefined,
       client_ip: clientIp || undefined,
-      result: result === "any" ? undefined : result,
+      result: result === "any" ? undefined : (result as DnsQueryResult),
     }),
     [domain, clientIp, result, page],
   );

--- a/source/daemon/crates/wardnet-common/src/api.rs
+++ b/source/daemon/crates/wardnet-common/src/api.rs
@@ -6,7 +6,7 @@ use crate::device::{Device, DeviceType, DhcpStatus};
 use crate::dhcp::{DhcpConfig, DhcpLease, DhcpReservation};
 use crate::dns::{
     AllowlistEntry, Blocklist, CustomFilterRule, DnsConfig, DnsProtocol, DnsQueryLogEntry,
-    UpstreamDns,
+    DnsQueryResult, UpstreamDns,
 };
 use crate::dns_filter::{DeviceDnsFilterSettings, DnsFilterConfig, DnsFilterProfile};
 use crate::routing::RoutingTarget;
@@ -1190,7 +1190,7 @@ pub struct ListQueryLogParams {
     #[serde(default)]
     pub client_ip: Option<String>,
     #[serde(default)]
-    pub result: Option<String>,
+    pub result: Option<DnsQueryResult>,
 }
 
 /// Response for `GET /api/dns/log`.
@@ -1209,7 +1209,7 @@ pub struct QueryLogEvent {
     pub client_ip: String,
     pub domain: String,
     pub query_type: String,
-    pub result: String,
+    pub result: DnsQueryResult,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub upstream: Option<String>,
     pub latency_ms: f64,

--- a/source/daemon/crates/wardnet-common/src/dns.rs
+++ b/source/daemon/crates/wardnet-common/src/dns.rs
@@ -201,25 +201,131 @@ pub struct ConditionalForwardingRule {
 }
 
 /// Result classification for a DNS query.
+///
+/// Each variant's `snake_case` serialisation exactly matches the string the DNS
+/// resolver writes to the `dns_query_log.result` column, so no translation is
+/// needed between the DB and the API.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, utoipa::ToSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum DnsQueryResult {
     /// Answered by upstream server.
     Forwarded,
-    /// Answered from cache.
-    Cached,
+    /// Answered from cache — resolver string `"cache_hit"`.
+    CacheHit,
     /// Blocked by the DNS filter.
     Blocked,
     /// Filter would have blocked the query, but the per-device kill switch
     /// (or the global emergency stop) suppressed the block. Surfaced in the
     /// query log so admins can see what filtering would catch.
     BlockedSkipped,
-    /// Answered by a custom local record or zone.
-    Local,
+    /// Answered by a custom local record or zone — resolver string `"rewritten"`.
+    Rewritten,
     /// Resolved recursively from root servers.
     Recursive,
-    /// Resolution failed.
+    /// Upstream resolver returned an error — resolver string `"upstream_error"`.
+    UpstreamError,
+    /// Resolution failed (parse fallback for unrecognised strings).
     Error,
+}
+
+impl DnsQueryResult {
+    /// Return the canonical `snake_case` string that the DNS resolver writes to
+    /// the `dns_query_log.result` column. Inverse of [`DnsQueryResult::parse`].
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Forwarded => "forwarded",
+            Self::CacheHit => "cache_hit",
+            Self::Blocked => "blocked",
+            Self::BlockedSkipped => "blocked_skipped",
+            Self::Rewritten => "rewritten",
+            Self::Recursive => "recursive",
+            Self::UpstreamError => "upstream_error",
+            Self::Error => "error",
+        }
+    }
+
+    /// Parse a raw DB / resolver string into the correct variant.
+    ///
+    /// Every string the DNS resolver writes to the database is matched
+    /// exactly. Unknown strings emit a [`tracing::warn!`] and fall back to
+    /// [`DnsQueryResult::Error`] so callers always get a typed value.
+    #[must_use]
+    pub fn parse(s: &str) -> Self {
+        match s {
+            "forwarded" => Self::Forwarded,
+            "cache_hit" => Self::CacheHit,
+            "blocked" => Self::Blocked,
+            "blocked_skipped" => Self::BlockedSkipped,
+            "rewritten" => Self::Rewritten,
+            "recursive" => Self::Recursive,
+            "upstream_error" => Self::UpstreamError,
+            other => {
+                tracing::warn!(
+                    result = other,
+                    "unknown DNS result string; defaulting to Error"
+                );
+                Self::Error
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_all_resolver_strings() {
+        assert_eq!(
+            DnsQueryResult::parse("forwarded"),
+            DnsQueryResult::Forwarded
+        );
+        assert_eq!(DnsQueryResult::parse("cache_hit"), DnsQueryResult::CacheHit);
+        assert_eq!(DnsQueryResult::parse("blocked"), DnsQueryResult::Blocked);
+        assert_eq!(
+            DnsQueryResult::parse("blocked_skipped"),
+            DnsQueryResult::BlockedSkipped
+        );
+        assert_eq!(
+            DnsQueryResult::parse("rewritten"),
+            DnsQueryResult::Rewritten
+        );
+        assert_eq!(
+            DnsQueryResult::parse("recursive"),
+            DnsQueryResult::Recursive
+        );
+        assert_eq!(
+            DnsQueryResult::parse("upstream_error"),
+            DnsQueryResult::UpstreamError
+        );
+    }
+
+    #[test]
+    fn parse_unknown_falls_back_to_error() {
+        assert_eq!(DnsQueryResult::parse("gibberish"), DnsQueryResult::Error);
+        assert_eq!(DnsQueryResult::parse(""), DnsQueryResult::Error);
+        // Old aliases no longer accepted — the migration removes those rows.
+        assert_eq!(DnsQueryResult::parse("cached"), DnsQueryResult::Error);
+        assert_eq!(DnsQueryResult::parse("local"), DnsQueryResult::Error);
+    }
+
+    #[test]
+    fn as_str_round_trips_through_parse() {
+        let variants = [
+            DnsQueryResult::Forwarded,
+            DnsQueryResult::CacheHit,
+            DnsQueryResult::Blocked,
+            DnsQueryResult::BlockedSkipped,
+            DnsQueryResult::Rewritten,
+            DnsQueryResult::Recursive,
+            DnsQueryResult::UpstreamError,
+            DnsQueryResult::Error,
+        ];
+        for v in variants {
+            assert_eq!(DnsQueryResult::parse(v.as_str()), v);
+        }
+    }
 }
 
 /// A single entry in the DNS query log.

--- a/source/daemon/crates/wardnet-common/src/tests/dns.rs
+++ b/source/daemon/crates/wardnet-common/src/tests/dns.rs
@@ -122,10 +122,12 @@ fn dns_record_type_screaming_snake_rename() {
 fn dns_query_result_round_trip() {
     for result in [
         DnsQueryResult::Forwarded,
-        DnsQueryResult::Cached,
+        DnsQueryResult::CacheHit,
         DnsQueryResult::Blocked,
-        DnsQueryResult::Local,
+        DnsQueryResult::BlockedSkipped,
+        DnsQueryResult::Rewritten,
         DnsQueryResult::Recursive,
+        DnsQueryResult::UpstreamError,
         DnsQueryResult::Error,
     ] {
         let json = serde_json::to_string(&result).unwrap();

--- a/source/daemon/crates/wardnetd-api/src/api/dns_log_ws.rs
+++ b/source/daemon/crates/wardnetd-api/src/api/dns_log_ws.rs
@@ -68,7 +68,12 @@ impl ClientFilter {
         if !self.client_ip.is_empty() && event.client_ip != self.client_ip {
             return false;
         }
-        if !self.results.is_empty() && !self.results.iter().any(|r| r == &event.result) {
+        if !self.results.is_empty()
+            && !self
+                .results
+                .iter()
+                .any(|r| r.as_str() == event.result.as_str())
+        {
             return false;
         }
         true
@@ -144,6 +149,7 @@ async fn handle_socket(mut socket: WebSocket, mut rx: broadcast::Receiver<QueryL
 #[cfg(test)]
 mod unit_tests {
     use super::*;
+    use wardnet_common::dns::DnsQueryResult;
 
     fn event(domain: &str, ip: &str, result: &str) -> QueryLogEvent {
         QueryLogEvent {
@@ -151,7 +157,7 @@ mod unit_tests {
             client_ip: ip.to_owned(),
             domain: domain.to_owned(),
             query_type: "A".to_owned(),
-            result: result.to_owned(),
+            result: DnsQueryResult::parse(result),
             upstream: None,
             latency_ms: 0.0,
             device_id: None,

--- a/source/daemon/crates/wardnetd-data/migrations/20260527000000_dns_query_log_result_enum.sql
+++ b/source/daemon/crates/wardnetd-data/migrations/20260527000000_dns_query_log_result_enum.sql
@@ -1,0 +1,6 @@
+-- Clear DNS query log rows written under the old enum mapping (Cached/Local
+-- variants). The table is a 7-day rolling log; data loss is acceptable.
+-- After this migration all result strings in the DB match the canonical
+-- resolver strings: forwarded, cache_hit, blocked, blocked_skipped,
+-- rewritten, recursive, upstream_error.
+DELETE FROM dns_query_log;

--- a/source/daemon/crates/wardnetd-data/src/repository/dns.rs
+++ b/source/daemon/crates/wardnetd-data/src/repository/dns.rs
@@ -11,6 +11,7 @@
 //! query log table.
 
 use async_trait::async_trait;
+use wardnet_common::dns::DnsQueryResult;
 
 #[async_trait]
 pub trait DnsRepository: Send + Sync {
@@ -52,5 +53,5 @@ pub struct QueryLogRow {
 pub struct QueryLogFilter {
     pub client_ip: Option<String>,
     pub domain: Option<String>,
-    pub result: Option<String>,
+    pub result: Option<DnsQueryResult>,
 }

--- a/source/daemon/crates/wardnetd-data/src/repository/sqlite/dns.rs
+++ b/source/daemon/crates/wardnetd-data/src/repository/sqlite/dns.rs
@@ -140,9 +140,9 @@ fn build_where(filter: &QueryLogFilter) -> (String, Vec<String>) {
         conditions.push("domain LIKE ?");
         binds.push(format!("%{domain}%"));
     }
-    if let Some(ref result) = filter.result {
+    if let Some(result) = filter.result {
         conditions.push("result = ?");
-        binds.push(result.clone());
+        binds.push(result.as_str().to_owned());
     }
     let where_clause = if conditions.is_empty() {
         String::new()

--- a/source/daemon/crates/wardnetd-data/src/repository/tests/dns.rs
+++ b/source/daemon/crates/wardnetd-data/src/repository/tests/dns.rs
@@ -2,6 +2,7 @@ use super::test_pool;
 use crate::repository::SqliteDnsRepository;
 use crate::repository::dns::{DnsRepository, QueryLogFilter, QueryLogRow};
 use chrono::Utc;
+use wardnet_common::dns::DnsQueryResult;
 
 fn ts_now() -> String {
     Utc::now().format("%Y-%m-%dT%H:%M:%SZ").to_string()
@@ -102,7 +103,7 @@ async fn query_log_filter_by_result() {
     repo.insert_query_log_batch(&entries).await.unwrap();
 
     let filter = QueryLogFilter {
-        result: Some("blocked".to_owned()),
+        result: Some(DnsQueryResult::Blocked),
         ..Default::default()
     };
     let rows = repo.query_log_paginated(10, 0, &filter).await.unwrap();
@@ -146,7 +147,7 @@ async fn query_log_count_with_filter() {
     repo.insert_query_log_batch(&entries).await.unwrap();
 
     let filter = QueryLogFilter {
-        result: Some("blocked".to_owned()),
+        result: Some(DnsQueryResult::Blocked),
         ..Default::default()
     };
     let count = repo.query_log_count(&filter).await.unwrap();
@@ -154,7 +155,7 @@ async fn query_log_count_with_filter() {
 
     let combined = QueryLogFilter {
         client_ip: Some("10.0.0.2".to_owned()),
-        result: Some("blocked".to_owned()),
+        result: Some(DnsQueryResult::Blocked),
         ..Default::default()
     };
     let count2 = repo.query_log_count(&combined).await.unwrap();

--- a/source/daemon/crates/wardnetd-services/src/dns/log_sink.rs
+++ b/source/daemon/crates/wardnetd-services/src/dns/log_sink.rs
@@ -30,6 +30,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 
 use tokio::sync::{broadcast, mpsc};
 use wardnet_common::api::QueryLogEvent;
+use wardnet_common::dns::DnsQueryResult;
 use wardnetd_data::repository::QueryLogRow;
 
 use crate::stats::meter::{Counter, Gauge, Meter};
@@ -153,7 +154,7 @@ pub fn row_to_event(row: &QueryLogRow) -> QueryLogEvent {
         client_ip: row.client_ip.clone(),
         domain: row.domain.clone(),
         query_type: row.query_type.clone(),
-        result: row.result.clone(),
+        result: DnsQueryResult::parse(&row.result),
         upstream: row.upstream.clone(),
         latency_ms: row.latency_ms,
         device_id: row.device_id.clone(),

--- a/source/daemon/crates/wardnetd-services/src/dns/service.rs
+++ b/source/daemon/crates/wardnetd-services/src/dns/service.rs
@@ -317,7 +317,7 @@ impl DnsService for DnsServiceImpl {
         let filter = QueryLogFilter {
             client_ip: params.client_ip,
             domain: params.domain,
-            result: params.result,
+            result: params.result, // already Option<DnsQueryResult>
         };
 
         let rows = self
@@ -345,7 +345,7 @@ impl DnsService for DnsServiceImpl {
                     client_ip: row.client_ip,
                     domain: row.domain,
                     query_type: row.query_type,
-                    result: parse_dns_query_result(&row.result),
+                    result: DnsQueryResult::parse(&row.result),
                     upstream: row.upstream,
                     latency_ms: row.latency_ms,
                     device_id,
@@ -376,16 +376,4 @@ fn parse_iso_timestamp(s: &str) -> anyhow::Result<chrono::DateTime<chrono::Utc>>
     use chrono::NaiveDateTime;
     let naive = NaiveDateTime::parse_from_str(s, "%Y-%m-%dT%H:%M:%SZ")?;
     Ok(chrono::TimeZone::from_utc_datetime(&chrono::Utc, &naive))
-}
-
-fn parse_dns_query_result(s: &str) -> DnsQueryResult {
-    match s {
-        "forwarded" => DnsQueryResult::Forwarded,
-        "cache_hit" | "cached" => DnsQueryResult::Cached,
-        "blocked" => DnsQueryResult::Blocked,
-        "blocked_skipped" => DnsQueryResult::BlockedSkipped,
-        "rewritten" | "local" => DnsQueryResult::Local,
-        "recursive" => DnsQueryResult::Recursive,
-        _ => DnsQueryResult::Error,
-    }
 }

--- a/source/sdk/wardnet-js/src/types/dns.ts
+++ b/source/sdk/wardnet-js/src/types/dns.ts
@@ -72,15 +72,21 @@ export interface DnsCacheFlushResponse {
 
 /** Result classification for a DNS query.
  *
+ *  Each value is the canonical snake_case string written by the DNS resolver to
+ *  the database. Both the paginated REST endpoint (`GET /api/dns/log`) and the
+ *  live-stream WebSocket (`/api/dns/log/stream`) serialise this enum, so a
+ *  given DB row will render the same badge regardless of which path served it.
+ *
  *  `blocked_skipped` is recorded when a query *would* have been blocked but the
  *  per-device kill switch (or global emergency stop) suppressed the block. */
 export type DnsQueryResult =
   | "forwarded"
-  | "cached"
+  | "cache_hit"
   | "blocked"
   | "blocked_skipped"
-  | "local"
+  | "rewritten"
   | "recursive"
+  | "upstream_error"
   | "error";
 
 /** A single entry in the persisted DNS query log. */
@@ -102,8 +108,7 @@ export interface QueryLogEvent {
   client_ip: string;
   domain: string;
   query_type: string;
-  /** Raw result string; superset of `DnsQueryResult` (includes `cache_hit`, `rewritten`, `upstream_error`). */
-  result: string;
+  result: DnsQueryResult;
   upstream?: string | null;
   latency_ms: number;
   device_id?: string | null;
@@ -114,7 +119,7 @@ export interface ListQueryLogParams {
   offset?: number;
   domain?: string;
   client_ip?: string;
-  result?: string;
+  result?: DnsQueryResult;
 }
 
 export interface ListQueryLogResponse {


### PR DESCRIPTION
## Problem

The DNS Logs page showed different badges for the same database row depending on whether live tail was on or off:
- **Paginated path** () ran through `parse_dns_query_result` in `service.rs`, which had no arm for `"upstream_error"` and collapsed it to `DnsQueryResult::Error` → serialised as `"error"`.
- **Live stream path** (`/api/dns/log/stream`) forwarded the raw DB string from `row_to_event` without parsing → forwarded `"upstream_error"` unchanged.

The existing enum also used aliases (`Cached` for `"cache_hit"`, `Local` for `"rewritten"`) that didn't match any resolver output, requiring IN-clause logic and a translation step.

## Solution

Replace `Cached`/`Local` with `CacheHit`/`Rewritten` (exact-match variants) and add `UpstreamError`. Both endpoints now call `DnsQueryResult::parse()` on the raw DB string so a given row always serialises to the same string, regardless of which path served it.

## Changes

| File | What changed |
|---|---|
| `wardnet-common/src/dns.rs` | Replace `Cached`→`CacheHit`, `Local`→`Rewritten`; add `UpstreamError`; add `as_str()` + `parse()` methods; `#[cfg(test)]` coverage for all 6 resolver strings + unknown fallback |
| `wardnet-common/src/api.rs` | `QueryLogEvent.result: String`→`DnsQueryResult`; `ListQueryLogParams.result: Option<String>`→`Option<DnsQueryResult>` |
| `wardnetd-data/src/repository/dns.rs` | `QueryLogFilter.result` typed |
| `wardnetd-data/src/repository/sqlite/dns.rs` | `build_where` calls `.as_str()` — no IN clause needed |
| `wardnetd-data/migrations/20260527000000_dns_query_log_result_enum.sql` | `DELETE FROM dns_query_log` clears rows under old mapping |
| `wardnetd-services/src/dns/service.rs` | Remove `parse_dns_query_result`; use `DnsQueryResult::parse` |
| `wardnetd-services/src/dns/log_sink.rs` | `row_to_event` uses `parse()` |
| `wardnetd-api/src/api/dns_log_ws.rs` | WS filter compares via `as_str()` |
| `source/sdk/wardnet-js/src/types/dns.ts` | Update `DnsQueryResult` union; tighten `QueryLogEvent.result` type; remove asymmetry comment |
| `source/admin-app/web/src/pages/DnsLogs.tsx` | Remove dead `cached`/`local` badge keys; add `error` badge |
| `docs/openapi.json` | Regenerated via `make openapi` |

## Verification

- `make check` passes: 120 Rust tests passed, 0 failed (including new `parse_all_resolver_strings`, `parse_unknown_falls_back_to_error`, `as_str_round_trips_through_parse` tests in `wardnet-common`)
- Frontend TypeScript typechecks clean
- `make openapi` regenerated: `DnsQueryResult` enum shows `cache_hit`/`rewritten`/`upstream_error`; `ListQueryLogParams.result` is now a typed ref

Closes #336

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)