### PR TITLE
feat(dns): add description field to filter profiles (#369)

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -16555,7 +16555,7 @@
               "string",
               "null"
             ],
-            "description": "`None` (omitted) = leave unchanged. `Some(None)` (`null`) = clear.\n`Some(Some(s))` = replace with `s` (max 200 characters)."
+            "description": "`undefined` / omitted = leave unchanged. `null` = clear. `string` = set.\n\nStandard serde cannot distinguish \"field absent\" from \"field: null\" for\n`Option<T>`. The custom deserializer below wraps the inner deserialize so\nthat `null` → `Some(None)` and absent → `None`, giving us three states."
           },
           "name": {
             "type": [

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -13524,6 +13524,13 @@
           "name"
         ],
         "properties": {
+          "description": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Optional free-text annotation (max 200 characters)."
+          },
           "name": {
             "type": "string"
           }
@@ -14300,7 +14307,7 @@
       },
       "DnsFilterProfile": {
         "type": "object",
-        "description": "A named bundle of DNS filter sources (blocklists, allowlist, custom rules).\n\nBuiltin profiles cannot be deleted — the API responds with `409 Conflict`\nwhen an admin tries.",
+        "description": "A named bundle of DNS filter sources (blocklists, allowlist, custom rules).\n\nBuiltin profiles cannot be deleted or modified — the API responds with\n`409 Conflict` when an admin attempts either operation.",
         "required": [
           "id",
           "name",
@@ -14315,6 +14322,13 @@
           "created_at": {
             "type": "string",
             "format": "date-time"
+          },
+          "description": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Optional operator-supplied annotation. Builtin profiles carry a\nseeded description; custom profiles default to `None`."
           },
           "id": {
             "type": "string",
@@ -16534,8 +16548,15 @@
       },
       "UpdateProfileRequest": {
         "type": "object",
-        "description": "Request body for PUT /api/dns/filter/profiles/{id}.",
+        "description": "Request body for PUT /api/dns/filter/profiles/{id}.\n\nAll fields are partial-update: omitting them from JSON leaves the stored\nvalue unchanged. Pass `description: null` to clear an existing description.",
         "properties": {
+          "description": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "`None` (omitted) = leave unchanged. `Some(None)` (`null`) = clear.\n`Some(Some(s))` = replace with `s` (max 200 characters)."
+          },
           "name": {
             "type": [
               "string",

--- a/source/admin-app/web/src/pages/DnsFilter.tsx
+++ b/source/admin-app/web/src/pages/DnsFilter.tsx
@@ -107,6 +107,9 @@ export default function DnsFilter() {
                   </Pill>
                 )}
               </div>
+              {row.original.description && (
+                <span className="truncate text-xs text-ink-3">{row.original.description}</span>
+              )}
             </div>
           </div>
         ),

--- a/source/admin-app/web/src/pages/DnsFilterProfile.tsx
+++ b/source/admin-app/web/src/pages/DnsFilterProfile.tsx
@@ -77,18 +77,13 @@ export default function DnsFilterProfile() {
         status={profile.builtin ? <Pill variant="ghost">Builtin</Pill> : undefined}
       />
 
-      {/* Builtin profiles have nothing to edit on the identity card
-          (name is fixed, deletion is forbidden), so we skip the card
-          entirely — the Builtin pill in the DetailPageHeader already
-          conveys the type. */}
-      {!profile.builtin && (
-        <ProfileIdentityCard
-          profileId={profile.id}
-          name={profile.name}
-          builtin={profile.builtin}
-          onDeleted={() => void navigate("/dns/filter")}
-        />
-      )}
+      <ProfileIdentityCard
+        profileId={profile.id}
+        name={profile.name}
+        description={profile.description}
+        builtin={profile.builtin}
+        onDeleted={() => void navigate("/dns/filter")}
+      />
 
       <BlocklistsCard profileId={profile.id} />
       <AllowlistCard profileId={profile.id} />
@@ -104,26 +99,44 @@ export default function DnsFilterProfile() {
 interface IdentityCardProps {
   profileId: string;
   name: string;
+  description: string | null;
   builtin: boolean;
   onDeleted: () => void;
 }
 
-function ProfileIdentityCard({ profileId, name, builtin, onDeleted }: IdentityCardProps) {
+function ProfileIdentityCard({
+  profileId,
+  name,
+  description,
+  builtin,
+  onDeleted,
+}: IdentityCardProps) {
   const update = useUpdateDnsFilterProfile();
   const del = useDeleteDnsFilterProfile();
 
   const [editing, setEditing] = useState(false);
   const [draft, setDraft] = useState(name);
+  const [draftDesc, setDraftDesc] = useState(description ?? "");
   const [confirmDelete, setConfirmDelete] = useState(false);
 
   function startEdit() {
     setDraft(name);
+    setDraftDesc(description ?? "");
     update.reset();
     setEditing(true);
   }
 
   async function handleSave() {
-    await update.mutateAsync({ id: profileId, body: { name: draft.trim() } });
+    const nameChanged = draft.trim() !== name;
+    const descChanged = draftDesc.trim() !== (description ?? "");
+    await update.mutateAsync({
+      id: profileId,
+      body: {
+        name: nameChanged ? draft.trim() : undefined,
+        // empty string → null (clear); unchanged → undefined (omit)
+        description: descChanged ? draftDesc.trim() || null : undefined,
+      },
+    });
     setEditing(false);
   }
 
@@ -131,6 +144,11 @@ function ProfileIdentityCard({ profileId, name, builtin, onDeleted }: IdentityCa
     await del.mutateAsync(profileId);
     onDeleted();
   }
+
+  const saveDisabled =
+    update.isPending ||
+    draft.trim() === "" ||
+    (draft.trim() === name && draftDesc.trim() === (description ?? ""));
 
   return (
     <Card>
@@ -151,6 +169,14 @@ function ProfileIdentityCard({ profileId, name, builtin, onDeleted }: IdentityCa
             <Field label="Name" htmlFor="profile-name">
               <Input id="profile-name" value={draft} onChange={(e) => setDraft(e.target.value)} />
             </Field>
+            <Field label="Description (optional)" htmlFor="profile-desc">
+              <Input
+                id="profile-desc"
+                value={draftDesc}
+                onChange={(e) => setDraftDesc(e.target.value)}
+                placeholder="e.g. Strict — for kids' devices"
+              />
+            </Field>
             {update.isError && (
               <ApiErrorAlert error={update.error} fallback="Failed to update profile" />
             )}
@@ -168,10 +194,7 @@ function ProfileIdentityCard({ profileId, name, builtin, onDeleted }: IdentityCa
               <Button variant="ghost" onClick={() => setEditing(false)} disabled={update.isPending}>
                 Cancel
               </Button>
-              <Button
-                onClick={handleSave}
-                disabled={update.isPending || draft.trim() === "" || draft.trim() === name}
-              >
+              <Button onClick={handleSave} disabled={saveDisabled}>
                 {update.isPending ? "Saving…" : "Save"}
               </Button>
             </div>
@@ -185,8 +208,14 @@ function ProfileIdentityCard({ profileId, name, builtin, onDeleted }: IdentityCa
           </div>
           <div className="flex flex-col gap-0.5">
             <span className="text-xs uppercase tracking-wide text-ink-3">Type</span>
-            <span className="text-sm">{builtin ? "Builtin (cannot delete)" : "Custom"}</span>
+            <span className="text-sm">{builtin ? "Builtin" : "Custom"}</span>
           </div>
+          {(description !== null || builtin) && (
+            <div className="flex flex-col gap-0.5 lg:col-span-2">
+              <span className="text-xs uppercase tracking-wide text-ink-3">Description</span>
+              <span className="text-sm text-ink-2">{description ?? "—"}</span>
+            </div>
+          )}
         </CardContent>
       )}
 

--- a/source/admin-app/web/src/pages/DnsFilterProfileNew.tsx
+++ b/source/admin-app/web/src/pages/DnsFilterProfileNew.tsx
@@ -13,9 +13,13 @@ export default function DnsFilterProfileNew() {
   const navigate = useNavigate();
   const create = useCreateDnsFilterProfile();
   const [name, setName] = useState("");
+  const [description, setDescription] = useState("");
 
   async function handleSave() {
-    const res = await create.mutateAsync({ name: name.trim() });
+    const res = await create.mutateAsync({
+      name: name.trim(),
+      description: description.trim() || undefined,
+    });
     void navigate(`/dns/filter/profiles/${res.profile.id}`);
   }
 
@@ -47,6 +51,15 @@ export default function DnsFilterProfileNew() {
               onChange={(e) => setName(e.target.value)}
               placeholder="Parental Controls"
               autoFocus
+            />
+          </Field>
+
+          <Field label="Description (optional)" htmlFor="profile-desc">
+            <Input
+              id="profile-desc"
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              placeholder="e.g. Strict — for kids' devices"
             />
           </Field>
 

--- a/source/daemon/crates/wardnet-common/src/api.rs
+++ b/source/daemon/crates/wardnet-common/src/api.rs
@@ -927,6 +927,9 @@ pub struct GetProfileResponse {
 #[derive(Debug, Clone, Serialize, Deserialize, utoipa::ToSchema)]
 pub struct CreateProfileRequest {
     pub name: String,
+    /// Optional free-text annotation (max 200 characters).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
 }
 
 /// Response for POST /api/dns/filter/profiles.
@@ -937,10 +940,17 @@ pub struct CreateProfileResponse {
 }
 
 /// Request body for PUT /api/dns/filter/profiles/{id}.
+///
+/// All fields are partial-update: omitting them from JSON leaves the stored
+/// value unchanged. Pass `description: null` to clear an existing description.
 #[derive(Debug, Clone, Default, Serialize, Deserialize, utoipa::ToSchema)]
 pub struct UpdateProfileRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
+    /// `None` (omitted) = leave unchanged. `Some(None)` (`null`) = clear.
+    /// `Some(Some(s))` = replace with `s` (max 200 characters).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<Option<String>>,
 }
 
 /// Response for PUT /api/dns/filter/profiles/{id}.

--- a/source/daemon/crates/wardnet-common/src/api.rs
+++ b/source/daemon/crates/wardnet-common/src/api.rs
@@ -947,9 +947,16 @@ pub struct CreateProfileResponse {
 pub struct UpdateProfileRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
-    /// `None` (omitted) = leave unchanged. `Some(None)` (`null`) = clear.
-    /// `Some(Some(s))` = replace with `s` (max 200 characters).
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    /// `undefined` / omitted = leave unchanged. `null` = clear. `string` = set.
+    ///
+    /// Standard serde cannot distinguish "field absent" from "field: null" for
+    /// `Option<T>`. The custom deserializer below wraps the inner deserialize so
+    /// that `null` → `Some(None)` and absent → `None`, giving us three states.
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "crate::serde_util::nullable_field"
+    )]
     pub description: Option<Option<String>>,
 }
 

--- a/source/daemon/crates/wardnet-common/src/dns_filter.rs
+++ b/source/daemon/crates/wardnet-common/src/dns_filter.rs
@@ -15,12 +15,15 @@ use uuid::Uuid;
 
 /// A named bundle of DNS filter sources (blocklists, allowlist, custom rules).
 ///
-/// Builtin profiles cannot be deleted — the API responds with `409 Conflict`
-/// when an admin tries.
+/// Builtin profiles cannot be deleted or modified — the API responds with
+/// `409 Conflict` when an admin attempts either operation.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, utoipa::ToSchema)]
 pub struct DnsFilterProfile {
     pub id: Uuid,
     pub name: String,
+    /// Optional operator-supplied annotation. Builtin profiles carry a
+    /// seeded description; custom profiles default to `None`.
+    pub description: Option<String>,
     pub builtin: bool,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,

--- a/source/daemon/crates/wardnet-common/src/lib.rs
+++ b/source/daemon/crates/wardnet-common/src/lib.rs
@@ -9,6 +9,7 @@ pub mod dns_filter;
 pub mod event;
 pub mod jobs;
 pub mod routing;
+pub mod serde_util;
 pub mod stats;
 pub mod tunnel;
 pub mod update;

--- a/source/daemon/crates/wardnet-common/src/serde_util.rs
+++ b/source/daemon/crates/wardnet-common/src/serde_util.rs
@@ -23,3 +23,39 @@ where
     // `null` → `Some(None)` and `"text"` → `Some(Some("text"))`.
     Ok(Some(Option::<T>::deserialize(de)?))
 }
+
+#[cfg(test)]
+mod tests {
+    use serde::Deserialize;
+
+    #[derive(Debug, Deserialize, PartialEq)]
+    struct Wrapper {
+        #[serde(default, deserialize_with = "super::nullable_field")]
+        value: Option<Option<String>>,
+    }
+
+    fn parse(json: &str) -> Option<Option<String>> {
+        serde_json::from_str::<Wrapper>(json).unwrap().value
+    }
+
+    /// Field absent → `None` (leave unchanged).
+    #[test]
+    fn absent_yields_none() {
+        assert_eq!(parse("{}"), None);
+    }
+
+    /// Field present as JSON `null` → `Some(None)` (clear to NULL).
+    #[test]
+    fn null_yields_some_none() {
+        assert_eq!(parse(r#"{"value": null}"#), Some(None));
+    }
+
+    /// Field present as a string → `Some(Some(s))` (replace value).
+    #[test]
+    fn string_yields_some_some() {
+        assert_eq!(
+            parse(r#"{"value": "hello"}"#),
+            Some(Some("hello".to_owned()))
+        );
+    }
+}

--- a/source/daemon/crates/wardnet-common/src/serde_util.rs
+++ b/source/daemon/crates/wardnet-common/src/serde_util.rs
@@ -1,0 +1,25 @@
+//! Small serde helpers used across the wardnet-common API types.
+
+use serde::{Deserialize, Deserializer};
+
+/// Deserializer for a "nullable field" — distinguishes three states that
+/// standard `Option<Option<T>>` cannot express without this helper:
+///
+/// | JSON           | Result           | Meaning          |
+/// |----------------|------------------|------------------|
+/// | field absent   | `None`           | don't touch      |
+/// | `null`         | `Some(None)`     | clear / set NULL |
+/// | `"text"`       | `Some(Some(s))`  | replace value    |
+///
+/// Used with `#[serde(default, deserialize_with = "crate::serde_util::nullable_field")]`.
+/// The `#[serde(default)]` handles the "absent" → `None` case; this function
+/// handles the two cases where the field IS present in the JSON.
+pub fn nullable_field<'de, D, T>(de: D) -> Result<Option<Option<T>>, D::Error>
+where
+    D: Deserializer<'de>,
+    T: Deserialize<'de>,
+{
+    // Field is present in the JSON — wrap the inner deserialize so that
+    // `null` → `Some(None)` and `"text"` → `Some(Some("text"))`.
+    Ok(Some(Option::<T>::deserialize(de)?))
+}

--- a/source/daemon/crates/wardnet-common/src/serde_util.rs
+++ b/source/daemon/crates/wardnet-common/src/serde_util.rs
@@ -25,6 +25,7 @@ where
 }
 
 #[cfg(test)]
+#[allow(clippy::option_option)]
 mod tests {
     use serde::Deserialize;
 

--- a/source/daemon/crates/wardnet-common/src/tests/dns_filter.rs
+++ b/source/daemon/crates/wardnet-common/src/tests/dns_filter.rs
@@ -7,6 +7,7 @@ fn dns_filter_profile_round_trip() {
     let profile = DnsFilterProfile {
         id: Uuid::new_v4(),
         name: "Ad Blocking".to_owned(),
+        description: Some("Blocks ads and trackers.".to_owned()),
         builtin: true,
         created_at: "2026-05-06T00:00:00Z".parse().unwrap(),
         updated_at: "2026-05-06T00:00:00Z".parse().unwrap(),

--- a/source/daemon/crates/wardnetd-api/src/api/tests/dns_filter.rs
+++ b/source/daemon/crates/wardnetd-api/src/api/tests/dns_filter.rs
@@ -104,6 +104,7 @@ fn sample_profile() -> DnsFilterProfile {
     DnsFilterProfile {
         id: PROFILE_ID,
         name: "Sample".into(),
+        description: None,
         builtin: false,
         created_at: Utc::now(),
         updated_at: Utc::now(),

--- a/source/daemon/crates/wardnetd-data/migrations/20260612000000_dns_filter_profile_description.sql
+++ b/source/daemon/crates/wardnetd-data/migrations/20260612000000_dns_filter_profile_description.sql
@@ -1,0 +1,16 @@
+-- Add optional description field to DNS filter profiles.
+-- Existing rows (including custom profiles) default to NULL.
+
+ALTER TABLE dns_filter_profiles ADD COLUMN description TEXT;
+
+UPDATE dns_filter_profiles
+SET description = 'Blocks ads, trackers, and unwanted content network-wide.'
+WHERE id = '00000000-0000-0000-0000-000000000100';
+
+UPDATE dns_filter_profiles
+SET description = 'Filters adult content, social media, and distracting sites — ideal for kids'' devices.'
+WHERE id = '00000000-0000-0000-0000-000000000101';
+
+UPDATE dns_filter_profiles
+SET description = 'Blocks known malware distribution and phishing domains to protect every device.'
+WHERE id = '00000000-0000-0000-0000-000000000102';

--- a/source/daemon/crates/wardnetd-data/src/repository/dns_filter.rs
+++ b/source/daemon/crates/wardnetd-data/src/repository/dns_filter.rs
@@ -95,8 +95,20 @@ pub trait DnsFilterRepository: Send + Sync {
 
     async fn list_profiles(&self) -> anyhow::Result<Vec<DnsFilterProfile>>;
     async fn get_profile(&self, id: Uuid) -> anyhow::Result<Option<DnsFilterProfile>>;
-    async fn create_profile(&self, id: Uuid, name: &str) -> anyhow::Result<DnsFilterProfile>;
-    async fn rename_profile(&self, id: Uuid, name: &str) -> anyhow::Result<bool>;
+    async fn create_profile(
+        &self,
+        id: Uuid,
+        name: &str,
+        description: Option<&str>,
+    ) -> anyhow::Result<DnsFilterProfile>;
+    /// Update mutable fields on a profile. Pass `None` to leave a field
+    /// unchanged; pass `Some(None)` for `description` to clear it to NULL.
+    async fn update_profile_fields(
+        &self,
+        id: Uuid,
+        name: Option<&str>,
+        description: Option<Option<&str>>,
+    ) -> anyhow::Result<bool>;
     /// Delete a non-builtin profile. Returns `Ok(false)` if no row matched.
     /// Builtin protection is enforced at the service layer (returns 409).
     async fn delete_profile(&self, id: Uuid) -> anyhow::Result<bool>;

--- a/source/daemon/crates/wardnetd-data/src/repository/sqlite/dns_filter.rs
+++ b/source/daemon/crates/wardnetd-data/src/repository/sqlite/dns_filter.rs
@@ -56,6 +56,7 @@ impl SqliteDnsFilterRepository {
 struct DbProfileRow {
     id: String,
     name: String,
+    description: Option<String>,
     builtin: i64,
     created_at: String,
     updated_at: String,
@@ -66,6 +67,7 @@ impl DbProfileRow {
         Ok(DnsFilterProfile {
             id: self.id.parse()?,
             name: self.name,
+            description: self.description,
             builtin: self.builtin != 0,
             created_at: parse_ts(&self.created_at)?,
             updated_at: parse_ts(&self.updated_at)?,
@@ -160,7 +162,7 @@ impl DnsFilterRepository for SqliteDnsFilterRepository {
 
     async fn list_profiles(&self) -> anyhow::Result<Vec<DnsFilterProfile>> {
         let rows = sqlx::query_as::<_, DbProfileRow>(
-            "SELECT id, name, builtin, created_at, updated_at \
+            "SELECT id, name, description, builtin, created_at, updated_at \
              FROM dns_filter_profiles ORDER BY builtin DESC, name ASC",
         )
         .fetch_all(&self.pools.read)
@@ -171,7 +173,7 @@ impl DnsFilterRepository for SqliteDnsFilterRepository {
     async fn get_profile(&self, id: Uuid) -> anyhow::Result<Option<DnsFilterProfile>> {
         let id_str = id.to_string();
         let row = sqlx::query_as::<_, DbProfileRow>(
-            "SELECT id, name, builtin, created_at, updated_at \
+            "SELECT id, name, description, builtin, created_at, updated_at \
              FROM dns_filter_profiles WHERE id = ?",
         )
         .bind(&id_str)
@@ -180,15 +182,21 @@ impl DnsFilterRepository for SqliteDnsFilterRepository {
         row.map(DbProfileRow::into_profile).transpose()
     }
 
-    async fn create_profile(&self, id: Uuid, name: &str) -> anyhow::Result<DnsFilterProfile> {
+    async fn create_profile(
+        &self,
+        id: Uuid,
+        name: &str,
+        description: Option<&str>,
+    ) -> anyhow::Result<DnsFilterProfile> {
         let now = now_iso();
         let id_str = id.to_string();
         sqlx::query(
-            "INSERT INTO dns_filter_profiles (id, name, builtin, created_at, updated_at) \
-             VALUES (?, ?, 0, ?, ?)",
+            "INSERT INTO dns_filter_profiles (id, name, description, builtin, created_at, updated_at) \
+             VALUES (?, ?, ?, 0, ?, ?)",
         )
         .bind(&id_str)
         .bind(name)
+        .bind(description)
         .bind(&now)
         .bind(&now)
         .execute(&self.pools.write)
@@ -196,22 +204,47 @@ impl DnsFilterRepository for SqliteDnsFilterRepository {
         Ok(DnsFilterProfile {
             id,
             name: name.to_owned(),
+            description: description.map(str::to_owned),
             builtin: false,
             created_at: parse_ts(&now)?,
             updated_at: parse_ts(&now)?,
         })
     }
 
-    async fn rename_profile(&self, id: Uuid, name: &str) -> anyhow::Result<bool> {
+    async fn update_profile_fields(
+        &self,
+        id: Uuid,
+        name: Option<&str>,
+        description: Option<Option<&str>>,
+    ) -> anyhow::Result<bool> {
+        if name.is_none() && description.is_none() {
+            // Nothing to update — not an error, return true (row exists).
+            return Ok(true);
+        }
         let now = now_iso();
         let id_str = id.to_string();
-        let result =
-            sqlx::query("UPDATE dns_filter_profiles SET name = ?, updated_at = ? WHERE id = ?")
-                .bind(name)
-                .bind(&now)
-                .bind(&id_str)
-                .execute(&self.pools.write)
-                .await?;
+        // Build the SET clause dynamically so we only touch the fields the
+        // caller asked to change, preserving the others unchanged.
+        let mut set_parts: Vec<&str> = vec!["updated_at = ?"];
+        if name.is_some() {
+            set_parts.push("name = ?");
+        }
+        if description.is_some() {
+            set_parts.push("description = ?");
+        }
+        let sql = format!(
+            "UPDATE dns_filter_profiles SET {} WHERE id = ?",
+            set_parts.join(", ")
+        );
+        let mut q = sqlx::query(&sql).bind(&now);
+        if let Some(n) = name {
+            q = q.bind(n);
+        }
+        if let Some(d) = description {
+            q = q.bind(d); // binds Option<&str>: None → SQL NULL
+        }
+        q = q.bind(&id_str);
+        let result = q.execute(&self.pools.write).await?;
         Ok(result.rows_affected() > 0)
     }
 

--- a/source/daemon/crates/wardnetd-data/src/repository/tests/dns_filter.rs
+++ b/source/daemon/crates/wardnetd-data/src/repository/tests/dns_filter.rs
@@ -100,18 +100,43 @@ async fn migration_sets_default_profile_to_ad_blocking() {
 // ── Profile CRUD ──────────────────────────────────────────────────────────
 
 #[tokio::test]
-async fn create_and_rename_user_profile() {
+async fn create_and_update_user_profile() {
     let pool = test_pool().await;
     let repo = SqliteDnsFilterRepository::new(pool);
 
     let id = Uuid::new_v4();
-    let p = repo.create_profile(id, "Kids").await.unwrap();
+    let p = repo.create_profile(id, "Kids", None).await.unwrap();
     assert_eq!(p.id, id);
     assert!(!p.builtin);
+    assert!(p.description.is_none());
 
-    assert!(repo.rename_profile(id, "Family").await.unwrap());
+    // Rename only.
+    assert!(
+        repo.update_profile_fields(id, Some("Family"), None)
+            .await
+            .unwrap()
+    );
     let fetched = repo.get_profile(id).await.unwrap().unwrap();
     assert_eq!(fetched.name, "Family");
+    assert!(fetched.description.is_none());
+
+    // Set description.
+    assert!(
+        repo.update_profile_fields(id, None, Some(Some("A family profile")))
+            .await
+            .unwrap()
+    );
+    let fetched = repo.get_profile(id).await.unwrap().unwrap();
+    assert_eq!(fetched.description.as_deref(), Some("A family profile"));
+
+    // Clear description.
+    assert!(
+        repo.update_profile_fields(id, None, Some(None))
+            .await
+            .unwrap()
+    );
+    let fetched = repo.get_profile(id).await.unwrap().unwrap();
+    assert!(fetched.description.is_none());
 }
 
 #[tokio::test]
@@ -133,7 +158,7 @@ async fn delete_user_profile_succeeds() {
     let repo = SqliteDnsFilterRepository::new(pool);
 
     let id = Uuid::new_v4();
-    repo.create_profile(id, "Temp").await.unwrap();
+    repo.create_profile(id, "Temp", None).await.unwrap();
 
     assert!(repo.delete_profile(id).await.unwrap());
     assert!(repo.get_profile(id).await.unwrap().is_none());
@@ -147,7 +172,7 @@ async fn blocklists_are_scoped_to_their_profile() {
     let repo = SqliteDnsFilterRepository::new(pool);
 
     let custom = Uuid::new_v4();
-    repo.create_profile(custom, "Custom").await.unwrap();
+    repo.create_profile(custom, "Custom", None).await.unwrap();
 
     let bl_id = Uuid::new_v4();
     repo.create_blocklist(&BlocklistRow {
@@ -502,8 +527,8 @@ async fn set_dns_filter_config_round_trip() {
 
     let a = Uuid::new_v4();
     let b = Uuid::new_v4();
-    repo.create_profile(a, "First").await.unwrap();
-    repo.create_profile(b, "Second").await.unwrap();
+    repo.create_profile(a, "First", None).await.unwrap();
+    repo.create_profile(b, "Second", None).await.unwrap();
 
     repo.set_dns_filter_config(&DnsFilterConfig {
         enabled: false,
@@ -528,8 +553,8 @@ async fn set_dns_filter_config_replaces_default_set() {
 
     let a = Uuid::new_v4();
     let b = Uuid::new_v4();
-    repo.create_profile(a, "A").await.unwrap();
-    repo.create_profile(b, "B").await.unwrap();
+    repo.create_profile(a, "A", None).await.unwrap();
+    repo.create_profile(b, "B", None).await.unwrap();
 
     // Seed a multi-profile default, then replace it with a single id.
     repo.set_dns_filter_config(&DnsFilterConfig {
@@ -572,7 +597,7 @@ async fn deleting_profile_cascades_default_membership() {
     let repo = SqliteDnsFilterRepository::new(pool);
 
     let p = Uuid::new_v4();
-    repo.create_profile(p, "Doomed").await.unwrap();
+    repo.create_profile(p, "Doomed", None).await.unwrap();
 
     repo.set_dns_filter_config(&DnsFilterConfig {
         enabled: true,

--- a/source/daemon/crates/wardnetd-services/src/dns_filter/service.rs
+++ b/source/daemon/crates/wardnetd-services/src/dns_filter/service.rs
@@ -715,10 +715,17 @@ impl DnsFilterService for DnsFilterServiceImpl {
         if req.name.trim().is_empty() {
             return Err(AppError::BadRequest("name must not be empty".to_owned()));
         }
+        if let Some(desc) = req.description.as_deref()
+            && desc.len() > 200
+        {
+            return Err(AppError::BadRequest(
+                "description must not exceed 200 characters".to_owned(),
+            ));
+        }
         let id = Uuid::new_v4();
         let profile = self
             .repo
-            .create_profile(id, &req.name)
+            .create_profile(id, &req.name, req.description.as_deref())
             .await
             .map_err(AppError::Internal)?;
         self.publish(DnsFilterChange::ProfileMembership { profile_id: id });
@@ -735,15 +742,31 @@ impl DnsFilterService for DnsFilterServiceImpl {
     ) -> Result<UpdateProfileResponse, AppError> {
         auth_context::require_admin()?;
         let existing = self.ensure_profile_exists(id).await?;
-        if let Some(name) = req.name.as_deref() {
-            if name.trim().is_empty() {
-                return Err(AppError::BadRequest("name must not be empty".to_owned()));
-            }
-            self.repo
-                .rename_profile(id, name)
-                .await
-                .map_err(AppError::Internal)?;
+        if existing.builtin {
+            return Err(AppError::Conflict(
+                "builtin profiles cannot be modified".to_owned(),
+            ));
         }
+        if let Some(name) = req.name.as_deref()
+            && name.trim().is_empty()
+        {
+            return Err(AppError::BadRequest("name must not be empty".to_owned()));
+        }
+        if let Some(Some(desc)) = req.description.as_ref()
+            && desc.len() > 200
+        {
+            return Err(AppError::BadRequest(
+                "description must not exceed 200 characters".to_owned(),
+            ));
+        }
+        self.repo
+            .update_profile_fields(
+                id,
+                req.name.as_deref(),
+                req.description.as_ref().map(|d| d.as_deref()),
+            )
+            .await
+            .map_err(AppError::Internal)?;
         let profile = self.ensure_profile_exists(id).await.unwrap_or(existing);
         self.publish(DnsFilterChange::ProfileMembership { profile_id: id });
         Ok(UpdateProfileResponse {

--- a/source/daemon/crates/wardnetd-services/src/dns_filter/tests/runner.rs
+++ b/source/daemon/crates/wardnetd-services/src/dns_filter/tests/runner.rs
@@ -258,10 +258,20 @@ impl DnsFilterRepository for EmptyRepo {
     async fn get_profile(&self, _id: Uuid) -> anyhow::Result<Option<DnsFilterProfile>> {
         Ok(None)
     }
-    async fn create_profile(&self, _id: Uuid, _name: &str) -> anyhow::Result<DnsFilterProfile> {
+    async fn create_profile(
+        &self,
+        _id: Uuid,
+        _name: &str,
+        _description: Option<&str>,
+    ) -> anyhow::Result<DnsFilterProfile> {
         unimplemented!()
     }
-    async fn rename_profile(&self, _id: Uuid, _name: &str) -> anyhow::Result<bool> {
+    async fn update_profile_fields(
+        &self,
+        _id: Uuid,
+        _name: Option<&str>,
+        _description: Option<Option<&str>>,
+    ) -> anyhow::Result<bool> {
         unimplemented!()
     }
     async fn delete_profile(&self, _id: Uuid) -> anyhow::Result<bool> {
@@ -567,6 +577,7 @@ impl DnsFilterRepository for CronRepo {
         Ok(vec![DnsFilterProfile {
             id: Uuid::nil(),
             name: "Ad Blocking".into(),
+            description: None,
             builtin: true,
             created_at: Utc::now(),
             updated_at: Utc::now(),
@@ -613,10 +624,20 @@ impl DnsFilterRepository for CronRepo {
     async fn get_profile(&self, _id: Uuid) -> anyhow::Result<Option<DnsFilterProfile>> {
         unimplemented!()
     }
-    async fn create_profile(&self, _id: Uuid, _name: &str) -> anyhow::Result<DnsFilterProfile> {
+    async fn create_profile(
+        &self,
+        _id: Uuid,
+        _name: &str,
+        _description: Option<&str>,
+    ) -> anyhow::Result<DnsFilterProfile> {
         unimplemented!()
     }
-    async fn rename_profile(&self, _id: Uuid, _name: &str) -> anyhow::Result<bool> {
+    async fn update_profile_fields(
+        &self,
+        _id: Uuid,
+        _name: Option<&str>,
+        _description: Option<Option<&str>>,
+    ) -> anyhow::Result<bool> {
         unimplemented!()
     }
     async fn delete_profile(&self, _id: Uuid) -> anyhow::Result<bool> {

--- a/source/daemon/crates/wardnetd-services/src/dns_filter/tests/service.rs
+++ b/source/daemon/crates/wardnetd-services/src/dns_filter/tests/service.rs
@@ -331,6 +331,7 @@ async fn create_profile_round_trips() {
             .service
             .create_profile(CreateProfileRequest {
                 name: "Custom".into(),
+                description: None,
             })
             .await
             .unwrap();
@@ -351,6 +352,7 @@ async fn create_profile_rejects_empty_name() {
             .service
             .create_profile(CreateProfileRequest {
                 name: String::new(),
+                description: None,
             })
             .await
             .unwrap_err();
@@ -388,6 +390,7 @@ async fn update_profile_renames() {
             .service
             .create_profile(CreateProfileRequest {
                 name: "Original".into(),
+                description: None,
             })
             .await
             .unwrap();
@@ -397,6 +400,7 @@ async fn update_profile_renames() {
                 created.profile.id,
                 UpdateProfileRequest {
                     name: Some("Renamed".into()),
+                    ..Default::default()
                 },
             )
             .await
@@ -849,6 +853,7 @@ async fn update_profile_rejects_empty_name() {
             .service
             .create_profile(CreateProfileRequest {
                 name: "Original".into(),
+                description: None,
             })
             .await
             .unwrap();
@@ -858,6 +863,7 @@ async fn update_profile_rejects_empty_name() {
                 created.profile.id,
                 UpdateProfileRequest {
                     name: Some(String::new()),
+                    ..Default::default()
                 },
             )
             .await
@@ -877,11 +883,159 @@ async fn update_profile_unknown_id_returns_not_found() {
                 Uuid::new_v4(),
                 UpdateProfileRequest {
                     name: Some("X".into()),
+                    ..Default::default()
                 },
             )
             .await
             .unwrap_err();
         assert!(matches!(err, AppError::NotFound(_)));
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn create_profile_with_description_round_trips() {
+    let h = build().await;
+    as_admin(async {
+        let resp = h
+            .service
+            .create_profile(CreateProfileRequest {
+                name: "With Desc".into(),
+                description: Some("A test description".into()),
+            })
+            .await
+            .unwrap();
+        assert_eq!(
+            resp.profile.description.as_deref(),
+            Some("A test description")
+        );
+        let fetched = h.service.get_profile(resp.profile.id).await.unwrap();
+        assert_eq!(
+            fetched.profile.description.as_deref(),
+            Some("A test description")
+        );
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn create_profile_rejects_description_over_200_chars() {
+    let h = build().await;
+    as_admin(async {
+        let err = h
+            .service
+            .create_profile(CreateProfileRequest {
+                name: "Long".into(),
+                description: Some("x".repeat(201)),
+            })
+            .await
+            .unwrap_err();
+        assert!(matches!(err, AppError::BadRequest(_)));
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn update_profile_sets_description() {
+    let h = build().await;
+    as_admin(async {
+        let created = h
+            .service
+            .create_profile(CreateProfileRequest {
+                name: "No Desc".into(),
+                description: None,
+            })
+            .await
+            .unwrap();
+        let updated = h
+            .service
+            .update_profile(
+                created.profile.id,
+                UpdateProfileRequest {
+                    description: Some(Some("Added later".into())),
+                    ..Default::default()
+                },
+            )
+            .await
+            .unwrap();
+        assert_eq!(updated.profile.description.as_deref(), Some("Added later"));
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn update_profile_clears_description() {
+    let h = build().await;
+    as_admin(async {
+        let created = h
+            .service
+            .create_profile(CreateProfileRequest {
+                name: "Has Desc".into(),
+                description: Some("Will be cleared".into()),
+            })
+            .await
+            .unwrap();
+        let updated = h
+            .service
+            .update_profile(
+                created.profile.id,
+                UpdateProfileRequest {
+                    description: Some(None), // explicit null = clear
+                    ..Default::default()
+                },
+            )
+            .await
+            .unwrap();
+        assert!(updated.profile.description.is_none());
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn update_profile_on_builtin_returns_conflict() {
+    let h = build().await;
+    as_admin(async {
+        let id = Uuid::parse_str(AD_BLOCKING).unwrap();
+        let err = h
+            .service
+            .update_profile(
+                id,
+                UpdateProfileRequest {
+                    name: Some("Hacked".into()),
+                    ..Default::default()
+                },
+            )
+            .await
+            .unwrap_err();
+        assert!(matches!(err, AppError::Conflict(_)));
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn update_profile_rejects_description_over_200_chars() {
+    let h = build().await;
+    as_admin(async {
+        let created = h
+            .service
+            .create_profile(CreateProfileRequest {
+                name: "Desc".into(),
+                description: None,
+            })
+            .await
+            .unwrap();
+        let err = h
+            .service
+            .update_profile(
+                created.profile.id,
+                UpdateProfileRequest {
+                    description: Some(Some("x".repeat(201))),
+                    ..Default::default()
+                },
+            )
+            .await
+            .unwrap_err();
+        assert!(matches!(err, AppError::BadRequest(_)));
     })
     .await;
 }
@@ -1082,6 +1236,7 @@ async fn delete_custom_profile_publishes_membership_event() {
             .service
             .create_profile(CreateProfileRequest {
                 name: "delete-me".into(),
+                description: None,
             })
             .await
             .unwrap();

--- a/source/sdk/wardnet-js/src/types/dns-filter.ts
+++ b/source/sdk/wardnet-js/src/types/dns-filter.ts
@@ -6,6 +6,8 @@
 export interface DnsFilterProfile {
   id: string;
   name: string;
+  /** Optional operator-supplied annotation. Builtin profiles carry a seeded description; custom profiles default to `null`. */
+  description: string | null;
   builtin: boolean;
   created_at: string;
   updated_at: string;
@@ -89,6 +91,8 @@ export interface GetProfileResponse {
 
 export interface CreateProfileRequest {
   name: string;
+  /** Optional free-text annotation (max 200 characters). */
+  description?: string;
 }
 
 export interface CreateProfileResponse {
@@ -98,6 +102,8 @@ export interface CreateProfileResponse {
 
 export interface UpdateProfileRequest {
   name?: string;
+  /** `undefined` = leave unchanged. `null` = clear. `string` = set to new value (max 200 characters). */
+  description?: string | null;
 }
 
 export interface UpdateProfileResponse {


### PR DESCRIPTION
## Summary

Adds an optional free-text description to DNS filter profiles, so operators can annotate profiles (e.g. _"Strict — for kids' devices"_) without crowding the name field.

Closes #369.

---

## Changes

### Database
- Migration `20260612000000_dns_filter_profile_description.sql` — adds `description TEXT` column and seeds the three builtin profiles with descriptive text.

### Rust (daemon)
- `DnsFilterProfile` struct gains `description: Option<String>`
- `CreateProfileRequest` gains `description: Option<String>`
- `UpdateProfileRequest` gains `description: Option<Option<String>>` with a custom serde deserializer that correctly distinguishes field-absent (don't touch) from JSON `null` (clear to NULL) — standard serde cannot express this with a plain `Option<T>`
- Repository trait: `rename_profile` replaced by `update_profile_fields(id, name, description)` — one DB write for any combination of field changes
- Service: description validated ≤ 200 chars; builtin guard now covers updates (previously only delete was guarded → 409 for any write on a builtin)
- New service tests: create with description, update/clear description, builtin update rejection, description over 200 chars

### JS SDK
- `DnsFilterProfile`, `CreateProfileRequest`, `UpdateProfileRequest` updated with `description` field

### Frontend (admin app)
- **Profile list** — description shown inline below the name in the Profile column
- **Create form** — optional Description field added
- **Profile detail / edit** — `ProfileIdentityCard` always renders (previously hidden for builtins); description shown read-only for builtins and editable for custom profiles; clearing the field sends `null` to the API

### OpenAPI
- `docs/openapi.json` regenerated to reflect new fields

---

## Notable design decisions

| Decision | Rationale |
|---|---|
| `Option<Option<String>>` + custom deserializer | Standard serde conflates absent + null → can't distinguish "leave alone" from "clear" |
| Single `update_profile_fields` repo method | One DB round-trip regardless of which fields changed |
| Builtin guard on update | Existing code only blocked delete; this closes the gap consistently |
| Descriptions seeded in migration | Builtins always had implicit meaning; makes it explicit at DB level |

🤖 Generated with [Claude Code](https://claude.com/claude-code)