### PR TITLE
feat(daemon): standalone DbMaintenanceRunner for daily incremental_vacuum

### DIFF
--- a/source/daemon/crates/wardnetd-data/src/repository/sqlite/maintenance.rs
+++ b/source/daemon/crates/wardnetd-data/src/repository/sqlite/maintenance.rs
@@ -52,3 +52,96 @@ impl MaintenanceRepository for SqliteMaintenanceRepository {
         Ok(u64::try_from((before - after).max(0)).unwrap_or(0))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use sqlx::sqlite::{SqliteAutoVacuum, SqliteConnectOptions, SqliteJournalMode};
+    use uuid::Uuid;
+
+    use super::*;
+
+    /// Open a temporary file-backed `SQLite` database with
+    /// `auto_vacuum=INCREMENTAL`. Returns the pool and the path so the
+    /// caller can delete the files after the test.
+    async fn make_incremental_pool() -> (SqlitePool, std::path::PathBuf) {
+        let path = std::env::temp_dir().join(format!(
+            "wardnet_vacuum_test_{}.db",
+            Uuid::new_v4().simple()
+        ));
+        let opts = SqliteConnectOptions::new()
+            .filename(&path)
+            .create_if_missing(true)
+            .journal_mode(SqliteJournalMode::Wal)
+            .auto_vacuum(SqliteAutoVacuum::Incremental);
+        let pool = sqlx::SqlitePool::connect_with(opts)
+            .await
+            .expect("open temp db");
+        (pool, path)
+    }
+
+    /// After a bulk `DELETE`, `PRAGMA freelist_count` must be non-zero and
+    /// `incremental_vacuum` must reclaim at least some of those pages.
+    #[tokio::test]
+    async fn incremental_vacuum_reduces_freelist() {
+        let (pool, path) = make_incremental_pool().await;
+
+        // Create a scratch table and fill it across several pages.
+        // 500 rows × ~200 bytes ≈ 100 KiB > default 4 KiB page, so many
+        // pages land on the freelist after the DELETE below.
+        sqlx::query("CREATE TABLE _vac_scratch (data TEXT NOT NULL)")
+            .execute(&pool)
+            .await
+            .unwrap();
+        let payload = "x".repeat(200);
+        for _ in 0..500 {
+            sqlx::query("INSERT INTO _vac_scratch (data) VALUES (?)")
+                .bind(&payload)
+                .execute(&pool)
+                .await
+                .unwrap();
+        }
+
+        // Delete all rows — pages go to the freelist.
+        sqlx::query("DELETE FROM _vac_scratch")
+            .execute(&pool)
+            .await
+            .unwrap();
+
+        // Checkpoint WAL so freelist pages are reflected in the DB file.
+        sqlx::query("PRAGMA wal_checkpoint(FULL)")
+            .execute(&pool)
+            .await
+            .unwrap();
+
+        let freelist_before: i64 = sqlx::query_scalar("PRAGMA freelist_count")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert!(
+            freelist_before > 0,
+            "expected free pages after bulk DELETE, got {freelist_before}"
+        );
+
+        let repo = SqliteMaintenanceRepository::new(pool.clone());
+        let reclaimed = repo.incremental_vacuum().await.unwrap();
+        assert!(
+            reclaimed > 0,
+            "incremental_vacuum should reclaim pages, got {reclaimed}"
+        );
+
+        let freelist_after: i64 = sqlx::query_scalar("PRAGMA freelist_count")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert!(
+            freelist_after < freelist_before,
+            "freelist should shrink after vacuum: before={freelist_before}, after={freelist_after}"
+        );
+
+        // Tidy up temp files.
+        pool.close().await;
+        let _ = std::fs::remove_file(&path);
+        let _ = std::fs::remove_file(path.with_extension("db-wal"));
+        let _ = std::fs::remove_file(path.with_extension("db-shm"));
+    }
+}

--- a/source/daemon/crates/wardnetd-mock/src/main.rs
+++ b/source/daemon/crates/wardnetd-mock/src/main.rs
@@ -33,6 +33,7 @@ use wardnetd_mock::backends::noop_routing::{NoopFirewallManager, NoopPolicyRoute
 use wardnetd_mock::backends::noop_tunnel::NoopTunnelInterface;
 use wardnetd_mock::events::FakeEventEmitter;
 use wardnetd_mock::seed;
+use wardnetd_services::db_maintenance_runner::DbMaintenanceRunner;
 use wardnetd_services::dns::query_log_runner::DnsQueryLogRunner;
 use wardnetd_services::dns_filter::blocklist_downloader::HttpBlocklistFetcher;
 use wardnetd_services::logging::{
@@ -293,11 +294,12 @@ async fn run(
     let dns_query_log_runner = DnsQueryLogRunner::start(
         services.dns.clone(),
         services.dns_repo.clone(),
-        services.maintenance_repo.clone(),
         services.dns_log_sink.clone(),
         dns_log_persist_rx,
         &tracing::Span::current(),
     );
+    let db_maintenance_runner =
+        DbMaintenanceRunner::start(services.maintenance_repo.clone(), &tracing::Span::current());
 
     // Drain the in-memory stats buffer into stats_intraday so the fake DNS
     // queries emitted by FakeEventEmitter show up in the live stats charts.
@@ -349,6 +351,7 @@ async fn run(
         emitter.shutdown().await;
     }
     dns_query_log_runner.shutdown().await;
+    db_maintenance_runner.shutdown().await;
     stats_flush_runner.shutdown().await;
 
     Ok(())

--- a/source/daemon/crates/wardnetd-services/src/db_maintenance_runner.rs
+++ b/source/daemon/crates/wardnetd-services/src/db_maintenance_runner.rs
@@ -202,9 +202,9 @@ mod tests {
     // -----------------------------------------------------------------------
 
     /// Starting and immediately shutting down the runner must complete without
-    /// panicking. Exercises DbMaintenanceRunner::start → start_with_interval
-    /// → start_with_interval_and_day → shutdown, and the cancel branch of
-    /// runner_loop.
+    /// panicking. Exercises `DbMaintenanceRunner::start` → `start_with_interval`
+    /// → `start_with_interval_and_day` → `shutdown`, and the cancel branch of
+    /// `runner_loop`.
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn runner_shuts_down_cleanly() {
         let repo = MockMaintenance::ok(0);

--- a/source/daemon/crates/wardnetd-services/src/db_maintenance_runner.rs
+++ b/source/daemon/crates/wardnetd-services/src/db_maintenance_runner.rs
@@ -35,17 +35,29 @@ impl DbMaintenanceRunner {
     }
 
     /// Start with a custom tick interval. Tests pass short intervals so they
-    /// can exercise the day-rollover logic without sleeping.
+    /// can exercise the day-rollover logic without sleeping for an hour.
     pub fn start_with_interval(
         maintenance_repo: Arc<dyn MaintenanceRepository>,
         tick_interval: Duration,
+        parent: &tracing::Span,
+    ) -> Self {
+        Self::start_with_interval_and_day(maintenance_repo, tick_interval, today(), parent)
+    }
+
+    /// Internal constructor that accepts an explicit initial day so tests can
+    /// set yesterday's date and have the first tick immediately fire a vacuum.
+    fn start_with_interval_and_day(
+        maintenance_repo: Arc<dyn MaintenanceRepository>,
+        tick_interval: Duration,
+        initial_day: chrono::NaiveDate,
         parent: &tracing::Span,
     ) -> Self {
         let cancel = CancellationToken::new();
         let span = tracing::info_span!(parent: parent, "db_maintenance_runner");
 
         let handle = tokio::spawn(
-            runner_loop(maintenance_repo, tick_interval, cancel.clone()).instrument(span),
+            runner_loop(maintenance_repo, tick_interval, cancel.clone(), initial_day)
+                .instrument(span),
         );
 
         Self { cancel, handle }
@@ -63,12 +75,13 @@ async fn runner_loop(
     maintenance_repo: Arc<dyn MaintenanceRepository>,
     tick_interval: Duration,
     cancel: CancellationToken,
+    initial_day: chrono::NaiveDate,
 ) {
     let mut ticker = tokio::time::interval(tick_interval);
     ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
     ticker.tick().await; // skip the immediate first tick
 
-    let mut last_vacuum_day = today();
+    let mut last_vacuum_day = initial_day;
 
     loop {
         tokio::select! {
@@ -87,7 +100,7 @@ async fn runner_loop(
     }
 }
 
-async fn run_vacuum(maintenance_repo: &dyn MaintenanceRepository) {
+pub(crate) async fn run_vacuum(maintenance_repo: &dyn MaintenanceRepository) {
     match maintenance_repo.incremental_vacuum().await {
         Ok(reclaimed) if reclaimed > 0 => {
             tracing::info!(
@@ -105,4 +118,144 @@ async fn run_vacuum(maintenance_repo: &dyn MaintenanceRepository) {
 
 fn today() -> chrono::NaiveDate {
     chrono::Utc::now().date_naive()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+    use std::sync::Mutex;
+    use std::time::Duration;
+
+    use async_trait::async_trait;
+
+    use wardnetd_data::repository::MaintenanceRepository;
+
+    use super::{DbMaintenanceRunner, run_vacuum};
+
+    // -----------------------------------------------------------------------
+    // Mock maintenance repository
+    // -----------------------------------------------------------------------
+
+    struct MockMaintenance {
+        result: anyhow::Result<u64>,
+        calls: Mutex<u32>,
+    }
+
+    impl MockMaintenance {
+        fn ok(reclaimed: u64) -> Arc<Self> {
+            Arc::new(Self {
+                result: Ok(reclaimed),
+                calls: Mutex::new(0),
+            })
+        }
+
+        fn err() -> Arc<Self> {
+            Arc::new(Self {
+                result: Err(anyhow::anyhow!("synthetic vacuum error")),
+                calls: Mutex::new(0),
+            })
+        }
+
+        fn call_count(&self) -> u32 {
+            *self.calls.lock().unwrap()
+        }
+    }
+
+    #[async_trait]
+    impl MaintenanceRepository for MockMaintenance {
+        async fn incremental_vacuum(&self) -> anyhow::Result<u64> {
+            *self.calls.lock().unwrap() += 1;
+            match &self.result {
+                Ok(n) => Ok(*n),
+                Err(e) => Err(anyhow::anyhow!("{e}")),
+            }
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // run_vacuum unit tests — cover all three match arms
+    // -----------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn run_vacuum_logs_when_pages_reclaimed() {
+        let repo = MockMaintenance::ok(42);
+        run_vacuum(repo.as_ref()).await;
+        assert_eq!(repo.call_count(), 1);
+    }
+
+    #[tokio::test]
+    async fn run_vacuum_silent_when_nothing_reclaimed() {
+        let repo = MockMaintenance::ok(0);
+        run_vacuum(repo.as_ref()).await;
+        assert_eq!(repo.call_count(), 1);
+    }
+
+    #[tokio::test]
+    async fn run_vacuum_warns_and_does_not_panic_on_error() {
+        let repo = MockMaintenance::err();
+        run_vacuum(repo.as_ref()).await; // must not panic
+        assert_eq!(repo.call_count(), 1);
+    }
+
+    // -----------------------------------------------------------------------
+    // Runner integration tests
+    // -----------------------------------------------------------------------
+
+    /// Starting and immediately shutting down the runner must complete without
+    /// panicking. Exercises DbMaintenanceRunner::start → start_with_interval
+    /// → start_with_interval_and_day → shutdown, and the cancel branch of
+    /// runner_loop.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn runner_shuts_down_cleanly() {
+        let repo = MockMaintenance::ok(0);
+        let runner = DbMaintenanceRunner::start(repo.clone(), &tracing::Span::none());
+        runner.shutdown().await;
+    }
+
+    /// When the runner is started with yesterday's date as the initial day,
+    /// the very first tick (after a short interval) crosses the day boundary
+    /// and fires a vacuum.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn runner_fires_vacuum_on_day_rollover() {
+        let repo = MockMaintenance::ok(5);
+        let yesterday = chrono::Utc::now().date_naive() - chrono::Days::new(1);
+
+        let runner = DbMaintenanceRunner::start_with_interval_and_day(
+            repo.clone(),
+            Duration::from_millis(20),
+            yesterday,
+            &tracing::Span::none(),
+        );
+
+        // Give the ticker enough time to fire at least once.
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        runner.shutdown().await;
+
+        assert!(
+            repo.call_count() >= 1,
+            "expected vacuum to fire on day rollover, call_count={}",
+            repo.call_count()
+        );
+    }
+
+    /// When the initial day is today, ticks must not fire a vacuum.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn runner_skips_vacuum_when_same_day() {
+        let repo = MockMaintenance::ok(0);
+
+        let runner = DbMaintenanceRunner::start_with_interval(
+            repo.clone(),
+            Duration::from_millis(20),
+            &tracing::Span::none(),
+        );
+
+        tokio::time::sleep(Duration::from_millis(80)).await;
+        runner.shutdown().await;
+
+        assert_eq!(
+            repo.call_count(),
+            0,
+            "vacuum must not fire when the day has not rolled over"
+        );
+    }
 }

--- a/source/daemon/crates/wardnetd-services/src/db_maintenance_runner.rs
+++ b/source/daemon/crates/wardnetd-services/src/db_maintenance_runner.rs
@@ -1,0 +1,108 @@
+//! Daily database-maintenance runner.
+//!
+//! Calls [`MaintenanceRepository::incremental_vacuum`] once per calendar day
+//! to return freed `SQLite` pages to the filesystem. Fires independently of
+//! any domain-level feature flag so it benefits **all** retention-driven
+//! tables (DNS query log, future event logs, audit trails), not just the ones
+//! whose per-feature runner happens to be active.
+//!
+//! The daily cadence is enforced by checking the calendar date on every hourly
+//! tick rather than sleeping for 24 hours, so the runner stays responsive to
+//! cancellation without a 24-hour drain delay.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use tokio_util::sync::CancellationToken;
+use tracing::Instrument;
+
+use wardnetd_data::repository::MaintenanceRepository;
+
+/// How often the runner wakes to check whether a day has rolled over.
+pub const TICK_INTERVAL: Duration = Duration::from_hours(1);
+
+/// Background task that runs [`MaintenanceRepository::incremental_vacuum`]
+/// once per calendar day.
+pub struct DbMaintenanceRunner {
+    cancel: CancellationToken,
+    handle: tokio::task::JoinHandle<()>,
+}
+
+impl DbMaintenanceRunner {
+    /// Start with the default hourly tick. Production entry point.
+    pub fn start(maintenance_repo: Arc<dyn MaintenanceRepository>, parent: &tracing::Span) -> Self {
+        Self::start_with_interval(maintenance_repo, TICK_INTERVAL, parent)
+    }
+
+    /// Start with a custom tick interval. Tests pass short intervals so they
+    /// can exercise the day-rollover logic without sleeping.
+    pub fn start_with_interval(
+        maintenance_repo: Arc<dyn MaintenanceRepository>,
+        tick_interval: Duration,
+        parent: &tracing::Span,
+    ) -> Self {
+        let cancel = CancellationToken::new();
+        let span = tracing::info_span!(parent: parent, "db_maintenance_runner");
+
+        let handle = tokio::spawn(
+            runner_loop(maintenance_repo, tick_interval, cancel.clone()).instrument(span),
+        );
+
+        Self { cancel, handle }
+    }
+
+    /// Cancel the runner and wait for it to stop.
+    pub async fn shutdown(self) {
+        self.cancel.cancel();
+        let _ = self.handle.await;
+        tracing::info!("DB maintenance runner shut down");
+    }
+}
+
+async fn runner_loop(
+    maintenance_repo: Arc<dyn MaintenanceRepository>,
+    tick_interval: Duration,
+    cancel: CancellationToken,
+) {
+    let mut ticker = tokio::time::interval(tick_interval);
+    ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+    ticker.tick().await; // skip the immediate first tick
+
+    let mut last_vacuum_day = today();
+
+    loop {
+        tokio::select! {
+            () = cancel.cancelled() => {
+                tracing::info!("DB maintenance runner cancellation received");
+                break;
+            }
+            _ = ticker.tick() => {
+                let today_now = today();
+                if today_now != last_vacuum_day {
+                    last_vacuum_day = today_now;
+                    run_vacuum(maintenance_repo.as_ref()).await;
+                }
+            }
+        }
+    }
+}
+
+async fn run_vacuum(maintenance_repo: &dyn MaintenanceRepository) {
+    match maintenance_repo.incremental_vacuum().await {
+        Ok(reclaimed) if reclaimed > 0 => {
+            tracing::info!(
+                reclaimed_pages = reclaimed,
+                "incremental vacuum reclaimed pages: reclaimed_pages={reclaimed}",
+                reclaimed = reclaimed,
+            );
+        }
+        Ok(_) => {}
+        Err(e) => {
+            tracing::warn!(error = %e, "incremental vacuum failed: {e}");
+        }
+    }
+}
+
+fn today() -> chrono::NaiveDate {
+    chrono::Utc::now().date_naive()
+}

--- a/source/daemon/crates/wardnetd-services/src/dns/query_log_runner.rs
+++ b/source/daemon/crates/wardnetd-services/src/dns/query_log_runner.rs
@@ -7,12 +7,15 @@
 //!   whichever fires first, into a single transactional insert.
 //! - Once per day (configurable in tests via the constructor), runs
 //!   `DnsRepository::cleanup_query_log(retention_days)` to enforce
-//!   retention. VACUUM is intentionally out of scope.
+//!   retention.
 //! - Honors `query_log_enabled = false` by draining the channel into
 //!   the void: still consumes (so the producer never blocks) but skips
 //!   the insert. Broadcast streaming is independent and untouched.
 //! - If [`DnsLogSink::take_dropped`] is non-zero, logs at `warn!` no
 //!   more than once per [`DROPPED_REPORT_INTERVAL`].
+//!
+//! Incremental vacuum is handled by [`crate::db_maintenance_runner::DbMaintenanceRunner`],
+//! which fires independently of the DNS query-log feature flag.
 
 use std::sync::Arc;
 use std::time::{Duration, Instant};
@@ -27,7 +30,7 @@ use crate::DnsService;
 use crate::auth_context;
 use crate::db_busy::retry_on_busy;
 use crate::dns::log_sink::DnsLogSink;
-use wardnetd_data::repository::{DnsRepository, MaintenanceRepository, QueryLogRow};
+use wardnetd_data::repository::{DnsRepository, QueryLogRow};
 
 /// Maximum entries flushed in a single insert batch.
 pub const BATCH_MAX: usize = 256;
@@ -62,7 +65,6 @@ impl DnsQueryLogRunner {
     pub fn start(
         service: Arc<dyn DnsService>,
         dns_repo: Arc<dyn DnsRepository>,
-        maintenance_repo: Arc<dyn MaintenanceRepository>,
         sink: Arc<DnsLogSink>,
         rx: mpsc::Receiver<QueryLogRow>,
         parent: &tracing::Span,
@@ -70,7 +72,6 @@ impl DnsQueryLogRunner {
         Self::start_with_intervals(
             service,
             dns_repo,
-            maintenance_repo,
             sink,
             rx,
             BATCH_INTERVAL,
@@ -82,11 +83,9 @@ impl DnsQueryLogRunner {
     /// Start the runner with custom flush + cleanup tick intervals.
     /// Production callers use [`Self::start`]; tests pass shorter
     /// intervals to exercise the loop without waiting.
-    #[allow(clippy::too_many_arguments)]
     pub fn start_with_intervals(
         service: Arc<dyn DnsService>,
         dns_repo: Arc<dyn DnsRepository>,
-        maintenance_repo: Arc<dyn MaintenanceRepository>,
         sink: Arc<DnsLogSink>,
         rx: mpsc::Receiver<QueryLogRow>,
         batch_interval: Duration,
@@ -100,7 +99,6 @@ impl DnsQueryLogRunner {
             runner_loop(
                 service,
                 dns_repo,
-                maintenance_repo,
                 sink,
                 rx,
                 batch_interval,
@@ -121,11 +119,9 @@ impl DnsQueryLogRunner {
     }
 }
 
-#[allow(clippy::too_many_arguments)]
 async fn runner_loop(
     service: Arc<dyn DnsService>,
     dns_repo: Arc<dyn DnsRepository>,
-    maintenance_repo: Arc<dyn MaintenanceRepository>,
     sink: Arc<DnsLogSink>,
     mut rx: mpsc::Receiver<QueryLogRow>,
     batch_interval: Duration,
@@ -183,13 +179,7 @@ async fn runner_loop(
                 let today_now = today();
                 if today_now != last_cleanup_day {
                     last_cleanup_day = today_now;
-                    cleanup(
-                        &service,
-                        dns_repo.as_ref(),
-                        maintenance_repo.as_ref(),
-                        &admin_ctx,
-                    )
-                    .await;
+                    cleanup(&service, dns_repo.as_ref(), &admin_ctx).await;
                 }
             }
         }
@@ -274,7 +264,6 @@ pub(crate) async fn flush(
 pub(crate) async fn cleanup(
     service: &Arc<dyn DnsService>,
     dns_repo: &dyn DnsRepository,
-    maintenance_repo: &dyn MaintenanceRepository,
     admin_ctx: &AuthContext,
 ) {
     let cfg = match auth_context::with_context(admin_ctx.clone(), service.get_dns_config()).await {
@@ -300,26 +289,6 @@ pub(crate) async fn cleanup(
                 deleted = deleted,
                 retention_days = retention,
             );
-            // Release the freelist back to the filesystem so the
-            // 7-day-retention envelope translates into a steady-state
-            // DB file size instead of monotonic growth. Only meaningful
-            // on databases with `auto_vacuum=INCREMENTAL`; a no-op
-            // elsewhere. Bounded per call so it can't monopolise the
-            // writer lock — leftover free pages get picked up on
-            // subsequent cleanup ticks.
-            match maintenance_repo.incremental_vacuum().await {
-                Ok(reclaimed) if reclaimed > 0 => {
-                    tracing::info!(
-                        reclaimed_pages = reclaimed,
-                        "incremental vacuum reclaimed pages: reclaimed_pages={reclaimed}",
-                        reclaimed = reclaimed,
-                    );
-                }
-                Ok(_) => {}
-                Err(e) => {
-                    tracing::warn!(error = %e, "incremental vacuum failed: {e}");
-                }
-            }
         }
         Err(e) => {
             tracing::error!(error = %e, "DNS query log cleanup failed: {e}");

--- a/source/daemon/crates/wardnetd-services/src/dns/tests/query_log_runner.rs
+++ b/source/daemon/crates/wardnetd-services/src/dns/tests/query_log_runner.rs
@@ -14,9 +14,7 @@ use wardnet_common::api::{
 };
 use wardnet_common::auth::AuthContext;
 use wardnet_common::dns::{DnsConfig, DnsResolutionMode};
-use wardnetd_data::repository::{
-    DnsRepository, MaintenanceRepository, QueryLogFilter, QueryLogRow,
-};
+use wardnetd_data::repository::{DnsRepository, QueryLogFilter, QueryLogRow};
 
 use crate::DnsService;
 use crate::dns::log_sink::DnsLogSink;
@@ -112,23 +110,6 @@ impl DnsRepository for RecordingRepo {
     }
 }
 
-/// Mock maintenance repo — records how many times `incremental_vacuum`
-/// was called so future cleanup-path tests can assert the post-cleanup
-/// hook fired.
-#[derive(Default)]
-struct RecordingMaintenance {
-    #[allow(dead_code)]
-    vacuums: Mutex<u32>,
-}
-
-#[async_trait]
-impl MaintenanceRepository for RecordingMaintenance {
-    async fn incremental_vacuum(&self) -> anyhow::Result<u64> {
-        *self.vacuums.lock().unwrap() += 1;
-        Ok(0)
-    }
-}
-
 fn sample_row() -> QueryLogRow {
     QueryLogRow {
         timestamp: "2026-05-05T00:00:00Z".to_owned(),
@@ -151,7 +132,6 @@ async fn runner_flushes_buffered_rows_when_enabled() {
     let runner = DnsQueryLogRunner::start_with_intervals(
         service,
         repo.clone(),
-        Arc::new(RecordingMaintenance::default()),
         sink.clone(),
         rx,
         Duration::from_millis(50),
@@ -177,7 +157,6 @@ async fn runner_drains_into_void_when_disabled() {
     let runner = DnsQueryLogRunner::start_with_intervals(
         service,
         repo.clone(),
-        Arc::new(RecordingMaintenance::default()),
         sink.clone(),
         rx,
         Duration::from_millis(50),
@@ -204,7 +183,6 @@ async fn runner_drains_remaining_on_shutdown() {
     let runner = DnsQueryLogRunner::start_with_intervals(
         service,
         repo.clone(),
-        Arc::new(RecordingMaintenance::default()),
         sink.clone(),
         rx,
         Duration::from_mins(1),
@@ -335,8 +313,7 @@ async fn cleanup_runs_when_enabled() {
     let admin_ctx = AuthContext::Admin {
         admin_id: Uuid::nil(),
     };
-    let maintenance = RecordingMaintenance::default();
-    crate::dns::query_log_runner::cleanup(&service, &repo, &maintenance, &admin_ctx).await;
+    crate::dns::query_log_runner::cleanup(&service, &repo, &admin_ctx).await;
     let calls = repo.cleanups.lock().unwrap().clone();
     assert_eq!(calls.len(), 1);
     assert_eq!(calls[0], 7);
@@ -349,7 +326,6 @@ async fn cleanup_skips_when_disabled() {
     let admin_ctx = AuthContext::Admin {
         admin_id: Uuid::nil(),
     };
-    let maintenance = RecordingMaintenance::default();
-    crate::dns::query_log_runner::cleanup(&service, &repo, &maintenance, &admin_ctx).await;
+    crate::dns::query_log_runner::cleanup(&service, &repo, &admin_ctx).await;
     assert!(repo.cleanups.lock().unwrap().is_empty());
 }

--- a/source/daemon/crates/wardnetd-services/src/dns/tests/query_log_runner.rs
+++ b/source/daemon/crates/wardnetd-services/src/dns/tests/query_log_runner.rs
@@ -214,6 +214,31 @@ async fn flush_no_op_on_empty_buffer() {
     assert!(repo.inserts.lock().unwrap().is_empty());
 }
 
+/// Repo whose `cleanup_query_log` always returns Err — exercises the error
+/// branch of [`crate::dns::query_log_runner::cleanup`].
+struct CleanupFailingRepo;
+
+#[async_trait]
+impl DnsRepository for CleanupFailingRepo {
+    async fn insert_query_log_batch(&self, _entries: &[QueryLogRow]) -> anyhow::Result<()> {
+        Ok(())
+    }
+    async fn query_log_paginated(
+        &self,
+        _limit: u32,
+        _offset: u32,
+        _filter: &QueryLogFilter,
+    ) -> anyhow::Result<Vec<QueryLogRow>> {
+        Ok(Vec::new())
+    }
+    async fn query_log_count(&self, _filter: &QueryLogFilter) -> anyhow::Result<u64> {
+        Ok(0)
+    }
+    async fn cleanup_query_log(&self, _retention_days: u32) -> anyhow::Result<u64> {
+        Err(anyhow::anyhow!("synthetic cleanup failure"))
+    }
+}
+
 /// Repo whose `insert_query_log_batch` always returns Err.
 struct InsertFailingRepo;
 
@@ -328,4 +353,15 @@ async fn cleanup_skips_when_disabled() {
     };
     crate::dns::query_log_runner::cleanup(&service, &repo, &admin_ctx).await;
     assert!(repo.cleanups.lock().unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn cleanup_logs_error_on_repo_failure() {
+    let service: Arc<dyn DnsService> = Arc::new(MockService { enabled: true });
+    let repo = CleanupFailingRepo;
+    let admin_ctx = AuthContext::Admin {
+        admin_id: Uuid::nil(),
+    };
+    // Must not panic — the error is logged and swallowed.
+    crate::dns::query_log_runner::cleanup(&service, &repo, &admin_ctx).await;
 }

--- a/source/daemon/crates/wardnetd-services/src/lib.rs
+++ b/source/daemon/crates/wardnetd-services/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod auth_context;
 pub mod command;
 pub mod db_busy;
+pub mod db_maintenance_runner;
 pub mod error;
 pub mod event;
 pub mod jobs;

--- a/source/daemon/crates/wardnetd/src/main.rs
+++ b/source/daemon/crates/wardnetd/src/main.rs
@@ -40,6 +40,7 @@ use wardnetd::tunnel_interface_wireguard::WireGuardTunnelInterface;
 use wardnetd::tunnel_latency_prober::SurgePingTunnelLatencyProber;
 use wardnetd::tunnel_monitor::TunnelMonitor;
 use wardnetd_api::state::AppState;
+use wardnetd_services::db_maintenance_runner::DbMaintenanceRunner;
 use wardnetd_services::dhcp::runner::DhcpRunner;
 use wardnetd_services::dns::query_log_runner::DnsQueryLogRunner;
 use wardnetd_services::dns::runner::DnsRunner;
@@ -495,11 +496,15 @@ async fn run(
     let dns_query_log_runner = DnsQueryLogRunner::start(
         services.dns.clone(),
         services.dns_repo.clone(),
-        services.maintenance_repo.clone(),
         services.dns_log_sink.clone(),
         dns_log_persist_rx,
         &root_span,
     );
+
+    // Return freed SQLite pages to the filesystem once per day — fires
+    // regardless of any per-feature flag so it covers all tables.
+    let db_maintenance_runner =
+        DbMaintenanceRunner::start(services.maintenance_repo.clone(), &root_span);
 
     // Start the auto-update poller. An initial check runs immediately; then
     // every `check_interval_secs` with ±10% jitter.
@@ -615,6 +620,7 @@ async fn run(
     dns_runner.shutdown().await;
     dns_filter_runner.shutdown().await;
     dns_query_log_runner.shutdown().await;
+    db_maintenance_runner.shutdown().await;
     update_runner.shutdown().await;
     backup_cleanup_runner.shutdown().await;
     stats_flush_runner.shutdown().await;


### PR DESCRIPTION
Closes #322.

## What

Finishes the remaining gaps from the issue plan:

### 1. Standalone `DbMaintenanceRunner` (new)
`wardnetd-services/src/db_maintenance_runner.rs` — fires `incremental_vacuum` once per calendar day using the same hourly-tick / day-rollover pattern as `DnsQueryLogRunner`. Crucially it runs **regardless of any feature flag**, so it covers all retention-driven tables (DNS query log, future event logs, audit trails), not just the DNS path.

### 2. Remove vacuum from `DnsQueryLogRunner`
The previous coupling was wrong: if DNS query logging was disabled, vacuum never fired. `maintenance_repo` has been removed from `DnsQueryLogRunner::start()`, `start_with_intervals()`, `runner_loop()`, and `cleanup()`. The stale `// VACUUM is intentionally out of scope` comment is replaced with a pointer to the new runner.

### 3. Wired into both binaries + shutdown sequences
`wardnetd` and `wardnetd-mock` both start `DbMaintenanceRunner` and call `shutdown().await` on it.

### 4. `incremental_vacuum_reduces_freelist` test
Opens a temp file SQLite DB with `auto_vacuum=INCREMENTAL`, inserts 500 rows (~100 KiB), deletes them all, checkpoints the WAL, then asserts that `freelist_count` decreases after `incremental_vacuum()`.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)