### PR TITLE
docs: PWA initiative — domain glossary and agent doc updates

### DIFF
--- a/.agents/project-structure.md
+++ b/.agents/project-structure.md
@@ -81,7 +81,8 @@ source/
 │           ├── client.ts            # WardnetClient base HTTP client
 │           ├── services/            # AuthService, DeviceService, TunnelService, ProviderService, SystemService, SetupService, InfoService, BackupService, UpdateService
 │           └── types/               # TypeScript type definitions (mirrors daemon API)
-├── web-ui/                          # React + TypeScript frontend
+├── admin-site/                      # PLANNED (issue #437): rename of web-ui/ — full desktop admin (not a PWA)
+├── web-ui/                          # React + TypeScript frontend (to be renamed admin-site — see issue #437)
 │   └── src/
 │       ├── components/
 │       │   ├── core/ui/             # shadcn/ui components (Button, Card, Sheet, Dialog, Select, Tabs, Switch, etc.)
@@ -92,6 +93,9 @@ source/
 │       ├── stores/                  # Zustand stores (authStore)
 │       ├── pages/                   # Route pages (Dashboard, Devices, Tunnels, Settings, Login, Setup, MyDevice)
 │       └── lib/                     # SDK instance (sdk.ts), utilities (cn, formatBytes, formatUptime, timeAgo)
+├── user-app/                        # PLANNED (issue #438): user PWA — self-service for non-admin household members; served at /
+├── admin-app/                       # PLANNED (issue #439): admin mobile PWA — daily operational tasks; served at /admin-app/
+├── web-lib/                         # PLANNED (issue #437): shared component library used by all three app surfaces
 └── site/                            # Public documentation + marketing site (Vite + React)
     ├── content/docs/                # Markdown articles served by DocsArticle.tsx
     ├── content/docs.yml             # Topic catalogue driving /docs

--- a/.agents/technical-stack.md
+++ b/.agents/technical-stack.md
@@ -33,3 +33,10 @@
 - Same stack as the web UI (React 19 + Vite + Tailwind 4)
 - Docs are plain markdown under `source/site/content/docs/`, rendered via `react-markdown` + `remark-gfm` with custom component mappings in `DocsArticle.tsx`
 - Topic catalogue in `source/site/content/docs.yml` (loaded via `@modyfi/vite-plugin-yaml`)
+
+## Planned infrastructure (PWA initiative — issues #435–#441)
+
+- **Caddy** — reverse proxy bundled in the release tarball alongside `wardnetd`. Runs as a companion systemd service. Handles TLS termination on port 443 and forwards to the daemon on port 7411. The daemon manages the Caddyfile on startup. See issue #436.
+- **DDNS + ACME bridge service** — wardnet-operated service assigning each install a subdomain (`<id>.wardnet.network`) and acting as ACME bridge for Let's Encrypt DNS-01 challenges. The cert private key is generated on the Pi and never leaves it. See issue #435.
+- **VAPID / Web Push** — daemon-side push notification support (VAPID key pair generated at setup, subscription records keyed to device MAC or admin session). See issue #440.
+- **Three app surfaces** — admin site (desktop, at `/admin/`), user PWA (at `/`), admin mobile PWA (at `/admin-app/`). All served from a single origin; independently installable via distinct `manifest.json` scopes. See `CONTEXT.md` for the full glossary and issues #437–#439 for implementation.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,3 +54,12 @@ you're about to make, rather than the whole set.
 - **[Workflow](.agents/workflow.md)** — git conventions,
   mandatory pre-push checklist, coverage rules, and the
   always/ask/never boundaries.
+
+## Domain glossary
+
+[`CONTEXT.md`](CONTEXT.md) is the canonical glossary for domain terms used
+across issues, design docs, and code comments. It covers the three app
+surfaces (admin site, user PWA, admin mobile PWA), identity model
+(device-keyed vs admin-session), infrastructure (DDNS service, Caddy,
+path-based routing), and planned features (route verification, VAPID push).
+Read it before working on any of the PWA initiative issues (#435–#441).

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,41 +1,31 @@
 # Wardnet Domain Glossary
 
-## Chart infrastructure (admin UI)
+## Surfaces
 
-**StatsRange**
-The unified time-window discriminant used across every stats chart and data-fetching hook: `"1h" | "12h" | "24h" | "7d" | "12mo"`. Defined in `hooks/useStats.ts` alongside the companion `RANGE_HOURS` map (range → numeric hours). All chart components accept `StatsRange`; the legacy per-hook range aliases have been removed.
+**Admin site** — The full desktop web admin. Served at `<id>.wardnet.network/admin/`. Not a PWA; intended for desktop use only. Previously named `admin-app` in source; renamed to `admin-site`.
 
-**RANGE_HOURS**
-A `Record<StatsRange, number>` that maps each range string to its equivalent in hours. Used by chart `XAxis` tick formatters to select the appropriate date/time representation: HH:MM for ≤24 h, "Jan 5 14:00" for ≤168 h, and "Jan 5" for longer ranges.
+**User PWA** — Installable mobile app for non-admin household members. Served at `<id>.wardnet.network/`. Scope: self-service only (own device routing, own DNS stats, own connection status). Cannot manage other devices.
 
-**ZoomRange**
-An inclusive index window into a sorted dataset: `{ startIndex: number; endIndex: number }`. Both indices refer to positions in the *unzoomed* data array. Exported from `hooks/useChartZoom.ts`.
+**Admin mobile PWA** — Installable mobile app for admins. Served at `<id>.wardnet.network/admin-app/`. Scope: daily operational tasks (device management, tunnel status, power actions). Not a replacement for the admin site; configuration work (DHCP, filter profiles, tunnel creation) stays on the desktop.
 
-**useChartZoom**
-React hook that owns drag-to-zoom behaviour for a Recharts time-series chart. Accepts `{ length, datasetKey, zoom, onZoomChange }` and returns `{ chartProps, previewRange, isZoomed, reset }`.
+## Identity and access
 
-- `chartProps` — Recharts mouse-event handlers (`onMouseDown / onMouseMove / onMouseUp / onMouseLeave`); spread directly onto the Recharts root element (`<AreaChart>`, `<LineChart>`, etc.).
-- `previewRange` — live `ZoomRange | null` during an active drag; render as a `<ReferenceArea>` so the user sees the pending window.
-- `isZoomed` — `true` when a committed zoom selection is narrower than the full dataset.
-- `reset` — clears the committed zoom (calls `onZoomChange(null)`).
+**Device-keyed** — Identified by MAC address / LAN IP. Non-admin users have no credentials; their identity is their device on the network. Push subscriptions and self-service routing rules are device-keyed.
 
-**datasetKey**
-A string that uniquely identifies the current dataset snapshot, e.g. `"24h|143"` (range + point count). Passed to `useChartZoom`; when it changes, any in-flight drag is automatically discarded without an extra `useEffect`. Prevents stale indices from a previous data fetch being committed as a zoom selection.
+**Admin session** — Credential-based (username + password). Required for any admin surface. Push subscriptions on the admin mobile PWA are admin-session-keyed.
 
-**ZoomableChartContainer**
-A compound component at `components/compound/ZoomableChartContainer.tsx` that wraps shadcn's `ChartContainer` and renders an overlaid "Reset zoom" ghost button when `isZoomed` is true. The chart's Recharts event wiring (`chartProps`) stays on the caller — `ZoomableChartContainer` only handles the visual container and reset affordance. Replaces bare `<ChartContainer>` on all interactive stats charts.
+**Admin lock** — Flag set by an admin on a device that prevents the device owner from changing their own routing rule. Read-only state visible in the user PWA.
 
-**applyZoom**
-Pure helper exported from `hooks/useChartZoom.ts`. Slices a data array down to the `ZoomRange` window (`data.slice(start, end + 1)`). Keep calls inside a `useMemo` alongside other per-chart derived values.
+## Features
 
-**Lifted zoom state**
-When two or more charts on the same page share a time window (e.g. tunnel throughput + latency on `TunnelDetail`), the `zoom: ZoomRange | null` state is lifted to the parent and passed down as props. Each chart receives the same `zoom` and `onZoomChange`; they share one `useChartZoom` call or each call `useChartZoom` with the same `zoom`/`onZoomChange`. Single-chart sections (e.g. `DnsStatsSection`) own their zoom locally.
+**Route verification** — User PWA feature. Makes a client-side request to an external IP geolocation API to show the device's current public IP and inferred country/location. Used to confirm that a VPN routing rule is working as intended. Client-side call is correct: the browser request travels through the Pi's per-device routing, so the result reflects the device's actual egress path.
 
-**useTunnelStats**
-Hook at `hooks/useTunnelStats.ts`. Fetches `tunnel.bytes.tx`, `tunnel.bytes.rx`, and `tunnel.latency.rtt_ms` for a single tunnel via `StatsService.queryMulti` with `label_filter = {"tunnel_id":"<uuid>"}`. Returns `TunnelStatsData { points: TunnelStatsPoint[]; bucketSecs: number; range: StatsRange }`. The parent (`TunnelDetail`) makes a single call and fans the result out to both `TunnelThroughputChart` and `TunnelLatencyChart`.
+**Device-keyed push subscription** — A Web Push subscription (VAPID) stored in the daemon's database keyed to a device record (MAC/IP). Allows the daemon to notify a specific device's browser even when the PWA is not open.
 
-**TunnelStatsData / TunnelStatsPoint**
-The shape returned by `useTunnelStats`. Each point carries `{ ts: string; bytesTx: number; bytesRx: number; rttMs: number | null }`. `rttMs` is nullable because the latency probe may not have run yet for a given bucket.
+## Infrastructure
 
-**label_filter (StatsQuery)**
-An exact-match filter on the `labels` JSON column in `stats_intraday` / `stats_hourly` / `stats_daily`. Passed as a JSON string (e.g. `'{"tunnel_id":"<uuid>"}'`) to scope a query to a single resource. No partial/single-key match — the full sorted-keys JSON object must match.
+**DDNS service** — Wardnet-operated service that assigns each installation a unique subdomain (`<install-id>.wardnet.network`) and manages DNS records for it. Also acts as an ACME bridge: handles `_acme-challenge` TXT records on behalf of the Pi so Let's Encrypt can issue a certificate via DNS-01 without the user needing a domain or DNS provider credentials. The cert private key is generated on the Pi and never leaves it.
+
+**Path-based app routing** — All three surfaces are served from a single domain (`<id>.wardnet.network`) at different paths (`/`, `/admin-app/`, `/admin/`). Each PWA has its own `manifest.json` with a distinct `scope` and `start_url`, making them independently installable despite sharing an origin.
+
+**Caddy** — Reverse proxy bundled in the wardnet release tarball alongside `wardnetd`. Runs as a companion systemd service. Handles TLS termination on port 443, certificate provisioning via Let's Encrypt DNS-01 (using the wardnet DDNS service as the ACME bridge), and forwards all traffic to the daemon on port 7411. The daemon manages the Caddyfile on startup and config changes.


### PR DESCRIPTION
## Summary

- Adds `CONTEXT.md` at the repo root with a domain glossary for the PWA initiative — three app surfaces, auth model, route verification rationale, DDNS service, and path-based routing decisions
- Updates `AGENTS.md` to point agents to the new glossary before working on PWA initiative tasks
- Annotates `.agents/project-structure.md` with planned package locations (`admin-site`, `user-app`, `admin-app`, `web-lib`) marked `PLANNED` with issue numbers, so agents don't invent locations for new code
- Adds a planned-infrastructure section to `.agents/technical-stack.md` covering Caddy (#436), DDNS + ACME bridge (#435), VAPID/Web Push (#440), and the three-surface app model (#437–#441)

## Related issues

Umbrella: #441
Sub-issues: #435 #436 #437 #438 #439 #440