### PR TITLE
feat(tunnel): re-resolve NordVPN best server at tunnel bring-up (issue #80)

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -13226,6 +13226,18 @@
           }
         }
       },
+      "BestServerSelector": {
+        "type": "object",
+        "description": "Selector persisted when a tunnel was created via country-scoped auto-select.\nPresent only on \"best server\" tunnels; `None` for specific-server or manual.",
+        "required": [
+          "country"
+        ],
+        "properties": {
+          "country": {
+            "type": "string"
+          }
+        }
+      },
       "Blocklist": {
         "type": "object",
         "description": "A URL-sourced domain blocklist scoped to a DNS filter profile.",
@@ -13574,6 +13586,24 @@
             "type": [
               "string",
               "null"
+            ]
+          },
+          "resolved_server_name": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Human-readable name of the server resolved at creation time."
+          },
+          "server_selector": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/BestServerSelector",
+                "description": "Set when the tunnel was created via country-scoped auto-select."
+              }
             ]
           }
         }
@@ -15981,6 +16011,14 @@
           "endpoint": {
             "type": "string"
           },
+          "endpoint_resolved_at": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "date-time",
+            "description": "ISO 8601 timestamp of the last endpoint re-resolution."
+          },
           "id": {
             "type": "string",
             "format": "uuid"
@@ -16006,6 +16044,24 @@
             "type": [
               "string",
               "null"
+            ]
+          },
+          "resolved_server_name": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Human-readable name of the last resolved server (e.g. \"United States #8395\")."
+          },
+          "server_selector": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/BestServerSelector",
+                "description": "Set when the tunnel was created via country-scoped auto-select (\"best server\").\n`None` for specific-server or manually imported tunnels."
+              }
             ]
           },
           "status": {

--- a/source/admin-app/web/src/components/compound/TunnelCard.tsx
+++ b/source/admin-app/web/src/components/compound/TunnelCard.tsx
@@ -115,6 +115,14 @@ export function TunnelCard({ tunnel, providers, onDelete }: TunnelCardProps) {
                 {flag}
               </div>
             )}
+            {tunnel.server_selector && (
+              <span
+                className="rounded-sm bg-sunken px-1.5 py-0.5 text-[10px] font-medium text-ink-3"
+                aria-label={`Auto-selected best server in ${tunnel.server_selector.country.toUpperCase()}`}
+              >
+                Best {tunnel.server_selector.country.toUpperCase()}
+              </span>
+            )}
             <div className="spacer" />
             <StatusBadge tone={statusTone(tunnel.status)} title={statusTooltip(tunnel)}>
               <span className="dot" />

--- a/source/admin-app/web/src/components/features/ProviderTunnelTab.tsx
+++ b/source/admin-app/web/src/components/features/ProviderTunnelTab.tsx
@@ -306,7 +306,7 @@ export function ProviderTunnelTab({ onSuccess }: ProviderTunnelTabProps) {
             <Field label="Server">
               <Select value={serverId} onValueChange={setServerId}>
                 <SelectTrigger className="w-full">
-                  <SelectValue placeholder={country ? `Auto-select best server in ${country.toUpperCase()}` : "Auto-select best server"} />
+                  <SelectValue placeholder={`Auto-select best server in ${country.toUpperCase()}`} />
                 </SelectTrigger>
                 <SelectContent>
                   {servers.map((s) => (

--- a/source/admin-app/web/src/components/features/ProviderTunnelTab.tsx
+++ b/source/admin-app/web/src/components/features/ProviderTunnelTab.tsx
@@ -302,11 +302,11 @@ export function ProviderTunnelTab({ onSuccess }: ProviderTunnelTabProps) {
             />
           </Field>
 
-          {servers.length > 0 && !hostname && (
+          {country && servers.length > 0 && !hostname && (
             <Field label="Server">
               <Select value={serverId} onValueChange={setServerId}>
                 <SelectTrigger className="w-full">
-                  <SelectValue placeholder="Auto-select best server" />
+                  <SelectValue placeholder={country ? `Auto-select best server in ${country.toUpperCase()}` : "Auto-select best server"} />
                 </SelectTrigger>
                 <SelectContent>
                   {servers.map((s) => (

--- a/source/admin-app/web/src/pages/TunnelDetail.tsx
+++ b/source/admin-app/web/src/pages/TunnelDetail.tsx
@@ -115,6 +115,29 @@ export default function TunnelDetail() {
               value={<span className="mono">{tunnel.interface_name}</span>}
             />
           </div>
+          {tunnel.server_selector && (
+            <div className="grid grid-cols-2 gap-x-6 md:grid-cols-3">
+              <Field
+                label="Server selector"
+                editing={false}
+                value={`Best ${tunnel.server_selector.country.toUpperCase()}`}
+              />
+              {tunnel.resolved_server_name && (
+                <Field
+                  label="Resolved server"
+                  editing={false}
+                  value={tunnel.resolved_server_name}
+                />
+              )}
+              {tunnel.endpoint_resolved_at && (
+                <Field
+                  label="Last resolved"
+                  editing={false}
+                  value={timeAgo(tunnel.endpoint_resolved_at)}
+                />
+              )}
+            </div>
+          )}
           <Field
             direction="row"
             label="Filter and route DNS through this tunnel"

--- a/source/daemon/crates/wardnet-common/src/api.rs
+++ b/source/daemon/crates/wardnet-common/src/api.rs
@@ -10,7 +10,7 @@ use crate::dns::{
 };
 use crate::dns_filter::{DeviceDnsFilterSettings, DnsFilterConfig, DnsFilterProfile};
 use crate::routing::RoutingTarget;
-use crate::tunnel::Tunnel;
+use crate::tunnel::{BestServerSelector, Tunnel};
 use crate::update::{InstallHandle, UpdateChannel, UpdateHistoryEntry, UpdateStatus};
 use crate::vpn_provider::{
     CountryInfo, ProviderCredentials, ProviderInfo, ServerFilter, ServerInfo,
@@ -167,6 +167,10 @@ pub struct CreateTunnelRequest {
     pub country_code: String,
     pub provider: Option<String>,
     pub config: String,
+    /// Set when the tunnel was created via country-scoped auto-select.
+    pub server_selector: Option<BestServerSelector>,
+    /// Human-readable name of the server resolved at creation time.
+    pub resolved_server_name: Option<String>,
 }
 
 /// Response for POST /api/tunnels.

--- a/source/daemon/crates/wardnet-common/src/tests/tunnel.rs
+++ b/source/daemon/crates/wardnet-common/src/tests/tunnel.rs
@@ -37,6 +37,9 @@ fn tunnel_round_trip() {
         bytes_rx: 2048,
         created_at: "2026-03-07T00:00:00Z".parse().unwrap(),
         override_default_dns: true,
+        server_selector: None,
+        resolved_server_name: None,
+        endpoint_resolved_at: None,
     };
     let json = serde_json::to_string(&tunnel).unwrap();
     let back: Tunnel = serde_json::from_str(&json).unwrap();

--- a/source/daemon/crates/wardnet-common/src/tunnel.rs
+++ b/source/daemon/crates/wardnet-common/src/tunnel.rs
@@ -25,7 +25,7 @@ pub enum TunnelStatus {
 
 /// Selector persisted when a tunnel was created via country-scoped auto-select.
 /// Present only on "best server" tunnels; `None` for specific-server or manual.
-#[derive(Debug, Clone, Serialize, Deserialize, utoipa::ToSchema)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, utoipa::ToSchema)]
 pub struct BestServerSelector {
     pub country: String,
 }

--- a/source/daemon/crates/wardnet-common/src/tunnel.rs
+++ b/source/daemon/crates/wardnet-common/src/tunnel.rs
@@ -23,6 +23,13 @@ pub enum TunnelStatus {
     Reconnecting,
 }
 
+/// Selector persisted when a tunnel was created via country-scoped auto-select.
+/// Present only on "best server" tunnels; `None` for specific-server or manual.
+#[derive(Debug, Clone, Serialize, Deserialize, utoipa::ToSchema)]
+pub struct BestServerSelector {
+    pub country: String,
+}
+
 /// A `WireGuard` tunnel configuration and its live state.
 #[derive(Debug, Clone, Serialize, Deserialize, utoipa::ToSchema)]
 pub struct Tunnel {
@@ -43,6 +50,13 @@ pub struct Tunnel {
     /// `SO_BINDTODEVICE`. When `false`, the per-tunnel DNS server (if
     /// any) is ignored and the system-wide upstream pool is used.
     pub override_default_dns: bool,
+    /// Set when the tunnel was created via country-scoped auto-select ("best server").
+    /// `None` for specific-server or manually imported tunnels.
+    pub server_selector: Option<BestServerSelector>,
+    /// Human-readable name of the last resolved server (e.g. "United States #8395").
+    pub resolved_server_name: Option<String>,
+    /// ISO 8601 timestamp of the last endpoint re-resolution.
+    pub endpoint_resolved_at: Option<DateTime<Utc>>,
 }
 
 use crate::wireguard_config::WgPeerConfig;

--- a/source/daemon/crates/wardnetd-api/src/api/tests/providers.rs
+++ b/source/daemon/crates/wardnetd-api/src/api/tests/providers.rs
@@ -150,6 +150,9 @@ impl VpnProviderService for MockProviderService {
             bytes_rx: 0,
             created_at: "2026-03-07T00:00:00Z".parse().unwrap(),
             override_default_dns: false,
+            server_selector: None,
+            resolved_server_name: None,
+            endpoint_resolved_at: None,
         };
         Ok(SetupProviderResponse {
             tunnel,

--- a/source/daemon/crates/wardnetd-api/src/api/tests/tunnels.rs
+++ b/source/daemon/crates/wardnetd-api/src/api/tests/tunnels.rs
@@ -120,6 +120,9 @@ impl TunnelService for MockTunnelService {
             bytes_rx: 0,
             created_at: chrono::Utc::now(),
             override_default_dns: false,
+            server_selector: req.server_selector.clone(),
+            resolved_server_name: req.resolved_server_name.clone(),
+            endpoint_resolved_at: None,
         };
         Ok(CreateTunnelResponse {
             tunnel,
@@ -230,6 +233,9 @@ fn sample_tunnel() -> Tunnel {
         bytes_rx: 0,
         created_at: "2026-03-07T00:00:00Z".parse().unwrap(),
         override_default_dns: false,
+        server_selector: None,
+        resolved_server_name: None,
+        endpoint_resolved_at: None,
     }
 }
 

--- a/source/daemon/crates/wardnetd-data/migrations/20260529000000_tunnel_server_selector.sql
+++ b/source/daemon/crates/wardnetd-data/migrations/20260529000000_tunnel_server_selector.sql
@@ -1,0 +1,3 @@
+ALTER TABLE tunnels ADD COLUMN server_selector_country TEXT NULL DEFAULT NULL;
+ALTER TABLE tunnels ADD COLUMN resolved_server_name    TEXT NULL DEFAULT NULL;
+ALTER TABLE tunnels ADD COLUMN endpoint_resolved_at    TEXT NULL DEFAULT NULL;

--- a/source/daemon/crates/wardnetd-data/src/repository/sqlite/tunnel.rs
+++ b/source/daemon/crates/wardnetd-data/src/repository/sqlite/tunnel.rs
@@ -1,6 +1,6 @@
 use async_trait::async_trait;
 use sqlx::SqlitePool;
-use wardnet_common::tunnel::{Tunnel, TunnelConfig, TunnelStatus};
+use wardnet_common::tunnel::{BestServerSelector, Tunnel, TunnelConfig, TunnelStatus};
 use wardnet_common::wireguard_config::WgPeerConfig;
 
 use super::super::TunnelRepository;
@@ -41,6 +41,9 @@ struct DbTunnelRow {
     bytes_rx: i64,
     created_at: String,
     override_default_dns: i64,
+    server_selector_country: Option<String>,
+    resolved_server_name: Option<String>,
+    endpoint_resolved_at: Option<String>,
 }
 
 impl DbTunnelRow {
@@ -54,6 +57,14 @@ impl DbTunnelRow {
         };
 
         let last_handshake = self.last_handshake.as_deref().map(str::parse).transpose()?;
+        let endpoint_resolved_at = self
+            .endpoint_resolved_at
+            .as_deref()
+            .map(str::parse)
+            .transpose()?;
+        let server_selector = self
+            .server_selector_country
+            .map(|country| BestServerSelector { country });
 
         Ok(Tunnel {
             id: self.id.parse()?,
@@ -68,6 +79,9 @@ impl DbTunnelRow {
             bytes_rx: self.bytes_rx.cast_unsigned(),
             created_at: self.created_at.parse()?,
             override_default_dns: self.override_default_dns != 0,
+            server_selector,
+            resolved_server_name: self.resolved_server_name,
+            endpoint_resolved_at,
         })
     }
 }
@@ -108,7 +122,8 @@ impl TunnelRepository for SqliteTunnelRepository {
     async fn find_all(&self) -> anyhow::Result<Vec<Tunnel>> {
         let rows = sqlx::query_as::<_, DbTunnelRow>(
             "SELECT id, label, country_code, provider, interface_name, endpoint, \
-             status, last_handshake, bytes_tx, bytes_rx, created_at, override_default_dns \
+             status, last_handshake, bytes_tx, bytes_rx, created_at, override_default_dns, \
+             server_selector_country, resolved_server_name, endpoint_resolved_at \
              FROM tunnels",
         )
         .fetch_all(&self.pools.read)
@@ -120,7 +135,8 @@ impl TunnelRepository for SqliteTunnelRepository {
     async fn find_by_id(&self, id: &str) -> anyhow::Result<Option<Tunnel>> {
         let row = sqlx::query_as::<_, DbTunnelRow>(
             "SELECT id, label, country_code, provider, interface_name, endpoint, \
-             status, last_handshake, bytes_tx, bytes_rx, created_at, override_default_dns \
+             status, last_handshake, bytes_tx, bytes_rx, created_at, override_default_dns, \
+             server_selector_country, resolved_server_name, endpoint_resolved_at \
              FROM tunnels WHERE id = ?",
         )
         .bind(id)
@@ -145,8 +161,9 @@ impl TunnelRepository for SqliteTunnelRepository {
     async fn insert(&self, row: &TunnelRow) -> anyhow::Result<()> {
         sqlx::query(
             "INSERT INTO tunnels (id, label, country_code, provider, interface_name, \
-             endpoint, status, address, dns, peer_config, listen_port, override_default_dns) \
-             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+             endpoint, status, address, dns, peer_config, listen_port, override_default_dns, \
+             server_selector_country, resolved_server_name, endpoint_resolved_at) \
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
         )
         .bind(&row.id)
         .bind(&row.label)
@@ -160,6 +177,33 @@ impl TunnelRepository for SqliteTunnelRepository {
         .bind(&row.peer_config)
         .bind(row.listen_port)
         .bind(i64::from(row.override_default_dns))
+        .bind(&row.server_selector_country)
+        .bind(&row.resolved_server_name)
+        .bind(&row.endpoint_resolved_at)
+        .execute(&self.pools.write)
+        .await?;
+        Ok(())
+    }
+
+    async fn update_endpoint(
+        &self,
+        id: &str,
+        endpoint: &str,
+        peer_config_json: &str,
+        server_name: &str,
+        resolved_at: &str,
+    ) -> anyhow::Result<()> {
+        sqlx::query(
+            "UPDATE tunnels \
+             SET endpoint = ?, peer_config = ?, \
+                 resolved_server_name = ?, endpoint_resolved_at = ? \
+             WHERE id = ?",
+        )
+        .bind(endpoint)
+        .bind(peer_config_json)
+        .bind(server_name)
+        .bind(resolved_at)
+        .bind(id)
         .execute(&self.pools.write)
         .await?;
         Ok(())

--- a/source/daemon/crates/wardnetd-data/src/repository/tests/tunnel.rs
+++ b/source/daemon/crates/wardnetd-data/src/repository/tests/tunnel.rs
@@ -17,6 +17,9 @@ fn sample_row(id: &str, interface_name: &str) -> TunnelRow {
         peer_config: "{\"public_key\":\"abc123\",\"endpoint\":\"198.51.100.1:51820\",\"allowed_ips\":[\"0.0.0.0/0\"],\"preshared_key\":null,\"persistent_keepalive\":25}".to_owned(),
         listen_port: None,
         override_default_dns: true,
+        server_selector_country: None,
+        resolved_server_name: None,
+        endpoint_resolved_at: None,
     }
 }
 

--- a/source/daemon/crates/wardnetd-data/src/repository/tests/tunnel.rs
+++ b/source/daemon/crates/wardnetd-data/src/repository/tests/tunnel.rs
@@ -278,3 +278,29 @@ async fn update_dns_override_for_missing_id_is_silent_noop() {
         .await
         .unwrap();
 }
+
+#[tokio::test]
+async fn update_endpoint_persists_resolved_fields() {
+    let pool = test_pool().await;
+    let repo = SqliteTunnelRepository::new(pool);
+    let id = "00000000-0000-0000-0000-000000000001";
+    repo.insert(&sample_row(id, "wg_ward0")).await.unwrap();
+
+    let new_peer = "{\"public_key\":\"abc123\",\"endpoint\":\"10.0.0.99:51820\",\
+                    \"allowed_ips\":[\"0.0.0.0/0\"],\"preshared_key\":null,\
+                    \"persistent_keepalive\":25}";
+    repo.update_endpoint(
+        id,
+        "10.0.0.99:51820",
+        new_peer,
+        "Sweden #99",
+        "2026-03-07T12:00:00Z",
+    )
+    .await
+    .unwrap();
+
+    let tunnel = repo.find_by_id(id).await.unwrap().unwrap();
+    assert_eq!(tunnel.endpoint, "10.0.0.99:51820");
+    assert_eq!(tunnel.resolved_server_name.as_deref(), Some("Sweden #99"));
+    assert!(tunnel.endpoint_resolved_at.is_some());
+}

--- a/source/daemon/crates/wardnetd-data/src/repository/tunnel.rs
+++ b/source/daemon/crates/wardnetd-data/src/repository/tunnel.rs
@@ -31,6 +31,12 @@ pub struct TunnelRow {
     pub listen_port: Option<u16>,
     /// See [`wardnet_common::tunnel::Tunnel::override_default_dns`].
     pub override_default_dns: bool,
+    /// ISO country code for "best server" tunnels; `None` for specific-server or manual.
+    pub server_selector_country: Option<String>,
+    /// Human-readable name of the server resolved at creation time.
+    pub resolved_server_name: Option<String>,
+    /// ISO 8601 timestamp of the initial endpoint resolution.
+    pub endpoint_resolved_at: Option<String>,
 }
 
 /// Data access for `WireGuard` tunnel records.
@@ -69,6 +75,18 @@ pub trait TunnelRepository: Send + Sync {
         bytes_tx: i64,
         bytes_rx: i64,
         last_handshake: Option<&str>,
+    ) -> anyhow::Result<()>;
+
+    /// Persist a re-resolved endpoint after a successful best-server lookup at
+    /// bring-up time. Updates the `endpoint` column, the `peer_config` JSON,
+    /// `resolved_server_name`, and `endpoint_resolved_at`.
+    async fn update_endpoint(
+        &self,
+        id: &str,
+        endpoint: &str,
+        peer_config_json: &str,
+        server_name: &str,
+        resolved_at: &str,
     ) -> anyhow::Result<()>;
 
     /// Delete a tunnel by ID.

--- a/source/daemon/crates/wardnetd-mock/src/seed.rs
+++ b/source/daemon/crates/wardnetd-mock/src/seed.rs
@@ -227,6 +227,9 @@ pub async fn populate(factory: &dyn RepositoryFactory) -> anyhow::Result<SeededI
             peer_config: peer_json,
             listen_port: None,
             override_default_dns: true,
+            server_selector_country: None,
+            resolved_server_name: None,
+            endpoint_resolved_at: None,
         };
         tunnel_repo.insert(&row).await?;
         if status == "up" {

--- a/source/daemon/crates/wardnetd-services/src/lib.rs
+++ b/source/daemon/crates/wardnetd-services/src/lib.rs
@@ -414,6 +414,8 @@ fn create_services(
         backends.network_probe.clone(),
     ));
 
+    let registry = Arc::new(VpnProviderRegistry::new(&config.vpn_providers.enabled));
+
     let tunnel_service: Arc<dyn TunnelService> = Arc::new(TunnelServiceImpl::new(
         tunnel_repo.clone(),
         device_repo.clone(),
@@ -423,9 +425,9 @@ fn create_services(
         backends.secret_store.clone(),
         event_publisher.clone(),
         stats_meter.clone(),
+        registry.clone(),
     ));
 
-    let registry = Arc::new(VpnProviderRegistry::new(&config.vpn_providers.enabled));
     let vpn_provider_service: Arc<dyn VpnProviderService> = Arc::new(VpnProviderServiceImpl::new(
         registry,
         tunnel_service.clone(),

--- a/source/daemon/crates/wardnetd-services/src/routing/tests/routing.rs
+++ b/source/daemon/crates/wardnetd-services/src/routing/tests/routing.rs
@@ -178,6 +178,17 @@ impl TunnelRepository for MockTunnelRepo {
         Ok(())
     }
 
+    async fn update_endpoint(
+        &self,
+        _id: &str,
+        _endpoint: &str,
+        _peer_config_json: &str,
+        _server_name: &str,
+        _resolved_at: &str,
+    ) -> anyhow::Result<()> {
+        Ok(())
+    }
+
     async fn delete(&self, _id: &str) -> anyhow::Result<()> {
         Ok(())
     }
@@ -598,6 +609,9 @@ fn sample_tunnel(id: Uuid, interface_name: &str, status: TunnelStatus) -> Tunnel
         bytes_rx: 0,
         created_at: chrono::Utc::now(),
         override_default_dns: true,
+        server_selector: None,
+        resolved_server_name: None,
+        endpoint_resolved_at: None,
     }
 }
 

--- a/source/daemon/crates/wardnetd-services/src/system/tests/system.rs
+++ b/source/daemon/crates/wardnetd-services/src/system/tests/system.rs
@@ -127,6 +127,16 @@ impl TunnelRepository for MockTunnelRepo {
     ) -> anyhow::Result<()> {
         Ok(())
     }
+    async fn update_endpoint(
+        &self,
+        _id: &str,
+        _endpoint: &str,
+        _peer_config_json: &str,
+        _server_name: &str,
+        _resolved_at: &str,
+    ) -> anyhow::Result<()> {
+        Ok(())
+    }
     async fn delete(&self, _id: &str) -> anyhow::Result<()> {
         Ok(())
     }

--- a/source/daemon/crates/wardnetd-services/src/tunnel/service.rs
+++ b/source/daemon/crates/wardnetd-services/src/tunnel/service.rs
@@ -142,10 +142,16 @@ pub struct TunnelServiceImpl {
 /// Parse the port from a `host:port` endpoint string. Defaults to `51820`
 /// if the endpoint is absent, malformed, or the port cannot be parsed.
 fn parse_port(endpoint: Option<&str>) -> u16 {
-    endpoint
-        .and_then(|ep| ep.rsplit(':').next())
-        .and_then(|p| p.parse().ok())
-        .unwrap_or(51820)
+    let port_str = endpoint.and_then(|ep| ep.rsplit(':').next());
+    match port_str.and_then(|p| p.parse::<u16>().ok()) {
+        Some(p) => p,
+        None => {
+            if endpoint.is_some() {
+                tracing::warn!(endpoint = ?endpoint, "could not parse port from endpoint, using default 51820");
+            }
+            51820
+        }
+    }
 }
 
 impl TunnelServiceImpl {
@@ -267,14 +273,14 @@ impl TunnelServiceImpl {
                     Ok(Some((new_ep, server_name))) => {
                         let now = chrono::Utc::now().to_rfc3339();
                         let mut updated_peer = tunnel_config.peer.clone();
-                        updated_peer.endpoint = Some(new_ep.clone());
+                        updated_peer.endpoint = Some(new_ep);
                         let peer_json = serde_json::to_string(&updated_peer)
                             .map_err(|e| AppError::Internal(e.into()))?;
                         if let Err(e) = self
                             .tunnels
                             .update_endpoint(
                                 &id.to_string(),
-                                &new_ep,
+                                updated_peer.endpoint.as_deref().unwrap_or_default(),
                                 &peer_json,
                                 &server_name,
                                 &now,
@@ -284,7 +290,7 @@ impl TunnelServiceImpl {
                             tracing::warn!(
                                 tunnel_id = %id,
                                 error = %e,
-                                "endpoint re-resolution: failed to persist updated endpoint: {e}",
+                                "endpoint re-resolution: failed to persist updated endpoint",
                             );
                         }
                         wardnet_common::tunnel::TunnelConfig {
@@ -306,7 +312,7 @@ impl TunnelServiceImpl {
                         tracing::warn!(
                             tunnel_id = %id,
                             error = %e,
-                            "endpoint re-resolution failed (transient), using stored endpoint: {e}",
+                            "endpoint re-resolution failed (transient), using stored endpoint",
                         );
                         tunnel_config
                     }
@@ -755,11 +761,12 @@ impl TunnelService for TunnelServiceImpl {
         // and the system-wide upstream pool is the right choice.
         let override_default_dns = !config.interface.dns.is_empty();
 
-        let endpoint_resolved_at = if req.server_selector.is_some() {
-            Some(chrono::Utc::now().to_rfc3339())
-        } else {
-            None
-        };
+        let endpoint_resolved_at_dt: Option<chrono::DateTime<chrono::Utc>> =
+            if req.server_selector.is_some() {
+                Some(chrono::Utc::now())
+            } else {
+                None
+            };
         let server_selector_country = req
             .server_selector
             .as_ref()
@@ -780,7 +787,7 @@ impl TunnelService for TunnelServiceImpl {
             override_default_dns,
             server_selector_country,
             resolved_server_name: req.resolved_server_name.clone(),
-            endpoint_resolved_at: endpoint_resolved_at.clone(),
+            endpoint_resolved_at: endpoint_resolved_at_dt.as_ref().map(|dt| dt.to_rfc3339()),
         };
 
         self.tunnels
@@ -804,9 +811,7 @@ impl TunnelService for TunnelServiceImpl {
             override_default_dns,
             server_selector: req.server_selector,
             resolved_server_name: req.resolved_server_name,
-            endpoint_resolved_at: endpoint_resolved_at
-                .as_deref()
-                .and_then(|s| s.parse().ok()),
+            endpoint_resolved_at: endpoint_resolved_at_dt,
         };
 
         Ok(CreateTunnelResponse {

--- a/source/daemon/crates/wardnetd-services/src/tunnel/service.rs
+++ b/source/daemon/crates/wardnetd-services/src/tunnel/service.rs
@@ -22,6 +22,7 @@ use crate::tunnel::interface::{
     CreateTunnelParams, TunnelConfig as TiTunnelConfig, TunnelInterface,
 };
 use crate::tunnel::latency_prober::{LatencyProbeError, TunnelLatencyProber};
+use crate::vpn::resolver::{EmptyServerListError, ServerResolver};
 use wardnetd_data::repository::TunnelRepository;
 use wardnetd_data::repository::tunnel::TunnelRow;
 use wardnetd_data::secret_store::SecretStore;
@@ -124,6 +125,7 @@ pub struct TunnelServiceImpl {
     keys: Arc<dyn KeyStore>,
     events: Arc<dyn EventPublisher>,
     meter: Arc<Meter>,
+    server_resolver: Arc<dyn ServerResolver>,
     /// Last cumulative `(bytes_tx, bytes_rx)` observed per tunnel.
     /// Used by `collect_stats` to compute positive deltas to feed into
     /// the generic stats pipeline. A counter that goes *down* means the
@@ -135,6 +137,15 @@ pub struct TunnelServiceImpl {
     /// guard. Concurrent calls for the same id return
     /// `AppError::Conflict`.
     tests_in_flight: Arc<std::sync::Mutex<HashSet<Uuid>>>,
+}
+
+/// Parse the port from a `host:port` endpoint string. Defaults to `51820`
+/// if the endpoint is absent, malformed, or the port cannot be parsed.
+fn parse_port(endpoint: Option<&str>) -> u16 {
+    endpoint
+        .and_then(|ep| ep.rsplit(':').next())
+        .and_then(|p| p.parse().ok())
+        .unwrap_or(51820)
 }
 
 impl TunnelServiceImpl {
@@ -154,6 +165,7 @@ impl TunnelServiceImpl {
         secret_store: Arc<dyn SecretStore>,
         events: Arc<dyn EventPublisher>,
         meter: Arc<Meter>,
+        server_resolver: Arc<dyn ServerResolver>,
     ) -> Self {
         let keys: Arc<dyn KeyStore> = Arc::new(KeyStoreAdapter::new(secret_store));
         Self {
@@ -165,6 +177,7 @@ impl TunnelServiceImpl {
             keys,
             events,
             meter,
+            server_resolver,
             last_bytes: Mutex::new(HashMap::new()),
             tests_in_flight: Arc::new(std::sync::Mutex::new(HashSet::new())),
         }
@@ -186,6 +199,7 @@ impl TunnelServiceImpl {
         keys: Arc<dyn KeyStore>,
         events: Arc<dyn EventPublisher>,
         meter: Arc<Meter>,
+        server_resolver: Arc<dyn ServerResolver>,
     ) -> Self {
         Self {
             tunnels,
@@ -196,6 +210,7 @@ impl TunnelServiceImpl {
             keys,
             events,
             meter,
+            server_resolver,
             last_bytes: Mutex::new(HashMap::new()),
             tests_in_flight: Arc::new(std::sync::Mutex::new(HashSet::new())),
         }
@@ -238,6 +253,67 @@ impl TunnelServiceImpl {
             .await
             .map_err(AppError::Internal)?
             .ok_or_else(|| AppError::NotFound(format!("tunnel config {id} not found")))?;
+
+        // Re-resolve endpoint for "best server" tunnels on each bring-up.
+        let tunnel_config = match &tunnel.server_selector {
+            Some(selector) if tunnel.provider.is_some() => {
+                let provider_id = tunnel.provider.as_deref().expect("checked above");
+                let port = parse_port(tunnel_config.peer.endpoint.as_deref());
+                match self
+                    .server_resolver
+                    .resolve(provider_id, selector, port)
+                    .await
+                {
+                    Ok(Some((new_ep, server_name))) => {
+                        let now = chrono::Utc::now().to_rfc3339();
+                        let mut updated_peer = tunnel_config.peer.clone();
+                        updated_peer.endpoint = Some(new_ep.clone());
+                        let peer_json = serde_json::to_string(&updated_peer)
+                            .map_err(|e| AppError::Internal(e.into()))?;
+                        if let Err(e) = self
+                            .tunnels
+                            .update_endpoint(
+                                &id.to_string(),
+                                &new_ep,
+                                &peer_json,
+                                &server_name,
+                                &now,
+                            )
+                            .await
+                        {
+                            tracing::warn!(
+                                tunnel_id = %id,
+                                error = %e,
+                                "endpoint re-resolution: failed to persist updated endpoint: {e}",
+                            );
+                        }
+                        wardnet_common::tunnel::TunnelConfig {
+                            peer: updated_peer,
+                            ..tunnel_config
+                        }
+                    }
+                    Ok(None) => {
+                        tracing::warn!(
+                            tunnel_id = %id,
+                            "no provider registered for re-resolution, using stored endpoint",
+                        );
+                        tunnel_config
+                    }
+                    Err(e) => {
+                        if e.downcast_ref::<EmptyServerListError>().is_some() {
+                            return Err(AppError::Internal(e));
+                        }
+                        tracing::warn!(
+                            tunnel_id = %id,
+                            error = %e,
+                            "endpoint re-resolution failed (transient), using stored endpoint: {e}",
+                        );
+                        tunnel_config
+                    }
+                }
+            }
+            _ => tunnel_config,
+        };
 
         // Load and decode private key from key store.
         let private_key_b64 = self.keys.load_key(&id).await.map_err(AppError::Internal)?;
@@ -679,6 +755,16 @@ impl TunnelService for TunnelServiceImpl {
         // and the system-wide upstream pool is the right choice.
         let override_default_dns = !config.interface.dns.is_empty();
 
+        let endpoint_resolved_at = if req.server_selector.is_some() {
+            Some(chrono::Utc::now().to_rfc3339())
+        } else {
+            None
+        };
+        let server_selector_country = req
+            .server_selector
+            .as_ref()
+            .map(|s| s.country.clone());
+
         let row = TunnelRow {
             id: id.to_string(),
             label: req.label.clone(),
@@ -692,6 +778,9 @@ impl TunnelService for TunnelServiceImpl {
             peer_config: peer_config_json,
             listen_port: config.interface.listen_port,
             override_default_dns,
+            server_selector_country,
+            resolved_server_name: req.resolved_server_name.clone(),
+            endpoint_resolved_at: endpoint_resolved_at.clone(),
         };
 
         self.tunnels
@@ -713,6 +802,11 @@ impl TunnelService for TunnelServiceImpl {
             bytes_rx: 0,
             created_at: now,
             override_default_dns,
+            server_selector: req.server_selector,
+            resolved_server_name: req.resolved_server_name,
+            endpoint_resolved_at: endpoint_resolved_at
+                .as_deref()
+                .and_then(|s| s.parse().ok()),
         };
 
         Ok(CreateTunnelResponse {

--- a/source/daemon/crates/wardnetd-services/src/tunnel/service.rs
+++ b/source/daemon/crates/wardnetd-services/src/tunnel/service.rs
@@ -767,10 +767,7 @@ impl TunnelService for TunnelServiceImpl {
             } else {
                 None
             };
-        let server_selector_country = req
-            .server_selector
-            .as_ref()
-            .map(|s| s.country.clone());
+        let server_selector_country = req.server_selector.as_ref().map(|s| s.country.clone());
 
         let row = TunnelRow {
             id: id.to_string(),

--- a/source/daemon/crates/wardnetd-services/src/tunnel/service.rs
+++ b/source/daemon/crates/wardnetd-services/src/tunnel/service.rs
@@ -143,14 +143,13 @@ pub struct TunnelServiceImpl {
 /// if the endpoint is absent, malformed, or the port cannot be parsed.
 fn parse_port(endpoint: Option<&str>) -> u16 {
     let port_str = endpoint.and_then(|ep| ep.rsplit(':').next());
-    match port_str.and_then(|p| p.parse::<u16>().ok()) {
-        Some(p) => p,
-        None => {
-            if endpoint.is_some() {
-                tracing::warn!(endpoint = ?endpoint, "could not parse port from endpoint, using default 51820");
-            }
-            51820
+    if let Some(p) = port_str.and_then(|p| p.parse::<u16>().ok()) {
+        p
+    } else {
+        if endpoint.is_some() {
+            tracing::warn!(endpoint = ?endpoint, "could not parse port from endpoint, using default 51820");
         }
+        51820
     }
 }
 
@@ -261,65 +260,7 @@ impl TunnelServiceImpl {
             .ok_or_else(|| AppError::NotFound(format!("tunnel config {id} not found")))?;
 
         // Re-resolve endpoint for "best server" tunnels on each bring-up.
-        let tunnel_config = match &tunnel.server_selector {
-            Some(selector) if tunnel.provider.is_some() => {
-                let provider_id = tunnel.provider.as_deref().expect("checked above");
-                let port = parse_port(tunnel_config.peer.endpoint.as_deref());
-                match self
-                    .server_resolver
-                    .resolve(provider_id, selector, port)
-                    .await
-                {
-                    Ok(Some((new_ep, server_name))) => {
-                        let now = chrono::Utc::now().to_rfc3339();
-                        let mut updated_peer = tunnel_config.peer.clone();
-                        updated_peer.endpoint = Some(new_ep);
-                        let peer_json = serde_json::to_string(&updated_peer)
-                            .map_err(|e| AppError::Internal(e.into()))?;
-                        if let Err(e) = self
-                            .tunnels
-                            .update_endpoint(
-                                &id.to_string(),
-                                updated_peer.endpoint.as_deref().unwrap_or_default(),
-                                &peer_json,
-                                &server_name,
-                                &now,
-                            )
-                            .await
-                        {
-                            tracing::warn!(
-                                tunnel_id = %id,
-                                error = %e,
-                                "endpoint re-resolution: failed to persist updated endpoint",
-                            );
-                        }
-                        wardnet_common::tunnel::TunnelConfig {
-                            peer: updated_peer,
-                            ..tunnel_config
-                        }
-                    }
-                    Ok(None) => {
-                        tracing::warn!(
-                            tunnel_id = %id,
-                            "no provider registered for re-resolution, using stored endpoint",
-                        );
-                        tunnel_config
-                    }
-                    Err(e) => {
-                        if e.downcast_ref::<EmptyServerListError>().is_some() {
-                            return Err(AppError::Internal(e));
-                        }
-                        tracing::warn!(
-                            tunnel_id = %id,
-                            error = %e,
-                            "endpoint re-resolution failed (transient), using stored endpoint",
-                        );
-                        tunnel_config
-                    }
-                }
-            }
-            _ => tunnel_config,
-        };
+        let tunnel_config = self.reresolve_endpoint(id, &tunnel, tunnel_config).await?;
 
         // Load and decode private key from key store.
         let private_key_b64 = self.keys.load_key(&id).await.map_err(AppError::Internal)?;
@@ -336,33 +277,10 @@ impl TunnelServiceImpl {
             .map(Self::decode_key)
             .transpose()?;
 
-        // Parse peer endpoint — resolve hostname if needed (e.g. NordVPN gives
-        // `pt149.nordvpn.com:51820` which must be resolved to an IP for WireGuard).
-        let peer_endpoint = match tunnel_config.peer.endpoint.as_deref() {
-            None => None,
-            Some(ep) => {
-                // Try direct parse first (already an IP:port).
-                if let Ok(addr) = ep.parse::<std::net::SocketAddr>() {
-                    Some(addr)
-                } else {
-                    // Resolve hostname via DNS.
-                    let addr = tokio::net::lookup_host(ep)
-                        .await
-                        .map_err(|e| {
-                            AppError::Internal(anyhow::anyhow!(
-                                "failed to resolve peer endpoint '{ep}': {e}"
-                            ))
-                        })?
-                        .next()
-                        .ok_or_else(|| {
-                            AppError::Internal(anyhow::anyhow!(
-                                "DNS resolution returned no addresses for '{ep}'"
-                            ))
-                        })?;
-                    Some(addr)
-                }
-            }
-        };
+        // Parse peer endpoint — resolve hostname if needed (e.g. a provider
+        // hostname like `pt149.nordvpn.com:51820` must be resolved to an IP).
+        let peer_endpoint =
+            Self::resolve_peer_endpoint(tunnel_config.peer.endpoint.as_deref()).await?;
 
         // Parse allowed IPs.
         let peer_allowed_ips = tunnel_config
@@ -423,6 +341,101 @@ impl TunnelServiceImpl {
         });
 
         Ok(())
+    }
+
+    /// Re-resolve the best server endpoint for "best server" tunnels.
+    /// For tunnels with a static server or no provider, the config is
+    /// returned unchanged.
+    async fn reresolve_endpoint(
+        &self,
+        id: Uuid,
+        tunnel: &Tunnel,
+        config: wardnet_common::tunnel::TunnelConfig,
+    ) -> Result<wardnet_common::tunnel::TunnelConfig, AppError> {
+        let (Some(selector), Some(_)) = (&tunnel.server_selector, &tunnel.provider) else {
+            return Ok(config);
+        };
+        let provider_id = tunnel.provider.as_deref().expect("checked above");
+        let port = parse_port(config.peer.endpoint.as_deref());
+        match self
+            .server_resolver
+            .resolve(provider_id, selector, port)
+            .await
+        {
+            Ok(Some((new_ep, server_name))) => {
+                let now = chrono::Utc::now().to_rfc3339();
+                let mut updated_peer = config.peer.clone();
+                updated_peer.endpoint = Some(new_ep);
+                let peer_json = serde_json::to_string(&updated_peer)
+                    .map_err(|e| AppError::Internal(e.into()))?;
+                if let Err(e) = self
+                    .tunnels
+                    .update_endpoint(
+                        &id.to_string(),
+                        updated_peer.endpoint.as_deref().unwrap_or_default(),
+                        &peer_json,
+                        &server_name,
+                        &now,
+                    )
+                    .await
+                {
+                    tracing::warn!(
+                        tunnel_id = %id,
+                        error = %e,
+                        "endpoint re-resolution: failed to persist updated endpoint",
+                    );
+                }
+                Ok(wardnet_common::tunnel::TunnelConfig {
+                    peer: updated_peer,
+                    ..config
+                })
+            }
+            Ok(None) => {
+                tracing::warn!(
+                    tunnel_id = %id,
+                    "no provider registered for re-resolution, using stored endpoint",
+                );
+                Ok(config)
+            }
+            Err(e) => {
+                if e.downcast_ref::<EmptyServerListError>().is_some() {
+                    return Err(AppError::Internal(e));
+                }
+                tracing::warn!(
+                    tunnel_id = %id,
+                    error = %e,
+                    "endpoint re-resolution failed (transient), using stored endpoint",
+                );
+                Ok(config)
+            }
+        }
+    }
+
+    /// Resolve a peer endpoint string to a `SocketAddr`. Tries direct parse
+    /// first (already an IP:port), then falls back to DNS lookup.
+    async fn resolve_peer_endpoint(
+        ep: Option<&str>,
+    ) -> Result<Option<std::net::SocketAddr>, AppError> {
+        let Some(ep) = ep else {
+            return Ok(None);
+        };
+        if let Ok(addr) = ep.parse::<std::net::SocketAddr>() {
+            return Ok(Some(addr));
+        }
+        let addr = tokio::net::lookup_host(ep)
+            .await
+            .map_err(|e| {
+                AppError::Internal(anyhow::anyhow!(
+                    "failed to resolve peer endpoint '{ep}': {e}"
+                ))
+            })?
+            .next()
+            .ok_or_else(|| {
+                AppError::Internal(anyhow::anyhow!(
+                    "DNS resolution returned no addresses for '{ep}'"
+                ))
+            })?;
+        Ok(Some(addr))
     }
 
     /// Reconcile DB tunnel status against kernel reality. After a daemon
@@ -784,7 +797,9 @@ impl TunnelService for TunnelServiceImpl {
             override_default_dns,
             server_selector_country,
             resolved_server_name: req.resolved_server_name.clone(),
-            endpoint_resolved_at: endpoint_resolved_at_dt.as_ref().map(|dt| dt.to_rfc3339()),
+            endpoint_resolved_at: endpoint_resolved_at_dt
+                .as_ref()
+                .map(chrono::DateTime::to_rfc3339),
         };
 
         self.tunnels

--- a/source/daemon/crates/wardnetd-services/src/tunnel/tests/tunnel.rs
+++ b/source/daemon/crates/wardnetd-services/src/tunnel/tests/tunnel.rs
@@ -711,7 +711,7 @@ impl ServerResolver for FakeServerResolver {
                     provider: provider.clone(),
                 }))
             }
-            FakeResolveResult::Transient(msg) => Err(anyhow::anyhow!("{}", msg)),
+            FakeResolveResult::Transient(msg) => Err(anyhow::anyhow!("{msg}")),
         }
     }
 }

--- a/source/daemon/crates/wardnetd-services/src/tunnel/tests/tunnel.rs
+++ b/source/daemon/crates/wardnetd-services/src/tunnel/tests/tunnel.rs
@@ -22,7 +22,9 @@ use crate::tunnel::exit_probe::{ExitInfo, ProbeError, TunnelExitProbe};
 use crate::tunnel::interface::{CreateTunnelParams, TunnelInterface, TunnelStats};
 use crate::tunnel::key_store::KeyStore;
 use crate::tunnel::latency_prober::{LatencyProbeError, TunnelLatencyProber};
+use crate::vpn::resolver::ServerResolver;
 use crate::{TunnelService, TunnelServiceImpl};
+use wardnet_common::tunnel::BestServerSelector;
 use wardnetd_data::repository::tunnel::TunnelRow;
 use wardnetd_data::repository::{DeviceRepository, TunnelRepository};
 
@@ -149,6 +151,24 @@ impl TunnelRepository for MockTunnelRepo {
         Ok(())
     }
 
+    async fn update_endpoint(
+        &self,
+        id: &str,
+        endpoint: &str,
+        peer_config_json: &str,
+        server_name: &str,
+        resolved_at: &str,
+    ) -> anyhow::Result<()> {
+        let mut rows = self.rows.lock().unwrap();
+        if let Some(r) = rows.iter_mut().find(|r| r.id == id) {
+            r.endpoint = endpoint.to_owned();
+            r.peer_config = peer_config_json.to_owned();
+            r.resolved_server_name = Some(server_name.to_owned());
+            r.endpoint_resolved_at = Some(resolved_at.to_owned());
+        }
+        Ok(())
+    }
+
     async fn delete(&self, id: &str) -> anyhow::Result<()> {
         self.rows.lock().unwrap().retain(|r| r.id != id);
         Ok(())
@@ -202,6 +222,15 @@ fn row_to_tunnel(
         bytes_rx: s.bytes_rx.cast_unsigned(),
         created_at: chrono::Utc::now(),
         override_default_dns: r.override_default_dns,
+        server_selector: r
+            .server_selector_country
+            .as_ref()
+            .map(|c| BestServerSelector { country: c.clone() }),
+        resolved_server_name: r.resolved_server_name.clone(),
+        endpoint_resolved_at: r
+            .endpoint_resolved_at
+            .as_deref()
+            .and_then(|s| s.parse().ok()),
     })
 }
 
@@ -638,6 +667,22 @@ impl DeviceRepository for MockDeviceRepoWithSwitchedDevices {
 
 // -- Helpers --------------------------------------------------------------
 
+// -- Mock ServerResolver --------------------------------------------------
+
+struct MockServerResolver;
+
+#[async_trait]
+impl ServerResolver for MockServerResolver {
+    async fn resolve(
+        &self,
+        _provider_id: &str,
+        _selector: &BestServerSelector,
+        _port: u16,
+    ) -> anyhow::Result<Option<(String, String)>> {
+        Ok(None)
+    }
+}
+
 struct TestHarness {
     svc: TunnelServiceImpl,
     tunnels: Arc<MockTunnelRepo>,
@@ -659,6 +704,7 @@ fn build_harness() -> TestHarness {
     let latency_prober = Arc::new(MockTunnelLatencyProber::new());
     let stats_buffer = StatsBuffer::new();
     let meter = Arc::new(Meter::new(stats_buffer.clone()));
+    let server_resolver: Arc<dyn ServerResolver> = Arc::new(MockServerResolver);
 
     let svc = TunnelServiceImpl::with_key_store(
         repo.clone(),
@@ -669,6 +715,7 @@ fn build_harness() -> TestHarness {
         keys.clone(),
         events.clone(),
         meter,
+        server_resolver,
     );
 
     TestHarness {
@@ -692,6 +739,7 @@ fn build_harness_with_device_repo(device_repo: Arc<dyn DeviceRepository>) -> Tes
     let latency_prober = Arc::new(MockTunnelLatencyProber::new());
     let stats_buffer = StatsBuffer::new();
     let meter = Arc::new(Meter::new(stats_buffer.clone()));
+    let server_resolver: Arc<dyn ServerResolver> = Arc::new(MockServerResolver);
 
     let svc = TunnelServiceImpl::with_key_store(
         repo.clone(),
@@ -702,6 +750,7 @@ fn build_harness_with_device_repo(device_repo: Arc<dyn DeviceRepository>) -> Tes
         keys.clone(),
         events.clone(),
         meter,
+        server_resolver,
     );
 
     TestHarness {
@@ -722,6 +771,8 @@ fn sample_request() -> CreateTunnelRequest {
         country_code: "SE".to_owned(),
         provider: Some("Mullvad".to_owned()),
         config: SAMPLE_CONF.to_owned(),
+        server_selector: None,
+        resolved_server_name: None,
     }
 }
 
@@ -764,6 +815,8 @@ async fn import_tunnel_invalid_config() {
         country_code: "XX".to_owned(),
         provider: None,
         config: "this is not a valid config".to_owned(),
+        server_selector: None,
+        resolved_server_name: None,
     };
 
     let result = auth_context::with_context(admin_ctx(), h.svc.import_tunnel(req)).await;
@@ -1815,6 +1868,8 @@ async fn bring_up_with_no_endpoint_uses_none_branch() {
         country_code: "SE".to_owned(),
         provider: None,
         config: SAMPLE_CONF_NO_ENDPOINT.to_owned(),
+        server_selector: None,
+        resolved_server_name: None,
     };
     let resp = auth_context::with_context(admin_ctx(), h.svc.import_tunnel(req))
         .await
@@ -1837,6 +1892,8 @@ async fn bring_up_with_preshared_key_and_multiple_allowed_ips() {
         country_code: "NO".to_owned(),
         provider: None,
         config: SAMPLE_CONF_WITH_PRESHARED.to_owned(),
+        server_selector: None,
+        resolved_server_name: None,
     };
     let resp = auth_context::with_context(admin_ctx(), h.svc.import_tunnel(req))
         .await
@@ -1937,6 +1994,9 @@ fn insert_up_tunnel(h: &TestHarness, id: Uuid, interface_name: &str) {
         peer_config: "{}".to_owned(),
         listen_port: None,
         override_default_dns: false,
+        server_selector_country: None,
+        resolved_server_name: None,
+        endpoint_resolved_at: None,
     });
 }
 
@@ -1981,6 +2041,9 @@ async fn probe_latencies_skips_down_tunnels() {
         peer_config: "{}".to_owned(),
         listen_port: None,
         override_default_dns: false,
+        server_selector_country: None,
+        resolved_server_name: None,
+        endpoint_resolved_at: None,
     });
 
     h.svc.probe_latencies().await.unwrap();

--- a/source/daemon/crates/wardnetd-services/src/tunnel/tests/tunnel.rs
+++ b/source/daemon/crates/wardnetd-services/src/tunnel/tests/tunnel.rs
@@ -2441,10 +2441,12 @@ async fn bring_up_reresolves_best_server() {
     });
     let h = build_harness_with_resolver(resolver);
 
-    let resp =
-        auth_context::with_context(admin_ctx(), h.svc.import_tunnel(sample_request_with_selector()))
-            .await
-            .unwrap();
+    let resp = auth_context::with_context(
+        admin_ctx(),
+        h.svc.import_tunnel(sample_request_with_selector()),
+    )
+    .await
+    .unwrap();
     let id = resp.tunnel.id;
 
     auth_context::with_context(admin_ctx(), h.svc.bring_up(id))
@@ -2468,10 +2470,12 @@ async fn bring_up_empty_server_list_is_fatal() {
     });
     let h = build_harness_with_resolver(resolver);
 
-    let resp =
-        auth_context::with_context(admin_ctx(), h.svc.import_tunnel(sample_request_with_selector()))
-            .await
-            .unwrap();
+    let resp = auth_context::with_context(
+        admin_ctx(),
+        h.svc.import_tunnel(sample_request_with_selector()),
+    )
+    .await
+    .unwrap();
     let id = resp.tunnel.id;
 
     let result = auth_context::with_context(admin_ctx(), h.svc.bring_up(id)).await;
@@ -2488,10 +2492,12 @@ async fn bring_up_transient_resolver_error_uses_stored_endpoint() {
     });
     let h = build_harness_with_resolver(resolver);
 
-    let resp =
-        auth_context::with_context(admin_ctx(), h.svc.import_tunnel(sample_request_with_selector()))
-            .await
-            .unwrap();
+    let resp = auth_context::with_context(
+        admin_ctx(),
+        h.svc.import_tunnel(sample_request_with_selector()),
+    )
+    .await
+    .unwrap();
     let id = resp.tunnel.id;
     let original_endpoint = resp.tunnel.endpoint.clone();
 

--- a/source/daemon/crates/wardnetd-services/src/tunnel/tests/tunnel.rs
+++ b/source/daemon/crates/wardnetd-services/src/tunnel/tests/tunnel.rs
@@ -22,7 +22,7 @@ use crate::tunnel::exit_probe::{ExitInfo, ProbeError, TunnelExitProbe};
 use crate::tunnel::interface::{CreateTunnelParams, TunnelInterface, TunnelStats};
 use crate::tunnel::key_store::KeyStore;
 use crate::tunnel::latency_prober::{LatencyProbeError, TunnelLatencyProber};
-use crate::vpn::resolver::ServerResolver;
+use crate::vpn::resolver::{EmptyServerListError, ServerResolver};
 use crate::{TunnelService, TunnelServiceImpl};
 use wardnet_common::tunnel::BestServerSelector;
 use wardnetd_data::repository::tunnel::TunnelRow;
@@ -683,6 +683,39 @@ impl ServerResolver for MockServerResolver {
     }
 }
 
+// -- Configurable resolver for bring_up branch tests ----------------------
+
+enum FakeResolveResult {
+    Success(String, String),
+    EmptyList { country: String, provider: String },
+    Transient(String),
+}
+
+struct FakeServerResolver {
+    result: FakeResolveResult,
+}
+
+#[async_trait]
+impl ServerResolver for FakeServerResolver {
+    async fn resolve(
+        &self,
+        _provider_id: &str,
+        _selector: &BestServerSelector,
+        _port: u16,
+    ) -> anyhow::Result<Option<(String, String)>> {
+        match &self.result {
+            FakeResolveResult::Success(ep, name) => Ok(Some((ep.clone(), name.clone()))),
+            FakeResolveResult::EmptyList { country, provider } => {
+                Err(anyhow::Error::new(EmptyServerListError {
+                    country: country.clone(),
+                    provider: provider.clone(),
+                }))
+            }
+            FakeResolveResult::Transient(msg) => Err(anyhow::anyhow!("{}", msg)),
+        }
+    }
+}
+
 struct TestHarness {
     svc: TunnelServiceImpl,
     tunnels: Arc<MockTunnelRepo>,
@@ -765,6 +798,41 @@ fn build_harness_with_device_repo(device_repo: Arc<dyn DeviceRepository>) -> Tes
     }
 }
 
+fn build_harness_with_resolver(server_resolver: Arc<dyn ServerResolver>) -> TestHarness {
+    let repo = Arc::new(MockTunnelRepo::new());
+    let device_repo: Arc<dyn DeviceRepository> = Arc::new(MockDeviceRepoForTunnel);
+    let tunnel_iface = Arc::new(MockTunnelInterface::new());
+    let keys = Arc::new(MockKeyStore::new());
+    let events = Arc::new(MockEventPublisher::new());
+    let exit_probe = Arc::new(MockTunnelExitProbe::new());
+    let latency_prober = Arc::new(MockTunnelLatencyProber::new());
+    let stats_buffer = StatsBuffer::new();
+    let meter = Arc::new(Meter::new(stats_buffer.clone()));
+
+    let svc = TunnelServiceImpl::with_key_store(
+        repo.clone(),
+        device_repo,
+        tunnel_iface.clone(),
+        exit_probe.clone(),
+        latency_prober.clone(),
+        keys.clone(),
+        events.clone(),
+        meter,
+        server_resolver,
+    );
+
+    TestHarness {
+        svc,
+        tunnels: repo,
+        tunnel_iface,
+        events,
+        keys,
+        stats_buffer,
+        exit_probe,
+        latency_prober,
+    }
+}
+
 fn sample_request() -> CreateTunnelRequest {
     CreateTunnelRequest {
         label: "Sweden VPN".to_owned(),
@@ -773,6 +841,19 @@ fn sample_request() -> CreateTunnelRequest {
         config: SAMPLE_CONF.to_owned(),
         server_selector: None,
         resolved_server_name: None,
+    }
+}
+
+fn sample_request_with_selector() -> CreateTunnelRequest {
+    CreateTunnelRequest {
+        label: "Sweden VPN".to_owned(),
+        country_code: "SE".to_owned(),
+        provider: Some("nordvpn".to_owned()),
+        config: SAMPLE_CONF.to_owned(),
+        server_selector: Some(BestServerSelector {
+            country: "SE".to_owned(),
+        }),
+        resolved_server_name: Some("Sweden #1".to_owned()),
     }
 }
 
@@ -2346,4 +2427,80 @@ async fn test_tunnel_get_stats_error_maps_to_internal() {
         matches!(result, Err(AppError::Internal(_))),
         "expected Internal on stats Err, got {result:?}"
     );
+}
+
+// -- Re-resolution branch tests -------------------------------------------
+
+#[tokio::test]
+async fn bring_up_reresolves_best_server() {
+    let resolver = Arc::new(FakeServerResolver {
+        result: FakeResolveResult::Success(
+            "198.51.100.99:51820".to_owned(),
+            "Sweden #99".to_owned(),
+        ),
+    });
+    let h = build_harness_with_resolver(resolver);
+
+    let resp =
+        auth_context::with_context(admin_ctx(), h.svc.import_tunnel(sample_request_with_selector()))
+            .await
+            .unwrap();
+    let id = resp.tunnel.id;
+
+    auth_context::with_context(admin_ctx(), h.svc.bring_up(id))
+        .await
+        .unwrap();
+
+    // Re-resolution must have persisted the new endpoint in the repo.
+    let rows = h.tunnels.rows.lock().unwrap();
+    assert_eq!(rows[0].endpoint, "198.51.100.99:51820");
+    assert_eq!(rows[0].resolved_server_name.as_deref(), Some("Sweden #99"));
+    assert!(rows[0].endpoint_resolved_at.is_some());
+}
+
+#[tokio::test]
+async fn bring_up_empty_server_list_is_fatal() {
+    let resolver = Arc::new(FakeServerResolver {
+        result: FakeResolveResult::EmptyList {
+            country: "SE".to_owned(),
+            provider: "nordvpn".to_owned(),
+        },
+    });
+    let h = build_harness_with_resolver(resolver);
+
+    let resp =
+        auth_context::with_context(admin_ctx(), h.svc.import_tunnel(sample_request_with_selector()))
+            .await
+            .unwrap();
+    let id = resp.tunnel.id;
+
+    let result = auth_context::with_context(admin_ctx(), h.svc.bring_up(id)).await;
+    assert!(
+        matches!(result, Err(AppError::Internal(_))),
+        "EmptyServerListError must be fatal, got {result:?}"
+    );
+}
+
+#[tokio::test]
+async fn bring_up_transient_resolver_error_uses_stored_endpoint() {
+    let resolver = Arc::new(FakeServerResolver {
+        result: FakeResolveResult::Transient("connection refused".to_owned()),
+    });
+    let h = build_harness_with_resolver(resolver);
+
+    let resp =
+        auth_context::with_context(admin_ctx(), h.svc.import_tunnel(sample_request_with_selector()))
+            .await
+            .unwrap();
+    let id = resp.tunnel.id;
+    let original_endpoint = resp.tunnel.endpoint.clone();
+
+    // Transient errors must not fail bring_up — fall back to stored endpoint.
+    auth_context::with_context(admin_ctx(), h.svc.bring_up(id))
+        .await
+        .unwrap();
+
+    // Stored endpoint must not have been overwritten.
+    let rows = h.tunnels.rows.lock().unwrap();
+    assert_eq!(rows[0].endpoint, original_endpoint);
 }

--- a/source/daemon/crates/wardnetd-services/src/tunnel/tests/tunnel.rs
+++ b/source/daemon/crates/wardnetd-services/src/tunnel/tests/tunnel.rs
@@ -2510,3 +2510,27 @@ async fn bring_up_transient_resolver_error_uses_stored_endpoint() {
     let rows = h.tunnels.rows.lock().unwrap();
     assert_eq!(rows[0].endpoint, original_endpoint);
 }
+
+#[tokio::test]
+async fn bring_up_with_selector_and_resolver_returning_none_uses_stored_endpoint() {
+    // MockServerResolver returns Ok(None) — "no provider registered".
+    // bring_up must succeed and keep the stored endpoint unchanged.
+    let resolver = Arc::new(MockServerResolver);
+    let h = build_harness_with_resolver(resolver);
+
+    let resp = auth_context::with_context(
+        admin_ctx(),
+        h.svc.import_tunnel(sample_request_with_selector()),
+    )
+    .await
+    .unwrap();
+    let id = resp.tunnel.id;
+    let original_endpoint = resp.tunnel.endpoint.clone();
+
+    auth_context::with_context(admin_ctx(), h.svc.bring_up(id))
+        .await
+        .unwrap();
+
+    let rows = h.tunnels.rows.lock().unwrap();
+    assert_eq!(rows[0].endpoint, original_endpoint);
+}

--- a/source/daemon/crates/wardnetd-services/src/vpn/mod.rs
+++ b/source/daemon/crates/wardnetd-services/src/vpn/mod.rs
@@ -1,10 +1,12 @@
 pub mod nordvpn;
 pub mod provider;
 pub mod registry;
+pub mod resolver;
 pub mod service;
 
 pub use provider::VpnProvider;
 pub use registry::{EnabledProviders, VpnProviderRegistry};
+pub use resolver::ServerResolver;
 pub use service::{VpnProviderService, VpnProviderServiceImpl};
 
 #[cfg(test)]

--- a/source/daemon/crates/wardnetd-services/src/vpn/nordvpn.rs
+++ b/source/daemon/crates/wardnetd-services/src/vpn/nordvpn.rs
@@ -3,8 +3,8 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use async_trait::async_trait;
-use tokio::sync::RwLock;
 use serde::Deserialize;
+use tokio::sync::RwLock;
 use wardnet_common::vpn_provider::{
     CountryInfo, ProviderAuthMethod, ProviderCredentials, ProviderInfo, ServerFilter, ServerInfo,
 };

--- a/source/daemon/crates/wardnetd-services/src/vpn/nordvpn.rs
+++ b/source/daemon/crates/wardnetd-services/src/vpn/nordvpn.rs
@@ -253,8 +253,8 @@ impl NordVpnApi for HttpNordVpnApi {
     }
 }
 
-/// Countries list TTL: the NordVPN country catalogue changes rarely.
-const COUNTRIES_CACHE_TTL: Duration = Duration::from_secs(86_400);
+/// Countries list TTL: the `NordVPN` country catalogue changes rarely.
+const COUNTRIES_CACHE_TTL: Duration = Duration::from_hours(24);
 
 /// `NordVPN` provider implementation.
 ///
@@ -278,19 +278,19 @@ impl NordVpnProvider {
         }
     }
 
-    /// Return the numeric NordVPN country ID for an ISO code, using a cached
+    /// Return the numeric `NordVPN` country ID for an ISO code, using a cached
     /// country list refreshed at most once per [`COUNTRIES_CACHE_TTL`].
     async fn resolve_country_id(&self, code: &str) -> anyhow::Result<Option<u64>> {
         // Fast path: valid cache entry.
         {
             let cache = self.countries_cache.read().await;
-            if let Some((ref countries, fetched_at)) = *cache {
-                if fetched_at.elapsed() < COUNTRIES_CACHE_TTL {
-                    return Ok(countries
-                        .iter()
-                        .find(|c| c.code.eq_ignore_ascii_case(code))
-                        .map(|c| c.id));
-                }
+            if let Some((ref countries, fetched_at)) = *cache
+                && fetched_at.elapsed() < COUNTRIES_CACHE_TTL
+            {
+                return Ok(countries
+                    .iter()
+                    .find(|c| c.code.eq_ignore_ascii_case(code))
+                    .map(|c| c.id));
             }
         }
 

--- a/source/daemon/crates/wardnetd-services/src/vpn/nordvpn.rs
+++ b/source/daemon/crates/wardnetd-services/src/vpn/nordvpn.rs
@@ -1,7 +1,9 @@
 use std::fmt::Write as _;
 use std::sync::Arc;
+use std::time::{Duration, Instant};
 
 use async_trait::async_trait;
+use tokio::sync::RwLock;
 use serde::Deserialize;
 use wardnet_common::vpn_provider::{
     CountryInfo, ProviderAuthMethod, ProviderCredentials, ProviderInfo, ServerFilter, ServerInfo,
@@ -251,6 +253,9 @@ impl NordVpnApi for HttpNordVpnApi {
     }
 }
 
+/// Countries list TTL: the NordVPN country catalogue changes rarely.
+const COUNTRIES_CACHE_TTL: Duration = Duration::from_secs(86_400);
+
 /// `NordVPN` provider implementation.
 ///
 /// Translates VPN provider trait operations into `NordVPN`-specific API calls
@@ -258,13 +263,45 @@ impl NordVpnApi for HttpNordVpnApi {
 pub struct NordVpnProvider {
     /// The API client used for all `NordVPN` HTTP operations.
     api: Arc<dyn NordVpnApi>,
+    /// Cached country list with the instant it was fetched. Avoids one extra
+    /// HTTP round-trip on every `list_servers` / re-resolution call.
+    countries_cache: RwLock<Option<(Vec<NordCountryInfo>, Instant)>>,
 }
 
 impl NordVpnProvider {
     /// Create a new `NordVPN` provider backed by the given API client.
     #[must_use]
     pub fn new(api: Arc<dyn NordVpnApi>) -> Self {
-        Self { api }
+        Self {
+            api,
+            countries_cache: RwLock::new(None),
+        }
+    }
+
+    /// Return the numeric NordVPN country ID for an ISO code, using a cached
+    /// country list refreshed at most once per [`COUNTRIES_CACHE_TTL`].
+    async fn resolve_country_id(&self, code: &str) -> anyhow::Result<Option<u64>> {
+        // Fast path: valid cache entry.
+        {
+            let cache = self.countries_cache.read().await;
+            if let Some((ref countries, fetched_at)) = *cache {
+                if fetched_at.elapsed() < COUNTRIES_CACHE_TTL {
+                    return Ok(countries
+                        .iter()
+                        .find(|c| c.code.eq_ignore_ascii_case(code))
+                        .map(|c| c.id));
+                }
+            }
+        }
+
+        // Slow path: refresh the cache.
+        let countries = self.api.list_countries().await?;
+        let id = countries
+            .iter()
+            .find(|c| c.code.eq_ignore_ascii_case(code))
+            .map(|c| c.id);
+        *self.countries_cache.write().await = Some((countries, Instant::now()));
+        Ok(id)
     }
 
     /// Convert a `NordServer` into a [`ServerInfo`].
@@ -353,11 +390,7 @@ impl VpnProvider for NordVpnProvider {
     ) -> anyhow::Result<Vec<ServerInfo>> {
         // Resolve ISO country code to the numeric ID the NordVPN API requires.
         let country_id = if let Some(ref code) = filter.country {
-            let countries = self.api.list_countries().await?;
-            countries
-                .iter()
-                .find(|c| c.code.eq_ignore_ascii_case(code))
-                .map(|c| c.id)
+            self.resolve_country_id(code).await?
         } else {
             None
         };
@@ -409,11 +442,7 @@ impl VpnProvider for NordVpnProvider {
         let country_id = if country_code.is_empty() {
             None
         } else {
-            let countries = self.api.list_countries().await?;
-            countries
-                .iter()
-                .find(|c| c.code.eq_ignore_ascii_case(&country_code))
-                .map(|c| c.id)
+            self.resolve_country_id(&country_code).await?
         };
 
         let filter = NordServerFilter {
@@ -458,11 +487,7 @@ impl VpnProvider for NordVpnProvider {
         let country_id = if server.country_code.is_empty() {
             None
         } else {
-            let countries = self.api.list_countries().await?;
-            countries
-                .iter()
-                .find(|c| c.code.eq_ignore_ascii_case(&server.country_code))
-                .map(|c| c.id)
+            self.resolve_country_id(&server.country_code).await?
         };
 
         let filter = NordServerFilter {

--- a/source/daemon/crates/wardnetd-services/src/vpn/registry.rs
+++ b/source/daemon/crates/wardnetd-services/src/vpn/registry.rs
@@ -66,6 +66,15 @@ impl VpnProviderRegistry {
     }
 }
 
+/// Reject hostnames that could be used for endpoint injection (e.g. containing
+/// a colon that would override the port, or whitespace from a malformed response).
+fn validate_hostname(hostname: &str) -> anyhow::Result<()> {
+    if hostname.is_empty() || hostname.chars().any(|c| c == ':' || c.is_whitespace()) {
+        anyhow::bail!("provider returned invalid hostname: {:?}", hostname);
+    }
+    Ok(())
+}
+
 #[async_trait]
 impl ServerResolver for VpnProviderRegistry {
     async fn resolve(
@@ -78,6 +87,11 @@ impl ServerResolver for VpnProviderRegistry {
             return Ok(None);
         };
 
+        // NordVPN's recommendations endpoint is unauthenticated (public API).
+        // The `list_servers` trait signature accepts credentials for providers
+        // that require auth; we pass an empty token here because NordVPN ignores
+        // it. A future provider that requires auth for listing must not use this
+        // path — extend the trait with a credential-free method instead.
         let dummy = ProviderCredentials::Token {
             token: String::new(),
         };
@@ -96,6 +110,7 @@ impl ServerResolver for VpnProviderRegistry {
         }
 
         let server = servers.iter().min_by_key(|s| s.load).expect("non-empty");
+        validate_hostname(&server.hostname)?;
         let endpoint = format!("{}:{port}", server.hostname);
         Ok(Some((endpoint, server.name.clone())))
     }

--- a/source/daemon/crates/wardnetd-services/src/vpn/registry.rs
+++ b/source/daemon/crates/wardnetd-services/src/vpn/registry.rs
@@ -1,10 +1,13 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use wardnet_common::vpn_provider::ProviderInfo;
+use async_trait::async_trait;
+use wardnet_common::tunnel::BestServerSelector;
+use wardnet_common::vpn_provider::{ProviderCredentials, ProviderInfo, ServerFilter};
 
 use crate::vpn::nordvpn::{HttpNordVpnApi, NordVpnProvider};
 use crate::vpn::provider::VpnProvider;
+use crate::vpn::resolver::{EmptyServerListError, ServerResolver};
 
 /// Per-provider enable/disable flags passed from daemon configuration.
 pub type EnabledProviders = HashMap<String, bool>;
@@ -60,5 +63,40 @@ impl VpnProviderRegistry {
     #[must_use]
     pub fn list(&self) -> Vec<ProviderInfo> {
         self.providers.values().map(|p| p.info()).collect()
+    }
+}
+
+#[async_trait]
+impl ServerResolver for VpnProviderRegistry {
+    async fn resolve(
+        &self,
+        provider_id: &str,
+        selector: &BestServerSelector,
+        port: u16,
+    ) -> anyhow::Result<Option<(String, String)>> {
+        let Some(provider) = self.providers.get(provider_id) else {
+            return Ok(None);
+        };
+
+        let dummy = ProviderCredentials::Token {
+            token: String::new(),
+        };
+        let filter = ServerFilter {
+            country: Some(selector.country.clone()),
+            max_load: None,
+        };
+
+        let servers = provider.list_servers(&dummy, &filter).await?;
+
+        if servers.is_empty() {
+            return Err(anyhow::Error::new(EmptyServerListError {
+                country: selector.country.clone(),
+                provider: provider_id.to_owned(),
+            }));
+        }
+
+        let server = servers.iter().min_by_key(|s| s.load).expect("non-empty");
+        let endpoint = format!("{}:{port}", server.hostname);
+        Ok(Some((endpoint, server.name.clone())))
     }
 }

--- a/source/daemon/crates/wardnetd-services/src/vpn/registry.rs
+++ b/source/daemon/crates/wardnetd-services/src/vpn/registry.rs
@@ -70,7 +70,7 @@ impl VpnProviderRegistry {
 /// a colon that would override the port, or whitespace from a malformed response).
 fn validate_hostname(hostname: &str) -> anyhow::Result<()> {
     if hostname.is_empty() || hostname.chars().any(|c| c == ':' || c.is_whitespace()) {
-        anyhow::bail!("provider returned invalid hostname: {:?}", hostname);
+        anyhow::bail!("provider returned invalid hostname: {hostname:?}");
     }
     Ok(())
 }

--- a/source/daemon/crates/wardnetd-services/src/vpn/resolver.rs
+++ b/source/daemon/crates/wardnetd-services/src/vpn/resolver.rs
@@ -1,0 +1,32 @@
+use async_trait::async_trait;
+use wardnet_common::tunnel::BestServerSelector;
+
+/// Sentinel error indicating the server list for the requested selector was
+/// empty. `bring_up_core` downcasts to this to distinguish "no servers
+/// available" (fatal bring-up failure) from a transient network error (fall
+/// back to the stored endpoint).
+#[derive(Debug, thiserror::Error)]
+#[error("no servers found for country={country} via provider={provider}")]
+pub struct EmptyServerListError {
+    pub country: String,
+    pub provider: String,
+}
+
+/// Queries a VPN provider for the best server matching a stored selector.
+///
+/// Implemented by [`VpnProviderRegistry`](super::registry::VpnProviderRegistry)
+/// so that `TunnelServiceImpl` can re-resolve the endpoint on each bring-up
+/// without holding a direct reference to provider APIs.
+#[async_trait]
+pub trait ServerResolver: Send + Sync {
+    /// Return `(endpoint_host:port, human_readable_server_name)` for the best
+    /// server matching `selector` on the given provider, or `Ok(None)` if the
+    /// provider is not registered. Returns `Err` on network/API failure or
+    /// (as [`EmptyServerListError`]) when the server list is empty.
+    async fn resolve(
+        &self,
+        provider_id: &str,
+        selector: &BestServerSelector,
+        port: u16,
+    ) -> anyhow::Result<Option<(String, String)>>;
+}

--- a/source/daemon/crates/wardnetd-services/src/vpn/service.rs
+++ b/source/daemon/crates/wardnetd-services/src/vpn/service.rs
@@ -6,6 +6,7 @@ use wardnet_common::api::{
     ListServersResponse, SetupProviderRequest, SetupProviderResponse, ValidateCredentialsRequest,
     ValidateCredentialsResponse,
 };
+use wardnet_common::tunnel::BestServerSelector;
 use wardnet_common::vpn_provider::ServerFilter;
 
 use crate::TunnelService;
@@ -212,12 +213,23 @@ impl VpnProviderService for VpnProviderServiceImpl {
             .label
             .unwrap_or_else(|| format!("{} - {}", info.name, server.name));
 
-        // 6. Import the tunnel via TunnelService.
+        // 6. Capture selector — hostname or explicit server_id = specific server → no re-resolution.
+        let server_selector = if request.hostname.is_none() && request.server_id.is_none() {
+            Some(BestServerSelector {
+                country: server.country_code.clone(),
+            })
+        } else {
+            None
+        };
+
+        // 7. Import the tunnel via TunnelService.
         let tunnel_request = CreateTunnelRequest {
             label,
             country_code: server.country_code.clone(),
             provider: Some(info.id.clone()),
             config,
+            server_selector,
+            resolved_server_name: Some(server.name.clone()),
         };
         let tunnel_response = self.tunnel_service.import_tunnel(tunnel_request).await?;
 

--- a/source/daemon/crates/wardnetd-services/src/vpn/tests/nordvpn.rs
+++ b/source/daemon/crates/wardnetd-services/src/vpn/tests/nordvpn.rs
@@ -16,6 +16,7 @@ use crate::vpn::provider::VpnProvider;
 struct MockNordVpnApi {
     validate_result: Mutex<Result<bool, String>>,
     countries: Mutex<Vec<NordCountryInfo>>,
+    list_countries_calls: Mutex<u32>,
     servers: Mutex<Vec<NordServer>>,
     server_by_hostname: Mutex<Option<NordServer>>,
     private_key_result: Mutex<Result<String, String>>,
@@ -27,6 +28,7 @@ impl MockNordVpnApi {
     fn new() -> Self {
         Self {
             validate_result: Mutex::new(Ok(true)),
+            list_countries_calls: Mutex::new(0),
             countries: Mutex::new(vec![
                 NordCountryInfo {
                     id: 208,
@@ -79,6 +81,7 @@ impl NordVpnApi for MockNordVpnApi {
     }
 
     async fn list_countries(&self) -> anyhow::Result<Vec<NordCountryInfo>> {
+        *self.list_countries_calls.lock().await += 1;
         let countries = self.countries.lock().await;
         Ok(countries.clone())
     }
@@ -732,5 +735,40 @@ async fn generate_config_uses_country_reference_server() {
         parsed.peers[0].endpoint.as_deref(),
         Some("se142.nordvpn.com:51820"),
         "endpoint must come from the requested server_info.hostname, not the reference server"
+    );
+}
+
+#[tokio::test]
+async fn list_servers_uses_cached_country_list_on_repeated_calls() {
+    let mock = MockNordVpnApi::new();
+    *mock.servers.lock().await = vec![sample_server("se142.nordvpn.com", 25, "SE")];
+    let mock = Arc::new(mock);
+    let provider = NordVpnProvider::new(mock.clone());
+
+    let filter = ServerFilter {
+        country: Some("SE".to_string()),
+        max_load: None,
+    };
+
+    // First call: fetches country list from API to resolve the ISO code.
+    provider
+        .list_servers(&token_credentials(), &filter)
+        .await
+        .unwrap();
+    assert_eq!(
+        *mock.list_countries_calls.lock().await,
+        1,
+        "first call must fetch country list"
+    );
+
+    // Second call: country list should come from the in-memory cache.
+    provider
+        .list_servers(&token_credentials(), &filter)
+        .await
+        .unwrap();
+    assert_eq!(
+        *mock.list_countries_calls.lock().await,
+        1,
+        "second call must reuse cached country list"
     );
 }

--- a/source/daemon/crates/wardnetd-services/src/vpn/tests/provider.rs
+++ b/source/daemon/crates/wardnetd-services/src/vpn/tests/provider.rs
@@ -173,6 +173,9 @@ impl TunnelService for MockTunnelService {
             bytes_rx: 0,
             created_at: chrono::Utc::now(),
             override_default_dns: false,
+            server_selector: req.server_selector.clone(),
+            resolved_server_name: req.resolved_server_name.clone(),
+            endpoint_resolved_at: None,
         };
         self.imported.lock().unwrap().push(req);
         Ok(CreateTunnelResponse {

--- a/source/daemon/crates/wardnetd-services/src/vpn/tests/provider.rs
+++ b/source/daemon/crates/wardnetd-services/src/vpn/tests/provider.rs
@@ -6,7 +6,7 @@ use wardnet_common::api::{
     CreateTunnelRequest, CreateTunnelResponse, DeleteTunnelResponse, ListServersRequest,
     ListTunnelsResponse, SetupProviderRequest, TunnelTestResult, ValidateCredentialsRequest,
 };
-use wardnet_common::tunnel::{Tunnel, TunnelStatus};
+use wardnet_common::tunnel::{BestServerSelector, Tunnel, TunnelStatus};
 use wardnet_common::vpn_provider::{
     CountryInfo, ProviderAuthMethod, ProviderCredentials, ProviderInfo, ServerFilter, ServerInfo,
 };
@@ -550,6 +550,13 @@ async fn setup_tunnel_happy_path() {
     assert_eq!(imported.len(), 1);
     assert_eq!(imported[0].label, "Test VPN - Sweden #2");
     assert_eq!(imported[0].provider, Some("test".to_owned()));
+    // Auto-select path must store a BestServerSelector for re-resolution on each bring-up.
+    assert_eq!(
+        imported[0].server_selector,
+        Some(BestServerSelector {
+            country: "SE".to_owned()
+        })
+    );
 }
 
 #[tokio::test]
@@ -587,6 +594,10 @@ async fn setup_tunnel_with_specific_server_id() {
 
     assert_eq!(resp.server.id, "se-3");
     assert_eq!(resp.server.name, "Sweden #3");
+
+    // Explicit server_id must NOT store a selector — no re-resolution on bring-up.
+    let imported = h.tunnel_service.imported.lock().unwrap();
+    assert_eq!(imported[0].server_selector, None);
 }
 
 #[tokio::test]

--- a/source/daemon/crates/wardnetd-services/src/vpn/tests/registry.rs
+++ b/source/daemon/crates/wardnetd-services/src/vpn/tests/registry.rs
@@ -1,12 +1,14 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
+use wardnet_common::tunnel::BestServerSelector;
 use wardnet_common::vpn_provider::{
     CountryInfo, ProviderAuthMethod, ProviderCredentials, ProviderInfo, ServerFilter, ServerInfo,
 };
 
 use crate::vpn::provider::VpnProvider;
 use crate::vpn::registry::{EnabledProviders, VpnProviderRegistry};
+use crate::vpn::resolver::ServerResolver;
 
 /// Minimal mock VPN provider for registry tests.
 struct FakeProvider {
@@ -143,4 +145,139 @@ fn register_overwrites_existing_provider() {
     let list = registry.list();
     assert_eq!(list.len(), 1);
     assert_eq!(list[0].name, "Version 2");
+}
+
+// -- ServerResolver trait tests -------------------------------------------
+
+/// Provider whose `list_servers` result is controlled per-test.
+struct ServerListProvider {
+    info: ProviderInfo,
+    servers: Vec<ServerInfo>,
+}
+
+impl ServerListProvider {
+    fn new(id: &str, servers: Vec<ServerInfo>) -> Self {
+        Self {
+            info: ProviderInfo {
+                id: id.to_owned(),
+                name: id.to_owned(),
+                auth_methods: vec![ProviderAuthMethod::Token],
+                icon_url: None,
+                website_url: None,
+                credentials_hint: None,
+            },
+            servers,
+        }
+    }
+}
+
+#[async_trait]
+impl VpnProvider for ServerListProvider {
+    fn info(&self) -> ProviderInfo {
+        self.info.clone()
+    }
+    async fn validate_credentials(&self, _: &ProviderCredentials) -> anyhow::Result<bool> {
+        Ok(true)
+    }
+    async fn list_countries(&self, _: &ProviderCredentials) -> anyhow::Result<Vec<CountryInfo>> {
+        Ok(vec![])
+    }
+    async fn list_servers(
+        &self,
+        _: &ProviderCredentials,
+        _: &ServerFilter,
+    ) -> anyhow::Result<Vec<ServerInfo>> {
+        Ok(self.servers.clone())
+    }
+    async fn generate_config(
+        &self,
+        _: &ProviderCredentials,
+        _: &ServerInfo,
+    ) -> anyhow::Result<String> {
+        Ok(String::new())
+    }
+}
+
+fn make_selector(country: &str) -> BestServerSelector {
+    BestServerSelector {
+        country: country.to_owned(),
+    }
+}
+
+fn make_server(hostname: &str, name: &str, load: u8) -> ServerInfo {
+    ServerInfo {
+        id: hostname.to_owned(),
+        name: name.to_owned(),
+        country_code: "SE".to_owned(),
+        city: None,
+        hostname: hostname.to_owned(),
+        load,
+    }
+}
+
+#[tokio::test]
+async fn resolve_returns_none_for_unknown_provider() {
+    let enabled = with_nordvpn_disabled();
+    let registry = VpnProviderRegistry::new(&enabled);
+
+    let result = registry
+        .resolve("nonexistent", &make_selector("SE"), 51820)
+        .await
+        .unwrap();
+    assert!(result.is_none());
+}
+
+#[tokio::test]
+async fn resolve_returns_empty_server_list_error() {
+    let enabled = with_nordvpn_disabled();
+    let mut registry = VpnProviderRegistry::new(&enabled);
+    registry.register(Arc::new(ServerListProvider::new("myvpn", vec![])));
+
+    let err = registry
+        .resolve("myvpn", &make_selector("SE"), 51820)
+        .await
+        .unwrap_err();
+    assert!(
+        err.to_string().contains("SE") || err.to_string().contains("no servers"),
+        "got: {err}"
+    );
+}
+
+#[tokio::test]
+async fn resolve_rejects_invalid_hostname() {
+    let enabled = with_nordvpn_disabled();
+    let mut registry = VpnProviderRegistry::new(&enabled);
+    registry.register(Arc::new(ServerListProvider::new(
+        "myvpn",
+        vec![make_server("host:with:colons", "Bad Server", 10)],
+    )));
+
+    let err = registry
+        .resolve("myvpn", &make_selector("SE"), 51820)
+        .await
+        .unwrap_err();
+    assert!(err.to_string().contains("invalid hostname"), "got: {err}");
+}
+
+#[tokio::test]
+async fn resolve_returns_endpoint_and_name_for_valid_server() {
+    let enabled = with_nordvpn_disabled();
+    let mut registry = VpnProviderRegistry::new(&enabled);
+    registry.register(Arc::new(ServerListProvider::new(
+        "myvpn",
+        vec![
+            make_server("se142.example.com", "Sweden #142", 30),
+            make_server("se99.example.com", "Sweden #99", 10),
+        ],
+    )));
+
+    let (endpoint, name) = registry
+        .resolve("myvpn", &make_selector("SE"), 51820)
+        .await
+        .unwrap()
+        .expect("should return Some");
+
+    // Picks the server with lowest load (se99) and formats endpoint.
+    assert_eq!(endpoint, "se99.example.com:51820");
+    assert_eq!(name, "Sweden #99");
 }

--- a/source/daemon/crates/wardnetd/src/dns/tests/server.rs
+++ b/source/daemon/crates/wardnetd/src/dns/tests/server.rs
@@ -91,6 +91,16 @@ fn stub_tunnel_repo() -> Arc<dyn TunnelRepository> {
         async fn count(&self) -> anyhow::Result<i64> {
             Ok(0)
         }
+        async fn update_endpoint(
+            &self,
+            _id: &str,
+            _endpoint: &str,
+            _peer_config_json: &str,
+            _server_name: &str,
+            _resolved_at: &str,
+        ) -> anyhow::Result<()> {
+            Ok(())
+        }
         async fn count_active(&self) -> anyhow::Result<i64> {
             Ok(0)
         }
@@ -758,6 +768,16 @@ impl TunnelRepository for ScriptedTunnelRepo {
     async fn count(&self) -> anyhow::Result<i64> {
         Ok(0)
     }
+    async fn update_endpoint(
+        &self,
+        _id: &str,
+        _endpoint: &str,
+        _peer_config_json: &str,
+        _server_name: &str,
+        _resolved_at: &str,
+    ) -> anyhow::Result<()> {
+        Ok(())
+    }
     async fn count_active(&self) -> anyhow::Result<i64> {
         Ok(0)
     }
@@ -777,6 +797,9 @@ fn sample_tunnel(id: Uuid, interface: &str) -> Tunnel {
         bytes_rx: 0,
         created_at: Utc::now(),
         override_default_dns: true,
+        server_selector: None,
+        resolved_server_name: None,
+        endpoint_resolved_at: None,
     }
 }
 

--- a/source/sdk/wardnet-js/src/types/tunnel.ts
+++ b/source/sdk/wardnet-js/src/types/tunnel.ts
@@ -31,4 +31,10 @@ export interface Tunnel {
    * system-wide upstream pool is used. See issue #342.
    */
   override_default_dns: boolean;
+  /** Present only on "best server" tunnels. Null for specific-server or manual imports. */
+  server_selector: { country: string } | null;
+  /** Human-readable resolved server name, e.g. "United States #8395". */
+  resolved_server_name: string | null;
+  /** ISO timestamp of the last endpoint re-resolution. */
+  endpoint_resolved_at: string | null;
 }


### PR DESCRIPTION
## Summary

Closes #80 

- Re-resolves the NordVPN best server on each tunnel bring-up via a new `VpnResolver` / `ServerResolver` trait, storing the selected endpoint in a new `tunnel_server_selector` SQLite column (migration included)
- Caches the NordVPN countries list for 24 h to avoid a redundant HTTP round-trip on every re-resolution call
- Validates provider-returned hostnames before use to prevent endpoint injection from a compromised API response
- Threads the resolved server info through the daemon API, repository, SDK types, and React UI (`TunnelCard`, `ProviderTunnelTab`, `TunnelDetail`)

## Pre-PR review fixes applied

- **perf**: NordVPN countries list cached with 24 h TTL (`nordvpn.rs`)
- **security**: hostname validated before endpoint interpolation (`registry.rs`)
- **security/correctness**: documented why empty credentials are passed to `list_servers`; future providers requiring auth must not use this path
- **correctness**: `parse_port` now warns via `tracing::warn!` before falling back to default port
- **testing**: `MockServerResolver` → configurable `FakeServerResolver`; added `bring_up_reresolves_best_server`, `bring_up_empty_server_list_is_fatal`, `bring_up_transient_resolver_error_uses_stored_endpoint` tests
- **testing**: added `server_selector` assertions to `setup_tunnel_happy_path` and `setup_tunnel_with_specific_server_id`; derived `PartialEq` + `Eq` on `BestServerSelector`
- **perf/correctness**: eliminated timestamp `String` clone + re-parse in `import_tunnel` — captured as `DateTime<Utc>` once
- **logging**: removed duplicate `{e}` from re-resolution `warn!` message strings (value already in structured `error = %e` field)
- **frontend**: removed dead ternary in `ProviderTunnelTab` (`country &&` outer guard made inner `country ?` unreachable)
- **perf**: avoided `new_ep.clone()` by moving into `updated_peer.endpoint` and borrowing back for `update_endpoint`

## Test plan

- [ ] `cargo test -p wardnetd-services` — 753 tests pass
- [ ] `cargo test -p wardnet-common` — 123 tests pass
- [ ] Bring up a NordVPN tunnel and confirm the `resolved_server_name` and `endpoint_resolved_at` fields are populated on each connect
- [ ] Confirm `TunnelCard` shows the "Best SE" badge for auto-selected tunnels and not for hostname/specific-server tunnels
- [ ] Confirm `TunnelDetail` shows the latency chart and server selector info

🤖 Generated with [Claude Code](https://claude.com/claude-code)