### PR TITLE
feat(daemon): include current routing target in GET /api/devices list response

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -22,6 +22,14 @@
 
 **Device-keyed push subscription** — A Web Push subscription (VAPID) stored in the daemon's database keyed to a device record (MAC/IP). Allows the daemon to notify a specific device's browser even when the PWA is not open.
 
+## Routing
+
+**Routing target** — Where a device's traffic egresses: a specific **tunnel**, **direct** (bypass all tunnels, use the WAN), or **default** (explicitly defer to the gateway's default policy). A device's *current* routing target is its per-device rule if one exists.
+
+**Routing rule** — A per-device binding of a device to a routing target, created by an admin or by the device owner (self-service). At most one rule exists per device.
+
+**Default policy** — The gateway-wide fallback applied to a device that has **no** routing rule of its own. A device following the default policy is distinct from one whose rule's target is explicitly *default*: the former has no rule (its current routing target is absent/`null`), the latter has a rule that names *default* as the target. Both ultimately follow the gateway policy, but only the latter is a persisted choice.
+
 ## Infrastructure
 
 **DDNS service** — Wardnet-operated service that assigns each installation a unique subdomain (`<install-id>.wardnet.network`) and manages DNS records for it. Also acts as an ACME bridge: handles `_acme-challenge` TXT records on behalf of the Pi so Let's Encrypt can issue a certificate via DNS-01 without the user needing a domain or DNS provider credentials. The cert private key is generated on the Pi and never leaves it.

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -835,7 +835,7 @@
         "tags": [
           "devices"
         ],
-        "description": "List every device the daemon has seen on the LAN, enriched with its current DHCP status (reservation, active lease, or external/unknown). Admin only.",
+        "description": "List every device the daemon has seen on the LAN, enriched with its current DHCP status (reservation, active lease, or external/unknown) and current routing target (a specific tunnel, direct, or null when the device follows the gateway default policy). Admin only.",
         "operationId": "list_devices",
         "responses": {
           "200": {
@@ -13916,13 +13916,23 @@
               "dhcp_status"
             ],
             "properties": {
+              "current_rule": {
+                "oneOf": [
+                  {
+                    "type": "null"
+                  },
+                  {
+                    "$ref": "#/components/schemas/RoutingTarget"
+                  }
+                ]
+              },
               "dhcp_status": {
                 "$ref": "#/components/schemas/DhcpStatus"
               }
             }
           }
         ],
-        "description": "A device enriched with its DHCP status for API responses.\n\nUses `#[serde(flatten)]` so the JSON output includes all `Device` fields\nat the top level alongside `dhcp_status`, keeping the response\nbackwards-compatible for consumers that ignore unknown fields."
+        "description": "A device enriched with its DHCP status and current routing target for API\nresponses.\n\nUses `#[serde(flatten)]` so the JSON output includes all `Device` fields\nat the top level alongside `dhcp_status` and `current_rule`, keeping the\nresponse backwards-compatible for consumers that ignore unknown fields.\n\n`current_rule` mirrors [`DeviceDetailResponse::current_rule`]: `None` means\nthe device has no rule of its own and follows the gateway default policy;\n`Some(RoutingTarget::Default)` is an explicit persisted default choice."
       },
       "DhcpConfig": {
         "type": "object",

--- a/source/daemon/crates/wardnet-common/src/api.rs
+++ b/source/daemon/crates/wardnet-common/src/api.rs
@@ -246,16 +246,22 @@ pub struct TunnelTestResponse {
     pub result: TunnelTestResult,
 }
 
-/// A device enriched with its DHCP status for API responses.
+/// A device enriched with its DHCP status and current routing target for API
+/// responses.
 ///
 /// Uses `#[serde(flatten)]` so the JSON output includes all `Device` fields
-/// at the top level alongside `dhcp_status`, keeping the response
-/// backwards-compatible for consumers that ignore unknown fields.
+/// at the top level alongside `dhcp_status` and `current_rule`, keeping the
+/// response backwards-compatible for consumers that ignore unknown fields.
+///
+/// `current_rule` mirrors [`DeviceDetailResponse::current_rule`]: `None` means
+/// the device has no rule of its own and follows the gateway default policy;
+/// `Some(RoutingTarget::Default)` is an explicit persisted default choice.
 #[derive(Debug, Clone, Serialize, utoipa::ToSchema)]
 pub struct DeviceWithStatus {
     #[serde(flatten)]
     pub device: Device,
     pub dhcp_status: DhcpStatus,
+    pub current_rule: Option<RoutingTarget>,
 }
 
 /// Response for GET /api/devices (admin).

--- a/source/daemon/crates/wardnetd-api/src/api/devices.rs
+++ b/source/daemon/crates/wardnetd-api/src/api/devices.rs
@@ -10,6 +10,7 @@ use wardnet_common::api::{
     SetMyRuleRequest, SetMyRuleResponse, UpdateDeviceRequest,
 };
 use wardnet_common::device::DhcpStatus;
+use wardnet_common::routing::RoutingTarget;
 
 use crate::api::middleware::{AdminAuth, ClientIp};
 use crate::api::responses::{AuthErrors, BadRequest, NotFound};
@@ -134,10 +135,13 @@ async fn build_dhcp_status_map(state: &AppState) -> Result<HashMap<String, DhcpS
     Ok(map)
 }
 
-/// Enrich a [`Device`](wardnet_common::device::Device) with its DHCP status.
+/// Enrich a [`Device`](wardnet_common::device::Device) with its DHCP status
+/// and current routing target. `current_rule` is `None` when the device has no
+/// rule of its own (it follows the gateway default policy).
 fn enrich_device(
     device: wardnet_common::device::Device,
     dhcp_map: &HashMap<String, DhcpStatus>,
+    current_rule: Option<RoutingTarget>,
 ) -> DeviceWithStatus {
     let status = dhcp_map
         .get(&device.mac)
@@ -146,6 +150,7 @@ fn enrich_device(
     DeviceWithStatus {
         device,
         dhcp_status: status,
+        current_rule,
     }
 }
 
@@ -154,8 +159,9 @@ fn enrich_device(
     path = PATH_LIST,
     tag = TAG,
     description = "List every device the daemon has seen on the LAN, enriched with its \
-                   current DHCP status (reservation, active lease, or external/unknown). \
-                   Admin only.",
+                   current DHCP status (reservation, active lease, or external/unknown) \
+                   and current routing target (a specific tunnel, direct, or null when \
+                   the device follows the gateway default policy). Admin only.",
     responses(
         (status = 200, description = "List of devices with DHCP status", body = ListDevicesResponse),
         AuthErrors,
@@ -171,10 +177,15 @@ pub async fn list_devices(
 ) -> Result<Json<ListDevicesResponse>, AppError> {
     let devices = state.discovery_service().get_all_devices().await?;
     let dhcp_map = build_dhcp_status_map(&state).await?;
+    // Single batched lookup of every device's routing rule — no N+1.
+    let mut routing_map = state.device_service().current_rules().await?;
 
     let devices = devices
         .into_iter()
-        .map(|d| enrich_device(d, &dhcp_map))
+        .map(|d| {
+            let rule = routing_map.remove(&d.id);
+            enrich_device(d, &dhcp_map, rule)
+        })
         .collect();
 
     Ok(Json(ListDevicesResponse { devices }))
@@ -214,7 +225,7 @@ pub async fn get_device(
         .ok()
         .and_then(|r| r.current_rule);
     let dhcp_map = build_dhcp_status_map(&state).await?;
-    let device = enrich_device(device, &dhcp_map);
+    let device = enrich_device(device, &dhcp_map, rule.clone());
     Ok(Json(DeviceDetailResponse {
         device,
         current_rule: rule,
@@ -294,7 +305,7 @@ pub async fn update_device(
         .and_then(|r| r.current_rule);
 
     let dhcp_map = build_dhcp_status_map(&state).await?;
-    let device = enrich_device(device, &dhcp_map);
+    let device = enrich_device(device, &dhcp_map, rule.clone());
     Ok(Json(DeviceDetailResponse {
         device,
         current_rule: rule,

--- a/source/daemon/crates/wardnetd-api/src/api/tests/devices.rs
+++ b/source/daemon/crates/wardnetd-api/src/api/tests/devices.rs
@@ -76,6 +76,8 @@ struct MockDeviceService {
     rule: Option<RoutingTarget>,
     admin_locked: bool,
     set_rule_error: Option<String>,
+    /// Batched routing rules returned by `current_rules` (used by the list path).
+    current_rules: std::collections::HashMap<Uuid, RoutingTarget>,
 }
 
 impl MockDeviceService {
@@ -86,6 +88,7 @@ impl MockDeviceService {
             rule,
             admin_locked,
             set_rule_error: None,
+            current_rules: std::collections::HashMap::new(),
         }
     }
 
@@ -95,6 +98,7 @@ impl MockDeviceService {
             rule: None,
             admin_locked: false,
             set_rule_error: Some("not_found".to_owned()),
+            current_rules: std::collections::HashMap::new(),
         }
     }
 
@@ -104,7 +108,14 @@ impl MockDeviceService {
             rule: None,
             admin_locked: true,
             set_rule_error: Some("forbidden".to_owned()),
+            current_rules: std::collections::HashMap::new(),
         }
+    }
+
+    /// Seed the batched `current_rules` map returned to the list handler.
+    fn with_current_rules(mut self, rules: std::collections::HashMap<Uuid, RoutingTarget>) -> Self {
+        self.current_rules = rules;
+        self
     }
 }
 
@@ -138,6 +149,12 @@ impl DeviceService for MockDeviceService {
 
     async fn set_rule(&self, _id: &str, _t: RoutingTarget) -> Result<(), AppError> {
         Ok(())
+    }
+
+    async fn current_rules(
+        &self,
+    ) -> Result<std::collections::HashMap<Uuid, RoutingTarget>, AppError> {
+        Ok(self.current_rules.clone())
     }
 
     async fn update_admin_locked(&self, _id: &str, _locked: bool) -> Result<(), AppError> {
@@ -566,6 +583,56 @@ async fn list_devices_returns_all() {
     assert_eq!(json["devices"][0]["mac"], "aa:bb:cc:dd:ee:01");
     // No lease or reservation for this device, so dhcp_status should be "external".
     assert_eq!(json["devices"][0]["dhcp_status"], "external");
+    // No routing rule for this device → it follows the gateway default policy,
+    // surfaced as a null current_rule.
+    assert!(json["devices"][0]["current_rule"].is_null());
+}
+
+#[tokio::test]
+async fn list_devices_includes_routing_target() {
+    // Two devices: one tunnel-routed, one with no rule (default policy).
+    let mut tunnel_device = sample_device();
+    let tunnel_id = Uuid::parse_str("11111111-1111-1111-1111-111111111111").unwrap();
+    tunnel_device.id = Uuid::parse_str("00000000-0000-0000-0000-000000000001").unwrap();
+    tunnel_device.mac = "aa:bb:cc:dd:ee:01".to_owned();
+
+    let mut default_device = sample_device();
+    default_device.id = Uuid::parse_str("00000000-0000-0000-0000-000000000002").unwrap();
+    default_device.mac = "aa:bb:cc:dd:ee:02".to_owned();
+
+    let mut rules = std::collections::HashMap::new();
+    rules.insert(tunnel_device.id, RoutingTarget::Tunnel { tunnel_id });
+
+    let state = build_state_with_dhcp(
+        MockDeviceService::not_found().with_current_rules(rules),
+        MockDiscoveryService {
+            devices: vec![tunnel_device, default_device],
+        },
+        MockDhcpService::empty(),
+    );
+    let app = device_router(state);
+
+    let (status, json) = get_json(app, "/api/devices").await;
+    assert_eq!(status, StatusCode::OK);
+
+    let devices = json["devices"].as_array().unwrap();
+    assert_eq!(devices.len(), 2);
+
+    let tunnel = devices
+        .iter()
+        .find(|d| d["mac"] == "aa:bb:cc:dd:ee:01")
+        .unwrap();
+    assert_eq!(tunnel["current_rule"]["type"], "tunnel");
+    assert_eq!(
+        tunnel["current_rule"]["tunnel_id"],
+        "11111111-1111-1111-1111-111111111111"
+    );
+
+    let default = devices
+        .iter()
+        .find(|d| d["mac"] == "aa:bb:cc:dd:ee:02")
+        .unwrap();
+    assert!(default["current_rule"].is_null());
 }
 
 #[tokio::test]

--- a/source/daemon/crates/wardnetd-api/src/api/tests/middleware.rs
+++ b/source/daemon/crates/wardnetd-api/src/api/tests/middleware.rs
@@ -382,6 +382,11 @@ impl DeviceService for MockDeviceService {
     async fn set_rule(&self, _id: &str, _t: RoutingTarget) -> Result<(), AppError> {
         unimplemented!()
     }
+    async fn current_rules(
+        &self,
+    ) -> Result<std::collections::HashMap<Uuid, RoutingTarget>, AppError> {
+        unimplemented!()
+    }
     async fn update_admin_locked(&self, _id: &str, _locked: bool) -> Result<(), AppError> {
         unimplemented!()
     }

--- a/source/daemon/crates/wardnetd-api/src/tests/stubs.rs
+++ b/source/daemon/crates/wardnetd-api/src/tests/stubs.rs
@@ -86,6 +86,11 @@ impl DeviceService for StubDeviceService {
     async fn set_rule(&self, _id: &str, _t: RoutingTarget) -> Result<(), AppError> {
         unimplemented!()
     }
+    async fn current_rules(
+        &self,
+    ) -> Result<std::collections::HashMap<Uuid, RoutingTarget>, AppError> {
+        unimplemented!()
+    }
     async fn update_admin_locked(&self, _id: &str, _locked: bool) -> Result<(), AppError> {
         unimplemented!()
     }

--- a/source/daemon/crates/wardnetd-data/src/repository/device.rs
+++ b/source/daemon/crates/wardnetd-data/src/repository/device.rs
@@ -64,6 +64,14 @@ pub trait DeviceRepository: Send + Sync {
     /// Return the routing rule for a device, if one exists.
     async fn find_rule_for_device(&self, device_id: &str) -> anyhow::Result<Option<RoutingRule>>;
 
+    /// Return every device's routing rule in a single query.
+    ///
+    /// Batched companion to [`find_rule_for_device`](Self::find_rule_for_device)
+    /// for callers that enrich the whole device list (e.g. `GET /api/devices`)
+    /// and must avoid an N+1. There is at most one rule per device, so each
+    /// device appears at most once; devices with no rule are simply absent.
+    async fn find_all_rules(&self) -> anyhow::Result<Vec<RoutingRule>>;
+
     /// Insert or update a user-created routing rule for a device.
     async fn upsert_user_rule(
         &self,

--- a/source/daemon/crates/wardnetd-data/src/repository/sqlite/device.rs
+++ b/source/daemon/crates/wardnetd-data/src/repository/sqlite/device.rs
@@ -214,6 +214,28 @@ impl DeviceRepository for SqliteDeviceRepository {
         }
     }
 
+    async fn find_all_rules(&self) -> anyhow::Result<Vec<RoutingRule>> {
+        let rows = sqlx::query_as::<_, RuleRow>(
+            "SELECT device_id, target_json, created_by FROM routing_rules",
+        )
+        .fetch_all(&self.pools.read)
+        .await?;
+
+        rows.into_iter()
+            .map(|r| {
+                let target: RoutingTarget = serde_json::from_str(&r.target_json)?;
+                let created_by: RuleCreator =
+                    serde_json::from_str(&format!("\"{}\"", r.created_by))
+                        .unwrap_or(RuleCreator::User);
+                Ok(RoutingRule {
+                    device_id: r.device_id.parse()?,
+                    target,
+                    created_by,
+                })
+            })
+            .collect()
+    }
+
     async fn upsert_user_rule(
         &self,
         device_id: &str,

--- a/source/daemon/crates/wardnetd-data/src/repository/tests/device.rs
+++ b/source/daemon/crates/wardnetd-data/src/repository/tests/device.rs
@@ -310,6 +310,68 @@ async fn find_rule_not_found() {
 }
 
 #[tokio::test]
+async fn find_all_rules_returns_every_rule_once() {
+    let pool = test_pool().await;
+    // DEV1 → tunnel, DEV2 → direct, DEV3 → explicit default; a fourth device
+    // with no rule must be absent from the result.
+    insert_device(&pool, DEV1, "aa:bb:cc:dd:ee:01", "192.168.1.10").await;
+    insert_device(&pool, DEV2, "aa:bb:cc:dd:ee:02", "192.168.1.11").await;
+    insert_device(&pool, DEV3, "aa:bb:cc:dd:ee:03", "192.168.1.12").await;
+    let dev4 = "00000000-0000-0000-0000-000000000004";
+    insert_device(&pool, dev4, "aa:bb:cc:dd:ee:04", "192.168.1.13").await;
+
+    let tunnel_id = "11111111-1111-1111-1111-111111111111";
+    for (id, target_json) in [
+        (
+            DEV1,
+            format!("{{\"type\":\"tunnel\",\"tunnel_id\":\"{tunnel_id}\"}}"),
+        ),
+        (DEV2, "{\"type\":\"direct\"}".to_owned()),
+        (DEV3, "{\"type\":\"default\"}".to_owned()),
+    ] {
+        sqlx::query(
+            "INSERT INTO routing_rules (id, device_id, target_json, created_by) \
+             VALUES (?, ?, ?, 'user')",
+        )
+        .bind(uuid::Uuid::new_v4().to_string())
+        .bind(id)
+        .bind(target_json)
+        .execute(&pool)
+        .await
+        .unwrap();
+    }
+
+    let repo = SqliteDeviceRepository::new(pool);
+    let rules = repo.find_all_rules().await.unwrap();
+
+    // Exactly the three devices with a rule — dev4 (no rule) is absent.
+    assert_eq!(rules.len(), 3);
+    let by_id: std::collections::HashMap<_, _> = rules
+        .into_iter()
+        .map(|r| (r.device_id.to_string(), r.target))
+        .collect();
+    assert_eq!(
+        by_id.get(DEV1),
+        Some(&RoutingTarget::Tunnel {
+            tunnel_id: tunnel_id.parse().unwrap(),
+        })
+    );
+    assert_eq!(by_id.get(DEV2), Some(&RoutingTarget::Direct));
+    assert_eq!(by_id.get(DEV3), Some(&RoutingTarget::Default));
+    assert!(!by_id.contains_key(dev4));
+}
+
+#[tokio::test]
+async fn find_all_rules_empty_when_no_rules() {
+    let pool = test_pool().await;
+    insert_device(&pool, DEV1, "aa:bb:cc:dd:ee:01", "192.168.1.10").await;
+    let repo = SqliteDeviceRepository::new(pool);
+
+    let rules = repo.find_all_rules().await.unwrap();
+    assert!(rules.is_empty());
+}
+
+#[tokio::test]
 async fn upsert_user_rule_insert_and_update() {
     let pool = test_pool().await;
     insert_device(&pool, DEV1, "aa:bb:cc:dd:ee:01", "192.168.1.10").await;

--- a/source/daemon/crates/wardnetd-services/src/device/service.rs
+++ b/source/daemon/crates/wardnetd-services/src/device/service.rs
@@ -1,6 +1,8 @@
+use std::collections::HashMap;
 use std::sync::Arc;
 
 use async_trait::async_trait;
+use uuid::Uuid;
 use wardnet_common::api::{DeviceMeResponse, SetMyRuleResponse};
 use wardnet_common::auth::AuthContext;
 use wardnet_common::event::WardnetEvent;
@@ -40,6 +42,14 @@ pub trait DeviceService: Send + Sync {
     ///
     /// Same authorization rules as [`set_rule_for_ip`](Self::set_rule_for_ip).
     async fn set_rule(&self, device_id: &str, target: RoutingTarget) -> Result<(), AppError>;
+
+    /// Return every device's current routing target, keyed by device ID.
+    ///
+    /// Batched companion to the per-device rule lookup used to enrich the
+    /// admin device list (`GET /api/devices`) without an N+1. Devices with no
+    /// rule are absent from the map (they follow the gateway default policy).
+    /// Requires admin privileges via the [`AuthContext`].
+    async fn current_rules(&self) -> Result<HashMap<Uuid, RoutingTarget>, AppError>;
 
     /// Update the `admin_locked` flag for a device.
     ///
@@ -200,6 +210,18 @@ impl DeviceService for DeviceServiceImpl {
         });
 
         Ok(())
+    }
+
+    async fn current_rules(&self) -> Result<HashMap<Uuid, RoutingTarget>, AppError> {
+        auth_context::require_admin()?;
+
+        let rules = self
+            .devices
+            .find_all_rules()
+            .await
+            .map_err(AppError::Internal)?;
+
+        Ok(rules.into_iter().map(|r| (r.device_id, r.target)).collect())
     }
 
     async fn update_admin_locked(&self, device_id: &str, locked: bool) -> Result<(), AppError> {

--- a/source/daemon/crates/wardnetd-services/src/device/tests/device.rs
+++ b/source/daemon/crates/wardnetd-services/src/device/tests/device.rs
@@ -19,6 +19,8 @@ use wardnetd_data::repository::device::DeviceRow;
 struct MockDeviceRepo {
     device: Option<Device>,
     rule: Option<RoutingRule>,
+    /// Rules returned by the batched `find_all_rules` lookup.
+    all_rules: Vec<RoutingRule>,
 }
 
 #[async_trait]
@@ -65,6 +67,9 @@ impl DeviceRepository for MockDeviceRepo {
     }
     async fn find_rule_for_device(&self, _id: &str) -> anyhow::Result<Option<RoutingRule>> {
         Ok(self.rule.clone())
+    }
+    async fn find_all_rules(&self) -> anyhow::Result<Vec<RoutingRule>> {
+        Ok(self.all_rules.clone())
     }
     async fn upsert_user_rule(&self, _id: &str, _json: &str, _now: &str) -> anyhow::Result<()> {
         Ok(())
@@ -146,6 +151,7 @@ fn make_svc(locked: bool, rule: Option<RoutingRule>) -> DeviceServiceImpl {
         Arc::new(MockDeviceRepo {
             device: Some(sample_device(locked)),
             rule,
+            all_rules: vec![],
         }),
         Arc::new(MockEventPublisher),
     )
@@ -156,9 +162,29 @@ fn make_svc_no_device() -> DeviceServiceImpl {
         Arc::new(MockDeviceRepo {
             device: None,
             rule: None,
+            all_rules: vec![],
         }),
         Arc::new(MockEventPublisher),
     )
+}
+
+fn make_svc_with_rules(all_rules: Vec<RoutingRule>) -> DeviceServiceImpl {
+    DeviceServiceImpl::new(
+        Arc::new(MockDeviceRepo {
+            device: None,
+            rule: None,
+            all_rules,
+        }),
+        Arc::new(MockEventPublisher),
+    )
+}
+
+fn rule_for(device_id: &str, target: RoutingTarget) -> RoutingRule {
+    RoutingRule {
+        device_id: Uuid::parse_str(device_id).unwrap(),
+        target,
+        created_by: RuleCreator::User,
+    }
 }
 
 // -- Tests: get_device_for_ip --------------------------------------------
@@ -401,6 +427,63 @@ async fn update_admin_locked_anonymous_forbidden() {
             .await
     })
     .await;
+
+    assert!(result.is_err());
+}
+
+// -- Tests: current_rules ------------------------------------------------
+
+#[tokio::test]
+async fn current_rules_maps_each_device_to_its_target() {
+    const DEV1: &str = "00000000-0000-0000-0000-000000000001";
+    const DEV2: &str = "00000000-0000-0000-0000-000000000002";
+    const DEV3: &str = "00000000-0000-0000-0000-000000000003";
+    let tunnel_id = Uuid::parse_str("11111111-1111-1111-1111-111111111111").unwrap();
+
+    let svc = make_svc_with_rules(vec![
+        rule_for(DEV1, RoutingTarget::Tunnel { tunnel_id }),
+        rule_for(DEV2, RoutingTarget::Direct),
+        rule_for(DEV3, RoutingTarget::Default),
+    ]);
+
+    let map = auth_context::with_context(admin_ctx(), svc.current_rules())
+        .await
+        .unwrap();
+
+    assert_eq!(map.len(), 3);
+    assert_eq!(
+        map.get(&Uuid::parse_str(DEV1).unwrap()),
+        Some(&RoutingTarget::Tunnel { tunnel_id })
+    );
+    assert_eq!(
+        map.get(&Uuid::parse_str(DEV2).unwrap()),
+        Some(&RoutingTarget::Direct)
+    );
+    assert_eq!(
+        map.get(&Uuid::parse_str(DEV3).unwrap()),
+        Some(&RoutingTarget::Default)
+    );
+}
+
+#[tokio::test]
+async fn current_rules_empty_when_no_rules() {
+    let svc = make_svc_with_rules(vec![]);
+
+    let map = auth_context::with_context(admin_ctx(), svc.current_rules())
+        .await
+        .unwrap();
+
+    assert!(map.is_empty());
+}
+
+#[tokio::test]
+async fn current_rules_anonymous_forbidden() {
+    let svc = make_svc_with_rules(vec![rule_for(
+        "00000000-0000-0000-0000-000000000001",
+        RoutingTarget::Direct,
+    )]);
+
+    let result = auth_context::with_context(AuthContext::Anonymous, svc.current_rules()).await;
 
     assert!(result.is_err());
 }

--- a/source/daemon/crates/wardnetd-services/src/device/tests/discovery.rs
+++ b/source/daemon/crates/wardnetd-services/src/device/tests/discovery.rs
@@ -191,6 +191,9 @@ impl DeviceRepository for MockDeviceRepo {
     async fn find_rule_for_device(&self, _id: &str) -> anyhow::Result<Option<RoutingRule>> {
         Ok(None)
     }
+    async fn find_all_rules(&self) -> anyhow::Result<Vec<RoutingRule>> {
+        Ok(vec![])
+    }
 
     async fn upsert_user_rule(&self, _id: &str, _json: &str, _now: &str) -> anyhow::Result<()> {
         Ok(())

--- a/source/daemon/crates/wardnetd-services/src/dns_filter/tests/service.rs
+++ b/source/daemon/crates/wardnetd-services/src/dns_filter/tests/service.rs
@@ -153,6 +153,9 @@ impl DeviceRepository for MemoryDeviceRepository {
     async fn find_rule_for_device(&self, _device_id: &str) -> anyhow::Result<Option<RoutingRule>> {
         unimplemented!()
     }
+    async fn find_all_rules(&self) -> anyhow::Result<Vec<RoutingRule>> {
+        unimplemented!()
+    }
     async fn upsert_user_rule(
         &self,
         _device_id: &str,

--- a/source/daemon/crates/wardnetd-services/src/routing/tests/routing.rs
+++ b/source/daemon/crates/wardnetd-services/src/routing/tests/routing.rs
@@ -105,6 +105,9 @@ impl DeviceRepository for MockDeviceRepo {
     async fn find_rule_for_device(&self, id: &str) -> anyhow::Result<Option<RoutingRule>> {
         Ok(self.rules.get(id).cloned())
     }
+    async fn find_all_rules(&self) -> anyhow::Result<Vec<RoutingRule>> {
+        Ok(self.rules.values().cloned().collect())
+    }
 
     async fn upsert_user_rule(&self, _id: &str, _json: &str, _now: &str) -> anyhow::Result<()> {
         Ok(())

--- a/source/daemon/crates/wardnetd-services/src/tunnel/tests/tunnel.rs
+++ b/source/daemon/crates/wardnetd-services/src/tunnel/tests/tunnel.rs
@@ -580,6 +580,9 @@ impl DeviceRepository for MockDeviceRepoForTunnel {
     async fn find_rule_for_device(&self, _id: &str) -> anyhow::Result<Option<RoutingRule>> {
         Ok(None)
     }
+    async fn find_all_rules(&self) -> anyhow::Result<Vec<RoutingRule>> {
+        Ok(vec![])
+    }
     async fn upsert_user_rule(&self, _id: &str, _json: &str, _now: &str) -> anyhow::Result<()> {
         Ok(())
     }
@@ -643,6 +646,9 @@ impl DeviceRepository for MockDeviceRepoWithSwitchedDevices {
     }
     async fn find_rule_for_device(&self, _id: &str) -> anyhow::Result<Option<RoutingRule>> {
         Ok(None)
+    }
+    async fn find_all_rules(&self) -> anyhow::Result<Vec<RoutingRule>> {
+        Ok(vec![])
     }
     async fn upsert_user_rule(&self, _id: &str, _json: &str, _now: &str) -> anyhow::Result<()> {
         Ok(())

--- a/source/daemon/crates/wardnetd/src/tests/stubs.rs
+++ b/source/daemon/crates/wardnetd/src/tests/stubs.rs
@@ -141,6 +141,11 @@ impl DeviceService for StubDeviceService {
     async fn set_rule(&self, _id: &str, _t: RoutingTarget) -> Result<(), AppError> {
         unimplemented!()
     }
+    async fn current_rules(
+        &self,
+    ) -> Result<std::collections::HashMap<Uuid, RoutingTarget>, AppError> {
+        unimplemented!()
+    }
     async fn update_admin_locked(&self, _id: &str, _locked: bool) -> Result<(), AppError> {
         unimplemented!()
     }

--- a/source/sdk/wardnet-js/src/types/device.ts
+++ b/source/sdk/wardnet-js/src/types/device.ts
@@ -28,6 +28,12 @@ export interface Device {
   last_ip: string;
   admin_locked: boolean;
   dhcp_status: DhcpStatus;
+  /**
+   * The device's current routing target. `null` when the device has no rule of
+   * its own and follows the gateway default policy; `{ type: "default" }` is an
+   * explicit persisted default choice.
+   */
+  current_rule: RoutingTarget | null;
 }
 
 /** Where a device's traffic is routed. */


### PR DESCRIPTION
## Summary

Part of #439 (admin mobile PWA). Enriches the shared device-list resource so every entry of `GET /api/devices` carries the device's **current routing target** (a specific tunnel, direct, or `null` when the device follows the gateway default policy). This removes the N+1 of `GET /api/devices/{id}` the Devices screen (sub-issue D2) would otherwise do on cellular, and benefits the desktop admin too.

Follows `docs/adr-pwa-data-fetching.md` ("enrich resources over view aggregators") — no BFF, no view-specific endpoint.

## Changes

- **Repository:** `DeviceRepository::find_all_rules` — a single batched query over `routing_rules` (no N+1 inside the daemon), companion to the per-device `find_rule_for_device`.
- **Service:** `DeviceService::current_rules` — admin-guarded (`require_admin()?`), returns a `device_id -> RoutingTarget` map.
- **DTO/handler:** `current_rule: Option<RoutingTarget>` added to `DeviceWithStatus`; `list_devices` fetches the map once and enriches each device. `get_device`/`update_device` keep their top-level `current_rule` for backwards compatibility (the detail JSON now carries it both nested and top-level — intentional and additive).
- **SDK:** `current_rule` added to the `@wardnet/js` `Device` type (following the existing `dhcp_status` precedent), so `DeviceService.list()` exposes it.
- **OpenAPI:** `docs/openapi.json` regenerated.
- **Glossary:** documented *Routing target* / *Routing rule* / *Default policy* in `CONTEXT.md`, including the no-rule vs explicit-`default` distinction.

## Field semantics

`current_rule` mirrors `DeviceDetailResponse.current_rule`: `None`/`null` = the device has no rule of its own and follows the gateway **default policy**; `{ "type": "default" }` = an explicit persisted default choice.

## Testing

Repository, service, and handler tests cover **Direct, tunnel-routed, explicit `Default`, and no-rule (default-policy)** devices, plus the service admin guard.

Verified locally on every crate this PR touches (`CARGO_BUILD_JOBS=1` in a Linux container):

- `cargo fmt --check` + `cargo clippy --all-targets -- -D warnings` — clean.
- `cargo test -p wardnetd-data -p wardnetd-services -p wardnetd-api` — **1,189 passed, 0 failed**.
- SDK `yarn type-check` + `yarn format:check` — clean.

> **Note for reviewers:** the full `cargo test --workspace` and `make coverage-daemon` could not be linked on the local 7.45 GiB dev VM (the 257-object `wardnetd` test mega-binary OOMs the linker; that binary contains only an `unimplemented!()` stub from this PR, no assertions). Deferred to CI, which runs the canonical `make check-daemon` + coverage gate on a larger runner.

Closes #472
