### PR TITLE
feat(web): PWA-shell helpers in wardnet-web (SW registration, install + offline hooks)

### DIFF
--- a/source/wardnet-web/src/hooks/useInstallPrompt.ts
+++ b/source/wardnet-web/src/hooks/useInstallPrompt.ts
@@ -1,0 +1,51 @@
+import { useCallback, useEffect, useState } from "react";
+
+interface BeforeInstallPromptEvent extends Event {
+  prompt(): Promise<void>;
+  userChoice: Promise<InstallPromptResult>;
+}
+
+export interface InstallPromptResult {
+  outcome: "accepted" | "dismissed";
+  platform: string;
+}
+
+/**
+ * Captures the browser's `beforeinstallprompt` event so it can be triggered
+ * on demand (e.g. from an "Install app" button) rather than shown immediately.
+ *
+ * `isInstallable` is `true` only on browsers that fire `beforeinstallprompt`
+ * (Chromium-based); it is always `false` on Safari / Firefox.
+ */
+export function useInstallPrompt() {
+  const [promptEvent, setPromptEvent] = useState<BeforeInstallPromptEvent | null>(null);
+
+  useEffect(() => {
+    const handler = (e: Event) => {
+      e.preventDefault();
+      setPromptEvent(e as BeforeInstallPromptEvent);
+    };
+    window.addEventListener("beforeinstallprompt", handler);
+    return () => window.removeEventListener("beforeinstallprompt", handler);
+  }, []);
+
+  /**
+   * Shows the browser's native install dialog.
+   * Returns the user's choice, or `null` if the prompt is not available.
+   * The prompt can only be shown once per `beforeinstallprompt` event, so
+   * `isInstallable` reverts to `false` after this is called.
+   */
+  const promptInstall = useCallback(async (): Promise<InstallPromptResult | null> => {
+    if (!promptEvent) return null;
+    await promptEvent.prompt();
+    const result = await promptEvent.userChoice;
+    setPromptEvent(null);
+    return result;
+  }, [promptEvent]);
+
+  return {
+    /** `true` when the browser has signalled that the app can be installed. */
+    isInstallable: promptEvent !== null,
+    promptInstall,
+  };
+}

--- a/source/wardnet-web/src/hooks/useInstallPrompt.ts
+++ b/source/wardnet-web/src/hooks/useInstallPrompt.ts
@@ -37,8 +37,11 @@ export function useInstallPrompt() {
    */
   const promptInstall = useCallback(async (): Promise<InstallPromptResult | null> => {
     if (!promptEvent) return null;
-    await promptEvent.prompt();
-    const result = await promptEvent.userChoice;
+    // Capture before the first await — the state update from a re-fired
+    // `beforeinstallprompt` could replace `promptEvent` while we await.
+    const captured = promptEvent;
+    await captured.prompt();
+    const result = await captured.userChoice;
     setPromptEvent(null);
     return result;
   }, [promptEvent]);

--- a/source/wardnet-web/src/hooks/useOnlineStatus.ts
+++ b/source/wardnet-web/src/hooks/useOnlineStatus.ts
@@ -1,0 +1,70 @@
+import { useEffect, useState } from "react";
+
+const DEFAULT_PROBE_INTERVAL_MS = 15_000;
+
+/**
+ * Tracks two independent dimensions of "reachability":
+ *
+ * 1. **Browser online/offline** — derived from `navigator.onLine` and the
+ *    `online`/`offline` window events. This goes `false` when the device
+ *    loses its network interface entirely; it does NOT reliably indicate
+ *    that the daemon is reachable.
+ *
+ * 2. **Daemon reachability** — a lightweight periodic `GET /api/info` probe.
+ *    Goes `false` when the request fails or returns a non-2xx status (e.g.
+ *    the device's IP changed, the daemon process is down, or the user is on
+ *    a different network). Starts `true` optimistically; the first probe
+ *    result arrives within one tick.
+ *
+ * Use `showingLastKnownState` to drive the "offline — showing last known state"
+ * banner: it is `true` whenever either dimension reports unreachable.
+ */
+export function useOnlineStatus(options?: {
+  /** How often to probe daemon reachability in milliseconds. Default: 15 000. */
+  daemonProbeIntervalMs?: number;
+}) {
+  const daemonProbeIntervalMs = options?.daemonProbeIntervalMs ?? DEFAULT_PROBE_INTERVAL_MS;
+
+  const [isOnline, setIsOnline] = useState(() => navigator.onLine);
+  const [isDaemonReachable, setIsDaemonReachable] = useState(true);
+
+  useEffect(() => {
+    const handleOnline = () => setIsOnline(true);
+    const handleOffline = () => setIsOnline(false);
+    window.addEventListener("online", handleOnline);
+    window.addEventListener("offline", handleOffline);
+    return () => {
+      window.removeEventListener("online", handleOnline);
+      window.removeEventListener("offline", handleOffline);
+    };
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const probe = async () => {
+      try {
+        const res = await fetch("/api/info", { cache: "no-store" });
+        if (!cancelled) setIsDaemonReachable(res.ok);
+      } catch {
+        if (!cancelled) setIsDaemonReachable(false);
+      }
+    };
+
+    void probe();
+    const id = setInterval(() => void probe(), daemonProbeIntervalMs);
+    return () => {
+      cancelled = true;
+      clearInterval(id);
+    };
+  }, [daemonProbeIntervalMs]);
+
+  return {
+    /** `true` when `navigator.onLine` reports network connectivity. */
+    isOnline,
+    /** `true` when a recent `/api/info` probe succeeded. */
+    isDaemonReachable,
+    /** `true` when the app is operating on stale cached data. Drives the offline banner. */
+    showingLastKnownState: !isOnline || !isDaemonReachable,
+  };
+}

--- a/source/wardnet-web/src/hooks/useOnlineStatus.ts
+++ b/source/wardnet-web/src/hooks/useOnlineStatus.ts
@@ -40,22 +40,38 @@ export function useOnlineStatus(options?: {
   }, []);
 
   useEffect(() => {
+    const controller = new AbortController();
     let cancelled = false;
+    let timeoutId: number | undefined;
 
     const probe = async () => {
       try {
-        const res = await fetch("/api/info", { cache: "no-store" });
+        const res = await fetch("/api/info", { cache: "no-store", signal: controller.signal });
         if (!cancelled) setIsDaemonReachable(res.ok);
-      } catch {
-        if (!cancelled) setIsDaemonReachable(false);
+      } catch (e) {
+        // Ignore AbortError — it means the component unmounted or the interval changed.
+        if (!cancelled && !(e instanceof DOMException && e.name === "AbortError")) {
+          setIsDaemonReachable(false);
+        }
       }
     };
 
-    void probe();
-    const id = setInterval(() => void probe(), daemonProbeIntervalMs);
+    // Chained setTimeout rather than setInterval: the next probe is only scheduled
+    // after the previous one resolves, preventing concurrent in-flight requests when
+    // the network is slow or the daemon is unreachable.
+    const schedule = async () => {
+      await probe();
+      if (!cancelled) {
+        timeoutId = window.setTimeout(() => void schedule(), daemonProbeIntervalMs);
+      }
+    };
+
+    void schedule();
+
     return () => {
       cancelled = true;
-      clearInterval(id);
+      controller.abort();
+      clearTimeout(timeoutId);
     };
   }, [daemonProbeIntervalMs]);
 

--- a/source/wardnet-web/src/index.ts
+++ b/source/wardnet-web/src/index.ts
@@ -181,3 +181,10 @@ export {
 
 // Hooks — setup wizard
 export { useSetupStatus, useSetup, useAdvanceWizard } from "./hooks/useSetup";
+
+// PWA helpers
+export { registerSW } from "./lib/registerSW";
+export type { RegisterSWOptions } from "./lib/registerSW";
+export { useInstallPrompt } from "./hooks/useInstallPrompt";
+export type { InstallPromptResult } from "./hooks/useInstallPrompt";
+export { useOnlineStatus } from "./hooks/useOnlineStatus";

--- a/source/wardnet-web/src/lib/registerSW.ts
+++ b/source/wardnet-web/src/lib/registerSW.ts
@@ -1,0 +1,100 @@
+export interface RegisterSWOptions {
+  /** Path to the compiled service-worker file. Defaults to `"sw.js"` (vite-plugin-pwa default). */
+  swPath?: string;
+  /** Skip the waiting SW and reload immediately when an update is found. Default: `false`. */
+  immediate?: boolean;
+  /** Called when a new SW version is waiting to take over. Call the returned `updateSW()` fn to apply it. */
+  onNeedRefresh?: () => void;
+  /** Called when the SW has installed for the first time and the app is ready to serve requests offline. */
+  onOfflineReady?: () => void;
+  /** Called once the SW is registered successfully. */
+  onRegistered?: (registration: ServiceWorkerRegistration) => void;
+  /** Called if registration throws. */
+  onRegisterError?: (error: unknown) => void;
+}
+
+/**
+ * Registers the app's own service worker and wires up update + offline-ready callbacks.
+ *
+ * Matches the contract of vite-plugin-pwa's `virtual:pwa-register` so consuming apps
+ * can keep the same call-site regardless of whether they use the plugin's auto-register
+ * or this helper. Designed to work with the `injectManifest` strategy.
+ *
+ * Returns a function that posts `SKIP_WAITING` to the pending SW and reloads the page,
+ * or `undefined` when service workers are not supported by the browser.
+ */
+export function registerSW(options: RegisterSWOptions = {}): (() => void) | undefined {
+  if (!("serviceWorker" in navigator)) return undefined;
+
+  const {
+    swPath = "sw.js",
+    immediate = false,
+    onNeedRefresh,
+    onOfflineReady,
+    onRegistered,
+    onRegisterError,
+  } = options;
+
+  let waitingWorker: ServiceWorker | null = null;
+
+  const updateSW = () => {
+    waitingWorker?.postMessage({ type: "SKIP_WAITING" });
+  };
+
+  const register = () => {
+    navigator.serviceWorker
+      .register(swPath)
+      .then((registration) => {
+        onRegistered?.(registration);
+
+        // A worker may already be waiting if the user refreshed while an update was pending.
+        if (registration.waiting) {
+          waitingWorker = registration.waiting;
+          onNeedRefresh?.();
+        }
+
+        registration.addEventListener("updatefound", () => {
+          const installing = registration.installing;
+          if (!installing) return;
+
+          installing.addEventListener("statechange", () => {
+            if (installing.state !== "installed") return;
+
+            if (navigator.serviceWorker.controller) {
+              // An existing SW is active — this is an update waiting to activate.
+              waitingWorker = installing;
+              if (immediate) {
+                updateSW();
+              } else {
+                onNeedRefresh?.();
+              }
+            } else {
+              // First install — app is now ready to serve requests offline.
+              onOfflineReady?.();
+            }
+          });
+        });
+
+        // Reload once the new SW takes control so all assets are served from the updated cache.
+        let refreshing = false;
+        navigator.serviceWorker.addEventListener("controllerchange", () => {
+          if (!refreshing) {
+            refreshing = true;
+            window.location.reload();
+          }
+        });
+      })
+      .catch((error: unknown) => {
+        onRegisterError?.(error);
+      });
+  };
+
+  // If the page is already fully loaded (e.g. helper called lazily), register immediately.
+  if (document.readyState === "complete") {
+    register();
+  } else {
+    window.addEventListener("load", register, { once: true });
+  }
+
+  return updateSW;
+}

--- a/source/wardnet-web/src/lib/registerSW.ts
+++ b/source/wardnet-web/src/lib/registerSW.ts
@@ -41,6 +41,17 @@ export function registerSW(options: RegisterSWOptions = {}): (() => void) | unde
     waitingWorker?.postMessage({ type: "SKIP_WAITING" });
   };
 
+  // Registered once — outside the `.then()` — so it fires exactly once even if
+  // `register()` is called multiple times (e.g. HMR in dev). The `refreshing`
+  // guard prevents double-reloads within the same listener.
+  let refreshing = false;
+  navigator.serviceWorker.addEventListener("controllerchange", () => {
+    if (!refreshing) {
+      refreshing = true;
+      window.location.reload();
+    }
+  });
+
   const register = () => {
     navigator.serviceWorker
       .register(swPath)
@@ -73,15 +84,6 @@ export function registerSW(options: RegisterSWOptions = {}): (() => void) | unde
               onOfflineReady?.();
             }
           });
-        });
-
-        // Reload once the new SW takes control so all assets are served from the updated cache.
-        let refreshing = false;
-        navigator.serviceWorker.addEventListener("controllerchange", () => {
-          if (!refreshing) {
-            refreshing = true;
-            window.location.reload();
-          }
         });
       })
       .catch((error: unknown) => {


### PR DESCRIPTION
Closes #474

## Summary

- **`registerSW(options)`** — framework-agnostic SW registration helper. Matches the `vite-plugin-pwa` `injectManifest` / `registerSW` contract (callbacks for update-ready, offline-ready, registration, and error). Returns an `updateSW()` fn that posts `SKIP_WAITING` and triggers a reload. The `controllerchange` listener is registered exactly once outside the `.then()` to prevent listener accumulation.

- **`useInstallPrompt`** — captures `beforeinstallprompt`, exposes `isInstallable` + `promptInstall()` so apps can show a native install dialog on demand rather than immediately. Captures the event before the first `await` to prevent stale-closure issues on concurrent re-fires.

- **`useOnlineStatus`** — combines browser `online`/`offline` events with a periodic `/api/info` daemon probe. Exposes `isOnline`, `isDaemonReachable`, and `showingLastKnownState` for the "offline — showing last known state" banner. Uses `AbortController` to cancel in-flight fetches on unmount/interval-change and a chained `setTimeout` (not `setInterval`) to prevent concurrent probes when the network is slow.

Push-subscription helper intentionally excluded — ships with VAPID/Web Push work (E1, #440).

## Test plan

- [ ] `wardnet-web` exports `registerSW`, `useInstallPrompt`, `useOnlineStatus` (and their option/result types)
- [ ] No admin-specific coupling — all three helpers have no dependency on admin-app internals
- [ ] Type-check passes on admin-site/web (CI validates wardnet-web via the portal dep)
- [ ] `registerSW`: calling with `immediate: true` skips waiting and reloads; callbacks fire at the right lifecycle stages
- [ ] `useInstallPrompt`: `isInstallable` is `false` on Safari/Firefox; `promptInstall()` returns `null` if prompt unavailable
- [ ] `useOnlineStatus`: toggling airplane mode flips `isOnline`; stopping the daemon flips `isDaemonReachable`; banner logic follows `showingLastKnownState`

https://claude.ai/code/session_01B9YkPt1z4QDa1Kx2GNxZbV

---
_Generated by [Claude Code](https://claude.ai/code/session_01B9YkPt1z4QDa1Kx2GNxZbV)_