### PR TITLE
chore: update stale Rust 1.95 references to 1.96

### DIFF
--- a/.agents/commands.md
+++ b/.agents/commands.md
@@ -11,7 +11,7 @@ All builds are driven by the root **Makefile**. Use `make help` to see all targe
 - **`make check`** — run all checks (SDK + web + site + daemon: format, lint, tests)
 - **`make check-sdk`** — SDK typecheck + format check
 - **`make check-web`** — web UI typecheck + lint + format check (depends on SDK)
-- **`make check-daemon`** — Rust format + clippy + tests. **Linux-only**: the daemon depends on Linux kernel interfaces (netlink, rtnetlink) and cannot compile on macOS. On non-Linux hosts this target auto-detects `podman` or `docker` and runs inside a `rust:1.95` container. Build artefacts are cached in `.target-linux/` (gitignored) and crate downloads in a named volume (`wardnet-cargo-cache`).
+- **`make check-daemon`** — Rust format + clippy + tests. **Linux-only**: the daemon depends on Linux kernel interfaces (netlink, rtnetlink) and cannot compile on macOS. On non-Linux hosts this target auto-detects `podman` or `docker` and runs inside a `rust:1.96` container. Build artefacts are cached in `.target-linux/` (gitignored) and crate downloads in a named volume (`wardnet-cargo-cache`).
 - **`make coverage-daemon`** — line-coverage summary via `cargo-llvm-cov`. Same platform auto-detection as `check-daemon` (container on macOS). Uses the same ignore regex as CI.
 - **`make run-dev`** — mock daemon + web UI dev server. `RESUME=true` persists the DB at `.wardnet-local/wardnet.db`.
 - **`make run-dev-daemon`** / **`make run-dev-web`** — run each piece independently.

--- a/.agents/technical-stack.md
+++ b/.agents/technical-stack.md
@@ -1,7 +1,7 @@
 # Technical Stack
 
 ## Daemon
-- Rust 1.95 (pinned in `rust-toolchain.toml`)
+- Rust 1.96 (pinned in `rust-toolchain.toml`)
 - **Multi-crate workspace**: `wardnet-common` (shared types/config) → `wardnetd-data` (repositories + database dumper + secret store) → `wardnetd-services` (business logic) → `wardnetd-api` (HTTP layer) → `wardnetd` (Linux binary)
 - axum 0.8 (with `macros`, `multipart`, `ws` features), tokio, tower-http
 - utoipa + utoipa-axum for OpenAPI generation, utoipa-scalar for the `/api/docs` UI

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [![CI](https://github.com/wardnet/wardnet/actions/workflows/ci.yml/badge.svg)](https://github.com/wardnet/wardnet/actions/workflows/ci.yml)
 [![codecov](https://codecov.io/gh/wardnet/wardnet/branch/main/graph/badge.svg)](https://codecov.io/gh/wardnet/wardnet)
-[![Rust](https://img.shields.io/badge/rust-1.95-orange.svg)](https://www.rust-lang.org)
+[![Rust](https://img.shields.io/badge/rust-1.96-orange.svg)](https://www.rust-lang.org)
 [![Rust Report Card](https://rust-reportcard.xuri.me/badge/github.com/wardnet/wardnet)](https://rust-reportcard.xuri.me/report/github.com/wardnet/wardnet)
 [![Security Audit](https://github.com/wardnet/wardnet/actions/workflows/security.yml/badge.svg)](https://github.com/wardnet/wardnet/actions/workflows/security.yml)
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/wardnet/wardnet/badge)](https://securityscorecards.dev/viewer/?uri=github.com/wardnet/wardnet)

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -89,7 +89,7 @@ All business logic lives in `@wardnet/js`. Components are pure presentation. Hoo
 
 | Component       | Technology                                                    |
 |-----------------|---------------------------------------------------------------|
-| Daemon          | Rust 1.95, axum 0.8, SQLite (sqlx 0.8)                        |
+| Daemon          | Rust 1.96, axum 0.8, SQLite (sqlx 0.8)                        |
 | Web UI          | React 19, TypeScript 5.9, Vite 8, Tailwind CSS 4              |
 | SDK             | TypeScript 5.9, zero runtime dependencies, native `fetch`     |
 | Package manager | Yarn 4 (via Corepack)                                         |
@@ -104,7 +104,7 @@ All business logic lives in `@wardnet/js`. Components are pure presentation. Hoo
 
 ### Prerequisites
 
-- Rust 1.95+ (pinned via `rust-toolchain.toml`)
+- Rust 1.96+ (pinned via `rust-toolchain.toml`)
 - Node.js 25+
 - Yarn 4 (enabled via `corepack enable`)
 - **Daemon checks on macOS**: Podman or Docker. The daemon uses Linux-only kernel interfaces (netlink, rtnetlink) and cannot compile natively on macOS — `make check-daemon` runs checks inside a Linux container automatically.


### PR DESCRIPTION
## Summary

- Updates the README badge, `.agents/technical-stack.md`, `.agents/commands.md`, and `docs/DEVELOPMENT.md` to reference Rust 1.96
- Follow-up to #484 which bumped the toolchain but left docs behind

## Test plan

- [ ] Verify README badge shows 1.96 after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)