### PR TITLE
fix(ci): pin Dockerfile.client base image by digest

### DIFF
--- a/source/end2end-tests/daemon/Dockerfile.client
+++ b/source/end2end-tests/daemon/Dockerfile.client
@@ -19,7 +19,7 @@
 #       -t wardnet-test-client-debian:dev .
 
 ARG WARDNETD_TEST_IMAGE=wardnetd:dev-test
-ARG BASE_IMAGE=debian:bookworm-slim
+ARG BASE_IMAGE=debian:bookworm-slim@sha256:0104b334637a5f19aa9c983a91b54c89887c0984081f2068983107a6f6c21eeb
 
 FROM ${WARDNETD_TEST_IMAGE} AS source
 


### PR DESCRIPTION
## Summary

- Pins `debian:bookworm-slim` to its sha256 digest in `source/end2end-tests/daemon/Dockerfile.client`
- Addresses OpenSSF Scorecard warning: *containerImage not pinned by hash*
- Resolves the line 26 warning; line 24 (`wardnetd:dev-test`) is a locally-built image with no public digest to pin

## Test plan

- [ ] E2E test suite builds successfully with the pinned image

🤖 Generated with [Claude Code](https://claude.com/claude-code)