### PR TITLE
feat(admin-app): app shell — tab bar, header/connection status, banners, toast, dialogs

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -2,7 +2,7 @@
 
 ## Surfaces
 
-**Admin site** — The full desktop web admin. Served at `<id>.wardnet.network/admin/`. Not a PWA; intended for desktop use only. Previously named `admin-app` in source; renamed to `admin-site`.
+**Admin site** — The full desktop web admin. Served at `<id>.wardnet.network/admin/`. Not a PWA; intended for desktop use only. Source package: `source/admin-site`.
 
 **User PWA** — Installable mobile app for non-admin household members. Served at `<id>.wardnet.network/`. Scope: self-service only (own device routing, own DNS stats, own connection status). Cannot manage other devices.
 

--- a/source/admin-app/src/App.tsx
+++ b/source/admin-app/src/App.tsx
@@ -7,6 +7,9 @@ import { AppLayout } from "@/layouts/AppLayout";
 import { AuthLayout } from "@/layouts/AuthLayout";
 import Login from "@/pages/Login";
 import Dashboard from "@/pages/Dashboard";
+import Devices from "@/pages/Devices";
+import Tunnels from "@/pages/Tunnels";
+import System from "@/pages/System";
 
 /** Redirects to /login if the user has no active session. */
 function AdminRoute() {
@@ -93,6 +96,9 @@ export default function App() {
         <Route element={<AdminRoute />}>
           <Route element={<AppLayout />}>
             <Route index element={<Dashboard />} />
+            <Route path="devices" element={<Devices />} />
+            <Route path="tunnels" element={<Tunnels />} />
+            <Route path="system" element={<System />} />
           </Route>
         </Route>
         <Route path="*" element={<Navigate to="/" replace />} />

--- a/source/admin-app/src/components/BusyOverlay.tsx
+++ b/source/admin-app/src/components/BusyOverlay.tsx
@@ -1,0 +1,40 @@
+import { CheckIcon } from "lucide-react";
+
+export type BusyPhase = "working" | "done";
+export type BusyAction = "reboot" | "restart";
+
+interface Props {
+  phase: BusyPhase;
+  action: BusyAction;
+}
+
+const COPY: Record<BusyAction, Record<BusyPhase, { title: string; subtitle: string }>> = {
+  reboot: {
+    working: { title: "Rebooting wardnet-pi…", subtitle: "This takes about 60 seconds" },
+    done: { title: "Pi is back online", subtitle: "Connection restored" },
+  },
+  restart: {
+    working: { title: "Restarting daemon…", subtitle: "Reloading service" },
+    done: { title: "Daemon restarted", subtitle: "Connection restored" },
+  },
+};
+
+export function BusyOverlay({ phase, action }: Props) {
+  const { title, subtitle } = COPY[action][phase];
+
+  return (
+    <div className="fixed inset-0 z-[60] flex flex-col items-center justify-center gap-5 bg-side text-white">
+      {phase === "working" ? (
+        <div className="h-[46px] w-[46px] animate-spin rounded-full border-[3px] border-white/15 border-t-accent" />
+      ) : (
+        <div className="flex h-[46px] w-[46px] items-center justify-center rounded-full bg-accent text-accent-ink">
+          <CheckIcon size={26} strokeWidth={2.6} />
+        </div>
+      )}
+      <div className="flex flex-col items-center gap-2 text-center">
+        <p className="text-[17px] font-semibold tracking-tight">{title}</p>
+        <p className="font-mono text-[12px] text-white/50">{subtitle}</p>
+      </div>
+    </div>
+  );
+}

--- a/source/admin-app/src/components/ConfirmDialog.tsx
+++ b/source/admin-app/src/components/ConfirmDialog.tsx
@@ -1,0 +1,68 @@
+import { Button } from "@wardnet/forge-web/button";
+import {
+  AlertModal,
+  AlertModalAction,
+  AlertModalCancel,
+  AlertModalContent,
+  AlertModalDescription,
+  AlertModalFooter,
+  AlertModalHeader,
+  AlertModalTitle,
+} from "@wardnet/forge-web/alert-modal";
+
+interface Props {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onConfirm: () => void;
+  title: string;
+  description: string;
+  confirmLabel?: string;
+  variant?: "danger" | "warn";
+  icon?: React.ReactNode;
+}
+
+export function ConfirmDialog({
+  open,
+  onOpenChange,
+  onConfirm,
+  title,
+  description,
+  confirmLabel = "Confirm",
+  variant = "danger",
+  icon,
+}: Props) {
+  return (
+    <AlertModal open={open} onOpenChange={onOpenChange}>
+      <AlertModalContent>
+        <AlertModalHeader>
+          {icon && (
+            <div
+              className={`mb-3 flex h-12 w-12 items-center justify-center rounded-xl ${
+                variant === "danger"
+                  ? "bg-danger-soft text-danger-soft-ink"
+                  : "bg-warn-soft text-warn-soft-ink"
+              }`}
+            >
+              {icon}
+            </div>
+          )}
+          <AlertModalTitle>{title}</AlertModalTitle>
+          <AlertModalDescription>{description}</AlertModalDescription>
+        </AlertModalHeader>
+        <AlertModalFooter>
+          <AlertModalCancel asChild>
+            <Button variant="outline">Cancel</Button>
+          </AlertModalCancel>
+          <AlertModalAction asChild>
+            <Button
+              variant={variant === "danger" ? "destructive" : "default"}
+              onClick={onConfirm}
+            >
+              {confirmLabel}
+            </Button>
+          </AlertModalAction>
+        </AlertModalFooter>
+      </AlertModalContent>
+    </AlertModal>
+  );
+}

--- a/source/admin-app/src/components/ConnectionBanner.tsx
+++ b/source/admin-app/src/components/ConnectionBanner.tsx
@@ -1,0 +1,32 @@
+import { RefreshCwIcon, WifiOffIcon } from "lucide-react";
+import { Banner } from "@wardnet/forge-web/banner";
+import type { ConnState } from "@/components/Header";
+
+interface Props {
+  connState: ConnState;
+}
+
+export function ConnectionBanner({ connState }: Props) {
+  if (connState === "online") return null;
+
+  if (connState === "offline") {
+    return (
+      <Banner
+        tone="down"
+        role="alert"
+        icon={<WifiOffIcon size={15} strokeWidth={1.9} />}
+      >
+        No connection to wardnet-pi — showing last known state
+      </Banner>
+    );
+  }
+
+  return (
+    <Banner
+      tone="warn"
+      icon={<RefreshCwIcon size={14} strokeWidth={2} className="animate-spin" />}
+    >
+      Reconnecting to wardnet-pi…
+    </Banner>
+  );
+}

--- a/source/admin-app/src/components/Header.tsx
+++ b/source/admin-app/src/components/Header.tsx
@@ -1,0 +1,46 @@
+import { ShieldIcon, RefreshCwIcon } from "lucide-react";
+
+export type ConnState = "online" | "reconnecting" | "offline";
+
+interface Props {
+  connState: ConnState;
+  version: string | null;
+}
+
+export function Header({ connState, version }: Props) {
+  return (
+    <header className="flex shrink-0 items-center gap-3 bg-side px-4 py-3">
+      <div className="flex h-7 w-7 shrink-0 items-center justify-center rounded-lg bg-accent text-accent-ink">
+        <ShieldIcon size={16} strokeWidth={2} />
+      </div>
+      <div className="flex flex-col leading-none">
+        <span className="text-[17px] font-bold tracking-tight text-white">
+          Ward<em className="not-italic text-accent">net</em>
+        </span>
+        {version && (
+          <span className="mt-0.5 font-mono text-[10px] text-white/40">{version}</span>
+        )}
+      </div>
+      <div className="ml-auto flex items-center gap-1.5 text-[11px] font-medium text-white/70">
+        {connState === "online" && (
+          <>
+            <span className="size-[7px] rounded-full bg-accent animate-pulse-dot" />
+            Connected
+          </>
+        )}
+        {connState === "reconnecting" && (
+          <>
+            <RefreshCwIcon size={12} strokeWidth={2} className="animate-spin" />
+            Reconnecting
+          </>
+        )}
+        {connState === "offline" && (
+          <>
+            <span className="size-[7px] rounded-full bg-warn" />
+            Offline
+          </>
+        )}
+      </div>
+    </header>
+  );
+}

--- a/source/admin-app/src/components/TabBar.tsx
+++ b/source/admin-app/src/components/TabBar.tsx
@@ -1,0 +1,28 @@
+import { NavLink } from "react-router";
+import { HomeIcon, MonitorIcon, NetworkIcon, SettingsIcon } from "lucide-react";
+import type { LucideIcon } from "lucide-react";
+
+const TABS: Array<{ to: string; label: string; Icon: LucideIcon; end?: boolean }> = [
+  { to: "/", label: "Home", Icon: HomeIcon, end: true },
+  { to: "/devices", label: "Devices", Icon: MonitorIcon },
+  { to: "/tunnels", label: "Tunnels", Icon: NetworkIcon },
+  { to: "/system", label: "System", Icon: SettingsIcon },
+];
+
+export function TabBar() {
+  return (
+    <nav className="flex shrink-0 gap-0.5 border-t border-white/[0.06] bg-side px-2 pb-1.5 pt-2">
+      {TABS.map(({ to, label, Icon, end }) => (
+        <NavLink
+          key={to}
+          to={to}
+          end={end}
+          className="flex flex-1 flex-col items-center gap-1 rounded-xl py-1.5 text-[10.5px] font-semibold tracking-wide text-white/50 transition-colors duration-snap aria-[current=page]:text-accent"
+        >
+          <Icon size={23} strokeWidth={2} />
+          {label}
+        </NavLink>
+      ))}
+    </nav>
+  );
+}

--- a/source/admin-app/src/components/index.ts
+++ b/source/admin-app/src/components/index.ts
@@ -1,0 +1,7 @@
+// Reusable shell primitives — imported by D-slice screen components.
+// Shell-internal components (Header, ConnectionBanner, TabBar) and
+// feature-level components (InstallPrompt) are imported directly, not
+// re-exported here.
+export { ConfirmDialog } from "./ConfirmDialog";
+export { BusyOverlay } from "./BusyOverlay";
+export type { BusyPhase, BusyAction } from "./BusyOverlay";

--- a/source/admin-app/src/features/InstallPrompt.tsx
+++ b/source/admin-app/src/features/InstallPrompt.tsx
@@ -1,0 +1,51 @@
+import { useState } from "react";
+import { ShieldIcon, DownloadIcon } from "lucide-react";
+import { useInstallPrompt } from "@wardnet/wardnet-web";
+import { useLocation } from "react-router";
+import { toast } from "sonner";
+
+export function InstallPrompt() {
+  const { isInstallable, promptInstall } = useInstallPrompt();
+  const location = useLocation();
+  const [dismissed, setDismissed] = useState(false);
+
+  if (!isInstallable || dismissed || location.pathname !== "/") return null;
+
+  async function handleInstall() {
+    try {
+      const result = await promptInstall();
+      if (result?.outcome === "accepted") {
+        toast.success("Added to home screen");
+      }
+    } catch {
+      // Browser cancelled or the prompt is no longer available — dismiss silently.
+    } finally {
+      setDismissed(true);
+    }
+  }
+
+  return (
+    <div className="absolute inset-x-3 bottom-3 z-30 flex animate-slide-up items-center gap-3 rounded-lg border border-line bg-card p-3.5 shadow-pop">
+      <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-[10px] bg-accent text-accent-ink">
+        <ShieldIcon size={20} strokeWidth={2} />
+      </div>
+      <div className="min-w-0 flex-1">
+        <p className="text-[14px] font-semibold leading-tight text-ink">Install Wardnet</p>
+        <p className="mt-0.5 text-[12px] text-ink-3">Add to home screen for one-tap access</p>
+      </div>
+      <button
+        onClick={() => setDismissed(true)}
+        className="rounded-md border border-line-strong px-3 py-1.5 text-[13px] font-medium text-ink"
+      >
+        Later
+      </button>
+      <button
+        onClick={handleInstall}
+        className="flex items-center gap-1.5 rounded-md bg-accent px-3 py-1.5 text-[13px] font-medium text-accent-ink"
+      >
+        <DownloadIcon size={14} strokeWidth={2} />
+        Install
+      </button>
+    </div>
+  );
+}

--- a/source/admin-app/src/index.css
+++ b/source/admin-app/src/index.css
@@ -26,6 +26,14 @@
   --color-ink-4: var(--ink-4);
   --color-ink-5: var(--ink-5);
 
+  /* Sidebar — bg-side, text-side-ink, text-side-ink-2, etc. */
+  --color-side: var(--side-bg);
+  --color-side-line: var(--side-line);
+  --color-side-ink: var(--side-ink);
+  --color-side-ink-2: var(--side-ink-2);
+  --color-side-ink-active: var(--side-ink-active);
+  --color-side-active: var(--side-active-bg);
+
   /* Brand */
   --color-accent: var(--accent);
   --color-accent-ink: var(--accent-ink);
@@ -70,5 +78,25 @@
   samp,
   pre {
     font-feature-settings: "zero";
+  }
+}
+
+@keyframes pulse-dot {
+  0%   { box-shadow: 0 0 0 0 color-mix(in srgb, var(--accent) 45%, transparent); }
+  70%  { box-shadow: 0 0 0 6px color-mix(in srgb, var(--accent) 0%, transparent); }
+  100% { box-shadow: 0 0 0 0 color-mix(in srgb, var(--accent) 0%, transparent); }
+}
+
+@keyframes slide-up {
+  from { transform: translateY(20px); opacity: 0; }
+  to   { transform: translateY(0);    opacity: 1; }
+}
+
+@layer utilities {
+  .animate-pulse-dot {
+    animation: pulse-dot 2.4s infinite;
+  }
+  .animate-slide-up {
+    animation: slide-up 0.3s cubic-bezier(0.2, 0.8, 0.2, 1);
   }
 }

--- a/source/admin-app/src/layouts/AppLayout.tsx
+++ b/source/admin-app/src/layouts/AppLayout.tsx
@@ -1,16 +1,32 @@
 import { Outlet } from "react-router";
+import { useOnlineStatus, useDaemonStatus } from "@wardnet/wardnet-web";
+import { Header } from "@/components/Header";
+import { ConnectionBanner } from "@/components/ConnectionBanner";
+import { TabBar } from "@/components/TabBar";
+import { InstallPrompt } from "@/features/InstallPrompt";
+import type { ConnState } from "@/components/Header";
 
-/**
- * Shell for authenticated routes.
- *
- * Minimal for now — a mobile nav bar will be added in a subsequent issue.
- */
+function deriveConnState(isOnline: boolean, isDaemonReachable: boolean): ConnState {
+  if (!isOnline) return "offline";
+  if (!isDaemonReachable) return "reconnecting";
+  return "online";
+}
+
 export function AppLayout() {
+  const { isOnline, isDaemonReachable } = useOnlineStatus();
+  const { data } = useDaemonStatus();
+  const connState = deriveConnState(isOnline, isDaemonReachable);
+  const version = data?.version ?? null;
+
   return (
-    <div className="flex min-h-screen flex-col bg-bg text-ink">
-      <main className="flex-1 overflow-y-auto">
+    <div className="relative flex h-screen flex-col overflow-hidden bg-bg text-ink">
+      <Header connState={connState} version={version} />
+      <ConnectionBanner connState={connState} />
+      <main className="flex-1 overflow-y-auto overscroll-contain [-webkit-overflow-scrolling:touch]">
         <Outlet />
       </main>
+      <TabBar />
+      <InstallPrompt />
     </div>
   );
 }

--- a/source/admin-app/src/pages/Devices.tsx
+++ b/source/admin-app/src/pages/Devices.tsx
@@ -1,0 +1,8 @@
+export default function Devices() {
+  return (
+    <div className="flex flex-col gap-4 p-4">
+      <h1 className="text-xl font-semibold text-ink">Devices</h1>
+      <p className="text-sm text-ink-3">Coming in a subsequent issue.</p>
+    </div>
+  );
+}

--- a/source/admin-app/src/pages/System.tsx
+++ b/source/admin-app/src/pages/System.tsx
@@ -1,0 +1,8 @@
+export default function System() {
+  return (
+    <div className="flex flex-col gap-4 p-4">
+      <h1 className="text-xl font-semibold text-ink">System</h1>
+      <p className="text-sm text-ink-3">Coming in a subsequent issue.</p>
+    </div>
+  );
+}

--- a/source/admin-app/src/pages/Tunnels.tsx
+++ b/source/admin-app/src/pages/Tunnels.tsx
@@ -1,0 +1,8 @@
+export default function Tunnels() {
+  return (
+    <div className="flex flex-col gap-4 p-4">
+      <h1 className="text-xl font-semibold text-ink">Tunnels</h1>
+      <p className="text-sm text-ink-3">Coming in a subsequent issue.</p>
+    </div>
+  );
+}


### PR DESCRIPTION
Closes #477. Unblocks D1–D4.

## Summary

- **Header**: Wardnet logo, version from `useDaemonStatus`, three-state connection chip (online / reconnecting / offline) driven by `useOnlineStatus`
- **ConnectionBanner**: forge-web `Banner` (tone `down` for full offline, `warn` for daemon unreachable) rendered below the header
- **TabBar**: four `NavLink`s (Home / Devices / Tunnels / System) with `aria-current` active state and accent colour via Tailwind modifier; Home link uses `end` to avoid matching sub-routes
- **InstallPrompt** (`src/features/`): captures `beforeinstallprompt`, shown on Home tab only; `try/finally` ensures dismiss even on browser rejection
- **ConfirmDialog** + **BusyOverlay**: reusable shell primitives exported from `src/components/` for the D-slice power-action screens (D4)
- Three stub route pages (Devices, Tunnels, System) wired in `App.tsx`
- CSS: sidebar `@theme` token block + `pulse-dot` / `slide-up` keyframe utilities added to `index.css`
- `CONTEXT.md`: removed stale "previously named admin-app" note from Admin site entry

## Test plan

- [ ] `yarn workspace @wardnet/admin-app type-check` passes
- [ ] `make run-dev-admin-app` — app loads at `/admin-app/`, login flow works
- [ ] Tab bar navigates between all four routes; active tab shows accent colour; Home tab is not stuck active on sub-routes
- [ ] Header shows daemon version and "Connected" status with green pulse dot
- [ ] Offline simulation → `tone="down"` offline banner; daemon unreachable → `tone="warn"` reconnecting banner
- [ ] Install prompt appears on Home tab in Chromium when PWA install criteria are met

🤖 Generated with [Claude Code](https://claude.com/claude-code)