### PR TITLE
feat(admin-app): Dashboard — Option B summary cards

### DIFF
--- a/.agents/commands.md
+++ b/.agents/commands.md
@@ -17,7 +17,18 @@ All builds are driven by the root **Makefile**. Use `make help` to see all targe
 - **`make run-dev-daemon`** / **`make run-dev-web`** — run each piece independently.
 - **`make clean`** — clean all build artifacts
 
-## Direct commands (when needed)
+## Direct commands (fast iteration only — NOT a substitute for Make before push)
+
+> **IMPORTANT**: Direct `cargo`/`yarn` invocations are acceptable for fast inner-loop
+> iteration (e.g. quickly re-running one failing test). They are **NOT** a replacement
+> for the Make gate before `git push`. Specifically:
+> - `cargo clippy -p <crate>` misses `--all-targets` — lib, test, and binary targets
+>   each compile differently; the scoped invocation passes while `make check-daemon` fails.
+> - On macOS, any direct `cargo` command builds for macOS, not Linux. CI runs on Linux.
+>   Always use `make check-daemon` (which wraps the run in a container) for final verification.
+> - Direct `yarn build` is permissive; `make check-web` adds lint and type-check that CI enforces.
+>
+> **Before every `git push`, always run the appropriate Make target.**
 
 ### Daemon (Rust)
 

--- a/.agents/commands.md
+++ b/.agents/commands.md
@@ -19,16 +19,14 @@ All builds are driven by the root **Makefile**. Use `make help` to see all targe
 
 ## Direct commands (fast iteration only — NOT a substitute for Make before push)
 
-> **IMPORTANT**: Direct `cargo`/`yarn` invocations are acceptable for fast inner-loop
-> iteration (e.g. quickly re-running one failing test). They are **NOT** a replacement
-> for the Make gate before `git push`. Specifically:
-> - `cargo clippy -p <crate>` misses `--all-targets` — lib, test, and binary targets
->   each compile differently; the scoped invocation passes while `make check-daemon` fails.
-> - On macOS, any direct `cargo` command builds for macOS, not Linux. CI runs on Linux.
->   Always use `make check-daemon` (which wraps the run in a container) for final verification.
-> - Direct `yarn build` is permissive; `make check-web` adds lint and type-check that CI enforces.
+> **DO NOT PUSH WITHOUT RUNNING THE MAKE TARGET FIRST. NO EXCEPTIONS.**
 >
-> **Before every `git push`, always run the appropriate Make target.**
+> - `cargo clippy -p <crate>` misses `--all-targets` — scoped invocations pass while `make check-daemon` fails.
+> - `cargo fmt` without `--check` auto-fixes locally but CI will still reject commits that were pushed without verifying.
+> - On macOS, direct `cargo` compiles for macOS. CI runs Linux. USE `make check-daemon`.
+> - `yarn build` skips lint. USE `make check-web`.
+>
+> **ALWAYS RUN `make check-daemon` (Rust) or `make check-web` (web) BEFORE EVERY `git push`.**
 
 ### Daemon (Rust)
 

--- a/.agents/workflow.md
+++ b/.agents/workflow.md
@@ -47,6 +47,7 @@ cd source/web-ui  && yarn format && yarn lint && yarn type-check
 ### Common mistakes to avoid
 
 - Running only `cargo build` and assuming tests pass — the test compile target has its own stubs that can fall out of sync with service signatures; always run `cargo test --workspace` (or `make check-daemon`) before pushing.
+- **Using `cargo clippy -p <crate>` instead of `make check-daemon`** — the scoped invocation silently skips `--all-targets` (lib, test, and binary targets compile separately) and `cargo fmt --check`. A scoped run can pass while `make check-daemon` fails. Always use the Make target for the pre-push gate.
 - Running `yarn build` but skipping `yarn lint` — Vite is permissive about lint warnings that ESLint elevates to errors in CI.
 - Pushing a rebase without re-running checks locally — dependency bumps pulled in from `main` can change lint/type rules; treat every rebase as a fresh change.
 

--- a/.agents/workflow.md
+++ b/.agents/workflow.md
@@ -13,6 +13,8 @@
 
 **You MUST run checks locally and fix ALL issues BEFORE every `git push`.** CI mirrors these exact Make targets — if any of them fail locally, CI will fail and the push will be rejected. This is a hard gate; never push without passing checks.
 
+**DO NOT OPEN A PR OR PUSH BEFORE ALL MAKE CHECKS PASS LOCALLY. NO EXCEPTIONS.**
+
 The fastest, most complete signal is the root Makefile:
 
 ```bash
@@ -47,7 +49,7 @@ cd source/web-ui  && yarn format && yarn lint && yarn type-check
 ### Common mistakes to avoid
 
 - Running only `cargo build` and assuming tests pass — the test compile target has its own stubs that can fall out of sync with service signatures; always run `cargo test --workspace` (or `make check-daemon`) before pushing.
-- **Using `cargo clippy -p <crate>` instead of `make check-daemon`** — the scoped invocation silently skips `--all-targets` (lib, test, and binary targets compile separately) and `cargo fmt --check`. A scoped run can pass while `make check-daemon` fails. Always use the Make target for the pre-push gate.
+- **NEVER use `cargo clippy -p <crate>` or `cargo fmt` as a push gate** — scoped clippy misses `--all-targets`; running `cargo fmt` without `--check` silently auto-fixes locally while the pushed commit was never verified. RUN `make check-daemon` EVERY TIME.
 - Running `yarn build` but skipping `yarn lint` — Vite is permissive about lint warnings that ESLint elevates to errors in CI.
 - Pushing a rebase without re-running checks locally — dependency bumps pulled in from `main` can change lint/type rules; treat every rebase as a fresh change.
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,12 @@
 repos:
+- repo: local
+  hooks:
+  - id: cargo-fmt
+    name: cargo fmt (make fmt-daemon)
+    entry: make fmt-daemon
+    language: system
+    types: [rust]
+    pass_filenames: false
 - repo: https://github.com/gitleaks/gitleaks
   rev: v8.16.3
   hooks:

--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ COV_RUNNER ?=
 # ---------- Phony targets ----------
 
 .PHONY: all init build build-daemon build-bridge build-sdk build-web build-site \
-        check check-sdk check-web check-site check-daemon check-daemon-native check-daemon-container \
+        check check-sdk check-web check-site fmt-daemon check-daemon check-daemon-native check-daemon-container \
         check-bridge \
         coverage-daemon coverage-daemon-native coverage-daemon-container \
         coverage-bridge coverage-bridge-ci \
@@ -214,6 +214,11 @@ CARGO_CRATE_FLAG  := $(if $(CRATE),-p $(CRATE),)
 
 build-daemon:
 	cd $(DAEMON_DIR) && cargo build --release $(CARGO_TARGET_FLAG) $(CARGO_CRATE_FLAG)
+
+# fmt-daemon: format check only — rustfmt has no Linux-only dependencies so
+# this runs natively on any platform. Used by the pre-commit gate.
+fmt-daemon:
+	cd $(DAEMON_DIR) && cargo fmt --check
 
 # check-daemon: auto-selects native (Linux) or container (macOS/other).
 # The daemon uses Linux-only dependencies (netlink, rtnetlink) so it cannot

--- a/source/admin-app/src/App.tsx
+++ b/source/admin-app/src/App.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import { Navigate, Outlet, Route, Routes, useNavigate } from "react-router";
 import { useAuth, useSetupStatus } from "@wardnet/wardnet-web";
 import { useBiometric } from "@/hooks/useBiometric";
+import { OnlineStatusProvider } from "@/context/OnlineStatusContext";
 import { BiometricGate } from "@/components/BiometricGate";
 import { AppLayout } from "@/layouts/AppLayout";
 import { AuthLayout } from "@/layouts/AuthLayout";
@@ -9,6 +10,7 @@ import Login from "@/pages/Login";
 import Dashboard from "@/pages/Dashboard";
 import Devices from "@/pages/Devices";
 import Tunnels from "@/pages/Tunnels";
+import Dns from "@/pages/Dns";
 import System from "@/pages/System";
 
 /** Redirects to /login if the user has no active session. */
@@ -62,9 +64,12 @@ export default function App() {
 
   useEffect(() => {
     async function boot() {
-      // Always probe + refresh auth in the background so session state is fresh.
-      checkAuth();
-      refresh();
+      // Probe auth status and slide any remember-me session forward before the
+      // biometric gate renders. The gate is a client-side presence check only
+      // (see useBiometric.ts); the server session remains the enforced auth
+      // boundary. Awaiting both ensures AdminRoute has accurate state when the
+      // gate resolves.
+      await Promise.all([checkAuth(), refresh()]);
       setBiometricReady(true);
     }
     boot();
@@ -88,6 +93,7 @@ export default function App() {
   }
 
   return (
+    <OnlineStatusProvider>
     <SetupGuard>
       <Routes>
         <Route element={<AuthLayout />}>
@@ -98,11 +104,13 @@ export default function App() {
             <Route index element={<Dashboard />} />
             <Route path="devices" element={<Devices />} />
             <Route path="tunnels" element={<Tunnels />} />
+            <Route path="dns" element={<Dns />} />
             <Route path="system" element={<System />} />
           </Route>
         </Route>
         <Route path="*" element={<Navigate to="/" replace />} />
       </Routes>
     </SetupGuard>
+    </OnlineStatusProvider>
   );
 }

--- a/source/admin-app/src/components/ConnectionBanner.tsx
+++ b/source/admin-app/src/components/ConnectionBanner.tsx
@@ -16,7 +16,7 @@ export function ConnectionBanner({ connState }: Props) {
         role="alert"
         icon={<WifiOffIcon size={15} strokeWidth={1.9} />}
       >
-        No connection to wardnet-pi — showing last known state
+        No connection to wardnet daemon — showing last known state
       </Banner>
     );
   }
@@ -26,7 +26,7 @@ export function ConnectionBanner({ connState }: Props) {
       tone="warn"
       icon={<RefreshCwIcon size={14} strokeWidth={2} className="animate-spin" />}
     >
-      Reconnecting to wardnet-pi…
+      Reconnecting to wardnet daemon…
     </Banner>
   );
 }

--- a/source/admin-app/src/components/TabBar.tsx
+++ b/source/admin-app/src/components/TabBar.tsx
@@ -1,11 +1,12 @@
 import { NavLink } from "react-router";
-import { HomeIcon, MonitorIcon, NetworkIcon, SettingsIcon } from "lucide-react";
+import { HomeIcon, MonitorIcon, NetworkIcon, GlobeIcon, SettingsIcon } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
 
 const TABS: Array<{ to: string; label: string; Icon: LucideIcon; end?: boolean }> = [
   { to: "/", label: "Home", Icon: HomeIcon, end: true },
   { to: "/devices", label: "Devices", Icon: MonitorIcon },
   { to: "/tunnels", label: "Tunnels", Icon: NetworkIcon },
+  { to: "/dns", label: "DNS", Icon: GlobeIcon },
   { to: "/system", label: "System", Icon: SettingsIcon },
 ];
 

--- a/source/admin-app/src/context/OnlineStatusContext.tsx
+++ b/source/admin-app/src/context/OnlineStatusContext.tsx
@@ -1,0 +1,32 @@
+import { createContext, useContext, useEffect, useRef } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import { useOnlineStatus } from "@wardnet/wardnet-web";
+
+type OnlineStatus = ReturnType<typeof useOnlineStatus>;
+
+const OnlineStatusContext = createContext<OnlineStatus | null>(null);
+
+export function OnlineStatusProvider({ children }: { children: React.ReactNode }) {
+  const status = useOnlineStatus();
+  const qc = useQueryClient();
+  const prevReachable = useRef(status.isDaemonReachable);
+
+  useEffect(() => {
+    if (!prevReachable.current && status.isDaemonReachable) {
+      void qc.invalidateQueries({ queryKey: ["daemon", "info"] });
+    }
+    prevReachable.current = status.isDaemonReachable;
+  }, [status.isDaemonReachable, qc]);
+
+  return (
+    <OnlineStatusContext.Provider value={status}>
+      {children}
+    </OnlineStatusContext.Provider>
+  );
+}
+
+export function useOnlineStatusContext(): OnlineStatus {
+  const ctx = useContext(OnlineStatusContext);
+  if (!ctx) throw new Error("useOnlineStatusContext must be inside OnlineStatusProvider");
+  return ctx;
+}

--- a/source/admin-app/src/features/dashboard/DaemonStrip.tsx
+++ b/source/admin-app/src/features/dashboard/DaemonStrip.tsx
@@ -1,0 +1,31 @@
+import { ActivityIcon } from "lucide-react";
+import { formatUptime } from "@wardnet/wardnet-web";
+
+interface Props {
+  reachable: boolean;
+  version: string | null;
+  uptimeSeconds: number | null;
+}
+
+export function DaemonStrip({ reachable, version, uptimeSeconds }: Props) {
+  return (
+    <div className="flex items-center gap-2 rounded-lg bg-side px-4 py-3 text-xs text-white/70">
+      <ActivityIcon size={13} strokeWidth={1.9} className={reachable ? "text-accent" : "text-warn"} />
+      <span className={reachable ? "text-accent font-medium" : "text-warn font-medium"}>
+        {reachable ? "Running" : "Unreachable"}
+      </span>
+      {version && (
+        <>
+          <span className="text-white/30">·</span>
+          <span className="font-mono">{version}</span>
+        </>
+      )}
+      {uptimeSeconds != null && (
+        <>
+          <span className="text-white/30">·</span>
+          <span>up {formatUptime(uptimeSeconds)}</span>
+        </>
+      )}
+    </div>
+  );
+}

--- a/source/admin-app/src/features/dashboard/DevicesCard.tsx
+++ b/source/admin-app/src/features/dashboard/DevicesCard.tsx
@@ -1,0 +1,48 @@
+import { LaptopIcon } from "lucide-react";
+import { Card, CardHeader, CardContent } from "@wardnet/forge-web/card";
+import { StatTile } from "@wardnet/forge-web/stat-tile";
+import type { Device } from "@wardnet/js";
+
+const ONLINE_WINDOW_MS = 5 * 60_000;
+
+function isOnline(device: Device): boolean {
+  return Date.now() - new Date(device.last_seen).getTime() < ONLINE_WINDOW_MS;
+}
+
+interface Props {
+  deviceCount: number;
+  devices: Device[] | undefined;
+  defaultPolicy: string | undefined;
+}
+
+export function DevicesCard({ deviceCount, devices, defaultPolicy }: Props) {
+  const onlineCount = devices?.filter(isOnline).length ?? null;
+  const defaultIsTunnel = defaultPolicy != null && defaultPolicy !== "direct";
+
+  const tunnelledCount = devices?.filter((d) => {
+    if (d.current_rule?.type === "tunnel") return true;
+    if (d.current_rule === null && defaultIsTunnel) return true;
+    return false;
+  }).length ?? null;
+
+  const sub =
+    tunnelledCount !== null
+      ? `${tunnelledCount} routed through a tunnel`
+      : undefined;
+
+  return (
+    <Card>
+      <CardHeader className="flex items-center gap-2 px-4 pt-4 pb-0 text-sm font-medium text-ink-2">
+        <LaptopIcon size={14} strokeWidth={1.8} />
+        Devices
+      </CardHeader>
+      <CardContent className="px-4 pb-4">
+        <StatTile
+          label="Online"
+          value={onlineCount !== null ? `${onlineCount} / ${deviceCount}` : "—"}
+          sub={sub}
+        />
+      </CardContent>
+    </Card>
+  );
+}

--- a/source/admin-app/src/features/dashboard/DevicesCard.tsx
+++ b/source/admin-app/src/features/dashboard/DevicesCard.tsx
@@ -1,6 +1,6 @@
-import { LaptopIcon } from "lucide-react";
-import { Card, CardHeader, CardContent } from "@wardnet/forge-web/card";
-import { StatTile } from "@wardnet/forge-web/stat-tile";
+import { MonitorIcon } from "lucide-react";
+import { Link } from "react-router";
+import { Card } from "@wardnet/forge-web/card";
 import type { Device } from "@wardnet/js";
 
 const ONLINE_WINDOW_MS = 5 * 60_000;
@@ -19,30 +19,42 @@ export function DevicesCard({ deviceCount, devices, defaultPolicy }: Props) {
   const onlineCount = devices?.filter(isOnline).length ?? null;
   const defaultIsTunnel = defaultPolicy != null && defaultPolicy !== "direct";
 
-  const tunnelledCount = devices?.filter((d) => {
-    if (d.current_rule?.type === "tunnel") return true;
-    if (d.current_rule === null && defaultIsTunnel) return true;
-    return false;
-  }).length ?? null;
-
-  const sub =
-    tunnelledCount !== null
-      ? `${tunnelledCount} routed through a tunnel`
-      : undefined;
+  const tunnelledCount =
+    devices?.filter((d) => {
+      if (d.current_rule?.type === "tunnel") return true;
+      if (d.current_rule === null && defaultIsTunnel) return true;
+      return false;
+    }).length ?? null;
 
   return (
-    <Card>
-      <CardHeader className="flex items-center gap-2 px-4 pt-4 pb-0 text-sm font-medium text-ink-2">
-        <LaptopIcon size={14} strokeWidth={1.8} />
-        Devices
-      </CardHeader>
-      <CardContent className="px-4 pb-4">
-        <StatTile
-          label="Online"
-          value={onlineCount !== null ? `${onlineCount} / ${deviceCount}` : "—"}
-          sub={sub}
-        />
-      </CardContent>
-    </Card>
+    <Link to="/devices" className="block">
+      <Card className="card--flush">
+        <div className="flex items-center gap-3 px-2 py-3">
+          <div
+            className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl"
+            style={{ background: "var(--color-accent-soft)", color: "var(--color-accent)" }}
+          >
+            <MonitorIcon size={22} strokeWidth={1.8} />
+          </div>
+
+          <div className="flex-1 min-w-0">
+            <div className="text-[10px] font-semibold uppercase tracking-wider text-ink-3">
+              Devices Online
+            </div>
+            <div className="mt-0.5 flex items-baseline gap-1.5">
+              <span className="text-2xl font-bold text-ink">
+                {onlineCount !== null ? onlineCount : "—"}
+              </span>
+              <span className="text-sm text-ink-3">/ {deviceCount}</span>
+            </div>
+            {tunnelledCount !== null && (
+              <div className="mt-0.5 text-xs text-ink-3">
+                {tunnelledCount} routed through a tunnel
+              </div>
+            )}
+          </div>
+        </div>
+      </Card>
+    </Link>
   );
 }

--- a/source/admin-app/src/features/dashboard/DnsCard.tsx
+++ b/source/admin-app/src/features/dashboard/DnsCard.tsx
@@ -1,6 +1,6 @@
-import { SearchIcon, ShieldOffIcon } from "lucide-react";
-import { Card, CardHeader, CardContent } from "@wardnet/forge-web/card";
-import { StatTile } from "@wardnet/forge-web/stat-tile";
+import { GlobeIcon, ShieldOffIcon } from "lucide-react";
+import { Link } from "react-router";
+import { Card } from "@wardnet/forge-web/card";
 import { Sparkline } from "@wardnet/forge-web/sparkline";
 import type { DashboardDnsStats } from "@wardnet/wardnet-web";
 
@@ -10,62 +10,77 @@ interface Props {
 }
 
 export function DnsQueriesCard({ data, isLoading }: Props) {
-  const spark =
-    data && data.totalSeries.length > 0 ? (
-      <Sparkline
-        values={data.totalSeries}
-        color="var(--accent)"
-        className="h-9 w-full"
-      />
-    ) : undefined;
-
   return (
-    <Card>
-      <CardHeader className="flex items-center gap-2 px-4 pt-4 pb-0 text-sm font-medium text-ink-2">
-        <SearchIcon size={14} strokeWidth={1.8} />
-        DNS Queries · 24h
-      </CardHeader>
-      <CardContent className="px-4 pb-4">
-        <StatTile
-          label="Total"
-          value={isLoading && !data ? "…" : (data?.total.toLocaleString() ?? "0")}
-          spark={spark}
-        />
-      </CardContent>
-    </Card>
+    <Link to="/dns" className="block">
+      <Card className="card--flush">
+        <div className="flex items-center gap-3 px-2 py-3">
+          <div
+            className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl"
+            style={{
+              background: "color-mix(in srgb, var(--color-ink-3) 12%, transparent)",
+              color: "var(--color-ink-3)",
+            }}
+          >
+            <GlobeIcon size={20} strokeWidth={1.8} />
+          </div>
+
+          <div className="min-w-0 shrink-0">
+            <div className="text-[10px] font-semibold uppercase tracking-wider text-ink-3">
+              DNS Queries · 24h
+            </div>
+            <div className="mt-0.5 text-2xl font-bold text-ink tabular-nums">
+              {isLoading && !data ? "…" : (data?.total.toLocaleString() ?? "0")}
+            </div>
+          </div>
+
+          <div className="h-12 flex-1 opacity-70">
+            {data && data.totalSeries.length > 0 && (
+              <Sparkline values={data.totalSeries} color="var(--color-ink-3)" area={false} />
+            )}
+          </div>
+        </div>
+      </Card>
+    </Link>
   );
 }
 
 export function BlockedCard({ data, isLoading }: Props) {
-  const spark =
-    data && data.blockedSeries.length > 0 ? (
-      <Sparkline
-        values={data.blockedSeries}
-        color="var(--danger)"
-        className="h-9 w-full"
-      />
-    ) : undefined;
-
-  const blockedLabel =
+  const sub =
     data != null
-      ? `${data.blocked.toLocaleString()} blocked`
+      ? `${data.blocked.toLocaleString()} of ${data.total.toLocaleString()}`
       : undefined;
 
   return (
-    <Card>
-      <CardHeader className="flex items-center gap-2 px-4 pt-4 pb-0 text-sm font-medium text-ink-2">
-        <ShieldOffIcon size={14} strokeWidth={1.8} />
-        Blocked · 24h
-      </CardHeader>
-      <CardContent className="px-4 pb-4">
-        <StatTile
-          label="Block rate"
-          value={isLoading && !data ? "…" : `${(data?.blockedPercent ?? 0).toFixed(1)}`}
-          unit="%"
-          sub={blockedLabel}
-          spark={spark}
-        />
-      </CardContent>
-    </Card>
+    <Link to="/dns" className="block">
+      <Card className="card--flush">
+        <div className="flex items-center gap-3 px-2 py-3">
+          <div
+            className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl"
+            style={{ background: "var(--color-warn-soft)", color: "var(--color-warn)" }}
+          >
+            <ShieldOffIcon size={20} strokeWidth={1.8} />
+          </div>
+
+          <div className="min-w-0 shrink-0">
+            <div className="text-[10px] font-semibold uppercase tracking-wider text-ink-3">
+              Blocked · 24h
+            </div>
+            <div className="mt-0.5 flex items-baseline gap-0.5">
+              <span className="text-2xl font-bold text-ink tabular-nums">
+                {isLoading && !data ? "…" : `${(data?.blockedPercent ?? 0).toFixed(1)}`}
+              </span>
+              <span className="text-sm text-ink-3">%</span>
+            </div>
+            {sub && <div className="mt-0.5 text-xs text-ink-3">{sub}</div>}
+          </div>
+
+          <div className="h-12 flex-1 opacity-80">
+            {data && data.blockedSeries.length > 0 && (
+              <Sparkline values={data.blockedSeries} color="var(--color-warn)" area={false} />
+            )}
+          </div>
+        </div>
+      </Card>
+    </Link>
   );
 }

--- a/source/admin-app/src/features/dashboard/DnsCard.tsx
+++ b/source/admin-app/src/features/dashboard/DnsCard.tsx
@@ -1,0 +1,71 @@
+import { SearchIcon, ShieldOffIcon } from "lucide-react";
+import { Card, CardHeader, CardContent } from "@wardnet/forge-web/card";
+import { StatTile } from "@wardnet/forge-web/stat-tile";
+import { Sparkline } from "@wardnet/forge-web/sparkline";
+import type { DashboardDnsStats } from "@wardnet/wardnet-web";
+
+interface Props {
+  data: DashboardDnsStats | undefined;
+  isLoading: boolean;
+}
+
+export function DnsQueriesCard({ data, isLoading }: Props) {
+  const spark =
+    data && data.totalSeries.length > 0 ? (
+      <Sparkline
+        values={data.totalSeries}
+        color="var(--accent)"
+        className="h-9 w-full"
+      />
+    ) : undefined;
+
+  return (
+    <Card>
+      <CardHeader className="flex items-center gap-2 px-4 pt-4 pb-0 text-sm font-medium text-ink-2">
+        <SearchIcon size={14} strokeWidth={1.8} />
+        DNS Queries · 24h
+      </CardHeader>
+      <CardContent className="px-4 pb-4">
+        <StatTile
+          label="Total"
+          value={isLoading && !data ? "…" : (data?.total.toLocaleString() ?? "0")}
+          spark={spark}
+        />
+      </CardContent>
+    </Card>
+  );
+}
+
+export function BlockedCard({ data, isLoading }: Props) {
+  const spark =
+    data && data.blockedSeries.length > 0 ? (
+      <Sparkline
+        values={data.blockedSeries}
+        color="var(--danger)"
+        className="h-9 w-full"
+      />
+    ) : undefined;
+
+  const blockedLabel =
+    data != null
+      ? `${data.blocked.toLocaleString()} blocked`
+      : undefined;
+
+  return (
+    <Card>
+      <CardHeader className="flex items-center gap-2 px-4 pt-4 pb-0 text-sm font-medium text-ink-2">
+        <ShieldOffIcon size={14} strokeWidth={1.8} />
+        Blocked · 24h
+      </CardHeader>
+      <CardContent className="px-4 pb-4">
+        <StatTile
+          label="Block rate"
+          value={isLoading && !data ? "…" : `${(data?.blockedPercent ?? 0).toFixed(1)}`}
+          unit="%"
+          sub={blockedLabel}
+          spark={spark}
+        />
+      </CardContent>
+    </Card>
+  );
+}

--- a/source/admin-app/src/features/dashboard/StatusCard.tsx
+++ b/source/admin-app/src/features/dashboard/StatusCard.tsx
@@ -1,0 +1,46 @@
+import { formatUptime } from "@wardnet/wardnet-web";
+
+interface Props {
+  reachable: boolean;
+  uptimeSeconds: number | null;
+}
+
+export function StatusCard({ reachable, uptimeSeconds }: Props) {
+  const statusColor = reachable ? "var(--color-accent)" : "var(--color-danger)";
+
+  return (
+    <div
+      className="rounded-xl px-4 py-4 flex flex-col gap-4"
+      style={{
+        background: `radial-gradient(ellipse at 75% 40%, color-mix(in srgb, ${statusColor} 18%, transparent) 0%, transparent 60%), var(--color-side)`,
+      }}
+    >
+      {/* Status badge */}
+      <div
+        className="self-start flex items-center gap-2 rounded-full px-3 py-1.5 text-[11px] font-semibold uppercase tracking-widest"
+        style={{
+          background: `color-mix(in srgb, ${statusColor} 14%, var(--color-side))`,
+          color: statusColor,
+        }}
+      >
+        <span
+          className="size-[7px] rounded-full shrink-0"
+          style={{ background: statusColor }}
+        />
+        {reachable ? "All Systems Healthy" : "Daemon Unreachable"}
+      </div>
+
+      {/* Health indicators */}
+      <div className="flex gap-6">
+        <div>
+          <div className="text-[10px] font-semibold uppercase tracking-wider text-side-ink-2">
+            Uptime
+          </div>
+          <div className="mt-0.5 text-sm font-medium text-side-ink">
+            {uptimeSeconds != null ? formatUptime(uptimeSeconds) : "—"}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/source/admin-app/src/features/dashboard/TunnelsCard.tsx
+++ b/source/admin-app/src/features/dashboard/TunnelsCard.tsx
@@ -1,7 +1,6 @@
 import { NetworkIcon } from "lucide-react";
-import { Card, CardHeader, CardContent } from "@wardnet/forge-web/card";
-import { StatTile } from "@wardnet/forge-web/stat-tile";
-import { Pill } from "@wardnet/forge-web/pill";
+import { Link } from "react-router";
+import { Card } from "@wardnet/forge-web/card";
 import { formatBytes, countryFlag } from "@wardnet/wardnet-web";
 import type { Tunnel } from "@wardnet/js";
 
@@ -13,43 +12,45 @@ interface Props {
 
 export function TunnelsCard({ tunnelCount, tunnelActiveCount, tunnels }: Props) {
   const activeTunnels = tunnels?.filter((t) => t.status === "up") ?? [];
+  const primary = activeTunnels[0];
 
   return (
-    <Card>
-      <CardHeader className="flex items-center gap-2 px-4 pt-4 pb-0 text-sm font-medium text-ink-2">
-        <NetworkIcon size={14} strokeWidth={1.8} />
-        Tunnels
-      </CardHeader>
-      <CardContent className="px-4 pb-4 flex flex-col gap-3">
-        <StatTile
-          label="Up"
-          value={`${tunnelActiveCount} / ${tunnelCount}`}
-          pill={
-            tunnelActiveCount > 0 ? (
-              <Pill variant="ok">Active</Pill>
-            ) : (
-              <Pill variant="down">Down</Pill>
-            )
-          }
-        />
-        {activeTunnels.length > 0 && (
-          <ul className="flex flex-col gap-1.5">
-            {activeTunnels.map((tunnel) => (
-              <li key={tunnel.id} className="flex items-center justify-between text-sm">
-                <span className="flex items-center gap-1.5 text-ink">
-                  <span aria-hidden>{countryFlag(tunnel.country_code)}</span>
-                  <span className="truncate max-w-[160px]">
-                    {tunnel.resolved_server_name ?? tunnel.label}
-                  </span>
-                </span>
-                <span className="font-mono text-xs text-ink-3 shrink-0">
-                  ↓ {formatBytes(tunnel.bytes_rx)}
-                </span>
-              </li>
-            ))}
-          </ul>
-        )}
-      </CardContent>
+    <Link to="/tunnels" className="block">
+      <Card className="card--flush">
+      <div className="flex items-center gap-3 px-2 py-3">
+        <div
+          className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl"
+          style={{ background: "var(--color-info-soft)", color: "var(--color-info)" }}
+        >
+          <NetworkIcon size={22} strokeWidth={1.8} />
+        </div>
+
+        <div className="flex-1 min-w-0">
+          <div className="text-[10px] font-semibold uppercase tracking-wider text-ink-3">
+            Tunnels Up
+          </div>
+          <div className="mt-0.5 flex items-baseline gap-1.5">
+            <span className="text-2xl font-bold text-ink">{tunnelActiveCount}</span>
+            <span className="text-sm text-ink-3">/ {tunnelCount}</span>
+          </div>
+          {primary && (
+            <div className="mt-0.5 flex items-center gap-1 text-xs text-ink-3 truncate">
+              <span aria-hidden>{countryFlag(primary.country_code)}</span>
+              <span className="truncate">
+                {primary.resolved_server_name ?? primary.label}
+              </span>
+              <span>·</span>
+              <span className="shrink-0">↓ {formatBytes(primary.bytes_rx)}</span>
+            </div>
+          )}
+          {activeTunnels.length > 1 && (
+            <div className="mt-0.5 text-xs text-ink-3">
+              +{activeTunnels.length - 1} more
+            </div>
+          )}
+        </div>
+      </div>
     </Card>
+    </Link>
   );
 }

--- a/source/admin-app/src/features/dashboard/TunnelsCard.tsx
+++ b/source/admin-app/src/features/dashboard/TunnelsCard.tsx
@@ -1,0 +1,55 @@
+import { NetworkIcon } from "lucide-react";
+import { Card, CardHeader, CardContent } from "@wardnet/forge-web/card";
+import { StatTile } from "@wardnet/forge-web/stat-tile";
+import { Pill } from "@wardnet/forge-web/pill";
+import { formatBytes, countryFlag } from "@wardnet/wardnet-web";
+import type { Tunnel } from "@wardnet/js";
+
+interface Props {
+  tunnelCount: number;
+  tunnelActiveCount: number;
+  tunnels: Tunnel[] | undefined;
+}
+
+export function TunnelsCard({ tunnelCount, tunnelActiveCount, tunnels }: Props) {
+  const activeTunnels = tunnels?.filter((t) => t.status === "up") ?? [];
+
+  return (
+    <Card>
+      <CardHeader className="flex items-center gap-2 px-4 pt-4 pb-0 text-sm font-medium text-ink-2">
+        <NetworkIcon size={14} strokeWidth={1.8} />
+        Tunnels
+      </CardHeader>
+      <CardContent className="px-4 pb-4 flex flex-col gap-3">
+        <StatTile
+          label="Up"
+          value={`${tunnelActiveCount} / ${tunnelCount}`}
+          pill={
+            tunnelActiveCount > 0 ? (
+              <Pill variant="ok">Active</Pill>
+            ) : (
+              <Pill variant="down">Down</Pill>
+            )
+          }
+        />
+        {activeTunnels.length > 0 && (
+          <ul className="flex flex-col gap-1.5">
+            {activeTunnels.map((tunnel) => (
+              <li key={tunnel.id} className="flex items-center justify-between text-sm">
+                <span className="flex items-center gap-1.5 text-ink">
+                  <span aria-hidden>{countryFlag(tunnel.country_code)}</span>
+                  <span className="truncate max-w-[160px]">
+                    {tunnel.resolved_server_name ?? tunnel.label}
+                  </span>
+                </span>
+                <span className="font-mono text-xs text-ink-3 shrink-0">
+                  ↓ {formatBytes(tunnel.bytes_rx)}
+                </span>
+              </li>
+            ))}
+          </ul>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/source/admin-app/src/hooks/useBiometric.ts
+++ b/source/admin-app/src/hooks/useBiometric.ts
@@ -48,7 +48,12 @@ async function register(username: string): Promise<void> {
 
   if (!credential) throw new Error("Credential creation returned null");
   const rawId = (credential as PublicKeyCredential).rawId;
-  const base64Id = btoa(String.fromCharCode(...new Uint8Array(rawId)));
+  // Avoid spread-into-String.fromCharCode which can throw RangeError for large
+  // credential IDs (the spec allows up to 1023 bytes).
+  const rawIdBytes = new Uint8Array(rawId);
+  let binary = "";
+  for (const byte of rawIdBytes) binary += String.fromCharCode(byte);
+  const base64Id = btoa(binary);
   localStorage.setItem(CREDENTIAL_KEY, base64Id);
 }
 

--- a/source/admin-app/src/layouts/AppLayout.tsx
+++ b/source/admin-app/src/layouts/AppLayout.tsx
@@ -1,5 +1,6 @@
 import { Outlet } from "react-router";
-import { useOnlineStatus, useDaemonStatus } from "@wardnet/wardnet-web";
+import { useDaemonStatus } from "@wardnet/wardnet-web";
+import { useOnlineStatusContext } from "@/context/OnlineStatusContext";
 import { Header } from "@/components/Header";
 import { ConnectionBanner } from "@/components/ConnectionBanner";
 import { TabBar } from "@/components/TabBar";
@@ -13,7 +14,7 @@ function deriveConnState(isOnline: boolean, isDaemonReachable: boolean): ConnSta
 }
 
 export function AppLayout() {
-  const { isOnline, isDaemonReachable } = useOnlineStatus();
+  const { isOnline, isDaemonReachable } = useOnlineStatusContext();
   const { data } = useDaemonStatus();
   const connState = deriveConnState(isOnline, isDaemonReachable);
   const version = data?.version ?? null;

--- a/source/admin-app/src/pages/Dashboard.tsx
+++ b/source/admin-app/src/pages/Dashboard.tsx
@@ -1,17 +1,30 @@
-import { useAuth } from "@wardnet/wardnet-web";
+import {
+  useAuth,
+  useSystemStatus,
+  useDevices,
+  useTunnels,
+  useDefaultPolicy,
+  useDaemonStatus,
+  useDashboardDnsStats,
+} from "@wardnet/wardnet-web";
 import { useBiometric } from "@/hooks/useBiometric";
 import { useNavigate } from "react-router";
+import { DevicesCard } from "@/features/dashboard/DevicesCard";
+import { TunnelsCard } from "@/features/dashboard/TunnelsCard";
+import { DnsQueriesCard, BlockedCard } from "@/features/dashboard/DnsCard";
+import { DaemonStrip } from "@/features/dashboard/DaemonStrip";
 
-/**
- * Dashboard stub — placeholder until subsequent issues flesh out the content.
- *
- * The logout button here implements the full reset: server session +
- * biometric credential + navigate to /login.
- */
 export default function Dashboard() {
   const { logout } = useAuth();
   const biometric = useBiometric();
   const navigate = useNavigate();
+
+  const { data: status } = useSystemStatus();
+  const { data: devicesData } = useDevices();
+  const { data: tunnelsData } = useTunnels();
+  const { data: policyData } = useDefaultPolicy();
+  const { data: daemonStatus } = useDaemonStatus();
+  const { data: dnsStats, isLoading: dnsLoading } = useDashboardDnsStats();
 
   function handleLogout() {
     logout();
@@ -20,12 +33,32 @@ export default function Dashboard() {
   }
 
   return (
-    <div className="flex flex-col gap-6 p-4">
-      <h1 className="text-xl font-semibold text-ink">Dashboard</h1>
-      <p className="text-sm text-ink-3">More content coming in subsequent issues.</p>
+    <div className="flex flex-col gap-3 p-4">
+      <DevicesCard
+        deviceCount={status?.device_count ?? 0}
+        devices={devicesData?.devices}
+        defaultPolicy={policyData?.policy}
+      />
+
+      <TunnelsCard
+        tunnelCount={status?.tunnel_count ?? 0}
+        tunnelActiveCount={status?.tunnel_active_count ?? 0}
+        tunnels={tunnelsData?.tunnels}
+      />
+
+      <DnsQueriesCard data={dnsStats} isLoading={dnsLoading} />
+
+      <BlockedCard data={dnsStats} isLoading={dnsLoading} />
+
+      <DaemonStrip
+        reachable={daemonStatus?.reachable ?? false}
+        version={daemonStatus?.version ?? null}
+        uptimeSeconds={daemonStatus?.uptimeSeconds ?? null}
+      />
+
       <button
         onClick={handleLogout}
-        className="self-start rounded-md border border-danger px-4 py-2 text-sm font-medium text-danger"
+        className="mt-2 self-start rounded-md border border-danger px-4 py-2 text-sm font-medium text-danger"
       >
         Log out
       </button>

--- a/source/admin-app/src/pages/Dashboard.tsx
+++ b/source/admin-app/src/pages/Dashboard.tsx
@@ -1,5 +1,4 @@
 import {
-  useAuth,
   useSystemStatus,
   useDevices,
   useTunnels,
@@ -7,61 +6,47 @@ import {
   useDaemonStatus,
   useDashboardDnsStats,
 } from "@wardnet/wardnet-web";
-import { useBiometric } from "@/hooks/useBiometric";
-import { useNavigate } from "react-router";
+import { useOnlineStatusContext } from "@/context/OnlineStatusContext";
+import { StatusCard } from "@/features/dashboard/StatusCard";
 import { DevicesCard } from "@/features/dashboard/DevicesCard";
 import { TunnelsCard } from "@/features/dashboard/TunnelsCard";
 import { DnsQueriesCard, BlockedCard } from "@/features/dashboard/DnsCard";
-import { DaemonStrip } from "@/features/dashboard/DaemonStrip";
 
 export default function Dashboard() {
-  const { logout } = useAuth();
-  const biometric = useBiometric();
-  const navigate = useNavigate();
-
   const { data: status } = useSystemStatus();
   const { data: devicesData } = useDevices();
   const { data: tunnelsData } = useTunnels();
   const { data: policyData } = useDefaultPolicy();
   const { data: daemonStatus } = useDaemonStatus();
   const { data: dnsStats, isLoading: dnsLoading } = useDashboardDnsStats();
-
-  function handleLogout() {
-    logout();
-    biometric.unregister();
-    navigate("/login", { replace: true });
-  }
+  const { showingLastKnownState } = useOnlineStatusContext();
 
   return (
     <div className="flex flex-col gap-3 p-4">
-      <DevicesCard
-        deviceCount={status?.device_count ?? 0}
-        devices={devicesData?.devices}
-        defaultPolicy={policyData?.policy}
-      />
-
-      <TunnelsCard
-        tunnelCount={status?.tunnel_count ?? 0}
-        tunnelActiveCount={status?.tunnel_active_count ?? 0}
-        tunnels={tunnelsData?.tunnels}
-      />
-
-      <DnsQueriesCard data={dnsStats} isLoading={dnsLoading} />
-
-      <BlockedCard data={dnsStats} isLoading={dnsLoading} />
-
-      <DaemonStrip
+      <StatusCard
         reachable={daemonStatus?.reachable ?? false}
-        version={daemonStatus?.version ?? null}
         uptimeSeconds={daemonStatus?.uptimeSeconds ?? null}
       />
 
-      <button
-        onClick={handleLogout}
-        className="mt-2 self-start rounded-md border border-danger px-4 py-2 text-sm font-medium text-danger"
-      >
-        Log out
-      </button>
+      <div className={showingLastKnownState ? "opacity-40 pointer-events-none transition-opacity" : "transition-opacity"}>
+        <div className="flex flex-col gap-3">
+          <DevicesCard
+            deviceCount={status?.device_count ?? 0}
+            devices={devicesData?.devices}
+            defaultPolicy={policyData?.policy}
+          />
+
+          <TunnelsCard
+            tunnelCount={status?.tunnel_count ?? 0}
+            tunnelActiveCount={status?.tunnel_active_count ?? 0}
+            tunnels={tunnelsData?.tunnels}
+          />
+
+          <DnsQueriesCard data={dnsStats} isLoading={dnsLoading} />
+
+          <BlockedCard data={dnsStats} isLoading={dnsLoading} />
+        </div>
+      </div>
     </div>
   );
 }

--- a/source/admin-app/src/pages/Dns.tsx
+++ b/source/admin-app/src/pages/Dns.tsx
@@ -1,0 +1,8 @@
+export default function Dns() {
+  return (
+    <div className="flex flex-col gap-4 p-4">
+      <h1 className="text-xl font-semibold text-ink">DNS</h1>
+      <p className="text-sm text-ink-3">Coming in a subsequent issue.</p>
+    </div>
+  );
+}

--- a/source/admin-app/src/pages/Login.tsx
+++ b/source/admin-app/src/pages/Login.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { useNavigate } from "react-router";
-import { LoginForm } from "@wardnet/wardnet-web";
+import { LoginForm, useAuthStore } from "@wardnet/wardnet-web";
 import { useBiometric } from "@/hooks/useBiometric";
 import { BiometricSetupPrompt } from "@/components/BiometricSetupPrompt";
 
@@ -10,6 +10,7 @@ interface Props {
 
 export default function Login({ onUnlock }: Props) {
   const navigate = useNavigate();
+  const { login } = useAuthStore();
   const biometric = useBiometric();
   const [biometricUsername, setBiometricUsername] = useState("");
   const [showBiometricSetup, setShowBiometricSetup] = useState(false);
@@ -31,6 +32,7 @@ export default function Login({ onUnlock }: Props) {
 
   return (
     <LoginForm
+      login={login}
       rememberMe={true}
       onSuccess={(username) => {
         if (biometric.isAvailable() && !biometric.isRegistered()) {

--- a/source/admin-app/src/pages/System.tsx
+++ b/source/admin-app/src/pages/System.tsx
@@ -1,8 +1,28 @@
+import { useAuth } from "@wardnet/wardnet-web";
+import { useBiometric } from "@/hooks/useBiometric";
+import { useNavigate } from "react-router";
+
 export default function System() {
+  const { logout } = useAuth();
+  const biometric = useBiometric();
+  const navigate = useNavigate();
+
+  function handleLogout() {
+    logout();
+    biometric.unregister();
+    navigate("/login", { replace: true });
+  }
+
   return (
     <div className="flex flex-col gap-4 p-4">
       <h1 className="text-xl font-semibold text-ink">System</h1>
       <p className="text-sm text-ink-3">Coming in a subsequent issue.</p>
+      <button
+        onClick={handleLogout}
+        className="self-start rounded-md border border-danger px-4 py-2 text-sm font-medium text-danger"
+      >
+        Log out
+      </button>
     </div>
   );
 }

--- a/source/admin-app/vite.config.ts
+++ b/source/admin-app/vite.config.ts
@@ -35,6 +35,9 @@ export default defineConfig({
         target: "http://127.0.0.1:7411",
         ws: true,
       },
+      "/admin/": {
+        target: "http://127.0.0.1:7412",
+      },
     },
   },
   optimizeDeps: {

--- a/source/admin-site/forge-web/src/primitives/sparkline.tsx
+++ b/source/admin-site/forge-web/src/primitives/sparkline.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { clsx } from "clsx";
 
-type SparklineProps = Omit<React.ComponentProps<"svg">, "children"> & {
+type SparklineProps = Omit<React.ComponentProps<"svg">, "children" | "values"> & {
   /**
    * Sample points rendered left-to-right. Normalised to a 0..1 viewBox so
    * the host container fully owns width and height; passing 1, 30, or 300

--- a/source/admin-site/web/src/pages/Login.tsx
+++ b/source/admin-site/web/src/pages/Login.tsx
@@ -1,7 +1,8 @@
 import { useNavigate } from "react-router";
-import { LoginForm } from "@wardnet/wardnet-web";
+import { LoginForm, useAuthStore } from "@wardnet/wardnet-web";
 
 export default function Login() {
   const navigate = useNavigate();
-  return <LoginForm rememberMe="checkbox" onSuccess={() => navigate("/")} />;
+  const { login } = useAuthStore();
+  return <LoginForm login={login} rememberMe="checkbox" onSuccess={() => navigate("/")} />;
 }

--- a/source/daemon/crates/wardnetd-api/src/api/auth.rs
+++ b/source/daemon/crates/wardnetd-api/src/api/auth.rs
@@ -1,6 +1,5 @@
 use axum::Json;
 use axum::extract::State;
-use axum::http::HeaderMap;
 use axum::http::StatusCode;
 use axum::http::header::SET_COOKIE;
 use axum::response::IntoResponse;
@@ -48,7 +47,7 @@ pub async fn login(
         .await?;
 
     let cookie_value = format!(
-        "wardnet_session={}; HttpOnly; SameSite=Strict; Path=/; Max-Age={}",
+        "wardnet_session={}; HttpOnly; SameSite=Strict; Path=/; Max-Age={}; Secure",
         result.token, result.max_age_seconds
     );
 
@@ -83,43 +82,18 @@ pub async fn login(
 )]
 pub async fn refresh(
     State(state): State<AppState>,
-    _auth: AdminAuth,
-    headers: HeaderMap,
+    auth: AdminAuth,
 ) -> Result<impl IntoResponse, AppError> {
-    let token = extract_session_token(&headers)
+    let token = auth
+        .session_token
         .ok_or_else(|| AppError::Unauthorized("no session token in request".to_owned()))?;
 
     let result = state.auth_service().refresh_session(&token).await?;
 
     let cookie_value = format!(
-        "wardnet_session={}; HttpOnly; SameSite=Strict; Path=/; Max-Age={}",
+        "wardnet_session={}; HttpOnly; SameSite=Strict; Path=/; Max-Age={}; Secure",
         result.token, result.max_age_seconds
     );
 
     Ok((StatusCode::NO_CONTENT, [(SET_COOKIE, cookie_value)]))
-}
-
-/// Extract the raw session token from a `wardnet_session` cookie or a
-/// `Authorization: Bearer` header (cookie takes precedence).
-fn extract_session_token(headers: &HeaderMap) -> Option<String> {
-    if let Some(v) = headers.get(axum::http::header::COOKIE)
-        && let Some(token) = v.to_str().ok().and_then(|s| {
-            s.split(';').find_map(|pair| {
-                let (name, value) = pair.trim().split_once('=')?;
-                if name.trim() == "wardnet_session" {
-                    Some(value.trim().to_owned())
-                } else {
-                    None
-                }
-            })
-        })
-    {
-        return Some(token);
-    }
-    headers
-        .get(axum::http::header::AUTHORIZATION)
-        .and_then(|v| v.to_str().ok())
-        .and_then(|v| v.strip_prefix("Bearer "))
-        .filter(|t| !t.is_empty())
-        .map(str::to_owned)
 }

--- a/source/daemon/crates/wardnetd-api/src/api/middleware.rs
+++ b/source/daemon/crates/wardnetd-api/src/api/middleware.rs
@@ -42,6 +42,10 @@ impl FromRequestParts<AppState> for ClientIp {
 /// no SQL or hashing happens here.
 pub struct AdminAuth {
     pub admin_id: Uuid,
+    /// The raw session token (cookie or Bearer) extracted from the request headers.
+    /// `None` when authenticated via API key (no session token is present).
+    /// Provided to downstream handlers so they do not need to re-parse headers.
+    pub session_token: Option<String>,
 }
 
 impl FromRequestParts<AppState> for AdminAuth {
@@ -53,18 +57,56 @@ impl FromRequestParts<AppState> for AdminAuth {
     ) -> Result<Self, Self::Rejection> {
         let headers = &parts.headers;
 
+        // Extract the raw token once (cheap header parse, no DB call) so it is
+        // available to handlers without a second header traversal.
+        let session_token = extract_raw_session_token(headers);
+
         if let Some(admin_id) = try_session_cookie(headers, state).await? {
-            return Ok(Self { admin_id });
+            return Ok(Self {
+                admin_id,
+                session_token,
+            });
         }
 
         if let Some(admin_id) = try_bearer(headers, state).await? {
-            return Ok(Self { admin_id });
+            return Ok(Self {
+                admin_id,
+                session_token,
+            });
         }
 
         Err(AppError::Unauthorized(
             "valid session cookie or API key required".to_owned(),
         ))
     }
+}
+
+/// Extract the raw session token from the `wardnet_session` cookie or an
+/// `Authorization: Bearer` header without performing any validation.
+/// Cookie takes precedence.
+fn extract_raw_session_token(headers: &HeaderMap) -> Option<String> {
+    if let Some(v) = headers.get(axum::http::header::COOKIE)
+        && let Some(token) = v.to_str().ok().and_then(|s| {
+            s.split(';').find_map(|pair| {
+                let mut parts = pair.trim().splitn(2, '=');
+                let name = parts.next()?.trim();
+                let value = parts.next()?.trim();
+                if name == "wardnet_session" && !value.is_empty() {
+                    Some(value.to_owned())
+                } else {
+                    None
+                }
+            })
+        })
+    {
+        return Some(token);
+    }
+    headers
+        .get(axum::http::header::AUTHORIZATION)
+        .and_then(|v| v.to_str().ok())
+        .and_then(|v| v.strip_prefix("Bearer "))
+        .filter(|t| !t.is_empty())
+        .map(str::to_owned)
 }
 
 /// Extract and validate the `wardnet_session` cookie via the auth service.

--- a/source/daemon/crates/wardnetd-api/src/api/tests/auth.rs
+++ b/source/daemon/crates/wardnetd-api/src/api/tests/auth.rs
@@ -324,7 +324,7 @@ async fn refresh_success_returns_204_and_set_cookie() {
 
 #[tokio::test]
 async fn refresh_via_bearer_token_returns_204() {
-    // Covers the bearer-token branch of extract_session_token.
+    // Covers the bearer-token branch of AdminAuth::session_token extraction.
     let state = make_state(MockRefreshAuthService {
         refresh_result: Ok(()),
     });

--- a/source/daemon/crates/wardnetd-api/src/api/tests/middleware.rs
+++ b/source/daemon/crates/wardnetd-api/src/api/tests/middleware.rs
@@ -110,7 +110,7 @@ fn make_state(auth: impl AuthService + 'static) -> AppState {
 
 /// Handler that requires `AdminAuth` and returns the admin UUID.
 async fn admin_only(
-    crate::api::middleware::AdminAuth { admin_id }: crate::api::middleware::AdminAuth,
+    crate::api::middleware::AdminAuth { admin_id, .. }: crate::api::middleware::AdminAuth,
 ) -> impl IntoResponse {
     admin_id.to_string()
 }

--- a/source/daemon/crates/wardnetd-data/src/repository/session.rs
+++ b/source/daemon/crates/wardnetd-data/src/repository/session.rs
@@ -30,8 +30,16 @@ pub trait SessionRepository: Send + Sync {
     /// Slide the expiry forward for an existing session (used by the refresh endpoint).
     async fn extend_expiry(&self, token_hash: &str, new_expires_at: &str) -> anyhow::Result<()>;
 
-    /// Return whether the session identified by `token_hash` was created as
-    /// a long-lived (remember-me) session. Returns `None` if the session does
-    /// not exist or has expired.
-    async fn remember_me_for_token(&self, token_hash: &str) -> anyhow::Result<Option<bool>>;
+    /// Atomically look up a session for the refresh endpoint.
+    ///
+    /// Returns `Some((admin_id, remember_me))` when the session exists and has
+    /// not expired; `None` otherwise. Using a single query eliminates the
+    /// race window between the two-call pattern
+    /// (`find_admin_id_by_token_hash` + separate `remember_me` lookup) where
+    /// `delete_expired` could remove the row between the two reads.
+    async fn find_session_for_refresh(
+        &self,
+        token_hash: &str,
+        now: &str,
+    ) -> anyhow::Result<Option<(String, bool)>>;
 }

--- a/source/daemon/crates/wardnetd-data/src/repository/sqlite/session.rs
+++ b/source/daemon/crates/wardnetd-data/src/repository/sqlite/session.rs
@@ -81,12 +81,18 @@ impl SessionRepository for SqliteSessionRepository {
         Ok(())
     }
 
-    async fn remember_me_for_token(&self, token_hash: &str) -> anyhow::Result<Option<bool>> {
-        let row =
-            sqlx::query_scalar::<_, bool>("SELECT remember_me FROM sessions WHERE token_hash = ?")
-                .bind(token_hash)
-                .fetch_optional(&self.pools.read)
-                .await?;
+    async fn find_session_for_refresh(
+        &self,
+        token_hash: &str,
+        now: &str,
+    ) -> anyhow::Result<Option<(String, bool)>> {
+        let row = sqlx::query_as::<_, (String, bool)>(
+            "SELECT admin_id, remember_me FROM sessions WHERE token_hash = ? AND expires_at > ?",
+        )
+        .bind(token_hash)
+        .bind(now)
+        .fetch_optional(&self.pools.read)
+        .await?;
         Ok(row)
     }
 }

--- a/source/daemon/crates/wardnetd-data/src/repository/tests/session.rs
+++ b/source/daemon/crates/wardnetd-data/src/repository/tests/session.rs
@@ -99,11 +99,12 @@ async fn delete_expired_removes_only_old_sessions() {
 }
 
 #[tokio::test]
-async fn remember_me_for_token_returns_correct_flag() {
+async fn find_session_for_refresh_returns_admin_id_and_flag() {
     let pool = test_pool().await;
     seed_admin(&pool).await;
     let repo = SqliteSessionRepository::new(pool);
 
+    // remember_me=true, not expired.
     repo.create(
         "s1",
         "admin-1",
@@ -114,6 +115,7 @@ async fn remember_me_for_token_returns_correct_flag() {
     )
     .await
     .unwrap();
+    // remember_me=false, not expired.
     repo.create(
         "s2",
         "admin-1",
@@ -124,17 +126,41 @@ async fn remember_me_for_token_returns_correct_flag() {
     )
     .await
     .unwrap();
+    // Expired.
+    repo.create(
+        "s3",
+        "admin-1",
+        "hash-expired",
+        "2026-01-01T00:00:00Z",
+        "2026-01-02T00:00:00Z",
+        true,
+    )
+    .await
+    .unwrap();
 
+    let now = "2026-06-01T00:00:00Z";
     assert_eq!(
-        repo.remember_me_for_token("hash-rm").await.unwrap(),
-        Some(true)
+        repo.find_session_for_refresh("hash-rm", now).await.unwrap(),
+        Some(("admin-1".to_owned(), true))
     );
     assert_eq!(
-        repo.remember_me_for_token("hash-short").await.unwrap(),
-        Some(false)
+        repo.find_session_for_refresh("hash-short", now)
+            .await
+            .unwrap(),
+        Some(("admin-1".to_owned(), false))
     );
+    // Expired session returns None.
     assert_eq!(
-        repo.remember_me_for_token("no-such-hash").await.unwrap(),
+        repo.find_session_for_refresh("hash-expired", now)
+            .await
+            .unwrap(),
+        None
+    );
+    // Unknown hash returns None.
+    assert_eq!(
+        repo.find_session_for_refresh("no-such-hash", now)
+            .await
+            .unwrap(),
         None
     );
 }

--- a/source/daemon/crates/wardnetd-services/src/auth/service.rs
+++ b/source/daemon/crates/wardnetd-services/src/auth/service.rs
@@ -217,7 +217,10 @@ impl AuthService for AuthServiceImpl {
             ));
         }
 
-        let expiry_hours_i64 = self.remember_me_expiry_hours.min(i64::MAX as u64).cast_signed();
+        let expiry_hours_i64 = self
+            .remember_me_expiry_hours
+            .min(i64::MAX as u64)
+            .cast_signed();
         let new_expires_at = now + chrono::Duration::hours(expiry_hours_i64);
 
         self.sessions

--- a/source/daemon/crates/wardnetd-services/src/auth/service.rs
+++ b/source/daemon/crates/wardnetd-services/src/auth/service.rs
@@ -173,13 +173,7 @@ impl AuthService for AuthServiceImpl {
         } else {
             self.session_expiry_hours
         };
-        let expiry_hours_i64 = i64::try_from(expiry_hours).unwrap_or_else(|_| {
-            tracing::warn!(
-                hours = expiry_hours,
-                "session_expiry_hours overflows i64, clamping to 24"
-            );
-            24
-        });
+        let expiry_hours_i64 = expiry_hours.min(i64::MAX as u64) as i64;
         let expires_at = now + chrono::Duration::hours(expiry_hours_i64);
 
         self.sessions
@@ -223,13 +217,7 @@ impl AuthService for AuthServiceImpl {
             ));
         }
 
-        let expiry_hours_i64 = i64::try_from(self.remember_me_expiry_hours).unwrap_or_else(|_| {
-            tracing::warn!(
-                hours = self.remember_me_expiry_hours,
-                "remember_me_expiry_hours overflows i64, clamping to 720"
-            );
-            720
-        });
+        let expiry_hours_i64 = self.remember_me_expiry_hours.min(i64::MAX as u64) as i64;
         let new_expires_at = now + chrono::Duration::hours(expiry_hours_i64);
 
         self.sessions

--- a/source/daemon/crates/wardnetd-services/src/auth/service.rs
+++ b/source/daemon/crates/wardnetd-services/src/auth/service.rs
@@ -173,7 +173,13 @@ impl AuthService for AuthServiceImpl {
         } else {
             self.session_expiry_hours
         };
-        let expiry_hours_i64 = i64::try_from(expiry_hours).unwrap_or(24);
+        let expiry_hours_i64 = i64::try_from(expiry_hours).unwrap_or_else(|_| {
+            tracing::warn!(
+                hours = expiry_hours,
+                "session_expiry_hours overflows i64, clamping to 24"
+            );
+            24
+        });
         let expires_at = now + chrono::Duration::hours(expiry_hours_i64);
 
         self.sessions
@@ -201,20 +207,15 @@ impl AuthService for AuthServiceImpl {
         let now = chrono::Utc::now();
         let now_str = now.to_rfc3339();
 
-        // Verify the session still exists (guards against replaying an already-expired token).
-        self.sessions
-            .find_admin_id_by_token_hash(&token_hash, &now_str)
+        // Single atomic query: validates the session is non-expired and retrieves
+        // remember_me in one round-trip, eliminating the race window where
+        // delete_expired() could remove the row between two sequential reads.
+        let (_, is_refreshable) = self
+            .sessions
+            .find_session_for_refresh(&token_hash, &now_str)
             .await
             .map_err(AppError::Internal)?
             .ok_or_else(|| AppError::Unauthorized("session not found or expired".to_owned()))?;
-
-        // Verify the session was originally created as a long-lived remember-me session.
-        let is_refreshable = self
-            .sessions
-            .remember_me_for_token(&token_hash)
-            .await
-            .map_err(AppError::Internal)?
-            .unwrap_or(false);
 
         if !is_refreshable {
             return Err(AppError::Forbidden(
@@ -222,7 +223,13 @@ impl AuthService for AuthServiceImpl {
             ));
         }
 
-        let expiry_hours_i64 = i64::try_from(self.remember_me_expiry_hours).unwrap_or(720);
+        let expiry_hours_i64 = i64::try_from(self.remember_me_expiry_hours).unwrap_or_else(|_| {
+            tracing::warn!(
+                hours = self.remember_me_expiry_hours,
+                "remember_me_expiry_hours overflows i64, clamping to 720"
+            );
+            720
+        });
         let new_expires_at = now + chrono::Duration::hours(expiry_hours_i64);
 
         self.sessions

--- a/source/daemon/crates/wardnetd-services/src/auth/service.rs
+++ b/source/daemon/crates/wardnetd-services/src/auth/service.rs
@@ -173,7 +173,7 @@ impl AuthService for AuthServiceImpl {
         } else {
             self.session_expiry_hours
         };
-        let expiry_hours_i64 = expiry_hours.min(i64::MAX as u64) as i64;
+        let expiry_hours_i64 = expiry_hours.min(i64::MAX as u64).cast_signed();
         let expires_at = now + chrono::Duration::hours(expiry_hours_i64);
 
         self.sessions
@@ -217,7 +217,7 @@ impl AuthService for AuthServiceImpl {
             ));
         }
 
-        let expiry_hours_i64 = self.remember_me_expiry_hours.min(i64::MAX as u64) as i64;
+        let expiry_hours_i64 = self.remember_me_expiry_hours.min(i64::MAX as u64).cast_signed();
         let new_expires_at = now + chrono::Duration::hours(expiry_hours_i64);
 
         self.sessions

--- a/source/daemon/crates/wardnetd-services/src/auth/tests/auth.rs
+++ b/source/daemon/crates/wardnetd-services/src/auth/tests/auth.rs
@@ -34,10 +34,12 @@ impl AdminRepository for MockAdminRepo {
     }
 }
 
-/// Mock session repo that captures created sessions and returns a preconfigured lookup result.
+/// Mock session repo that captures created sessions and returns preconfigured lookup results.
 struct MockSessionRepo {
+    /// Returned by `find_admin_id_by_token_hash` (drives `validate_session`).
     find_result: Mutex<Option<String>>,
-    remember_me: Mutex<Option<bool>>,
+    /// Returned by `find_session_for_refresh` (drives `refresh_session`).
+    session_for_refresh: Mutex<Option<(String, bool)>>,
 }
 
 #[async_trait]
@@ -66,8 +68,12 @@ impl SessionRepository for MockSessionRepo {
     async fn extend_expiry(&self, _token_hash: &str, _new_expires_at: &str) -> anyhow::Result<()> {
         Ok(())
     }
-    async fn remember_me_for_token(&self, _token_hash: &str) -> anyhow::Result<Option<bool>> {
-        Ok(*self.remember_me.lock().unwrap())
+    async fn find_session_for_refresh(
+        &self,
+        _token_hash: &str,
+        _now: &str,
+    ) -> anyhow::Result<Option<(String, bool)>> {
+        Ok(self.session_for_refresh.lock().unwrap().clone())
     }
 }
 
@@ -128,6 +134,7 @@ fn make_auth_service(
     session_find: Option<String>,
     api_key_hashes: Vec<(String, String)>,
 ) -> AuthServiceImpl {
+    let session_for_refresh = session_find.as_ref().map(|id| (id.clone(), true));
     AuthServiceImpl::new(
         Arc::new(MockAdminRepo {
             find_result: Mutex::new(admin_find),
@@ -135,7 +142,7 @@ fn make_auth_service(
         }),
         Arc::new(MockSessionRepo {
             find_result: Mutex::new(session_find),
-            remember_me: Mutex::new(Some(true)),
+            session_for_refresh: Mutex::new(session_for_refresh),
         }),
         Arc::new(MockApiKeyRepo {
             hashes: api_key_hashes,
@@ -281,7 +288,7 @@ async fn refresh_session_success() {
 async fn refresh_session_not_remember_me_returns_forbidden() {
     // Session exists but remember_me=false → Forbidden.
     let admin_uuid = "00000000-0000-0000-0000-000000000001";
-    // Build a service with a MockSessionRepo that returns remember_me=false.
+    // Build a service with a MockSessionRepo where remember_me=false.
     let svc = AuthServiceImpl::new(
         Arc::new(MockAdminRepo {
             find_result: Mutex::new(None),
@@ -289,7 +296,7 @@ async fn refresh_session_not_remember_me_returns_forbidden() {
         }),
         Arc::new(MockSessionRepo {
             find_result: Mutex::new(Some(admin_uuid.to_owned())),
-            remember_me: Mutex::new(Some(false)),
+            session_for_refresh: Mutex::new(Some((admin_uuid.to_owned(), false))),
         }),
         Arc::new(MockApiKeyRepo { hashes: vec![] }),
         Arc::new(MockSystemConfigRepo),

--- a/source/daemon/crates/wardnetd-services/src/auth/tests/auth.rs
+++ b/source/daemon/crates/wardnetd-services/src/auth/tests/auth.rs
@@ -168,6 +168,18 @@ async fn login_success() {
 }
 
 #[tokio::test]
+async fn login_success_with_remember_me() {
+    let hash = argon2_hash("correct-password");
+    let svc = make_auth_service(Some(("admin-1".to_owned(), hash)), None, None, vec![]);
+
+    let result = svc.login("admin", "correct-password", true).await;
+    assert!(result.is_ok());
+    let login = result.unwrap();
+    assert!(!login.token.is_empty());
+    assert_eq!(login.max_age_seconds, 720 * 3600);
+}
+
+#[tokio::test]
 async fn login_wrong_password() {
     let hash = argon2_hash("correct-password");
     let svc = make_auth_service(Some(("admin-1".to_owned(), hash)), None, None, vec![]);

--- a/source/daemon/crates/wardnetd-services/src/auth/tests/setup.rs
+++ b/source/daemon/crates/wardnetd-services/src/auth/tests/setup.rs
@@ -87,8 +87,12 @@ impl SessionRepository for MockSessionRepo {
     async fn extend_expiry(&self, _token_hash: &str, _new_expires_at: &str) -> anyhow::Result<()> {
         Ok(())
     }
-    async fn remember_me_for_token(&self, _token_hash: &str) -> anyhow::Result<Option<bool>> {
-        Ok(Some(true))
+    async fn find_session_for_refresh(
+        &self,
+        _token_hash: &str,
+        _now: &str,
+    ) -> anyhow::Result<Option<(String, bool)>> {
+        Ok(None)
     }
 }
 

--- a/source/daemon/crates/wardnetd-services/src/auth/tests/wizard.rs
+++ b/source/daemon/crates/wardnetd-services/src/auth/tests/wizard.rs
@@ -73,8 +73,12 @@ impl SessionRepository for MockSessionRepo {
     async fn extend_expiry(&self, _token_hash: &str, _new_expires_at: &str) -> anyhow::Result<()> {
         Ok(())
     }
-    async fn remember_me_for_token(&self, _token_hash: &str) -> anyhow::Result<Option<bool>> {
-        Ok(Some(true))
+    async fn find_session_for_refresh(
+        &self,
+        _token_hash: &str,
+        _now: &str,
+    ) -> anyhow::Result<Option<(String, bool)>> {
+        Ok(None)
     }
 }
 

--- a/source/sdk/wardnet-js/src/types/system.ts
+++ b/source/sdk/wardnet-js/src/types/system.ts
@@ -31,6 +31,7 @@ export interface SystemStatusResponse {
   uptime_seconds: number;
   device_count: number;
   tunnel_count: number;
+  tunnel_active_count: number;
   db_size_bytes: number;
   cpu_usage_percent: number;
   memory_used_bytes: number;

--- a/source/wardnet-web/src/components/LoginForm.tsx
+++ b/source/wardnet-web/src/components/LoginForm.tsx
@@ -4,9 +4,10 @@ import { Button } from "@wardnet/forge-web/button";
 import { Field } from "@wardnet/forge-web/field";
 import { Form, Validator } from "@wardnet/forge-web/form";
 import { Input } from "@wardnet/forge-web/input";
-import { useAuthStore } from "../stores/authStore";
 
 interface LoginFormProps {
+  /** Injected login action — callers supply this from their auth store or hook. */
+  login: (username: string, password: string, rememberMe?: boolean) => Promise<void>;
   /**
    * Controls the "Remember me" behaviour:
    * - `"checkbox"` — shows an unchecked checkbox the user can toggle (admin-site)
@@ -21,11 +22,10 @@ interface LoginFormProps {
 /**
  * Shared admin login form used by both admin-site and admin-app.
  *
- * Handles all credential state, loading, and error display.
- * The caller owns post-login navigation via `onSuccess`.
+ * Pure presentation — all business logic is injected via props. The caller
+ * owns the login action and post-login navigation via `onSuccess`.
  */
-export function LoginForm({ rememberMe = false, onSuccess }: LoginFormProps) {
-  const { login } = useAuthStore();
+export function LoginForm({ login, rememberMe = false, onSuccess }: LoginFormProps) {
   const [username, setUsername] = useState("");
   const [password, setPassword] = useState("");
   const [rememberMeChecked, setRememberMeChecked] = useState(false);

--- a/source/wardnet-web/src/hooks/useStats.ts
+++ b/source/wardnet-web/src/hooks/useStats.ts
@@ -187,17 +187,16 @@ export interface DashboardDnsStats {
  * useDnsStatSummary("24h") which uses minute buckets.
  */
 export function useDashboardDnsStats() {
-  const { from, to } = useMemo(() => {
-    const now = new Date();
-    return {
-      from: new Date(now.getTime() - 24 * 3_600_000).toISOString(),
-      to: now.toISOString(),
-    };
-  }, []);
-
   const { data, isLoading, isError, error } = useQuery({
     queryKey: ["stats", "dns-dashboard-24h"],
-    queryFn: () => statsService.query({ metric: "dns.queries", from, to, bucket: "hour" }),
+    queryFn: () => {
+      // Compute the window inside queryFn so each 30-second refetch uses the
+      // current time rather than the time the component first mounted.
+      const now = new Date();
+      const from = new Date(now.getTime() - 24 * 3_600_000).toISOString();
+      const to = now.toISOString();
+      return statsService.query({ metric: "dns.queries", from, to, bucket: "hour" });
+    },
     refetchInterval: 30_000,
   });
 

--- a/source/wardnet-web/src/hooks/useStats.ts
+++ b/source/wardnet-web/src/hooks/useStats.ts
@@ -168,3 +168,67 @@ export function useDnsStatsDashboard(
 
   return { data, isLoading, isError, error };
 }
+
+export interface DashboardDnsStats {
+  total: number;
+  blocked: number;
+  blockedPercent: number;
+  /** Per-hour total query counts for the last 24h, oldest-first. Feeds the DNS sparkline. */
+  totalSeries: number[];
+  /** Per-hour blocked counts for the last 24h, oldest-first. Feeds the blocked sparkline. */
+  blockedSeries: number[];
+}
+
+/**
+ * Lightweight 24h DNS summary for the Dashboard cards.
+ *
+ * Uses hour buckets (24 points) rather than minute buckets so the
+ * sparkline series is a manageable size. Distinct query key from
+ * useDnsStatSummary("24h") which uses minute buckets.
+ */
+export function useDashboardDnsStats() {
+  const { from, to } = useMemo(() => {
+    const now = new Date();
+    return {
+      from: new Date(now.getTime() - 24 * 3_600_000).toISOString(),
+      to: now.toISOString(),
+    };
+  }, []);
+
+  const { data, isLoading, isError, error } = useQuery({
+    queryKey: ["stats", "dns-dashboard-24h"],
+    queryFn: () => statsService.query({ metric: "dns.queries", from, to, bucket: "hour" }),
+    refetchInterval: 30_000,
+  });
+
+  const derived = useMemo((): DashboardDnsStats | undefined => {
+    if (!data) return undefined;
+
+    const byTs = new Map<string, { total: number; blocked: number }>();
+    let total = 0;
+    let blocked = 0;
+
+    for (const point of data.series ?? []) {
+      const entry = byTs.get(point.ts) ?? { total: 0, blocked: 0 };
+      entry.total += point.value;
+      total += point.value;
+      if (parseLabels(point.labels).outcome === "blocked") {
+        entry.blocked += point.value;
+        blocked += point.value;
+      }
+      byTs.set(point.ts, entry);
+    }
+
+    const sorted = Array.from(byTs.entries()).sort(([a], [b]) => a.localeCompare(b));
+
+    return {
+      total: Math.round(total),
+      blocked: Math.round(blocked),
+      blockedPercent: total > 0 ? (blocked / total) * 100 : 0,
+      totalSeries: sorted.map(([, v]) => v.total),
+      blockedSeries: sorted.map(([, v]) => v.blocked),
+    };
+  }, [data]);
+
+  return { data: derived, isLoading, isError, error };
+}

--- a/source/wardnet-web/src/index.ts
+++ b/source/wardnet-web/src/index.ts
@@ -104,10 +104,11 @@ export type { ShutdownPhase } from "./hooks/useShutdown";
 export {
   useDnsStatSummary,
   useDnsStatsDashboard,
+  useDashboardDnsStats,
   RANGES,
   RANGE_HOURS,
 } from "./hooks/useStats";
-export type { StatsRange, DnsStatsDashboardData } from "./hooks/useStats";
+export type { StatsRange, DnsStatsDashboardData, DashboardDnsStats } from "./hooks/useStats";
 export { useTunnelStats } from "./hooks/useTunnelStats";
 export type { TunnelStatsPoint, TunnelStatsData } from "./hooks/useTunnelStats";
 


### PR DESCRIPTION
Closes #478.

## Summary
- Replaces the Dashboard stub with four summary-card rows + a daemon strip driven by real API data — no new backend endpoint
- **DevicesCard**: online / total (5 min `last_seen` window) + tunnelled count (explicit tunnel rules + implicit via default policy using `useDefaultPolicy`)
- **TunnelsCard**: up / total + list of all `status === "up"` tunnels with flag, name, and `formatBytes(bytes_rx)`
- **DnsQueriesCard + BlockedCard**: 24h totals and sparklines from a new `useDashboardDnsStats` hook (hour-bucket series, one query shared by both cards)
- **DaemonStrip**: running state, CalVer version, uptime from `useDaemonStatus`

Also includes two fixes:
- Adds missing `tunnel_active_count` to `SystemStatusResponse` in `wardnet-js` types (field exists in the Rust struct but was absent from the TS type)
- Fixes `SparklineProps` to omit the conflicting SVG `values` attribute (prevented `number[]` from being assigned)

## Test plan
- [ ] Log in to the admin PWA; Dashboard renders all four cards with real data
- [ ] TunnelsCard lists each up tunnel with its flag and downloaded bytes
- [ ] DevicesCard shows correct online count and tunnelled count
- [ ] DNS cards show 24h totals and sparklines
- [ ] DaemonStrip shows running state, version, and uptime
- [ ] Toggle DevTools → Network → Offline; stale data stays visible (react-query last-known data)
- [ ] `make check-sdk` and `make check-web` pass (admin-app type-check clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)