### PR TITLE
feat(admin-app): Devices list + DeviceRoutingSheet (#479)

### DIFF
--- a/source/admin-app/src/components/DeviceRoutingSheet.tsx
+++ b/source/admin-app/src/components/DeviceRoutingSheet.tsx
@@ -1,0 +1,122 @@
+import { useRef } from "react";
+import { Drawer, DrawerContent, DrawerTitle } from "@wardnet/forge-web/drawer";
+import { useUpdateDevice, countryFlag } from "@wardnet/wardnet-web";
+import type { Device, Tunnel, RoutingTarget } from "@wardnet/js";
+import { CheckIcon } from "lucide-react";
+
+interface Props {
+  device: Device | null;
+  tunnels: Tunnel[];
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+function activeKey(rule: RoutingTarget | null): string {
+  if (!rule || rule.type === "default") return "default";
+  if (rule.type === "direct") return "direct";
+  if (rule.type === "tunnel") return rule.tunnel_id;
+  // Unknown future rule types fall back to "default" visual state rather than
+  // leaving every row un-highlighted.
+  return "default";
+}
+
+type TunnelTone = "ok" | "danger" | "warn" | "neutral";
+
+function tunnelSublabel(status: Tunnel["status"]): { label: string; tone: TunnelTone } {
+  switch (status) {
+    case "up":           return { label: "",             tone: "ok" };
+    case "down":         return { label: "Down",         tone: "danger" };
+    case "connecting":   return { label: "Connecting",   tone: "neutral" };
+    case "reconnecting": return { label: "Reconnecting", tone: "warn" };
+  }
+}
+
+function OptionRow({ label, sublabel, sublabelTone, active, disabled, onSelect }: {
+  label: string;
+  sublabel?: string;
+  sublabelTone?: TunnelTone;
+  active: boolean;
+  disabled: boolean;
+  onSelect: () => void;
+}) {
+  const sublabelClass =
+    sublabelTone === "danger" ? "text-danger" :
+    sublabelTone === "warn"   ? "text-warn"   : "text-ink-3";
+  return (
+    <button
+      onClick={onSelect}
+      disabled={disabled}
+      className="flex w-full items-center gap-3 px-4 py-3.5 text-left transition-colors duration-snap active:bg-sunken disabled:pointer-events-none disabled:opacity-40"
+    >
+      {active
+        ? <CheckIcon size={16} className="shrink-0 text-accent" />
+        : <span className="size-4 shrink-0" />}
+      <div className="flex min-w-0 flex-1 flex-col">
+        <span className="text-[15px] font-medium text-ink">{label}</span>
+        {sublabel && (
+          <span className={`text-[12px] ${sublabelClass}`}>{sublabel}</span>
+        )}
+      </div>
+    </button>
+  );
+}
+
+export function DeviceRoutingSheet({ device, tunnels, open, onOpenChange }: Props) {
+  const updateDevice = useUpdateDevice({ successMessage: "Routing updated" });
+
+  // Keep the last non-null device in a ref so the exit animation can complete
+  // even if the parent clears selectedDevice while the sheet is animating closed.
+  const latchedRef = useRef<Device | null>(null);
+  if (device !== null) latchedRef.current = device;
+  const activeDevice = latchedRef.current;
+
+  const current = activeKey(activeDevice?.current_rule ?? null);
+  const deviceLabel = activeDevice?.name ?? activeDevice?.hostname ?? activeDevice?.mac ?? "";
+
+  function handleSelect(target: RoutingTarget) {
+    if (!activeDevice) return;
+    const id = activeDevice.id;
+    updateDevice.mutate(
+      { id, body: { routing_target: target } },
+      { onSuccess: () => onOpenChange(false) },
+    );
+  }
+
+  return (
+    <Drawer open={open} onOpenChange={onOpenChange}>
+      <DrawerContent side="bottom" aria-describedby={undefined}>
+        <div className="mx-auto mt-3 mb-4 h-1 w-10 rounded-full bg-line" />
+        <DrawerTitle className="px-4 pb-1 text-[11px] font-semibold uppercase tracking-wider text-ink-3">
+          Route: {deviceLabel}
+        </DrawerTitle>
+        <div className="flex flex-col" style={{ paddingBottom: "max(24px, env(safe-area-inset-bottom))" }}>
+          <OptionRow
+            label="Default" sublabel="Follow gateway policy"
+            active={current === "default"} disabled={updateDevice.isPending}
+            onSelect={() => handleSelect({ type: "default" })}
+          />
+          <OptionRow
+            label="Direct" sublabel="No VPN"
+            active={current === "direct"} disabled={updateDevice.isPending}
+            onSelect={() => handleSelect({ type: "direct" })}
+          />
+          {tunnels.length > 0 && <div className="mx-4 my-2 h-px bg-line" />}
+          {tunnels.map((tunnel) => {
+            const { label: statusLabel, tone } = tunnelSublabel(tunnel.status);
+            return (
+              <OptionRow
+                key={tunnel.id}
+                label={`${countryFlag(tunnel.country_code)} ${tunnel.label}`}
+                sublabel={statusLabel || undefined}
+                sublabelTone={tone === "ok" ? undefined : tone}
+                active={current === tunnel.id}
+                disabled={updateDevice.isPending}
+                onSelect={() => handleSelect({ type: "tunnel", tunnel_id: tunnel.id })}
+              />
+            );
+          })}
+        </div>
+      </DrawerContent>
+    </Drawer>
+  );
+}

--- a/source/admin-app/src/features/dashboard/DevicesCard.tsx
+++ b/source/admin-app/src/features/dashboard/DevicesCard.tsx
@@ -1,13 +1,8 @@
 import { MonitorIcon } from "lucide-react";
 import { Link } from "react-router";
 import { Card } from "@wardnet/forge-web/card";
+import { isDeviceOnline } from "@wardnet/wardnet-web";
 import type { Device } from "@wardnet/js";
-
-const ONLINE_WINDOW_MS = 5 * 60_000;
-
-function isOnline(device: Device): boolean {
-  return Date.now() - new Date(device.last_seen).getTime() < ONLINE_WINDOW_MS;
-}
 
 interface Props {
   deviceCount: number;
@@ -16,13 +11,13 @@ interface Props {
 }
 
 export function DevicesCard({ deviceCount, devices, defaultPolicy }: Props) {
-  const onlineCount = devices?.filter(isOnline).length ?? null;
+  const onlineCount = devices?.filter((d) => isDeviceOnline(d.last_seen)).length ?? null;
   const defaultIsTunnel = defaultPolicy != null && defaultPolicy !== "direct";
 
   const tunnelledCount =
     devices?.filter((d) => {
       if (d.current_rule?.type === "tunnel") return true;
-      if (d.current_rule === null && defaultIsTunnel) return true;
+      if ((d.current_rule === null || d.current_rule.type === "default") && defaultIsTunnel) return true;
       return false;
     }).length ?? null;
 

--- a/source/admin-app/src/pages/Devices.tsx
+++ b/source/admin-app/src/pages/Devices.tsx
@@ -1,8 +1,190 @@
-export default function Devices() {
+import { memo, useCallback, useMemo, useState } from "react";
+import { useDevices, useTunnels, useDefaultPolicy, countryFlag, isDeviceOnline } from "@wardnet/wardnet-web";
+import { DeviceRoutingSheet } from "@/components/DeviceRoutingSheet";
+import { ChevronRightIcon } from "lucide-react";
+import type { Device, Tunnel } from "@wardnet/js";
+
+type Filter = "all" | "online" | "vpn";
+
+const FILTER_LABELS: Record<Filter, string> = { all: "All", online: "Online", vpn: "On VPN" };
+
+function isOnVpn(device: Device, defaultPolicy: string | undefined): boolean {
+  if (device.current_rule?.type === "tunnel") return true;
+  if (
+    (device.current_rule === null || device.current_rule.type === "default") &&
+    defaultPolicy !== undefined &&
+    defaultPolicy !== "direct"
+  ) return true;
+  return false;
+}
+
+function routeLabel(device: Device, tunnels: Tunnel[]): string {
+  const rule = device.current_rule;
+  if (!rule || rule.type === "default") return "Default";
+  if (rule.type === "direct") return "Direct";
+  const tunnel = tunnels.find((t) => t.id === rule.tunnel_id);
+  return tunnel ? `${countryFlag(tunnel.country_code)} ${tunnel.label}` : "Via tunnel";
+}
+
+type Annotated = { device: Device; online: boolean; onVpn: boolean };
+
+function sortAnnotated(annotated: Annotated[]): Annotated[] {
+  return [...annotated].sort((a, b) => {
+    if (a.online !== b.online) return a.online ? -1 : 1;
+    const la = (a.device.name ?? a.device.hostname ?? a.device.mac).toLowerCase();
+    const lb = (b.device.name ?? b.device.hostname ?? b.device.mac).toLowerCase();
+    return la.localeCompare(lb);
+  });
+}
+
+const DeviceRow = memo(function DeviceRow({
+  device,
+  online,
+  tunnels,
+  onSelect,
+}: {
+  device: Device;
+  online: boolean;
+  tunnels: Tunnel[];
+  onSelect: (id: string) => void;
+}) {
   return (
-    <div className="flex flex-col gap-4 p-4">
-      <h1 className="text-xl font-semibold text-ink">Devices</h1>
-      <p className="text-sm text-ink-3">Coming in a subsequent issue.</p>
+    <button
+      onClick={() => onSelect(device.id)}
+      className="flex w-full items-center gap-3 px-4 py-3 text-left transition-colors duration-snap active:bg-sunken first:rounded-t-xl last:rounded-b-xl"
+    >
+      <span className={[
+        "mt-0.5 size-2 shrink-0 self-start rounded-full",
+        online ? "bg-accent" : "bg-line-strong",
+      ].join(" ")} />
+      <div className="flex min-w-0 flex-1 flex-col">
+        <span className="truncate text-[14px] font-medium text-ink">
+          {device.name ?? device.hostname ?? device.mac}
+        </span>
+        <span className="truncate text-[12px] text-ink-3">
+          {device.last_ip} · {routeLabel(device, tunnels)}
+        </span>
+      </div>
+      <ChevronRightIcon size={16} className="shrink-0 text-ink-4" />
+    </button>
+  );
+});
+
+export default function Devices() {
+  const { data: devicesData, isLoading } = useDevices();
+  const { data: tunnelsData } = useTunnels();
+  const { data: policyData } = useDefaultPolicy();
+
+  const [filter, setFilter] = useState<Filter>("all");
+  const [selectedDeviceId, setSelectedDeviceId] = useState<string | null>(null);
+  const [sheetOpen, setSheetOpen] = useState(false);
+
+  const allDevices = devicesData?.devices ?? [];
+  const tunnels = tunnelsData?.tunnels ?? [];
+  const defaultPolicy = policyData?.policy;
+
+  // Derived from live query data — always reflects the latest refetch.
+  const selectedDevice = useMemo(
+    () => allDevices.find((d) => d.id === selectedDeviceId) ?? null,
+    [allDevices, selectedDeviceId],
+  );
+
+  // Single pass: annotate each device once; counts and visible both derive from this.
+  const annotated = useMemo<Annotated[]>(
+    () => allDevices.map((d) => ({
+      device: d,
+      online: isDeviceOnline(d.last_seen),
+      onVpn: isOnVpn(d, defaultPolicy),
+    })),
+    [allDevices, defaultPolicy],
+  );
+
+  const counts = useMemo(() => ({
+    all: annotated.length,
+    online: annotated.filter((a) => a.online).length,
+    vpn: annotated.filter((a) => a.onVpn).length,
+  }), [annotated]);
+
+  const visible = useMemo(
+    () => sortAnnotated(
+      annotated.filter((a) =>
+        filter === "online" ? a.online :
+        filter === "vpn"    ? a.onVpn : true
+      )
+    ),
+    [annotated, filter],
+  );
+
+  const handleDeviceClick = useCallback((id: string) => {
+    setSelectedDeviceId(id);
+    setSheetOpen(true);
+  }, []);
+
+  if (isLoading) {
+    return (
+      <div className="flex flex-col gap-0 p-4">
+        <h1 className="mb-4 text-xl font-semibold text-ink">Devices</h1>
+        <div className="mb-3 flex gap-2">
+          {[80, 100, 90].map((w, i) => (
+            <div key={i} className="h-8 animate-pulse rounded-full bg-sunken" style={{ width: w }} />
+          ))}
+        </div>
+        {Array.from({ length: 6 }).map((_, i) => (
+          <div key={i} className="flex items-center gap-3 border-b border-line py-3">
+            <div className="size-9 animate-pulse rounded-lg bg-sunken" />
+            <div className="flex flex-col gap-1.5">
+              <div className="h-3.5 w-32 animate-pulse rounded bg-sunken" />
+              <div className="h-3 w-24 animate-pulse rounded bg-sunken" />
+            </div>
+          </div>
+        ))}
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col p-4">
+      <h1 className="mb-4 text-xl font-semibold text-ink">Devices</h1>
+
+      {/* Filter pills */}
+      <div className="mb-3 flex gap-2 overflow-x-auto pb-1">
+        {(["all", "online", "vpn"] as Filter[]).map((id) => (
+          <button
+            key={id}
+            onClick={() => setFilter(id)}
+            className={[
+              "shrink-0 rounded-full px-3.5 py-1.5 text-[13px] font-medium transition-colors duration-snap",
+              filter === id ? "bg-accent text-accent-ink" : "bg-sunken text-ink-3 active:bg-line",
+            ].join(" ")}
+          >
+            {FILTER_LABELS[id]} ({counts[id]})
+          </button>
+        ))}
+      </div>
+
+      {/* Device list */}
+      {visible.length === 0
+        ? <p className="py-16 text-center text-sm text-ink-3">No devices match this filter.</p>
+        : (
+          <div className="flex flex-col divide-y divide-line rounded-xl border border-line bg-card">
+            {visible.map(({ device, online }) => (
+              <DeviceRow
+                key={device.id}
+                device={device}
+                online={online}
+                tunnels={tunnels}
+                onSelect={handleDeviceClick}
+              />
+            ))}
+          </div>
+        )}
+
+      <DeviceRoutingSheet
+        device={selectedDevice}
+        tunnels={tunnels}
+        open={sheetOpen}
+        onOpenChange={setSheetOpen}
+      />
     </div>
   );
 }

--- a/source/admin-site/forge-web/src/primitives/drawer.tsx
+++ b/source/admin-site/forge-web/src/primitives/drawer.tsx
@@ -15,7 +15,7 @@ function DrawerTrigger(props: DrawerTriggerProps) {
 }
 
 type DrawerContentProps = React.ComponentProps<typeof Dialog.Content> & {
-  side?: "left" | "right";
+  side?: "left" | "right" | "bottom";
   container?: React.ComponentProps<typeof Dialog.Portal>["container"];
 };
 

--- a/source/forge/styles.css
+++ b/source/forge/styles.css
@@ -1302,6 +1302,19 @@ button { font-family: inherit; }
   to   { transform: translateX(100%); }
 }
 
+/* Bottom sheet variant — full width, pinned to viewport bottom, card surface. */
+.drawer[data-side="bottom"] {
+  top: auto; left: 0; right: 0; bottom: 0;
+  width: 100%; max-width: 100%; max-height: 85vh;
+  background: var(--bg-card); color: var(--ink);
+  border-top: 1px solid var(--line); border-right: none; border-left: none;
+  border-radius: var(--radius-xl) var(--radius-xl) 0 0;
+}
+.drawer[data-state="open"][data-side="bottom"]  { animation: drawer-in-bottom  200ms ease; }
+.drawer[data-state="closed"][data-side="bottom"] { animation: drawer-out-bottom 160ms ease forwards; }
+@keyframes drawer-in-bottom  { from { transform: translateY(100%); } to { transform: translateY(0); } }
+@keyframes drawer-out-bottom { from { transform: translateY(0); } to { transform: translateY(100%); } }
+
 /* ---------- Popover ---------- */
 .popover {
   background: var(--bg-card);

--- a/source/wardnet-web/src/hooks/useDevices.ts
+++ b/source/wardnet-web/src/hooks/useDevices.ts
@@ -1,3 +1,4 @@
+import { useRef } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 import type { RoutingTarget, UpdateDeviceRequest } from "@wardnet/js";
@@ -38,14 +39,17 @@ export function useSetMyRule() {
   });
 }
 
-export function useUpdateDevice() {
+export function useUpdateDevice(options?: { successMessage?: string }) {
   const qc = useQueryClient();
+  const optionsRef = useRef(options);
+  optionsRef.current = options;
   return useMutation({
     mutationFn: ({ id, body }: { id: string; body: UpdateDeviceRequest }) =>
       deviceService.update(id, body),
-    onSuccess: () => {
-      toast.success("Device updated");
-      qc.invalidateQueries({ queryKey: ["devices"] });
+    onSuccess: (_, variables) => {
+      toast.success(optionsRef.current?.successMessage ?? "Device updated");
+      qc.invalidateQueries({ queryKey: ["devices"], exact: true });
+      qc.invalidateQueries({ queryKey: ["devices", variables.id], exact: true });
     },
     onError: () => toast.error("Failed to update device"),
   });

--- a/source/wardnet-web/src/index.ts
+++ b/source/wardnet-web/src/index.ts
@@ -36,7 +36,7 @@ export {
 
 // Country / device helpers
 export { countryFlag } from "./lib/country";
-export { DEVICE_TYPE_OPTIONS, deviceTypeLabel } from "./lib/device";
+export { DEVICE_TYPE_OPTIONS, deviceTypeLabel, isDeviceOnline } from "./lib/device";
 export { cronToHuman } from "./lib/cron";
 export { logger, createLogger, setLevel } from "./lib/logger";
 export type { Logger, LogLevel } from "./lib/logger";

--- a/source/wardnet-web/src/lib/device.ts
+++ b/source/wardnet-web/src/lib/device.ts
@@ -1,5 +1,13 @@
 import type { DeviceType } from "@wardnet/js";
 
+const ONLINE_THRESHOLD_MS = 5 * 60 * 1000;
+
+/** Returns true when the device was seen within the last 5 minutes. */
+export function isDeviceOnline(lastSeen: string): boolean {
+  const ts = new Date(lastSeen).getTime();
+  return Number.isFinite(ts) && Date.now() - ts <= ONLINE_THRESHOLD_MS;
+}
+
 /** Display labels for each {@link DeviceType}, ordered for selection menus. */
 export const DEVICE_TYPE_OPTIONS: { value: DeviceType; label: string }[] = [
   { value: "tv", label: "TV" },


### PR DESCRIPTION
## Summary

- **Devices screen** for the admin mobile PWA: filterable list (All / Online / On VPN), online-first alphabetical sort, tap-to-open routing sheet
- **DeviceRoutingSheet** bottom-sheet with tap-to-apply routing overrides (Default / Direct / per-tunnel), animated slide-up/down via new `[data-side="bottom"]` CSS variant and `DrawerContent` type extension
- **Shared `isDeviceOnline`** helper in `wardnet-web` replaces two independently-drifted copies; `DevicesCard` on the dashboard also updated
- **`isOnVpn` fix** in both `Devices.tsx` and `DevicesCard.tsx`: devices with `{type:"default"}` rule now correctly counted under the On VPN metric when the gateway default policy is a tunnel
- **`useUpdateDevice` hardened**: optional `successMessage`, options ref-latched to prevent stale-closure toasts, query invalidation tightened to exact list + per-device keys (no longer prefix-matches `["devices","me"]`)
- **Sheet UX**: `selectedDevice` derived from live query data by ID (always reflects the latest refetch); `mutate` + per-call `onSuccess` replaces `mutateAsync` (no unhandled rejections); `latchedRef` preserves content during exit animation
- **Render efficiency**: single annotation pass over `allDevices`, `memo`'d `DeviceRow` with stable `useCallback` click handler

## Test plan

- [ ] `make check-web` passes (TypeScript + lint across all web packages)
- [ ] Device list loads; filter pills show correct counts including devices with `{type:"default"}` rule under "On VPN"
- [ ] Online devices appear first within each filter view
- [ ] Tap a device → sheet slides up from bottom with current routing highlighted
- [ ] Tap a tunnel option → mutation fires, sheet closes, "Routing updated" toast appears, list refreshes
- [ ] Down / Connecting / Reconnecting tunnels show the appropriate label/tone in the sheet
- [ ] On mutation error → sheet stays open, error toast shown, no unhandled rejection in console
- [ ] Dashboard "Devices Online" and tunnelled count match the Devices page filter counts

🤖 Generated with [Claude Code](https://claude.com/claude-code)