### PR TITLE
feat(admin-app): Tunnels status page + rebuild tunnel action

### DIFF
--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -29,6 +29,15 @@ wardnetd-mock         ─  Dev binary: same wardnetd-api/services/data stack, no
 - **Secret-store concerns are provider-owned too**: `SecretStore::backup_contents` / `restore_from_backup` live on the trait, so each provider (`FileSecretStore` today; `HashicorpVault`, `1Password`, etc. later) decides what travels with a bundle and what stays in the external service.
 - **mDNS advertisement is a self-contained runner**: `wardnetd::mdns_advertiser::MdnsAdvertiser` (Linux production binary only) publishes `<hostname>.local.` so the setup wizard is reachable without a known IP. It is a runner, not a service — mirrors `HeartbeatRunner` / `RouteMonitor`, not a trait-backed service. The mock binary does not start it.
 
+## Tunnel rebuild endpoint (issue #480)
+
+`POST /api/tunnels/{id}/rebuild` — admin-only endpoint that invokes `TunnelService::rebuild(id)`. The service method calls `tear_down_core` then `bring_up_core` (the same path used by the internal watchdog). The handler returns 404 for unknown tunnel IDs and guards against issuing a rebuild while a test probe is already in flight (409 Conflict). The response is `RebuildTunnelResponse { ok: true }`.
+
+Key conventions:
+- `tear_down_core` / `bring_up_core` are the internal primitives shared between `test_tunnel`, the idle watchdog, and `rebuild`. Always call them — never reach into `TunnelInterface` directly from `rebuild`.
+- Errors from `bring_up_core` are **logged** (not silently swallowed) before returning to the caller.
+- The in-flight guard reuses the same `Arc<Mutex<HashSet<Uuid>>>` that `test_tunnel` already holds; this prevents a rebuild from racing a concurrent test.
+
 ## Stats subsystem (issue #409)
 
 A generic pre-aggregating stats subsystem. All layers (data, services, API) are complete as of PR 2.

--- a/.agents/code-conventions.md
+++ b/.agents/code-conventions.md
@@ -21,6 +21,9 @@
 - Prettier for formatting (configured in `.prettierrc`).
 - ESLint with Prettier integration.
 - React Router 7 imports from `react-router` (not `react-router-dom`).
+- **All shared hooks live in `wardnet-web`** — do not put TanStack Query hooks that are used by more than one app surface in an app-local `hooks/` folder. Extract them to `source/wardnet-web/src/hooks/` and re-export from `source/wardnet-web/src/index.ts`.
+- **Mutation hoisting** — when a mutation (e.g. `useRebuildTunnel`) is called from multiple list-item cards on the same page, hoist the single `useMutation` result to the page component and pass `mutate` + `isPending`/`variables` down as props. This keeps the in-flight indicator accurate across the whole list without each card owning an independent mutation.
+- **Offline overlay pattern (admin-app)** — `OnlineStatusContext` exposes `showingLastKnownState: boolean`. Pages wrap their content in a `pointer-events-none opacity-40` div when this is true. The loading skeleton should be gated on **all** required queries being loaded (e.g. both `devicesLoading && policyLoading`), not just one, to avoid a premature flash.
 - **Component layers** (strict separation):
   - `core/ui/` — shadcn components, no business logic, do not modify directly (re-pull via shadcn CLI)
   - `compound/` — compositions of core components, data via props only, no API calls

--- a/.agents/commands.md
+++ b/.agents/commands.md
@@ -13,8 +13,10 @@ All builds are driven by the root **Makefile**. Use `make help` to see all targe
 - **`make check-web`** — web UI typecheck + lint + format check (depends on SDK)
 - **`make check-daemon`** — Rust format + clippy + tests. **Linux-only**: the daemon depends on Linux kernel interfaces (netlink, rtnetlink) and cannot compile on macOS. On non-Linux hosts this target auto-detects `podman` or `docker` and runs inside a `rust:1.96` container. Build artefacts are cached in `.target-linux/` (gitignored) and crate downloads in a named volume (`wardnet-cargo-cache`).
 - **`make coverage-daemon`** — line-coverage summary via `cargo-llvm-cov`. Same platform auto-detection as `check-daemon` (container on macOS). Uses the same ignore regex as CI.
-- **`make run-dev`** — mock daemon + web UI dev server. `RESUME=true` persists the DB at `.wardnet-local/wardnet.db`.
-- **`make run-dev-daemon`** / **`make run-dev-web`** — run each piece independently.
+- **`make run-dev`** — mock daemon + all three Vite dev servers (admin-site :7412/admin/, user-app :7413, admin-app :7414/admin-app/). `RESUME=true` persists the DB at `.wardnet-local/wardnet.db`.
+- **`make run-dev-daemon`** — run just `wardnetd-mock` on :7411.
+- **`make run-dev-web`** — run just the admin-site Vite server on :7412.
+- **`make run-dev-admin-app`** — run just the admin-app Vite server on :7414/admin-app/.
 - **`make clean`** — clean all build artifacts
 
 ## Direct commands (fast iteration only — NOT a substitute for Make before push)
@@ -46,13 +48,30 @@ All commands run from `source/sdk/wardnet-js/`. Uses **Yarn 4** (via Corepack).
 - **Type check**: `yarn type-check`
 - **Format**: `yarn format` (check: `yarn format:check`)
 
-### Web UI
+### Admin site (desktop)
 
-All commands run from `source/web-ui/`. Uses **Yarn 4** (via Corepack).
+All commands run from `source/admin-site/web/`. Uses **Yarn 4** (via Corepack).
 
 - **Install**: `yarn install`
 - **Dev server**: `yarn dev` (port 7412, proxies `/api` to daemon on 7411)
 - **Build**: `yarn build`
 - **Type check**: `yarn type-check`
 - **Lint**: `yarn lint`
+- **Format**: `yarn format` (check: `yarn format:check`)
+
+### Admin mobile PWA
+
+All commands run from `source/admin-app/`. Uses **Yarn 4** (via Corepack).
+
+- **Install**: `yarn install`
+- **Dev server**: `yarn dev` (port 7414, base path `/admin-app/`)
+- **Build**: `yarn build`
+- **Type check**: `yarn type-check`
+
+### Shared React library (`wardnet-web`)
+
+All commands run from `source/wardnet-web/`. Uses **Yarn 4** (via Corepack).
+
+- **Install**: `yarn install`
+- **Type check**: `yarn type-check`
 - **Format**: `yarn format` (check: `yarn format:check`)

--- a/.agents/project-structure.md
+++ b/.agents/project-structure.md
@@ -38,6 +38,7 @@ source/
 │       │   └── src/
 │       │       ├── api/             # Endpoint handlers (auth, devices, dhcp, dns, info, setup, stats, system, tunnels, providers, backup, update)
 │       │       │   ├── stats.rs     # GET /api/stats (time-series query) + GET /api/stats/top (top-N)
+│       │       │   ├── tunnels.rs   # includes POST /api/tunnels/{id}/rebuild → TunnelService::rebuild()
 │       │       │   └── logs_ws.rs   # WebSocket log streaming endpoint
 │       │       ├── middleware.rs    # AuthContextLayer, RequestContextLayer, CORS, tracing
 │       │       ├── state.rs         # AppState (holds Arc<dyn Service> trait objects + EventPublisher)
@@ -79,23 +80,48 @@ source/
 │   └── wardnet-js/                  # @wardnet/js — TypeScript SDK (browser + Node)
 │       └── src/
 │           ├── client.ts            # WardnetClient base HTTP client
-│           ├── services/            # AuthService, DeviceService, TunnelService, ProviderService, SystemService, SetupService, InfoService, BackupService, UpdateService
-│           └── types/               # TypeScript type definitions (mirrors daemon API)
-├── admin-site/                      # PLANNED (issue #437): rename of web-ui/ — full desktop admin (not a PWA)
-├── web-ui/                          # React + TypeScript frontend (to be renamed admin-site — see issue #437)
-│   └── src/
-│       ├── components/
-│       │   ├── core/ui/             # shadcn/ui components (Button, Card, Sheet, Dialog, Select, Tabs, Switch, etc.)
-│       │   ├── compound/            # Compositions (Sidebar, MobileMenu, PageHeader, DeviceIcon, ConnectionStatus, Logo, CountryCombobox, RoutingSelector, ApiErrorAlert)
-│       │   ├── features/            # Use-case components (DeviceList, TunnelList, LoginForm, BackupCard, RestartProgressDialog, UpdateCard)
-│       │   └── layouts/             # Page shells (AppLayout, AuthLayout)
-│       ├── hooks/                   # React hooks bridging SDK ↔ React (useAuth, useTheme, useDevices, useTunnels, useProviders, useSystemStatus, useBackup, useRestart, useUpdate, …)
-│       ├── stores/                  # Zustand stores (authStore)
-│       ├── pages/                   # Route pages (Dashboard, Devices, Tunnels, Settings, Login, Setup, MyDevice)
-│       └── lib/                     # SDK instance (sdk.ts), utilities (cn, formatBytes, formatUptime, timeAgo)
+│           ├── services/            # AuthService, DeviceService, TunnelService (includes rebuild()), ProviderService,
+│           │                        #   SystemService, SetupService, InfoService, BackupService, UpdateService
+│           └── types/               # TypeScript type definitions (mirrors daemon API);
+│                                    #   RebuildTunnelResponse added for POST /api/tunnels/{id}/rebuild
+├── admin-site/                      # Full desktop admin UI (renamed from web-ui/ — issue #437); served at /admin/
+│   ├── forge-web/                   # @wardnet/forge-web — Forge design-system component library (Card, Pill, Sparkline, Button, etc.)
+│   └── web/                         # Admin site app (React + TypeScript)
+│       └── src/
+│           ├── components/
+│           │   ├── core/ui/         # shadcn/ui components (Button, Card, Sheet, Dialog, Select, Tabs, Switch, etc.)
+│           │   ├── compound/        # Compositions (Sidebar, MobileMenu, PageHeader, DeviceIcon, ConnectionStatus, TunnelCard, TunnelDetail, etc.)
+│           │   ├── features/        # Use-case components (DeviceList, TunnelList, LoginForm, BackupCard, RestartProgressDialog, UpdateCard)
+│           │   └── layouts/         # Page shells (AppLayout, AuthLayout)
+│           ├── hooks/               # React hooks bridging SDK ↔ React (see wardnet-web for shared hooks)
+│           ├── stores/              # Zustand stores (authStore)
+│           ├── pages/               # Route pages (Dashboard, Devices, Tunnels, Settings, Login, Setup, MyDevice)
+│           └── lib/                 # SDK instance (sdk.ts), utilities (cn, formatBytes, formatUptime, timeAgo)
 ├── user-app/                        # PLANNED (issue #438): user PWA — self-service for non-admin household members; served at /
-├── admin-app/                       # PLANNED (issue #439): admin mobile PWA — daily operational tasks; served at /admin-app/
-├── web-lib/                         # PLANNED (issue #437): shared component library used by all three app surfaces
+├── admin-app/                       # Admin mobile PWA (issue #439) — daily operational tasks; served at /admin-app/
+│   └── src/
+│       ├── components/              # Mobile-specific components (Header, TabBar, BusyOverlay, ConfirmDialog, DeviceRoutingSheet, ConnectionBanner, etc.)
+│       ├── context/                 # OnlineStatusContext — exposes `showingLastKnownState` flag for offline overlay
+│       ├── features/                # Dashboard feature cards (DevicesCard, TunnelsCard, DnsCard, DaemonStrip, StatusCard)
+│       ├── hooks/                   # App-local hooks (useBiometric)
+│       ├── layouts/                 # AppLayout, AuthLayout
+│       └── pages/                   # Route pages: Dashboard, Devices, Tunnels, Dns, System, Login
+│                                    #   Tunnels page: summary header card (sparkline + combined throughput) + per-tunnel
+│                                    #   cards with status pill, rebuild button, and live throughput; uses
+│                                    #   useCombinedTunnelStats and useRebuildTunnel from wardnet-web.
+│                                    #   Devices page: showingLastKnownState offline overlay; loading skeleton
+│                                    #   gated on both devices + policy loaded.
+├── wardnet-web/                     # @wardnet/wardnet-web — shared React hooks + utilities used by all app surfaces
+│   └── src/
+│       ├── hooks/                   # All shared TanStack Query hooks: useAuth, useDevices, useTunnels, useStats,
+│       │                            #   useTunnelStats, useCombinedTunnelStats, useProviders, useSystemStatus,
+│       │                            #   useDns, useDhcp, useBackup, useUpdate, useSetup, useDaemonStatus, etc.
+│       │                            #   useCombinedTunnelStats — aggregates tunnel.bytes.tx + tunnel.bytes.rx
+│       │                            #   over 1-hour window (1-min buckets) for sparkline + combined throughput.
+│       │                            #   useRebuildTunnel — mutation wrapping POST /api/tunnels/{id}/rebuild.
+│       ├── components/              # LoginForm, JobProgressDescription
+│       ├── stores/                  # Zustand stores (authStore)
+│       └── lib/                     # SDK singletons (sdk.ts), utility functions, country helpers, logger
 └── site/                            # Public documentation + marketing site (Vite + React)
     ├── content/docs/                # Markdown articles served by DocsArticle.tsx
     ├── content/docs.yml             # Topic catalogue driving /docs

--- a/.agents/technical-stack.md
+++ b/.agents/technical-stack.md
@@ -17,15 +17,31 @@
 - TypeScript 5.9, zero runtime dependencies
 - Uses native `fetch` (works in browser and Node 18+)
 - No DOM types — minimal `globals.d.ts` for cross-environment support
-- Linked to web-ui via Yarn `portal:` protocol (`"@wardnet/js": "portal:../sdk/wardnet-js"`)
+- Linked via Yarn `portal:` protocol from all app surfaces (`"@wardnet/js": "portal:../sdk/wardnet-js"`)
 - Yarn 4 with `nodeLinker: node-modules`
 
-## Web UI
+## Shared React library (`@wardnet/wardnet-web`)
+- Lives at `source/wardnet-web/`; linked via `"@wardnet/wardnet-web": "portal:../wardnet-web"`
+- Contains all shared TanStack Query hooks (useTunnels, useRebuildTunnel, useCombinedTunnelStats, useDevices, useStats, …), shared components (LoginForm, JobProgressDescription), Zustand stores, and utility functions
+- All app surfaces (admin-site, user-app, admin-app) import hooks and utilities from here — **do not duplicate hook logic in app-local hook files**
+
+## Admin site (`source/admin-site/web/` — `@wardnet/admin-site`)
+- Full desktop admin UI; served at `/admin/`
 - React 19, TypeScript 5.9, Vite 7
 - Tailwind CSS 4 (CSS-first config: `@import "tailwindcss"` + `@tailwindcss/vite` plugin)
 - shadcn/ui (Radix UI primitives + Tailwind styling) — components in `src/components/core/ui/`
+- Forge design-system components from `@wardnet/forge-web` (`source/admin-site/forge-web/`)
 - TanStack Query 5, React Router 7, Zustand 5
 - ESLint 10 + Prettier
+- Yarn 4 with `nodeLinker: node-modules`
+- Path alias: `@/` → `src/` (Vite + tsconfig)
+
+## Admin mobile PWA (`source/admin-app/` — `@wardnet/admin-app`)
+- Admin PWA for daily operational tasks; served at `/admin-app/`
+- React 19, TypeScript 5.9, Vite 7
+- Tailwind CSS 4; Forge design-system components from `@wardnet/forge-web`
+- TanStack Query 5, React Router 7, Zustand 5, Sonner (toasts)
+- `OnlineStatusContext` — provides `showingLastKnownState: boolean` to all pages; pages wrap content in an offline overlay (pointer-events disabled + opacity dimmed) when true
 - Yarn 4 with `nodeLinker: node-modules`
 - Path alias: `@/` → `src/` (Vite + tsconfig)
 
@@ -34,9 +50,9 @@
 - Docs are plain markdown under `source/site/content/docs/`, rendered via `react-markdown` + `remark-gfm` with custom component mappings in `DocsArticle.tsx`
 - Topic catalogue in `source/site/content/docs.yml` (loaded via `@modyfi/vite-plugin-yaml`)
 
-## Planned infrastructure (PWA initiative — issues #435–#441)
+## PWA initiative (issues #435–#441)
 
+- **Three app surfaces** — admin site (desktop, at `/admin/`), user PWA (at `/`), admin mobile PWA (at `/admin-app/`). All served from a single origin; independently installable via distinct `manifest.json` scopes. Admin site and admin-app are both live; user-app is still planned (issue #438). See `CONTEXT.md` for the full glossary.
 - **Caddy** — reverse proxy bundled in the release tarball alongside `wardnetd`. Runs as a companion systemd service. Handles TLS termination on port 443 and forwards to the daemon on port 7411. The daemon manages the Caddyfile on startup. See issue #436.
 - **DDNS + ACME bridge service** — wardnet-operated service assigning each install a subdomain (`<id>.wardnet.network`) and acting as ACME bridge for Let's Encrypt DNS-01 challenges. The cert private key is generated on the Pi and never leaves it. See issue #435.
 - **VAPID / Web Push** — daemon-side push notification support (VAPID key pair generated at setup, subscription records keyed to device MAC or admin session). See issue #440.
-- **Three app surfaces** — admin site (desktop, at `/admin/`), user PWA (at `/`), admin mobile PWA (at `/admin-app/`). All served from a single origin; independently installable via distinct `manifest.json` scopes. See `CONTEXT.md` for the full glossary and issues #437–#439 for implementation.

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -11948,6 +11948,175 @@
         ]
       }
     },
+    "/api/tunnels/{id}/rebuild": {
+      "post": {
+        "tags": [
+          "tunnels"
+        ],
+        "description": "Tear down the WireGuard interface and re-apply it from the persisted config. Use when a tunnel is stale or devices cannot route through it. Equivalent to the internal watchdog recovery path. Admin only.",
+        "operationId": "rebuild_tunnel",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Tunnel ID",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Tunnel rebuild initiated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RebuildTunnelResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthenticated — session cookie or API key missing/invalid",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "description": "Standard API error response.",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "detail": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "error": {
+                      "type": "string"
+                    },
+                    "request_id": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "description": "Request ID for correlation with server logs."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden — caller is not an admin",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "description": "Standard API error response.",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "detail": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "error": {
+                      "type": "string"
+                    },
+                    "request_id": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "description": "Request ID for correlation with server logs."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Resource not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "description": "Standard API error response.",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "detail": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "error": {
+                      "type": "string"
+                    },
+                    "request_id": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "description": "Request ID for correlation with server logs."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "description": "Standard API error response.",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "detail": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "error": {
+                      "type": "string"
+                    },
+                    "request_id": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "description": "Request ID for correlation with server logs."
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "session_cookie": []
+          },
+          {
+            "bearer_auth": []
+          }
+        ]
+      }
+    },
     "/api/tunnels/{id}/test": {
       "post": {
         "tags": [
@@ -15362,6 +15531,19 @@
               "null"
             ],
             "description": "URL to the provider's website."
+          }
+        }
+      },
+      "RebuildTunnelResponse": {
+        "type": "object",
+        "description": "Response for POST /api/tunnels/:id/rebuild.",
+        "required": [
+          "ok"
+        ],
+        "properties": {
+          "ok": {
+            "type": "boolean",
+            "description": "Always `true` on a 200 response. Errors surface as non-200 status codes."
           }
         }
       },

--- a/source/admin-app/src/pages/Devices.tsx
+++ b/source/admin-app/src/pages/Devices.tsx
@@ -1,5 +1,6 @@
 import { memo, useCallback, useMemo, useState } from "react";
 import { useDevices, useTunnels, useDefaultPolicy, countryFlag, isDeviceOnline } from "@wardnet/wardnet-web";
+import { useOnlineStatusContext } from "@/context/OnlineStatusContext";
 import { DeviceRoutingSheet } from "@/components/DeviceRoutingSheet";
 import { ChevronRightIcon } from "lucide-react";
 import type { Device, Tunnel } from "@wardnet/js";
@@ -71,9 +72,12 @@ const DeviceRow = memo(function DeviceRow({
 });
 
 export default function Devices() {
-  const { data: devicesData, isLoading } = useDevices();
+  const { data: devicesData, isLoading: devicesLoading } = useDevices();
   const { data: tunnelsData } = useTunnels();
-  const { data: policyData } = useDefaultPolicy();
+  const { data: policyData, isLoading: policyLoading } = useDefaultPolicy();
+  const isLoading = devicesLoading || policyLoading;
+
+  const { showingLastKnownState } = useOnlineStatusContext();
 
   const [filter, setFilter] = useState<Filter>("all");
   const [selectedDeviceId, setSelectedDeviceId] = useState<string | null>(null);
@@ -146,38 +150,42 @@ export default function Devices() {
     <div className="flex flex-col p-4">
       <h1 className="mb-4 text-xl font-semibold text-ink">Devices</h1>
 
-      {/* Filter pills */}
-      <div className="mb-3 flex gap-2 overflow-x-auto pb-1">
-        {(["all", "online", "vpn"] as Filter[]).map((id) => (
-          <button
-            key={id}
-            onClick={() => setFilter(id)}
-            className={[
-              "shrink-0 rounded-full px-3.5 py-1.5 text-[13px] font-medium transition-colors duration-snap",
-              filter === id ? "bg-accent text-accent-ink" : "bg-sunken text-ink-3 active:bg-line",
-            ].join(" ")}
-          >
-            {FILTER_LABELS[id]} ({counts[id]})
-          </button>
-        ))}
-      </div>
+      <div className={showingLastKnownState ? "pointer-events-none opacity-40 transition-opacity" : "transition-opacity"}>
 
-      {/* Device list */}
-      {visible.length === 0
-        ? <p className="py-16 text-center text-sm text-ink-3">No devices match this filter.</p>
-        : (
-          <div className="flex flex-col divide-y divide-line rounded-xl border border-line bg-card">
-            {visible.map(({ device, online }) => (
-              <DeviceRow
-                key={device.id}
-                device={device}
-                online={online}
-                tunnels={tunnels}
-                onSelect={handleDeviceClick}
-              />
-            ))}
-          </div>
-        )}
+        {/* Filter pills */}
+        <div className="mb-3 flex gap-2 overflow-x-auto pb-1">
+          {(["all", "online", "vpn"] as Filter[]).map((id) => (
+            <button
+              key={id}
+              onClick={() => setFilter(id)}
+              className={[
+                "shrink-0 rounded-full px-3.5 py-1.5 text-[13px] font-medium transition-colors duration-snap",
+                filter === id ? "bg-accent text-accent-ink" : "bg-sunken text-ink-3 active:bg-line",
+              ].join(" ")}
+            >
+              {FILTER_LABELS[id]} ({counts[id]})
+            </button>
+          ))}
+        </div>
+
+        {/* Device list */}
+        {visible.length === 0
+          ? <p className="py-16 text-center text-sm text-ink-3">No devices match this filter.</p>
+          : (
+            <div className="flex flex-col divide-y divide-line rounded-xl border border-line bg-card">
+              {visible.map(({ device, online }) => (
+                <DeviceRow
+                  key={device.id}
+                  device={device}
+                  online={online}
+                  tunnels={tunnels}
+                  onSelect={handleDeviceClick}
+                />
+              ))}
+            </div>
+          )}
+
+      </div>
 
       <DeviceRoutingSheet
         device={selectedDevice}

--- a/source/admin-app/src/pages/Tunnels.tsx
+++ b/source/admin-app/src/pages/Tunnels.tsx
@@ -1,8 +1,249 @@
+import { memo } from "react";
+import { RotateCcwIcon } from "lucide-react";
+import { Card } from "@wardnet/forge-web/card";
+import { Pill } from "@wardnet/forge-web/pill";
+import { Sparkline } from "@wardnet/forge-web/sparkline";
+import {
+  useTunnels,
+  useDevices,
+  useDefaultPolicy,
+  useRebuildTunnel,
+  useTunnelStats,
+  useCombinedTunnelStats,
+  countryFlag,
+  formatBytes,
+  timeAgo,
+} from "@wardnet/wardnet-web";
+import { useOnlineStatusContext } from "@/context/OnlineStatusContext";
+import type { Device, Tunnel, TunnelStatus } from "@wardnet/js";
+
+const BUCKET_SECS = 60;
+
+function pillVariant(status: TunnelStatus) {
+  switch (status) {
+    case "up":
+      return "ok" as const;
+    case "connecting":
+      return "info" as const;
+    case "reconnecting":
+      return "warn" as const;
+    case "down":
+      return "down" as const;
+  }
+}
+
+function pillLabel(status: TunnelStatus) {
+  switch (status) {
+    case "up":
+      return "Active";
+    case "connecting":
+      return "Connecting";
+    case "reconnecting":
+      return "Reconnecting";
+    case "down":
+      return "Down";
+  }
+}
+
+function deviceCount(
+  tunnelId: string,
+  devices: Device[],
+  defaultPolicy: string | undefined,
+): number {
+  const explicit = devices.filter(
+    (d) => d.current_rule?.type === "tunnel" && d.current_rule.tunnel_id === tunnelId,
+  ).length;
+  const onDefault =
+    defaultPolicy === tunnelId
+      ? devices.filter((d) => d.current_rule === null || d.current_rule.type === "default").length
+      : 0;
+  return explicit + onDefault;
+}
+
+const TunnelCard = memo(function TunnelCard({
+  tunnel,
+  devices,
+  defaultPolicy,
+  onRebuild,
+  rebuildingId,
+}: {
+  tunnel: Tunnel;
+  devices: Device[];
+  defaultPolicy: string | undefined;
+  onRebuild: (id: string) => void;
+  rebuildingId: string | undefined;
+}) {
+  const { data: stats } = useTunnelStats(tunnel.id, "1h");
+
+  const subtitle = [tunnel.country_code, tunnel.provider, tunnel.interface_name]
+    .filter(Boolean)
+    .join(" · ");
+
+  const devCount = deviceCount(tunnel.id, devices, defaultPolicy);
+
+  const lastPoint = stats?.points[stats.points.length - 1];
+  const rxRate = lastPoint ? lastPoint.bytesRx / BUCKET_SECS : 0;
+  const txRate = lastPoint ? lastPoint.bytesTx / BUCKET_SECS : 0;
+
+  const isRebuilding = rebuildingId === tunnel.id;
+
+  return (
+    <Card className="card--flush">
+      <div className="flex flex-col gap-3 p-4">
+        {/* Header row */}
+        <div className="flex items-start gap-2">
+          <span className="text-2xl leading-none" aria-hidden>
+            {countryFlag(tunnel.country_code)}
+          </span>
+          <div className="min-w-0 flex-1">
+            <p className="truncate font-semibold text-ink">
+              {tunnel.resolved_server_name ?? tunnel.label}
+            </p>
+            <p className="truncate text-xs text-ink-3">{subtitle}</p>
+          </div>
+          <div className="flex shrink-0 items-center gap-2">
+            <Pill variant={pillVariant(tunnel.status)}>
+              <span className="mr-1" aria-hidden>●</span>
+              {pillLabel(tunnel.status)}
+            </Pill>
+            <button
+              onClick={() => onRebuild(tunnel.id)}
+              disabled={isRebuilding}
+              className="flex h-7 w-7 items-center justify-center rounded-lg bg-sunken text-ink-3 transition-colors duration-snap active:bg-line disabled:opacity-40"
+              aria-label="Rebuild tunnel"
+            >
+              <RotateCcwIcon
+                size={14}
+                className={isRebuilding ? "animate-spin" : undefined}
+              />
+            </button>
+          </div>
+        </div>
+
+        {/* 2×2 data grid */}
+        <div className="grid grid-cols-2 gap-x-4 gap-y-3 border-t border-line pt-3">
+          <div>
+            <p className="text-[10px] font-semibold uppercase tracking-wider text-ink-3">
+              Endpoint
+            </p>
+            <p className="mt-0.5 break-all font-mono text-[13px] text-ink">{tunnel.endpoint}</p>
+          </div>
+          <div>
+            <p className="text-[10px] font-semibold uppercase tracking-wider text-ink-3">
+              Last Handshake
+            </p>
+            <p className="mt-0.5 text-[13px] text-ink">
+              {tunnel.last_handshake ? timeAgo(tunnel.last_handshake) : "—"}
+            </p>
+          </div>
+          <div>
+            <p className="text-[10px] font-semibold uppercase tracking-wider text-ink-3">
+              Data ↓ / ↑
+            </p>
+            <p className="mt-0.5 text-[13px] text-ink">
+              {formatBytes(tunnel.bytes_rx)} · {formatBytes(tunnel.bytes_tx)}
+            </p>
+          </div>
+          <div>
+            <p className="text-[10px] font-semibold uppercase tracking-wider text-ink-3">
+              Devices
+            </p>
+            <p className="mt-0.5 text-[13px] text-ink">{devCount} routed</p>
+          </div>
+        </div>
+
+        {/* Live throughput — up tunnels only */}
+        {tunnel.status === "up" && (
+          <div className="flex items-center gap-3 border-t border-line pt-3">
+            <span className="text-xs text-ink-3">↓ {formatBytes(rxRate)}/s</span>
+            <span className="text-xs text-ink-3">↑ {formatBytes(txRate)}/s</span>
+          </div>
+        )}
+      </div>
+    </Card>
+  );
+});
+
 export default function Tunnels() {
+  const { data: tunnelsData, isLoading } = useTunnels();
+  const { data: devicesData } = useDevices();
+  const { data: policyData } = useDefaultPolicy();
+  const { showingLastKnownState } = useOnlineStatusContext();
+  const rebuild = useRebuildTunnel();
+  const { data: combinedStats } = useCombinedTunnelStats();
+
+  const tunnels = tunnelsData?.tunnels ?? [];
+  const devices = devicesData?.devices ?? [];
+  const defaultPolicy = policyData?.policy;
+  const upCount = tunnels.filter((t) => t.status === "up").length;
+
+  const sparkValues = combinedStats?.sparkValues ?? [];
+  const combinedRxRate = combinedStats?.rxRate ?? 0;
+  const combinedTxRate = combinedStats?.txRate ?? 0;
+
+  if (isLoading) {
+    return (
+      <div className="flex flex-col gap-4 p-4">
+        <h1 className="text-xl font-semibold text-ink">Tunnels</h1>
+        <div className="h-24 animate-pulse rounded-xl bg-sunken" />
+        {Array.from({ length: 3 }).map((_, i) => (
+          <div key={i} className="h-48 animate-pulse rounded-xl bg-sunken" />
+        ))}
+      </div>
+    );
+  }
+
   return (
     <div className="flex flex-col gap-4 p-4">
       <h1 className="text-xl font-semibold text-ink">Tunnels</h1>
-      <p className="text-sm text-ink-3">Coming in a subsequent issue.</p>
+
+      <div className={showingLastKnownState ? "pointer-events-none opacity-40 transition-opacity" : "transition-opacity"}>
+      <div className="flex flex-col gap-4">
+
+      {/* Summary header */}
+      <Card className="card--flush">
+        <div className="flex items-center gap-3 p-4">
+          <div className="min-w-0 shrink-0">
+            <div className="text-[10px] font-semibold uppercase tracking-wider text-ink-3">
+              Tunnels Up
+            </div>
+            <div className="mt-0.5 flex items-baseline gap-1.5">
+              <span className="text-2xl font-bold text-ink tabular-nums">{upCount}</span>
+              <span className="text-sm text-ink-3">/ {tunnels.length}</span>
+            </div>
+            <div className="mt-0.5 text-xs text-ink-3">
+              ↓ {formatBytes(combinedRxRate)}/s · ↑ {formatBytes(combinedTxRate)}/s
+            </div>
+          </div>
+
+          <div className="h-12 flex-1 opacity-70">
+            {sparkValues.length > 0 && (
+              <Sparkline values={sparkValues} color="var(--color-info)" area={false} />
+            )}
+          </div>
+        </div>
+      </Card>
+
+      {/* Per-tunnel cards */}
+      {tunnels.length === 0 ? (
+        <p className="py-16 text-center text-sm text-ink-3">No tunnels configured.</p>
+      ) : (
+        <div className="flex flex-col gap-3">
+          {tunnels.map((tunnel) => (
+            <TunnelCard
+              key={tunnel.id}
+              tunnel={tunnel}
+              devices={devices}
+              defaultPolicy={defaultPolicy}
+              onRebuild={rebuild.mutate}
+              rebuildingId={rebuild.isPending ? rebuild.variables : undefined}
+            />
+          ))}
+        </div>
+      )}
+
+      </div>
+      </div>
     </div>
   );
 }

--- a/source/admin-site/web/src/components/compound/TunnelCard.tsx
+++ b/source/admin-site/web/src/components/compound/TunnelCard.tsx
@@ -1,11 +1,10 @@
-import { ArrowDown, ArrowUp, Loader2, SlidersHorizontal } from "lucide-react";
+import { ArrowDown, ArrowUp, Loader2, RotateCcw, SlidersHorizontal } from "lucide-react";
 import { useState } from "react";
 import { Link } from "react-router";
 import { Button } from "@wardnet/forge-web/button";
 import { StatusBadge } from "./StatusBadge";
-import { formatBytes, timeAgo } from "@wardnet/wardnet-web";
-import { countryFlag } from "@wardnet/wardnet-web";
-import { useTestTunnel } from "@wardnet/wardnet-web";
+import { countryFlag, formatBytes, timeAgo } from "@wardnet/wardnet-web";
+import { useTestTunnel, useRebuildTunnel } from "@wardnet/wardnet-web";
 import type { Tunnel, TunnelStatus, ProviderInfo, TunnelTestResult } from "@wardnet/js";
 
 function statusTone(status: TunnelStatus): "success" | "neutral" | "danger" {
@@ -67,6 +66,7 @@ export function TunnelCard({ tunnel, providers, onDelete }: TunnelCardProps) {
   const flag = tunnel.country_code ? countryFlag(tunnel.country_code) : "";
 
   const testTunnel = useTestTunnel();
+  const rebuildTunnel = useRebuildTunnel();
   const [testResult, setTestResult] = useState<TunnelTestResult | null>(null);
   const [testError, setTestError] = useState<string | null>(null);
   const [testedAt, setTestedAt] = useState<string | null>(null);
@@ -194,6 +194,24 @@ export function TunnelCard({ tunnel, providers, onDelete }: TunnelCardProps) {
             </>
           ) : (
             "Test"
+          )}
+        </Button>
+        <Button
+          size="sm"
+          variant="outline"
+          disabled={rebuildTunnel.isPending && rebuildTunnel.variables === tunnel.id}
+          onClick={() => rebuildTunnel.mutate(tunnel.id)}
+        >
+          {rebuildTunnel.isPending && rebuildTunnel.variables === tunnel.id ? (
+            <>
+              <Loader2 className="mr-1 size-3 animate-spin" aria-hidden />
+              Rebuilding
+            </>
+          ) : (
+            <>
+              <RotateCcw className="mr-1 size-3" aria-hidden />
+              Rebuild
+            </>
           )}
         </Button>
         <Button

--- a/source/admin-site/web/src/pages/TunnelDetail.tsx
+++ b/source/admin-site/web/src/pages/TunnelDetail.tsx
@@ -10,7 +10,12 @@ import { StatusBadge } from "@/components/compound/StatusBadge";
 import { TunnelDevicesTable } from "@/components/features/TunnelDevicesTable";
 import { TunnelThroughputChart } from "@/components/features/TunnelThroughputChart";
 import { TunnelLatencyChart } from "@/components/features/TunnelLatencyChart";
-import { useTunnel, useDeleteTunnel, useSetTunnelDnsOverride } from "@wardnet/wardnet-web";
+import {
+  useTunnel,
+  useDeleteTunnel,
+  useSetTunnelDnsOverride,
+  useRebuildTunnel,
+} from "@wardnet/wardnet-web";
 import { useTunnelStats, RANGES, type StatsRange } from "@wardnet/wardnet-web";
 import { type ZoomRange } from "@/hooks/useChartZoom";
 import { countryFlag } from "@wardnet/wardnet-web";
@@ -49,6 +54,7 @@ export default function TunnelDetail() {
   const navigate = useNavigate();
   const { data, isLoading, isError } = useTunnel(id);
   const deleteTunnel = useDeleteTunnel();
+  const rebuildTunnel = useRebuildTunnel();
   const setDnsOverride = useSetTunnelDnsOverride();
   const {
     data: statsData,
@@ -194,7 +200,14 @@ export default function TunnelDetail() {
 
       <TunnelDevicesTable tunnelId={tunnel.id} />
 
-      <div className="row justify-end">
+      <div className="row justify-end gap-8">
+        <Button
+          variant="outline"
+          disabled={rebuildTunnel.isPending}
+          onClick={() => rebuildTunnel.mutate(tunnel.id)}
+        >
+          {rebuildTunnel.isPending ? "Rebuilding…" : "Rebuild tunnel"}
+        </Button>
         <Button
           variant="destructive"
           onClick={() => {

--- a/source/daemon/crates/wardnet-common/src/api.rs
+++ b/source/daemon/crates/wardnet-common/src/api.rs
@@ -199,6 +199,13 @@ pub struct DeleteTunnelResponse {
     pub message: String,
 }
 
+/// Response for POST /api/tunnels/:id/rebuild.
+#[derive(Debug, Clone, Serialize, Deserialize, utoipa::ToSchema)]
+pub struct RebuildTunnelResponse {
+    /// Always `true` on a 200 response. Errors surface as non-200 status codes.
+    pub ok: bool,
+}
+
 /// Response for GET /api/tunnels/{id}.
 #[derive(Debug, Clone, Serialize, Deserialize, utoipa::ToSchema)]
 pub struct TunnelDetailResponse {

--- a/source/daemon/crates/wardnetd-api/src/api/tests/tunnels.rs
+++ b/source/daemon/crates/wardnetd-api/src/api/tests/tunnels.rs
@@ -163,6 +163,10 @@ impl TunnelService for MockTunnelService {
         Ok(updated)
     }
 
+    async fn rebuild(&self, _id: Uuid) -> Result<(), AppError> {
+        Ok(())
+    }
+
     async fn bring_up(&self, _id: Uuid) -> Result<(), AppError> {
         Ok(())
     }

--- a/source/daemon/crates/wardnetd-api/src/api/tests/tunnels.rs
+++ b/source/daemon/crates/wardnetd-api/src/api/tests/tunnels.rs
@@ -163,7 +163,10 @@ impl TunnelService for MockTunnelService {
         Ok(updated)
     }
 
-    async fn rebuild(&self, _id: Uuid) -> Result<(), AppError> {
+    async fn rebuild(&self, id: Uuid) -> Result<(), AppError> {
+        if !self.tunnels.iter().any(|t| t.id == id) {
+            return Err(AppError::NotFound(format!("tunnel {id} not found")));
+        }
         Ok(())
     }
 
@@ -294,6 +297,10 @@ fn tunnel_router(state: AppState) -> Router {
         .route(
             "/api/tunnels/{id}/dns-override",
             axum::routing::put(crate::api::tunnels::update_tunnel_dns_override),
+        )
+        .route(
+            "/api/tunnels/{id}/rebuild",
+            axum::routing::post(crate::api::tunnels::rebuild_tunnel),
         )
         .with_state(state)
 }
@@ -854,6 +861,59 @@ async fn update_tunnel_dns_override_unauthorized_without_session() {
                 .header("Content-Type", "application/json")
                 .extension(connect_info())
                 .body(Body::from(r#"{"override_default_dns": true}"#))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+}
+
+// ---------------------------------------------------------------------------
+// POST /api/tunnels/:id/rebuild
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn rebuild_tunnel_success() {
+    let tunnel = sample_tunnel();
+    let state = build_state(MockTunnelService::with_tunnels(vec![tunnel]));
+    let app = tunnel_router(state);
+
+    let (status, json) = post_empty(
+        app,
+        "/api/tunnels/00000000-0000-0000-0000-000000000010/rebuild",
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(json["ok"], true);
+}
+
+#[tokio::test]
+async fn rebuild_tunnel_not_found() {
+    let state = build_state(MockTunnelService::empty());
+    let app = tunnel_router(state);
+
+    let (status, json) = post_empty(
+        app,
+        "/api/tunnels/00000000-0000-0000-0000-000000000099/rebuild",
+    )
+    .await;
+    assert_eq!(status, StatusCode::NOT_FOUND);
+    assert_eq!(json["error"], "not found");
+}
+
+#[tokio::test]
+async fn rebuild_tunnel_unauthorized_without_session() {
+    let state = build_state(MockTunnelService::empty());
+    let app = tunnel_router(state);
+
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/tunnels/00000000-0000-0000-0000-000000000010/rebuild")
+                .extension(connect_info())
+                .body(Body::empty())
                 .unwrap(),
         )
         .await

--- a/source/daemon/crates/wardnetd-api/src/api/tunnels.rs
+++ b/source/daemon/crates/wardnetd-api/src/api/tunnels.rs
@@ -6,7 +6,7 @@ use utoipa_axum::routes;
 use uuid::Uuid;
 use wardnet_common::api::{
     CreateTunnelRequest, CreateTunnelResponse, DeleteTunnelResponse, ListTunnelsResponse,
-    TunnelDetailResponse, TunnelDevicesResponse, TunnelTestResponse,
+    RebuildTunnelResponse, TunnelDetailResponse, TunnelDevicesResponse, TunnelTestResponse,
     UpdateTunnelDnsOverrideRequest, UpdateTunnelDnsOverrideResponse,
 };
 
@@ -23,6 +23,7 @@ pub fn register(router: OpenApiRouter<AppState>) -> OpenApiRouter<AppState> {
         .routes(routes!(list_tunnel_devices))
         .routes(routes!(test_tunnel))
         .routes(routes!(update_tunnel_dns_override))
+        .routes(routes!(rebuild_tunnel))
 }
 
 #[utoipa::path(
@@ -218,4 +219,31 @@ pub async fn update_tunnel_dns_override(
         .set_dns_override(id, body.override_default_dns)
         .await?;
     Ok(Json(UpdateTunnelDnsOverrideResponse { tunnel }))
+}
+
+#[utoipa::path(
+    post,
+    path = "/api/tunnels/{id}/rebuild",
+    tag = "tunnels",
+    description = "Tear down the WireGuard interface and re-apply it from the persisted \
+                   config. Use when a tunnel is stale or devices cannot route through it. \
+                   Equivalent to the internal watchdog recovery path. Admin only.",
+    params(("id" = Uuid, Path, description = "Tunnel ID")),
+    responses(
+        (status = 200, description = "Tunnel rebuild initiated", body = RebuildTunnelResponse),
+        AuthErrors,
+        NotFound,
+    ),
+    security(
+        ("session_cookie" = []),
+        ("bearer_auth" = []),
+    ),
+)]
+pub async fn rebuild_tunnel(
+    State(state): State<AppState>,
+    _auth: AdminAuth,
+    Path(id): Path<Uuid>,
+) -> Result<Json<RebuildTunnelResponse>, AppError> {
+    state.tunnel_service().rebuild(id).await?;
+    Ok(Json(RebuildTunnelResponse { ok: true }))
 }

--- a/source/daemon/crates/wardnetd-api/src/tests/stubs.rs
+++ b/source/daemon/crates/wardnetd-api/src/tests/stubs.rs
@@ -612,6 +612,9 @@ impl TunnelService for StubTunnelService {
     ) -> Result<wardnet_common::tunnel::Tunnel, AppError> {
         unimplemented!()
     }
+    async fn rebuild(&self, _id: Uuid) -> Result<(), AppError> {
+        unimplemented!()
+    }
     async fn bring_up(&self, _id: Uuid) -> Result<(), AppError> {
         unimplemented!()
     }

--- a/source/daemon/crates/wardnetd-services/src/routing/tests/routing.rs
+++ b/source/daemon/crates/wardnetd-services/src/routing/tests/routing.rs
@@ -303,6 +303,10 @@ impl TunnelService for MockTunnelService {
         unimplemented!("not used in routing tests")
     }
 
+    async fn rebuild(&self, _id: Uuid) -> Result<(), AppError> {
+        unimplemented!("not used in routing tests")
+    }
+
     async fn bring_up(&self, _id: Uuid) -> Result<(), AppError> {
         unimplemented!("not used in routing tests")
     }

--- a/source/daemon/crates/wardnetd-services/src/tunnel/service.rs
+++ b/source/daemon/crates/wardnetd-services/src/tunnel/service.rs
@@ -71,6 +71,13 @@ pub trait TunnelService: Send + Sync {
     /// upstream pool (`false`).
     async fn set_dns_override(&self, id: Uuid, value: bool) -> Result<Tunnel, AppError>;
 
+    /// Tear down and re-apply a tunnel interface from scratch (admin rebuild).
+    ///
+    /// Equivalent to the watchdog recovery path: tears down the WireGuard
+    /// interface and brings it back up from the persisted config. Use when
+    /// the tunnel is stale or devices cannot route through it.
+    async fn rebuild(&self, id: Uuid) -> Result<(), AppError>;
+
     /// Bring a tunnel interface up.
     async fn bring_up(&self, id: Uuid) -> Result<(), AppError>;
 
@@ -918,6 +925,17 @@ impl TunnelService for TunnelServiceImpl {
         });
         let tunnel = self.require_tunnel(id).await?;
         Ok(tunnel)
+    }
+
+    async fn rebuild(&self, id: Uuid) -> Result<(), AppError> {
+        auth_context::require_admin()?;
+        let _guard = self.acquire_in_flight(id)?;
+        self.tear_down_core(id, "admin rebuild").await?;
+        if let Err(e) = self.bring_up_core(id).await {
+            tracing::error!(tunnel_id = %id, error = %e, "rebuild: tear-down succeeded but bring-up failed — tunnel is down");
+            return Err(e);
+        }
+        Ok(())
     }
 
     async fn bring_up(&self, id: Uuid) -> Result<(), AppError> {

--- a/source/daemon/crates/wardnetd-services/src/tunnel/service.rs
+++ b/source/daemon/crates/wardnetd-services/src/tunnel/service.rs
@@ -73,7 +73,7 @@ pub trait TunnelService: Send + Sync {
 
     /// Tear down and re-apply a tunnel interface from scratch (admin rebuild).
     ///
-    /// Equivalent to the watchdog recovery path: tears down the WireGuard
+    /// Equivalent to the watchdog recovery path: tears down the `WireGuard`
     /// interface and brings it back up from the persisted config. Use when
     /// the tunnel is stale or devices cannot route through it.
     async fn rebuild(&self, id: Uuid) -> Result<(), AppError>;

--- a/source/daemon/crates/wardnetd-services/src/tunnel/tests/tunnel.rs
+++ b/source/daemon/crates/wardnetd-services/src/tunnel/tests/tunnel.rs
@@ -2567,16 +2567,27 @@ async fn rebuild_success() {
         .unwrap();
 
     // Rebuild must tear down the existing interface and bring a fresh one up.
-    assert_eq!(h.tunnel_iface.torn_down.lock().unwrap().as_slice(), ["wg_ward0"]);
-    assert_eq!(h.tunnel_iface.removed.lock().unwrap().as_slice(), ["wg_ward0"]);
-    assert_eq!(h.tunnel_iface.created.lock().unwrap().as_slice(), ["wg_ward0"]);
-    assert_eq!(h.tunnel_iface.brought_up.lock().unwrap().as_slice(), ["wg_ward0"]);
+    assert_eq!(
+        h.tunnel_iface.torn_down.lock().unwrap().as_slice(),
+        ["wg_ward0"]
+    );
+    assert_eq!(
+        h.tunnel_iface.removed.lock().unwrap().as_slice(),
+        ["wg_ward0"]
+    );
+    assert_eq!(
+        h.tunnel_iface.created.lock().unwrap().as_slice(),
+        ["wg_ward0"]
+    );
+    assert_eq!(
+        h.tunnel_iface.brought_up.lock().unwrap().as_slice(),
+        ["wg_ward0"]
+    );
 }
 
 #[tokio::test]
 async fn rebuild_not_found() {
     let h = build_harness();
-    let result =
-        auth_context::with_context(admin_ctx(), h.svc.rebuild(Uuid::new_v4())).await;
+    let result = auth_context::with_context(admin_ctx(), h.svc.rebuild(Uuid::new_v4())).await;
     assert!(matches!(result, Err(AppError::NotFound(_))));
 }

--- a/source/daemon/crates/wardnetd-services/src/tunnel/tests/tunnel.rs
+++ b/source/daemon/crates/wardnetd-services/src/tunnel/tests/tunnel.rs
@@ -2540,3 +2540,43 @@ async fn bring_up_with_selector_and_resolver_returning_none_uses_stored_endpoint
     let rows = h.tunnels.rows.lock().unwrap();
     assert_eq!(rows[0].endpoint, original_endpoint);
 }
+
+// -- rebuild ------------------------------------------------------------------
+
+#[tokio::test]
+async fn rebuild_success() {
+    let h = build_harness();
+    let resp = auth_context::with_context(admin_ctx(), h.svc.import_tunnel(sample_request()))
+        .await
+        .unwrap();
+    let id = resp.tunnel.id;
+
+    // Bring the tunnel up so it is in `Connecting` state — rebuild has work to do.
+    auth_context::with_context(admin_ctx(), h.svc.bring_up(id))
+        .await
+        .unwrap();
+
+    // Clear the interface call counts so we can assert rebuild's own calls.
+    h.tunnel_iface.torn_down.lock().unwrap().clear();
+    h.tunnel_iface.removed.lock().unwrap().clear();
+    h.tunnel_iface.created.lock().unwrap().clear();
+    h.tunnel_iface.brought_up.lock().unwrap().clear();
+
+    auth_context::with_context(admin_ctx(), h.svc.rebuild(id))
+        .await
+        .unwrap();
+
+    // Rebuild must tear down the existing interface and bring a fresh one up.
+    assert_eq!(h.tunnel_iface.torn_down.lock().unwrap().as_slice(), ["wg_ward0"]);
+    assert_eq!(h.tunnel_iface.removed.lock().unwrap().as_slice(), ["wg_ward0"]);
+    assert_eq!(h.tunnel_iface.created.lock().unwrap().as_slice(), ["wg_ward0"]);
+    assert_eq!(h.tunnel_iface.brought_up.lock().unwrap().as_slice(), ["wg_ward0"]);
+}
+
+#[tokio::test]
+async fn rebuild_not_found() {
+    let h = build_harness();
+    let result =
+        auth_context::with_context(admin_ctx(), h.svc.rebuild(Uuid::new_v4())).await;
+    assert!(matches!(result, Err(AppError::NotFound(_))));
+}

--- a/source/daemon/crates/wardnetd-services/src/vpn/tests/provider.rs
+++ b/source/daemon/crates/wardnetd-services/src/vpn/tests/provider.rs
@@ -211,6 +211,10 @@ impl TunnelService for MockTunnelService {
         unimplemented!()
     }
 
+    async fn rebuild(&self, _id: Uuid) -> Result<(), AppError> {
+        Ok(())
+    }
+
     async fn bring_up(&self, _id: Uuid) -> Result<(), AppError> {
         Ok(())
     }

--- a/source/daemon/crates/wardnetd/src/tests/stubs.rs
+++ b/source/daemon/crates/wardnetd/src/tests/stubs.rs
@@ -321,6 +321,9 @@ impl TunnelService for StubTunnelService {
     ) -> Result<wardnet_common::tunnel::Tunnel, AppError> {
         unimplemented!()
     }
+    async fn rebuild(&self, _id: Uuid) -> Result<(), AppError> {
+        unimplemented!()
+    }
     async fn bring_up(&self, _id: Uuid) -> Result<(), AppError> {
         unimplemented!()
     }

--- a/source/daemon/crates/wardnetd/src/tests/tunnel_idle.rs
+++ b/source/daemon/crates/wardnetd/src/tests/tunnel_idle.rs
@@ -77,6 +77,10 @@ impl TunnelService for MockTunnelService {
         unimplemented!()
     }
 
+    async fn rebuild(&self, _id: Uuid) -> Result<(), AppError> {
+        Ok(())
+    }
+
     async fn bring_up(&self, _id: Uuid) -> Result<(), AppError> {
         Ok(())
     }

--- a/source/daemon/crates/wardnetd/src/tests/tunnel_monitor.rs
+++ b/source/daemon/crates/wardnetd/src/tests/tunnel_monitor.rs
@@ -89,6 +89,9 @@ impl TunnelService for MockTunnelService {
     ) -> Result<wardnet_common::tunnel::Tunnel, AppError> {
         unimplemented!()
     }
+    async fn rebuild(&self, _id: Uuid) -> Result<(), AppError> {
+        unimplemented!()
+    }
     async fn bring_up(&self, _id: Uuid) -> Result<(), AppError> {
         unimplemented!()
     }

--- a/source/sdk/wardnet-js/src/index.ts
+++ b/source/sdk/wardnet-js/src/index.ts
@@ -114,6 +114,7 @@ export type {
   CreateTunnelResponse,
   ListTunnelsResponse,
   DeleteTunnelResponse,
+  RebuildTunnelResponse,
   TunnelDetailResponse,
   TunnelDevicesResponse,
   TunnelTestResult,

--- a/source/sdk/wardnet-js/src/services/tunnels.ts
+++ b/source/sdk/wardnet-js/src/services/tunnels.ts
@@ -4,6 +4,7 @@ import type {
   CreateTunnelResponse,
   DeleteTunnelResponse,
   ListTunnelsResponse,
+  RebuildTunnelResponse,
   TunnelDetailResponse,
   TunnelDevicesResponse,
   TunnelTestResponse,
@@ -70,6 +71,17 @@ export class TunnelService {
     return this.client.request<UpdateTunnelDnsOverrideResponse>(`/tunnels/${id}/dns-override`, {
       method: "PUT",
       body: JSON.stringify(body),
+    });
+  }
+
+  /**
+   * Tear down and re-apply the WireGuard interface from persisted config
+   * (admin only). Use when a tunnel is stale or devices cannot route through
+   * it.
+   */
+  async rebuild(id: string): Promise<RebuildTunnelResponse> {
+    return this.client.request<RebuildTunnelResponse>(`/tunnels/${id}/rebuild`, {
+      method: "POST",
     });
   }
 }

--- a/source/sdk/wardnet-js/src/types/api.ts
+++ b/source/sdk/wardnet-js/src/types/api.ts
@@ -85,6 +85,11 @@ export interface DeleteTunnelResponse {
   message: string;
 }
 
+/** Response for POST /api/tunnels/:id/rebuild. */
+export interface RebuildTunnelResponse {
+  ok: boolean;
+}
+
 /** Response for GET /api/tunnels/:id. */
 export interface TunnelDetailResponse {
   tunnel: Tunnel;

--- a/source/wardnet-web/src/components/LoginForm.tsx
+++ b/source/wardnet-web/src/components/LoginForm.tsx
@@ -7,7 +7,11 @@ import { Input } from "@wardnet/forge-web/input";
 
 interface LoginFormProps {
   /** Injected login action — callers supply this from their auth store or hook. */
-  login: (username: string, password: string, rememberMe?: boolean) => Promise<void>;
+  login: (
+    username: string,
+    password: string,
+    rememberMe?: boolean,
+  ) => Promise<void>;
   /**
    * Controls the "Remember me" behaviour:
    * - `"checkbox"` — shows an unchecked checkbox the user can toggle (admin-site)
@@ -25,14 +29,19 @@ interface LoginFormProps {
  * Pure presentation — all business logic is injected via props. The caller
  * owns the login action and post-login navigation via `onSuccess`.
  */
-export function LoginForm({ login, rememberMe = false, onSuccess }: LoginFormProps) {
+export function LoginForm({
+  login,
+  rememberMe = false,
+  onSuccess,
+}: LoginFormProps) {
   const [username, setUsername] = useState("");
   const [password, setPassword] = useState("");
   const [rememberMeChecked, setRememberMeChecked] = useState(false);
   const [formError, setFormError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
 
-  const effectiveRememberMe = rememberMe === "checkbox" ? rememberMeChecked : (rememberMe as boolean);
+  const effectiveRememberMe =
+    rememberMe === "checkbox" ? rememberMeChecked : (rememberMe as boolean);
 
   async function handleSubmit(values: { username: string; password: string }) {
     setFormError(null);
@@ -52,7 +61,11 @@ export function LoginForm({ login, rememberMe = false, onSuccess }: LoginFormPro
   }
 
   return (
-    <Form values={{ username, password }} onSubmit={handleSubmit} className="flex flex-col gap-5">
+    <Form
+      values={{ username, password }}
+      onSubmit={handleSubmit}
+      className="flex flex-col gap-5"
+    >
       <Field label="Username" htmlFor="username" name="username">
         <Input
           id="username"
@@ -62,7 +75,11 @@ export function LoginForm({ login, rememberMe = false, onSuccess }: LoginFormPro
           placeholder="admin"
         />
       </Field>
-      <Validator name="username" rule="required" message="Username is required." />
+      <Validator
+        name="username"
+        rule="required"
+        message="Username is required."
+      />
 
       <Field label="Password" htmlFor="password" name="password">
         <Input
@@ -74,7 +91,11 @@ export function LoginForm({ login, rememberMe = false, onSuccess }: LoginFormPro
           placeholder="••••••••"
         />
       </Field>
-      <Validator name="password" rule="required" message="Password is required." />
+      <Validator
+        name="password"
+        rule="required"
+        message="Password is required."
+      />
 
       {rememberMe === "checkbox" && (
         <label className="flex items-center gap-2 text-sm text-ink-2 cursor-pointer select-none">

--- a/source/wardnet-web/src/hooks/useBackup.ts
+++ b/source/wardnet-web/src/hooks/useBackup.ts
@@ -69,9 +69,15 @@ export function useExportBackup() {
 
 /** Preview an import — decrypts server-side, returns manifest + token. */
 export function usePreviewImport() {
-  return useMutation<RestorePreviewResponse, unknown, { bundle: Blob; passphrase: string }>({
-    mutationFn: ({ bundle, passphrase }) => backupService.previewImport(bundle, passphrase),
-    onError: (err) => toast.error(errorMessage(err, "Bundle could not be decrypted")),
+  return useMutation<
+    RestorePreviewResponse,
+    unknown,
+    { bundle: Blob; passphrase: string }
+  >({
+    mutationFn: ({ bundle, passphrase }) =>
+      backupService.previewImport(bundle, passphrase),
+    onError: (err) =>
+      toast.error(errorMessage(err, "Bundle could not be decrypted")),
   });
 }
 

--- a/source/wardnet-web/src/hooks/useCombinedTunnelStats.ts
+++ b/source/wardnet-web/src/hooks/useCombinedTunnelStats.ts
@@ -1,0 +1,69 @@
+import { useMemo } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { statsService } from "../lib/sdk";
+
+const BUCKET_SECS = 60;
+
+export interface CombinedTunnelStatsData {
+  /** Combined tx+rx values per minute bucket, sorted ascending by timestamp. */
+  sparkValues: number[];
+  /** Current download rate in bytes/s (last bucket ÷ bucket seconds). */
+  rxRate: number;
+  /** Current upload rate in bytes/s (last bucket ÷ bucket seconds). */
+  txRate: number;
+}
+
+/**
+ * Fetches aggregate `tunnel.bytes.tx` and `tunnel.bytes.rx` across all
+ * tunnels for the trailing 1-hour window (1-minute buckets). The window
+ * advances on each 60-second refetch. Use for the summary header sparkline
+ * and combined throughput rate.
+ */
+export function useCombinedTunnelStats(): {
+  data: CombinedTunnelStatsData | undefined;
+  isLoading: boolean;
+} {
+  const { data: rawStats, isLoading } = useQuery({
+    queryKey: ["stats", "tunnels-combined", "1h"],
+    queryFn: () => {
+      const now = new Date();
+      return statsService.queryMulti({
+        metrics: ["tunnel.bytes.tx", "tunnel.bytes.rx"],
+        to: now.toISOString(),
+        from: new Date(now.getTime() - 3_600_000).toISOString(),
+        bucket: "minute",
+      });
+    },
+    refetchInterval: 60_000,
+  });
+
+  const data = useMemo<CombinedTunnelStatsData | undefined>(() => {
+    if (!rawStats) return undefined;
+
+    const byTs = new Map<number, { tx: number; rx: number }>();
+    for (const p of rawStats["tunnel.bytes.tx"] ?? []) {
+      const ts = new Date(p.ts).getTime();
+      const e = byTs.get(ts) ?? { tx: 0, rx: 0 };
+      e.tx += p.value;
+      byTs.set(ts, e);
+    }
+    for (const p of rawStats["tunnel.bytes.rx"] ?? []) {
+      const ts = new Date(p.ts).getTime();
+      const e = byTs.get(ts) ?? { tx: 0, rx: 0 };
+      e.rx += p.value;
+      byTs.set(ts, e);
+    }
+
+    const sortedEntries = Array.from(byTs.entries()).sort(([a], [b]) => a - b);
+    const sparkValues = sortedEntries.map(([, v]) => v.tx + v.rx);
+    const last = sortedEntries[sortedEntries.length - 1]?.[1] ?? { tx: 0, rx: 0 };
+
+    return {
+      sparkValues,
+      rxRate: last.rx / BUCKET_SECS,
+      txRate: last.tx / BUCKET_SECS,
+    };
+  }, [rawStats]);
+
+  return { data, isLoading };
+}

--- a/source/wardnet-web/src/hooks/useDaemonReachability.ts
+++ b/source/wardnet-web/src/hooks/useDaemonReachability.ts
@@ -122,7 +122,10 @@ export function useDaemonReachability() {
         if (!probeOk) {
           seenDown = true;
           downStreak += 1;
-          if (mode.kind === "shutdown" && downStreak >= OFF_CONFIRM_DOWN_PROBES) {
+          if (
+            mode.kind === "shutdown" &&
+            downStreak >= OFF_CONFIRM_DOWN_PROBES
+          ) {
             // Daemon has been silent long enough — host is off.
             if (!cancelled) setPhase("off");
             return;

--- a/source/wardnet-web/src/hooks/useDevices.ts
+++ b/source/wardnet-web/src/hooks/useDevices.ts
@@ -49,7 +49,10 @@ export function useUpdateDevice(options?: { successMessage?: string }) {
     onSuccess: (_, variables) => {
       toast.success(optionsRef.current?.successMessage ?? "Device updated");
       qc.invalidateQueries({ queryKey: ["devices"], exact: true });
-      qc.invalidateQueries({ queryKey: ["devices", variables.id], exact: true });
+      qc.invalidateQueries({
+        queryKey: ["devices", variables.id],
+        exact: true,
+      });
     },
     onError: () => toast.error("Failed to update device"),
   });

--- a/source/wardnet-web/src/hooks/useDhcp.ts
+++ b/source/wardnet-web/src/hooks/useDhcp.ts
@@ -45,7 +45,9 @@ export function useToggleDhcp() {
   return useMutation({
     mutationFn: (enabled: boolean) => dhcpService.toggle({ enabled }),
     onSuccess: (data) => {
-      toast.success(data.config.enabled ? "DHCP server enabled" : "DHCP server disabled");
+      toast.success(
+        data.config.enabled ? "DHCP server enabled" : "DHCP server disabled",
+      );
       qc.invalidateQueries({ queryKey: ["dhcp"] });
     },
     onError: () => toast.error("Failed to toggle DHCP server"),
@@ -55,7 +57,8 @@ export function useToggleDhcp() {
 export function useUpdateDhcpConfig() {
   const qc = useQueryClient();
   return useMutation({
-    mutationFn: (body: UpdateDhcpConfigRequest) => dhcpService.updateConfig(body),
+    mutationFn: (body: UpdateDhcpConfigRequest) =>
+      dhcpService.updateConfig(body),
     onSuccess: () => {
       toast.success("DHCP configuration updated");
       qc.invalidateQueries({ queryKey: ["dhcp"] });
@@ -67,7 +70,8 @@ export function useUpdateDhcpConfig() {
 export function useCreateReservation() {
   const qc = useQueryClient();
   return useMutation({
-    mutationFn: (body: CreateDhcpReservationRequest) => dhcpService.createReservation(body),
+    mutationFn: (body: CreateDhcpReservationRequest) =>
+      dhcpService.createReservation(body),
     onSuccess: (data) => {
       toast.success(data.message || "Reservation created");
       qc.invalidateQueries({ queryKey: ["dhcp", "reservations"] });

--- a/source/wardnet-web/src/hooks/useDns.tsx
+++ b/source/wardnet-web/src/hooks/useDns.tsx
@@ -28,7 +28,9 @@ export function useToggleDns() {
   return useMutation({
     mutationFn: (enabled: boolean) => dnsService.toggle({ enabled }),
     onSuccess: (data) => {
-      toast.success(data.config.enabled ? "DNS server enabled" : "DNS server disabled");
+      toast.success(
+        data.config.enabled ? "DNS server enabled" : "DNS server disabled",
+      );
       qc.invalidateQueries({ queryKey: ["dns"] });
     },
     onError: () => toast.error("Failed to toggle DNS server"),

--- a/source/wardnet-web/src/hooks/useDnsFilter.tsx
+++ b/source/wardnet-web/src/hooks/useDnsFilter.tsx
@@ -48,7 +48,8 @@ export function useDnsFilterProfile(profileId: string | undefined) {
 export function useCreateDnsFilterProfile() {
   const qc = useQueryClient();
   return useMutation({
-    mutationFn: (body: CreateProfileRequest) => dnsFilterService.createProfile(body),
+    mutationFn: (body: CreateProfileRequest) =>
+      dnsFilterService.createProfile(body),
     onSuccess: (data) => {
       toast.success(data.message || "Profile created");
       qc.invalidateQueries({ queryKey: ["dns-filter"] });
@@ -108,7 +109,9 @@ export function useCreateBlocklist(profileId: string | undefined) {
       dnsFilterService.createBlocklist(profileId!, body),
     onSuccess: (data) => {
       toast.success(data.message || "Blocklist added");
-      qc.invalidateQueries({ queryKey: ["dns-filter", "profile", profileId, "blocklists"] });
+      qc.invalidateQueries({
+        queryKey: ["dns-filter", "profile", profileId, "blocklists"],
+      });
     },
     onError: () => toast.error("Failed to add blocklist"),
   });
@@ -121,7 +124,9 @@ export function useUpdateBlocklist(profileId: string | undefined) {
       dnsFilterService.updateBlocklist(profileId!, id, body),
     onSuccess: (data) => {
       toast.success(data.message || "Blocklist updated");
-      qc.invalidateQueries({ queryKey: ["dns-filter", "profile", profileId, "blocklists"] });
+      qc.invalidateQueries({
+        queryKey: ["dns-filter", "profile", profileId, "blocklists"],
+      });
     },
     onError: () => toast.error("Failed to update blocklist"),
   });
@@ -130,10 +135,13 @@ export function useUpdateBlocklist(profileId: string | undefined) {
 export function useDeleteBlocklist(profileId: string | undefined) {
   const qc = useQueryClient();
   return useMutation({
-    mutationFn: (id: string) => dnsFilterService.deleteBlocklist(profileId!, id),
+    mutationFn: (id: string) =>
+      dnsFilterService.deleteBlocklist(profileId!, id),
     onSuccess: (data) => {
       toast.success(data.message || "Blocklist deleted");
-      qc.invalidateQueries({ queryKey: ["dns-filter", "profile", profileId, "blocklists"] });
+      qc.invalidateQueries({
+        queryKey: ["dns-filter", "profile", profileId, "blocklists"],
+      });
     },
     onError: () => toast.error("Failed to delete blocklist"),
   });
@@ -148,11 +156,17 @@ export function useDeleteBlocklist(profileId: string | undefined) {
  *  `entry_count` refresh. Only one refresh is tracked at a time. */
 export function useRefreshBlocklist(profileId: string | undefined) {
   const qc = useQueryClient();
-  const [active, setActive] = useState<{ jobId: string; blocklistId: string } | null>(null);
+  const [active, setActive] = useState<{
+    jobId: string;
+    blocklistId: string;
+  } | null>(null);
 
   const dispatch = useMutation({
     mutationFn: async (blocklistId: string) => {
-      const res = await dnsFilterService.refreshBlocklist(profileId!, blocklistId);
+      const res = await dnsFilterService.refreshBlocklist(
+        profileId!,
+        blocklistId,
+      );
       return { blocklistId, jobId: res.job_id };
     },
     onSuccess: ({ blocklistId, jobId }) => {
@@ -182,14 +196,18 @@ export function useRefreshBlocklist(profileId: string | undefined) {
     if (job.status === "RUNNING" || job.status === "PENDING") {
       toast.loading("Refreshing blocklist…", {
         id: active.jobId,
-        description: <JobProgressDescription percentage={job.percentage_done} />,
+        description: (
+          <JobProgressDescription percentage={job.percentage_done} />
+        ),
       });
     } else if (job.status === "SUCCEED") {
       toast.success("Blocklist refreshed", {
         id: active.jobId,
         description: undefined,
       });
-      qc.invalidateQueries({ queryKey: ["dns-filter", "profile", profileId, "blocklists"] });
+      qc.invalidateQueries({
+        queryKey: ["dns-filter", "profile", profileId, "blocklists"],
+      });
       // eslint-disable-next-line react-hooks/set-state-in-effect
       setActive(null);
     } else if (job.status === "TERMINATED_WITH_ERRORS") {
@@ -197,7 +215,9 @@ export function useRefreshBlocklist(profileId: string | undefined) {
         id: active.jobId,
         description: undefined,
       });
-      qc.invalidateQueries({ queryKey: ["dns-filter", "profile", profileId, "blocklists"] });
+      qc.invalidateQueries({
+        queryKey: ["dns-filter", "profile", profileId, "blocklists"],
+      });
       setActive(null);
     }
   }, [jobQuery.data, active, qc, profileId]);
@@ -228,7 +248,9 @@ export function useCreateAllowlistEntry(profileId: string | undefined) {
       dnsFilterService.createAllowlistEntry(profileId!, body),
     onSuccess: (data) => {
       toast.success(data.message || "Domain allowlisted");
-      qc.invalidateQueries({ queryKey: ["dns-filter", "profile", profileId, "allowlist"] });
+      qc.invalidateQueries({
+        queryKey: ["dns-filter", "profile", profileId, "allowlist"],
+      });
     },
     onError: () => toast.error("Failed to add allowlist entry"),
   });
@@ -237,10 +259,13 @@ export function useCreateAllowlistEntry(profileId: string | undefined) {
 export function useDeleteAllowlistEntry(profileId: string | undefined) {
   const qc = useQueryClient();
   return useMutation({
-    mutationFn: (id: string) => dnsFilterService.deleteAllowlistEntry(profileId!, id),
+    mutationFn: (id: string) =>
+      dnsFilterService.deleteAllowlistEntry(profileId!, id),
     onSuccess: (data) => {
       toast.success(data.message || "Allowlist entry removed");
-      qc.invalidateQueries({ queryKey: ["dns-filter", "profile", profileId, "allowlist"] });
+      qc.invalidateQueries({
+        queryKey: ["dns-filter", "profile", profileId, "allowlist"],
+      });
     },
     onError: () => toast.error("Failed to remove allowlist entry"),
   });
@@ -265,7 +290,9 @@ export function useCreateFilterRule(profileId: string | undefined) {
       dnsFilterService.createFilterRule(profileId!, body),
     onSuccess: (data) => {
       toast.success(data.message || "Filter rule added");
-      qc.invalidateQueries({ queryKey: ["dns-filter", "profile", profileId, "rules"] });
+      qc.invalidateQueries({
+        queryKey: ["dns-filter", "profile", profileId, "rules"],
+      });
     },
     onError: () => toast.error("Failed to add filter rule"),
   });
@@ -278,7 +305,9 @@ export function useUpdateFilterRule(profileId: string | undefined) {
       dnsFilterService.updateFilterRule(profileId!, id, body),
     onSuccess: (data) => {
       toast.success(data.message || "Filter rule updated");
-      qc.invalidateQueries({ queryKey: ["dns-filter", "profile", profileId, "rules"] });
+      qc.invalidateQueries({
+        queryKey: ["dns-filter", "profile", profileId, "rules"],
+      });
     },
     onError: () => toast.error("Failed to update filter rule"),
   });
@@ -287,10 +316,13 @@ export function useUpdateFilterRule(profileId: string | undefined) {
 export function useDeleteFilterRule(profileId: string | undefined) {
   const qc = useQueryClient();
   return useMutation({
-    mutationFn: (id: string) => dnsFilterService.deleteFilterRule(profileId!, id),
+    mutationFn: (id: string) =>
+      dnsFilterService.deleteFilterRule(profileId!, id),
     onSuccess: (data) => {
       toast.success(data.message || "Filter rule deleted");
-      qc.invalidateQueries({ queryKey: ["dns-filter", "profile", profileId, "rules"] });
+      qc.invalidateQueries({
+        queryKey: ["dns-filter", "profile", profileId, "rules"],
+      });
     },
     onError: () => toast.error("Failed to delete filter rule"),
   });
@@ -300,9 +332,12 @@ export function useDeleteFilterRule(profileId: string | undefined) {
 // Per-device settings
 // ---------------------------------------------------------------------------
 
-export function useDeviceFilterSettingsList(params: ListDeviceFilterSettingsParams = {}) {
+export function useDeviceFilterSettingsList(
+  params: ListDeviceFilterSettingsParams = {},
+) {
   // Stable cache key — `enabled === undefined` collapses to "all".
-  const key = params.enabled === undefined ? "all" : params.enabled ? "true" : "false";
+  const key =
+    params.enabled === undefined ? "all" : params.enabled ? "true" : "false";
   return useQuery<ListDeviceFilterSettingsResponse>({
     queryKey: ["dns-filter", "devices", key],
     queryFn: () => dnsFilterService.listDeviceSettings(params),
@@ -320,11 +355,18 @@ export function useDeviceFilterSettings(deviceId: string | undefined) {
 export function useUpdateDeviceFilterSettings() {
   const qc = useQueryClient();
   return useMutation({
-    mutationFn: ({ id, body }: { id: string; body: UpdateDeviceFilterSettingsRequest }) =>
-      dnsFilterService.updateDeviceSettings(id, body),
+    mutationFn: ({
+      id,
+      body,
+    }: {
+      id: string;
+      body: UpdateDeviceFilterSettingsRequest;
+    }) => dnsFilterService.updateDeviceSettings(id, body),
     onSuccess: (data, variables) => {
       toast.success(data.message || "DNS filter settings updated");
-      qc.invalidateQueries({ queryKey: ["dns-filter", "device", variables.id] });
+      qc.invalidateQueries({
+        queryKey: ["dns-filter", "device", variables.id],
+      });
       qc.invalidateQueries({ queryKey: ["dns-filter", "devices"] });
     },
     onError: () => toast.error("Failed to update DNS filter settings"),
@@ -345,13 +387,16 @@ export function useDnsFilterConfig() {
 export function useUpdateDnsFilterConfig() {
   const qc = useQueryClient();
   return useMutation({
-    mutationFn: (body: UpdateDnsFilterConfigRequest) => dnsFilterService.updateConfig(body),
+    mutationFn: (body: UpdateDnsFilterConfigRequest) =>
+      dnsFilterService.updateConfig(body),
     onSuccess: () => {
       // Stable `id` collapses rapid successive calls (e.g. clicking
       // a default-profile toggle on and off quickly) into a single
       // toast slot. Without it sonner sometimes renders the second
       // toast with an empty body for a frame.
-      toast.success("DNS filter configuration updated", { id: "dns-filter-config-update" });
+      toast.success("DNS filter configuration updated", {
+        id: "dns-filter-config-update",
+      });
       qc.invalidateQueries({ queryKey: ["dns-filter", "config"] });
     },
     onError: () =>

--- a/source/wardnet-web/src/hooks/useInstallPrompt.ts
+++ b/source/wardnet-web/src/hooks/useInstallPrompt.ts
@@ -18,7 +18,8 @@ export interface InstallPromptResult {
  * (Chromium-based); it is always `false` on Safari / Firefox.
  */
 export function useInstallPrompt() {
-  const [promptEvent, setPromptEvent] = useState<BeforeInstallPromptEvent | null>(null);
+  const [promptEvent, setPromptEvent] =
+    useState<BeforeInstallPromptEvent | null>(null);
 
   useEffect(() => {
     const handler = (e: Event) => {
@@ -35,16 +36,17 @@ export function useInstallPrompt() {
    * The prompt can only be shown once per `beforeinstallprompt` event, so
    * `isInstallable` reverts to `false` after this is called.
    */
-  const promptInstall = useCallback(async (): Promise<InstallPromptResult | null> => {
-    if (!promptEvent) return null;
-    // Capture before the first await — the state update from a re-fired
-    // `beforeinstallprompt` could replace `promptEvent` while we await.
-    const captured = promptEvent;
-    await captured.prompt();
-    const result = await captured.userChoice;
-    setPromptEvent(null);
-    return result;
-  }, [promptEvent]);
+  const promptInstall =
+    useCallback(async (): Promise<InstallPromptResult | null> => {
+      if (!promptEvent) return null;
+      // Capture before the first await — the state update from a re-fired
+      // `beforeinstallprompt` could replace `promptEvent` while we await.
+      const captured = promptEvent;
+      await captured.prompt();
+      const result = await captured.userChoice;
+      setPromptEvent(null);
+      return result;
+    }, [promptEvent]);
 
   return {
     /** `true` when the browser has signalled that the app can be installed. */

--- a/source/wardnet-web/src/hooks/useNetwork.ts
+++ b/source/wardnet-web/src/hooks/useNetwork.ts
@@ -19,7 +19,8 @@ export function useNetworkStatus() {
  */
 export function useDiscoverGatewayMac() {
   return useMutation({
-    mutationFn: (body: DiscoverGatewayMacRequest = {}) => networkService.discoverGatewayMac(body),
+    mutationFn: (body: DiscoverGatewayMacRequest = {}) =>
+      networkService.discoverGatewayMac(body),
   });
 }
 

--- a/source/wardnet-web/src/hooks/useOnlineStatus.ts
+++ b/source/wardnet-web/src/hooks/useOnlineStatus.ts
@@ -23,7 +23,8 @@ export function useOnlineStatus(options?: {
   /** How often to probe daemon reachability in milliseconds. Default: 15 000. */
   daemonProbeIntervalMs?: number;
 }) {
-  const daemonProbeIntervalMs = options?.daemonProbeIntervalMs ?? DEFAULT_PROBE_INTERVAL_MS;
+  const daemonProbeIntervalMs =
+    options?.daemonProbeIntervalMs ?? DEFAULT_PROBE_INTERVAL_MS;
 
   const [isOnline, setIsOnline] = useState(() => navigator.onLine);
   const [isDaemonReachable, setIsDaemonReachable] = useState(true);
@@ -46,11 +47,17 @@ export function useOnlineStatus(options?: {
 
     const probe = async () => {
       try {
-        const res = await fetch("/api/info", { cache: "no-store", signal: controller.signal });
+        const res = await fetch("/api/info", {
+          cache: "no-store",
+          signal: controller.signal,
+        });
         if (!cancelled) setIsDaemonReachable(res.ok);
       } catch (e) {
         // Ignore AbortError — it means the component unmounted or the interval changed.
-        if (!cancelled && !(e instanceof DOMException && e.name === "AbortError")) {
+        if (
+          !cancelled &&
+          !(e instanceof DOMException && e.name === "AbortError")
+        ) {
           setIsDaemonReachable(false);
         }
       }
@@ -62,7 +69,10 @@ export function useOnlineStatus(options?: {
     const schedule = async () => {
       await probe();
       if (!cancelled) {
-        timeoutId = window.setTimeout(() => void schedule(), daemonProbeIntervalMs);
+        timeoutId = window.setTimeout(
+          () => void schedule(),
+          daemonProbeIntervalMs,
+        );
       }
     };
 

--- a/source/wardnet-web/src/hooks/useProviders.ts
+++ b/source/wardnet-web/src/hooks/useProviders.ts
@@ -24,23 +24,38 @@ export function useProviderCountries(providerId: string) {
 
 export function useValidateCredentials() {
   return useMutation({
-    mutationFn: ({ providerId, body }: { providerId: string; body: ValidateCredentialsRequest }) =>
-      providerService.validateCredentials(providerId, body),
+    mutationFn: ({
+      providerId,
+      body,
+    }: {
+      providerId: string;
+      body: ValidateCredentialsRequest;
+    }) => providerService.validateCredentials(providerId, body),
   });
 }
 
 export function useProviderServers() {
   return useMutation({
-    mutationFn: ({ providerId, body }: { providerId: string; body: ListServersRequest }) =>
-      providerService.listServers(providerId, body),
+    mutationFn: ({
+      providerId,
+      body,
+    }: {
+      providerId: string;
+      body: ListServersRequest;
+    }) => providerService.listServers(providerId, body),
   });
 }
 
 export function useProviderSetup() {
   const qc = useQueryClient();
   return useMutation({
-    mutationFn: ({ providerId, body }: { providerId: string; body: SetupProviderRequest }) =>
-      providerService.setupTunnel(providerId, body),
+    mutationFn: ({
+      providerId,
+      body,
+    }: {
+      providerId: string;
+      body: SetupProviderRequest;
+    }) => providerService.setupTunnel(providerId, body),
     onSuccess: (data) => {
       toast.success(data.message || "Tunnel created via provider");
       qc.invalidateQueries({ queryKey: ["tunnels"] });

--- a/source/wardnet-web/src/hooks/useSetup.ts
+++ b/source/wardnet-web/src/hooks/useSetup.ts
@@ -15,7 +15,8 @@ export function useSetup() {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: (body: { username: string; password: string }) => setupService.setup(body),
+    mutationFn: (body: { username: string; password: string }) =>
+      setupService.setup(body),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["setup", "status"] });
     },

--- a/source/wardnet-web/src/hooks/useStats.ts
+++ b/source/wardnet-web/src/hooks/useStats.ts
@@ -22,11 +22,16 @@ export const RANGE_HOURS: Record<StatsRange, number> = {
   "12mo": 12 * 30 * 24,
 };
 
-function makeWindow(range: StatsRange): { from: string; to: string; bucket: StatsBucket } {
+function makeWindow(range: StatsRange): {
+  from: string;
+  to: string;
+  bucket: StatsBucket;
+} {
   const hours = RANGE_HOURS[range];
   const to = new Date();
   const from = new Date(to.getTime() - hours * 3_600_000);
-  const bucket: StatsBucket = hours <= 24 ? "minute" : hours <= 168 ? "hour" : "day";
+  const bucket: StatsBucket =
+    hours <= 24 ? "minute" : hours <= 168 ? "hour" : "day";
   return { from: from.toISOString(), to: to.toISOString(), bucket };
 }
 
@@ -44,7 +49,8 @@ export function useDnsStatSummary(range: StatsRange) {
 
   const { data, isLoading, isError, error } = useQuery({
     queryKey: ["stats", "dns-summary", range],
-    queryFn: () => statsService.query({ metric: "dns.queries", from, to, bucket }),
+    queryFn: () =>
+      statsService.query({ metric: "dns.queries", from, to, bucket }),
     refetchInterval: 30_000,
   });
 
@@ -54,10 +60,15 @@ export function useDnsStatSummary(range: StatsRange) {
     let blocked = 0;
     for (const point of data.series ?? []) {
       total += point.value;
-      if (parseLabels(point.labels).outcome === "blocked") blocked += point.value;
+      if (parseLabels(point.labels).outcome === "blocked")
+        blocked += point.value;
     }
     const blockedPercent = total > 0 ? (blocked / total) * 100 : 0;
-    return { total: Math.round(total), blocked: Math.round(blocked), blockedPercent };
+    return {
+      total: Math.round(total),
+      blocked: Math.round(blocked),
+      blockedPercent,
+    };
   }, [data]);
 
   return { data: derived, isLoading, isError, error };
@@ -93,7 +104,8 @@ export function useDnsStatsDashboard(
     queries: [
       {
         queryKey: ["stats", "dns-series", range],
-        queryFn: () => statsService.query({ metric: "dns.queries", from, to, bucket }),
+        queryFn: () =>
+          statsService.query({ metric: "dns.queries", from, to, bucket }),
         refetchInterval: 30_000,
       },
       {
@@ -124,11 +136,15 @@ export function useDnsStatsDashboard(
   });
 
   const isLoading =
-    queryResult.isLoading || topDomainsResult.isLoading || topClientsResult.isLoading;
+    queryResult.isLoading ||
+    topDomainsResult.isLoading ||
+    topClientsResult.isLoading;
 
-  const isError = queryResult.isError || topDomainsResult.isError || topClientsResult.isError;
+  const isError =
+    queryResult.isError || topDomainsResult.isError || topClientsResult.isError;
 
-  const error = queryResult.error ?? topDomainsResult.error ?? topClientsResult.error;
+  const error =
+    queryResult.error ?? topDomainsResult.error ?? topClientsResult.error;
 
   const data = useMemo((): DnsStatsDashboardData | undefined => {
     const raw = queryResult.data;
@@ -161,8 +177,14 @@ export function useDnsStatsDashboard(
       total: Math.round(total),
       blocked: Math.round(blocked),
       blockedPercent,
-      topDomains: topDomainsResult.data ?? { metric: "dns.queries.by_domain", entries: [] },
-      topClients: topClientsResult.data ?? { metric: "dns.queries.by_client", entries: [] },
+      topDomains: topDomainsResult.data ?? {
+        metric: "dns.queries.by_domain",
+        entries: [],
+      },
+      topClients: topClientsResult.data ?? {
+        metric: "dns.queries.by_client",
+        entries: [],
+      },
     };
   }, [queryResult.data, topDomainsResult.data, topClientsResult.data]);
 
@@ -195,7 +217,12 @@ export function useDashboardDnsStats() {
       const now = new Date();
       const from = new Date(now.getTime() - 24 * 3_600_000).toISOString();
       const to = now.toISOString();
-      return statsService.query({ metric: "dns.queries", from, to, bucket: "hour" });
+      return statsService.query({
+        metric: "dns.queries",
+        from,
+        to,
+        bucket: "hour",
+      });
     },
     refetchInterval: 30_000,
   });
@@ -218,7 +245,9 @@ export function useDashboardDnsStats() {
       byTs.set(point.ts, entry);
     }
 
-    const sorted = Array.from(byTs.entries()).sort(([a], [b]) => a.localeCompare(b));
+    const sorted = Array.from(byTs.entries()).sort(([a], [b]) =>
+      a.localeCompare(b),
+    );
 
     return {
       total: Math.round(total),

--- a/source/wardnet-web/src/hooks/useTunnelStats.ts
+++ b/source/wardnet-web/src/hooks/useTunnelStats.ts
@@ -19,8 +19,10 @@ function makeWindow(range: StatsRange): Window {
   const hours = RANGE_HOURS[range];
   const to = new Date();
   const from = new Date(to.getTime() - hours * 3_600_000);
-  const bucket: StatsBucket = hours <= 24 ? "minute" : hours <= 168 ? "hour" : "day";
-  const bucketSecs = bucket === "minute" ? 60 : bucket === "hour" ? 3_600 : 86_400;
+  const bucket: StatsBucket =
+    hours <= 24 ? "minute" : hours <= 168 ? "hour" : "day";
+  const bucketSecs =
+    bucket === "minute" ? 60 : bucket === "hour" ? 3_600 : 86_400;
   return { from: from.toISOString(), to: to.toISOString(), bucket, bucketSecs };
 }
 
@@ -49,19 +51,30 @@ export interface TunnelStatsData {
  * for intraday, 5 min for hour, 1 h for daily).
  */
 export function useTunnelStats(tunnelId: string, range: StatsRange) {
-  const { from, to, bucket, bucketSecs } = useMemo(() => makeWindow(range), [range]);
+  const { from, to, bucket, bucketSecs } = useMemo(
+    () => makeWindow(range),
+    [range],
+  );
 
   // `label_filter` is matched against the canonical sorted-JSON label
   // string the daemon writes — single-key filters are unambiguous.
-  const labelFilter = useMemo(() => JSON.stringify({ tunnel_id: tunnelId }), [tunnelId]);
+  const labelFilter = useMemo(
+    () => JSON.stringify({ tunnel_id: tunnelId }),
+    [tunnelId],
+  );
 
-  const refetchInterval = bucket === "minute" ? 60_000 : bucket === "hour" ? 5 * 60_000 : 3_600_000;
+  const refetchInterval =
+    bucket === "minute" ? 60_000 : bucket === "hour" ? 5 * 60_000 : 3_600_000;
 
   const { data, isLoading, isError, error } = useQuery({
     queryKey: ["stats", "tunnel", tunnelId, range],
     queryFn: () =>
       statsService.queryMulti({
-        metrics: ["tunnel.bytes.tx", "tunnel.bytes.rx", "tunnel.latency.rtt_ms"],
+        metrics: [
+          "tunnel.bytes.tx",
+          "tunnel.bytes.rx",
+          "tunnel.latency.rtt_ms",
+        ],
         from,
         to,
         bucket,

--- a/source/wardnet-web/src/hooks/useTunnels.ts
+++ b/source/wardnet-web/src/hooks/useTunnels.ts
@@ -57,7 +57,8 @@ export function useTestTunnel() {
   return useMutation({
     mutationFn: (id: string) => tunnelService.test(id),
     onError: (error) => {
-      const message = error instanceof Error ? error.message : "Tunnel test failed";
+      const message =
+        error instanceof Error ? error.message : "Tunnel test failed";
       // 409 surfaces as "conflict" / "test already in progress" — show a
       // dedicated toast so a rapid double-click is obviously rate-limited
       // rather than a generic failure.
@@ -67,6 +68,18 @@ export function useTestTunnel() {
         toast.error(message);
       }
     },
+  });
+}
+
+export function useRebuildTunnel() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (id: string) => tunnelService.rebuild(id),
+    onSuccess: () => {
+      toast.success("Tunnel rebuild initiated");
+      qc.invalidateQueries({ queryKey: ["tunnels"] });
+    },
+    onError: () => toast.error("Failed to rebuild tunnel"),
   });
 }
 

--- a/source/wardnet-web/src/hooks/useUpdate.ts
+++ b/source/wardnet-web/src/hooks/useUpdate.ts
@@ -63,24 +63,33 @@ export function useCheckForUpdates() {
     onSuccess: (data) => {
       qc.setQueryData(STATUS_KEY, data);
       if (data.status.update_available) {
-        toast.success(`Update available: v${data.status.latest_version}`, { id: TOAST_CHECK });
+        toast.success(`Update available: v${data.status.latest_version}`, {
+          id: TOAST_CHECK,
+        });
       } else {
         toast.success("Wardnet is up to date", { id: TOAST_CHECK });
       }
     },
-    onError: (err) => toast.error(errorMessage(err, "Update check failed"), { id: TOAST_CHECK }),
+    onError: (err) =>
+      toast.error(errorMessage(err, "Update check failed"), {
+        id: TOAST_CHECK,
+      }),
   });
 }
 
 export function useInstallUpdate() {
   const qc = useQueryClient();
   return useMutation({
-    mutationFn: (body: InstallUpdateRequest = {}) => updateService.install(body),
+    mutationFn: (body: InstallUpdateRequest = {}) =>
+      updateService.install(body),
     onSuccess: (data) => {
-      toast.success(`Installing v${data.handle.target_version}...`, { id: TOAST_INSTALL });
+      toast.success(`Installing v${data.handle.target_version}...`, {
+        id: TOAST_INSTALL,
+      });
       qc.invalidateQueries({ queryKey: STATUS_KEY });
     },
-    onError: (err) => toast.error(errorMessage(err, "Install failed"), { id: TOAST_INSTALL }),
+    onError: (err) =>
+      toast.error(errorMessage(err, "Install failed"), { id: TOAST_INSTALL }),
   });
 }
 
@@ -89,10 +98,13 @@ export function useRollbackUpdate() {
   return useMutation({
     mutationFn: () => updateService.rollback(),
     onSuccess: () => {
-      toast.success("Rollback staged — daemon will restart", { id: TOAST_ROLLBACK });
+      toast.success("Rollback staged — daemon will restart", {
+        id: TOAST_ROLLBACK,
+      });
       qc.invalidateQueries({ queryKey: STATUS_KEY });
     },
-    onError: (err) => toast.error(errorMessage(err, "Rollback failed"), { id: TOAST_ROLLBACK }),
+    onError: (err) =>
+      toast.error(errorMessage(err, "Rollback failed"), { id: TOAST_ROLLBACK }),
   });
 }
 
@@ -105,6 +117,8 @@ export function useUpdateConfig() {
       toast.success("Update settings saved", { id: TOAST_CONFIG });
     },
     onError: (err) =>
-      toast.error(errorMessage(err, "Failed to save update settings"), { id: TOAST_CONFIG }),
+      toast.error(errorMessage(err, "Failed to save update settings"), {
+        id: TOAST_CONFIG,
+      }),
   });
 }

--- a/source/wardnet-web/src/index.ts
+++ b/source/wardnet-web/src/index.ts
@@ -36,7 +36,11 @@ export {
 
 // Country / device helpers
 export { countryFlag } from "./lib/country";
-export { DEVICE_TYPE_OPTIONS, deviceTypeLabel, isDeviceOnline } from "./lib/device";
+export {
+  DEVICE_TYPE_OPTIONS,
+  deviceTypeLabel,
+  isDeviceOnline,
+} from "./lib/device";
 export { cronToHuman } from "./lib/cron";
 export { logger, createLogger, setLevel } from "./lib/logger";
 export type { Logger, LogLevel } from "./lib/logger";
@@ -52,7 +56,13 @@ export { LoginForm } from "./components/LoginForm";
 export { useAuth } from "./hooks/useAuth";
 
 // Hooks — devices
-export { useDevices, useDevice, useMyDevice, useSetMyRule, useUpdateDevice } from "./hooks/useDevices";
+export {
+  useDevices,
+  useDevice,
+  useMyDevice,
+  useSetMyRule,
+  useUpdateDevice,
+} from "./hooks/useDevices";
 
 // Hooks — tunnels
 export {
@@ -62,6 +72,7 @@ export {
   useCreateTunnel,
   useDeleteTunnel,
   useTestTunnel,
+  useRebuildTunnel,
   useSetTunnelDnsOverride,
 } from "./hooks/useTunnels";
 
@@ -82,13 +93,14 @@ export {
 } from "./hooks/useSystemStatus";
 export type { RecentError } from "./hooks/useSystemStatus";
 
-export { useDefaultPolicy, useSetDefaultPolicy } from "./hooks/useDefaultPolicy";
+export {
+  useDefaultPolicy,
+  useSetDefaultPolicy,
+} from "./hooks/useDefaultPolicy";
 
 // Hooks — daemon lifecycle
 export { useDaemonStatus } from "./hooks/useDaemonStatus";
-export {
-  useDaemonReachability,
-} from "./hooks/useDaemonReachability";
+export { useDaemonReachability } from "./hooks/useDaemonReachability";
 export type {
   DaemonReachabilityPhase,
   ReachabilityMode,
@@ -108,9 +120,15 @@ export {
   RANGES,
   RANGE_HOURS,
 } from "./hooks/useStats";
-export type { StatsRange, DnsStatsDashboardData, DashboardDnsStats } from "./hooks/useStats";
+export type {
+  StatsRange,
+  DnsStatsDashboardData,
+  DashboardDnsStats,
+} from "./hooks/useStats";
 export { useTunnelStats } from "./hooks/useTunnelStats";
 export type { TunnelStatsPoint, TunnelStatsData } from "./hooks/useTunnelStats";
+export { useCombinedTunnelStats } from "./hooks/useCombinedTunnelStats";
+export type { CombinedTunnelStatsData } from "./hooks/useCombinedTunnelStats";
 
 // Hooks — DNS
 export {
@@ -149,7 +167,11 @@ export {
 export { useDnsQueryLog } from "./hooks/useDnsLogs";
 
 // Hooks — network + DHCP
-export { useNetworkStatus, useDiscoverGatewayMac, useDhcpSelfProbe } from "./hooks/useNetwork";
+export {
+  useNetworkStatus,
+  useDiscoverGatewayMac,
+  useDhcpSelfProbe,
+} from "./hooks/useNetwork";
 export {
   useDhcpStatus,
   useDhcpConfig,

--- a/source/wardnet-web/src/lib/country.ts
+++ b/source/wardnet-web/src/lib/country.ts
@@ -2,5 +2,7 @@
 export function countryFlag(code: string): string {
   const upper = code.toUpperCase();
   if (upper.length !== 2) return "";
-  return String.fromCodePoint(...upper.split("").map((c) => 0x1f1e6 + c.charCodeAt(0) - 65));
+  return String.fromCodePoint(
+    ...upper.split("").map((c) => 0x1f1e6 + c.charCodeAt(0) - 65),
+  );
 }

--- a/source/wardnet-web/src/lib/registerSW.ts
+++ b/source/wardnet-web/src/lib/registerSW.ts
@@ -23,7 +23,9 @@ export interface RegisterSWOptions {
  * Returns a function that posts `SKIP_WAITING` to the pending SW and reloads the page,
  * or `undefined` when service workers are not supported by the browser.
  */
-export function registerSW(options: RegisterSWOptions = {}): (() => void) | undefined {
+export function registerSW(
+  options: RegisterSWOptions = {},
+): (() => void) | undefined {
   if (!("serviceWorker" in navigator)) return undefined;
 
   const {

--- a/source/wardnet-web/src/lib/sdk.ts
+++ b/source/wardnet-web/src/lib/sdk.ts
@@ -33,7 +33,10 @@ export const infoService = new InfoService(client);
 export const dhcpService = new DhcpService(client);
 export const dnsService = new DnsService(client);
 export const dnsFilterService = new DnsFilterService(client);
-export const dnsLogStreamService = new DnsLogStreamService(client, window.location.origin);
+export const dnsLogStreamService = new DnsLogStreamService(
+  client,
+  window.location.origin,
+);
 export const jobsService = new JobsService(client);
 export const logService = new LogService(client, window.location.origin);
 export const statsService = new StatsService(client);

--- a/source/wardnet-web/src/lib/utils.ts
+++ b/source/wardnet-web/src/lib/utils.ts
@@ -26,7 +26,10 @@ export function formatUptime(seconds: number): string {
 }
 
 /** Extract a user-friendly error message from an API error. */
-export function apiErrorMessage(error: unknown, fallback = "Something went wrong"): string {
+export function apiErrorMessage(
+  error: unknown,
+  fallback = "Something went wrong",
+): string {
   if (error instanceof WardnetApiError) {
     return error.body.detail ?? error.body.error;
   }
@@ -51,7 +54,9 @@ function pad(n: number): string {
 
 /** Parse a value into a Date; returns `null` if invalid or pre-2000
  *  (which the backend may emit as a stand-in for "never"). */
-function parseDate(value: Date | string | number | null | undefined): Date | null {
+function parseDate(
+  value: Date | string | number | null | undefined,
+): Date | null {
   if (value == null) return null;
   const d = value instanceof Date ? value : new Date(value);
   const ts = d.getTime();
@@ -62,14 +67,18 @@ function parseDate(value: Date | string | number | null | undefined): Date | nul
 /** YYYY-MM-DD (local time). Used everywhere a date column needs to
  *  read identically across locales — single source of truth for the
  *  date half of the app's date/time format. */
-export function formatDate(value: Date | string | number | null | undefined): string {
+export function formatDate(
+  value: Date | string | number | null | undefined,
+): string {
   const d = parseDate(value);
   if (!d) return "—";
   return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`;
 }
 
 /** HH:MM:SS in 24-hour clock (local time). */
-export function formatTime(value: Date | string | number | null | undefined): string {
+export function formatTime(
+  value: Date | string | number | null | undefined,
+): string {
   const d = parseDate(value);
   if (!d) return "—";
   return `${pad(d.getHours())}:${pad(d.getMinutes())}:${pad(d.getSeconds())}`;
@@ -77,7 +86,9 @@ export function formatTime(value: Date | string | number | null | undefined): st
 
 /** HH:MM in 24-hour clock (local time) — the compact form used in
  *  toolbars and chart axis ticks where seconds add noise. */
-export function formatTimeShort(value: Date | string | number | null | undefined): string {
+export function formatTimeShort(
+  value: Date | string | number | null | undefined,
+): string {
   const d = parseDate(value);
   if (!d) return "—";
   return `${pad(d.getHours())}:${pad(d.getMinutes())}`;
@@ -87,7 +98,9 @@ export function formatTimeShort(value: Date | string | number | null | undefined
  *  "show me when this happened" cell — keeps every row the same
  *  width and avoids the AM/PM that broke the UpdateCard layout on
  *  iPhone widths. */
-export function formatDateTime(value: Date | string | number | null | undefined): string {
+export function formatDateTime(
+  value: Date | string | number | null | undefined,
+): string {
   const d = parseDate(value);
   if (!d) return "—";
   return `${formatDate(d)} ${formatTime(d)}`;

--- a/source/wardnet-web/src/stores/authStore.ts
+++ b/source/wardnet-web/src/stores/authStore.ts
@@ -5,7 +5,11 @@ import { authService, systemService } from "../lib/sdk";
 interface AuthState {
   isAdmin: boolean;
   isChecking: boolean;
-  login: (username: string, password: string, rememberMe?: boolean) => Promise<void>;
+  login: (
+    username: string,
+    password: string,
+    rememberMe?: boolean,
+  ) => Promise<void>;
   logout: () => void;
   checkAuth: () => Promise<void>;
   refresh: () => Promise<void>;


### PR DESCRIPTION
## Summary

- **Tunnels page** (admin mobile PWA): summary header card (up/total, combined throughput + sparkline), per-tunnel cards (flag, name, status pill, rebuild button, endpoint, last handshake, cumulative data, device count via effective routing, live throughput for up tunnels), offline overlay
- **Rebuild tunnel** action across all layers: `POST /api/tunnels/{id}/rebuild` daemon endpoint → SDK method → `useRebuildTunnel` hook → rebuild icon button on admin-app cards and admin-site `TunnelCard`/`TunnelDetail`
- **Devices page** (admin-app): backfilled offline overlay; loading skeleton now gates on both devices + policy data to prevent VPN-count flash
- **`useCombinedTunnelStats`** extracted to `wardnet-web` — fetches aggregate stats for all tunnels with a rolling 1-hour window (window advances on each 60s refetch, not frozen at mount)
- **`.agents/` docs** updated: rebuild endpoint pattern, mutation hoisting convention, offline overlay pattern, live admin-app/wardnet-web entries

## Test plan

- [ ] Log in to admin PWA → navigate to `/tunnels` — summary card and per-tunnel cards render
- [ ] Verify rebuild button triggers `POST /api/tunnels/{id}/rebuild`, card enters loading state, list refreshes on completion
- [ ] Bring daemon down — Tunnels and Devices pages dim with offline overlay; header stays interactive
- [ ] Admin site `/tunnels` — Rebuild button visible on TunnelCard and TunnelDetail; Test/Delete still work
- [ ] `make check-web` passes (type-check + lint + format)

Closes #480

🤖 Generated with [Claude Code](https://claude.com/claude-code)