### PR TITLE
feat(admin-app): DNS screen + session security hardening

### DIFF
--- a/source/admin-app/src/components/Bar.tsx
+++ b/source/admin-app/src/components/Bar.tsx
@@ -1,0 +1,23 @@
+/** variant="usage" — high percent is bad (CPU, memory, disk): danger ≥90, warn ≥70, accent below.
+ *  variant="rate"  — high percent is good (cache hit rate):   accent ≥80, warn ≥50, danger below. */
+export function Bar({
+  percent,
+  variant = "usage",
+}: {
+  percent: number;
+  variant?: "usage" | "rate";
+}) {
+  const clamped = Math.min(100, Math.max(0, percent));
+  const color =
+    variant === "rate"
+      ? clamped >= 80 ? "bg-accent" : clamped >= 50 ? "bg-warn" : "bg-danger"
+      : clamped >= 90 ? "bg-danger" : clamped >= 70 ? "bg-warn" : "bg-accent";
+  return (
+    <div className="mt-1.5 h-1 overflow-hidden rounded-full bg-line">
+      <div
+        className={`h-full rounded-full transition-all ${color}`}
+        style={{ width: `${clamped}%` }}
+      />
+    </div>
+  );
+}

--- a/source/admin-app/src/components/SectionLabel.tsx
+++ b/source/admin-app/src/components/SectionLabel.tsx
@@ -1,0 +1,9 @@
+import type { ReactNode } from "react";
+
+export function SectionLabel({ children }: { children: ReactNode }) {
+  return (
+    <p className="mb-2 px-1 text-[10px] font-semibold uppercase tracking-wider text-ink-3">
+      {children}
+    </p>
+  );
+}

--- a/source/admin-app/src/components/index.ts
+++ b/source/admin-app/src/components/index.ts
@@ -5,3 +5,5 @@
 export { ConfirmDialog } from "./ConfirmDialog";
 export { BusyOverlay } from "./BusyOverlay";
 export type { BusyPhase, BusyAction } from "./BusyOverlay";
+export { SectionLabel } from "./SectionLabel";
+export { Bar } from "./Bar";

--- a/source/admin-app/src/context/OnlineStatusContext.tsx
+++ b/source/admin-app/src/context/OnlineStatusContext.tsx
@@ -1,4 +1,4 @@
-import { createContext, useContext, useEffect, useRef } from "react";
+import { createContext, useContext, useEffect, useMemo, useRef } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import { useOnlineStatus } from "@wardnet/wardnet-web";
 
@@ -18,8 +18,14 @@ export function OnlineStatusProvider({ children }: { children: React.ReactNode }
     prevReachable.current = status.isDaemonReachable;
   }, [status.isDaemonReachable, qc]);
 
+  const value = useMemo(
+    () => status,
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [status.isOnline, status.isDaemonReachable, status.showingLastKnownState],
+  );
+
   return (
-    <OnlineStatusContext.Provider value={status}>
+    <OnlineStatusContext.Provider value={value}>
       {children}
     </OnlineStatusContext.Provider>
   );

--- a/source/admin-app/src/pages/Devices.tsx
+++ b/source/admin-app/src/pages/Devices.tsx
@@ -127,7 +127,10 @@ export default function Devices() {
   if (isLoading) {
     return (
       <div className="flex flex-col gap-0 p-4">
-        <h1 className="mb-4 text-xl font-semibold text-ink">Devices</h1>
+        <div className="mb-4">
+          <h1 className="text-[28px] font-bold text-ink">Devices</h1>
+          <p className="text-[14px] text-ink-3">Manage devices and routing overrides.</p>
+        </div>
         <div className="mb-3 flex gap-2">
           {[80, 100, 90].map((w, i) => (
             <div key={i} className="h-8 animate-pulse rounded-full bg-sunken" style={{ width: w }} />
@@ -148,7 +151,10 @@ export default function Devices() {
 
   return (
     <div className="flex flex-col p-4">
-      <h1 className="mb-4 text-xl font-semibold text-ink">Devices</h1>
+      <div className="mb-4">
+        <h1 className="text-[28px] font-bold text-ink">Devices</h1>
+        <p className="text-[14px] text-ink-3">Manage devices and routing overrides.</p>
+      </div>
 
       <div className={showingLastKnownState ? "pointer-events-none opacity-40 transition-opacity" : "transition-opacity"}>
 

--- a/source/admin-app/src/pages/Dns.tsx
+++ b/source/admin-app/src/pages/Dns.tsx
@@ -1,8 +1,274 @@
+import { useState } from "react";
+import { GlobeIcon, ShieldIcon, Trash2Icon, Loader2Icon } from "lucide-react";
+import { Pill } from "@wardnet/forge-web/pill";
+import { Sparkline } from "@wardnet/forge-web/sparkline";
+import { Toggle } from "@wardnet/forge-web/toggle";
+import {
+  useDnsStatus,
+  useDnsConfig,
+  useToggleDns,
+  useUpdateDnsConfig,
+  useFlushDnsCache,
+  useDashboardDnsStats,
+  useDnsTopBlockedDomains,
+  parseLabels,
+} from "@wardnet/wardnet-web";
+import { useOnlineStatusContext } from "@/context/OnlineStatusContext";
+import { ConfirmDialog } from "@/components/ConfirmDialog";
+import { SectionLabel } from "@/components/SectionLabel";
+import { Bar } from "@/components/Bar";
+
 export default function Dns() {
+  const { data: status, isLoading: statusLoading } = useDnsStatus();
+  const { data: configData, isLoading: configLoading } = useDnsConfig();
+  const { data: dnsStats, isLoading: statsLoading } = useDashboardDnsStats();
+  const { data: topDomains, isLoading: topDomainsLoading } = useDnsTopBlockedDomains(10);
+  const toggleDns = useToggleDns();
+  const updateConfig = useUpdateDnsConfig();
+  const flushCache = useFlushDnsCache();
+  const { showingLastKnownState } = useOnlineStatusContext();
+
+  const [dnsToggleConfirmOpen, setDnsToggleConfirmOpen] = useState(false);
+  const [filterToggleConfirmOpen, setFilterToggleConfirmOpen] = useState(false);
+
+  const isLoading = statusLoading || configLoading || statsLoading || topDomainsLoading;
+  const config = configData?.config;
+  const dnsEnabled = config?.enabled ?? false;
+  const filteringEnabled = config?.dns_filtering_enabled ?? false;
+  const isRunning = status?.running ?? false;
+  const cacheSize = status?.cache_size ?? 0;
+  const cacheCapacity = status?.cache_capacity ?? 0;
+  const cacheHitRate = status?.cache_hit_rate ?? 0;
+  const topEntries = topDomains?.entries ?? [];
+
+  if (isLoading) {
+    return (
+      <div className="flex flex-col gap-5 p-4">
+        <div>
+          <div className="h-8 w-24 animate-pulse rounded-lg bg-sunken" />
+          <div className="mt-1 h-4 w-48 animate-pulse rounded bg-sunken" />
+        </div>
+        <div className="h-52 animate-pulse rounded-xl bg-sunken" />
+        <div className="h-28 animate-pulse rounded-xl bg-sunken" />
+        <div className="h-48 animate-pulse rounded-xl bg-sunken" />
+      </div>
+    );
+  }
+
   return (
-    <div className="flex flex-col gap-4 p-4">
-      <h1 className="text-xl font-semibold text-ink">DNS</h1>
-      <p className="text-sm text-ink-3">Coming in a subsequent issue.</p>
+    <div className="flex flex-col gap-5 p-4">
+      {/* Page header */}
+      <div>
+        <h1 className="text-[28px] font-bold text-ink">DNS</h1>
+        <p className="text-[14px] text-ink-3">Server status, stats, and filtering.</p>
+      </div>
+
+      <div
+        className={
+          showingLastKnownState
+            ? "pointer-events-none opacity-40 transition-opacity"
+            : "transition-opacity"
+        }
+      >
+        <div className="flex flex-col gap-5">
+
+          {/* ── Status card ── */}
+          <div>
+            <SectionLabel>Status</SectionLabel>
+            <div className="rounded-xl border border-line bg-card p-4">
+              {/* Running state row */}
+              <div className="flex items-center gap-2.5">
+                <span
+                  className={`size-2 shrink-0 rounded-full ${isRunning ? "bg-accent" : "bg-warn"}`}
+                />
+                <span className="text-[15px] font-semibold text-ink">DNS Server</span>
+                <div className="ml-auto">
+                  <Pill variant={isRunning ? "ok" : "down"}>
+                    <span className="mr-1" aria-hidden>●</span>
+                    {isRunning ? "Running" : "Stopped"}
+                  </Pill>
+                </div>
+              </div>
+
+              {/* Stats + cache metric grid */}
+              <div className="mt-4 grid grid-cols-2 gap-x-4 gap-y-4 border-t border-line pt-4">
+                <div>
+                  <p className="text-[10px] font-semibold uppercase tracking-wider text-ink-3">
+                    Queries · 24h
+                  </p>
+                  <p className="mt-1 text-[14px] text-ink tabular-nums">
+                    {dnsStats?.total.toLocaleString() ?? "—"}
+                  </p>
+                  {dnsStats && dnsStats.totalSeries.length > 0 && (
+                    <div className="mt-1.5 h-6">
+                      <Sparkline
+                        values={dnsStats.totalSeries}
+                        color="var(--color-ink-3)"
+                        area={false}
+                      />
+                    </div>
+                  )}
+                </div>
+                <div>
+                  <p className="text-[10px] font-semibold uppercase tracking-wider text-ink-3">
+                    Blocked · 24h
+                  </p>
+                  <p className="mt-1 text-[14px] text-ink tabular-nums">
+                    {dnsStats ? `${dnsStats.blockedPercent.toFixed(1)}%` : "—"}
+                  </p>
+                  {dnsStats && dnsStats.blockedSeries.length > 0 && (
+                    <div className="mt-1.5 h-6">
+                      <Sparkline
+                        values={dnsStats.blockedSeries}
+                        color="var(--color-warn)"
+                        area={false}
+                      />
+                    </div>
+                  )}
+                </div>
+                <div>
+                  <p className="text-[10px] font-semibold uppercase tracking-wider text-ink-3">
+                    Cache
+                  </p>
+                  <p className="mt-1 text-[14px] text-ink tabular-nums">
+                    {cacheSize.toLocaleString()} / {cacheCapacity.toLocaleString()}
+                  </p>
+                </div>
+                <div>
+                  <p className="text-[10px] font-semibold uppercase tracking-wider text-ink-3">
+                    Hit Rate
+                  </p>
+                  <p className="mt-1 text-[14px] text-ink tabular-nums">
+                    {(cacheHitRate * 100).toFixed(1)}%
+                  </p>
+                  <Bar percent={cacheHitRate * 100} variant="rate" />
+                </div>
+              </div>
+
+              {/* Flush cache action */}
+              <div className="mt-4 flex justify-end border-t border-line pt-4">
+                <button
+                  onClick={() => flushCache.mutate()}
+                  disabled={flushCache.isPending}
+                  className="flex items-center gap-1.5 text-[13px] font-medium text-ink-3 disabled:opacity-40 active:text-ink"
+                >
+                  {flushCache.isPending ? (
+                    <Loader2Icon size={13} className="animate-spin" />
+                  ) : (
+                    <Trash2Icon size={13} />
+                  )}
+                  Flush DNS cache
+                </button>
+              </div>
+            </div>
+          </div>
+
+          {/* ── Controls section — split cards ── */}
+          <div>
+            <SectionLabel>Controls</SectionLabel>
+            <div className="flex flex-col gap-2">
+              <div className="flex items-center gap-3 rounded-xl border border-line bg-card px-4 py-3.5">
+                <div className="flex size-10 shrink-0 items-center justify-center rounded-xl bg-sunken">
+                  <GlobeIcon size={18} className="text-ink-2" />
+                </div>
+                <div className="min-w-0 flex-1">
+                  <p className="text-[14px] font-semibold text-ink">DNS Server</p>
+                  <p className="text-[12px] text-ink-3">Enable or disable the DNS resolver</p>
+                </div>
+                <Toggle
+                  checked={dnsEnabled}
+                  onCheckedChange={() => setDnsToggleConfirmOpen(true)}
+                  disabled={toggleDns.isPending}
+                  aria-label="Toggle DNS server"
+                />
+              </div>
+
+              <div className="flex items-center gap-3 rounded-xl border border-line bg-card px-4 py-3.5">
+                <div className="flex size-10 shrink-0 items-center justify-center rounded-xl bg-sunken">
+                  <ShieldIcon size={18} className="text-ink-2" />
+                </div>
+                <div className="min-w-0 flex-1">
+                  <p className="text-[14px] font-semibold text-ink">DNS Filtering</p>
+                  <p className="text-[12px] text-ink-3">Global emergency stop for all filtering</p>
+                </div>
+                <Toggle
+                  checked={filteringEnabled}
+                  onCheckedChange={() => setFilterToggleConfirmOpen(true)}
+                  disabled={updateConfig.isPending}
+                  aria-label="Toggle DNS filtering"
+                />
+              </div>
+            </div>
+          </div>
+
+          {/* ── Top blocked domains ── */}
+          <div>
+            <SectionLabel>Top Blocked Domains · 24h</SectionLabel>
+            <div className="rounded-xl border border-line bg-card">
+              {topEntries.length === 0 ? (
+                <p className="py-8 text-center text-[13px] text-ink-3">
+                  No blocked queries in the last 24 hours.
+                </p>
+              ) : (
+                <ol className="divide-y divide-line">
+                  {topEntries.map((entry, i) => {
+                    const domain =
+                      parseLabels(entry.labels).domain ?? entry.labels;
+                    return (
+                      <li key={domain ?? String(i)} className="flex items-center gap-3 px-4 py-3">
+                        <span className="w-5 shrink-0 text-right text-[12px] text-ink-4 tabular-nums">
+                          {i + 1}
+                        </span>
+                        <span className="min-w-0 flex-1 truncate font-mono text-[13px] text-ink">
+                          {domain}
+                        </span>
+                        <span className="shrink-0 text-[13px] text-ink-3 tabular-nums">
+                          {entry.total.toLocaleString()}
+                        </span>
+                      </li>
+                    );
+                  })}
+                </ol>
+              )}
+            </div>
+          </div>
+
+        </div>
+      </div>
+
+      {/* Confirm dialogs */}
+      <ConfirmDialog
+        open={dnsToggleConfirmOpen}
+        onOpenChange={setDnsToggleConfirmOpen}
+        onConfirm={() => {
+          toggleDns.mutate(!dnsEnabled);
+          setDnsToggleConfirmOpen(false);
+        }}
+        title={dnsEnabled ? "Disable DNS server?" : "Enable DNS server?"}
+        description={
+          dnsEnabled
+            ? "All devices on the network will lose DNS resolution until the server is re-enabled."
+            : "The DNS server will start resolving queries for all devices."
+        }
+        confirmLabel={dnsEnabled ? "Disable" : "Enable"}
+        variant={dnsEnabled ? "danger" : "warn"}
+      />
+      <ConfirmDialog
+        open={filterToggleConfirmOpen}
+        onOpenChange={setFilterToggleConfirmOpen}
+        onConfirm={() => {
+          updateConfig.mutate({ dns_filtering_enabled: !filteringEnabled });
+          setFilterToggleConfirmOpen(false);
+        }}
+        title={filteringEnabled ? "Disable DNS filtering?" : "Enable DNS filtering?"}
+        description={
+          filteringEnabled
+            ? "All filtering will be bypassed for every device. Blocklists and custom rules will have no effect."
+            : "DNS filtering will resume for all devices using their configured profiles."
+        }
+        confirmLabel={filteringEnabled ? "Disable filtering" : "Enable filtering"}
+        variant={filteringEnabled ? "danger" : "warn"}
+      />
     </div>
   );
 }

--- a/source/admin-app/src/pages/System.tsx
+++ b/source/admin-app/src/pages/System.tsx
@@ -16,32 +16,8 @@ import { useOnlineStatusContext } from "@/context/OnlineStatusContext";
 import { useBiometric } from "@/hooks/useBiometric";
 import { BusyOverlay } from "@/components/BusyOverlay";
 import { ConfirmDialog } from "@/components/ConfirmDialog";
-
-function barColor(percent: number): string {
-  if (percent >= 90) return "bg-danger";
-  if (percent >= 70) return "bg-warn";
-  return "bg-accent";
-}
-
-function SectionLabel({ children }: { children: React.ReactNode }) {
-  return (
-    <p className="mb-2 px-1 text-[10px] font-semibold uppercase tracking-wider text-ink-3">
-      {children}
-    </p>
-  );
-}
-
-function Bar({ percent }: { percent: number }) {
-  const clamped = Math.min(100, Math.max(0, percent));
-  return (
-    <div className="mt-1.5 h-1 overflow-hidden rounded-full bg-line">
-      <div
-        className={`h-full rounded-full transition-all ${barColor(clamped)}`}
-        style={{ width: `${clamped}%` }}
-      />
-    </div>
-  );
-}
+import { SectionLabel } from "@/components/SectionLabel";
+import { Bar } from "@/components/Bar";
 
 export default function System() {
   const { data: status } = useSystemStatus();

--- a/source/admin-app/src/pages/Tunnels.tsx
+++ b/source/admin-app/src/pages/Tunnels.tsx
@@ -184,7 +184,10 @@ export default function Tunnels() {
   if (isLoading) {
     return (
       <div className="flex flex-col gap-4 p-4">
-        <h1 className="text-xl font-semibold text-ink">Tunnels</h1>
+        <div>
+          <h1 className="text-[28px] font-bold text-ink">Tunnels</h1>
+          <p className="text-[14px] text-ink-3">VPN tunnel status and throughput.</p>
+        </div>
         <div className="h-24 animate-pulse rounded-xl bg-sunken" />
         {Array.from({ length: 3 }).map((_, i) => (
           <div key={i} className="h-48 animate-pulse rounded-xl bg-sunken" />
@@ -195,7 +198,10 @@ export default function Tunnels() {
 
   return (
     <div className="flex flex-col gap-4 p-4">
-      <h1 className="text-xl font-semibold text-ink">Tunnels</h1>
+      <div>
+        <h1 className="text-[28px] font-bold text-ink">Tunnels</h1>
+        <p className="text-[14px] text-ink-3">VPN tunnel status and throughput.</p>
+      </div>
 
       <div className={showingLastKnownState ? "pointer-events-none opacity-40 transition-opacity" : "transition-opacity"}>
       <div className="flex flex-col gap-4">

--- a/source/daemon/crates/wardnetd-data/src/repository/session.rs
+++ b/source/daemon/crates/wardnetd-data/src/repository/session.rs
@@ -30,9 +30,17 @@ pub trait SessionRepository: Send + Sync {
     /// Slide the expiry forward for an existing session (used by the refresh endpoint).
     async fn extend_expiry(&self, token_hash: &str, new_expires_at: &str) -> anyhow::Result<()>;
 
+    /// Atomically replace the token hash and extend expiry (token rotation on refresh).
+    async fn rotate_token(
+        &self,
+        old_token_hash: &str,
+        new_token_hash: &str,
+        new_expires_at: &str,
+    ) -> anyhow::Result<()>;
+
     /// Atomically look up a session for the refresh endpoint.
     ///
-    /// Returns `Some((admin_id, remember_me))` when the session exists and has
+    /// Returns `Some((admin_id, remember_me, created_at))` when the session exists and has
     /// not expired; `None` otherwise. Using a single query eliminates the
     /// race window between the two-call pattern
     /// (`find_admin_id_by_token_hash` + separate `remember_me` lookup) where
@@ -41,5 +49,5 @@ pub trait SessionRepository: Send + Sync {
         &self,
         token_hash: &str,
         now: &str,
-    ) -> anyhow::Result<Option<(String, bool)>>;
+    ) -> anyhow::Result<Option<(String, bool, String)>>;
 }

--- a/source/daemon/crates/wardnetd-data/src/repository/sqlite/session.rs
+++ b/source/daemon/crates/wardnetd-data/src/repository/sqlite/session.rs
@@ -81,13 +81,29 @@ impl SessionRepository for SqliteSessionRepository {
         Ok(())
     }
 
+    async fn rotate_token(
+        &self,
+        old_token_hash: &str,
+        new_token_hash: &str,
+        new_expires_at: &str,
+    ) -> anyhow::Result<()> {
+        sqlx::query("UPDATE sessions SET token_hash = ?, expires_at = ? WHERE token_hash = ?")
+            .bind(new_token_hash)
+            .bind(new_expires_at)
+            .bind(old_token_hash)
+            .execute(&self.pools.write)
+            .await?;
+        Ok(())
+    }
+
     async fn find_session_for_refresh(
         &self,
         token_hash: &str,
         now: &str,
-    ) -> anyhow::Result<Option<(String, bool)>> {
-        let row = sqlx::query_as::<_, (String, bool)>(
-            "SELECT admin_id, remember_me FROM sessions WHERE token_hash = ? AND expires_at > ?",
+    ) -> anyhow::Result<Option<(String, bool, String)>> {
+        let row = sqlx::query_as::<_, (String, bool, String)>(
+            "SELECT admin_id, remember_me, created_at FROM sessions \
+             WHERE token_hash = ? AND expires_at > ?",
         )
         .bind(token_hash)
         .bind(now)

--- a/source/daemon/crates/wardnetd-data/src/repository/tests/session.rs
+++ b/source/daemon/crates/wardnetd-data/src/repository/tests/session.rs
@@ -141,13 +141,21 @@ async fn find_session_for_refresh_returns_admin_id_and_flag() {
     let now = "2026-06-01T00:00:00Z";
     assert_eq!(
         repo.find_session_for_refresh("hash-rm", now).await.unwrap(),
-        Some(("admin-1".to_owned(), true))
+        Some((
+            "admin-1".to_owned(),
+            true,
+            "2026-01-01T00:00:00Z".to_owned()
+        ))
     );
     assert_eq!(
         repo.find_session_for_refresh("hash-short", now)
             .await
             .unwrap(),
-        Some(("admin-1".to_owned(), false))
+        Some((
+            "admin-1".to_owned(),
+            false,
+            "2026-01-01T00:00:00Z".to_owned()
+        ))
     );
     // Expired session returns None.
     assert_eq!(
@@ -162,5 +170,43 @@ async fn find_session_for_refresh_returns_admin_id_and_flag() {
             .await
             .unwrap(),
         None
+    );
+}
+
+#[tokio::test]
+async fn rotate_token_replaces_hash_and_expiry() {
+    let pool = test_pool().await;
+    seed_admin(&pool).await;
+    let repo = SqliteSessionRepository::new(pool);
+
+    repo.create(
+        "s1",
+        "admin-1",
+        "old-hash",
+        "2026-01-01T00:00:00Z",
+        "2099-01-01T00:00:00Z",
+        true,
+    )
+    .await
+    .unwrap();
+
+    repo.rotate_token("old-hash", "new-hash", "2099-06-01T00:00:00Z")
+        .await
+        .unwrap();
+
+    // Old hash no longer resolves.
+    assert!(
+        repo.find_admin_id_by_token_hash("old-hash", "2026-06-01T00:00:00Z")
+            .await
+            .unwrap()
+            .is_none()
+    );
+
+    // New hash resolves correctly.
+    assert_eq!(
+        repo.find_admin_id_by_token_hash("new-hash", "2026-06-01T00:00:00Z")
+            .await
+            .unwrap(),
+        Some("admin-1".to_owned())
     );
 }

--- a/source/daemon/crates/wardnetd-services/src/auth/service.rs
+++ b/source/daemon/crates/wardnetd-services/src/auth/service.rs
@@ -103,6 +103,9 @@ pub trait AuthService: Send + Sync {
     ) -> Result<WizardState, AppError>;
 }
 
+/// Maximum lifetime of a `remember_me` session regardless of sliding-window refreshes.
+const MAX_SESSION_DAYS: i64 = 90;
+
 /// Default implementation of [`AuthService`] backed by repository traits.
 pub struct AuthServiceImpl {
     admins: Arc<dyn AdminRepository>,
@@ -197,19 +200,38 @@ impl AuthService for AuthServiceImpl {
     async fn refresh_session(&self, token: &str) -> Result<LoginResult, AppError> {
         auth_context::require_admin()?;
 
+        // Extract the calling admin's identity for cross-validation below.
+        let wardnet_common::auth::AuthContext::Admin {
+            admin_id: ctx_admin_id,
+        } = auth_context::current()
+        else {
+            return Err(AppError::Forbidden(
+                "must be authenticated as admin".to_owned(),
+            ));
+        };
+
         let token_hash = hex::encode(Sha256::digest(token.as_bytes()));
         let now = chrono::Utc::now();
         let now_str = now.to_rfc3339();
 
         // Single atomic query: validates the session is non-expired and retrieves
-        // remember_me in one round-trip, eliminating the race window where
+        // remember_me + created_at in one round-trip, eliminating the race window where
         // delete_expired() could remove the row between two sequential reads.
-        let (_, is_refreshable) = self
+        let (session_admin_id, is_refreshable, created_at_str) = self
             .sessions
             .find_session_for_refresh(&token_hash, &now_str)
             .await
             .map_err(AppError::Internal)?
             .ok_or_else(|| AppError::Unauthorized("session not found or expired".to_owned()))?;
+
+        // Cross-validate: the session row must belong to the calling admin.
+        let session_admin_uuid = Uuid::parse_str(&session_admin_id)
+            .map_err(|_| AppError::Internal(anyhow::anyhow!("invalid admin_id in session row")))?;
+        if session_admin_uuid != ctx_admin_id {
+            return Err(AppError::Forbidden(
+                "session does not belong to this admin".to_owned(),
+            ));
+        }
 
         if !is_refreshable {
             return Err(AppError::Forbidden(
@@ -217,19 +239,36 @@ impl AuthService for AuthServiceImpl {
             ));
         }
 
+        // Enforce an absolute lifetime cap so remember_me sessions cannot refresh indefinitely.
+        let created_at = chrono::DateTime::parse_from_rfc3339(&created_at_str)
+            .map_err(|_| AppError::Internal(anyhow::anyhow!("invalid created_at in session row")))?
+            .with_timezone(&chrono::Utc);
+        let absolute_expiry = created_at + chrono::Duration::days(MAX_SESSION_DAYS);
+        if now >= absolute_expiry {
+            return Err(AppError::Unauthorized(
+                "session has exceeded maximum lifetime — please log in again".to_owned(),
+            ));
+        }
+
         let expiry_hours_i64 = self
             .remember_me_expiry_hours
             .min(i64::MAX as u64)
             .cast_signed();
-        let new_expires_at = now + chrono::Duration::hours(expiry_hours_i64);
+        let slid_expiry = now + chrono::Duration::hours(expiry_hours_i64);
+        let new_expires_at = slid_expiry.min(absolute_expiry);
+
+        // Rotate token: generate a fresh secret so a captured token cannot be re-used.
+        let new_token_bytes: [u8; 32] = rand::random();
+        let new_token = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(new_token_bytes);
+        let new_token_hash = hex::encode(Sha256::digest(new_token.as_bytes()));
 
         self.sessions
-            .extend_expiry(&token_hash, &new_expires_at.to_rfc3339())
+            .rotate_token(&token_hash, &new_token_hash, &new_expires_at.to_rfc3339())
             .await
             .map_err(AppError::Internal)?;
 
         Ok(LoginResult {
-            token: token.to_owned(),
+            token: new_token,
             max_age_seconds: self.remember_me_expiry_hours * 3600,
         })
     }

--- a/source/daemon/crates/wardnetd-services/src/auth/tests/auth.rs
+++ b/source/daemon/crates/wardnetd-services/src/auth/tests/auth.rs
@@ -39,7 +39,7 @@ struct MockSessionRepo {
     /// Returned by `find_admin_id_by_token_hash` (drives `validate_session`).
     find_result: Mutex<Option<String>>,
     /// Returned by `find_session_for_refresh` (drives `refresh_session`).
-    session_for_refresh: Mutex<Option<(String, bool)>>,
+    session_for_refresh: Mutex<Option<(String, bool, String)>>,
 }
 
 #[async_trait]
@@ -68,11 +68,19 @@ impl SessionRepository for MockSessionRepo {
     async fn extend_expiry(&self, _token_hash: &str, _new_expires_at: &str) -> anyhow::Result<()> {
         Ok(())
     }
+    async fn rotate_token(
+        &self,
+        _old_token_hash: &str,
+        _new_token_hash: &str,
+        _new_expires_at: &str,
+    ) -> anyhow::Result<()> {
+        Ok(())
+    }
     async fn find_session_for_refresh(
         &self,
         _token_hash: &str,
         _now: &str,
-    ) -> anyhow::Result<Option<(String, bool)>> {
+    ) -> anyhow::Result<Option<(String, bool, String)>> {
         Ok(self.session_for_refresh.lock().unwrap().clone())
     }
 }
@@ -134,7 +142,10 @@ fn make_auth_service(
     session_find: Option<String>,
     api_key_hashes: Vec<(String, String)>,
 ) -> AuthServiceImpl {
-    let session_for_refresh = session_find.as_ref().map(|id| (id.clone(), true));
+    let recent_created_at = (chrono::Utc::now() - chrono::Duration::days(30)).to_rfc3339();
+    let session_for_refresh = session_find
+        .as_ref()
+        .map(|id| (id.clone(), true, recent_created_at));
     AuthServiceImpl::new(
         Arc::new(MockAdminRepo {
             find_result: Mutex::new(admin_find),
@@ -280,19 +291,21 @@ async fn is_setup_completed_delegates() {
 
 #[tokio::test]
 async fn refresh_session_success() {
-    // Session exists and was created as remember_me=true → extends expiry.
+    // Session exists and was created as remember_me=true → rotates token and extends expiry.
     let admin_uuid = "00000000-0000-0000-0000-000000000001";
     let svc = make_auth_service(None, None, Some(admin_uuid.to_owned()), vec![]);
     let result = auth_context::with_context(
         AuthContext::Admin {
-            admin_id: Uuid::nil(),
+            admin_id: Uuid::parse_str(admin_uuid).unwrap(),
         },
         async { svc.refresh_session("any-token").await },
     )
     .await;
     assert!(result.is_ok());
     let r = result.unwrap();
+    // Token must be rotated: returned token must be non-empty and different from the input.
     assert!(!r.token.is_empty());
+    assert_ne!(r.token, "any-token");
     assert_eq!(r.max_age_seconds, 720 * 3600);
 }
 
@@ -308,7 +321,11 @@ async fn refresh_session_not_remember_me_returns_forbidden() {
         }),
         Arc::new(MockSessionRepo {
             find_result: Mutex::new(Some(admin_uuid.to_owned())),
-            session_for_refresh: Mutex::new(Some((admin_uuid.to_owned(), false))),
+            session_for_refresh: Mutex::new(Some((
+                admin_uuid.to_owned(),
+                false,
+                (chrono::Utc::now() - chrono::Duration::days(30)).to_rfc3339(),
+            ))),
         }),
         Arc::new(MockApiKeyRepo { hashes: vec![] }),
         Arc::new(MockSystemConfigRepo),
@@ -317,7 +334,7 @@ async fn refresh_session_not_remember_me_returns_forbidden() {
     );
     let result = auth_context::with_context(
         AuthContext::Admin {
-            admin_id: Uuid::nil(),
+            admin_id: Uuid::parse_str(admin_uuid).unwrap(),
         },
         async { svc.refresh_session("any-token").await },
     )

--- a/source/daemon/crates/wardnetd-services/src/auth/tests/setup.rs
+++ b/source/daemon/crates/wardnetd-services/src/auth/tests/setup.rs
@@ -87,11 +87,19 @@ impl SessionRepository for MockSessionRepo {
     async fn extend_expiry(&self, _token_hash: &str, _new_expires_at: &str) -> anyhow::Result<()> {
         Ok(())
     }
+    async fn rotate_token(
+        &self,
+        _old_token_hash: &str,
+        _new_token_hash: &str,
+        _new_expires_at: &str,
+    ) -> anyhow::Result<()> {
+        Ok(())
+    }
     async fn find_session_for_refresh(
         &self,
         _token_hash: &str,
         _now: &str,
-    ) -> anyhow::Result<Option<(String, bool)>> {
+    ) -> anyhow::Result<Option<(String, bool, String)>> {
         Ok(None)
     }
 }

--- a/source/daemon/crates/wardnetd-services/src/auth/tests/wizard.rs
+++ b/source/daemon/crates/wardnetd-services/src/auth/tests/wizard.rs
@@ -73,11 +73,19 @@ impl SessionRepository for MockSessionRepo {
     async fn extend_expiry(&self, _token_hash: &str, _new_expires_at: &str) -> anyhow::Result<()> {
         Ok(())
     }
+    async fn rotate_token(
+        &self,
+        _old_token_hash: &str,
+        _new_token_hash: &str,
+        _new_expires_at: &str,
+    ) -> anyhow::Result<()> {
+        Ok(())
+    }
     async fn find_session_for_refresh(
         &self,
         _token_hash: &str,
         _now: &str,
-    ) -> anyhow::Result<Option<(String, bool)>> {
+    ) -> anyhow::Result<Option<(String, bool, String)>> {
         Ok(None)
     }
 }

--- a/source/daemon/crates/wardnetd-services/src/system/service.rs
+++ b/source/daemon/crates/wardnetd-services/src/system/service.rs
@@ -246,12 +246,17 @@ impl SystemService for SystemServiceImpl {
         };
 
         let (disk_free_bytes, disk_total_bytes) = if let Some(ref db_path) = self.db_path {
-            let disks = Disks::new_with_refreshed_list();
-            let best = disks
-                .iter()
-                .filter(|d| db_path.starts_with(d.mount_point()))
-                .max_by_key(|d| d.mount_point().as_os_str().len());
-            best.map_or((0, 0), |d| (d.available_space(), d.total_space()))
+            let path = db_path.clone();
+            tokio::task::spawn_blocking(move || {
+                let disks = Disks::new_with_refreshed_list();
+                let best = disks
+                    .iter()
+                    .filter(|d| path.starts_with(d.mount_point()))
+                    .max_by_key(|d| d.mount_point().as_os_str().len());
+                best.map_or((0, 0), |d| (d.available_space(), d.total_space()))
+            })
+            .await
+            .map_err(|e| AppError::Internal(e.into()))?
         } else {
             (0, 0)
         };

--- a/source/wardnet-web/src/hooks/useStats.ts
+++ b/source/wardnet-web/src/hooks/useStats.ts
@@ -35,7 +35,7 @@ function makeWindow(range: StatsRange): {
   return { from: from.toISOString(), to: to.toISOString(), bucket };
 }
 
-function parseLabels(json: string): Record<string, string> {
+export function parseLabels(json: string): Record<string, string> {
   try {
     return JSON.parse(json) as Record<string, string>;
   } catch {
@@ -259,4 +259,22 @@ export function useDashboardDnsStats() {
   }, [data]);
 
   return { data: derived, isLoading, isError, error };
+}
+
+export function useDnsTopBlockedDomains(limit = 10) {
+  return useQuery({
+    queryKey: ["stats", "dns-top-blocked-domains", limit],
+    queryFn: () => {
+      const now = new Date();
+      const from = new Date(now.getTime() - 24 * 3_600_000).toISOString();
+      return statsService.top({
+        metric: "dns.queries.by_domain",
+        label_key: "domain",
+        from,
+        to: now.toISOString(),
+        limit,
+      });
+    },
+    refetchInterval: 30_000,
+  });
 }

--- a/source/wardnet-web/src/index.ts
+++ b/source/wardnet-web/src/index.ts
@@ -117,6 +117,8 @@ export {
   useDnsStatSummary,
   useDnsStatsDashboard,
   useDashboardDnsStats,
+  useDnsTopBlockedDomains,
+  parseLabels,
   RANGES,
   RANGE_HOURS,
 } from "./hooks/useStats";


### PR DESCRIPTION
## Summary

- **DNS screen** (`/dns`) for the admin mobile PWA: status card with running state, 24h query/blocked sparklines, cache stats + hit-rate bar, flush-cache action, DNS server toggle, global filtering emergency-stop toggle (both with bottom-drawer confirmation), and top-10 blocked domains list
- **Shared UI components**: `Bar` (with `variant="usage"|"rate"` thresholds) and `SectionLabel` extracted from `System.tsx` so all pages share one implementation
- **Page title alignment**: Devices and Tunnels pages updated to the `text-[28px]/subtitle` header pattern introduced by System
- **Hook additions**: `useDnsTopBlockedDomains`, `parseLabels` exported from `wardnet-web`
- **Context fix**: `OnlineStatusContext` value memoized to prevent cascade re-renders across all page consumers
- **Session security hardening**: token rotation on refresh (captured tokens can't be replayed), 90-day absolute lifetime cap on `remember_me` sessions, admin_id cross-validation in `refresh_session`
- **System service**: disk scan (`Disks::new_with_refreshed_list`) moved to `spawn_blocking`

## Test plan

- [ ] `make check-daemon` passes (fmt + clippy + all tests including new `rotate_token_replaces_hash_and_expiry` and updated `find_session_for_refresh` tests)
- [ ] `make check-web` passes (typecheck + lint + format for all web packages)
- [ ] DNS page renders at `/admin-app/dns`: status card, stats sparklines, cache bar, controls toggles, top blocked domains list
- [ ] Tapping a toggle opens the confirm drawer; cancelling leaves state unchanged; confirming fires the mutation and shows toast
- [ ] Flush cache button fires and shows success toast
- [ ] Loading skeleton covers all four queries before the page is shown
- [ ] Offline fade (`opacity-40`) applies when daemon is unreachable
- [ ] Session refresh returns a different token each call (token rotation)
- [ ] Session refresh is rejected after 90 days from `created_at`

Closes #439

🤖 Generated with [Claude Code](https://claude.com/claude-code)