### PR TITLE
fix(ci): install Codecov CLI from PyPI to work around broken keybase GPG verification (#1956)

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -235,11 +235,29 @@ jobs:
           echo "lcov=${LCOV%,}" >> $GITHUB_OUTPUT
           echo "junit=${JUNIT%,}" >> $GITHUB_OUTPUT
 
+      # Pre-install the Codecov CLI from PyPI and hand it to both upload
+      # steps via `binary:`. The default path (download from cli.codecov.io
+      # + PGP verification against keybase.io) currently hangs until the
+      # job timeout: Codecov migrated their keybase account, bricking the
+      # old one and breaking signature verification — codecov/codecov-action#1956.
+      # PyPI provides its own integrity, so this avoids the broken keybase
+      # path WITHOUT `skip_validation` (which would disable integrity
+      # checking outright). Revert to the action's own download once
+      # upstream ships the fix.
+      - name: Install Codecov CLI from PyPI
+        id: codecovcli
+        if: ${{ !cancelled() && (steps.files.outputs.lcov != '' || steps.files.outputs.junit != '') }}
+        run: |
+          python3 -m venv "$RUNNER_TEMP/codecov-cli-venv"
+          "$RUNNER_TEMP/codecov-cli-venv/bin/pip" install --quiet codecov-cli
+          echo "bin=$RUNNER_TEMP/codecov-cli-venv/bin/codecovcli" >> "$GITHUB_OUTPUT"
+
       - name: Upload coverage to Codecov
         if: steps.files.outputs.lcov != ''
-        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v6
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           files: ${{ steps.files.outputs.lcov }}
+          binary: ${{ steps.codecovcli.outputs.bin }}
           fail_ci_if_error: false
           token: ${{ secrets.CODECOV_TOKEN }}
 
@@ -248,5 +266,6 @@ jobs:
         uses: codecov/test-results-action@0fa95f0e1eeaafde2c782583b36b28ad0d8c77d3 # v1
         with:
           files: ${{ steps.files.outputs.junit }}
+          binary: ${{ steps.codecovcli.outputs.bin }}
           fail_ci_if_error: false
           token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
## Problem

Since the codecov-action 6→7 bump (#562), the **Upload to Codecov** step
hangs until the job's 5-minute timeout and fails the required
**"All checks passed"** gate — repo-wide.

Root cause is upstream and current: codecov-action's CLI integrity check
downloads the CLI from `cli.codecov.io` and verifies its PGP signature
against **keybase.io**, and Codecov just migrated their keybase account
(`codecovsecurity` → `codecovsecops`), bricking the old one and breaking
verification — [codecov/codecov-action#1956](https://github.com/codecov/codecov-action/issues/1956).
The `gpg`/`curl keybase.io` processes block until the runner kills them
(confirmed: orphaned `gpg`/`curl` pids at cleanup). `fail_ci_if_error: false`
doesn't help because it **hangs** rather than erroring.

## Fix

Pre-install the Codecov CLI from **PyPI** into a venv and pass it to both
upload steps via `binary:`, bypassing the `cli.codecov.io` download and
its keybase verification. PyPI provides its own integrity, so this avoids
`skip_validation` (which would disable integrity checking and weaken
supply-chain posture). Applied to both `codecov/codecov-action` and
`codecov/test-results-action`; also corrects the stale `# v6` pin comment
to `# v7.0.0`.

Revert to the action's own download once upstream ships the keybase fix.

## Verification

Verified working in an earlier run: the Codecov upload completes in ~29s
instead of timing out.