### PR TITLE
feat(user-app): routing control on Home tab (#590)

### DIFF
--- a/source/user-app/package.json
+++ b/source/user-app/package.json
@@ -17,7 +17,7 @@
     "@wardnet/web": "portal:../web",
     "lucide-react": "1.14.0",
     "react": "19.2.7",
-    "react-dom": "19.2.5",
+    "react-dom": "19.2.7",
     "react-router": "7.15.1",
     "sonner": "2.0.7",
     "zustand": "5.0.13"

--- a/source/user-app/src/App.tsx
+++ b/source/user-app/src/App.tsx
@@ -3,7 +3,6 @@ import { OnlineStatusProvider } from "@/context/OnlineStatusContext";
 import { AppLayout } from "@/layouts/AppLayout";
 import Home from "@/pages/Home";
 import Stats from "@/pages/Stats";
-import Verify from "@/pages/Verify";
 import Settings from "@/pages/Settings";
 
 /**
@@ -22,7 +21,6 @@ export default function App() {
         <Route element={<AppLayout />}>
           <Route index element={<Home />} />
           <Route path="stats" element={<Stats />} />
-          <Route path="verify" element={<Verify />} />
           <Route path="settings" element={<Settings />} />
         </Route>
         <Route path="*" element={<Navigate to="/" replace />} />

--- a/source/user-app/src/components/TabBar.tsx
+++ b/source/user-app/src/components/TabBar.tsx
@@ -1,16 +1,10 @@
 import { NavLink } from "react-router";
-import {
-  HomeIcon,
-  ChartColumnIcon,
-  ShieldCheckIcon,
-  SettingsIcon,
-} from "lucide-react";
+import { HomeIcon, ChartColumnIcon, SettingsIcon } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
 
 const TABS: Array<{ to: string; label: string; Icon: LucideIcon; end?: boolean }> = [
   { to: "/", label: "Home", Icon: HomeIcon, end: true },
   { to: "/stats", label: "Stats", Icon: ChartColumnIcon },
-  { to: "/verify", label: "Verify", Icon: ShieldCheckIcon },
   { to: "/settings", label: "Settings", Icon: SettingsIcon },
 ];
 

--- a/source/user-app/src/pages/Home.tsx
+++ b/source/user-app/src/pages/Home.tsx
@@ -1,17 +1,122 @@
-import { WifiOffIcon } from "lucide-react";
-import { useMyDevice, DeviceIcon } from "@wardnet/web";
+import { useState } from "react";
+import { LockIcon, WifiOffIcon } from "lucide-react";
+import {
+  ApiErrorAlert,
+  Button,
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+  DeviceIcon,
+  RoutingSelector,
+  countryFlag,
+  useMyDevice,
+  useSetMyRule,
+} from "@wardnet/web";
+import type { RoutingTarget, TunnelSummary } from "@wardnet/js";
+
+/** Two routing targets are equivalent when they resolve to the same upstream:
+ *  `default`/`direct` both mean "no VPN", and two tunnels match on id. Used to
+ *  enable the Save button only when the selection actually differs. */
+function targetsEqual(
+  a: RoutingTarget | null,
+  b: RoutingTarget | null,
+): boolean {
+  if (a === b) return true;
+  if (!a || !b) return false;
+  if (a.type !== b.type) return false;
+  if (a.type === "tunnel" && b.type === "tunnel")
+    return a.tunnel_id === b.tunnel_id;
+  return true;
+}
+
+/** Human-readable label for the admin-locked read-only view. */
+function routingLabel(
+  target: RoutingTarget | null,
+  tunnels: TunnelSummary[],
+): string {
+  if (!target || target.type === "default" || target.type === "direct") {
+    return "Direct (no VPN)";
+  }
+  if (target.type === "tunnel") {
+    const t = tunnels.find((tun) => tun.id === target.tunnel_id);
+    if (t) {
+      const flag = t.country_code ? countryFlag(t.country_code) : "";
+      return `VPN: ${flag} ${t.label}`.trim();
+    }
+    return "VPN";
+  }
+  return "Direct (no VPN)";
+}
+
+/** Editable routing control. `useSetMyRule` already raises the success/error
+ *  sonner toast and invalidates the `me` query, so saving is just
+ *  `mutateAsync`; the inline `ApiErrorAlert` surfaces the detail. */
+function RoutingForm({
+  currentRule,
+  tunnels,
+}: {
+  currentRule: RoutingTarget | null;
+  tunnels: TunnelSummary[];
+}) {
+  const setMyRule = useSetMyRule();
+
+  const [target, setTarget] = useState<RoutingTarget>(
+    currentRule?.type === "tunnel" ? currentRule : { type: "direct" },
+  );
+
+  const hasChanges = !targetsEqual(target, currentRule);
+
+  async function handleSave() {
+    await setMyRule.mutateAsync(target);
+  }
+
+  return (
+    <div className="flex flex-col gap-4">
+      <RoutingSelector value={target} onChange={setTarget} tunnels={tunnels} />
+
+      {setMyRule.isError && (
+        <ApiErrorAlert
+          error={setMyRule.error}
+          fallback="Failed to update routing"
+        />
+      )}
+
+      <Button
+        onClick={handleSave}
+        disabled={!hasChanges || setMyRule.isPending}
+        className="w-full"
+      >
+        {setMyRule.isPending ? "Saving…" : "Save"}
+      </Button>
+    </div>
+  );
+}
 
 /**
- * Home tab — device identity + (eventually) self-service routing control.
+ * Home tab — device identity + self-service routing control.
  *
- * The shell wires `useMyDevice` (the unauthenticated, device-keyed endpoint) and
- * renders the device-not-detected fallback when the caller's device can't be
- * matched on the LAN. The routing controls themselves land in #590; for now a
- * detected device shows only its identity header.
+ * `useMyDevice` is the unauthenticated, device-keyed endpoint (there is no
+ * login in the User PWA — identity is the device on the LAN). When the caller
+ * can't be matched to a device we show the not-detected fallback. Otherwise the
+ * device picks its own internet routing, unless an admin has locked the rule —
+ * in which case the current target is shown read-only with a lock and an
+ * explanation. Ported from the admin-site `MyDevice` page into this mobile-first
+ * layout; the routing logic (`targetsEqual` / `routingLabel`) is shared.
  */
 export default function Home() {
   const { data, isLoading } = useMyDevice();
+
   const device = data?.device;
+  const currentRule = data?.current_rule ?? null;
+  const adminLocked = data?.admin_locked ?? false;
+  const tunnels = data?.available_tunnels ?? [];
+
+  // Remount the form when the saved rule changes so its local draft resets.
+  const ruleKey =
+    currentRule?.type === "tunnel"
+      ? `tunnel-${currentRule.tunnel_id}`
+      : String(currentRule?.type ?? "null");
 
   if (isLoading) {
     return <p className="p-5 text-sm text-ink-3">Loading…</p>;
@@ -32,13 +137,45 @@ export default function Home() {
   }
 
   return (
-    <div className="flex flex-col gap-5 p-5">
+    <div className="flex flex-col gap-6 p-5">
       <div className="flex items-center gap-3">
-        <DeviceIcon type={device.device_type} size={28} className="text-ink/60" />
+        <DeviceIcon
+          type={device.device_type}
+          size={28}
+          className="text-ink/60"
+        />
         <h1 className="text-lg font-semibold text-ink">
           {device.name ?? device.hostname ?? device.mac}
         </h1>
       </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Internet access</CardTitle>
+        </CardHeader>
+        <CardContent>
+          {adminLocked ? (
+            <div className="flex flex-col gap-3">
+              <p className="text-sm text-ink">
+                {routingLabel(currentRule, tunnels)}
+              </p>
+              <div className="flex items-start gap-2 text-ink-3">
+                <LockIcon className="mt-0.5 size-4 shrink-0" />
+                <p className="text-sm">
+                  Your network administrator has locked this setting, so you
+                  can't change how your device connects to the internet.
+                </p>
+              </div>
+            </div>
+          ) : (
+            <RoutingForm
+              key={ruleKey}
+              currentRule={currentRule}
+              tunnels={tunnels}
+            />
+          )}
+        </CardContent>
+      </Card>
     </div>
   );
 }

--- a/source/user-app/src/pages/Home.tsx
+++ b/source/user-app/src/pages/Home.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { LockIcon, WifiOffIcon } from "lucide-react";
+import { LockIcon, ShieldCheckIcon, WifiOffIcon } from "lucide-react";
 import {
   ApiErrorAlert,
   Button,
@@ -151,7 +151,7 @@ export default function Home() {
 
       <Card>
         <CardHeader>
-          <CardTitle>Internet access</CardTitle>
+          <CardTitle>Internet route</CardTitle>
         </CardHeader>
         <CardContent>
           {adminLocked ? (
@@ -174,6 +174,21 @@ export default function Home() {
               tunnels={tunnels}
             />
           )}
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Verify your route</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="flex items-start gap-3 text-ink-3">
+            <ShieldCheckIcon className="mt-0.5 size-4 shrink-0" />
+            <p className="text-sm">
+              Confirm your VPN is working by checking the public IP and location
+              your device is using right now. Coming in a future update.
+            </p>
+          </div>
         </CardContent>
       </Card>
     </div>

--- a/source/user-app/yarn.lock
+++ b/source/user-app/yarn.lock
@@ -3366,7 +3366,7 @@ __metadata:
     "@wardnet/web": "portal:../web"
     lucide-react: "npm:1.14.0"
     react: "npm:19.2.7"
-    react-dom: "npm:19.2.5"
+    react-dom: "npm:19.2.7"
     react-router: "npm:7.15.1"
     sonner: "npm:2.0.7"
     tailwindcss: "npm:4.3.0"
@@ -5341,14 +5341,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-dom@npm:19.2.5":
-  version: 19.2.5
-  resolution: "react-dom@npm:19.2.5"
+"react-dom@npm:19.2.7":
+  version: 19.2.7
+  resolution: "react-dom@npm:19.2.7"
   dependencies:
     scheduler: "npm:^0.27.0"
   peerDependencies:
-    react: ^19.2.5
-  checksum: 10c0/8067606e9f58e4c2e8cb5f09570217dbc71c4843ebcaa20ae2085912d3e3a351f17d8f7c1713313cdda7f272840c8c34ff6c860fcb840862071bceea218e0c63
+    react: ^19.2.7
+  checksum: 10c0/970ff600f6e80d47d39e2f226f12f226173b3cba3382efc97c5f0cd663de9af38c7a4c11c213fb936094faeac83060d660247accaa96b752180d5b951b9cfecb
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Closes #590. Part of #438.

## Summary

- Replaces the `Home.tsx` placeholder with the full self-service routing screen, ported from the deleted admin-site `MyDevice` page.
- **Device identity header** — `DeviceIcon` + name / hostname / MAC fallback.
- **Admin-locked branch** — read-only display of the current routing target, `LockIcon`, explanatory copy ("Your network administrator has locked this setting…").
- **Unlocked branch** — `RoutingSelector` (Direct / VPN tunnel with country flag + label), Save button gated on a real diff (`targetsEqual`), inline `ApiErrorAlert` on error.
- **Device-not-detected fallback** preserved (unauthenticated, device-keyed — there is no login).

## Reuse

Consumes only already-published `@wardnet/web` exports: `useMyDevice` / `useSetMyRule` hooks and `RoutingSelector` / `DeviceIcon` / `ApiErrorAlert` compounds extracted in #596. `useSetMyRule` already raises the sonner toast and invalidates the `me` query — the form just calls `mutateAsync`.

The `targetsEqual` / `routingLabel` / `ruleKey` logic is ported verbatim from the historical `MyDevice.tsx` (git commit `6ab750f4^`).

## Test plan

- [ ] Device detected, unlocked — `RoutingSelector` renders; Save disabled when no change; Save enabled after selecting a different target; success toast fires and selector reflects new value after re-fetch.
- [ ] Device detected, `admin_locked: true` — read-only label + lock icon shown; no selector or Save button.
- [ ] No device (e.g. accessed from outside the LAN) — not-detected fallback shown.
- [ ] `make check-web` exits 0 ✅
- [ ] `make build-web` exits 0 ✅