### PR TITLE
fix(ci): upload coverage on push-to-main so Codecov's default-branch number updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,10 +2,13 @@ name: CI
 
 # Orchestrator for pushes to `main`.
 #
-# Composes the same reusable leaves as pr.yml but skips the PR-only
-# gates (coverage, tests-e2e). Coverage runs only on PR because
-# Codecov's patch-coverage + PR-comment flow is PR-keyed; running it
-# on push-to-main would just produce uncommented uploads.
+# Composes the same reusable leaves as pr.yml. Coverage ALSO runs here
+# (push-to-main) so Codecov records a report for the merged main commit —
+# that default-branch upload is what advances the coverage number/badge
+# and gives later PRs an accurate base to diff against. Without it (main
+# is squash-merged, so PR-head reports are never main ancestors) the
+# default-branch number freezes. Patch-coverage and the PR comment stay
+# PR-only — a push has no PR to land them on, which is fine.
 #
 # Structure:
 #   preflight     — detect-changes + check-version composite actions
@@ -120,12 +123,30 @@ jobs:
     uses: ./.github/workflows/build-user-app.yml
     secrets: inherit
 
+  coverage:
+    name: Coverage
+    needs: preflight
+    # Default-branch coverage upload so the Codecov number/badge advances on
+    # every merge. NO bot-author skip here (unlike pr.yml): that skip exists
+    # because `pull_request` events from same-repo bot branches get no repo
+    # secrets, so CODECOV_TOKEN is absent. A `push` to main is a trusted event
+    # that DOES receive secrets regardless of who authored the merge, so the
+    # token is always present. And this runs post-merge with non-fatal uploads
+    # (`fail_ci_if_error: false`), so it can neither block a merge nor go red
+    # from an upload hiccup.
+    if: >
+      needs.preflight.outputs.daemon == 'true' ||
+      needs.preflight.outputs.bridge == 'true' ||
+      needs.preflight.outputs.site == 'true' ||
+      needs.preflight.outputs.ci == 'true'
+    uses: ./.github/workflows/coverage.yml
+    secrets: inherit
+
   tests-e2e:
     name: E2E Tests
     needs: preflight
     # Push-to-main parity with pr.yml — daemon or CI changes trigger
-    # the full e2e gauntlet. Coverage stays PR-only (Codecov's
-    # PR-comment flow has nothing to land on for push-to-main).
+    # the full e2e gauntlet.
     if: needs.preflight.outputs.daemon == 'true' || needs.preflight.outputs.ci == 'true'
     uses: ./.github/workflows/tests-e2e.yml
     secrets: inherit


### PR DESCRIPTION
## Problem

Codecov's coverage for `main` has been **frozen since ~April** even though every PR merges with patch coverage ≥ 85%. This is **not** corrupted Codecov data — the pipeline stopped feeding `main`'s coverage.

### Root cause (three facts compound)

1. **Coverage only runs on PRs.** `coverage.yml` is invoked solely from `pr.yml`. `ci.yml` (push-to-main) deliberately skipped it.
2. **Main is squash-merged.** Every main commit has 1 parent, so the PR-head commit — the one that actually carries a Codecov report — is orphaned and is never an ancestor of the squashed commit on main.
3. **No `codecov.yml`** → no carryforward config to paper over the gap.

Net effect: **no commit on `main`'s history ever receives a coverage report.** Codecov can only advance the default-branch number when a commit on the default branch has a report — none arrive, so the dashboard/badge is frozen.

### Why "since April"

`coverage.yml` was created on **2026-04-23 in #142** ("restructure workflows into reusable leaves"), which moved coverage out of the push-to-main path and into a PR-only reusable workflow. Before that, coverage ran in the CI/push flow (originally added in #3, "CI coverage job"). The freeze date matches exactly.

> The Codecov keybase/GPG breakage (#1956, worked around in #589) is a *separate, June* issue affecting PR uploads — a red herring for this April stall. The working 85% PR gate confirms PR uploads are fine.

### Bonus: PR deltas were wrong too

Because the base never updated, every PR's "project coverage" delta has been diffed against the April baseline — silently inaccurate.

## Fix

Call `coverage.yml` from `ci.yml` on push-to-main (mirroring `pr.yml`), gated on the same daemon/bridge/site/ci preflight outputs. Every merge now records a Codecov report for the `main` commit, so the dashboard/badge resumes updating and PR base comparisons become accurate.

## Safety — no risk to merges

The bot-author skip from `pr.yml` is intentionally **not** copied, and that's correct:

- That skip exists because `pull_request` events from same-repo bot branches (Dependabot) get **no repo secrets**, so `CODECOV_TOKEN` is absent and the upload fails. A **`push` to `main` is a trusted event that always receives secrets**, regardless of who authored the merge — so the token is always present.
- `ci.yml` runs **post-merge**, so it can't block or revert a merge.
- `coverage.yml`'s uploads use `fail_ci_if_error: false`, so an upload hiccup can't fail CI.

The reasoning is captured in the workflow comments so the skip isn't mistakenly re-added.

`actionlint` clean (validates the reusable-workflow permission/secret subset rules).

## Trade-off

~one extra coverage run (daemon/bridge/site) per qualifying merge to main. Non-blocking.

## Follow-up (not in this PR)

A small `codecov.yml` could encode the 85% targets and carryforward flags explicitly; left out here to keep this change minimal and avoid touching PR-gate behavior.