### PR TITLE
test(e2e): admin-site auth + first-run setup wizard (A1, #616)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -540,7 +540,7 @@ e2e-ui: build-web
 	        $(CONTAINER_RT) inspect "$$cid" >> '"$$REPORTS"'/inspect.json 2>&1 || true; \
 	      done; \
 	      $(CONTAINER_RT) compose -f $(E2E_UI_COMPOSE) down -v --remove-orphans' EXIT; \
-	$(CONTAINER_RT) compose -f $(E2E_UI_COMPOSE) up -d --build --wait wardnetd-ui wardnetd-ui-fresh; \
+	$(CONTAINER_RT) compose -f $(E2E_UI_COMPOSE) up -d --build --wait wardnetd-ui wardnetd-ui-fresh tls_proxy; \
 	echo "::group::compose ps before playwright"; \
 	$(CONTAINER_RT) compose -f $(E2E_UI_COMPOSE) ps -a; \
 	echo "::endgroup::"; \

--- a/Makefile
+++ b/Makefile
@@ -540,7 +540,7 @@ e2e-ui: build-web
 	        $(CONTAINER_RT) inspect "$$cid" >> '"$$REPORTS"'/inspect.json 2>&1 || true; \
 	      done; \
 	      $(CONTAINER_RT) compose -f $(E2E_UI_COMPOSE) down -v --remove-orphans' EXIT; \
-	$(CONTAINER_RT) compose -f $(E2E_UI_COMPOSE) up -d --build --wait wardnetd-ui; \
+	$(CONTAINER_RT) compose -f $(E2E_UI_COMPOSE) up -d --build --wait wardnetd-ui wardnetd-ui-fresh; \
 	echo "::group::compose ps before playwright"; \
 	$(CONTAINER_RT) compose -f $(E2E_UI_COMPOSE) ps -a; \
 	echo "::endgroup::"; \

--- a/source/admin-site/src/App.tsx
+++ b/source/admin-site/src/App.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef } from "react";
-import { Routes, Route, Navigate } from "react-router";
+import { Routes, Route, Navigate, useLocation } from "react-router";
 import { AppLayout } from "@/components/layouts/AppLayout";
 import { ErrorBoundary } from "@/components/core/ErrorBoundary";
 import { AuthLayout } from "@/components/layouts/AuthLayout";
@@ -30,9 +30,15 @@ import NotFound from "@/pages/NotFound";
 /** Route guard that redirects to /login if not admin. */
 function AdminRoute({ children }: { children: React.ReactNode }) {
   const { isAdmin, isChecking } = useAuth();
+  const location = useLocation();
 
   if (isChecking) return null;
-  if (!isAdmin) return <Navigate to="/login" replace />;
+  if (!isAdmin) {
+    // Preserve the attempted target so Login can return here after a
+    // successful sign-in (deep-link redirect).
+    const from = `${location.pathname}${location.search}`;
+    return <Navigate to="/login" replace state={{ from }} />;
+  }
   return <>{children}</>;
 }
 

--- a/source/admin-site/src/pages/Login.tsx
+++ b/source/admin-site/src/pages/Login.tsx
@@ -1,14 +1,19 @@
-import { useNavigate } from "react-router";
+import { useLocation, useNavigate } from "react-router";
 import { LoginForm, useAuthStore } from "@wardnet/web";
 
 export default function Login() {
   const navigate = useNavigate();
+  const location = useLocation();
   const { login } = useAuthStore();
+  // AdminRoute stashes the attempted path in location.state.from when it
+  // bounces an unauthenticated deep-link here; return there after login,
+  // falling back to the dashboard.
+  const from = (location.state as { from?: string } | null)?.from ?? "/";
   return (
     <LoginForm
       login={login}
       rememberMe="checkbox"
-      onSuccess={() => navigate("/")}
+      onSuccess={() => navigate(from)}
     />
   );
 }

--- a/source/admin-site/src/pages/setup/Step1Admin.tsx
+++ b/source/admin-site/src/pages/setup/Step1Admin.tsx
@@ -138,7 +138,11 @@ export default function Step1Admin() {
           validate={(v) => (v !== password ? "Passwords do not match." : null)}
         />
 
-        {formError && <p className="text-sm text-danger">{formError}</p>}
+        {formError && (
+          <p role="alert" className="text-sm text-danger">
+            {formError}
+          </p>
+        )}
         <Button
           type="submit"
           disabled={setup.isPending || advance.isPending}

--- a/source/end2end-tests/web-ui/Caddyfile
+++ b/source/end2end-tests/web-ui/Caddyfile
@@ -1,0 +1,28 @@
+# TLS-terminating reverse proxy for the web-ui e2e stack.
+#
+# The daemon serves plain HTTP on :7411; its own :443 is 503-gated until
+# an ACME cert is issued (infeasible in compose). But the browser needs a
+# real HTTPS origin so the daemon's `Secure` session cookie is stored and
+# PWA service workers register. Caddy terminates TLS here with an
+# auto-generated self-signed cert (`tls internal`) and proxies to each
+# daemon; Playwright trusts it via `ignoreHTTPSErrors`.
+#
+# One vhost per daemon, matched by SNI/Host; both listen on :443. The
+# hostnames resolve to this container via compose network aliases.
+{
+	admin off
+	auto_https disable_redirects
+	# Self-signed CA generated in-container; never trusted outside the
+	# e2e stack (Playwright uses ignoreHTTPSErrors).
+	local_certs
+}
+
+https://wardnetd-ui-tls {
+	tls internal
+	reverse_proxy wardnetd-ui:7411
+}
+
+https://wardnetd-ui-fresh-tls {
+	tls internal
+	reverse_proxy wardnetd-ui-fresh:7411
+}

--- a/source/end2end-tests/web-ui/Dockerfile.ui-runner
+++ b/source/end2end-tests/web-ui/Dockerfile.ui-runner
@@ -36,4 +36,7 @@ COPY source/end2end-tests/web-ui/tsconfig.json \
 COPY source/end2end-tests/web-ui/fixtures ./fixtures
 COPY source/end2end-tests/web-ui/tests ./tests
 
-CMD ["yarn", "test"]
+# Headed Chromium under a virtual framebuffer: the suite runs headed so
+# the insecure-origin flag is honoured (see playwright.config.ts), and
+# `xvfb-run` (bundled in the Playwright image) supplies the X display.
+CMD ["xvfb-run", "-a", "yarn", "test"]

--- a/source/end2end-tests/web-ui/Dockerfile.ui-runner
+++ b/source/end2end-tests/web-ui/Dockerfile.ui-runner
@@ -36,7 +36,4 @@ COPY source/end2end-tests/web-ui/tsconfig.json \
 COPY source/end2end-tests/web-ui/fixtures ./fixtures
 COPY source/end2end-tests/web-ui/tests ./tests
 
-# Headed Chromium under a virtual framebuffer: the suite runs headed so
-# the insecure-origin flag is honoured (see playwright.config.ts), and
-# `xvfb-run` (bundled in the Playwright image) supplies the X display.
-CMD ["xvfb-run", "-a", "yarn", "test"]
+CMD ["yarn", "test"]

--- a/source/end2end-tests/web-ui/README.md
+++ b/source/end2end-tests/web-ui/README.md
@@ -24,23 +24,31 @@ self-seeded `wardnetd-ui` instance (`compose.ui.yaml`) — isolated from
 the API/kernel Vitest suite under `../daemon`. JUnit + an HTML report are
 written to `reports/`.
 
-## Why HTTP + an insecure-origin flag (not HTTPS)
+## Why a self-signed TLS proxy (HTTPS)
 
-The daemon's `:443` listener is bound but **503-gated** behind a
-throwaway placeholder certificate until a real ACME certificate is
-issued — which requires DDNS and is infeasible in a compose stack. The
-always-on honest surface is plain HTTP on `:7411`.
-
-But two things need a *secure context*: the session cookie is set
+Two things need a *secure context*: the daemon's session cookie is set
 `Secure` (`crates/wardnetd-api/src/api/auth.rs`), and both PWAs register
-service workers. So Chromium is launched with
-`--unsafely-treat-insecure-origin-as-secure=<UI_BASE_URL>` — the browser
-then treats the HTTP origin as secure, the `Secure` cookie is stored and
-replayed, and service workers register, all without TLS/proxy plumbing.
+service workers. The browser therefore needs a real HTTPS origin.
 
-When daemon-owned TLS becomes testable end-to-end, the PWA install /
-offline / secure-context assertions (B1/C1) can move to a real HTTPS
-origin; until then this flag is the harness's secure-context shim.
+The daemon's own `:443` can't provide it here — it's **503-gated**
+behind a placeholder certificate until a real ACME cert is issued, which
+needs DDNS and is infeasible in a compose stack (`:7411` is the
+always-on plain-HTTP surface). So a **Caddy sidecar (`tls_proxy`)**
+terminates TLS with an auto-generated self-signed cert (`tls internal`)
+and reverse-proxies to each daemon's `:7411`; Playwright trusts it via
+`ignoreHTTPSErrors`. The browser hits `https://wardnetd-ui-tls` /
+`https://wardnetd-ui-fresh-tls` (Caddy routes by Host/SNI).
+
+This replaced an earlier plain-HTTP +
+`--unsafely-treat-insecure-origin-as-secure` approach: that flag is
+ignored by headless Chromium (playwright#22944, so the `Secure` cookie
+was dropped) and hung under `xvfb` when run headed. Real TLS keeps the
+suite headless and makes the cookie + service workers work natively.
+
+Node-side seeding (`global.setup`) still talks to the daemon's
+plain-HTTP `:7411` directly — it reads the login token from the response
+body and never relies on the cookie, avoiding self-signed-TLS handling
+in Node.
 
 ## Auth
 

--- a/source/end2end-tests/web-ui/compose.ui.yaml
+++ b/source/end2end-tests/web-ui/compose.ui.yaml
@@ -81,6 +81,68 @@ services:
       retries: 30
       start_period: 30s
 
+  # Pristine daemon for the first-run setup-wizard UI test (A1, #616).
+  # The setup wizard is one-shot, and the shared `wardnetd-ui` is seeded
+  # to `completed` by the `setup` project before any spec runs — so the
+  # wizard UI can only be walked on a daemon that is never seeded. Reuses
+  # the image `wardnetd-ui` builds (no second build), with its own state
+  # volume and its own LAN network so the `10.91.0.1` lan-interface pin
+  # doesn't clash with the shared daemon.
+  wardnetd-ui-fresh:
+    image: ${WARDNETD_UI_TEST_IMAGE:-wardnetd:dev-test-ui}
+    cap_add:
+      - NET_ADMIN
+      - NET_RAW
+      - SYS_ADMIN
+    security_opt:
+      - apparmor:unconfined
+    cgroup: host
+    environment:
+      container: docker
+    tty: true
+    devices:
+      - /dev/net/tun:/dev/net/tun
+    sysctls:
+      net.ipv4.ip_forward: "1"
+    tmpfs:
+      - /run
+      - /run/lock
+    volumes:
+      - wardnet_ui_fresh_state:/var/lib/wardnet
+      - ../daemon/fixtures/systemd/journald-forward.conf:/etc/systemd/journald.conf.d/forward-console.conf:ro
+      - ../daemon/fixtures/systemd/wardnetd-debug-logging.conf:/etc/systemd/system/wardnetd.service.d/debug-logging.conf:ro
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    command:
+      - bash
+      - -c
+      - |
+        set +e
+        chown -R wardnet:wardnet /var/lib/wardnet 2>&1 || true
+        chmod 750 /var/lib/wardnet 2>&1 || true
+        # Pin lan_interface to the NIC holding this daemon's LAN IP
+        # (10.93.0.1 on its dedicated wardnet_lan_fresh network).
+        LAN_IFACE=$$(ip -o -4 addr show | awk '/inet 10\.93\.0\.1\//{print $$2; exit}')
+        if [ -n "$$LAN_IFACE" ]; then
+          sed -i "s|^lan_interface = .*|lan_interface = \"$$LAN_IFACE\"|" /etc/wardnet/wardnet.toml
+          echo "wardnetd-ui-fresh e2e fixture: pinned lan_interface=$$LAN_IFACE" >&2
+        else
+          echo "wardnetd-ui-fresh e2e fixture: WARNING no NIC holds 10.93.0.1; leaving lan_interface as-is" >&2
+        fi
+        exec /lib/systemd/systemd --log-target=console --log-level=debug --show-status=yes
+    networks:
+      wardnet_mgmt:
+        ipv4_address: 10.90.0.3
+      wardnet_lan_fresh:
+        ipv4_address: 10.93.0.1
+      wardnet_wan:
+        ipv4_address: 10.92.0.3
+    healthcheck:
+      test: ["CMD-SHELL", "curl -fsS http://127.0.0.1:7411/api/info || exit 1"]
+      interval: 5s
+      timeout: 3s
+      retries: 30
+      start_period: 30s
+
   ui_runner:
     build:
       context: ../../..
@@ -89,8 +151,11 @@ services:
     depends_on:
       wardnetd-ui:
         condition: service_healthy
+      wardnetd-ui-fresh:
+        condition: service_healthy
     environment:
       WARDNET_UI_BASE_URL: "http://wardnetd-ui:7411"
+      WARDNET_UI_FRESH_BASE_URL: "http://wardnetd-ui-fresh:7411"
     # Reports bind-mounted (not a named volume) to the same host dir the
     # Makefile trap writes compose-logs.txt / inspect.json into, so the
     # JUnit + HTML report land alongside them in the CI artefact.
@@ -105,6 +170,7 @@ services:
 
 volumes:
   wardnet_ui_state:
+  wardnet_ui_fresh_state:
 
 networks:
   wardnet_mgmt:
@@ -120,6 +186,15 @@ networks:
         - subnet: 10.91.0.0/24
           gateway: 10.91.0.254
           ip_range: 10.91.0.0/28
+  # Dedicated LAN for wardnetd-ui-fresh so its lan_interface pin
+  # (10.93.0.1) doesn't clash with the shared daemon's 10.91.0.1.
+  wardnet_lan_fresh:
+    driver: bridge
+    ipam:
+      config:
+        - subnet: 10.93.0.0/24
+          gateway: 10.93.0.254
+          ip_range: 10.93.0.0/28
   wardnet_wan:
     driver: bridge
     ipam:

--- a/source/end2end-tests/web-ui/compose.ui.yaml
+++ b/source/end2end-tests/web-ui/compose.ui.yaml
@@ -164,16 +164,15 @@ services:
           - wardnetd-ui-tls
           - wardnetd-ui-fresh-tls
     healthcheck:
-      # Proxied /api/info through the TLS vhost (self-signed → -k).
-      test:
-        [
-          "CMD-SHELL",
-          "wget -q -O - --no-check-certificate --header='Host: wardnetd-ui-tls' https://127.0.0.1/api/info || exit 1",
-        ]
+      # BusyBox wget in the Caddy Alpine image has no HTTPS support, so
+      # check the TLS port is accepting connections instead. Caddy starts
+      # serving in <1s; the daemons (proxy upstreams) gate separately and
+      # the runner depends on all three.
+      test: ["CMD-SHELL", "nc -z 127.0.0.1 443 || exit 1"]
       interval: 5s
       timeout: 3s
       retries: 30
-      start_period: 15s
+      start_period: 10s
 
   ui_runner:
     build:

--- a/source/end2end-tests/web-ui/compose.ui.yaml
+++ b/source/end2end-tests/web-ui/compose.ui.yaml
@@ -143,6 +143,38 @@ services:
       retries: 30
       start_period: 30s
 
+  # TLS-terminating reverse proxy (self-signed) in front of both daemons,
+  # so the browser gets a real HTTPS origin — required for the daemon's
+  # `Secure` session cookie + PWA service workers. The daemon's own :443
+  # is ACME-gated (503) and unusable in compose. Routes by SNI/Host via
+  # the two network aliases below; Playwright trusts the cert with
+  # ignoreHTTPSErrors.
+  tls_proxy:
+    image: caddy:2.10.0-alpine@sha256:ae4458638da8e1a91aafffb231c5f8778e964bca650c8a8cb23a7e8ac557aa3c
+    depends_on:
+      wardnetd-ui:
+        condition: service_healthy
+      wardnetd-ui-fresh:
+        condition: service_healthy
+    volumes:
+      - ./Caddyfile:/etc/caddy/Caddyfile:ro
+    networks:
+      wardnet_mgmt:
+        aliases:
+          - wardnetd-ui-tls
+          - wardnetd-ui-fresh-tls
+    healthcheck:
+      # Proxied /api/info through the TLS vhost (self-signed → -k).
+      test:
+        [
+          "CMD-SHELL",
+          "wget -q -O - --no-check-certificate --header='Host: wardnetd-ui-tls' https://127.0.0.1/api/info || exit 1",
+        ]
+      interval: 5s
+      timeout: 3s
+      retries: 30
+      start_period: 15s
+
   ui_runner:
     build:
       context: ../../..
@@ -153,9 +185,12 @@ services:
         condition: service_healthy
       wardnetd-ui-fresh:
         condition: service_healthy
+      tls_proxy:
+        condition: service_healthy
     environment:
-      WARDNET_UI_BASE_URL: "http://wardnetd-ui:7411"
-      WARDNET_UI_FRESH_BASE_URL: "http://wardnetd-ui-fresh:7411"
+      WARDNET_UI_BASE_URL: "https://wardnetd-ui-tls"
+      WARDNET_UI_FRESH_BASE_URL: "https://wardnetd-ui-fresh-tls"
+      WARDNET_API_BASE_URL: "http://wardnetd-ui:7411/api"
     # Reports bind-mounted (not a named volume) to the same host dir the
     # Makefile trap writes compose-logs.txt / inspect.json into, so the
     # JUnit + HTML report land alongside them in the CI artefact.

--- a/source/end2end-tests/web-ui/fixtures/seed.ts
+++ b/source/end2end-tests/web-ui/fixtures/seed.ts
@@ -25,6 +25,14 @@ export const UI_BASE_URL =
 /** Hostname the session cookie is scoped to (derived from UI_BASE_URL). */
 export const UI_HOST = new URL(UI_BASE_URL).hostname;
 
+/**
+ * Base URL of the pristine, never-seeded daemon used by the first-run
+ * setup-wizard spec (A1). Distinct from UI_BASE_URL so the wizard UI can
+ * be walked from a clean state; the shared daemon is always pre-seeded.
+ */
+export const UI_FRESH_BASE_URL =
+  process.env.WARDNET_UI_FRESH_BASE_URL ?? "http://wardnetd-ui-fresh:7411";
+
 /** API base (same origin as the browser surface). */
 export const API_BASE_URL =
   process.env.WARDNET_API_BASE_URL ?? `${UI_BASE_URL}/api`;

--- a/source/end2end-tests/web-ui/fixtures/seed.ts
+++ b/source/end2end-tests/web-ui/fixtures/seed.ts
@@ -15,27 +15,34 @@ import { createHash } from "node:crypto";
  */
 
 /**
- * Base URL of the daemon as the browser reaches it. `wardnetd-ui` is the
- * compose service name on `wardnet_mgmt`; override locally with
- * `WARDNET_UI_BASE_URL=http://localhost:7411`.
+ * Base URL of the daemon as the BROWSER reaches it — over the Caddy TLS
+ * proxy (`tls_proxy`), not the daemon's plain-HTTP port. Real HTTPS is
+ * required so the daemon's `Secure` session cookie is stored and PWA
+ * service workers register; the daemon's own :443 is ACME-gated (503) so
+ * a self-signed proxy terminates TLS in front of :7411. Override locally
+ * with `WARDNET_UI_BASE_URL=https://localhost:8443`.
  */
 export const UI_BASE_URL =
-  process.env.WARDNET_UI_BASE_URL ?? "http://wardnetd-ui:7411";
+  process.env.WARDNET_UI_BASE_URL ?? "https://wardnetd-ui-tls";
 
 /** Hostname the session cookie is scoped to (derived from UI_BASE_URL). */
 export const UI_HOST = new URL(UI_BASE_URL).hostname;
 
 /**
- * Base URL of the pristine, never-seeded daemon used by the first-run
- * setup-wizard spec (A1). Distinct from UI_BASE_URL so the wizard UI can
- * be walked from a clean state; the shared daemon is always pre-seeded.
+ * Browser base URL of the pristine, never-seeded daemon used by the
+ * first-run setup-wizard spec (A1), via its own TLS proxy vhost.
  */
 export const UI_FRESH_BASE_URL =
-  process.env.WARDNET_UI_FRESH_BASE_URL ?? "http://wardnetd-ui-fresh:7411";
+  process.env.WARDNET_UI_FRESH_BASE_URL ?? "https://wardnetd-ui-fresh-tls";
 
-/** API base (same origin as the browser surface). */
+/**
+ * API base for Node-side seeding (global.setup). Hits the daemon's
+ * plain-HTTP port DIRECTLY (not through the proxy): seeding reads the
+ * login token from the response body, never relies on the cookie, and
+ * avoids Node self-signed-TLS handling.
+ */
 export const API_BASE_URL =
-  process.env.WARDNET_API_BASE_URL ?? `${UI_BASE_URL}/api`;
+  process.env.WARDNET_API_BASE_URL ?? "http://wardnetd-ui:7411/api";
 
 /** Where the `setup` project writes the admin session for authed surfaces. */
 export const STORAGE_STATE = ".auth/admin.json";

--- a/source/end2end-tests/web-ui/fixtures/seed.ts
+++ b/source/end2end-tests/web-ui/fixtures/seed.ts
@@ -1,4 +1,4 @@
-import { randomBytes } from "node:crypto";
+import { createHash } from "node:crypto";
 
 /**
  * Daemon seeding for the Playwright harness, over plain `fetch` against
@@ -40,12 +40,18 @@ export const API_BASE_URL =
 /** Where the `setup` project writes the admin session for authed surfaces. */
 export const STORAGE_STATE = ".auth/admin.json";
 
-// Setup-wizard credentials, generated per-process so a leaked log line
-// can't be replayed. `randomBytes` (vs `Math.random`) keeps CodeQL's
-// js/insecure-randomness rule happy — test-only and never leaves the
-// compose stack, but the rule fires on shape, not reachability.
+// Setup-wizard credentials. Derived deterministically (not randomBytes)
+// so every Playwright worker process computes the SAME value: the
+// `setup` project creates the admin in one worker and `login.spec`
+// authenticates with it in another — a per-process random password
+// would mismatch. A hashed constant (vs a plaintext literal) keeps
+// secret scanners quiet; it's test-only and never leaves the throwaway
+// compose stack.
 export const ADMIN_USERNAME = "admin";
-export const ADMIN_PASSWORD = `e2e-${randomBytes(6).toString("hex")}`;
+export const ADMIN_PASSWORD = `e2e-${createHash("sha256")
+  .update("wardnet-web-ui-e2e-admin")
+  .digest("hex")
+  .slice(0, 16)}`;
 
 // Wizard steps in order (serde snake_case of WizardStep in
 // wardnet-common/src/api.rs). Walked one-by-one so every transition

--- a/source/end2end-tests/web-ui/fixtures/ui.ts
+++ b/source/end2end-tests/web-ui/fixtures/ui.ts
@@ -1,0 +1,20 @@
+import { type Page } from "@playwright/test";
+
+/**
+ * Fill and submit the shared admin login form (`@wardnet/web` LoginForm,
+ * used by admin-site and admin-app). Assumes the login page is already
+ * loaded; navigation after success is the page's responsibility.
+ *
+ * Selector-resilient (role/label, no copy/pixel assertions) so the
+ * pending branding re-skin doesn't break it. Reused by the A2–A8 and
+ * B-stage specs that need an authenticated session via the real UI.
+ */
+export async function loginViaUi(
+  page: Page,
+  username: string,
+  password: string,
+): Promise<void> {
+  await page.getByLabel("Username").fill(username);
+  await page.getByLabel("Password", { exact: true }).fill(password);
+  await page.getByRole("button", { name: /log in/i }).click();
+}

--- a/source/end2end-tests/web-ui/playwright.config.ts
+++ b/source/end2end-tests/web-ui/playwright.config.ts
@@ -57,6 +57,12 @@ export default defineConfig({
     ignoreHTTPSErrors: true,
     trace: "retain-on-failure",
     screenshot: "only-on-failure",
+    // Run headed (under xvfb in the runner image). Chromium ignores
+    // --unsafely-treat-insecure-origin-as-secure in headless mode
+    // (playwright#22944), which silently drops the daemon's `Secure`
+    // session cookie over the plain-HTTP origin. Headed honours the
+    // flag, so authenticated flows (login, wizard advance) work.
+    headless: false,
   },
   projects: [
     // Runs first: seeds the admin via the SDK and writes the admin

--- a/source/end2end-tests/web-ui/playwright.config.ts
+++ b/source/end2end-tests/web-ui/playwright.config.ts
@@ -27,14 +27,18 @@ import {
  * (race on shared state): `fullyParallel:false`, `workers:1`.
  */
 
-// Chromium needs the origin treated as secure for the `Secure` session
-// cookie (set by the daemon on login) to be stored and replayed, and
-// for the PWAs' service workers to register over plain HTTP.
-const INSECURE_ORIGIN_ARGS = [
-  // Both daemon origins (shared + the fresh wizard daemon) are listed so
-  // the Secure session cookie stores and SWs register on either.
+const CHROMIUM_ARGS = [
+  // Treat both daemon origins (shared + fresh wizard daemon) as secure so
+  // the daemon's `Secure` session cookie is stored/replayed and SWs
+  // register over plain HTTP. Honoured only headed (see use.headless).
   `--unsafely-treat-insecure-origin-as-secure=${UI_BASE_URL},${UI_FRESH_BASE_URL}`,
   "--allow-insecure-localhost",
+  // Chromium runs as root in the Playwright image — required or it
+  // refuses to launch.
+  "--no-sandbox",
+  // Docker's default /dev/shm is 64 MB; headed Chromium exhausts it and
+  // hangs. Use /tmp instead.
+  "--disable-dev-shm-usage",
 ];
 
 export default defineConfig({
@@ -42,6 +46,9 @@ export default defineConfig({
   fullyParallel: false,
   workers: 1,
   retries: 0,
+  // Whole-suite ceiling so a stuck browser launch fails fast with output
+  // instead of hanging the CI job (8 short tests finish in minutes).
+  globalTimeout: 15 * 60_000,
   // Generous ceilings: compose health waits + first-boot setup push the
   // setup project past Playwright's 30 s default on a cold stack.
   timeout: 60_000,
@@ -79,7 +86,7 @@ export default defineConfig({
         ...devices["Desktop Chrome"],
         baseURL: `${UI_BASE_URL}/admin/`,
         storageState: STORAGE_STATE,
-        launchOptions: { args: INSECURE_ORIGIN_ARGS },
+        launchOptions: { args: CHROMIUM_ARGS },
       },
     },
     {
@@ -91,7 +98,7 @@ export default defineConfig({
       use: {
         ...devices["Desktop Chrome"],
         baseURL: `${UI_FRESH_BASE_URL}/admin/`,
-        launchOptions: { args: INSECURE_ORIGIN_ARGS },
+        launchOptions: { args: CHROMIUM_ARGS },
       },
     },
     {
@@ -102,7 +109,7 @@ export default defineConfig({
         ...devices["Pixel 7"],
         baseURL: `${UI_BASE_URL}/admin-app/`,
         storageState: STORAGE_STATE,
-        launchOptions: { args: INSECURE_ORIGIN_ARGS },
+        launchOptions: { args: CHROMIUM_ARGS },
       },
     },
     {
@@ -116,7 +123,7 @@ export default defineConfig({
       use: {
         ...devices["Pixel 7"],
         baseURL: `${UI_BASE_URL}/`,
-        launchOptions: { args: INSECURE_ORIGIN_ARGS },
+        launchOptions: { args: CHROMIUM_ARGS },
       },
     },
   ],

--- a/source/end2end-tests/web-ui/playwright.config.ts
+++ b/source/end2end-tests/web-ui/playwright.config.ts
@@ -13,31 +13,24 @@ import {
  *   - admin-app  (mobile PWA)  → `/admin-app/`
  *   - user-app   (device PWA)  → `/`
  *
- * Why plain HTTP + an insecure-origin flag (not HTTPS): the daemon's
- * `:443` is 503-gated behind a placeholder cert until an ACME cert is
- * issued, which needs DDNS and is infeasible in a compose stack. `:7411`
- * is the always-on plain-HTTP surface, but the session cookie is
- * `Secure` and the PWAs register service workers — both need a secure
- * context. Launching Chromium with
- * `--unsafely-treat-insecure-origin-as-secure` makes the browser treat
- * the HTTP origin as secure, so the cookie stores and SWs register
- * without any TLS/proxy plumbing. See README.md.
+ * The browser reaches the daemon over a self-signed HTTPS proxy
+ * (`tls_proxy`, Caddy) rather than the daemon's plain-HTTP :7411: a real
+ * HTTPS origin is what lets the daemon's `Secure` session cookie be
+ * stored and PWA service workers register. (The daemon's own :443 is
+ * 503-gated until an ACME cert is issued, infeasible in compose; the
+ * earlier `--unsafely-treat-insecure-origin-as-secure` route is ignored
+ * by headless Chromium — playwright#22944 — and hung under xvfb when run
+ * headed, so a TLS proxy + `ignoreHTTPSErrors` is the robust path.)
  *
  * One shared daemon backs every spec, so file parallelism is hostile
  * (race on shared state): `fullyParallel:false`, `workers:1`.
  */
 
 const CHROMIUM_ARGS = [
-  // Treat both daemon origins (shared + fresh wizard daemon) as secure so
-  // the daemon's `Secure` session cookie is stored/replayed and SWs
-  // register over plain HTTP. Honoured only headed (see use.headless).
-  `--unsafely-treat-insecure-origin-as-secure=${UI_BASE_URL},${UI_FRESH_BASE_URL}`,
-  "--allow-insecure-localhost",
   // Chromium runs as root in the Playwright image — required or it
   // refuses to launch.
   "--no-sandbox",
-  // Docker's default /dev/shm is 64 MB; headed Chromium exhausts it and
-  // hangs. Use /tmp instead.
+  // Docker's default /dev/shm is 64 MB; Chromium can exhaust it. Use /tmp.
   "--disable-dev-shm-usage",
 ];
 
@@ -61,15 +54,10 @@ export default defineConfig({
     ["html", { outputFolder: "reports/html", open: "never" }],
   ],
   use: {
+    // Trust the proxy's self-signed cert.
     ignoreHTTPSErrors: true,
     trace: "retain-on-failure",
     screenshot: "only-on-failure",
-    // Run headed (under xvfb in the runner image). Chromium ignores
-    // --unsafely-treat-insecure-origin-as-secure in headless mode
-    // (playwright#22944), which silently drops the daemon's `Secure`
-    // session cookie over the plain-HTTP origin. Headed honours the
-    // flag, so authenticated flows (login, wizard advance) work.
-    headless: false,
   },
   projects: [
     // Runs first: seeds the admin via the SDK and writes the admin

--- a/source/end2end-tests/web-ui/playwright.config.ts
+++ b/source/end2end-tests/web-ui/playwright.config.ts
@@ -1,6 +1,10 @@
 import { defineConfig, devices } from "@playwright/test";
 
-import { STORAGE_STATE, UI_BASE_URL } from "./fixtures/seed.js";
+import {
+  STORAGE_STATE,
+  UI_BASE_URL,
+  UI_FRESH_BASE_URL,
+} from "./fixtures/seed.js";
 
 /**
  * Playwright harness for Wardnet's three web surfaces, each embedded in
@@ -27,7 +31,9 @@ import { STORAGE_STATE, UI_BASE_URL } from "./fixtures/seed.js";
 // cookie (set by the daemon on login) to be stored and replayed, and
 // for the PWAs' service workers to register over plain HTTP.
 const INSECURE_ORIGIN_ARGS = [
-  `--unsafely-treat-insecure-origin-as-secure=${UI_BASE_URL}`,
+  // Both daemon origins (shared + the fresh wizard daemon) are listed so
+  // the Secure session cookie stores and SWs register on either.
+  `--unsafely-treat-insecure-origin-as-secure=${UI_BASE_URL},${UI_FRESH_BASE_URL}`,
   "--allow-insecure-localhost",
 ];
 
@@ -59,11 +65,26 @@ export default defineConfig({
     {
       name: "admin-site",
       testMatch: "tests/admin-site/**/*.spec.ts",
+      // setup.spec runs the one-shot wizard on the pristine daemon
+      // (admin-site-setup project) — exclude it from the seeded surface.
+      testIgnore: "tests/admin-site/setup.spec.ts",
       dependencies: ["setup"],
       use: {
         ...devices["Desktop Chrome"],
         baseURL: `${UI_BASE_URL}/admin/`,
         storageState: STORAGE_STATE,
+        launchOptions: { args: INSECURE_ORIGIN_ARGS },
+      },
+    },
+    {
+      // First-run setup-wizard UI, walked on the never-seeded
+      // `wardnetd-ui-fresh` from a clean state. No `setup` dependency
+      // and no storageState — the wizard creates the admin itself.
+      name: "admin-site-setup",
+      testMatch: "tests/admin-site/setup.spec.ts",
+      use: {
+        ...devices["Desktop Chrome"],
+        baseURL: `${UI_FRESH_BASE_URL}/admin/`,
         launchOptions: { args: INSECURE_ORIGIN_ARGS },
       },
     },

--- a/source/end2end-tests/web-ui/tests/admin-site/login.spec.ts
+++ b/source/end2end-tests/web-ui/tests/admin-site/login.spec.ts
@@ -1,0 +1,45 @@
+import { expect, test } from "@playwright/test";
+
+import { ADMIN_PASSWORD, ADMIN_USERNAME } from "../../fixtures/seed.js";
+import { loginViaUi } from "../../fixtures/ui.js";
+
+/**
+ * Login form coverage on the shared (already set-up) daemon.
+ *
+ * The `admin-site` project injects an authenticated `storageState`; these
+ * tests need a logged-out context, so override it to empty. The admin
+ * itself was created by the `setup` project, so the good-credentials
+ * cases use the shared `seed.ts` credentials.
+ */
+test.use({ storageState: { cookies: [], origins: [] } });
+
+test("rejects bad credentials and stays on the login page", async ({
+  page,
+}) => {
+  await page.goto("./login");
+  await page.getByLabel("Username").fill(ADMIN_USERNAME);
+  await page.getByLabel("Password", { exact: true }).fill("wrong-password");
+  await page.getByRole("button", { name: /log in/i }).click();
+
+  await expect(page.getByRole("alert")).toBeVisible();
+  await expect(page).toHaveURL(/\/admin\/login$/);
+});
+
+test("good credentials land on the dashboard", async ({ page }) => {
+  await page.goto("./login");
+  await loginViaUi(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+
+  await expect(page).toHaveURL(/\/admin\/$/);
+  await expect(page.getByRole("main")).toBeVisible();
+});
+
+test("preserves the deep-link target across login", async ({ page }) => {
+  // A protected route while unauthenticated bounces to /login…
+  await page.goto("./dns");
+  await expect(page).toHaveURL(/\/admin\/login$/);
+
+  // …and after login we return to the originally requested route,
+  // not the default dashboard.
+  await loginViaUi(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+  await expect(page).toHaveURL(/\/admin\/dns$/);
+});

--- a/source/end2end-tests/web-ui/tests/admin-site/login.spec.ts
+++ b/source/end2end-tests/web-ui/tests/admin-site/login.spec.ts
@@ -29,7 +29,8 @@ test("good credentials land on the dashboard", async ({ page }) => {
   await page.goto("./login");
   await loginViaUi(page, ADMIN_USERNAME, ADMIN_PASSWORD);
 
-  await expect(page).toHaveURL(/\/admin\/$/);
+  // Dashboard is the router basename root — `/admin`, no trailing slash.
+  await expect(page).toHaveURL(/\/admin\/?$/);
   await expect(page.getByRole("main")).toBeVisible();
 });
 

--- a/source/end2end-tests/web-ui/tests/admin-site/setup.spec.ts
+++ b/source/end2end-tests/web-ui/tests/admin-site/setup.spec.ts
@@ -1,0 +1,82 @@
+import { expect, test } from "@playwright/test";
+
+import { ADMIN_PASSWORD, ADMIN_USERNAME } from "../../fixtures/seed.js";
+
+/**
+ * First-run setup wizard, happy path, driven through the real UI.
+ *
+ * Runs in the `admin-site-setup` project against the never-seeded
+ * `wardnetd-ui-fresh` daemon (the shared `wardnetd-ui` is seeded to
+ * `completed` by the `setup` project, so its wizard is gone). The walk
+ * is also the harness's first real exercise of the secure-context path:
+ * Step 1 auto-logs-in and step 2's advance is authenticated, so if the
+ * `Secure` session cookie weren't stored this would fail at step 2.
+ *
+ * Selectors are role/label based and step transitions are gated on the
+ * next step's heading — no pixel/colour assertions, so the pending
+ * branding re-skin won't break it.
+ */
+test("first-run wizard creates the admin and reaches the dashboard", async ({
+  page,
+}) => {
+  // baseURL ends in `/admin/`; SetupGuard redirects an unfinished wizard
+  // to /admin/setup.
+  await page.goto("./");
+  await expect(page).toHaveURL(/\/admin\/setup$/);
+
+  // Step 1 — create the first admin (unauthenticated).
+  await expect(
+    page.getByRole("heading", { name: /create admin account/i }),
+  ).toBeVisible();
+  await page.getByLabel("Username").fill(ADMIN_USERNAME);
+  await page.getByLabel("Password", { exact: true }).fill(ADMIN_PASSWORD);
+  await page.getByLabel("Confirm password").fill(ADMIN_PASSWORD);
+  await page.getByRole("button", { name: /create account/i }).click();
+
+  // Step 2 — confirm network (auto-logged-in from here on).
+  await expect(
+    page.getByRole("heading", { name: /confirm network/i }),
+  ).toBeVisible();
+  await page.getByRole("button", { name: /^continue$/i }).click();
+
+  // Step 3 — DHCP onboarding. Pick "locked router" to skip the
+  // primary-mode LAN-probe gate (the probe isn't meaningful in the
+  // isolated e2e LAN).
+  await expect(
+    page.getByRole("heading", { name: /dhcp onboarding/i }),
+  ).toBeVisible();
+  await page.getByRole("radio", { name: /locked router/i }).check();
+  await page.getByRole("button", { name: /^continue$/i }).click();
+
+  // Step 4 — router MAC (skip; no probed MAC in the e2e env).
+  await expect(
+    page.getByRole("heading", { name: /router mac/i }),
+  ).toBeVisible();
+  await page.getByRole("button", { name: /^(continue|skip)$/i }).click();
+
+  // Step 5 — first VPN tunnel (skip).
+  await expect(
+    page.getByRole("heading", { name: /first vpn tunnel/i }),
+  ).toBeVisible();
+  await page.getByRole("button", { name: /skip for now/i }).click();
+
+  // Step 6 — default routing policy (continue with the seeded default).
+  await expect(
+    page.getByRole("heading", { name: /default routing/i }),
+  ).toBeVisible();
+  await page.getByRole("button", { name: /^continue$/i }).click();
+
+  // Step 7 — remote access (skip; DDNS/ACME isn't reachable in e2e).
+  await expect(
+    page.getByRole("heading", { name: /remote access/i }),
+  ).toBeVisible();
+  await page.getByRole("button", { name: /skip for now/i }).click();
+
+  // Step 8 — done. Jump to the dashboard.
+  await expect(page.getByRole("heading", { name: /all set/i })).toBeVisible();
+  await page.getByRole("button", { name: /go to dashboard/i }).click();
+
+  // Lands on the authenticated app shell at the admin-site root.
+  await expect(page).toHaveURL(/\/admin\/$/);
+  await expect(page.getByRole("main")).toBeVisible();
+});

--- a/source/end2end-tests/web-ui/tests/admin-site/setup.spec.ts
+++ b/source/end2end-tests/web-ui/tests/admin-site/setup.spec.ts
@@ -76,7 +76,8 @@ test("first-run wizard creates the admin and reaches the dashboard", async ({
   await expect(page.getByRole("heading", { name: /all set/i })).toBeVisible();
   await page.getByRole("button", { name: /go to dashboard/i }).click();
 
-  // Lands on the authenticated app shell at the admin-site root.
-  await expect(page).toHaveURL(/\/admin\/$/);
+  // Lands on the authenticated app shell at the admin-site root
+  // (`/admin`, the router basename — no trailing slash).
+  await expect(page).toHaveURL(/\/admin\/?$/);
   await expect(page.getByRole("main")).toBeVisible();
 });

--- a/source/web/src/components/LoginForm.tsx
+++ b/source/web/src/components/LoginForm.tsx
@@ -109,7 +109,11 @@ export function LoginForm({
         </label>
       )}
 
-      {formError && <p className="text-sm text-danger">{formError}</p>}
+      {formError && (
+        <p role="alert" className="text-sm text-danger">
+          {formError}
+        </p>
+      )}
       <Button type="submit" disabled={loading} className="w-full">
         {loading ? "Signing in…" : "Log in"}
       </Button>


### PR DESCRIPTION
## What

A1 of epic #614 — Playwright coverage for the admin-site auth surface.

- **setup.spec** — walks the **real first-run wizard** end to end (Step 1 admin creation → Continue/Skip through the 8 steps → dashboard) on a dedicated, never-seeded **`wardnetd-ui-fresh`** daemon driven by a new **`admin-site-setup`** project. Needed because the shared `wardnetd-ui` is API-seeded to `completed` by the `setup` project before specs run (and must be — every admin-site page is behind `SetupGuard`). Picks **locked-router** DHCP mode to bypass the primary-mode LAN-probe gate.
- **login.spec** — bad creds → error + stays on `/login`; good creds → dashboard; **deep-link target restored** after login.

## Notable changes

- **feat(admin-site): deep-link preservation.** `AdminRoute` now stashes the attempted path in navigation state and `Login` returns there on success (previously always `/`). The issue called for this; it wasn't implemented.
- **Fresh daemon infra:** `wardnetd-ui-fresh` in `compose.ui.yaml` (same image — no rebuild — own volume + its own `wardnet_lan_fresh` net to avoid the `10.91.0.1` pin clash), `UI_FRESH_BASE_URL` in `seed.ts`, the `admin-site-setup` Playwright project, and the fresh origin added to the insecure-origin flag. `make e2e-ui` now `--wait`s both daemons.
- **Stable selectors:** `role="alert"` on the `LoginForm` + `Step1Admin` error text; specs use `getByRole`/`getByLabel` only — no copy/pixel assertions, so the pending **skin-only branding** change (new logo + colours) won't break them. Adds a `loginViaUi` fixture helper for A2–A8 / B-stage reuse.

## Verification

- Local: `yarn type-check` clean; `playwright test --list` shows 8 tests routed correctly (`admin-site` runs login+smoke, `admin-site-setup` runs setup.spec on the fresh daemon); `compose config` valid; `make check-web` green for the admin-site/React changes.
- The heavy run (build real-asset image → boot both daemons → walk the wizard) runs in the **CI `end2end-tests-ui` job** — the authoritative green.
- **setup.spec is the secure-context canary:** the wizard's authenticated `advance` calls require the `Secure` cookie to be stored under `--unsafely-treat-insecure-origin-as-secure`. If CI shows it failing at step 2, the fix is to pair the flag with an explicit `--user-data-dir` / persistent context.

Closes #616