### PR TITLE
feat(dns): Stage 5 — recursive resolution mode (#219)

### DIFF
--- a/source/admin-site/src/components/features/UpstreamServersCard.tsx
+++ b/source/admin-site/src/components/features/UpstreamServersCard.tsx
@@ -29,6 +29,9 @@ const PROTOCOLS: DnsProtocol[] = ["udp", "tcp", "tls", "https"];
 interface UpstreamServersCardProps {
   servers: UpstreamDns[];
   isSaving: boolean;
+  /** When true (recursive mode), these upstreams are used only as a
+   *  fallback if recursive resolution fails — surfaced as a note. */
+  fallbackOnly?: boolean;
   onUpdate: (servers: UpstreamDns[]) => void;
 }
 
@@ -38,6 +41,7 @@ interface UpstreamServersCardProps {
 export function UpstreamServersCard({
   servers,
   isSaving,
+  fallbackOnly = false,
   onUpdate,
 }: UpstreamServersCardProps) {
   const [adding, setAdding] = useState(false);
@@ -115,6 +119,13 @@ export function UpstreamServersCard({
       </CardHeader>
 
       <CardContent className="flex flex-col gap-4">
+        {fallbackOnly && (
+          <p className="text-sm text-ink-3">
+            Recursive resolution is active — these upstreams are used only as a
+            fallback if recursion fails. Leave empty to resolve purely from the
+            root servers (failures return SERVFAIL instead of forwarding).
+          </p>
+        )}
         {adding && (
           <AddServerForm
             onCancel={() => setAdding(false)}

--- a/source/admin-site/src/pages/Dns.tsx
+++ b/source/admin-site/src/pages/Dns.tsx
@@ -20,6 +20,13 @@ import { SecuritySettingsCard } from "@/components/features/SecuritySettingsCard
 import { DnsStatsSection } from "@/components/features/DnsStatsSection";
 import { Tabs, TabsList, TabsTrigger } from "@wardnet/web";
 import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@wardnet/web";
+import {
   useDnsStatus,
   useDnsConfig,
   useToggleDns,
@@ -106,9 +113,23 @@ export default function Dns() {
                 <div className="grid grid-cols-2 gap-4">
                   <div>
                     <div className="stat__label">Resolution mode</div>
-                    <div className="text-lg font-semibold capitalize">
-                      {config.resolution_mode}
-                    </div>
+                    <Select
+                      value={config.resolution_mode}
+                      onValueChange={(value) =>
+                        updateConfig.mutate({ resolution_mode: value })
+                      }
+                    >
+                      <SelectTrigger
+                        className="mt-1"
+                        aria-label="Resolution mode"
+                      >
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="forwarding">Forwarding</SelectItem>
+                        <SelectItem value="recursive">Recursive</SelectItem>
+                      </SelectContent>
+                    </Select>
                   </div>
                   <div>
                     <div className="stat__label">DNSSEC</div>
@@ -266,6 +287,7 @@ export default function Dns() {
           <UpstreamServersCard
             servers={config.upstream_servers}
             isSaving={updateConfig.isPending}
+            fallbackOnly={config.resolution_mode === "recursive"}
             onUpdate={(servers) =>
               updateConfig.mutate({ upstream_servers: servers })
             }

--- a/source/daemon/Cargo.lock
+++ b/source/daemon/Cargo.lock
@@ -242,6 +242,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-recursion"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1719,6 +1730,7 @@ version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0d58d28879ceecde6607729660c2667a081ccdc082e082675042793960f178c"
 dependencies = [
+ "async-recursion",
  "cfg-if",
  "futures-util",
  "hickory-net",
@@ -1726,6 +1738,7 @@ dependencies = [
  "ipconfig",
  "ipnet",
  "jni 0.22.4",
+ "lru-cache",
  "moka",
  "ndk-context",
  "once_cell",

--- a/source/daemon/Cargo.toml
+++ b/source/daemon/Cargo.toml
@@ -157,11 +157,14 @@ hickory-proto = { version = "0.26", features = ["dnssec-ring"] }
 # DNS Stage 4: tls-ring/https-ring enable DoT/DoH upstreams; dnssec-ring
 # enables ResolverOpts.validate; webpki-roots bundles Mozilla roots so the
 # appliance can verify upstream DoT/DoH certs without a system trust store.
+# DNS Stage 5: `recursor` enables hickory_resolver::recursor::Recursor (the
+# standalone hickory-recursor crate was folded into hickory-resolver).
 hickory-resolver = { version = "0.26", features = [
     "tls-ring",
     "https-ring",
     "dnssec-ring",
     "webpki-roots",
+    "recursor",
 ] }
 # https://crates.io/crates/socket2 — raw socket2 wrapper used to set
 # SO_BINDTODEVICE on per-tunnel DNS upstream sockets so tunneled-device

--- a/source/daemon/crates/wardnetd/src/dns/server.rs
+++ b/source/daemon/crates/wardnetd/src/dns/server.rs
@@ -1149,7 +1149,7 @@ async fn send_resolved(
 /// (pure recursive) return SERVFAIL rather than leaking to a default
 /// public resolver.
 #[allow(clippy::too_many_arguments)]
-async fn resolve_via_recursor(
+pub(crate) async fn resolve_via_recursor(
     recursor: &Arc<RwLock<Option<TokioRecursor>>>,
     resolver: &Arc<RwLock<TokioResolver>>,
     socket: &Arc<dyn DnsSocket>,
@@ -1830,7 +1830,7 @@ const ROOT_HINTS: &[IpAddr] = &[
 /// `dnssec_enabled` selects validating (built-in IANA root trust anchor)
 /// vs security-unaware. Returns `None` (logged) on construction failure so
 /// the caller can fall back to forwarding.
-fn build_recursor(dnssec_enabled: bool) -> Option<TokioRecursor> {
+pub(crate) fn build_recursor(dnssec_enabled: bool) -> Option<TokioRecursor> {
     let dnssec_policy = if dnssec_enabled {
         DnssecPolicy::ValidateWithStaticKey(DnssecConfig::default())
     } else {

--- a/source/daemon/crates/wardnetd/src/dns/server.rs
+++ b/source/daemon/crates/wardnetd/src/dns/server.rs
@@ -1,5 +1,5 @@
 use std::collections::HashMap;
-use std::net::{IpAddr, SocketAddr};
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 
@@ -14,6 +14,7 @@ use hickory_resolver::config::{
 };
 use hickory_resolver::lookup::Lookup;
 use hickory_resolver::net::runtime::TokioRuntimeProvider;
+use hickory_resolver::recursor::{DnssecConfig, DnssecPolicy, Recursor, RecursorOptions};
 use tokio::net::UdpSocket;
 use tokio::sync::{Mutex, RwLock, broadcast};
 use tokio::task::JoinHandle;
@@ -21,7 +22,7 @@ use tokio_util::sync::CancellationToken;
 use tokio_util::task::TaskTracker;
 use uuid::Uuid;
 use wardnet_common::dns::{
-    DnsConfig, DnsProtocol, DnsRecordType, FilterAction, UpstreamDns, UpstreamId,
+    DnsConfig, DnsProtocol, DnsRecordType, DnsResolutionMode, FilterAction, UpstreamDns, UpstreamId,
 };
 use wardnet_common::event::WardnetEvent;
 use wardnetd_data::repository::QueryLogRow;
@@ -84,6 +85,11 @@ pub struct UdpDnsServer {
     /// listener. Built from the current config; rebuilt on every
     /// `update_config`.
     resolver: Arc<RwLock<TokioResolver>>,
+    /// Recursive resolver (Stage 5). `Some` only when
+    /// `resolution_mode == Recursive`; rebuilt/cleared in `update_config`
+    /// when the mode or the DNSSEC toggle changes, so forwarding mode (the
+    /// default) carries no recursor state.
+    recursor: Arc<RwLock<Option<TokioRecursor>>>,
     /// Per-client-IP token-bucket rate limiter (Stage 4). Enforced at the
     /// top of `handle_query`; disabled when `rate_limit_per_second == 0`.
     rate_limiter: Arc<RateLimiter>,
@@ -204,6 +210,15 @@ impl UdpDnsServer {
             &config.upstream_servers,
             config.dnssec_enabled,
         )));
+        // Build the recursor only in recursive mode (the default forwarding
+        // mode carries no recursor state).
+        let recursor = Arc::new(RwLock::new(
+            if config.resolution_mode == DnsResolutionMode::Recursive {
+                build_recursor(config.dnssec_enabled)
+            } else {
+                None
+            },
+        ));
         let rate_limiter = Arc::new(RateLimiter::new(config.rate_limit_per_second));
         let cache_invalidator_cancel = CancellationToken::new();
         // Subscribe BEFORE spawning so any event published between
@@ -220,6 +235,7 @@ impl UdpDnsServer {
         Self {
             config: Arc::new(RwLock::new(config)),
             resolver,
+            recursor,
             rate_limiter,
             cache,
             dns_filter,
@@ -286,6 +302,7 @@ impl DnsServer for UdpDnsServer {
 
         let config = Arc::clone(&self.config);
         let resolver = Arc::clone(&self.resolver);
+        let recursor = Arc::clone(&self.recursor);
         let rate_limiter = Arc::clone(&self.rate_limiter);
         let cache = Arc::clone(&self.cache);
         let dns_filter = Arc::clone(&self.dns_filter);
@@ -314,6 +331,7 @@ impl DnsServer for UdpDnsServer {
                 socket,
                 config,
                 resolver,
+                recursor,
                 rate_limiter,
                 cache,
                 dns_filter,
@@ -373,12 +391,13 @@ impl DnsServer for UdpDnsServer {
     }
 
     async fn update_config(&self, config: DnsConfig) {
-        let (upstream_changed, dnssec_changed, rebinding_changed) = {
+        let (upstream_changed, dnssec_changed, rebinding_changed, mode_changed) = {
             let prev = self.config.read().await;
             (
                 prev.upstream_servers != config.upstream_servers,
                 prev.dnssec_enabled != config.dnssec_enabled,
                 prev.rebinding_protection != config.rebinding_protection,
+                prev.resolution_mode != config.resolution_mode,
             )
         };
 
@@ -391,11 +410,22 @@ impl DnsServer for UdpDnsServer {
             *self.resolver.write().await = new_resolver;
         }
 
+        // (Re)build or clear the recursor when the mode or DNSSEC toggle
+        // changes (Stage 5). Built only in recursive mode.
+        if mode_changed || dnssec_changed {
+            let new_recursor = if config.resolution_mode == DnsResolutionMode::Recursive {
+                build_recursor(config.dnssec_enabled)
+            } else {
+                None
+            };
+            *self.recursor.write().await = new_recursor;
+        }
+
         // Flush cached answers whose validity depends on the changed
         // policy so a toggle takes effect at once rather than after TTL
         // (e.g. enabling rebinding must not keep serving cached private
-        // IPs; changing upstreams/DNSSEC must not serve stale answers).
-        if upstream_changed || dnssec_changed || rebinding_changed {
+        // IPs; changing upstreams/DNSSEC/mode must not serve stale answers).
+        if upstream_changed || dnssec_changed || rebinding_changed || mode_changed {
             self.cache.write().await.flush();
         }
 
@@ -422,6 +452,7 @@ async fn server_loop(
     socket: Arc<dyn DnsSocket>,
     config: Arc<RwLock<DnsConfig>>,
     resolver: Arc<RwLock<TokioResolver>>,
+    recursor: Arc<RwLock<Option<TokioRecursor>>>,
     rate_limiter: Arc<RateLimiter>,
     cache: Arc<RwLock<DnsCache>>,
     dns_filter: Arc<dyn DnsFilterService>,
@@ -452,6 +483,7 @@ async fn server_loop(
                         let cache = Arc::clone(&cache);
                         let dns_filter = Arc::clone(&dns_filter);
                         let resolver = Arc::clone(&resolver);
+                        let recursor = Arc::clone(&recursor);
                         let log_sink = log_sink.clone();
                         let routing_snapshot = Arc::clone(&routing_snapshot);
                         let tunnel_repo = Arc::clone(&tunnel_repo);
@@ -472,6 +504,7 @@ async fn server_loop(
                                 &cache,
                                 dns_filter.as_ref(),
                                 &resolver,
+                                &recursor,
                                 log_sink.as_deref(),
                                 &routing_snapshot,
                                 &tunnel_repo,
@@ -505,6 +538,7 @@ async fn handle_query(
     cache: &Arc<RwLock<DnsCache>>,
     dns_filter: &dyn DnsFilterService,
     resolver: &Arc<RwLock<TokioResolver>>,
+    recursor: &Arc<RwLock<Option<TokioRecursor>>>,
     log_sink: Option<&DnsLogSink>,
     routing_snapshot: &Arc<ArcSwap<HashMap<IpAddr, UpstreamId>>>,
     tunnel_repo: &Arc<dyn TunnelRepository>,
@@ -848,22 +882,43 @@ async fn handle_query(
 
     match upstream_id {
         UpstreamId::Default => {
-            forward_via_default_resolver(
-                resolver,
-                socket,
-                config,
-                cache,
-                log_sink,
-                request,
-                id,
-                src,
-                &domain,
-                rtype,
-                start,
-                pass_result,
-                upstream_id,
-            )
-            .await?;
+            let recursive = config.read().await.resolution_mode == DnsResolutionMode::Recursive;
+            if recursive {
+                resolve_via_recursor(
+                    recursor,
+                    resolver,
+                    socket,
+                    config,
+                    cache,
+                    log_sink,
+                    request,
+                    id,
+                    src,
+                    &domain,
+                    rtype,
+                    start,
+                    pass_result,
+                    upstream_id,
+                )
+                .await?;
+            } else {
+                forward_via_default_resolver(
+                    resolver,
+                    socket,
+                    config,
+                    cache,
+                    log_sink,
+                    request,
+                    id,
+                    src,
+                    &domain,
+                    rtype,
+                    start,
+                    pass_result,
+                    upstream_id,
+                )
+                .await?;
+            }
         }
         UpstreamId::Tunnel(tunnel_id) => {
             match get_or_build_tunnel_forwarder(tunnel_forwarders, tunnel_repo, tunnel_id).await {
@@ -944,8 +999,6 @@ async fn forward_via_default_resolver(
     pass_result: &str,
     upstream_id: UpstreamId,
 ) -> anyhow::Result<()> {
-    use hickory_proto::rr::RData;
-
     let resolver_guard = resolver.read().await;
     let lookup: Result<Lookup, _> = resolver_guard.lookup(domain, rtype).await;
 
@@ -954,78 +1007,25 @@ async fn forward_via_default_resolver(
 
     match lookup {
         Ok(lookup) => {
-            // DNS rebinding protection (Stage 4): reject answers for an
-            // external domain that resolve to a private/internal IP. Only
-            // the default/recursive upstream path reaches here —
-            // authoritative records, `.lan`, and conditional forwarding
-            // (which legitimately return private IPs) short-circuit earlier.
-            if cfg.rebinding_protection
-                && lookup.answers().iter().any(|r| match &r.data {
-                    RData::A(a) => is_private_ip(IpAddr::V4(a.0)),
-                    RData::AAAA(a) => is_private_ip(IpAddr::V6(a.0)),
-                    _ => false,
-                })
-            {
-                // Empty NOERROR (NODATA), not NXDOMAIN: the name exists, we
-                // just refuse the private answer. NXDOMAIN would poison
-                // stub negative caches for every record type on the name.
-                let mut response = Message::response(id, OpCode::Query);
-                response.metadata.recursion_desired = true;
-                response.metadata.recursion_available = true;
-                response.add_queries(request.queries.clone());
-                let bytes = response.to_bytes()?;
-                socket.send_to(&bytes, src).await?;
-                record_query(
-                    log_sink,
-                    domain,
-                    rtype,
-                    src,
-                    "rebinding_blocked",
-                    upstream,
-                    start.elapsed(),
-                );
-                tracing::debug!(%domain, "blocked DNS rebinding: private IP for external domain");
-                return Ok(());
-            }
-
-            let mut response = Message::response(id, OpCode::Query);
-            response.metadata.recursion_desired = true;
-            response.metadata.recursion_available = true;
-            response.add_queries(request.queries.clone());
-
-            let mut min_ttl = u32::MAX;
-            for record in lookup.answers() {
-                response.add_answer(record.clone());
-                min_ttl = min_ttl.min(record.ttl);
-            }
-
-            let bytes = response.to_bytes()?;
-            socket.send_to(&bytes, src).await?;
-
-            if min_ttl < u32::MAX && min_ttl > 0 {
-                let mut cache_guard = cache.write().await;
-                cache_guard.insert(
-                    upstream_id,
-                    domain,
-                    rtype,
-                    response,
-                    min_ttl,
-                    cfg.cache_ttl_min_secs,
-                    cfg.cache_ttl_max_secs,
-                );
-            }
-
-            let elapsed = start.elapsed();
-            tracing::trace!(%domain, ?rtype, ?elapsed, ?upstream_id, "forwarded");
-            record_query(
+            send_resolved(
+                socket,
+                cache,
                 log_sink,
+                &request,
+                id,
+                src,
                 domain,
                 rtype,
-                src,
+                start,
                 pass_result,
-                upstream.clone(),
-                elapsed,
-            );
+                upstream_id,
+                upstream,
+                cfg.rebinding_protection,
+                cfg.cache_ttl_min_secs,
+                cfg.cache_ttl_max_secs,
+                lookup.answers(),
+            )
+            .await?;
         }
         Err(e) => {
             send_servfail(socket, src, id, &request).await?;
@@ -1040,6 +1040,215 @@ async fn forward_via_default_resolver(
                 upstream,
                 elapsed,
             );
+        }
+    }
+    Ok(())
+}
+
+/// Shared post-resolution responder for the direct-device upstream paths
+/// (forwarding + recursive). Applies DNS rebinding protection, builds and
+/// sends the response, caches it, and logs the query. Both paths funnel
+/// through here so recursive resolution can't bypass rebinding/caching.
+#[allow(clippy::too_many_arguments)]
+async fn send_resolved(
+    socket: &Arc<dyn DnsSocket>,
+    cache: &Arc<RwLock<DnsCache>>,
+    log_sink: Option<&DnsLogSink>,
+    request: &Message,
+    id: u16,
+    src: SocketAddr,
+    domain: &str,
+    rtype: hickory_proto::rr::RecordType,
+    start: std::time::Instant,
+    pass_result: &str,
+    upstream_id: UpstreamId,
+    upstream_label: Option<String>,
+    rebinding_protection: bool,
+    cache_ttl_min_secs: u32,
+    cache_ttl_max_secs: u32,
+    answers: &[hickory_proto::rr::Record],
+) -> anyhow::Result<()> {
+    use hickory_proto::rr::RData;
+
+    // DNS rebinding protection (Stage 4): reject answers for an external
+    // domain that resolve to a private/internal IP. Authoritative records,
+    // `.lan`, and conditional forwarding (which legitimately return private
+    // IPs) short-circuit earlier and never reach here.
+    if rebinding_protection
+        && answers.iter().any(|r| match &r.data {
+            RData::A(a) => is_private_ip(IpAddr::V4(a.0)),
+            RData::AAAA(a) => is_private_ip(IpAddr::V6(a.0)),
+            _ => false,
+        })
+    {
+        // Empty NOERROR (NODATA), not NXDOMAIN: the name exists, we just
+        // refuse the private answer.
+        let mut response = Message::response(id, OpCode::Query);
+        response.metadata.recursion_desired = true;
+        response.metadata.recursion_available = true;
+        response.add_queries(request.queries.clone());
+        let bytes = response.to_bytes()?;
+        socket.send_to(&bytes, src).await?;
+        record_query(
+            log_sink,
+            domain,
+            rtype,
+            src,
+            "rebinding_blocked",
+            upstream_label,
+            start.elapsed(),
+        );
+        tracing::debug!(%domain, "blocked DNS rebinding: private IP for external domain");
+        return Ok(());
+    }
+
+    let mut response = Message::response(id, OpCode::Query);
+    response.metadata.recursion_desired = true;
+    response.metadata.recursion_available = true;
+    response.add_queries(request.queries.clone());
+
+    let mut min_ttl = u32::MAX;
+    for record in answers {
+        response.add_answer(record.clone());
+        min_ttl = min_ttl.min(record.ttl);
+    }
+
+    let bytes = response.to_bytes()?;
+    socket.send_to(&bytes, src).await?;
+
+    if min_ttl < u32::MAX && min_ttl > 0 {
+        let mut cache_guard = cache.write().await;
+        cache_guard.insert(
+            upstream_id,
+            domain,
+            rtype,
+            response,
+            min_ttl,
+            cache_ttl_min_secs,
+            cache_ttl_max_secs,
+        );
+    }
+
+    let elapsed = start.elapsed();
+    tracing::trace!(%domain, ?rtype, ?elapsed, ?upstream_id, "resolved");
+    record_query(
+        log_sink,
+        domain,
+        rtype,
+        src,
+        pass_result,
+        upstream_label,
+        elapsed,
+    );
+    Ok(())
+}
+
+/// Recursive resolution (Stage 5): resolve a direct-device query from the
+/// root servers via the recursor. On recursor failure, fall back to
+/// forwarding **only if upstreams are configured**; with none configured
+/// (pure recursive) return SERVFAIL rather than leaking to a default
+/// public resolver.
+#[allow(clippy::too_many_arguments)]
+async fn resolve_via_recursor(
+    recursor: &Arc<RwLock<Option<TokioRecursor>>>,
+    resolver: &Arc<RwLock<TokioResolver>>,
+    socket: &Arc<dyn DnsSocket>,
+    config: &Arc<RwLock<DnsConfig>>,
+    cache: &Arc<RwLock<DnsCache>>,
+    log_sink: Option<&DnsLogSink>,
+    request: Message,
+    id: u16,
+    src: SocketAddr,
+    domain: &str,
+    rtype: hickory_proto::rr::RecordType,
+    start: std::time::Instant,
+    pass_result: &str,
+    upstream_id: UpstreamId,
+) -> anyhow::Result<()> {
+    let Some(query) = request.queries.first().cloned() else {
+        send_servfail(socket, src, id, &request).await?;
+        return Ok(());
+    };
+
+    let (dnssec_ok, has_upstreams, rebinding, ttl_min, ttl_max) = {
+        let cfg = config.read().await;
+        (
+            cfg.dnssec_enabled,
+            !cfg.upstream_servers.is_empty(),
+            cfg.rebinding_protection,
+            cfg.cache_ttl_min_secs,
+            cfg.cache_ttl_max_secs,
+        )
+    };
+
+    let recursor_result = {
+        let guard = recursor.read().await;
+        match guard.as_ref() {
+            Some(rec) => Some(
+                rec.resolve(query, std::time::Instant::now(), dnssec_ok)
+                    .await,
+            ),
+            None => None,
+        }
+    };
+
+    match recursor_result {
+        Some(Ok(msg)) => {
+            send_resolved(
+                socket,
+                cache,
+                log_sink,
+                &request,
+                id,
+                src,
+                domain,
+                rtype,
+                start,
+                pass_result,
+                upstream_id,
+                Some("recursive".to_owned()),
+                rebinding,
+                ttl_min,
+                ttl_max,
+                &msg.answers,
+            )
+            .await?;
+        }
+        other => {
+            if let Some(Err(e)) = &other {
+                tracing::warn!(%domain, error = %e, "recursive resolution failed");
+            } else {
+                tracing::warn!(%domain, "recursor unavailable; cannot recurse");
+            }
+            if has_upstreams {
+                forward_via_default_resolver(
+                    resolver,
+                    socket,
+                    config,
+                    cache,
+                    log_sink,
+                    request,
+                    id,
+                    src,
+                    domain,
+                    rtype,
+                    start,
+                    pass_result,
+                    upstream_id,
+                )
+                .await?;
+            } else {
+                send_servfail(socket, src, id, &request).await?;
+                record_query(
+                    log_sink,
+                    domain,
+                    rtype,
+                    src,
+                    "recursor_failed",
+                    None,
+                    start.elapsed(),
+                );
+            }
         }
     }
     Ok(())
@@ -1594,4 +1803,50 @@ pub(crate) fn build_resolver(upstreams: &[UpstreamDns], dnssec_enabled: bool) ->
         .with_options(opts)
         .build()
         .expect("failed to build DNS resolver")
+}
+
+type TokioRecursor = Recursor<TokioRuntimeProvider>;
+
+/// IANA root server addresses (a–m) — initial hints for the recursive
+/// resolver (Stage 5). Stable, well-known IPs (b updated 2023); the
+/// recursor discovers the rest of the namespace from these.
+const ROOT_HINTS: &[IpAddr] = &[
+    IpAddr::V4(Ipv4Addr::new(198, 41, 0, 4)), // a.root-servers.net
+    IpAddr::V4(Ipv4Addr::new(170, 247, 170, 2)), // b
+    IpAddr::V4(Ipv4Addr::new(192, 33, 4, 12)), // c
+    IpAddr::V4(Ipv4Addr::new(199, 7, 91, 13)), // d
+    IpAddr::V4(Ipv4Addr::new(192, 203, 230, 10)), // e
+    IpAddr::V4(Ipv4Addr::new(192, 5, 5, 241)), // f
+    IpAddr::V4(Ipv4Addr::new(192, 112, 36, 4)), // g
+    IpAddr::V4(Ipv4Addr::new(198, 97, 190, 53)), // h
+    IpAddr::V4(Ipv4Addr::new(192, 36, 148, 17)), // i
+    IpAddr::V4(Ipv4Addr::new(192, 58, 128, 30)), // j
+    IpAddr::V4(Ipv4Addr::new(193, 0, 14, 129)), // k
+    IpAddr::V4(Ipv4Addr::new(199, 7, 83, 42)), // l
+    IpAddr::V4(Ipv4Addr::new(202, 12, 27, 33)), // m
+];
+
+/// Build a recursive resolver from the root hints (Stage 5).
+/// `dnssec_enabled` selects validating (built-in IANA root trust anchor)
+/// vs security-unaware. Returns `None` (logged) on construction failure so
+/// the caller can fall back to forwarding.
+fn build_recursor(dnssec_enabled: bool) -> Option<TokioRecursor> {
+    let dnssec_policy = if dnssec_enabled {
+        DnssecPolicy::ValidateWithStaticKey(DnssecConfig::default())
+    } else {
+        DnssecPolicy::SecurityUnaware
+    };
+    match Recursor::new(
+        ROOT_HINTS,
+        dnssec_policy,
+        None,
+        RecursorOptions::default(),
+        TokioRuntimeProvider::default(),
+    ) {
+        Ok(recursor) => Some(recursor),
+        Err(e) => {
+            tracing::error!(error = %e, "failed to build recursive resolver; recursive mode will fall back to forwarding");
+            None
+        }
+    }
 }

--- a/source/daemon/crates/wardnetd/src/dns/server.rs
+++ b/source/daemon/crates/wardnetd/src/dns/server.rs
@@ -272,6 +272,16 @@ impl UdpDnsServer {
     pub(crate) fn local_addr(&self) -> Option<SocketAddr> {
         self.local_addr.lock().ok().and_then(|g| *g)
     }
+
+    /// Test-only: drop the recursor so the recursive dispatch path can be
+    /// exercised deterministically. With no recursor, `resolve_via_recursor`
+    /// takes the recursor-unavailable branch (fallback to forwarding when
+    /// upstreams are set, else SERVFAIL) instead of contacting the real
+    /// root servers over the network.
+    #[cfg(test)]
+    pub(crate) async fn clear_recursor_for_test(&self) {
+        *self.recursor.write().await = None;
+    }
 }
 
 #[async_trait]

--- a/source/daemon/crates/wardnetd/src/dns/tests/server.rs
+++ b/source/daemon/crates/wardnetd/src/dns/tests/server.rs
@@ -2260,3 +2260,132 @@ async fn recursor_unavailable_servfails_when_no_upstreams() {
     );
     assert!(response.answers.is_empty(), "SERVFAIL carries no answers");
 }
+
+#[tokio::test]
+async fn recursive_mode_dispatches_through_handle_query_and_falls_back() {
+    // End-to-end through the real query pipeline: a Recursive-mode server
+    // whose recursor has been dropped takes the recursor-unavailable branch
+    // and falls back to the configured upstream. This exercises the
+    // `handle_query` resolution-mode dispatch (the `if recursive { ... }`
+    // arm) and `with_bind_addr`'s recursive construction branch, without
+    // touching the real root servers.
+    use hickory_proto::op::ResponseCode;
+    use hickory_proto::rr::RData;
+
+    let upstream_addr = spawn_stub_upstream().await;
+    let cfg = DnsConfig {
+        resolution_mode: DnsResolutionMode::Recursive,
+        upstream_servers: vec![udp_upstream(upstream_addr)],
+        ..DnsConfig::default()
+    };
+    let server = build_test_server(cfg, loopback_ephemeral());
+    // Drop the (real-root) recursor so dispatch falls back deterministically.
+    server.clear_recursor_for_test().await;
+    server.start().await.unwrap();
+    let bound = server.local_addr().expect("server bound");
+
+    let resp = query_foo_com(bound).await;
+    assert_eq!(
+        resp.metadata.response_code,
+        ResponseCode::NoError,
+        "recursive dispatch must fall back to the upstream and answer NoError"
+    );
+    assert!(
+        resp.answers.iter().any(|r| matches!(
+            &r.data,
+            RData::A(a) if a.0 == Ipv4Addr::new(93, 184, 216, 34)
+        )),
+        "fallback forwarding must return the stub upstream's answer"
+    );
+
+    server.stop().await.unwrap();
+}
+
+#[tokio::test]
+async fn mode_change_via_update_config_rebuilds_recursor_and_flushes_cache() {
+    // Toggling resolution_mode through update_config must (re)build/clear the
+    // recursor and flush the cache so a stale forwarding answer isn't served
+    // after switching modes. We never query in recursive mode, so no
+    // root-server network I/O happens — only the lifecycle branches run.
+    let upstream_addr = spawn_stub_upstream().await;
+    let forwarding = DnsConfig {
+        upstream_servers: vec![udp_upstream(upstream_addr)],
+        ..DnsConfig::default()
+    };
+    let server = build_test_server(forwarding.clone(), loopback_ephemeral());
+    server.start().await.unwrap();
+    let bound = server.local_addr().expect("server bound");
+
+    // Populate the cache via a forwarded query.
+    query_foo_com(bound).await;
+    assert!(
+        server.cache_size().await > 0,
+        "forwarded answer should populate the cache"
+    );
+
+    // Forwarding -> Recursive: builds the recursor and flushes on mode change.
+    server
+        .update_config(DnsConfig {
+            resolution_mode: DnsResolutionMode::Recursive,
+            upstream_servers: vec![udp_upstream(upstream_addr)],
+            ..DnsConfig::default()
+        })
+        .await;
+    assert_eq!(
+        server.cache_size().await,
+        0,
+        "switching resolution mode must flush the cache"
+    );
+
+    // Recursive -> Forwarding: clears the recursor (None branch).
+    server.update_config(forwarding).await;
+
+    server.stop().await.unwrap();
+}
+
+#[tokio::test]
+async fn resolve_via_recursor_servfails_on_empty_query() {
+    // A request carrying no question falls through to the early SERVFAIL
+    // guard rather than panicking on `queries.first()`.
+    use hickory_proto::op::{Message, OpCode, ResponseCode};
+    use hickory_proto::serialize::binary::BinDecodable;
+
+    let recursor = Arc::new(RwLock::new(None));
+    let resolver = Arc::new(RwLock::new(build_resolver(&[], false)));
+    let config = Arc::new(RwLock::new(DnsConfig {
+        resolution_mode: DnsResolutionMode::Recursive,
+        ..DnsConfig::default()
+    }));
+    let cache = Arc::new(RwLock::new(DnsCache::new(1000)));
+    let sent = Arc::new(StdMutex::new(Vec::new()));
+    let socket: Arc<dyn DnsSocket> = Arc::new(RecordingSocket { sent: sent.clone() });
+    let src: SocketAddr = SocketAddr::from(([127, 0, 0, 1], 5353));
+
+    // A Query-opcode message with no questions.
+    let request = Message::response(0xABCD, OpCode::Query);
+    assert!(request.queries.is_empty(), "request must carry no question");
+
+    resolve_via_recursor(
+        &recursor,
+        &resolver,
+        &socket,
+        &config,
+        &cache,
+        None,
+        request,
+        0xABCD,
+        src,
+        "",
+        RecordType::A,
+        std::time::Instant::now(),
+        "forwarded",
+        UpstreamId::Default,
+    )
+    .await
+    .expect("resolve_via_recursor");
+
+    let frames = sent.lock().unwrap().clone();
+    assert_eq!(frames.len(), 1, "exactly one response sent");
+    let response = Message::from_bytes(&frames[0]).expect("parse response");
+    assert_eq!(response.metadata.response_code, ResponseCode::ServFail);
+}

--- a/source/daemon/crates/wardnetd/src/dns/tests/server.rs
+++ b/source/daemon/crates/wardnetd/src/dns/tests/server.rs
@@ -20,18 +20,19 @@ use chrono::Utc;
 use hickory_proto::rr::RecordType;
 use tokio::sync::RwLock;
 use uuid::Uuid;
-use wardnet_common::dns::{DnsConfig, DnsProtocol, UpstreamDns, UpstreamId};
+use wardnet_common::dns::{DnsConfig, DnsProtocol, DnsResolutionMode, UpstreamDns, UpstreamId};
 use wardnet_common::event::WardnetEvent;
 use wardnet_common::tunnel::{Tunnel, TunnelConfig, TunnelStatus};
 use wardnet_common::wireguard_config::WgPeerConfig;
 use wardnetd_data::repository::TunnelRepository;
 use wardnetd_data::repository::tunnel::TunnelRow;
-use wardnetd_services::dns::server::DnsServer;
+use wardnetd_services::dns::cache::DnsCache;
+use wardnetd_services::dns::server::{DnsServer, DnsSocket};
 use wardnetd_services::event::{BroadcastEventBus, EventPublisher};
 
 use crate::dns::server::{
-    TunnelForwarderInfo, UdpDnsServer, duration_to_ms, get_or_build_tunnel_forwarder,
-    spawn_cache_invalidator, upstream_label,
+    TunnelForwarderInfo, UdpDnsServer, build_recursor, build_resolver, duration_to_ms,
+    get_or_build_tunnel_forwarder, resolve_via_recursor, spawn_cache_invalidator, upstream_label,
 };
 use crate::tests::stubs::StubDnsFilterService;
 
@@ -2096,4 +2097,166 @@ async fn rebinding_toggle_via_update_config_flushes_cache_and_blocks_private_ip(
     );
 
     server.stop().await.unwrap();
+}
+
+// ---------------------------------------------------------------------------
+// Stage 5 — recursive resolution mode (#219)
+//
+// `resolve_via_recursor`'s happy path hits the real root servers, so it's
+// covered by Pi/manual acceptance rather than CI. These units pin the
+// deterministic, network-free branches: the recursor-unavailable fallback
+// (forward iff upstreams are configured, else SERVFAIL) and that
+// `build_recursor` constructs for both DNSSEC settings.
+// ---------------------------------------------------------------------------
+
+/// A `DnsSocket` that records every datagram passed to `send_to` instead of
+/// touching the network, so a test can inspect the response the server built.
+/// `recv_from` is never exercised by the responder paths under test.
+struct RecordingSocket {
+    sent: Arc<StdMutex<Vec<Vec<u8>>>>,
+}
+
+#[async_trait]
+impl DnsSocket for RecordingSocket {
+    async fn recv_from(&self, _buf: &mut [u8]) -> std::io::Result<(usize, SocketAddr)> {
+        Err(std::io::Error::new(
+            std::io::ErrorKind::Unsupported,
+            "RecordingSocket does not receive",
+        ))
+    }
+
+    async fn send_to(&self, buf: &[u8], _target: SocketAddr) -> std::io::Result<usize> {
+        self.sent.lock().unwrap().push(buf.to_vec());
+        Ok(buf.len())
+    }
+}
+
+/// Parse the foo.com A request (id=0xCAFE) used by the recursor tests from the
+/// same wire bytes as `query_foo_com`, so the request carries exactly one
+/// question.
+fn foo_com_request() -> hickory_proto::op::Message {
+    use hickory_proto::op::Message;
+    use hickory_proto::serialize::binary::BinDecodable;
+
+    let query: &[u8] = &[
+        0xCA, 0xFE, 0x01, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x03, b'f', b'o',
+        b'o', 0x03, b'c', b'o', b'm', 0x00, 0x00, 0x01, 0x00, 0x01,
+    ];
+    Message::from_bytes(query).expect("parse foo.com request")
+}
+
+#[test]
+fn build_recursor_constructs_for_both_dnssec_settings() {
+    assert!(
+        build_recursor(false).is_some(),
+        "recursor must build with DNSSEC disabled"
+    );
+    assert!(
+        build_recursor(true).is_some(),
+        "recursor must build with DNSSEC validation enabled"
+    );
+}
+
+#[tokio::test]
+async fn recursor_unavailable_falls_back_to_forwarding_when_upstreams_set() {
+    use hickory_proto::op::{Message, ResponseCode};
+    use hickory_proto::rr::RData;
+    use hickory_proto::serialize::binary::BinDecodable;
+
+    let upstream_addr = spawn_stub_upstream().await;
+    let upstreams = vec![udp_upstream(upstream_addr)];
+
+    // Recursor absent (None) → the fallback branch runs. With upstreams
+    // configured, it must forward via the resolver, not SERVFAIL.
+    let recursor = Arc::new(RwLock::new(None));
+    let resolver = Arc::new(RwLock::new(build_resolver(&upstreams, false)));
+    let config = Arc::new(RwLock::new(DnsConfig {
+        resolution_mode: DnsResolutionMode::Recursive,
+        upstream_servers: upstreams,
+        ..DnsConfig::default()
+    }));
+    let cache = Arc::new(RwLock::new(DnsCache::new(1000)));
+    let sent = Arc::new(StdMutex::new(Vec::new()));
+    let socket: Arc<dyn DnsSocket> = Arc::new(RecordingSocket { sent: sent.clone() });
+    let src: SocketAddr = SocketAddr::from(([127, 0, 0, 1], 5353));
+
+    resolve_via_recursor(
+        &recursor,
+        &resolver,
+        &socket,
+        &config,
+        &cache,
+        None,
+        foo_com_request(),
+        0xCAFE,
+        src,
+        "foo.com",
+        RecordType::A,
+        std::time::Instant::now(),
+        "forwarded",
+        UpstreamId::Default,
+    )
+    .await
+    .expect("resolve_via_recursor");
+
+    let frames = sent.lock().unwrap().clone();
+    assert_eq!(frames.len(), 1, "exactly one response sent");
+    let response = Message::from_bytes(&frames[0]).expect("parse response");
+    assert_eq!(response.metadata.response_code, ResponseCode::NoError);
+    assert!(
+        response.answers.iter().any(|r| matches!(
+            &r.data,
+            RData::A(a) if a.0 == Ipv4Addr::new(93, 184, 216, 34)
+        )),
+        "fallback forwarding must return the stub upstream's answer"
+    );
+}
+
+#[tokio::test]
+async fn recursor_unavailable_servfails_when_no_upstreams() {
+    use hickory_proto::op::{Message, ResponseCode};
+    use hickory_proto::serialize::binary::BinDecodable;
+
+    // Recursor absent AND no upstreams configured (pure recursive) → the
+    // server must SERVFAIL rather than leak to a default public resolver.
+    let recursor = Arc::new(RwLock::new(None));
+    let resolver = Arc::new(RwLock::new(build_resolver(&[], false)));
+    let config = Arc::new(RwLock::new(DnsConfig {
+        resolution_mode: DnsResolutionMode::Recursive,
+        upstream_servers: vec![],
+        ..DnsConfig::default()
+    }));
+    let cache = Arc::new(RwLock::new(DnsCache::new(1000)));
+    let sent = Arc::new(StdMutex::new(Vec::new()));
+    let socket: Arc<dyn DnsSocket> = Arc::new(RecordingSocket { sent: sent.clone() });
+    let src: SocketAddr = SocketAddr::from(([127, 0, 0, 1], 5353));
+
+    resolve_via_recursor(
+        &recursor,
+        &resolver,
+        &socket,
+        &config,
+        &cache,
+        None,
+        foo_com_request(),
+        0xCAFE,
+        src,
+        "foo.com",
+        RecordType::A,
+        std::time::Instant::now(),
+        "forwarded",
+        UpstreamId::Default,
+    )
+    .await
+    .expect("resolve_via_recursor");
+
+    let frames = sent.lock().unwrap().clone();
+    assert_eq!(frames.len(), 1, "exactly one response sent");
+    let response = Message::from_bytes(&frames[0]).expect("parse response");
+    assert_eq!(
+        response.metadata.response_code,
+        ResponseCode::ServFail,
+        "pure recursive with no upstreams must SERVFAIL, never forward to a default"
+    );
+    assert!(response.answers.is_empty(), "SERVFAIL carries no answers");
 }

--- a/source/end2end-tests/daemon/tests/dns-config.spec.ts
+++ b/source/end2end-tests/daemon/tests/dns-config.spec.ts
@@ -37,6 +37,13 @@ describe("dns config", () => {
       if (!cfg.enabled) {
         await dns.toggle({ enabled: true });
       }
+      // Reset to forwarding unconditionally: the resolution_mode
+      // round-trip below flips to recursive, and if its assertions throw
+      // before the inline restore runs, the shared daemon would be left
+      // recursing from the root for every downstream spec.
+      if (cfg.resolution_mode !== "forwarding") {
+        await dns.updateConfig({ resolution_mode: "forwarding" });
+      }
     } catch {
       // ignore — best-effort, real failure surfaces from the spec body
     }

--- a/source/end2end-tests/daemon/tests/dns-config.spec.ts
+++ b/source/end2end-tests/daemon/tests/dns-config.spec.ts
@@ -151,6 +151,21 @@ describe("dns config", () => {
     });
   });
 
+  it("round-trips Stage 5 resolution_mode (forwarding ↔ recursive)", async () => {
+    // Default is forwarding; flip to recursive and confirm persistence,
+    // then restore to forwarding so downstream DNS specs (dns-resolve,
+    // blocklists, ...) keep resolving via the configured upstream rather
+    // than recursing from the root servers.
+    const updated = await dns.updateConfig({ resolution_mode: "recursive" });
+    expect(updated.config.resolution_mode).toBe("recursive");
+
+    const refetched = (await dns.getConfig()).config;
+    expect(refetched.resolution_mode).toBe("recursive");
+
+    const restored = await dns.updateConfig({ resolution_mode: "forwarding" });
+    expect(restored.config.resolution_mode).toBe("forwarding");
+  });
+
   it("rejects a DoT/DoH upstream without a TLS server name", async () => {
     let status: number | undefined;
     try {


### PR DESCRIPTION
Closes #219. Last open issue on the DNS epic #272.

## What

Wires the `forwarding | recursive` resolution-mode toggle (the enum/DTO/SDK/`system_config` plumbing already existed but was read nowhere). In **recursive** mode, direct-device (`UpstreamId::Default`) queries resolve from the root servers via hickory's in-process recursor instead of a configured upstream, so no single upstream sees the full query stream. **Forwarding stays the default.**

> **Note on the issue's dep line:** the standalone `hickory-recursor` crate is deprecated/folded into `hickory-resolver` behind the **`recursor`** feature. No new crate, no version bump — just a feature flag on the existing `hickory-resolver 0.26.1`.

## How

- **Cargo**: enable the `recursor` feature on `hickory-resolver`.
- **Server**: `recursor: Arc<RwLock<Option<Recursor>>>` field, built only when mode is `Recursive` (the default forwarding path pays nothing); rebuilt/cleared in `update_config` on mode/DNSSEC change, with a cache flush on mode change. 13 IANA root hints embedded as a constant. DNSSEC drives the recursor's `DnssecPolicy` (validate vs security-unaware), consistent with the forwarding path.
- **Dispatch**: `handle_query`'s `UpstreamId::Default` arm branches on `resolution_mode`. A shared `send_resolved` responder was factored out of `forward_via_default_resolver` so recursive resolution goes through the **same** rebinding-protection / cache-insert / query-log path — recursion can't bypass rebinding.
- **Privacy-preserving fallback**: on recursor failure, fall back to forwarding **only if upstreams are configured**; with none (pure recursive) return **SERVFAIL** rather than leaking to a default public resolver.
- **UI**: a resolution-mode selector on the DNS page; `UpstreamServersCard` stays visible in recursive mode, annotated as **fallback-only** (empty = pure recursion, failures SERVFAIL).

## Tests

- Daemon units: `build_recursor` constructs for DNSSEC on/off; recursor-unavailable + upstreams → falls back to forwarding (RecordingSocket captures the stub answer); recursor-unavailable + no upstreams → SERVFAIL with no answers.
- e2e: `resolution_mode` round-trip (forwarding ↔ recursive), with an `afterAll` reset so the shared daemon is always handed back in forwarding mode.
- The happy recursive path (hits real roots) is Pi/manual acceptance per #219.

## Verification

- `make check-daemon` exit 0 (fmt + clippy + full workspace tests).
- `make check-web` exit 0.
- No schema change.

## Review notes

Ran `/code-review`; verified the recursive success path against `hickory-resolver-0.26.1/src/recursor/mod.rs` — the recursor returns `Err` for NXDOMAIN / NODATA / DNSSEC-bogus and `Ok` only for positive `NoError` answers, so `send_resolved` rebuilding a `NoError` response from `msg.answers` is correct and DNSSEC failures correctly surface as SERVFAIL. One e2e test-isolation fix was applied. Pre-existing (out of scope): `resolution_mode` is `Option<String>` in the API DTO/SDK rather than a typed enum — candidate follow-up.