### PR TITLE
refactor(dns): type resolution_mode as DnsResolutionMode enum

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -21911,9 +21911,13 @@
             ]
           },
           "resolution_mode": {
-            "type": [
-              "string",
-              "null"
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/DnsResolutionMode"
+              }
             ]
           },
           "upstream_servers": {

--- a/source/admin-site/src/pages/Dns.tsx
+++ b/source/admin-site/src/pages/Dns.tsx
@@ -34,6 +34,7 @@ import {
   useUpdateDnsConfig,
 } from "@wardnet/web";
 import { RANGES, type StatsRange } from "@wardnet/web";
+import type { DnsResolutionMode } from "@wardnet/js";
 
 /** DNS server configuration page (admin only). */
 export default function Dns() {
@@ -116,7 +117,9 @@ export default function Dns() {
                     <Select
                       value={config.resolution_mode}
                       onValueChange={(value) =>
-                        updateConfig.mutate({ resolution_mode: value })
+                        updateConfig.mutate({
+                          resolution_mode: value as DnsResolutionMode,
+                        })
                       }
                     >
                       <SelectTrigger

--- a/source/daemon/crates/wardnet-common/src/api.rs
+++ b/source/daemon/crates/wardnet-common/src/api.rs
@@ -7,7 +7,7 @@ use crate::dhcp::{DhcpConfig, DhcpLease, DhcpReservation};
 use crate::dns::{
     AllowlistEntry, Blocklist, ConditionalForwardingRule, CustomDnsRecord, CustomFilterRule,
     DnsConfig, DnsProtocol, DnsQueryLogEntry, DnsQueryResult, DnsRecordSource, DnsRecordType,
-    DnsZone, UpstreamDns,
+    DnsResolutionMode, DnsZone, UpstreamDns,
 };
 use crate::dns_filter::{DeviceDnsFilterSettings, DnsFilterConfig, DnsFilterProfile};
 use crate::routing::RoutingTarget;
@@ -851,7 +851,7 @@ pub struct DnsConfigResponse {
 #[derive(Debug, Deserialize, utoipa::ToSchema)]
 pub struct UpdateDnsConfigRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub resolution_mode: Option<String>,
+    pub resolution_mode: Option<DnsResolutionMode>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub upstream_servers: Option<Vec<UpstreamDnsRequest>>,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/source/daemon/crates/wardnet-common/src/dns.rs
+++ b/source/daemon/crates/wardnet-common/src/dns.rs
@@ -29,6 +29,18 @@ pub enum DnsResolutionMode {
     Recursive,
 }
 
+impl DnsResolutionMode {
+    /// The `snake_case` wire string, matching the serde representation.
+    /// Used to persist the mode in the `system_config` KV store.
+    #[must_use]
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Forwarding => "forwarding",
+            Self::Recursive => "recursive",
+        }
+    }
+}
+
 /// Transport protocol for upstream DNS communication.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, utoipa::ToSchema)]
 #[serde(rename_all = "snake_case")]

--- a/source/daemon/crates/wardnet-common/src/tests/dns.rs
+++ b/source/daemon/crates/wardnet-common/src/tests/dns.rs
@@ -197,12 +197,29 @@ fn update_dns_config_request_full_deserialization() {
         "query_log_retention_days": 14
     }"#;
     let req: UpdateDnsConfigRequest = serde_json::from_str(json).unwrap();
-    assert_eq!(req.resolution_mode.as_deref(), Some("recursive"));
+    assert_eq!(req.resolution_mode, Some(DnsResolutionMode::Recursive));
     assert_eq!(req.cache_size, Some(20_000));
     assert_eq!(req.dnssec_enabled, Some(true));
     assert_eq!(req.rate_limit_per_second, Some(100));
     assert!(req.upstream_servers.is_some());
     assert_eq!(req.upstream_servers.as_ref().unwrap().len(), 1);
+}
+
+#[test]
+fn update_dns_config_request_rejects_invalid_resolution_mode() {
+    // Now that the field is typed as the enum, an unknown mode is a hard
+    // deserialization error (HTTP 422) instead of silently defaulting to
+    // forwarding.
+    let json = r#"{ "resolution_mode": "sideways" }"#;
+    assert!(serde_json::from_str::<UpdateDnsConfigRequest>(json).is_err());
+}
+
+#[test]
+fn dns_resolution_mode_as_str_matches_serde() {
+    for mode in [DnsResolutionMode::Forwarding, DnsResolutionMode::Recursive] {
+        let serde_repr = serde_json::to_string(&mode).unwrap();
+        assert_eq!(serde_repr, format!("\"{}\"", mode.as_str()));
+    }
 }
 
 #[test]

--- a/source/daemon/crates/wardnetd-services/src/dns/service.rs
+++ b/source/daemon/crates/wardnetd-services/src/dns/service.rs
@@ -192,9 +192,9 @@ impl DnsService for DnsServiceImpl {
             )));
         }
 
-        if let Some(ref mode) = req.resolution_mode {
+        if let Some(mode) = req.resolution_mode {
             self.system_config
-                .set("dns_resolution_mode", mode)
+                .set("dns_resolution_mode", mode.as_str())
                 .await
                 .map_err(AppError::Internal)?;
         }

--- a/source/sdk/wardnet-js/src/types/dns.ts
+++ b/source/sdk/wardnet-js/src/types/dns.ts
@@ -42,7 +42,7 @@ export interface DnsConfigResponse {
 }
 
 export interface UpdateDnsConfigRequest {
-  resolution_mode?: string;
+  resolution_mode?: DnsResolutionMode;
   upstream_servers?: UpstreamDns[];
   cache_size?: number;
   cache_ttl_min_secs?: number;


### PR DESCRIPTION
Follow-up to #637 (DNS Stage 5). Tightens the DNS resolution-mode config field from a free-form string to the existing `DnsResolutionMode` enum.

## Why

`UpdateDnsConfigRequest.resolution_mode` was `Option<String>`: the service persisted it verbatim and `load_config` silently defaulted any unrecognized value to `Forwarding`. An admin (or buggy client) sending `"recurse"` or `"RECURSIVE"` would get forwarding with no error. Typing the field as the enum makes serde reject unknown values at deserialization (HTTP 422) instead of silently mis-configuring the resolver.

## Changes

- `api.rs`: `UpdateDnsConfigRequest.resolution_mode` → `Option<DnsResolutionMode>`.
- `dns.rs`: `DnsResolutionMode::as_str()` for `snake_case` KV persistence (single source of truth with serde; covered by a test).
- `service.rs`: store `mode.as_str()` instead of the raw request string.
- SDK: `resolution_mode?: DnsResolutionMode` (was `string`); cast at the `Select` call site in `Dns.tsx`.
- `openapi.json`: `resolution_mode` now `$ref`s `DnsResolutionMode` (`oneOf [null, enum]`) instead of a bare string — regenerated via `make openapi`.
- Tests: invalid value now fails to deserialize; `as_str()` matches the serde representation.

## Verification

- `make check-daemon` exit 0 (fmt + clippy + tests).
- `make check-web` exit 0.
- `make openapi` regenerated; drift gate green.

No runtime behavior change for valid values; only previously-silent invalid input now returns 422.