### PR TITLE
fix(gt): render .claude at gt root on clone, fetch on cold cache

### DIFF
--- a/.gt.yaml
+++ b/.gt.yaml
@@ -7,7 +7,8 @@ setup:
           curl -fsSL https://raw.githubusercontent.com/pedromvgomes/agentic-toolkit/main/install.sh | sh
 
         if [ "$GT_SETUP_PHASE" = "worktree" ]; then
-          agtk sync                                       # worktree has its own checkout, source from cwd
+          agtk sync                                                       # worktree has its own checkout, source from cwd
         else
-          agtk sync --source "${GT_ROOT}/${GT_DEFAULT_BRANCH}"   # clone: source the stack tree from main
+          cd "$GT_ROOT"                                                   # clone: render .claude next to .bare at the gt root
+          agtk sync --config "${GT_ROOT}/${GT_DEFAULT_BRANCH}/.agentic-toolkit.yaml"   # config + lockfile from main, fetch over network
         fi


### PR DESCRIPTION
## Problem

The `.gt.yaml` clone-phase template used:

```sh
agtk sync --source "${GT_ROOT}/${GT_DEFAULT_BRANCH}"
```

Two faults:

1. **Wrong location** — `agtk` renders into the current working dir, which is `main/` during the clone phase, so `.claude` landed in `main/.claude` instead of next to `.bare` at the gt root.
2. **Cold-cache error** — `--source` expects a *toolkit source tree* (`stacks/` + `definitions/`) and skips the network fetch. Pointed at a consumer dir on a fresh machine it can't resolve sources and errors.

## Fix

```sh
cd "$GT_ROOT"
agtk sync --config "${GT_ROOT}/${GT_DEFAULT_BRANCH}/.agentic-toolkit.yaml"
```

Same fix applied to `inforge` and `wardnet-cloud`. The worktree phase is unchanged.

## ⚠️ Pre-existing blocker (out of scope for this PR)

While testing, worktree-phase `agtk sync` fails on this repo's **manifest**, independent of this change:

```
agtk: failed to parse stack manifest
  reason: invalid_entry
  detail: skills[0]: skill name ".agents/skills/bump-rust" cannot contain '/';
          only commands support nested names like 'group/cmd'
```

The current `agtk` no longer accepts local-path skill entries with `/` in `.agentic-toolkit.yaml`. Until the manifest is updated, the toolkit won't render here even with this `.gt.yaml` fix. Flagging for a follow-up.

https://claude.ai/code/session_01DX7SWGnBBRxga9L74hycXB