### PR TITLE
test(e2e): admin-site shell specs + data-testid selector convention (#617)

### DIFF
--- a/.agents/testing.md
+++ b/.agents/testing.md
@@ -70,3 +70,17 @@ async fn create_and_find_by_username() {
 ### Infrastructure tests — real impl, temp resources
 
 `FileSecretStore`, `AgeArchiver`, `SqliteDumper` are tested against real filesystem / real pool with tempfile-based isolation. Each test creates a unique directory under `std::env::temp_dir()` and cleans up on completion.
+
+## Web UI end-to-end tests (Playwright)
+
+The Playwright suite for the three web surfaces lives under
+`source/end2end-tests/web-ui/` (run with `make e2e-ui`). Its setup,
+topology, and the **authoritative selector convention** are documented in
+that directory's [`README.md`](../source/end2end-tests/web-ui/README.md).
+
+Selector convention in brief: **`data-testid` is the primary locator**
+(located via `page.getByTestId(...)`), with a human-facing label/role/text
+assertion added where meaningful. See the README for naming, placement,
+and label-assertion rules; the rationale for reversing the earlier
+role/label-first approach is in
+[`docs/adr-e2e-selector-convention.md`](../docs/adr-e2e-selector-convention.md).

--- a/docs/adr-e2e-selector-convention.md
+++ b/docs/adr-e2e-selector-convention.md
@@ -1,0 +1,75 @@
+# ADR: `data-testid`-primary selectors for the web-ui Playwright suite
+
+**Status**: Accepted  
+**Date**: 2026-06-27  
+**Issue**: #617 (epic #614)
+
+---
+
+## Context
+
+The web-ui Playwright suite (`source/end2end-tests/web-ui/`) covers three
+frontend surfaces. The PW-0 scaffold and the A1 auth/setup specs adopted
+**role/label-first selectors** (`getByRole`, `getByLabel`) — Playwright's
+own recommended default — documented only in code comments
+(`fixtures/ui.ts`, `tests/admin-site/setup.spec.ts`), never in an ADR.
+
+Two forces made that default a liability for this codebase:
+
+1. **A branding re-skin and copy churn are pending.** Role/label/text
+   locators are coupled to visible copy and DOM/ARIA structure, so a
+   re-skin or a wording change breaks specs that test unrelated
+   behaviour — the locator changes when the *presentation* changes, not
+   when the *contract* changes.
+2. **The shell has many low-text, repeated controls** (stat tiles, nav
+   items, icon-only triggers) where a role/label locator is either
+   ambiguous or absent, pushing specs toward brittle text matching.
+
+We needed a locator strategy stable under re-skin without losing the
+accessibility/intent coverage that role/label assertions give.
+
+---
+
+## Decision
+
+**`data-testid` is the primary locator across the whole suite**, and
+specs **additionally assert** the human-facing label/role/text where it
+is meaningful. This reverses the role/label-first approach.
+
+- **Attribute**: `data-testid` (Playwright's zero-config `getByTestId()`
+  default — no `testIdAttribute` override).
+- **Naming**: flat, kebab-case, area-prefixed (`nav-devices`,
+  `mobile-menu-trigger`, `stat-devices`, `page-title`, `login-username`,
+  `notfound-page`). Per-surface project scoping removes the need for
+  namespacing.
+- **Placement**: testids are declared on app components and the shared
+  `@wardnet/web` components (e.g. `LoginForm`), and forwarded through
+  `@wardnet/ui` primitives via their existing `...props` spread
+  (`Button`, `Input`, `StatTile` already forward). Generic primitives
+  carry no consumer-specific test contracts.
+- **Label assertion**: applied only to elements with a meaningful label —
+  interactive controls and headings. Structural containers get a testid
+  but no text assertion.
+- **Scope**: testids are added as specs need them, not pre-seeded.
+
+The full, operational version of these rules lives in the suite's
+[`README.md`](../source/end2end-tests/web-ui/README.md) ("Selector
+convention"); `.agents/testing.md` links to it.
+
+---
+
+## Consequences
+
+- The A1 specs (`login.spec.ts`, `setup.spec.ts`) and the `ui.ts` login
+  helper were retrofitted to the new convention in the #617 PR. The
+  per-surface `smoke.spec.ts` files use only `#root` and were unaffected.
+- App and shared components now carry `data-testid` attributes that ship
+  to production. This is an accepted, negligible cost (a few bytes per
+  attribute) for locator stability.
+- Setup-wizard step transitions remain gated on `getByRole("heading", …)`
+  — the heading is the meaningful label, so the role assertion both gates
+  the step and satisfies the label-assertion rule; the interactive
+  controls within each step are located by testid.
+- Because the locator is decoupled from copy, a spec failing after a
+  re-skin now signals a *real* contract change, not incidental wording
+  drift — the property this decision was made to buy.

--- a/source/admin-site/src/components/compound/DashboardStatCard.tsx
+++ b/source/admin-site/src/components/compound/DashboardStatCard.tsx
@@ -12,6 +12,8 @@ interface DashboardStatCardProps {
   to?: string;
   /** If provided, renders the card in error mode instead of the stat tile. */
   error?: string | null;
+  /** e2e locator, forwarded to the rendered tile (or error card) as `data-testid`. */
+  testId?: string;
 }
 
 /** Single stat card for the admin dashboard. */
@@ -22,10 +24,12 @@ export function DashboardStatCard({
   usagePercent,
   to,
   error,
+  testId,
 }: DashboardStatCardProps) {
   if (error) {
     return (
       <div
+        data-testid={testId}
         className="card flex items-start gap-2 p-3.5 text-danger-soft-ink"
         style={{ background: "var(--danger-soft)" }}
       >
@@ -39,6 +43,7 @@ export function DashboardStatCard({
 
   const tile = (
     <StatTile
+      data-testid={testId}
       label={title}
       value={value}
       sub={subtitle}

--- a/source/admin-site/src/components/compound/MobileMenu.tsx
+++ b/source/admin-site/src/components/compound/MobileMenu.tsx
@@ -15,7 +15,12 @@ export function MobileMenu() {
   return (
     <Drawer open={open} onOpenChange={setOpen}>
       <DrawerTrigger asChild>
-        <Button variant="ghost" size="icon" className="topbar__menu">
+        <Button
+          variant="ghost"
+          size="icon"
+          className="topbar__menu"
+          data-testid="mobile-menu-trigger"
+        >
           <svg
             xmlns="http://www.w3.org/2000/svg"
             width="20"

--- a/source/admin-site/src/components/compound/PageHeader.tsx
+++ b/source/admin-site/src/components/compound/PageHeader.tsx
@@ -12,7 +12,9 @@ export function PageHeader({ title, description, actions }: PageHeaderProps) {
   return (
     <div className="row mb-6 justify-between">
       <div>
-        <h2 className="h-title">{title}</h2>
+        <h2 className="h-title" data-testid="page-title">
+          {title}
+        </h2>
         {description && <p className="h-sub">{description}</p>}
       </div>
       {actions && <div className="row gap-8">{actions}</div>}

--- a/source/admin-site/src/components/compound/Sidebar.tsx
+++ b/source/admin-site/src/components/compound/Sidebar.tsx
@@ -33,6 +33,8 @@ interface NavItem {
   label: string;
   icon: Icon;
   end?: boolean;
+  /** e2e locator rendered as `data-testid` on the nav link. */
+  testId: string;
 }
 
 interface NavSection {
@@ -42,31 +44,76 @@ interface NavSection {
 }
 
 const adminSections: NavSection[] = [
-  { items: [{ to: "/", label: "Dashboard", icon: LayoutGrid, end: true }] },
+  {
+    items: [
+      {
+        to: "/",
+        label: "Dashboard",
+        icon: LayoutGrid,
+        end: true,
+        testId: "nav-dashboard",
+      },
+    ],
+  },
   {
     heading: "Network",
     items: [
-      { to: "/devices", label: "Devices", icon: Monitor },
-      { to: "/tunnels", label: "Tunnels", icon: Cable },
-      { to: "/dhcp", label: "DHCP", icon: Router },
+      {
+        to: "/devices",
+        label: "Devices",
+        icon: Monitor,
+        testId: "nav-devices",
+      },
+      { to: "/tunnels", label: "Tunnels", icon: Cable, testId: "nav-tunnels" },
+      { to: "/dhcp", label: "DHCP", icon: Router, testId: "nav-dhcp" },
     ],
   },
   {
     heading: "Resolver",
     items: [
-      { to: "/dns", label: "DNS", icon: Globe, end: true },
-      { to: "/dns/local", label: "Local DNS", icon: Network },
-      { to: "/dns/filter", label: "DNS Filtering", icon: ShieldCheck },
-      { to: "/rule-requests", label: "Rule requests", icon: Inbox },
+      { to: "/dns", label: "DNS", icon: Globe, end: true, testId: "nav-dns" },
+      {
+        to: "/dns/local",
+        label: "Local DNS",
+        icon: Network,
+        testId: "nav-dns-local",
+      },
+      {
+        to: "/dns/filter",
+        label: "DNS Filtering",
+        icon: ShieldCheck,
+        testId: "nav-dns-filter",
+      },
+      {
+        to: "/rule-requests",
+        label: "Rule requests",
+        icon: Inbox,
+        testId: "nav-rule-requests",
+      },
     ],
   },
   {
     heading: "System",
     items: [
-      { to: "/settings", label: "Settings", icon: SettingsIcon },
-      { to: "/remote-access", label: "Remote access", icon: GlobeLock },
-      { to: "/backups", label: "Backups", icon: Archive },
-      { to: "/power", label: "Power", icon: Power },
+      {
+        to: "/settings",
+        label: "Settings",
+        icon: SettingsIcon,
+        testId: "nav-settings",
+      },
+      {
+        to: "/remote-access",
+        label: "Remote access",
+        icon: GlobeLock,
+        testId: "nav-remote-access",
+      },
+      {
+        to: "/backups",
+        label: "Backups",
+        icon: Archive,
+        testId: "nav-backups",
+      },
+      { to: "/power", label: "Power", icon: Power, testId: "nav-power" },
     ],
   },
 ];
@@ -132,6 +179,7 @@ export function Sidebar({ onNavigate }: SidebarProps) {
                   to={item.to}
                   end={item.end}
                   onClick={onNavigate}
+                  data-testid={item.testId}
                   className={({ isActive }) =>
                     `side__item${isActive ? " is-active" : ""}`
                   }

--- a/source/admin-site/src/pages/Dashboard.tsx
+++ b/source/admin-site/src/pages/Dashboard.tsx
@@ -49,12 +49,14 @@ export default function Dashboard() {
         {/* Stat cards */}
         <div className="grid grid-cols-1 gap-3.5 sm:grid-cols-2 lg:grid-cols-3">
           <DashboardStatCard
+            testId="stat-devices"
             title="Devices"
             value={deviceCount}
             subtitle="on the network"
             to="/devices"
           />
           <DashboardStatCard
+            testId="stat-tunnels"
             title="Tunnels"
             value={tunnelCount}
             subtitle={`${activeTunnels} active`}
@@ -63,22 +65,26 @@ export default function Dashboard() {
           {status && (
             <>
               <DashboardStatCard
+                testId="stat-uptime"
                 title="Uptime"
                 value={formatUptime(status.uptime_seconds)}
                 subtitle={`v${status.release_version}`}
               />
               <DashboardStatCard
+                testId="stat-cpu"
                 title="CPU"
                 value={`${status.cpu_usage_percent.toFixed(1)}%`}
                 usagePercent={status.cpu_usage_percent}
               />
               <DashboardStatCard
+                testId="stat-memory"
                 title="Memory"
                 value={formatBytes(status.memory_used_bytes)}
                 subtitle={`of ${formatBytes(status.memory_total_bytes)}`}
                 usagePercent={memoryPercent}
               />
               <DashboardStatCard
+                testId="stat-disk"
                 title="Disk"
                 value={formatBytes(status.disk_free_bytes)}
                 subtitle={`free of ${formatBytes(status.disk_total_bytes)}`}
@@ -94,12 +100,14 @@ export default function Dashboard() {
             </>
           )}
           <DashboardStatCard
+            testId="stat-dns-queries"
             title="DNS queries (24h)"
             value={dnsStats?.total.toLocaleString() ?? "—"}
             to="/dns/logs"
             error={dnsStatsErrorMsg}
           />
           <DashboardStatCard
+            testId="stat-blocked"
             title="Blocked traffic (24h)"
             value={dnsStats ? `${dnsStats.blockedPercent.toFixed(1)}%` : "—"}
             subtitle={

--- a/source/admin-site/src/pages/NotFound.tsx
+++ b/source/admin-site/src/pages/NotFound.tsx
@@ -6,13 +6,20 @@ export default function NotFound() {
   const navigate = useNavigate();
 
   return (
-    <div className="empty col items-center justify-center gap-4">
+    <div
+      className="empty col items-center justify-center gap-4"
+      data-testid="notfound-page"
+    >
       <p className="h-title text-6xl">404</p>
       <h2 className="h-title">Page not found</h2>
       <p className="h-sub max-w-md">
         The page you're looking for doesn't exist or has been moved.
       </p>
-      <Button variant="outline" onClick={() => navigate("/")}>
+      <Button
+        variant="outline"
+        onClick={() => navigate("/")}
+        data-testid="notfound-home"
+      >
         Go to Dashboard
       </Button>
     </div>

--- a/source/admin-site/src/pages/setup/Step1Admin.tsx
+++ b/source/admin-site/src/pages/setup/Step1Admin.tsx
@@ -78,6 +78,7 @@ export default function Step1Admin() {
         <Field label="Username" htmlFor="username" name="username">
           <Input
             id="username"
+            data-testid="setup-username"
             value={username}
             onChange={(e) => setUsername(e.target.value)}
             autoComplete="username"
@@ -94,6 +95,7 @@ export default function Step1Admin() {
           <Input
             id="password"
             type="password"
+            data-testid="setup-password"
             value={password}
             onChange={(e) => setPassword(e.target.value)}
             autoComplete="new-password"
@@ -122,6 +124,7 @@ export default function Step1Admin() {
           <Input
             id="confirm-password"
             type="password"
+            data-testid="setup-confirm-password"
             value={confirmPassword}
             onChange={(e) => setConfirmPassword(e.target.value)}
             autoComplete="new-password"
@@ -146,6 +149,7 @@ export default function Step1Admin() {
         <Button
           type="submit"
           disabled={setup.isPending || advance.isPending}
+          data-testid="setup-admin-submit"
           className="w-full"
         >
           {setup.isPending || advance.isPending

--- a/source/admin-site/src/pages/setup/Step2Network.tsx
+++ b/source/admin-site/src/pages/setup/Step2Network.tsx
@@ -78,6 +78,7 @@ export default function Step2Network() {
       <Button
         onClick={() => advance.mutate({ to_step: "dhcp" })}
         disabled={advance.isPending}
+        data-testid="setup-network-continue"
         className="w-full"
       >
         {advance.isPending ? "Saving…" : "Continue"}

--- a/source/admin-site/src/pages/setup/Step3DhcpOnboarding.tsx
+++ b/source/admin-site/src/pages/setup/Step3DhcpOnboarding.tsx
@@ -88,6 +88,7 @@ export default function Step3DhcpOnboarding({
             type="radio"
             name="dhcp-mode"
             value="locked_router"
+            data-testid="setup-dhcp-mode-locked"
             checked={mode === "locked_router"}
             onChange={() => setMode("locked_router")}
             className="mt-1 accent-accent"
@@ -195,6 +196,7 @@ export default function Step3DhcpOnboarding({
       <Button
         onClick={handleContinue}
         disabled={advance.isPending || (mode === "primary" && !probeClean)}
+        data-testid="setup-dhcp-continue"
         className="w-full"
       >
         {advance.isPending

--- a/source/admin-site/src/pages/setup/Step4RouterMac.tsx
+++ b/source/admin-site/src/pages/setup/Step4RouterMac.tsx
@@ -116,6 +116,7 @@ export default function Step4RouterMac() {
       <Button
         onClick={handleContinue}
         disabled={advance.isPending}
+        data-testid="setup-router-mac-continue"
         className="w-full"
       >
         {advance.isPending ? "Saving…" : probedMac ? "Continue" : "Skip"}

--- a/source/admin-site/src/pages/setup/Step5Tunnel.tsx
+++ b/source/admin-site/src/pages/setup/Step5Tunnel.tsx
@@ -70,6 +70,7 @@ export default function Step5Tunnel() {
         <Button
           onClick={() => advance.mutate({ to_step: "policy" })}
           disabled={advance.isPending}
+          data-testid="setup-tunnel-skip"
           className="w-full"
         >
           {advance.isPending

--- a/source/admin-site/src/pages/setup/Step6Policy.tsx
+++ b/source/admin-site/src/pages/setup/Step6Policy.tsx
@@ -74,6 +74,7 @@ export default function Step6Policy() {
       <Button
         onClick={handleContinue}
         disabled={setDefault.isPending || advance.isPending}
+        data-testid="setup-policy-continue"
         className="w-full"
       >
         {setDefault.isPending || advance.isPending ? "Saving…" : "Continue"}

--- a/source/admin-site/src/pages/setup/Step7RemoteAccess.tsx
+++ b/source/admin-site/src/pages/setup/Step7RemoteAccess.tsx
@@ -347,6 +347,7 @@ export default function Step7RemoteAccess() {
           variant="outline"
           onClick={finish}
           disabled={advance.isPending}
+          data-testid="setup-remote-access-skip"
           className="w-full"
         >
           {advance.isPending ? "Skipping…" : "Skip for now"}

--- a/source/admin-site/src/pages/setup/Step8Confirm.tsx
+++ b/source/admin-site/src/pages/setup/Step8Confirm.tsx
@@ -21,7 +21,11 @@ export default function Step8Confirm() {
           filtering from the dashboard.
         </p>
       </div>
-      <Button onClick={() => navigate("/")} className="w-full">
+      <Button
+        onClick={() => navigate("/")}
+        data-testid="setup-go-dashboard"
+        className="w-full"
+      >
         Go to dashboard
       </Button>
     </div>

--- a/source/end2end-tests/web-ui/README.md
+++ b/source/end2end-tests/web-ui/README.md
@@ -65,3 +65,45 @@ it shows the no-device state.
 - `WARDNET_UI_BASE_URL` — daemon base URL the browser hits (default
   `http://wardnetd-ui:7411`; e.g. `http://localhost:7411` against a
   locally port-mapped daemon).
+
+## Selector convention
+
+This is the **authoritative** selector convention for the whole web-ui
+Playwright suite. `.agents/testing.md` links here; the rationale is
+recorded in
+[`docs/adr-e2e-selector-convention.md`](../../../docs/adr-e2e-selector-convention.md).
+
+**`data-testid` is the primary locator.** Locate every element with
+`page.getByTestId(...)`, then **additionally assert** the human-facing
+label / role / text where it is meaningful. The testid keeps locators
+stable across the pending branding re-skin and copy/DOM churn (a spec
+only changes when the contract changes); the extra label assertion
+preserves accessibility/intent coverage.
+
+Rules:
+
+1. **Attribute**: `data-testid` (Playwright's zero-config default — no
+   `testIdAttribute` override).
+2. **Naming**: flat, kebab-case, area-prefixed — `nav-devices`,
+   `mobile-menu-trigger`, `stat-devices`, `page-title`, `login-username`,
+   `notfound-page`. Per-surface project scoping prevents cross-surface
+   clashes, so no namespacing.
+3. **Placement**: declare testids on **app components** (admin-site /
+   admin-app / user-app) and the shared `@wardnet/web` components (e.g.
+   `LoginForm`); forward them through `@wardnet/ui` primitives via their
+   existing `...props` spread (`Button`, `Input`, `StatTile` already
+   forward). Generic primitives stay free of consumer-specific test
+   contracts.
+4. **Label assertion**: assert a label/role/text only on elements that
+   carry a meaningful one — interactive controls (`toContainText`,
+   `toHaveRole`, `toHaveAttribute("aria-current", …)`) and headings
+   (asserted via `getByRole("heading", …)`, which doubles as both the
+   step gate and the label). Structural containers get a testid but no
+   text assertion.
+5. **Scope**: add testids as specs need them. Don't pre-seed testids for
+   elements no spec exercises.
+
+A note on `getByRole("heading", …)` in the setup wizard: each step
+transition is gated on the next step's heading. The heading is the
+meaningful label, so the role-based assertion satisfies rule 4 — the
+interactive controls within the step are still located by testid.

--- a/source/end2end-tests/web-ui/fixtures/ui.ts
+++ b/source/end2end-tests/web-ui/fixtures/ui.ts
@@ -5,16 +5,18 @@ import { type Page } from "@playwright/test";
  * used by admin-site and admin-app). Assumes the login page is already
  * loaded; navigation after success is the page's responsibility.
  *
- * Selector-resilient (role/label, no copy/pixel assertions) so the
- * pending branding re-skin doesn't break it. Reused by the A2–A8 and
- * B-stage specs that need an authenticated session via the real UI.
+ * Locators are `data-testid`-based per the suite's selector convention
+ * (see README.md → "Selector convention"): testids give locator stability
+ * across the pending branding re-skin / copy changes. This is a pure action
+ * helper — label/role assertions belong in the calling spec. Reused by the
+ * A2–A8 and B-stage specs that need an authenticated session via the real UI.
  */
 export async function loginViaUi(
   page: Page,
   username: string,
   password: string,
 ): Promise<void> {
-  await page.getByLabel("Username").fill(username);
-  await page.getByLabel("Password", { exact: true }).fill(password);
-  await page.getByRole("button", { name: /log in/i }).click();
+  await page.getByTestId("login-username").fill(username);
+  await page.getByTestId("login-password").fill(password);
+  await page.getByTestId("login-submit").click();
 }

--- a/source/end2end-tests/web-ui/tests/admin-site/dashboard.spec.ts
+++ b/source/end2end-tests/web-ui/tests/admin-site/dashboard.spec.ts
@@ -1,0 +1,34 @@
+import { expect, test } from "@playwright/test";
+
+/**
+ * Admin-site dashboard (Home) shell coverage.
+ *
+ * Runs in the `admin-site` project (seeded daemon + admin storageState),
+ * so `./` lands on the authenticated dashboard. Selectors follow the
+ * suite's `data-testid` convention (README.md → "Selector convention"):
+ * tiles are located by testid, with their human-facing label asserted too.
+ *
+ * Only the always-present tiles are asserted. The system tiles
+ * (uptime/CPU/memory/disk/DHCP) render conditionally off live daemon
+ * status and aren't deterministic enough to gate the shell test on.
+ */
+test("dashboard renders its always-present stat tiles", async ({ page }) => {
+  await page.goto("./");
+
+  // We're on the dashboard, not bounced to login or setup.
+  await expect(page).toHaveURL(/\/admin\/?$/);
+  await expect(page.getByTestId("page-title")).toHaveText("Dashboard");
+
+  // Always-present tiles: locate by testid, assert the visible label.
+  const tiles: Array<[string, string | RegExp]> = [
+    ["stat-devices", "Devices"],
+    ["stat-tunnels", "Tunnels"],
+    ["stat-dns-queries", /DNS queries/i],
+    ["stat-blocked", /Blocked traffic/i],
+  ];
+  for (const [testId, label] of tiles) {
+    const tile = page.getByTestId(testId);
+    await expect(tile).toBeVisible();
+    await expect(tile).toContainText(label);
+  }
+});

--- a/source/end2end-tests/web-ui/tests/admin-site/layout.spec.ts
+++ b/source/end2end-tests/web-ui/tests/admin-site/layout.spec.ts
@@ -1,0 +1,66 @@
+import { expect, test } from "@playwright/test";
+
+/**
+ * Admin-site app shell (AppLayout) coverage: sidebar navigation and the
+ * mobile drawer. Runs in the `admin-site` project (seeded daemon + admin
+ * storageState). Selectors follow the suite's `data-testid` convention
+ * (README.md → "Selector convention").
+ *
+ * NOTE: admin-site has no theme toggle — theme is OS-driven via
+ * `prefers-color-scheme` → `data-theme` (see `src/hooks/useTheme.ts`),
+ * with no UI control and no persistence. The epic's "theme toggle
+ * persists across reload" assertion therefore has nothing to target here
+ * and is intentionally omitted.
+ */
+
+// Desktop sidebar entries that should navigate, keyed by testid → [URL, title].
+const NAV: Array<[string, RegExp, string]> = [
+  ["nav-devices", /\/admin\/devices$/, "Devices"],
+  ["nav-tunnels", /\/admin\/tunnels$/, "Tunnels"],
+  ["nav-dns", /\/admin\/dns$/, "DNS"],
+  ["nav-settings", /\/admin\/settings$/, "Settings"],
+  ["nav-dashboard", /\/admin\/?$/, "Dashboard"],
+];
+
+test("sidebar links navigate and mark the active route", async ({ page }) => {
+  await page.goto("./");
+
+  for (const [testId, url, title] of NAV) {
+    await page.getByTestId(testId).click();
+    await expect(page).toHaveURL(url);
+    // The page header reflects the destination (human-facing label)…
+    await expect(page.getByTestId("page-title")).toHaveText(title);
+    // …and react-router's NavLink marks the link active via aria-current.
+    await expect(page.getByTestId(testId)).toHaveAttribute(
+      "aria-current",
+      "page",
+    );
+  }
+});
+
+test("mobile menu opens the navigation drawer and navigates", async ({
+  page,
+}) => {
+  // Below the 768px breakpoint the desktop sidebar is hidden and the
+  // hamburger trigger appears (see source/styles/styles.css).
+  await page.setViewportSize({ width: 390, height: 844 });
+  await page.goto("./");
+
+  // The drawer isn't mounted until the trigger is clicked.
+  await expect(page.getByRole("dialog")).toBeHidden();
+  await page.getByTestId("mobile-menu-trigger").click();
+
+  const drawer = page.getByRole("dialog");
+  await expect(drawer).toBeVisible();
+
+  // The desktop sidebar also carries nav testids (hidden via CSS), so scope
+  // to the drawer to keep the locator unambiguous.
+  const devicesLink = drawer.getByTestId("nav-devices");
+  await expect(devicesLink).toBeVisible();
+  await expect(devicesLink).toContainText("Devices");
+
+  await devicesLink.click();
+  await expect(page).toHaveURL(/\/admin\/devices$/);
+  // Selecting an item closes the drawer.
+  await expect(page.getByRole("dialog")).toBeHidden();
+});

--- a/source/end2end-tests/web-ui/tests/admin-site/login.spec.ts
+++ b/source/end2end-tests/web-ui/tests/admin-site/login.spec.ts
@@ -6,6 +6,10 @@ import { loginViaUi } from "../../fixtures/ui.js";
 /**
  * Login form coverage on the shared (already set-up) daemon.
  *
+ * Selectors follow the suite's `data-testid` convention (README.md →
+ * "Selector convention"): testids locate, and human-facing label/role/text
+ * is additionally asserted where meaningful.
+ *
  * The `admin-site` project injects an authenticated `storageState`; these
  * tests need a logged-out context, so override it to empty. The admin
  * itself was created by the `setup` project, so the good-credentials
@@ -17,11 +21,16 @@ test("rejects bad credentials and stays on the login page", async ({
   page,
 }) => {
   await page.goto("./login");
-  await page.getByLabel("Username").fill(ADMIN_USERNAME);
-  await page.getByLabel("Password", { exact: true }).fill("wrong-password");
-  await page.getByRole("button", { name: /log in/i }).click();
+  await page.getByTestId("login-username").fill(ADMIN_USERNAME);
+  await page.getByTestId("login-password").fill("wrong-password");
+  await page.getByTestId("login-submit").click();
 
-  await expect(page.getByRole("alert")).toBeVisible();
+  // Locate the error by testid; assert it carries the alert role and the
+  // human-facing failure copy.
+  const error = page.getByTestId("login-error");
+  await expect(error).toBeVisible();
+  await expect(error).toHaveRole("alert");
+  await expect(error).toContainText(/invalid username or password/i);
   await expect(page).toHaveURL(/\/admin\/login$/);
 });
 

--- a/source/end2end-tests/web-ui/tests/admin-site/notfound.spec.ts
+++ b/source/end2end-tests/web-ui/tests/admin-site/notfound.spec.ts
@@ -1,0 +1,22 @@
+import { expect, test } from "@playwright/test";
+
+/**
+ * Admin-site 404 coverage. The `*` route sits outside the auth/setup
+ * guards in App.tsx, so an unknown path renders NotFound directly.
+ * Selectors follow the suite's `data-testid` convention (README.md →
+ * "Selector convention").
+ */
+test("unknown route shows the 404 page and returns home", async ({ page }) => {
+  await page.goto("./this-route-does-not-exist");
+
+  const notFound = page.getByTestId("notfound-page");
+  await expect(notFound).toBeVisible();
+  // Human-facing copy alongside the testid locator.
+  await expect(notFound).toContainText("404");
+  await expect(notFound).toContainText(/page not found/i);
+
+  // The CTA returns to the dashboard.
+  await page.getByTestId("notfound-home").click();
+  await expect(page).toHaveURL(/\/admin\/?$/);
+  await expect(page.getByTestId("page-title")).toHaveText("Dashboard");
+});

--- a/source/end2end-tests/web-ui/tests/admin-site/setup.spec.ts
+++ b/source/end2end-tests/web-ui/tests/admin-site/setup.spec.ts
@@ -12,9 +12,11 @@ import { ADMIN_PASSWORD, ADMIN_USERNAME } from "../../fixtures/seed.js";
  * Step 1 auto-logs-in and step 2's advance is authenticated, so if the
  * `Secure` session cookie weren't stored this would fail at step 2.
  *
- * Selectors are role/label based and step transitions are gated on the
- * next step's heading — no pixel/colour assertions, so the pending
- * branding re-skin won't break it.
+ * Selectors follow the suite's `data-testid` convention (README.md →
+ * "Selector convention"): interactive controls are located by testid, while
+ * each step transition is gated on the next step's heading — the heading
+ * doubles as the human-facing label assertion. No pixel/colour assertions,
+ * so the pending branding re-skin won't break it.
  */
 test("first-run wizard creates the admin and reaches the dashboard", async ({
   page,
@@ -28,16 +30,16 @@ test("first-run wizard creates the admin and reaches the dashboard", async ({
   await expect(
     page.getByRole("heading", { name: /create admin account/i }),
   ).toBeVisible();
-  await page.getByLabel("Username").fill(ADMIN_USERNAME);
-  await page.getByLabel("Password", { exact: true }).fill(ADMIN_PASSWORD);
-  await page.getByLabel("Confirm password").fill(ADMIN_PASSWORD);
-  await page.getByRole("button", { name: /create account/i }).click();
+  await page.getByTestId("setup-username").fill(ADMIN_USERNAME);
+  await page.getByTestId("setup-password").fill(ADMIN_PASSWORD);
+  await page.getByTestId("setup-confirm-password").fill(ADMIN_PASSWORD);
+  await page.getByTestId("setup-admin-submit").click();
 
   // Step 2 — confirm network (auto-logged-in from here on).
   await expect(
     page.getByRole("heading", { name: /confirm network/i }),
   ).toBeVisible();
-  await page.getByRole("button", { name: /^continue$/i }).click();
+  await page.getByTestId("setup-network-continue").click();
 
   // Step 3 — DHCP onboarding. Pick "locked router" to skip the
   // primary-mode LAN-probe gate (the probe isn't meaningful in the
@@ -45,36 +47,36 @@ test("first-run wizard creates the admin and reaches the dashboard", async ({
   await expect(
     page.getByRole("heading", { name: /dhcp onboarding/i }),
   ).toBeVisible();
-  await page.getByRole("radio", { name: /locked router/i }).check();
-  await page.getByRole("button", { name: /^continue$/i }).click();
+  await page.getByTestId("setup-dhcp-mode-locked").check();
+  await page.getByTestId("setup-dhcp-continue").click();
 
   // Step 4 — router MAC (skip; no probed MAC in the e2e env).
   await expect(
     page.getByRole("heading", { name: /router mac/i }),
   ).toBeVisible();
-  await page.getByRole("button", { name: /^(continue|skip)$/i }).click();
+  await page.getByTestId("setup-router-mac-continue").click();
 
   // Step 5 — first VPN tunnel (skip).
   await expect(
     page.getByRole("heading", { name: /first vpn tunnel/i }),
   ).toBeVisible();
-  await page.getByRole("button", { name: /skip for now/i }).click();
+  await page.getByTestId("setup-tunnel-skip").click();
 
   // Step 6 — default routing policy (continue with the seeded default).
   await expect(
     page.getByRole("heading", { name: /default routing/i }),
   ).toBeVisible();
-  await page.getByRole("button", { name: /^continue$/i }).click();
+  await page.getByTestId("setup-policy-continue").click();
 
   // Step 7 — remote access (skip; DDNS/ACME isn't reachable in e2e).
   await expect(
     page.getByRole("heading", { name: /remote access/i }),
   ).toBeVisible();
-  await page.getByRole("button", { name: /skip for now/i }).click();
+  await page.getByTestId("setup-remote-access-skip").click();
 
   // Step 8 — done. Jump to the dashboard.
   await expect(page.getByRole("heading", { name: /all set/i })).toBeVisible();
-  await page.getByRole("button", { name: /go to dashboard/i }).click();
+  await page.getByTestId("setup-go-dashboard").click();
 
   // Lands on the authenticated app shell at the admin-site root
   // (`/admin`, the router basename — no trailing slash).

--- a/source/web/src/components/LoginForm.tsx
+++ b/source/web/src/components/LoginForm.tsx
@@ -69,6 +69,7 @@ export function LoginForm({
       <Field label="Username" htmlFor="username" name="username">
         <Input
           id="username"
+          data-testid="login-username"
           value={username}
           onChange={(e) => setUsername(e.target.value)}
           autoComplete="username"
@@ -85,6 +86,7 @@ export function LoginForm({
         <Input
           id="password"
           type="password"
+          data-testid="login-password"
           value={password}
           onChange={(e) => setPassword(e.target.value)}
           autoComplete="current-password"
@@ -110,11 +112,16 @@ export function LoginForm({
       )}
 
       {formError && (
-        <p role="alert" className="login-form__error">
+        <p role="alert" data-testid="login-error" className="login-form__error">
           {formError}
         </p>
       )}
-      <Button type="submit" disabled={loading} className="login-form__submit">
+      <Button
+        type="submit"
+        disabled={loading}
+        data-testid="login-submit"
+        className="login-form__submit"
+      >
         {loading ? "Signing in…" : "Log in"}
       </Button>
       <p className="login-form__hint">


### PR DESCRIPTION
Closes #617 (epic #614, A2).

## What

Adds the **admin-site shell** Playwright coverage and establishes the
suite-wide **`data-testid` selector convention** it relies on.

### Specs (`admin-site` project)
- `dashboard.spec.ts` — the always-present stat tiles (Devices, Tunnels,
  DNS queries, Blocked traffic) render with their labels on the seeded
  dashboard.
- `layout.spec.ts` — sidebar links navigate and mark the active route via
  `aria-current`; the mobile drawer opens (<768px) and navigates.
  **Theme assertion intentionally omitted** — admin-site has no theme
  toggle (theme is OS-driven via `prefers-color-scheme` → `data-theme`,
  no UI, no persistence); a code comment records this.
- `notfound.spec.ts` — an unknown route shows the 404 page and the CTA
  returns to the dashboard.

### Selector convention (reverses A1's role/label-first choice)
- **`data-testid` is the primary locator** everywhere
  (`page.getByTestId(...)`), with a human-facing label/role/text
  assertion added where meaningful (interactive controls, headings).
  Buys locator stability across the pending branding re-skin / copy churn.
- testids declared on **app components** + the shared `@wardnet/web`
  `LoginForm`, forwarded through `@wardnet/ui` primitives via their
  existing `...props` spread (`Button`, `Input`, `StatTile`).
- Shell testids added: `stat-*`, `nav-*`, `page-title`,
  `mobile-menu-trigger`, `notfound-*`, `login-*`, and the setup-wizard
  controls (`setup-*`).
- **Retrofitted** `login.spec.ts`, `setup.spec.ts`, and the `ui.ts` login
  helper to the new convention.

### Docs
- Authoritative convention section in the e2e `README.md`.
- Pointer + cross-link from `.agents/testing.md`.
- `docs/adr-e2e-selector-convention.md` records the reversal and rationale.

## Verification

Static checks green: admin-site type-check + e2e `tsc --noEmit`, lint,
format. The Playwright run itself is exercised by the `tests-e2e` CI job
(building the daemon image locally was skipped by choice).

## Decisions

Twelve decisions were locked via the `challenge` interview — see the
[planning checkpoint](https://github.com/wardnet/wardnet/issues/617#issuecomment) on #617 (decisions 1–8) plus the four resolved this session
(label-assertion mechanism, shell-scoped testid breadth, README-authoritative docs, and writing the ADR).

https://claude.ai/code/session_01A9ABpFErcKnhFDy2ftEhuW