### PR TITLE
fix(agentic-toolkit): make manifest parse and render on current agtk

### DIFF
--- a/.agentic-toolkit.lock.yaml
+++ b/.agentic-toolkit.lock.yaml
@@ -1,11 +1,11 @@
 version: 2
 sources:
+- url: github.com/wardnet/agentic-stacks.git
+  ref: main
+  sha: 3a19c994319dd8a0d16db16629d19df46cd7e920
 - url: github.com/pedromvgomes/agentic-toolkit.git
   ref: main
-  sha: 06b0c4e9e21b9859b91c504d69f20a0f97cc9de1
+  sha: 9491c8a3004cdaf2eb3a8eb1ce4913de59d77bc4
 - url: github.com/anthropics/skills.git
   ref: main
-  sha: d230a6dd6eb1a0dbee9fec55e2f00a96e28dff81
-- url: github.com/pedromvgomes/gt.git
-  ref: main
-  sha: a932b54e7a390b41f067081e37207821242c319d
+  sha: 35414756ca55738e050562e272a6bbc6273aa926

--- a/.agentic-toolkit.yaml
+++ b/.agentic-toolkit.yaml
@@ -2,6 +2,6 @@ root: agentic
 extends:
    - github.com/wardnet/agentic-stacks/wardnet.yaml@main
 skills:
-  - .agents/skills/bump-rust
+  - ./.agents/skills/bump-rust
 agents:
-  - .agents/agents/rust-engineer
+  - ./.agents/agents/rust-engineer

--- a/.agents/agents/rust-engineer/AGENT.md
+++ b/.agents/agents/rust-engineer/AGENT.md
@@ -1,10 +1,26 @@
 ---
 name: rust-engineer
 description: "Use this agent when the user needs help writing, debugging, refactoring, or reviewing Rust code. This includes implementing new features in Rust, fixing compilation errors, optimizing performance, designing data structures and APIs, working with async/await patterns, managing lifetimes and borrowing, writing idiomatic Rust, and working with the Rust ecosystem (cargo, crates, etc.).\\n\\nExamples:\\n- user: \"Implement a concurrent task queue with work stealing\"\\n  assistant: \"Let me use the rust-engineer agent to design and implement this concurrent data structure.\"\\n  <uses Agent tool to launch rust-engineer>\\n\\n- user: \"I'm getting a lifetime error in this function, can you help?\"\\n  assistant: \"Let me use the rust-engineer agent to diagnose and fix this lifetime issue.\"\\n  <uses Agent tool to launch rust-engineer>\\n\\n- user: \"Refactor this module to use async/await instead of threads\"\\n  assistant: \"Let me use the rust-engineer agent to handle this async refactoring.\"\\n  <uses Agent tool to launch rust-engineer>\\n\\n- user: \"Add error handling to this parser\"\\n  assistant: \"Let me use the rust-engineer agent to implement proper error handling.\"\\n  <uses Agent tool to launch rust-engineer>"
-tools: Bash, Glob, Grep, Read, Edit, Write, NotebookEdit, WebFetch, WebSearch, Skill, LSP, ToolSearch, mcp__plugin_context7_context7__resolve-library-id, mcp__plugin_context7_context7__query-docs
 model: opus
+tools:
+  - Bash
+  - Glob
+  - Grep
+  - Read
+  - Edit
+  - Write
+  - NotebookEdit
+  - WebFetch
+  - WebSearch
+  - Skill
+  - LSP
+  - ToolSearch
+  - mcp__plugin_context7_context7__resolve-library-id
+  - mcp__plugin_context7_context7__query-docs
 color: red
-memory: project
+extensions:
+  claude:
+    memory: project
 ---
 
 You are an elite Rust systems engineer with deep expertise in the Rust programming language, its type system, ownership model, and ecosystem. You have extensive experience building production-grade Rust applications including systems programming, network services, CLI tools, and libraries. You think in terms of zero-cost abstractions, memory safety, and fearless concurrency.


### PR DESCRIPTION
## Problem

This repo's committed `.agentic-toolkit.yaml` no longer resolves with the current `agtk` — worktree/clone setup (and `agtk sync`) fails:

```
agtk: failed to parse stack manifest
  detail: skills[0]: skill name ".agents/skills/bump-rust" cannot contain '/';
          only commands support nested names like 'group/cmd'
```

Follow-up to the `.gt.yaml` clone-phase fix (#685) — that fix is necessary but not sufficient, because the manifest itself didn't parse.

## Changes

1. **Local entries need a `./` prefix.** `.agents/skills/bump-rust` was parsed as a skill *name* (names may not contain `/`). `./.agents/...` marks it as a local path. Applied to both the skill and agent entries.
2. **Agents resolve to `<path>/AGENT.md`.** Moved the flat `.agents/agents/rust-engineer.md` → `.agents/agents/rust-engineer/AGENT.md` and migrated its frontmatter to the agtk agent schema:
   - `tools:` comma-string → YAML list
   - top-level `memory: project` → `extensions.claude.memory: project`
3. **Re-lock** drops the stale `github.com/pedromvgomes/gt.git` source (no longer referenced by the manifest) and adds the previously missing `github.com/wardnet/agentic-stacks.git` pin, so manifest + lockfile + definitions are consistent.

Rendered `.claude/` and `CLAUDE.md` remain untracked (regenerated), as before.

## Verification

Cold-cache `agtk sync` renders `.claude/`, the `rust-engineer` agent, and the `bump-rust` skill — exit 0. The agent's selection description and body are preserved verbatim.

https://claude.ai/code/session_01DX7SWGnBBRxga9L74hycXB