### PR TITLE
test(e2e): admin-site DHCP toggle/pool/reservations/leases specs (#618)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -504,6 +504,8 @@ e2e-ui: build-web
 	      done; \
 	      $(CONTAINER_RT) compose -f $(E2E_UI_COMPOSE) down -v --remove-orphans' EXIT; \
 	$(CONTAINER_RT) compose -f $(E2E_UI_COMPOSE) up -d --build --wait wardnetd-ui wardnetd-ui-fresh tls_proxy; \
+	$(CONTAINER_RT) compose -f $(E2E_UI_COMPOSE) up -d --build --wait test_debian || \
+	    echo "warning: test_debian (LAN client) not healthy; running playwright anyway so failures surface as assertions"; \
 	echo "::group::compose ps before playwright"; \
 	$(CONTAINER_RT) compose -f $(E2E_UI_COMPOSE) ps -a; \
 	echo "::endgroup::"; \

--- a/source/admin-site/src/components/compound/ConfirmDialog.tsx
+++ b/source/admin-site/src/components/compound/ConfirmDialog.tsx
@@ -39,12 +39,15 @@ export function ConfirmDialog({
         </AlertModalHeader>
         <AlertModalFooter>
           <AlertModalCancel asChild>
-            <Button variant="outline">Cancel</Button>
+            <Button variant="outline" data-testid="confirm-dialog-cancel">
+              Cancel
+            </Button>
           </AlertModalCancel>
           <AlertModalAction asChild>
             <Button
               variant={destructive ? "destructive" : "default"}
               onClick={onConfirm}
+              data-testid="confirm-dialog-confirm"
             >
               {confirmLabel}
             </Button>

--- a/source/admin-site/src/components/compound/DhcpConfigCard.tsx
+++ b/source/admin-site/src/components/compound/DhcpConfigCard.tsx
@@ -73,7 +73,8 @@ export function DhcpConfigCard({ config }: DhcpConfigCardProps) {
   // are only checked when the user typed something.
   const validationError = useMemo<string | null>(() => {
     if (!editing) return null;
-    if (!isCompleteIpv4(poolStart)) return "Enter a complete pool start address.";
+    if (!isCompleteIpv4(poolStart))
+      return "Enter a complete pool start address.";
     if (!isCompleteIpv4(poolEnd)) return "Enter a complete pool end address.";
     if (!isCompleteIpv4(subnetMask)) return "Enter a complete subnet mask.";
     if (routerIp !== "" && !isCompleteIpv4(routerIp))

--- a/source/admin-site/src/components/compound/DhcpConfigCard.tsx
+++ b/source/admin-site/src/components/compound/DhcpConfigCard.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { Button } from "@wardnet/web";
 import {
   Card,
@@ -12,6 +12,7 @@ import { Field } from "@wardnet/web";
 import { Input } from "@wardnet/web";
 import { Text } from "@wardnet/web";
 import { Ipv4Input } from "@/components/core/ui/ipv4-input";
+import { isCompleteIpv4, ipv4ToInt } from "@wardnet/js";
 import { ApiErrorAlert } from "@wardnet/web";
 import { useUpdateDhcpConfig } from "@wardnet/web";
 import { useDnsConfig } from "@wardnet/web";
@@ -65,7 +66,25 @@ export function DhcpConfigCard({ config }: DhcpConfigCardProps) {
     updateConfig.reset();
   }
 
+  // Client-side guard for the pool editor. `Ipv4Input` already clamps
+  // octets to 0–255, so we only catch incomplete addresses and a pool
+  // range whose end precedes its start — the same rules the daemon
+  // enforces, surfaced before the round-trip. Optional fields (router)
+  // are only checked when the user typed something.
+  const validationError = useMemo<string | null>(() => {
+    if (!editing) return null;
+    if (!isCompleteIpv4(poolStart)) return "Enter a complete pool start address.";
+    if (!isCompleteIpv4(poolEnd)) return "Enter a complete pool end address.";
+    if (!isCompleteIpv4(subnetMask)) return "Enter a complete subnet mask.";
+    if (routerIp !== "" && !isCompleteIpv4(routerIp))
+      return "Enter a complete fallback router address.";
+    if (ipv4ToInt(poolEnd) < ipv4ToInt(poolStart))
+      return "Pool end must be at or after pool start.";
+    return null;
+  }, [editing, poolStart, poolEnd, subnetMask, routerIp]);
+
   async function handleSave() {
+    if (validationError) return;
     await updateConfig.mutateAsync({
       pool_start: poolStart,
       pool_end: poolEnd,
@@ -88,7 +107,12 @@ export function DhcpConfigCard({ config }: DhcpConfigCardProps) {
         </CardTitle>
         {!editing && (
           <CardAction>
-            <Button variant="outline" size="sm" onClick={startEdit}>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={startEdit}
+              data-testid="dhcp-config-edit"
+            >
               Edit
             </Button>
           </CardAction>
@@ -106,6 +130,7 @@ export function DhcpConfigCard({ config }: DhcpConfigCardProps) {
               >
                 <Ipv4Input
                   id="dhcp-pool-start"
+                  data-testid="dhcp-pool-start"
                   value={poolStart}
                   onChange={setPoolStart}
                   placeholder="192.168.1.100"
@@ -118,6 +143,7 @@ export function DhcpConfigCard({ config }: DhcpConfigCardProps) {
               >
                 <Ipv4Input
                   id="dhcp-pool-end"
+                  data-testid="dhcp-pool-end"
                   value={poolEnd}
                   onChange={setPoolEnd}
                   placeholder="192.168.1.200"
@@ -128,6 +154,7 @@ export function DhcpConfigCard({ config }: DhcpConfigCardProps) {
             <Field label="Subnet mask" htmlFor="dhcp-subnet">
               <Ipv4Input
                 id="dhcp-subnet"
+                data-testid="dhcp-subnet"
                 value={subnetMask}
                 onChange={setSubnetMask}
                 placeholder="255.255.255.0"
@@ -157,6 +184,7 @@ export function DhcpConfigCard({ config }: DhcpConfigCardProps) {
               >
                 <Ipv4Input
                   id="dhcp-router"
+                  data-testid="dhcp-router"
                   value={routerIp}
                   onChange={setRouterIp}
                   placeholder="10.232.1.1"
@@ -179,6 +207,17 @@ export function DhcpConfigCard({ config }: DhcpConfigCardProps) {
               </Field>
             )}
 
+            {validationError && (
+              <Text
+                as="p"
+                size="sm"
+                className="text-danger-soft-ink"
+                data-testid="dhcp-config-validation"
+              >
+                {validationError}
+              </Text>
+            )}
+
             {updateConfig.isError && (
               <ApiErrorAlert
                 error={updateConfig.error}
@@ -191,10 +230,15 @@ export function DhcpConfigCard({ config }: DhcpConfigCardProps) {
               variant="ghost"
               onClick={cancelEdit}
               disabled={updateConfig.isPending}
+              data-testid="dhcp-config-cancel"
             >
               Cancel
             </Button>
-            <Button onClick={handleSave} disabled={updateConfig.isPending}>
+            <Button
+              onClick={handleSave}
+              disabled={updateConfig.isPending || validationError !== null}
+              data-testid="dhcp-config-save"
+            >
               {updateConfig.isPending ? "Saving…" : "Save"}
             </Button>
           </CardFooter>
@@ -210,7 +254,12 @@ export function DhcpConfigCard({ config }: DhcpConfigCardProps) {
             </div>
             <div>
               <dt className="text-ink-3">Pool range</dt>
-              <Text as="dd" size="xs" className="font-mono">
+              <Text
+                as="dd"
+                size="xs"
+                className="font-mono"
+                data-testid="dhcp-config-pool-range"
+              >
                 {config.pool_start} &ndash; {config.pool_end}
               </Text>
             </div>

--- a/source/admin-site/src/components/compound/DhcpEntryTable.tsx
+++ b/source/admin-site/src/components/compound/DhcpEntryTable.tsx
@@ -216,9 +216,19 @@ export function DhcpEntryTable({
   const columns = useMemo(() => buildColumns(deviceIndex), [deviceIndex]);
 
   const groups: DataTableGroup[] = [
-    { id: "all", label: "All", count: counts.all },
-    { id: "reservations", label: "Reservations", count: counts.reservations },
-    { id: "leases", label: "Leases", count: counts.leases },
+    { id: "all", label: "All", count: counts.all, testId: "dhcp-group-all" },
+    {
+      id: "reservations",
+      label: "Reservations",
+      count: counts.reservations,
+      testId: "dhcp-group-reservations",
+    },
+    {
+      id: "leases",
+      label: "Leases",
+      count: counts.leases,
+      testId: "dhcp-group-leases",
+    },
   ];
 
   // Empty initial state — show the discovery placeholder while we
@@ -243,8 +253,11 @@ export function DhcpEntryTable({
       searchValue={searchValue}
       onSearchChange={onSearchChange}
       searchPlaceholder="Search by MAC, hostname or IP"
+      searchTestId="dhcp-search"
       addLabel="Add reservation"
       onAdd={onAddReservation}
+      addTestId="dhcp-add-reservation"
+      rowActionsTestId="dhcp-entry-menu"
       onRowClick={
         onDeviceClick
           ? (entry) => {
@@ -260,6 +273,7 @@ export function DhcpEntryTable({
             <RowAction
               onSelect={() => onDeleteReservation(entry.reservation!.id)}
               destructive
+              testId="dhcp-entry-delete"
             >
               Delete
             </RowAction>
@@ -272,12 +286,16 @@ export function DhcpEntryTable({
         ) {
           return (
             <>
-              <RowAction onSelect={() => onMakeStatic(entry.lease!)}>
+              <RowAction
+                onSelect={() => onMakeStatic(entry.lease!)}
+                testId="dhcp-entry-make-static"
+              >
                 Make static
               </RowAction>
               <RowAction
                 onSelect={() => onRevokeLease(entry.lease!.id)}
                 destructive
+                testId="dhcp-entry-revoke"
               >
                 Revoke
               </RowAction>

--- a/source/admin-site/src/components/compound/DhcpStatusCard.tsx
+++ b/source/admin-site/src/components/compound/DhcpStatusCard.tsx
@@ -31,13 +31,17 @@ export function DhcpStatusCard({
     <Card>
       <CardHeader>
         <CardTitle>DHCP server</CardTitle>
-        <Pill variant={status.running ? "ok" : "ghost"}>
+        <Pill
+          variant={status.running ? "ok" : "ghost"}
+          data-testid="dhcp-status-pill"
+        >
           <span className="dot" />
           {status.running ? "Running" : "Stopped"}
         </Pill>
         <CardAction>
           <Toggle
             id="dhcp-toggle"
+            data-testid="dhcp-toggle"
             aria-label="Enable DHCP"
             checked={status.enabled}
             onCheckedChange={onToggle}

--- a/source/admin-site/src/components/core/ui/data-table.tsx
+++ b/source/admin-site/src/components/core/ui/data-table.tsx
@@ -35,6 +35,10 @@ export interface DataTableGroup {
   id: string;
   label: string;
   count?: number;
+  /** Optional `data-testid` for this group's tab, forwarded from the
+   *  consuming component so the generic primitive carries no baked-in
+   *  test contract (e2e selector ADR). */
+  testId?: string;
 }
 
 export interface RowActionProps {
@@ -46,6 +50,9 @@ export interface RowActionProps {
   destructive?: boolean;
   /** Optional leading icon (rendered before the label). */
   icon?: ReactNode;
+  /** Optional `data-testid` for the menu item so e2e specs can target
+   *  a specific action without relying on its label text. */
+  testId?: string;
   children: ReactNode;
 }
 
@@ -58,12 +65,14 @@ export function RowAction({
   onSelect,
   destructive,
   icon,
+  testId,
   children,
 }: RowActionProps) {
   return (
     <DropdownMenuItem
       onSelect={onSelect}
       variant={destructive ? "destructive" : "default"}
+      data-testid={testId}
     >
       {icon}
       <span>{children}</span>
@@ -110,6 +119,13 @@ interface DataTableProps<TData, TValue> {
    *  reimplement it. */
   addLabel?: string;
   onAdd?: () => void;
+  /** Optional `data-testid`s forwarded onto the toolbar search input,
+   *  the Add CTA, and each row's overflow-menu trigger. Kept as props
+   *  (not literals) so this shared primitive holds no consumer-specific
+   *  test contract — the consuming compound/feature component owns it. */
+  searchTestId?: string;
+  addTestId?: string;
+  rowActionsTestId?: string;
   /** Free-form action slot — escape hatch for non-standard toolbar
    *  controls (multiple buttons, a custom widget). Prefer `addLabel`
    *  + `onAdd` for the common "Add X" case. */
@@ -150,6 +166,9 @@ export function DataTable<TData, TValue>({
   filters,
   addLabel,
   onAdd,
+  searchTestId,
+  addTestId,
+  rowActionsTestId,
   action,
   rowActions,
 }: DataTableProps<TData, TValue>) {
@@ -188,6 +207,7 @@ export function DataTable<TData, TValue>({
                       role="tab"
                       aria-selected={g.id === activeGroup}
                       data-state={g.id === activeGroup ? "active" : "inactive"}
+                      data-testid={g.testId}
                       onClick={() => onGroupChange?.(g.id)}
                     >
                       {g.label}
@@ -231,11 +251,12 @@ export function DataTable<TData, TValue>({
                 value={searchValue ?? ""}
                 onChange={(e) => onSearchChange(e.target.value)}
                 placeholder={searchPlaceholder}
+                data-testid={searchTestId}
               />
             </label>
           )}
           {hasAddCta && (
-            <Button variant="outline" onClick={onAdd}>
+            <Button variant="outline" onClick={onAdd} data-testid={addTestId}>
               <Plus aria-hidden />
               {addLabel}
             </Button>
@@ -302,6 +323,7 @@ export function DataTable<TData, TValue>({
                             variant="ghost"
                             size="icon-sm"
                             aria-label="Row actions"
+                            data-testid={rowActionsTestId}
                           >
                             <MoreHorizontal />
                           </Button>

--- a/source/admin-site/src/components/core/ui/ipv4-input.tsx
+++ b/source/admin-site/src/components/core/ui/ipv4-input.tsx
@@ -15,9 +15,11 @@ interface Ipv4InputProps {
   readOnly?: boolean;
   className?: string;
   id?: string;
-  /** Forwarded onto the first octet input so e2e specs can locate and
-   *  drive the whole field (the `.`-keydown auto-tab carries typing
-   *  across the remaining segments). */
+  /** Forwarded onto the field wrapper so e2e specs can locate it and
+   *  fill each octet input individually (`getByTestId(id).locator("input")`).
+   *  Per-segment filling avoids the auto-tab-on-`.` behaviour, which
+   *  can skip an octet that another octet's >25 auto-advance already
+   *  jumped past. */
   "data-testid"?: string;
 }
 
@@ -137,6 +139,7 @@ export function Ipv4Input({
   return (
     <div
       data-segmented
+      data-testid={dataTestId}
       className={cn(
         "input",
         disabled && "cursor-not-allowed opacity-60",
@@ -149,7 +152,6 @@ export function Ipv4Input({
           <input
             ref={refs[i]}
             id={i === 0 ? id : undefined}
-            data-testid={i === 0 ? dataTestId : undefined}
             type="text"
             inputMode="numeric"
             value={octet}

--- a/source/admin-site/src/components/core/ui/ipv4-input.tsx
+++ b/source/admin-site/src/components/core/ui/ipv4-input.tsx
@@ -15,6 +15,10 @@ interface Ipv4InputProps {
   readOnly?: boolean;
   className?: string;
   id?: string;
+  /** Forwarded onto the first octet input so e2e specs can locate and
+   *  drive the whole field (the `.`-keydown auto-tab carries typing
+   *  across the remaining segments). */
+  "data-testid"?: string;
 }
 
 function parseOctets(value: string): [string, string, string, string] {
@@ -36,6 +40,7 @@ export function Ipv4Input({
   readOnly,
   className,
   id,
+  "data-testid": dataTestId,
 }: Ipv4InputProps) {
   const ref0 = useRef<HTMLInputElement>(null);
   const ref1 = useRef<HTMLInputElement>(null);
@@ -144,6 +149,7 @@ export function Ipv4Input({
           <input
             ref={refs[i]}
             id={i === 0 ? id : undefined}
+            data-testid={i === 0 ? dataTestId : undefined}
             type="text"
             inputMode="numeric"
             value={octet}

--- a/source/admin-site/src/components/core/ui/mac-input.tsx
+++ b/source/admin-site/src/components/core/ui/mac-input.tsx
@@ -15,9 +15,10 @@ interface MacInputProps {
   readOnly?: boolean;
   className?: string;
   id?: string;
-  /** Forwarded onto the first hex segment input so e2e specs can locate
-   *  and drive the whole field (the 2-char auto-tab carries typing
-   *  across the remaining segments). */
+  /** Forwarded onto the field wrapper so e2e specs can locate it and
+   *  fill each hex-segment input individually
+   *  (`getByTestId(id).locator("input")`), avoiding reliance on the
+   *  2-char auto-tab while typing. */
   "data-testid"?: string;
 }
 
@@ -142,6 +143,7 @@ export function MacInput({
   return (
     <div
       data-segmented
+      data-testid={dataTestId}
       className={cn(
         "input",
         disabled && "cursor-not-allowed opacity-60",
@@ -154,7 +156,6 @@ export function MacInput({
           <input
             ref={refs[i]}
             id={i === 0 ? id : undefined}
-            data-testid={i === 0 ? dataTestId : undefined}
             type="text"
             value={seg.toUpperCase()}
             placeholder={placeholderSegs[i] ?? "00"}

--- a/source/admin-site/src/components/core/ui/mac-input.tsx
+++ b/source/admin-site/src/components/core/ui/mac-input.tsx
@@ -15,6 +15,10 @@ interface MacInputProps {
   readOnly?: boolean;
   className?: string;
   id?: string;
+  /** Forwarded onto the first hex segment input so e2e specs can locate
+   *  and drive the whole field (the 2-char auto-tab carries typing
+   *  across the remaining segments). */
+  "data-testid"?: string;
 }
 
 function parseSegments(
@@ -49,6 +53,7 @@ export function MacInput({
   readOnly,
   className,
   id,
+  "data-testid": dataTestId,
 }: MacInputProps) {
   // Six individual useRef calls (hook count must be constant and not called
   // inside a callback — `Array.from(() => useRef(...))` violates both).
@@ -149,6 +154,7 @@ export function MacInput({
           <input
             ref={refs[i]}
             id={i === 0 ? id : undefined}
+            data-testid={i === 0 ? dataTestId : undefined}
             type="text"
             value={seg.toUpperCase()}
             placeholder={placeholderSegs[i] ?? "00"}

--- a/source/admin-site/src/components/features/CreateReservationInline.tsx
+++ b/source/admin-site/src/components/features/CreateReservationInline.tsx
@@ -84,6 +84,7 @@ export function CreateReservationInline({
           <Field label="MAC address" htmlFor="res-mac" className="flex-1">
             <MacInput
               id="res-mac"
+              data-testid="dhcp-reservation-mac"
               value={macAddress}
               onChange={setMacAddress}
               readOnly={macReadOnly}
@@ -93,6 +94,7 @@ export function CreateReservationInline({
           <Field label="IP address" htmlFor="res-ip" className="flex-1">
             <Ipv4Input
               id="res-ip"
+              data-testid="dhcp-reservation-ip"
               value={ipAddress}
               onChange={setIpAddress}
               placeholder="10.232.1.50"
@@ -108,6 +110,7 @@ export function CreateReservationInline({
           >
             <Input
               id="res-hostname"
+              data-testid="dhcp-reservation-hostname"
               value={hostname}
               onChange={(e) => setHostname(e.target.value)}
               placeholder="my-printer"
@@ -121,6 +124,7 @@ export function CreateReservationInline({
           >
             <Input
               id="res-desc"
+              data-testid="dhcp-reservation-desc"
               value={description}
               onChange={(e) => setDescription(e.target.value)}
               placeholder="Office printer"
@@ -140,10 +144,15 @@ export function CreateReservationInline({
           variant="ghost"
           onClick={onClose}
           disabled={createReservation.isPending}
+          data-testid="dhcp-reservation-cancel"
         >
           Cancel
         </Button>
-        <Button onClick={handleSave} disabled={createReservation.isPending}>
+        <Button
+          onClick={handleSave}
+          disabled={createReservation.isPending}
+          data-testid="dhcp-reservation-submit"
+        >
           {createReservation.isPending ? "Creating…" : "Create reservation"}
         </Button>
       </CardFooter>

--- a/source/end2end-tests/web-ui/README.md
+++ b/source/end2end-tests/web-ui/README.md
@@ -24,6 +24,19 @@ self-seeded `wardnetd-ui` instance (`compose.ui.yaml`) — isolated from
 the API/kernel Vitest suite under `../daemon`. JUnit + an HTML report are
 written to `reports/`.
 
+### LAN client (`test_debian`)
+
+A real Debian container running `wardnet-test-agent client serve` on `:3001`
+is attached to `wardnet_lan`. DHCP-lease specs drive it via
+`fixtures/dhcp.ts:seedDhcpLease` (calls `/dhcp/renew` until a daemon-issued
+address lands on `eth0`). `ui_runner` depends on it with
+`condition: service_started`, not `service_healthy` — a flaky client should
+fail only the leases spec, not abort the whole suite. The IPAM range
+(`.2–.15`) sits below the pool the spec sets (`.100–.150`), so any `.100+`
+address is unambiguously daemon-issued. Agent helpers in `fixtures/dhcp.ts`
+are ported from `source/end2end-tests/daemon/tests/helpers.ts` because this
+harness deliberately avoids importing the daemon package.
+
 ## Why a self-signed TLS proxy (HTTPS)
 
 Two things need a *secure context*: the daemon's session cookie is set
@@ -92,8 +105,11 @@ Rules:
    admin-app / user-app) and the shared `@wardnet/web` components (e.g.
    `LoginForm`); forward them through `@wardnet/ui` primitives via their
    existing `...props` spread (`Button`, `Input`, `StatTile` already
-   forward). Generic primitives stay free of consumer-specific test
-   contracts.
+   forward). Complex primitives that expose several independently-targetable
+   slots (e.g. `data-table` with `searchTestId`, `addTestId`,
+   `rowActionsTestId`; `DataTableGroup.testId`; `RowAction.testId`) use
+   explicit named props instead of a single spread — the principle is the
+   same: consumers supply testids, the primitive never hardcodes them.
 4. **Label assertion**: assert a label/role/text only on elements that
    carry a meaningful one — interactive controls (`toContainText`,
    `toHaveRole`, `toHaveAttribute("aria-current", …)`) and headings

--- a/source/end2end-tests/web-ui/compose.ui.yaml
+++ b/source/end2end-tests/web-ui/compose.ui.yaml
@@ -174,6 +174,43 @@ services:
       retries: 30
       start_period: 10s
 
+  # Real LAN client used by the DHCP-leases spec (A3, #618). Runs the
+  # wardnet-test-agent HTTP server on :3001; the spec drives its
+  # /dhcp/renew to make `wardnetd-ui`'s DHCP server hand out a lease,
+  # then asserts that lease surfaces in the admin-site DHCP table. Same
+  # image + custom dhclient script as the daemon stack's test_debian
+  # (the leased address lands as a secondary IPv4 so compose's
+  # service-name DNS to test_debian keeps resolving). The wardnet_lan
+  # IPAM range (.2-.15) sits below the .100-.150 pool the spec sets, so
+  # a .100+ address is unambiguously daemon-issued.
+  #
+  # WARDNETD_TEST_IMAGE points at the image `wardnetd-ui` already builds
+  # (WEB_DIST=real, same Dockerfile.test that bundles wardnet-test-agent),
+  # so no second daemon image is compiled. The Makefile builds
+  # wardnetd-ui before this service so the `FROM` resolves.
+  test_debian:
+    build:
+      context: ../../..
+      dockerfile: source/end2end-tests/daemon/Dockerfile.client
+      args:
+        BASE_IMAGE: debian:bookworm-slim
+        WARDNETD_TEST_IMAGE: ${WARDNETD_UI_TEST_IMAGE:-wardnetd:dev-test-ui}
+    image: wardnet-test-client-debian:dev
+    depends_on:
+      wardnetd-ui:
+        condition: service_healthy
+    cap_add:
+      - NET_ADMIN
+      - NET_RAW
+    networks:
+      wardnet_lan: {}
+    healthcheck:
+      test: ["CMD-SHELL", "curl -fsS http://127.0.0.1:3001/health || exit 1"]
+      interval: 3s
+      timeout: 2s
+      retries: 20
+      start_period: 10s
+
   ui_runner:
     build:
       context: ../../..
@@ -186,10 +223,20 @@ services:
         condition: service_healthy
       tls_proxy:
         condition: service_healthy
+      # Best-effort only (started, not healthy): the LAN client backs a
+      # single spec (dhcp-leases). If it never goes healthy, the runner
+      # must still start so the rest of the suite executes and that one
+      # spec surfaces its own assertion failure — matching the Makefile's
+      # `|| echo … running playwright anyway`. A hard `service_healthy`
+      # here (with `compose run`, no `--no-deps`) would instead abort the
+      # whole suite on a flaky LAN client.
+      test_debian:
+        condition: service_started
     environment:
       WARDNET_UI_BASE_URL: "https://wardnetd-ui-tls"
       WARDNET_UI_FRESH_BASE_URL: "https://wardnetd-ui-fresh-tls"
       WARDNET_API_BASE_URL: "http://wardnetd-ui:7411/api"
+      WARDNET_TEST_DEBIAN_AGENT: "http://test_debian:3001"
     # Reports bind-mounted (not a named volume) to the same host dir the
     # Makefile trap writes compose-logs.txt / inspect.json into, so the
     # JUnit + HTML report land alongside them in the CI artefact.

--- a/source/end2end-tests/web-ui/fixtures/dhcp.ts
+++ b/source/end2end-tests/web-ui/fixtures/dhcp.ts
@@ -194,3 +194,27 @@ export async function seedDhcpLease(): Promise<string> {
     DHCP_POOL_END,
   );
 }
+
+/**
+ * Create a static reservation via the API so the admin-site DHCP table
+ * is non-empty (the table renders a placeholder with no toolbar — and
+ * thus no "Add reservation" button — when it has zero entries). Needs
+ * no LAN client, so it's a cheap, order-independent precondition.
+ * Idempotent: a 409 (reservation already exists) is treated as success.
+ */
+export async function seedReservation(
+  macAddress: string,
+  ipAddress: string,
+): Promise<void> {
+  const token = await ensureAdminSetup();
+  try {
+    await api("/dhcp/reservations", {
+      method: "POST",
+      token,
+      body: JSON.stringify({ mac_address: macAddress, ip_address: ipAddress }),
+    });
+  } catch (err) {
+    // A repeat run hits "reservation already exists" (409) — fine.
+    if (!String(err).includes("409")) throw err;
+  }
+}

--- a/source/end2end-tests/web-ui/fixtures/dhcp.ts
+++ b/source/end2end-tests/web-ui/fixtures/dhcp.ts
@@ -1,0 +1,196 @@
+/**
+ * DHCP seeding for the admin-site DHCP specs (A3, #618).
+ *
+ * Leases can't be created over the API — they only arise from real DHCP
+ * traffic. So `seedDhcpLease` enables the daemon's DHCP server, narrows
+ * the pool, then drives the `test_debian` LAN client (running
+ * `wardnet-test-agent client serve`) through `dhclient` until it holds
+ * an in-pool address. The agent + interface helpers are ported from the
+ * daemon Vitest suite (`../../daemon/tests/helpers.ts`) — the web-ui
+ * harness can't import that package, so the small surface we need is
+ * duplicated here.
+ */
+
+import { api, ensureAdminSetup } from "./seed";
+
+/** The LAN-client agent's serve URL (compose service name on wardnet_lan). */
+export const TEST_DEBIAN_AGENT =
+  process.env.WARDNET_TEST_DEBIAN_AGENT ?? "http://test_debian:3001";
+
+/**
+ * DHCP pool the spec narrows to. Both bounds sit above wardnet_lan's
+ * docker IPAM range (.2-.15), so any leased `.100-.150` address can
+ * only have come from the daemon's DHCP server, not docker.
+ */
+export const DHCP_POOL_START = "10.91.0.100";
+export const DHCP_POOL_END = "10.91.0.150";
+
+/** Subset of the daemon's DhcpConfig we read back before re-saving. */
+interface DhcpConfig {
+  enabled: boolean;
+  subnet_mask: string;
+  upstream_dns: string[];
+  lease_duration_secs: number;
+  router_ip: string | null;
+}
+
+/** Shape returned by `wardnet-test-agent client serve`'s /interfaces. */
+interface AgentInterface {
+  name: string;
+  addrs: Array<{ family: string; local: string; prefixlen: number }>;
+}
+
+interface AgentInterfacesResponse {
+  interfaces: AgentInterface[];
+}
+
+interface AgentDhcpRenewResponse {
+  renew_success: boolean;
+  stderr: string;
+}
+
+/** GET against a test-agent serve URL. Throws on non-2xx. */
+async function agentGet<T>(baseUrl: string, path: string): Promise<T> {
+  const res = await fetch(`${baseUrl}${path}`);
+  if (!res.ok) {
+    throw new Error(
+      `agent GET ${baseUrl}${path} failed: ${res.status} ${await res.text()}`,
+    );
+  }
+  return (await res.json()) as T;
+}
+
+/** POST JSON to a test-agent serve URL. Throws on non-2xx. */
+async function agentPost<T>(
+  baseUrl: string,
+  path: string,
+  body: unknown,
+): Promise<T> {
+  const res = await fetch(`${baseUrl}${path}`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) {
+    throw new Error(
+      `agent POST ${baseUrl}${path} failed: ${res.status} ${await res.text()}`,
+    );
+  }
+  return (await res.json()) as T;
+}
+
+/** Dotted-quad IPv4 → 32-bit int. Multiply-and-add stays positive where
+ *  bitwise ops would coerce to signed 32-bit. Mirrors `ipv4ToInt` in
+ *  `@wardnet/js`, re-implemented here because this harness deliberately
+ *  avoids importing the SDK (see the seed.ts header for why). */
+export function ipToInt(ip: string): number {
+  return ip.split(".").reduce((acc, n) => acc * 256 + Number(n), 0);
+}
+
+/**
+ * The IPv4 on `name` whose value sits within `[start, end]`, or
+ * undefined. The client keeps both its docker-IPAM address and the
+ * daemon-issued lease on the interface at once, so a "first inet wins"
+ * pick can return the wrong one.
+ */
+function ipv4InRange(
+  ifaces: AgentInterfacesResponse,
+  name: string,
+  startInclusive: string,
+  endInclusive: string,
+): string | undefined {
+  const lo = ipToInt(startInclusive);
+  const hi = ipToInt(endInclusive);
+  return ifaces.interfaces
+    .find((i) => i.name === name)
+    ?.addrs.filter((a) => a.family === "inet")
+    .map((a) => a.local)
+    .find((ip) => {
+      const v = ipToInt(ip);
+      return v >= lo && v <= hi;
+    });
+}
+
+/**
+ * Drives the agent's /dhcp/renew until an address in `[poolStart,
+ * poolEnd]` lands on `iface`, or fails after `attempts`. Retries because
+ * dhclient races the daemon's DHCP-runner spawn after the enable toggle
+ * on a cold stack.
+ */
+export async function acquireLeaseInRange(
+  agent: string,
+  iface: string,
+  poolStart: string,
+  poolEnd: string,
+  attempts = 5,
+): Promise<string> {
+  let lastErr: unknown;
+  for (let i = 0; i < attempts; i++) {
+    try {
+      const renew = await agentPost<AgentDhcpRenewResponse>(
+        agent,
+        "/dhcp/renew",
+        { interface: iface },
+      );
+      if (renew.renew_success) {
+        const ifaces = await agentGet<AgentInterfacesResponse>(
+          agent,
+          `/interfaces?name=${iface}`,
+        );
+        const ip = ipv4InRange(ifaces, iface, poolStart, poolEnd);
+        if (ip) return ip;
+      }
+      lastErr = new Error(
+        `attempt ${i + 1}: renew_success=${renew.renew_success}, no in-pool IP yet — stderr: ${renew.stderr}`,
+      );
+    } catch (err) {
+      lastErr = err;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 1_500));
+  }
+  throw new Error(
+    `could not acquire lease in ${poolStart}-${poolEnd} on ${agent}/${iface}: ${String(lastErr)}`,
+  );
+}
+
+/**
+ * Make a real DHCP lease exist so the admin-site leases table is
+ * populated. Enables the daemon DHCP server, narrows the pool above
+ * docker's IPAM block, then drives the test_debian client through
+ * dhclient until it holds an in-pool address. Returns the leased IP.
+ * Idempotent: a client already holding an in-pool lease just renews.
+ */
+export async function seedDhcpLease(): Promise<string> {
+  const token = await ensureAdminSetup();
+
+  const { config } = await api<{ config: DhcpConfig }>("/dhcp/config", {
+    token,
+  });
+  if (!config.enabled) {
+    await api("/dhcp/config/toggle", {
+      method: "POST",
+      token,
+      body: JSON.stringify({ enabled: true }),
+    });
+  }
+  // updateConfig is idempotent — re-setting to the same values is safe.
+  await api("/dhcp/config", {
+    method: "PUT",
+    token,
+    body: JSON.stringify({
+      pool_start: DHCP_POOL_START,
+      pool_end: DHCP_POOL_END,
+      subnet_mask: config.subnet_mask,
+      upstream_dns: config.upstream_dns,
+      lease_duration_secs: config.lease_duration_secs,
+      ...(config.router_ip ? { router_ip: config.router_ip } : {}),
+    }),
+  });
+
+  return acquireLeaseInRange(
+    TEST_DEBIAN_AGENT,
+    "eth0",
+    DHCP_POOL_START,
+    DHCP_POOL_END,
+  );
+}

--- a/source/end2end-tests/web-ui/fixtures/seed.ts
+++ b/source/end2end-tests/web-ui/fixtures/seed.ts
@@ -82,7 +82,7 @@ interface SetupStatus {
 }
 
 /** JSON request against the daemon API. Throws on non-2xx. */
-async function api<T>(
+export async function api<T>(
   path: string,
   init?: RequestInit & { token?: string },
 ): Promise<T> {

--- a/source/end2end-tests/web-ui/tests/admin-site/dhcp-leases.spec.ts
+++ b/source/end2end-tests/web-ui/tests/admin-site/dhcp-leases.spec.ts
@@ -1,0 +1,35 @@
+import { expect, test } from "@playwright/test";
+
+import { seedDhcpLease } from "../../fixtures/dhcp.js";
+
+/**
+ * Admin-site DHCP leases table. A real lease is seeded before the spec
+ * runs: `seedDhcpLease` enables the daemon's DHCP server, narrows the
+ * pool, and drives the `test_debian` LAN client through dhclient until
+ * it holds an in-pool address (see fixtures/dhcp.ts). The table should
+ * then surface that lease under the Leases group.
+ *
+ * Runs in the `admin-site` project (seeded daemon + admin storageState).
+ * Selectors follow the suite's `data-testid` convention.
+ */
+
+let leasedIp: string;
+
+test.beforeAll(async () => {
+  leasedIp = await seedDhcpLease();
+});
+
+test("the leases table shows the seeded LAN-client lease", async ({ page }) => {
+  await page.goto("./dhcp");
+  await expect(page).toHaveURL(/\/admin\/dhcp$/);
+  await expect(page.getByTestId("page-title")).toHaveText("DHCP");
+
+  // Scope the table to dynamic leases.
+  await page.getByTestId("dhcp-group-leases").click();
+
+  const row = page.getByRole("row").filter({ hasText: leasedIp });
+  await expect(row).toBeVisible();
+  // A dynamic lease is tagged "Lease" and, while held, "Active".
+  await expect(row).toContainText(/lease/i);
+  await expect(row).toContainText(/active/i);
+});

--- a/source/end2end-tests/web-ui/tests/admin-site/dhcp.spec.ts
+++ b/source/end2end-tests/web-ui/tests/admin-site/dhcp.spec.ts
@@ -1,0 +1,126 @@
+import { expect, test } from "@playwright/test";
+
+/**
+ * Admin-site DHCP page coverage: the enable/disable toggle, the
+ * pool-config editor (client-side range validation), and reservation
+ * create/delete. Runs in the `admin-site` project (seeded daemon + admin
+ * storageState). Selectors follow the suite's `data-testid` convention
+ * (README.md → "Selector convention"): testids locate, and human-facing
+ * label/role/text is additionally asserted where meaningful.
+ *
+ * Self-contained: each test re-establishes the DHCP state it needs and
+ * leaves the server enabled, so behaviour doesn't depend on spec order
+ * on the shared single-worker daemon.
+ */
+
+test("the status toggle enables and disables the DHCP server", async ({
+  page,
+}) => {
+  await page.goto("./dhcp");
+  await expect(page).toHaveURL(/\/admin\/dhcp$/);
+  await expect(page.getByTestId("page-title")).toHaveText("DHCP");
+
+  const toggle = page.getByTestId("dhcp-toggle");
+  await expect(toggle).toBeVisible();
+
+  // Normalise to enabled first, so both transitions below are
+  // deterministic regardless of what an earlier spec left behind. The
+  // `running` status pill can lag a poll interval behind `enabled`
+  // (the daemon spawns the DHCP server asynchronously), so we assert on
+  // the switch's own `aria-checked` rather than the pill text.
+  if ((await toggle.getAttribute("aria-checked")) !== "true") {
+    await toggle.click();
+    await expect(toggle).toHaveAttribute("aria-checked", "true");
+  }
+
+  // Disable, then re-enable — the control drives both directions and we
+  // leave the server enabled.
+  await toggle.click();
+  await expect(toggle).toHaveAttribute("aria-checked", "false");
+  await toggle.click();
+  await expect(toggle).toHaveAttribute("aria-checked", "true");
+});
+
+test("the pool editor validates the range client-side and persists a valid edit", async ({
+  page,
+}) => {
+  await page.goto("./dhcp");
+
+  await page.getByTestId("dhcp-config-edit").click();
+
+  const poolStart = page.getByTestId("dhcp-pool-start");
+  const poolEnd = page.getByTestId("dhcp-pool-end");
+  const save = page.getByTestId("dhcp-config-save");
+
+  // Inverted range — pool end below pool start. The segmented Ipv4Input
+  // auto-tabs between octets on each "." so typing the dotted-quad fills
+  // the whole field and overwrites the pre-filled value.
+  await poolStart.click();
+  await poolStart.pressSequentially("10.91.0.200");
+  await poolEnd.click();
+  await poolEnd.pressSequentially("10.91.0.100");
+
+  // Client-side guard blocks the save with an inline message.
+  const validation = page.getByTestId("dhcp-config-validation");
+  await expect(validation).toBeVisible();
+  await expect(validation).toContainText(
+    /pool end must be at or after pool start/i,
+  );
+  await expect(save).toBeDisabled();
+
+  // Fix the range to a valid one that still contains any seeded lease
+  // (.100–.150): start .100, end .180. The message clears, save unlocks.
+  await poolStart.click();
+  await poolStart.pressSequentially("10.91.0.100");
+  await poolEnd.click();
+  await poolEnd.pressSequentially("10.91.0.180");
+
+  await expect(validation).toBeHidden();
+  await expect(save).toBeEnabled();
+
+  await save.click();
+
+  // Back in read mode the new range is shown.
+  const range = page.getByTestId("dhcp-config-pool-range");
+  await expect(range).toBeVisible();
+  await expect(range).toContainText("10.91.0.100");
+  await expect(range).toContainText("10.91.0.180");
+});
+
+test("a reservation can be created and then deleted", async ({ page }) => {
+  await page.goto("./dhcp");
+
+  // Below the dynamic pool (.100+) and unique, so create can't collide
+  // with a lease or an existing reservation.
+  const reservationIp = "10.91.0.60";
+  const hostname = "e2e-printer";
+
+  // Open the inline create form from the table toolbar.
+  await page.getByTestId("dhcp-add-reservation").click();
+
+  await page.getByTestId("dhcp-reservation-mac").click();
+  await page
+    .getByTestId("dhcp-reservation-mac")
+    .pressSequentially("AABBCCDDEE60");
+  await page.getByTestId("dhcp-reservation-ip").click();
+  await page
+    .getByTestId("dhcp-reservation-ip")
+    .pressSequentially(reservationIp);
+  await page.getByTestId("dhcp-reservation-hostname").fill(hostname);
+  await page.getByTestId("dhcp-reservation-submit").click();
+
+  // On success the form closes, the table switches to the reservations
+  // group, and the new row appears.
+  const row = page.getByRole("row").filter({ hasText: reservationIp });
+  await expect(row).toBeVisible();
+  await expect(row).toContainText(hostname);
+
+  // Delete via the row's overflow menu → confirm dialog.
+  await row.getByTestId("dhcp-entry-menu").click();
+  await page.getByTestId("dhcp-entry-delete").click();
+  await page.getByTestId("confirm-dialog-confirm").click();
+
+  await expect(
+    page.getByRole("row").filter({ hasText: reservationIp }),
+  ).toHaveCount(0);
+});

--- a/source/end2end-tests/web-ui/tests/admin-site/dhcp.spec.ts
+++ b/source/end2end-tests/web-ui/tests/admin-site/dhcp.spec.ts
@@ -1,4 +1,6 @@
-import { expect, test } from "@playwright/test";
+import { expect, test, type Locator } from "@playwright/test";
+
+import { seedReservation } from "../../fixtures/dhcp.js";
 
 /**
  * Admin-site DHCP page coverage: the enable/disable toggle, the
@@ -12,6 +14,20 @@ import { expect, test } from "@playwright/test";
  * leaves the server enabled, so behaviour doesn't depend on spec order
  * on the shared single-worker daemon.
  */
+
+/**
+ * Fill a segmented Ipv4Input/MacInput by setting each octet/segment
+ * input directly. Filling per-segment (rather than typing the dotted
+ * string) avoids the component's auto-tab: an octet > 25 auto-advances
+ * focus, which would otherwise let a following "." skip the next
+ * segment and produce a malformed value.
+ */
+async function fillSegments(field: Locator, parts: string[]): Promise<void> {
+  const inputs = field.locator("input");
+  for (let i = 0; i < parts.length; i++) {
+    await inputs.nth(i).fill(parts[i]);
+  }
+}
 
 test("the status toggle enables and disables the DHCP server", async ({
   page,
@@ -52,13 +68,9 @@ test("the pool editor validates the range client-side and persists a valid edit"
   const poolEnd = page.getByTestId("dhcp-pool-end");
   const save = page.getByTestId("dhcp-config-save");
 
-  // Inverted range — pool end below pool start. The segmented Ipv4Input
-  // auto-tabs between octets on each "." so typing the dotted-quad fills
-  // the whole field and overwrites the pre-filled value.
-  await poolStart.click();
-  await poolStart.pressSequentially("10.91.0.200");
-  await poolEnd.click();
-  await poolEnd.pressSequentially("10.91.0.100");
+  // Inverted range — pool end below pool start.
+  await fillSegments(poolStart, ["10", "91", "0", "200"]);
+  await fillSegments(poolEnd, ["10", "91", "0", "100"]);
 
   // Client-side guard blocks the save with an inline message.
   const validation = page.getByTestId("dhcp-config-validation");
@@ -70,10 +82,8 @@ test("the pool editor validates the range client-side and persists a valid edit"
 
   // Fix the range to a valid one that still contains any seeded lease
   // (.100–.150): start .100, end .180. The message clears, save unlocks.
-  await poolStart.click();
-  await poolStart.pressSequentially("10.91.0.100");
-  await poolEnd.click();
-  await poolEnd.pressSequentially("10.91.0.180");
+  await fillSegments(poolStart, ["10", "91", "0", "100"]);
+  await fillSegments(poolEnd, ["10", "91", "0", "180"]);
 
   await expect(validation).toBeHidden();
   await expect(save).toBeEnabled();
@@ -87,6 +97,14 @@ test("the pool editor validates the range client-side and persists a valid edit"
   await expect(range).toContainText("10.91.0.180");
 });
 
+// Guarantee the entry table is non-empty so its toolbar (and the "Add
+// reservation" button) renders — the table shows a placeholder with no
+// toolbar when it has zero leases and zero reservations. Seeded via the
+// API so the test doesn't depend on the leases spec running first.
+test.beforeAll(async () => {
+  await seedReservation("AA:BB:CC:DD:EE:50", "10.91.0.50");
+});
+
 test("a reservation can be created and then deleted", async ({ page }) => {
   await page.goto("./dhcp");
 
@@ -98,14 +116,20 @@ test("a reservation can be created and then deleted", async ({ page }) => {
   // Open the inline create form from the table toolbar.
   await page.getByTestId("dhcp-add-reservation").click();
 
-  await page.getByTestId("dhcp-reservation-mac").click();
-  await page
-    .getByTestId("dhcp-reservation-mac")
-    .pressSequentially("AABBCCDDEE60");
-  await page.getByTestId("dhcp-reservation-ip").click();
-  await page
-    .getByTestId("dhcp-reservation-ip")
-    .pressSequentially(reservationIp);
+  await fillSegments(page.getByTestId("dhcp-reservation-mac"), [
+    "AA",
+    "BB",
+    "CC",
+    "DD",
+    "EE",
+    "60",
+  ]);
+  await fillSegments(page.getByTestId("dhcp-reservation-ip"), [
+    "10",
+    "91",
+    "0",
+    "60",
+  ]);
   await page.getByTestId("dhcp-reservation-hostname").fill(hostname);
   await page.getByTestId("dhcp-reservation-submit").click();
 

--- a/source/sdk/wardnet-js/src/index.ts
+++ b/source/sdk/wardnet-js/src/index.ts
@@ -306,3 +306,6 @@ export type {
   UpdateForwardingRuleResponse,
   DeleteForwardingRuleResponse,
 } from "./types/dns-local.js";
+
+// Utils
+export { isCompleteIpv4, ipv4ToInt } from "./utils/ipv4.js";

--- a/source/sdk/wardnet-js/src/utils/ipv4.ts
+++ b/source/sdk/wardnet-js/src/utils/ipv4.ts
@@ -1,0 +1,20 @@
+/** IPv4 helpers shared across surfaces (UI form validation, etc.). */
+
+/** True when `value` is a complete dotted-quad: four non-empty octets,
+ *  each a number in 0–255. Partial input like "10.0.1." is rejected. */
+export function isCompleteIpv4(value: string): boolean {
+  const octets = value.split(".");
+  if (octets.length !== 4) return false;
+  return octets.every((o) => {
+    if (o === "" || !/^\d{1,3}$/.test(o)) return false;
+    const n = Number(o);
+    return n >= 0 && n <= 255;
+  });
+}
+
+/** Dotted-quad → 32-bit integer for range comparisons. Assumes a valid
+ *  IPv4 (guard with {@link isCompleteIpv4} first). Multiply-and-add keeps
+ *  the result positive where bitwise ops would coerce to signed 32-bit. */
+export function ipv4ToInt(value: string): number {
+  return value.split(".").reduce((acc, o) => acc * 256 + Number(o), 0);
+}


### PR DESCRIPTION
Closes #618 (A3 of the Playwright UI-e2e epic #614).

Adds e2e coverage for the admin-site DHCP page (`/admin/dhcp`).

## Specs
- **`dhcp.spec.ts`** — enable/disable toggle; pool-range edit with form validation; reservation create + delete (CRUD).
- **`dhcp-leases.spec.ts`** — leases table populated after a **real** lease is seeded via the `test_debian` LAN client.

## How the lease is seeded
The issue calls for "LAN-client leases" — but leases only arise from real DHCP traffic (no API write-path). So the web-ui compose gains a real `test_debian` LAN client (the same one the daemon suite uses), reusing the `dev-test-ui` image's `wardnet-test-agent` binary — **zero new production surface**. `seedDhcpLease` (in `fixtures/dhcp.ts`) enables DHCP, narrows the pool above docker's IPAM range, and drives `dhclient` until the client holds an in-pool address.

`ui_runner` depends on `test_debian` via `service_started` (not `service_healthy`): a flaky LAN client fails only the leases spec, never the whole suite.

## Product changes
- **`DhcpConfigCard`** — added client-side pool validation (complete-IPv4 + `pool_end ≥ pool_start`), disabling Save with an inline message.
- **`isCompleteIpv4`/`ipv4ToInt`** moved into `@wardnet/js` (business logic belongs in the SDK).
- **`data-testid`** threaded through the DHCP components and the segmented `core/ui` inputs. The shared `data-table` primitive **forwards** testids via props (`searchTestId`, `addTestId`, `rowActionsTestId`, `DataTableGroup.testId`, `RowAction.testId`) — consumers supply per-page ids; the primitive hardcodes none (per the e2e-selector ADR).

## Verification
- `make check-web` (SDK + apps type-check, lint, format) — exit 0.
- e2e package `yarn type-check` — exit 0; prettier clean.
- Full suite: `make e2e-ui` (Docker; builds the three frontends + daemon image + LAN client). Not run in this environment.

https://claude.ai/code/session_01A9ABpFErcKnhFDy2ftEhuW