### PR TITLE
test(e2e): admin-site Devices list/detail/routing specs (#621)

### DIFF
--- a/source/admin-site/src/components/features/DeviceSettingsCard.tsx
+++ b/source/admin-site/src/components/features/DeviceSettingsCard.tsx
@@ -108,7 +108,12 @@ export function DeviceSettingsCard({
         <CardTitle>Settings</CardTitle>
         {!editing && (
           <CardAction>
-            <Button variant="outline" size="sm" onClick={startEdit}>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={startEdit}
+              data-testid="device-settings-edit"
+            >
               Edit
             </Button>
           </CardAction>
@@ -154,6 +159,7 @@ export function DeviceSettingsCard({
                 onChange={setRoutingTarget}
                 tunnels={tunnels}
                 isAdmin
+                data-testid="device-settings-routing"
               />
             </Field>
 
@@ -187,7 +193,11 @@ export function DeviceSettingsCard({
             >
               Cancel
             </Button>
-            <Button onClick={handleSave} disabled={updateDevice.isPending}>
+            <Button
+              onClick={handleSave}
+              disabled={updateDevice.isPending}
+              data-testid="device-settings-save"
+            >
               {updateDevice.isPending ? savingLabel : saveLabel}
             </Button>
           </CardFooter>
@@ -213,7 +223,9 @@ export function DeviceSettingsCard({
             <Text size="xs" className="uppercase tracking-wide text-ink-3">
               Routing
             </Text>
-            <Text size="sm">{routingLabel(currentRule, tunnels)}</Text>
+            <Text size="sm" data-testid="device-settings-routing-value">
+              {routingLabel(currentRule, tunnels)}
+            </Text>
           </div>
           <div className="flex flex-col gap-0.5">
             <Text size="xs" className="uppercase tracking-wide text-ink-3">

--- a/source/end2end-tests/web-ui/fixtures/devices.ts
+++ b/source/end2end-tests/web-ui/fixtures/devices.ts
@@ -1,0 +1,183 @@
+/**
+ * Device seeding for the admin-site Devices specs (A6, #621).
+ *
+ * There is no create-device API — the daemon only materializes a device
+ * row when its packet-capture discovery (`device/discovery.rs`
+ * `process_observation`) observes LAN traffic for a new MAC. So
+ * `seedDiscoveredDevice` makes the `test_debian` test-agent emit an ARP
+ * frame (`POST /arp/send`, the same endpoint the daemon arp-failover spec
+ * drives) with a synthetic, fully-controlled in-subnet MAC/IP, then polls
+ * `/api/devices` until the daemon has discovered it.
+ *
+ * The routing-change spec also needs a tunnel in the routing selector
+ * (the picker is disabled with zero tunnels). `seedTunnel` imports a
+ * deterministic WireGuard `.conf` over the API — import only parses and
+ * persists the definition (status `Down`, no interface brought up), so it
+ * has no WireGuard kernel dependency in the compose stack.
+ *
+ * Like the other fixtures here, this talks to the daemon over plain
+ * `fetch` against the REST API rather than the source-only `@wardnet/js`
+ * SDK (see fixtures/seed.ts header for why).
+ */
+
+import { api, ensureAdminSetup } from "./seed";
+import { TEST_DEBIAN_AGENT } from "./dhcp";
+
+/**
+ * Synthetic LAN client we conjure for the Devices specs. The MAC is
+ * locally-administered (`02:…`) so it can't collide with `test_debian`'s
+ * real NIC, and the IP sits inside the daemon's LAN subnet
+ * (`10.91.0.0/24`) so discovery's subnet filter accepts the observation.
+ * The daemon stores MACs canonical-lowercase (issue #312).
+ */
+export const SEED_DEVICE_MAC = "02:e2:e2:00:00:21";
+export const SEED_DEVICE_IP = "10.91.0.123";
+/** The daemon's LAN gateway IP — the ARP frame's target. */
+const SEED_TARGET_IP = "10.91.0.1";
+
+/** Subset of the daemon's Device we read back from `/api/devices`. */
+interface SeededDevice {
+  id: string;
+  mac: string;
+  last_ip: string;
+}
+
+interface ListDevicesResponse {
+  devices: SeededDevice[];
+}
+
+interface TunnelSummary {
+  id: string;
+  label: string;
+}
+
+interface ListTunnelsResponse {
+  tunnels: TunnelSummary[];
+}
+
+/** POST JSON to a test-agent serve URL. Throws on non-2xx. */
+async function agentPost(
+  baseUrl: string,
+  path: string,
+  body: unknown,
+): Promise<void> {
+  const res = await fetch(`${baseUrl}${path}`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) {
+    throw new Error(
+      `agent POST ${baseUrl}${path} failed: ${res.status} ${await res.text()}`,
+    );
+  }
+}
+
+/** Make `test_debian` emit a small ARP burst announcing the seed device. */
+async function emitArp(): Promise<void> {
+  await agentPost(TEST_DEBIAN_AGENT, "/arp/send", {
+    sender_mac: SEED_DEVICE_MAC,
+    sender_ip: SEED_DEVICE_IP,
+    target_ip: SEED_TARGET_IP,
+    interface: "eth0",
+    count: 3,
+    interval_ms: 100,
+  });
+}
+
+/**
+ * Conjure a discovered device and return its daemon-assigned id (plus the
+ * mac/ip the specs assert on). Emits an ARP frame from the LAN client,
+ * then polls `/api/devices`, re-emitting every few seconds (the discovery
+ * service batches observations and flushes on an interval, default 30 s),
+ * until the device appears. Throws on timeout — a missing device is a
+ * hard failure, not a skip: it means packet capture isn't reaching
+ * `wardnet_lan` in this environment. Idempotent: a device already present
+ * is returned immediately without re-seeding.
+ */
+export async function seedDiscoveredDevice(
+  timeoutMs = 60_000,
+): Promise<{ id: string; mac: string; ip: string }> {
+  const token = await ensureAdminSetup();
+
+  // Match on MAC alone — the device's stable identity. The daemon always
+  // records last_ip from the ARP sender (SEED_DEVICE_IP), but keying on the
+  // MAC avoids ever returning an unrelated device that happens to share the
+  // IP, which the table/detail specs then filter and navigate by.
+  const found = async (): Promise<SeededDevice | undefined> => {
+    const { devices } = await api<ListDevicesResponse>("/devices", { token });
+    return devices.find((d) => d.mac === SEED_DEVICE_MAC);
+  };
+
+  const existing = await found();
+  if (existing) {
+    return { id: existing.id, mac: existing.mac, ip: existing.last_ip };
+  }
+
+  const deadline = Date.now() + timeoutMs;
+  let lastErr: unknown;
+  while (Date.now() < deadline) {
+    try {
+      await emitArp();
+      const match = await found();
+      if (match) return { id: match.id, mac: match.mac, ip: match.last_ip };
+    } catch (err) {
+      lastErr = err;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 3_000));
+  }
+  throw new Error(
+    `device ${SEED_DEVICE_MAC} (${SEED_DEVICE_IP}) was not discovered within ${timeoutMs}ms — ` +
+      `packet capture may not be reaching wardnet_lan in this environment${
+        lastErr ? `: ${String(lastErr)}` : ""
+      }`,
+  );
+}
+
+/**
+ * A deterministic, syntactically-valid WireGuard config. The daemon's
+ * parser (`wardnet-common/src/wireguard_config.rs`) only requires
+ * `[Interface] PrivateKey` and `[Peer] PublicKey` and does not validate
+ * the key material, so these throwaway base64 blobs are fine — the tunnel
+ * is never brought up.
+ */
+const SEED_TUNNEL_CONFIG = [
+  "[Interface]",
+  "PrivateKey = SHFlsItPbjj4u4nNZbR8Ej2cTSDDTNeWiR+ej8a4tEM=",
+  "Address = 10.99.0.2/32",
+  "DNS = 1.1.1.1",
+  "",
+  "[Peer]",
+  "PublicKey = HIgo9xNzJMWLKASShiTqIybxZ0U3wGLiUeJ1PKf8ykw=",
+  "Endpoint = 198.51.100.1:51820",
+  "AllowedIPs = 0.0.0.0/0",
+  "",
+].join("\n");
+
+/**
+ * Ensure a tunnel exists so the device routing selector offers a
+ * non-Direct option. Idempotent: returns the existing tunnel's label if
+ * one with this label is already configured, otherwise imports the
+ * deterministic config above. Returns the label so the spec can match the
+ * selector option by its accessible name.
+ */
+export async function seedTunnel(
+  label = "E2E Test Tunnel",
+  countryCode = "de",
+): Promise<string> {
+  const token = await ensureAdminSetup();
+
+  const { tunnels } = await api<ListTunnelsResponse>("/tunnels", { token });
+  if (tunnels.some((t) => t.label === label)) return label;
+
+  await api("/tunnels", {
+    method: "POST",
+    token,
+    body: JSON.stringify({
+      label,
+      country_code: countryCode,
+      config: SEED_TUNNEL_CONFIG,
+    }),
+  });
+  return label;
+}

--- a/source/end2end-tests/web-ui/tests/admin-site/devices.spec.ts
+++ b/source/end2end-tests/web-ui/tests/admin-site/devices.spec.ts
@@ -1,0 +1,88 @@
+import { expect, test } from "@playwright/test";
+
+import {
+  SEED_DEVICE_IP,
+  SEED_DEVICE_MAC,
+  seedDiscoveredDevice,
+  seedTunnel,
+} from "../../fixtures/devices.js";
+
+/**
+ * Admin-site Devices coverage (A6, #621): the device table lists a
+ * discovered LAN client, the drill-in detail page surfaces its fields,
+ * and the routing rule can be changed to a tunnel.
+ *
+ * A synthetic device is seeded before the spec runs: `seedDiscoveredDevice`
+ * makes the `test_debian` test-agent emit an ARP frame for a controlled
+ * in-subnet MAC/IP, then polls `/api/devices` until the daemon's
+ * packet-capture discovery materializes the row (see fixtures/devices.ts).
+ * A tunnel is imported so the routing selector offers a non-Direct option.
+ * Both are hard preconditions — if the device never appears (packet
+ * capture not reaching wardnet_lan), `beforeAll` throws and the spec fails
+ * rather than silently skipping.
+ *
+ * Runs in the `admin-site` project (seeded daemon + admin storageState).
+ * Selectors follow the suite's `data-testid` convention (README.md →
+ * "Selector convention"): testids locate, human-facing label/text is
+ * additionally asserted. Self-contained: the routing test sets the rule it
+ * asserts, so behaviour doesn't depend on spec order.
+ */
+
+let deviceId: string;
+const TUNNEL_LABEL = "E2E Test Tunnel";
+
+test.beforeAll(async () => {
+  const device = await seedDiscoveredDevice();
+  deviceId = device.id;
+  await seedTunnel(TUNNEL_LABEL);
+});
+
+test("the devices table lists the discovered LAN client", async ({ page }) => {
+  await page.goto("./devices");
+  await expect(page).toHaveURL(/\/admin\/devices$/);
+  await expect(page.getByTestId("page-title")).toHaveText("Devices");
+
+  // Unmanaged, hostname-less device: the Device column falls back to the
+  // MAC (deviceDisplayName → name ?? hostname ?? mac) and the IP column
+  // shows last_ip. Scope to the row by IP, then assert the MAC.
+  const row = page.getByRole("row").filter({ hasText: SEED_DEVICE_IP });
+  await expect(row).toBeVisible();
+  await expect(row).toContainText(SEED_DEVICE_MAC);
+});
+
+test("the device detail page shows the device fields", async ({ page }) => {
+  await page.goto("./devices");
+
+  // Row-click navigates to the detail route.
+  await page.getByRole("row").filter({ hasText: SEED_DEVICE_IP }).click();
+  await expect(page).toHaveURL(new RegExp(`/admin/devices/${deviceId}$`));
+
+  // Identity card surfaces the MAC; the network card / header surface the IP.
+  // Both also appear in the detail header, so match the first occurrence.
+  await expect(page.getByText(SEED_DEVICE_MAC).first()).toBeVisible();
+  await expect(page.getByText(SEED_DEVICE_IP).first()).toBeVisible();
+});
+
+test("the device routing rule can be changed to a tunnel", async ({ page }) => {
+  await page.goto(`./devices/${deviceId}`);
+  await expect(page).toHaveURL(new RegExp(`/admin/devices/${deviceId}$`));
+
+  // Enter edit mode on the Settings card.
+  await page.getByTestId("device-settings-edit").click();
+
+  // Open the routing dropdown and pick the seeded tunnel (Radix renders
+  // options in a portal with role="option"; the flag glyph is aria-hidden
+  // so the accessible name is the bare label).
+  await page.getByTestId("device-settings-routing").click();
+  await page.getByRole("option", { name: TUNNEL_LABEL }).click();
+
+  // Save (label is "To Managed Device" while the device is unmanaged — we
+  // locate by testid regardless).
+  await page.getByTestId("device-settings-save").click();
+
+  // Back in read mode the routing value reflects the new tunnel target.
+  const routingValue = page.getByTestId("device-settings-routing-value");
+  await expect(routingValue).toBeVisible();
+  await expect(routingValue).toContainText(/via tunnel/i);
+  await expect(routingValue).toContainText(TUNNEL_LABEL);
+});

--- a/source/web/src/components/RoutingSelector.tsx
+++ b/source/web/src/components/RoutingSelector.tsx
@@ -28,6 +28,8 @@ interface RoutingSelectorProps {
   tunnels: TunnelSummary[];
   disabled?: boolean;
   isAdmin?: boolean;
+  /** e2e locator, forwarded to the rendered `<SelectTrigger>`. */
+  "data-testid"?: string;
 }
 
 /** Compound component for selecting a device's routing target.
@@ -42,6 +44,7 @@ export function RoutingSelector({
   tunnels,
   disabled,
   isAdmin,
+  "data-testid": dataTestId,
 }: RoutingSelectorProps) {
   const selected = valueFromTarget(value, tunnels);
 
@@ -57,7 +60,7 @@ export function RoutingSelector({
     return (
       <div className="flex flex-col gap-2">
         <Select value={DIRECT_VALUE} onValueChange={handleChange} disabled>
-          <SelectTrigger className="w-full">
+          <SelectTrigger className="w-full" data-testid={dataTestId}>
             <SelectValue />
           </SelectTrigger>
           <SelectContent>
@@ -85,7 +88,7 @@ export function RoutingSelector({
 
   return (
     <Select value={selected} onValueChange={handleChange} disabled={disabled}>
-      <SelectTrigger className="w-full">
+      <SelectTrigger className="w-full" data-testid={dataTestId}>
         <SelectValue />
       </SelectTrigger>
       <SelectContent>


### PR DESCRIPTION
## Summary

Closes #621 (parent #614, the PW-0 e2e epic). Adds Playwright coverage for the **admin-site Devices** surface — the Devices counterpart to the merged DHCP specs (#618, #686).

Three tests in `devices.spec.ts`:
1. The devices table lists a discovered LAN client (row located by IP, asserts the MAC).
2. Row-click → the detail page surfaces the device fields (MAC, IP).
3. The routing rule can be changed to a tunnel (edit → pick tunnel → save → assert the persisted "Via tunnel: …" label).

## How a device is seeded

There is **no create-device API** — rows only materialise when the daemon's packet-capture discovery observes LAN traffic for a new MAC. `seedDiscoveredDevice()` makes the `test_debian` test-agent emit an ARP frame (`POST /arp/send`) for a synthetic, fully-controlled in-subnet MAC/IP (`02:e2:e2:00:00:21` / `10.91.0.123`), then polls `/api/devices` keyed on the MAC. A missing device **hard-fails** (not a skip), so the spec also flags when packet capture isn't reaching `wardnet_lan`.

`seedTunnel()` imports a deterministic WireGuard `.conf` via `POST /api/tunnels` so the routing selector offers a non-Direct option. Import only parses + persists the definition (status `Down`) — assigning a tunnel target just upserts a rule and publishes an event, so there's **no WireGuard kernel dependency** in the compose stack.

## Component changes (selector convention)

Per the suite's `data-testid` convention (web-ui `README.md`):
- `RoutingSelector` (`@wardnet/web`) gains an optional `data-testid`, forwarded to its `SelectTrigger` (verified it spreads to the Radix `<button>`).
- `DeviceSettingsCard` gets `device-settings-edit` / `-save` / `-routing` / `-routing-value`.

Existing `RoutingSelector` call sites (Home, Step6Policy) are unaffected — the prop is optional.

## Testing

- ✅ e2e web-ui `tsc --noEmit`, admin-site `type-check`, admin-site `eslint`, prettier — all clean.
- ⏳ Live `make e2e-ui` (rebuilds the web bundle into the daemon image to pick up the new testids) needs a Docker-enabled environment; not run here.

## Merge Commit Message

```
test(e2e): admin-site Devices list/detail/routing specs (#621)
```

https://claude.ai/code/session_01DJ2wuKWvkuNPtKaGEhoocY