### PR TITLE
test(e2e): admin-site DNS + ad-blocking Playwright specs (#619)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -503,7 +503,7 @@ e2e-ui: build-web
 	        $(CONTAINER_RT) inspect "$$cid" >> '"$$REPORTS"'/inspect.json 2>&1 || true; \
 	      done; \
 	      $(CONTAINER_RT) compose -f $(E2E_UI_COMPOSE) down -v --remove-orphans' EXIT; \
-	$(CONTAINER_RT) compose -f $(E2E_UI_COMPOSE) up -d --build --wait wardnetd-ui wardnetd-ui-fresh tls_proxy; \
+	$(CONTAINER_RT) compose -f $(E2E_UI_COMPOSE) up -d --build --wait wardnetd-ui wardnetd-ui-fresh tls_proxy blocklist_server; \
 	$(CONTAINER_RT) compose -f $(E2E_UI_COMPOSE) up -d --build --wait test_debian || \
 	    echo "warning: test_debian (LAN client) not healthy; running playwright anyway so failures surface as assertions"; \
 	echo "::group::compose ps before playwright"; \

--- a/source/admin-site/src/components/compound/AllowlistTable.tsx
+++ b/source/admin-site/src/components/compound/AllowlistTable.tsx
@@ -61,6 +61,7 @@ export function AllowlistTable({
         hint="Domains added here will never be blocked, even if they appear in a blocklist."
         actionLabel="Add domain"
         onAction={onAdd}
+        actionTestId="allowlist-add"
       />
     );
   }
@@ -72,6 +73,7 @@ export function AllowlistTable({
       fixedLayout
       addLabel="Add domain"
       onAdd={onAdd}
+      addTestId="allowlist-add"
       rowActions={(entry) => (
         <RowAction onSelect={() => onDelete(entry.id)} destructive>
           Remove

--- a/source/admin-site/src/components/compound/BlocklistTable.tsx
+++ b/source/admin-site/src/components/compound/BlocklistTable.tsx
@@ -104,6 +104,7 @@ export function BlocklistTable({
         hint="Add a blocklist URL to start blocking ads and trackers network-wide."
         actionLabel="Add blocklist"
         onAction={onAdd}
+        actionTestId="blocklist-add"
       />
     );
   }
@@ -118,12 +119,17 @@ export function BlocklistTable({
       fixedLayout
       addLabel="Add blocklist"
       onAdd={onAdd}
+      addTestId="blocklist-add"
+      rowActionsTestId="blocklist-row-menu"
       rowActions={(b) => (
         <>
           <RowAction onSelect={() => onToggle(b)}>
             {b.enabled ? "Disable" : "Enable"}
           </RowAction>
-          <RowAction onSelect={() => onRefresh(b.id)}>
+          <RowAction
+            onSelect={() => onRefresh(b.id)}
+            testId="blocklist-refresh"
+          >
             {refreshingId === b.id ? "Updating…" : "Update now"}
           </RowAction>
           <RowAction onSelect={() => onDelete(b.id)} destructive>

--- a/source/admin-site/src/components/compound/EmptyStatePlaceholder.tsx
+++ b/source/admin-site/src/components/compound/EmptyStatePlaceholder.tsx
@@ -13,6 +13,10 @@ interface EmptyStatePlaceholderProps {
   actionLabel?: string;
   /** Action button callback. */
   onAction?: () => void;
+  /** Optional `data-testid` for the action button, forwarded from the
+   *  consuming component so this shared placeholder carries no baked-in
+   *  test contract (e2e selector ADR). */
+  actionTestId?: string;
   /** Override the default icon. */
   icon?: ReactNode;
 }
@@ -31,6 +35,7 @@ export function EmptyStatePlaceholder({
   hint,
   actionLabel,
   onAction,
+  actionTestId,
   icon,
 }: EmptyStatePlaceholderProps) {
   // Pre-computed token tints keep the rings + icon hierarchy that defines
@@ -133,7 +138,11 @@ export function EmptyStatePlaceholder({
           </Text>
         )}
         {actionLabel && onAction && (
-          <Button onClick={onAction} className="mt-2">
+          <Button
+            onClick={onAction}
+            data-testid={actionTestId}
+            className="mt-2"
+          >
             {actionLabel}
           </Button>
         )}

--- a/source/admin-site/src/components/compound/FilterRuleTable.tsx
+++ b/source/admin-site/src/components/compound/FilterRuleTable.tsx
@@ -73,6 +73,7 @@ export function FilterRuleTable({
         hint="Add AdGuard-syntax rules for fine-grained control over what gets blocked or allowed."
         actionLabel="Add rule"
         onAction={onAdd}
+        actionTestId="rule-add"
       />
     );
   }
@@ -84,6 +85,7 @@ export function FilterRuleTable({
       fixedLayout
       addLabel="Add rule"
       onAdd={onAdd}
+      addTestId="rule-add"
       rowActions={(rule) => (
         <>
           <RowAction onSelect={() => onToggle(rule.id, !rule.enabled)}>

--- a/source/admin-site/src/components/features/UpstreamServersCard.tsx
+++ b/source/admin-site/src/components/features/UpstreamServersCard.tsx
@@ -112,6 +112,7 @@ export function UpstreamServersCard({
           {!adding && (
             <Button
               variant="outline"
+              data-testid="upstream-add"
               onClick={() => setAdding(true)}
               disabled={isSaving}
             >
@@ -143,6 +144,7 @@ export function UpstreamServersCard({
           <DataTable
             columns={columns}
             data={rows}
+            rowActionsTestId="upstream-row-menu"
             rowActions={(row) => (
               <>
                 <RowAction
@@ -157,7 +159,11 @@ export function UpstreamServersCard({
                 >
                   Move down
                 </RowAction>
-                <RowAction onSelect={() => remove(row.__index)} destructive>
+                <RowAction
+                  onSelect={() => remove(row.__index)}
+                  testId="upstream-remove"
+                  destructive
+                >
                   Remove
                 </RowAction>
               </>
@@ -221,6 +227,7 @@ function AddServerForm({ onCancel, onSubmit, isSaving }: AddServerFormProps) {
             >
               <Input
                 id="ups-name"
+                data-testid="upstream-name"
                 value={name}
                 onChange={(e) => setName(e.target.value)}
                 placeholder="Cloudflare"
@@ -260,6 +267,7 @@ function AddServerForm({ onCancel, onSubmit, isSaving }: AddServerFormProps) {
             >
               <Input
                 id="ups-addr"
+                data-testid="upstream-address"
                 value={address}
                 onChange={(e) => setAddress(e.target.value)}
                 placeholder="1.1.1.1"
@@ -319,7 +327,11 @@ function AddServerForm({ onCancel, onSubmit, isSaving }: AddServerFormProps) {
           >
             Cancel
           </Button>
-          <Button type="submit" disabled={isSaving}>
+          <Button
+            type="submit"
+            data-testid="upstream-submit"
+            disabled={isSaving}
+          >
             Add server
           </Button>
         </CardFooter>

--- a/source/admin-site/src/pages/Dns.tsx
+++ b/source/admin-site/src/pages/Dns.tsx
@@ -97,13 +97,17 @@ export default function Dns() {
             <Card>
               <CardHeader>
                 <CardTitle>DNS server</CardTitle>
-                <Pill variant={status.running ? "ok" : "ghost"}>
+                <Pill
+                  variant={status.running ? "ok" : "ghost"}
+                  data-testid="dns-status-pill"
+                >
                   <span className="dot" />
                   {status.running ? "Running" : "Stopped"}
                 </Pill>
                 <CardAction>
                   <Toggle
                     id="dns-toggle"
+                    data-testid="dns-toggle"
                     aria-label="Enable DNS"
                     checked={status.enabled}
                     onCheckedChange={(enabled) => toggleDns.mutate(enabled)}
@@ -153,6 +157,7 @@ export default function Dns() {
                   <Button
                     variant="outline"
                     size="sm"
+                    data-testid="dns-flush-cache"
                     onClick={() => flushCache.mutate()}
                     disabled={flushCache.isPending}
                   >

--- a/source/admin-site/src/pages/DnsFilter.tsx
+++ b/source/admin-site/src/pages/DnsFilter.tsx
@@ -174,7 +174,9 @@ export default function DnsFilter() {
         description="Block ads, trackers, and unwanted domains across every device on the network. Profiles bundle blocklists, allowlists, and custom rules."
         actions={
           hasProfiles ? (
-            <Button onClick={addProfile}>Add profile</Button>
+            <Button onClick={addProfile} data-testid="filter-add-profile">
+              Add profile
+            </Button>
           ) : undefined
         }
       />

--- a/source/admin-site/src/pages/DnsFilterProfile.tsx
+++ b/source/admin-site/src/pages/DnsFilterProfile.tsx
@@ -390,6 +390,7 @@ function BlocklistForm({
         <Field label="Name" htmlFor="bl-name">
           <Input
             id="bl-name"
+            data-testid="blocklist-name"
             value={name}
             onChange={(e) => setName(e.target.value)}
             placeholder="Steven Black Hosts"
@@ -402,6 +403,7 @@ function BlocklistForm({
         >
           <Input
             id="bl-url"
+            data-testid="blocklist-url"
             value={url}
             onChange={(e) => setUrl(e.target.value)}
             placeholder="https://raw.githubusercontent.com/StevenBlack/hosts/master/hosts"
@@ -445,6 +447,7 @@ function BlocklistForm({
           Cancel
         </Button>
         <Button
+          data-testid="blocklist-submit"
           onClick={() =>
             onSubmit({ name, url, cron_schedule: schedule, enabled })
           }
@@ -514,6 +517,7 @@ function AllowlistCard({ profileId }: SubSectionProps) {
               >
                 <Input
                   id="al-domain"
+                  data-testid="allowlist-domain"
                   value={domain}
                   onChange={(e) => setDomain(e.target.value)}
                   placeholder="example.com"
@@ -546,6 +550,7 @@ function AllowlistCard({ profileId }: SubSectionProps) {
               </Button>
               <Button
                 onClick={handleSave}
+                data-testid="allowlist-submit"
                 disabled={create.isPending || domain.trim() === ""}
               >
                 {create.isPending ? "Adding…" : "Allow domain"}
@@ -632,6 +637,7 @@ function CustomRulesCard({ profileId }: SubSectionProps) {
               >
                 <Input
                   id="fr-text"
+                  data-testid="rule-text"
                   value={ruleText}
                   onChange={(e) => setRuleText(e.target.value)}
                   placeholder="||example.com^"
@@ -676,6 +682,7 @@ function CustomRulesCard({ profileId }: SubSectionProps) {
               </Button>
               <Button
                 onClick={handleSave}
+                data-testid="rule-submit"
                 disabled={create.isPending || ruleText.trim() === ""}
               >
                 {create.isPending ? "Adding…" : "Add rule"}

--- a/source/admin-site/src/pages/DnsFilterProfileNew.tsx
+++ b/source/admin-site/src/pages/DnsFilterProfileNew.tsx
@@ -53,6 +53,7 @@ export default function DnsFilterProfileNew() {
           >
             <Input
               id="profile-name"
+              data-testid="profile-name"
               value={name}
               onChange={(e) => setName(e.target.value)}
               placeholder="Parental Controls"
@@ -86,6 +87,7 @@ export default function DnsFilterProfileNew() {
           </Button>
           <Button
             onClick={handleSave}
+            data-testid="profile-create-submit"
             disabled={create.isPending || name.trim() === ""}
           >
             {create.isPending ? "Creating…" : "Create profile"}

--- a/source/end2end-tests/web-ui/README.md
+++ b/source/end2end-tests/web-ui/README.md
@@ -37,6 +37,19 @@ address is unambiguously daemon-issued. Agent helpers in `fixtures/dhcp.ts`
 are ported from `source/end2end-tests/daemon/tests/helpers.ts` because this
 harness deliberately avoids importing the daemon package.
 
+### Blocklist fixture server (`blocklist_server`)
+
+A static HTTP server (Caddy `file-server`, same pinned image as `tls_proxy`)
+on `wardnet_mgmt` at the fixed IP `10.90.0.20`, serving
+`fixtures/blocklist/hosts.txt`. The ad-blocking spec (`adblocking.spec.ts`)
+adds a blocklist pointing at `http://10.90.0.20/hosts.txt`
+(`WARDNET_BLOCKLIST_FIXTURE_URL`) and forces an update; the **daemon** fetches
+and parses it, so this exercises the real download path (the daemon's
+downloader uses a plain `reqwest` client — no HTTPS/SSRF guard). The URL uses
+the server's IP, not its Docker service name, because the daemon is itself the
+DNS resolver on this stack. `ui_runner` depends on it with
+`condition: service_healthy`.
+
 ## Why a self-signed TLS proxy (HTTPS)
 
 Two things need a *secure context*: the daemon's session cookie is set

--- a/source/end2end-tests/web-ui/compose.ui.yaml
+++ b/source/end2end-tests/web-ui/compose.ui.yaml
@@ -220,9 +220,13 @@ services:
   # used (not the service name) because the daemon is itself the DNS
   # resolver on this stack, so the spec's blocklist URL is
   # `http://10.90.0.20/hosts.txt`, sidestepping Docker service-name DNS.
+  #
+  # The command leads with `caddy`: this image's default CMD is the full
+  # `caddy …` invocation (it does not prepend `caddy` via ENTRYPOINT), so
+  # overriding `command` must name the binary explicitly.
   blocklist_server:
     image: caddy:2.10.0-alpine@sha256:ae4458638da8e1a91aafffb231c5f8778e964bca650c8a8cb23a7e8ac557aa3c
-    command: ["file-server", "--root", "/srv", "--listen", ":80"]
+    command: ["caddy", "file-server", "--root", "/srv", "--listen", ":80"]
     volumes:
       - ./fixtures/blocklist:/srv:ro
     networks:

--- a/source/end2end-tests/web-ui/compose.ui.yaml
+++ b/source/end2end-tests/web-ui/compose.ui.yaml
@@ -211,6 +211,32 @@ services:
       retries: 20
       start_period: 10s
 
+  # Static HTTP server for the ad-blocking spec (A4, #619). Serves a
+  # tiny hosts-format blocklist that the daemon fetches when the spec
+  # forces a blocklist update. The daemon's downloader uses a plain
+  # reqwest client (no HTTPS/SSRF guard), so plain HTTP over the mgmt
+  # network is sufficient. Reuses the pinned Caddy image (same digest as
+  # tls_proxy) as a `file-server` — no extra image pull. A FIXED IP is
+  # used (not the service name) because the daemon is itself the DNS
+  # resolver on this stack, so the spec's blocklist URL is
+  # `http://10.90.0.20/hosts.txt`, sidestepping Docker service-name DNS.
+  blocklist_server:
+    image: caddy:2.10.0-alpine@sha256:ae4458638da8e1a91aafffb231c5f8778e964bca650c8a8cb23a7e8ac557aa3c
+    command: ["file-server", "--root", "/srv", "--listen", ":80"]
+    volumes:
+      - ./fixtures/blocklist:/srv:ro
+    networks:
+      wardnet_mgmt:
+        ipv4_address: 10.90.0.20
+    healthcheck:
+      # BusyBox in the Caddy Alpine image has `nc`; just check the port
+      # is accepting connections (file-server starts in <1s).
+      test: ["CMD-SHELL", "nc -z 127.0.0.1 80 || exit 1"]
+      interval: 5s
+      timeout: 3s
+      retries: 30
+      start_period: 5s
+
   ui_runner:
     build:
       context: ../../..
@@ -232,11 +258,16 @@ services:
       # whole suite on a flaky LAN client.
       test_debian:
         condition: service_started
+      # The ad-blocking spec needs this up before it forces a blocklist
+      # refresh; gate the runner on it being healthy.
+      blocklist_server:
+        condition: service_healthy
     environment:
       WARDNET_UI_BASE_URL: "https://wardnetd-ui-tls"
       WARDNET_UI_FRESH_BASE_URL: "https://wardnetd-ui-fresh-tls"
       WARDNET_API_BASE_URL: "http://wardnetd-ui:7411/api"
       WARDNET_TEST_DEBIAN_AGENT: "http://test_debian:3001"
+      WARDNET_BLOCKLIST_FIXTURE_URL: "http://10.90.0.20/hosts.txt"
     # Reports bind-mounted (not a named volume) to the same host dir the
     # Makefile trap writes compose-logs.txt / inspect.json into, so the
     # JUnit + HTML report land alongside them in the CI artefact.

--- a/source/end2end-tests/web-ui/fixtures/blocklist/hosts.txt
+++ b/source/end2end-tests/web-ui/fixtures/blocklist/hosts.txt
@@ -1,0 +1,9 @@
+# e2e ad-blocking fixture (hosts format)
+#
+# Served by the `blocklist_server` compose service and fetched by the
+# daemon when the adblocking spec forces a blocklist update. Hosts-file
+# format (`0.0.0.0 <domain>`) is parsed by the daemon's filter parser
+# into block rules. The `.test` TLD keeps these unmistakably synthetic.
+0.0.0.0 ads.e2e-fixture.test
+0.0.0.0 tracker.e2e-fixture.test
+0.0.0.0 analytics.e2e-fixture.test

--- a/source/end2end-tests/web-ui/fixtures/dns-filter.ts
+++ b/source/end2end-tests/web-ui/fixtures/dns-filter.ts
@@ -1,0 +1,51 @@
+/**
+ * DNS-filter seeding helpers for the admin-site ad-blocking spec (A4, #619).
+ *
+ * The spec creates its filter profile through the UI (real coverage of the
+ * create flow), so the only seeding done here is *cleanup*: profile names are
+ * UNIQUE in the daemon schema, so a re-run against a persisted state volume
+ * would collide on create. `deleteTestProfiles` removes any leftover test
+ * profile up front, keeping the UI-create flow deterministic. Uses the same
+ * plain-`fetch` `api`/`ensureAdminSetup` path as the other fixtures (see
+ * seed.ts for why this harness avoids the source-only SDK).
+ */
+
+import { api, ensureAdminSetup } from "./seed";
+
+/**
+ * Blocklist URL the ad-blocking spec adds, served by the `blocklist_server`
+ * compose service. Fetched by the daemon (not the browser), so it points at
+ * that service's fixed mgmt-network IP — the daemon is its own DNS resolver,
+ * so a Docker service name wouldn't resolve from inside it.
+ */
+export const BLOCKLIST_FIXTURE_URL =
+  process.env.WARDNET_BLOCKLIST_FIXTURE_URL ?? "http://10.90.0.20/hosts.txt";
+
+/** Name of the profile the ad-blocking spec creates through the UI. */
+export const TEST_PROFILE_NAME = "e2e-adblock";
+
+interface FilterProfile {
+  id: string;
+  name: string;
+  builtin: boolean;
+}
+
+/**
+ * Delete any non-builtin filter profile matching `name`, so the spec's
+ * UI-create step starts from a clean slate. Idempotent: a missing profile
+ * (already deleted) is a no-op; builtin profiles are never touched.
+ */
+export async function deleteTestProfiles(
+  name = TEST_PROFILE_NAME,
+): Promise<void> {
+  const token = await ensureAdminSetup();
+  const { profiles } = await api<{ profiles: FilterProfile[] }>(
+    "/dns/filter/profiles",
+    { token },
+  );
+  for (const p of profiles) {
+    if (p.name === name && !p.builtin) {
+      await api(`/dns/filter/profiles/${p.id}`, { method: "DELETE", token });
+    }
+  }
+}

--- a/source/end2end-tests/web-ui/tests/admin-site/adblocking.spec.ts
+++ b/source/end2end-tests/web-ui/tests/admin-site/adblocking.spec.ts
@@ -1,0 +1,92 @@
+import { expect, test } from "@playwright/test";
+
+import {
+  BLOCKLIST_FIXTURE_URL,
+  TEST_PROFILE_NAME,
+  deleteTestProfiles,
+} from "../../fixtures/dns-filter.js";
+
+/**
+ * Admin-site ad-blocking coverage (A4, #619) — the day-zero feature.
+ *
+ * Ad blocking is configured per DNS filter profile, so this spec creates
+ * a profile *through the UI* (real coverage of the create flow), then
+ * exercises the three source kinds on its detail page: add a blocklist
+ * and force an update that the daemon actually fetches from the
+ * `blocklist_server` compose fixture, add an allowlist entry, and add a
+ * custom rule. Profile management (list, default-assignment, delete) is
+ * covered separately by A5.
+ *
+ * Runs in the `admin-site` project (seeded daemon + admin storageState).
+ * Selectors follow the suite's `data-testid` convention (README.md).
+ */
+
+// Profile names are UNIQUE in the daemon schema, so a re-run against a
+// persisted state volume would collide on the UI-create step. Clear any
+// leftover test profile first so creation is deterministic.
+test.beforeAll(async () => {
+  await deleteTestProfiles();
+});
+
+test("ad blocking: create a profile, add a blocklist + force update, allow a domain, add a custom rule", async ({
+  page,
+}) => {
+  // ── Create the profile via the UI ──────────────────────────────────
+  await page.goto("./dns/filter");
+  await page.getByTestId("filter-add-profile").click();
+  await expect(page).toHaveURL(/\/admin\/dns\/filter\/profiles\/new$/);
+
+  await page.getByTestId("profile-name").fill(TEST_PROFILE_NAME);
+  await page.getByTestId("profile-create-submit").click();
+
+  // Lands on the new profile's detail page, titled with its name.
+  await expect(page).toHaveURL(/\/admin\/dns\/filter\/profiles\/[0-9a-f-]+$/);
+  await expect(page.getByText(TEST_PROFILE_NAME).first()).toBeVisible();
+
+  // ── Blocklist: add, then force an update the daemon really fetches ──
+  const blocklistName = "e2e-blocklist";
+
+  await page.getByTestId("blocklist-add").click();
+  await page.getByTestId("blocklist-name").fill(blocklistName);
+  await page.getByTestId("blocklist-url").fill(BLOCKLIST_FIXTURE_URL);
+  await page.getByTestId("blocklist-submit").click();
+
+  const blocklistRow = page.getByRole("row").filter({ hasText: blocklistName });
+  await expect(blocklistRow).toBeVisible();
+
+  // Force an update via the row's overflow menu. The daemon downloads the
+  // fixture, parses it, and on success sets `last_updated` + a non-zero
+  // entry count — so the row's "Updated at" stops reading "Never". That
+  // durable row change is the success signal (the toast is transient).
+  //
+  // We deliberately do NOT assert "Never" *before* refreshing: the daemon's
+  // blocklist cron ticks every 60s and treats a never-fetched blocklist as
+  // always-due (`last_updated == None`), so it can refresh a brand-new
+  // blocklist on its own before this assertion would run — which would make
+  // a pre-refresh "Never" check flaky.
+  await blocklistRow.getByTestId("blocklist-row-menu").click();
+  await page.getByTestId("blocklist-refresh").click();
+  await expect(blocklistRow).not.toContainText("Never");
+
+  // ── Allowlist: add an entry ────────────────────────────────────────
+  const allowedDomain = "allowed.e2e-fixture.test";
+
+  await page.getByTestId("allowlist-add").click();
+  await page.getByTestId("allowlist-domain").fill(allowedDomain);
+  await page.getByTestId("allowlist-submit").click();
+
+  await expect(
+    page.getByRole("row").filter({ hasText: allowedDomain }),
+  ).toBeVisible();
+
+  // ── Custom rule: add an AdGuard-syntax rule ────────────────────────
+  const ruleText = "||example.com^";
+
+  await page.getByTestId("rule-add").click();
+  await page.getByTestId("rule-text").fill(ruleText);
+  await page.getByTestId("rule-submit").click();
+
+  await expect(
+    page.getByRole("row").filter({ hasText: ruleText }),
+  ).toBeVisible();
+});

--- a/source/end2end-tests/web-ui/tests/admin-site/dns.spec.ts
+++ b/source/end2end-tests/web-ui/tests/admin-site/dns.spec.ts
@@ -1,0 +1,85 @@
+import { expect, test } from "@playwright/test";
+
+/**
+ * Admin-site DNS page coverage (A4, #619): the enable/disable toggle and
+ * status indicator, the upstream-servers editor (add + remove), and the
+ * cache flush. Runs in the `admin-site` project (seeded daemon + admin
+ * storageState). Selectors follow the suite's `data-testid` convention
+ * (README.md → "Selector convention"): testids locate, and human-facing
+ * label/text is additionally asserted where meaningful.
+ *
+ * Self-contained: each test re-establishes the state it needs and leaves
+ * the DNS server enabled, so behaviour doesn't depend on spec order on
+ * the shared single-worker daemon. Ad-blocking (blocklists / allowlist /
+ * custom rules) lives on the filter-profile detail page and is covered
+ * by adblocking.spec.ts.
+ */
+
+test("the status toggle enables and disables the DNS server", async ({
+  page,
+}) => {
+  await page.goto("./dns");
+  await expect(page).toHaveURL(/\/admin\/dns$/);
+  await expect(page.getByTestId("page-title")).toHaveText("DNS");
+
+  // The status banner renders and reflects a real running state. We don't
+  // assert it equals "Running" right after enabling: the `running` pill
+  // can lag a poll behind `enabled` (the daemon spawns the resolver
+  // asynchronously), so the toggle's own `aria-checked` is the
+  // deterministic signal — matching the DHCP spec's approach.
+  const statusPill = page.getByTestId("dns-status-pill");
+  await expect(statusPill).toBeVisible();
+  await expect(statusPill).toHaveText(/Running|Stopped/);
+
+  const toggle = page.getByTestId("dns-toggle");
+  await expect(toggle).toBeVisible();
+
+  // Normalise to enabled first, so both transitions below are
+  // deterministic regardless of what an earlier spec left behind.
+  if ((await toggle.getAttribute("aria-checked")) !== "true") {
+    await toggle.click();
+    await expect(toggle).toHaveAttribute("aria-checked", "true");
+  }
+
+  // Disable, then re-enable — the control drives both directions and we
+  // leave the server enabled.
+  await toggle.click();
+  await expect(toggle).toHaveAttribute("aria-checked", "false");
+  await toggle.click();
+  await expect(toggle).toHaveAttribute("aria-checked", "true");
+});
+
+test("an upstream server can be added and then removed", async ({ page }) => {
+  await page.goto("./dns");
+
+  // Distinctive name/address so the row can be located unambiguously and
+  // create can't collide with a seeded default upstream.
+  const name = "e2e-upstream";
+  const address = "9.9.9.9";
+
+  // Open the inline add form (UDP is the default protocol).
+  await page.getByTestId("upstream-add").click();
+  await page.getByTestId("upstream-name").fill(name);
+  await page.getByTestId("upstream-address").fill(address);
+  await page.getByTestId("upstream-submit").click();
+
+  // The new row appears in the table.
+  const row = page.getByRole("row").filter({ hasText: name });
+  await expect(row).toBeVisible();
+  await expect(row).toContainText(address);
+
+  // Remove it via the row's overflow menu, leaving the list as we found it.
+  await row.getByTestId("upstream-row-menu").click();
+  await page.getByTestId("upstream-remove").click();
+
+  await expect(page.getByRole("row").filter({ hasText: name })).toHaveCount(0);
+});
+
+test("the cache can be flushed", async ({ page }) => {
+  await page.goto("./dns");
+
+  await page.getByTestId("dns-flush-cache").click();
+
+  // Success surfaces as a toast reporting how many entries were cleared.
+  await expect(page.getByText(/Cache flushed/i)).toBeVisible();
+});


### PR DESCRIPTION
Closes #619.

Playwright A4 (epic #614): DNS + Ad Blocking coverage for the admin-site surface.

## Specs
- **`dns.spec.ts`** (`/admin/dns`): server enable/disable toggle + status pill, upstream-server add/remove, cache flush.
- **`adblocking.spec.ts`** — the day-zero feature. Creates a DNS filter profile **through the UI**, then on its detail page: adds a blocklist, forces an update that the **daemon actually fetches and parses** from a new fixture HTTP server, adds an allowlist entry, and adds a custom rule.

## Infrastructure
- New **`blocklist_server`** compose service (Caddy `file-server`, fixed mgmt IP `10.90.0.20`, serving `fixtures/blocklist/hosts.txt`). The daemon fetches it by IP to sidestep its own DNS resolver. Wired into `ui_runner.depends_on`, the Makefile `--wait` group, and the README.
- New **`fixtures/dns-filter.ts`** helper (`deleteTestProfiles` for idempotent re-runs, since profile names are `UNIQUE`).

## Selector convention
The DNS/filter components carried no `data-testid` (unlike the DHCP components), so this threads testids through them per the suite's authoritative convention, and adds an `actionTestId` prop to `EmptyStatePlaceholder` so one id works in both empty and populated states.

## Verification
- `make check-web` (type-check all apps + admin-site lint/format) — green.
- e2e package `type-check` + prettier on new files — green.
- `make e2e-ui` (full Playwright run) needs Docker, so it runs in the CI `tests-e2e.yml` job rather than locally.

## Review
A medium-effort multi-agent review ran on the diff; the one surviving finding — a pre-refresh `"Never"` assertion that raced the daemon's 60s always-due blocklist cron — was fixed (assertion dropped, rationale documented). Remaining candidates were refuted.

https://claude.ai/code/session_01A9ABpFErcKnhFDy2ftEhuW