### PR TITLE
test(e2e): admin-app PWA shell specs

### DIFF
--- a/source/admin-app/src/components/BiometricSetupPrompt.tsx
+++ b/source/admin-app/src/components/BiometricSetupPrompt.tsx
@@ -49,6 +49,7 @@ export function BiometricSetupPrompt({ username, onAccept, onDecline }: Props) {
           <button
             onClick={handleAccept}
             disabled={loading}
+            data-testid="biometric-setup-enable"
             className="flex-1 rounded-md bg-accent px-4 py-2 text-sm font-medium text-accent-ink disabled:opacity-50"
           >
             {loading ? "Setting up…" : "Enable"}
@@ -56,6 +57,7 @@ export function BiometricSetupPrompt({ username, onAccept, onDecline }: Props) {
           <button
             onClick={onDecline}
             disabled={loading}
+            data-testid="biometric-setup-decline"
             className="flex-1 rounded-md border border-line px-4 py-2 text-sm font-medium text-ink disabled:opacity-50"
           >
             Not now

--- a/source/admin-app/src/components/TabBar.tsx
+++ b/source/admin-app/src/components/TabBar.tsx
@@ -18,6 +18,7 @@ export function TabBar() {
           key={to}
           to={to}
           end={end}
+          data-testid={`tab-${label.toLowerCase()}`}
           className="flex flex-1 flex-col items-center gap-1 rounded-xl py-1.5 text-[10.5px] font-semibold tracking-wide text-white/50 transition-colors duration-snap aria-[current=page]:text-accent"
         >
           <Icon size={23} strokeWidth={2} />

--- a/source/admin-site/src/components/features/DeviceSettingsCard.tsx
+++ b/source/admin-site/src/components/features/DeviceSettingsCard.tsx
@@ -108,7 +108,12 @@ export function DeviceSettingsCard({
         <CardTitle>Settings</CardTitle>
         {!editing && (
           <CardAction>
-            <Button variant="outline" size="sm" onClick={startEdit}>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={startEdit}
+              data-testid="device-settings-edit"
+            >
               Edit
             </Button>
           </CardAction>
@@ -154,6 +159,7 @@ export function DeviceSettingsCard({
                 onChange={setRoutingTarget}
                 tunnels={tunnels}
                 isAdmin
+                data-testid="device-settings-routing"
               />
             </Field>
 
@@ -187,7 +193,11 @@ export function DeviceSettingsCard({
             >
               Cancel
             </Button>
-            <Button onClick={handleSave} disabled={updateDevice.isPending}>
+            <Button
+              onClick={handleSave}
+              disabled={updateDevice.isPending}
+              data-testid="device-settings-save"
+            >
               {updateDevice.isPending ? savingLabel : saveLabel}
             </Button>
           </CardFooter>
@@ -213,7 +223,9 @@ export function DeviceSettingsCard({
             <Text size="xs" className="uppercase tracking-wide text-ink-3">
               Routing
             </Text>
-            <Text size="sm">{routingLabel(currentRule, tunnels)}</Text>
+            <Text size="sm" data-testid="device-settings-routing-value">
+              {routingLabel(currentRule, tunnels)}
+            </Text>
           </div>
           <div className="flex flex-col gap-0.5">
             <Text size="xs" className="uppercase tracking-wide text-ink-3">

--- a/source/end2end-tests/web-ui/README.md
+++ b/source/end2end-tests/web-ui/README.md
@@ -9,8 +9,13 @@ in `wardnetd` via rust-embed and served on one origin:
 | `admin-app`  | admin mobile PWA       | `/admin-app/` |
 | `user-app`   | device-keyed user PWA  | `/`           |
 
-This is the **PW-0 scaffold** (epic #614): harness + one smoke spec per
-surface. Feature coverage lands in the A/B/C-stage sub-issues.
+The harness (epic #614, PW-0) is established; feature coverage lands per
+A/B/C-stage sub-issue. Each surface keeps a `smoke.spec.ts` canary
+alongside its feature specs — `admin-site/` carries the desktop SPA
+coverage (dashboard, devices, DHCP, login, setup, layout, not-found) and
+`admin-app/pwa-shell.spec.ts` covers the mobile PWA shell (manifest +
+installability, the service-worker offline shell, tab-bar nav, and
+`/admin-app/login` + shared admin-session reuse).
 
 ## Run
 

--- a/source/end2end-tests/web-ui/fixtures/devices.ts
+++ b/source/end2end-tests/web-ui/fixtures/devices.ts
@@ -1,0 +1,183 @@
+/**
+ * Device seeding for the admin-site Devices specs (A6, #621).
+ *
+ * There is no create-device API — the daemon only materializes a device
+ * row when its packet-capture discovery (`device/discovery.rs`
+ * `process_observation`) observes LAN traffic for a new MAC. So
+ * `seedDiscoveredDevice` makes the `test_debian` test-agent emit an ARP
+ * frame (`POST /arp/send`, the same endpoint the daemon arp-failover spec
+ * drives) with a synthetic, fully-controlled in-subnet MAC/IP, then polls
+ * `/api/devices` until the daemon has discovered it.
+ *
+ * The routing-change spec also needs a tunnel in the routing selector
+ * (the picker is disabled with zero tunnels). `seedTunnel` imports a
+ * deterministic WireGuard `.conf` over the API — import only parses and
+ * persists the definition (status `Down`, no interface brought up), so it
+ * has no WireGuard kernel dependency in the compose stack.
+ *
+ * Like the other fixtures here, this talks to the daemon over plain
+ * `fetch` against the REST API rather than the source-only `@wardnet/js`
+ * SDK (see fixtures/seed.ts header for why).
+ */
+
+import { api, ensureAdminSetup } from "./seed";
+import { TEST_DEBIAN_AGENT } from "./dhcp";
+
+/**
+ * Synthetic LAN client we conjure for the Devices specs. The MAC is
+ * locally-administered (`02:…`) so it can't collide with `test_debian`'s
+ * real NIC, and the IP sits inside the daemon's LAN subnet
+ * (`10.91.0.0/24`) so discovery's subnet filter accepts the observation.
+ * The daemon stores MACs canonical-lowercase (issue #312).
+ */
+export const SEED_DEVICE_MAC = "02:e2:e2:00:00:21";
+export const SEED_DEVICE_IP = "10.91.0.123";
+/** The daemon's LAN gateway IP — the ARP frame's target. */
+const SEED_TARGET_IP = "10.91.0.1";
+
+/** Subset of the daemon's Device we read back from `/api/devices`. */
+interface SeededDevice {
+  id: string;
+  mac: string;
+  last_ip: string;
+}
+
+interface ListDevicesResponse {
+  devices: SeededDevice[];
+}
+
+interface TunnelSummary {
+  id: string;
+  label: string;
+}
+
+interface ListTunnelsResponse {
+  tunnels: TunnelSummary[];
+}
+
+/** POST JSON to a test-agent serve URL. Throws on non-2xx. */
+async function agentPost(
+  baseUrl: string,
+  path: string,
+  body: unknown,
+): Promise<void> {
+  const res = await fetch(`${baseUrl}${path}`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) {
+    throw new Error(
+      `agent POST ${baseUrl}${path} failed: ${res.status} ${await res.text()}`,
+    );
+  }
+}
+
+/** Make `test_debian` emit a small ARP burst announcing the seed device. */
+async function emitArp(): Promise<void> {
+  await agentPost(TEST_DEBIAN_AGENT, "/arp/send", {
+    sender_mac: SEED_DEVICE_MAC,
+    sender_ip: SEED_DEVICE_IP,
+    target_ip: SEED_TARGET_IP,
+    interface: "eth0",
+    count: 3,
+    interval_ms: 100,
+  });
+}
+
+/**
+ * Conjure a discovered device and return its daemon-assigned id (plus the
+ * mac/ip the specs assert on). Emits an ARP frame from the LAN client,
+ * then polls `/api/devices`, re-emitting every few seconds (the discovery
+ * service batches observations and flushes on an interval, default 30 s),
+ * until the device appears. Throws on timeout — a missing device is a
+ * hard failure, not a skip: it means packet capture isn't reaching
+ * `wardnet_lan` in this environment. Idempotent: a device already present
+ * is returned immediately without re-seeding.
+ */
+export async function seedDiscoveredDevice(
+  timeoutMs = 60_000,
+): Promise<{ id: string; mac: string; ip: string }> {
+  const token = await ensureAdminSetup();
+
+  // Match on MAC alone — the device's stable identity. The daemon always
+  // records last_ip from the ARP sender (SEED_DEVICE_IP), but keying on the
+  // MAC avoids ever returning an unrelated device that happens to share the
+  // IP, which the table/detail specs then filter and navigate by.
+  const found = async (): Promise<SeededDevice | undefined> => {
+    const { devices } = await api<ListDevicesResponse>("/devices", { token });
+    return devices.find((d) => d.mac === SEED_DEVICE_MAC);
+  };
+
+  const existing = await found();
+  if (existing) {
+    return { id: existing.id, mac: existing.mac, ip: existing.last_ip };
+  }
+
+  const deadline = Date.now() + timeoutMs;
+  let lastErr: unknown;
+  while (Date.now() < deadline) {
+    try {
+      await emitArp();
+      const match = await found();
+      if (match) return { id: match.id, mac: match.mac, ip: match.last_ip };
+    } catch (err) {
+      lastErr = err;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 3_000));
+  }
+  throw new Error(
+    `device ${SEED_DEVICE_MAC} (${SEED_DEVICE_IP}) was not discovered within ${timeoutMs}ms — ` +
+      `packet capture may not be reaching wardnet_lan in this environment${
+        lastErr ? `: ${String(lastErr)}` : ""
+      }`,
+  );
+}
+
+/**
+ * A deterministic, syntactically-valid WireGuard config. The daemon's
+ * parser (`wardnet-common/src/wireguard_config.rs`) only requires
+ * `[Interface] PrivateKey` and `[Peer] PublicKey` and does not validate
+ * the key material, so these throwaway base64 blobs are fine — the tunnel
+ * is never brought up.
+ */
+const SEED_TUNNEL_CONFIG = [
+  "[Interface]",
+  "PrivateKey = SHFlsItPbjj4u4nNZbR8Ej2cTSDDTNeWiR+ej8a4tEM=",
+  "Address = 10.99.0.2/32",
+  "DNS = 1.1.1.1",
+  "",
+  "[Peer]",
+  "PublicKey = HIgo9xNzJMWLKASShiTqIybxZ0U3wGLiUeJ1PKf8ykw=",
+  "Endpoint = 198.51.100.1:51820",
+  "AllowedIPs = 0.0.0.0/0",
+  "",
+].join("\n");
+
+/**
+ * Ensure a tunnel exists so the device routing selector offers a
+ * non-Direct option. Idempotent: returns the existing tunnel's label if
+ * one with this label is already configured, otherwise imports the
+ * deterministic config above. Returns the label so the spec can match the
+ * selector option by its accessible name.
+ */
+export async function seedTunnel(
+  label = "E2E Test Tunnel",
+  countryCode = "de",
+): Promise<string> {
+  const token = await ensureAdminSetup();
+
+  const { tunnels } = await api<ListTunnelsResponse>("/tunnels", { token });
+  if (tunnels.some((t) => t.label === label)) return label;
+
+  await api("/tunnels", {
+    method: "POST",
+    token,
+    body: JSON.stringify({
+      label,
+      country_code: countryCode,
+      config: SEED_TUNNEL_CONFIG,
+    }),
+  });
+  return label;
+}

--- a/source/end2end-tests/web-ui/playwright.config.ts
+++ b/source/end2end-tests/web-ui/playwright.config.ts
@@ -32,6 +32,16 @@ const CHROMIUM_ARGS = [
   "--no-sandbox",
   // Docker's default /dev/shm is 64 MB; Chromium can exhaust it. Use /tmp.
   "--disable-dev-shm-usage",
+  // Trust the tls_proxy's self-signed cert at the BROWSER level, not just the
+  // context level. `ignoreHTTPSErrors` (set in `use` below) covers page
+  // navigations and fetches, but NOT the service-worker *script* fetch:
+  // registering a SW from an origin with a cert error fails with
+  // "An SSL certificate error occurred when fetching the script" even with
+  // `ignoreHTTPSErrors`. This flag disables cert verification process-wide so
+  // the admin-app / user-app service workers register and the offline-shell
+  // specs can run. (Harmless here — the whole stack is a throwaway self-signed
+  // proxy; see README.md → "Why a self-signed TLS proxy".)
+  "--ignore-certificate-errors",
 ];
 
 export default defineConfig({

--- a/source/end2end-tests/web-ui/tests/admin-app/pwa-shell.spec.ts
+++ b/source/end2end-tests/web-ui/tests/admin-app/pwa-shell.spec.ts
@@ -1,0 +1,161 @@
+import { expect, test } from "@playwright/test";
+
+import { ADMIN_PASSWORD, ADMIN_USERNAME } from "../../fixtures/seed.js";
+import { loginViaUi } from "../../fixtures/ui.js";
+
+/**
+ * admin-app PWA shell coverage (epic #614 → B1): web-app manifest +
+ * installability criteria, the service-worker offline shell, the mobile
+ * tab-bar navigation, and `/admin-app/login` + admin-session reuse via the
+ * project's shared `storageState`.
+ *
+ * Runs in the `admin-app` project — Pixel 7 viewport, seeded daemon, admin
+ * `storageState` (see playwright.config.ts). Selectors follow the suite's
+ * `data-testid` convention (README.md → "Selector convention"): testids
+ * locate, human-facing label/role/text is additionally asserted where
+ * meaningful.
+ */
+
+// Tab-bar entries that should navigate, keyed by testid → [URL, h1 | null].
+// The dashboard (`tab-home`) renders status cards with no <h1>, so it asserts
+// URL + active state only; every other tab carries a level-1 page heading.
+const TABS: Array<[string, RegExp, string | null]> = [
+  ["tab-devices", /\/admin-app\/devices$/, "Devices"],
+  ["tab-tunnels", /\/admin-app\/tunnels$/, "Tunnels"],
+  ["tab-dns", /\/admin-app\/dns$/, "DNS"],
+  ["tab-system", /\/admin-app\/system$/, "System"],
+  ["tab-home", /\/admin-app\/?$/, null],
+];
+
+test.describe("manifest + installability", () => {
+  test("serves a manifest and meets the installable criteria", async ({
+    page,
+  }) => {
+    await page.goto("./");
+
+    // The document advertises a manifest; resolve its href against the page
+    // URL (Vite rewrites the root-absolute href to the `/admin-app/` base in
+    // the built output) and fetch it through the browser context so the
+    // self-signed TLS proxy and any session cookie are honoured.
+    const href = await page
+      .locator('link[rel="manifest"]')
+      .getAttribute("href");
+    expect(href, "a <link rel=manifest> is present").toBeTruthy();
+    const manifestUrl = new URL(href!, page.url()).toString();
+
+    const res = await page.request.get(manifestUrl);
+    expect(res.ok(), `manifest fetch ${manifestUrl} → ${res.status()}`).toBe(
+      true,
+    );
+    const manifest = await res.json();
+
+    // Core installability fields: a name, an in-scope start URL, standalone
+    // display, and the 192/512 icons Chrome requires to offer installation.
+    expect(manifest.name).toBeTruthy();
+    expect(manifest.start_url).toContain("/admin-app/");
+    expect(manifest.scope).toContain("/admin-app/");
+    expect(manifest.display).toBe("standalone");
+    const iconSizes: string[] = (manifest.icons ?? []).map(
+      (icon: { sizes: string }) => icon.sizes,
+    );
+    expect(iconSizes).toContain("192x192");
+    expect(iconSizes).toContain("512x512");
+
+    // The remaining install-gate components: a registered service worker on a
+    // secure origin. (The actual `beforeinstallprompt` event is asserted
+    // indirectly — headless Chromium does not reliably fire it, so we verify
+    // the criteria that produce it instead.)
+    await page.evaluate(() => navigator.serviceWorker.ready.then(() => {}));
+    expect(new URL(page.url()).protocol).toBe("https:");
+  });
+});
+
+test("service worker serves the cached app shell offline", async ({
+  page,
+  context,
+}) => {
+  await page.goto("./");
+
+  // Wait for the SW to install/activate, then reload so it controls the page:
+  // sw.ts does not call clients.claim(), so the first load is uncontrolled.
+  await page.evaluate(() => navigator.serviceWorker.ready.then(() => {}));
+  await page.reload();
+  await page.waitForFunction(() => Boolean(navigator.serviceWorker.controller));
+
+  // Cut the network and reload. The SW's NavigationRoute must answer the
+  // navigation from the precache (denylist `^/api`); otherwise the reload
+  // would surface a browser network-error page.
+  await context.setOffline(true);
+  try {
+    await page.reload();
+
+    // The title and #root both live in the cached static index.html, so their
+    // presence proves the shell was served from the SW cache while offline.
+    await expect(page).toHaveTitle(/Wardnet/i);
+    await expect(page.locator("#root")).toBeAttached();
+  } finally {
+    await context.setOffline(false);
+  }
+});
+
+test("tab bar navigates between sections and marks the active tab", async ({
+  page,
+}) => {
+  // Pixel 7 viewport (project default) — the mobile tab bar is the primary nav.
+  await page.goto("./");
+
+  for (const [testId, url, heading] of TABS) {
+    await page.getByTestId(testId).click();
+    await expect(page).toHaveURL(url);
+    // react-router's NavLink marks the active tab via aria-current.
+    await expect(page.getByTestId(testId)).toHaveAttribute(
+      "aria-current",
+      "page",
+    );
+    // Non-dashboard tabs land on a page with a level-1 heading (human-facing
+    // label); the dashboard has none, so URL + active state is the contract.
+    if (heading) {
+      await expect(
+        page.getByRole("heading", { level: 1, name: heading }),
+      ).toBeVisible();
+    }
+  }
+});
+
+test("reuses the shared admin session on load", async ({ page }) => {
+  // The admin-app project injects the admin `storageState`; landing on the
+  // dashboard (not bounced to /login) proves the session is reused. The tab
+  // bar only mounts inside the authenticated AppLayout.
+  await page.goto("./");
+  await expect(page).toHaveURL(/\/admin-app\/?$/);
+  await expect(page.getByTestId("tab-home")).toBeVisible();
+});
+
+test.describe("login", () => {
+  // These need a logged-out context, so override the project's storageState.
+  test.use({ storageState: { cookies: [], origins: [] } });
+
+  test("renders the login form and authenticates into the shell", async ({
+    page,
+  }) => {
+    await page.goto("./login");
+
+    const submit = page.getByTestId("login-submit");
+    await expect(page.getByTestId("login-username")).toBeVisible();
+    await expect(submit).toBeVisible();
+    await expect(submit).toContainText(/log in/i);
+
+    await loginViaUi(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+
+    // Chromium exposes `window.PublicKeyCredential`, so the app treats
+    // biometrics as available and shows the one-time setup prompt after the
+    // first login (nothing registered yet). Decline it to reach the dashboard.
+    const declineBiometric = page.getByTestId("biometric-setup-decline");
+    await expect(declineBiometric).toContainText(/not now/i);
+    await declineBiometric.click();
+
+    // A successful login lands on the dashboard with the authed tab bar.
+    await expect(page).toHaveURL(/\/admin-app\/?$/);
+    await expect(page.getByTestId("tab-home")).toBeVisible();
+  });
+});

--- a/source/end2end-tests/web-ui/tests/admin-app/smoke.spec.ts
+++ b/source/end2end-tests/web-ui/tests/admin-app/smoke.spec.ts
@@ -1,8 +1,9 @@
 import { expect, test } from "@playwright/test";
 
 /**
- * Scaffold smoke: the admin-app PWA shell loads in a mobile viewport
- * without throwing. PWA install / offline / nav coverage lands in B1.
+ * Smoke canary: the admin-app PWA shell loads in a mobile viewport without
+ * throwing. Full PWA install / offline / nav coverage lives in
+ * `pwa-shell.spec.ts`.
  */
 test("admin-app shell renders", async ({ page }) => {
   const pageErrors: string[] = [];

--- a/source/end2end-tests/web-ui/tests/admin-site/devices.spec.ts
+++ b/source/end2end-tests/web-ui/tests/admin-site/devices.spec.ts
@@ -1,0 +1,88 @@
+import { expect, test } from "@playwright/test";
+
+import {
+  SEED_DEVICE_IP,
+  SEED_DEVICE_MAC,
+  seedDiscoveredDevice,
+  seedTunnel,
+} from "../../fixtures/devices.js";
+
+/**
+ * Admin-site Devices coverage (A6, #621): the device table lists a
+ * discovered LAN client, the drill-in detail page surfaces its fields,
+ * and the routing rule can be changed to a tunnel.
+ *
+ * A synthetic device is seeded before the spec runs: `seedDiscoveredDevice`
+ * makes the `test_debian` test-agent emit an ARP frame for a controlled
+ * in-subnet MAC/IP, then polls `/api/devices` until the daemon's
+ * packet-capture discovery materializes the row (see fixtures/devices.ts).
+ * A tunnel is imported so the routing selector offers a non-Direct option.
+ * Both are hard preconditions — if the device never appears (packet
+ * capture not reaching wardnet_lan), `beforeAll` throws and the spec fails
+ * rather than silently skipping.
+ *
+ * Runs in the `admin-site` project (seeded daemon + admin storageState).
+ * Selectors follow the suite's `data-testid` convention (README.md →
+ * "Selector convention"): testids locate, human-facing label/text is
+ * additionally asserted. Self-contained: the routing test sets the rule it
+ * asserts, so behaviour doesn't depend on spec order.
+ */
+
+let deviceId: string;
+const TUNNEL_LABEL = "E2E Test Tunnel";
+
+test.beforeAll(async () => {
+  const device = await seedDiscoveredDevice();
+  deviceId = device.id;
+  await seedTunnel(TUNNEL_LABEL);
+});
+
+test("the devices table lists the discovered LAN client", async ({ page }) => {
+  await page.goto("./devices");
+  await expect(page).toHaveURL(/\/admin\/devices$/);
+  await expect(page.getByTestId("page-title")).toHaveText("Devices");
+
+  // Unmanaged, hostname-less device: the Device column falls back to the
+  // MAC (deviceDisplayName → name ?? hostname ?? mac) and the IP column
+  // shows last_ip. Scope to the row by IP, then assert the MAC.
+  const row = page.getByRole("row").filter({ hasText: SEED_DEVICE_IP });
+  await expect(row).toBeVisible();
+  await expect(row).toContainText(SEED_DEVICE_MAC);
+});
+
+test("the device detail page shows the device fields", async ({ page }) => {
+  await page.goto("./devices");
+
+  // Row-click navigates to the detail route.
+  await page.getByRole("row").filter({ hasText: SEED_DEVICE_IP }).click();
+  await expect(page).toHaveURL(new RegExp(`/admin/devices/${deviceId}$`));
+
+  // Identity card surfaces the MAC; the network card / header surface the IP.
+  // Both also appear in the detail header, so match the first occurrence.
+  await expect(page.getByText(SEED_DEVICE_MAC).first()).toBeVisible();
+  await expect(page.getByText(SEED_DEVICE_IP).first()).toBeVisible();
+});
+
+test("the device routing rule can be changed to a tunnel", async ({ page }) => {
+  await page.goto(`./devices/${deviceId}`);
+  await expect(page).toHaveURL(new RegExp(`/admin/devices/${deviceId}$`));
+
+  // Enter edit mode on the Settings card.
+  await page.getByTestId("device-settings-edit").click();
+
+  // Open the routing dropdown and pick the seeded tunnel (Radix renders
+  // options in a portal with role="option"; the flag glyph is aria-hidden
+  // so the accessible name is the bare label).
+  await page.getByTestId("device-settings-routing").click();
+  await page.getByRole("option", { name: TUNNEL_LABEL }).click();
+
+  // Save (label is "To Managed Device" while the device is unmanaged — we
+  // locate by testid regardless).
+  await page.getByTestId("device-settings-save").click();
+
+  // Back in read mode the routing value reflects the new tunnel target.
+  const routingValue = page.getByTestId("device-settings-routing-value");
+  await expect(routingValue).toBeVisible();
+  await expect(routingValue).toContainText(/via tunnel/i);
+  await expect(routingValue).toContainText(TUNNEL_LABEL);
+});

--- a/source/web/src/components/RoutingSelector.tsx
+++ b/source/web/src/components/RoutingSelector.tsx
@@ -28,6 +28,8 @@ interface RoutingSelectorProps {
   tunnels: TunnelSummary[];
   disabled?: boolean;
   isAdmin?: boolean;
+  /** e2e locator, forwarded to the rendered `<SelectTrigger>`. */
+  "data-testid"?: string;
 }
 
 /** Compound component for selecting a device's routing target.
@@ -42,6 +44,7 @@ export function RoutingSelector({
   tunnels,
   disabled,
   isAdmin,
+  "data-testid": dataTestId,
 }: RoutingSelectorProps) {
   const selected = valueFromTarget(value, tunnels);
 
@@ -57,7 +60,7 @@ export function RoutingSelector({
     return (
       <div className="flex flex-col gap-2">
         <Select value={DIRECT_VALUE} onValueChange={handleChange} disabled>
-          <SelectTrigger className="w-full">
+          <SelectTrigger className="w-full" data-testid={dataTestId}>
             <SelectValue />
           </SelectTrigger>
           <SelectContent>
@@ -85,7 +88,7 @@ export function RoutingSelector({
 
   return (
     <Select value={selected} onValueChange={handleChange} disabled={disabled}>
-      <SelectTrigger className="w-full">
+      <SelectTrigger className="w-full" data-testid={dataTestId}>
         <SelectValue />
       </SelectTrigger>
       <SelectContent>


### PR DESCRIPTION
Closes #624 (B1, epic #614).

Adds Playwright e2e coverage for the **admin-app** mobile PWA surface
(`/admin-app/`) via a new `pwa-shell.spec.ts`.

## What's covered
- **Manifest + installability** — resolves the `<link rel="manifest">` href
  from the live DOM and fetches it, asserting name, in-scope `start_url`/`scope`,
  `display: standalone`, and the 192/512 icons; plus a registered service worker
  on an `https:` origin. (We assert the install-gate *criteria* rather than the
  `beforeinstallprompt` event, which headless Chromium does not reliably fire.)
- **Service-worker offline shell** — waits for the SW to control the page, goes
  offline, reloads, and asserts the cached `index.html` shell is served (title +
  `#root`) instead of a browser network-error page.
- **Mobile tab-bar nav** — clicks each tab, asserting URL, `aria-current="page"`,
  and the destination `<h1>` (dashboard has none, so URL + active state only).
- **Login + shared session** — authed `storageState` lands on the dashboard
  (session reuse); a logged-out context logs in via the real form, dismisses the
  biometric setup prompt, and reaches the dashboard.

## Supporting changes
- `data-testid`s added per the suite's selector convention: `tab-*` on each
  `TabBar` NavLink, and `biometric-setup-enable`/`biometric-setup-decline` on the
  `BiometricSetupPrompt` buttons. The prompt appears after login whenever the
  browser exposes `window.PublicKeyCredential`, so the login spec must dismiss it.
- Tidied the admin-app smoke-spec comment and refreshed the web-ui README now that
  per-surface feature specs have landed.

## Verification
- `yarn type-check` passes for the web-ui suite and admin-app.
- `playwright test --project=admin-app --list` discovers all specs.
- `make e2e-ui` (full Linux/CI stack) is the authoritative run; the systemd
  daemon container is CI-targeted and not validated on a macOS dev host.

## Merge Commit Message
test(e2e): admin-app PWA shell specs (manifest, offline, nav, login) (#624)

https://claude.ai/code/session_01DJ2wuKWvkuNPtKaGEhoocY