### PR TITLE
test(e2e): admin-site System area specs + fix backup-restore WAL bug (#623)

### DIFF
--- a/source/admin-site/src/components/compound/ProgressDialog.tsx
+++ b/source/admin-site/src/components/compound/ProgressDialog.tsx
@@ -91,9 +91,12 @@ export function ProgressDialog({
         if (!next && terminal) onDismiss();
       }}
     >
-      <AlertModalContent>
+      <AlertModalContent data-testid="progress-dialog">
         <AlertModalHeader>
-          <AlertModalTitle className="flex items-center gap-2">
+          <AlertModalTitle
+            className="flex items-center gap-2"
+            data-testid="progress-title"
+          >
             {phase === "in-progress" && (
               <Loader2Icon className="h-5 w-5 animate-spin text-ink-3" />
             )}
@@ -134,7 +137,11 @@ export function ProgressDialog({
           <AlertModalFooter>
             {phase === "success" && successAction}
             <AlertModalCancel asChild>
-              <Button variant="outline" onClick={onDismiss}>
+              <Button
+                variant="outline"
+                onClick={onDismiss}
+                data-testid="progress-dismiss"
+              >
                 Dismiss
               </Button>
             </AlertModalCancel>

--- a/source/admin-site/src/components/features/BackupCard.tsx
+++ b/source/admin-site/src/components/features/BackupCard.tsx
@@ -170,6 +170,7 @@ export function BackupCard({
                 variant="outline"
                 onClick={enterExport}
                 disabled={isExporting}
+                data-testid="backup-export-open"
               >
                 <DownloadIcon />
                 Download backup
@@ -216,6 +217,7 @@ export function BackupCard({
               >
                 <Input
                   id="backup-passphrase"
+                  data-testid="backup-passphrase"
                   type="password"
                   autoComplete="new-password"
                   value={exportPassphrase}
@@ -246,6 +248,7 @@ export function BackupCard({
               >
                 <Input
                   id="backup-passphrase-confirm"
+                  data-testid="backup-passphrase-confirm"
                   type="password"
                   autoComplete="new-password"
                   value={exportConfirm}
@@ -281,7 +284,11 @@ export function BackupCard({
               >
                 Cancel
               </Button>
-              <Button type="submit" disabled={isExporting}>
+              <Button
+                type="submit"
+                disabled={isExporting}
+                data-testid="backup-export-submit"
+              >
                 {isExporting ? (
                   <>
                     <Loader2 className="animate-spin" />
@@ -312,6 +319,7 @@ export function BackupCard({
                 variant="destructive"
                 onClick={enterRestore}
                 disabled={isPreviewing || isApplying}
+                data-testid="backup-restore-open"
               >
                 <UploadIcon />
                 Restore…
@@ -341,6 +349,7 @@ export function BackupCard({
               <Field label="Bundle file" htmlFor="backup-bundle" name="bundle">
                 <input
                   id="backup-bundle"
+                  data-testid="backup-bundle"
                   ref={fileInputRef}
                   type="file"
                   accept=".age,.wardnet,.wardnet.age"
@@ -363,6 +372,7 @@ export function BackupCard({
               >
                 <Input
                   id="restore-passphrase"
+                  data-testid="restore-passphrase"
                   type="password"
                   // `off` + `new-password` together suppress every popular
                   // browser's autofill for this field — this is a bundle
@@ -409,7 +419,11 @@ export function BackupCard({
               >
                 Cancel
               </Button>
-              <Button type="submit" disabled={isPreviewing}>
+              <Button
+                type="submit"
+                disabled={isPreviewing}
+                data-testid="backup-preview-submit"
+              >
                 {isPreviewing ? (
                   <>
                     <Loader2 className="animate-spin" />
@@ -447,6 +461,7 @@ export function BackupCard({
                 variant="destructive"
                 onClick={handleApply}
                 disabled={!preview.compatible || isApplying}
+                data-testid="backup-apply-submit"
               >
                 {isApplying ? (
                   <>
@@ -471,7 +486,12 @@ function RestorePreviewDetails({
   preview: RestorePreviewResponse;
 }) {
   return (
-    <Text as="div" size="sm" className="space-y-3">
+    <Text
+      as="div"
+      size="sm"
+      className="space-y-3"
+      data-testid="restore-preview"
+    >
       {!preview.compatible && (
         <div className="flex gap-2 rounded-md bg-danger-soft p-3 text-danger-soft-ink">
           <AlertTriangleIcon className="mt-0.5 h-4 w-4 shrink-0" />

--- a/source/admin-site/src/components/features/PowerCard.tsx
+++ b/source/admin-site/src/components/features/PowerCard.tsx
@@ -91,6 +91,7 @@ export function PowerCard({
               onClick={() => setRestartOpen(true)}
               disabled={busy}
               aria-label="Restart daemon"
+              data-testid="power-restart-daemon"
             >
               <RefreshCwIcon />
               Restart daemon
@@ -204,6 +205,7 @@ export function PowerCard({
             </AlertModalCancel>
             <AlertModalAction asChild>
               <Button
+                data-testid="power-restart-confirm"
                 onClick={() => {
                   setRestartOpen(false);
                   onRestartDaemon();

--- a/source/admin-site/src/components/features/RestartProgressDialog.tsx
+++ b/source/admin-site/src/components/features/RestartProgressDialog.tsx
@@ -122,7 +122,7 @@ function contentFor(phase: RestartPhase, onSignIn: () => void): PhaseContent {
       : "Service is back on and your session is still valid.",
     successAction: signedOut ? (
       <AlertModalAction asChild>
-        <Button onClick={onSignIn}>
+        <Button onClick={onSignIn} data-testid="restart-signin">
           <LogInIcon className="mr-2 h-4 w-4" />
           Sign in again
         </Button>

--- a/source/admin-site/src/components/features/UpdateCard.tsx
+++ b/source/admin-site/src/components/features/UpdateCard.tsx
@@ -127,6 +127,7 @@ export function UpdateCard({
               token would ripple across the whole app. */}
         <Toggle
           id="auto-update-toggle"
+          data-testid="update-auto-toggle"
           aria-label="Enable automatic updates"
           className="ml-auto min-[890px]:order-last min-[890px]:ml-0"
           checked={autoEnabled}
@@ -139,7 +140,10 @@ export function UpdateCard({
             onValueChange={(v) => onChangeChannel(v as UpdateChannel)}
             disabled={!status || phaseActive}
           >
-            <SelectTrigger className="select-trigger--md w-40">
+            <SelectTrigger
+              className="select-trigger--md w-40"
+              data-testid="update-channel-trigger"
+            >
               <SelectValue />
             </SelectTrigger>
             <SelectContent>
@@ -152,6 +156,7 @@ export function UpdateCard({
             onClick={onCheck}
             disabled={isChecking || phaseActive}
             aria-label="Check for updates"
+            data-testid="update-check"
           >
             <RefreshCwIcon
               className={isChecking ? "animate-spin" : undefined}

--- a/source/admin-site/src/pages/Settings.tsx
+++ b/source/admin-site/src/pages/Settings.tsx
@@ -47,6 +47,7 @@ export default function Settings() {
               as="dl"
               size="sm"
               className="grid grid-cols-2 gap-x-8 gap-y-3 sm:grid-cols-3"
+              data-testid="system-info"
             >
               <div>
                 <Text
@@ -60,6 +61,7 @@ export default function Settings() {
                   as="dd"
                   weight="medium"
                   title={`build: ${status.version}`}
+                  data-testid="system-version"
                 >
                   {status.release_version}
                 </Text>

--- a/source/daemon/crates/wardnetd-data/src/db.rs
+++ b/source/daemon/crates/wardnetd-data/src/db.rs
@@ -1,4 +1,4 @@
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 use sqlx::SqlitePool;
@@ -23,6 +23,72 @@ const BUSY_TIMEOUT: Duration = Duration::from_secs(30);
 /// at the default 4 KiB page size is ~100 MiB of reclaimable space.
 const VACUUM_FREELIST_THRESHOLD_PAGES: i64 = 25_000;
 const MEMORY_CONNECTION_STRING: &str = ":memory:";
+/// File-name suffix for the sentinel a backup restore drops next to the
+/// database. Its presence on startup means the `<db>` file was just
+/// replaced by a restored snapshot and any leftover WAL/SHM sidecars
+/// belong to the *pre-restore* database — they must be discarded, not
+/// recovered onto the snapshot.
+const RESTORE_PENDING_SUFFIX: &str = ".restore-pending";
+
+/// Path of the restore-pending sentinel for a given database file.
+///
+/// The backup service writes this after laying down a restored snapshot;
+/// [`init_db_pools_from_connection_string`] consumes it on the next
+/// startup. Shared here so writer and reader agree on the location.
+#[must_use]
+pub fn restore_pending_marker_path(db_path: &Path) -> PathBuf {
+    let mut name = db_path.as_os_str().to_owned();
+    name.push(RESTORE_PENDING_SUFFIX);
+    PathBuf::from(name)
+}
+
+/// Build the path of a sibling sidecar (`-wal`, `-shm`, …) for a database file.
+fn sidecar_path(db_path: &Path, suffix: &str) -> PathBuf {
+    let mut name = db_path.as_os_str().to_owned();
+    name.push(suffix);
+    PathBuf::from(name)
+}
+
+/// If a backup restore is pending, discard the stale WAL/SHM sidecars
+/// before any pool opens the database.
+///
+/// A file-swap restore replaces `<db>` with a complete, self-contained
+/// `VACUUM INTO` snapshot, but the *live* WAL-mode pool keeps writing the
+/// pre-restore database's frames into `<db>-wal` until the process exits
+/// (the restart-pending write, the graceful-shutdown record, …). On the
+/// next boot `SQLite` would recover that WAL onto the freshly restored
+/// snapshot, silently resurrecting pre-restore state. Gated on the
+/// sentinel so a normal crash still recovers its WAL as usual.
+pub(crate) fn discard_stale_wal_for_restore(db_path: &Path) {
+    let marker = restore_pending_marker_path(db_path);
+    if !marker.exists() {
+        return;
+    }
+    for suffix in ["-wal", "-shm"] {
+        let sidecar = sidecar_path(db_path, suffix);
+        match std::fs::remove_file(&sidecar) {
+            Ok(()) => tracing::warn!(
+                path = %sidecar.display(),
+                "restore pending: discarded stale SQLite sidecar so it isn't recovered onto the restored snapshot",
+            ),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+            Err(e) => tracing::error!(
+                path = %sidecar.display(),
+                error = %e,
+                "restore pending: failed to discard stale SQLite sidecar",
+            ),
+        }
+    }
+    if let Err(e) = std::fs::remove_file(&marker)
+        && e.kind() != std::io::ErrorKind::NotFound
+    {
+        tracing::error!(
+            path = %marker.display(),
+            error = %e,
+            "restore pending: failed to remove restore sentinel; WAL discard may repeat next boot",
+        );
+    }
+}
 
 /// A reader/writer pair backed by `SQLite`.
 ///
@@ -101,6 +167,11 @@ pub async fn init_db_pools_from_connection_string(conn: &str) -> anyhow::Result<
         if let Some(parent) = path.parent() {
             std::fs::create_dir_all(parent)?;
         }
+
+        // Before opening any pool: if a backup restore just laid down a
+        // fresh snapshot, drop the pre-restore WAL/SHM sidecars so SQLite
+        // recovers the restored database, not the stale WAL.
+        discard_stale_wal_for_restore(path);
 
         // Shared options used by both pools — they must agree on
         // journal mode, synchronous level, FK enforcement and the

--- a/source/daemon/crates/wardnetd-data/src/tests/db.rs
+++ b/source/daemon/crates/wardnetd-data/src/tests/db.rs
@@ -1,4 +1,37 @@
-use crate::db::{init_pool, init_pool_from_connection_string};
+use std::path::{Path, PathBuf};
+
+use sqlx::sqlite::{SqliteConnectOptions, SqliteJournalMode};
+use sqlx::{ConnectOptions, Connection};
+use uuid::Uuid;
+
+use crate::db::{
+    discard_stale_wal_for_restore, init_pool, init_pool_from_connection_string,
+    restore_pending_marker_path,
+};
+
+/// Sibling sidecar path (`-wal` / `-shm`) for a database file.
+fn sidecar(db: &Path, suffix: &str) -> PathBuf {
+    let mut name = db.as_os_str().to_owned();
+    name.push(suffix);
+    PathBuf::from(name)
+}
+
+/// Open `path` (WAL mode) and read the single `kv.channel` value. Used by
+/// the restore-WAL regression test to observe which database state wins.
+async fn read_channel(path: &Path) -> String {
+    let mut conn = SqliteConnectOptions::new()
+        .filename(path)
+        .journal_mode(SqliteJournalMode::Wal)
+        .connect()
+        .await
+        .unwrap();
+    let v: String = sqlx::query_scalar("SELECT v FROM kv WHERE k = 'channel'")
+        .fetch_one(&mut conn)
+        .await
+        .unwrap();
+    conn.close().await.unwrap();
+    v
+}
 
 #[tokio::test]
 async fn init_pool_from_connection_string_in_memory_runs_migrations() {
@@ -42,6 +75,133 @@ async fn init_pool_from_connection_string_in_memory_persists_writes() {
             .expect("select should return the inserted row");
 
     assert_eq!(value, "ok");
+}
+
+#[tokio::test]
+async fn restore_marker_discards_stale_wal_so_snapshot_wins() {
+    // Regression for the backup-restore WAL bug: a file-swap restore lays
+    // down a fresh snapshot as `<db>`, but the live WAL-mode pool keeps
+    // writing the pre-restore database's frames into `<db>-wal` until the
+    // process restarts. Without the restore sentinel, SQLite recovers that
+    // stale WAL onto the snapshot on the next boot and resurrects
+    // pre-restore state. The guard must discard the sidecars so the
+    // snapshot wins.
+    let dir = std::env::temp_dir();
+    let live = dir.join(format!("wardnet-wal-live-{}.db", Uuid::new_v4()));
+
+    // Build a WAL-mode DB, fold a "stable" value fully into the main file
+    // (checkpoint TRUNCATE empties the WAL), and capture the main bytes as
+    // the restore *snapshot*.
+    let mut conn = SqliteConnectOptions::new()
+        .filename(&live)
+        .create_if_missing(true)
+        .journal_mode(SqliteJournalMode::Wal)
+        .connect()
+        .await
+        .unwrap();
+    sqlx::query("PRAGMA wal_autocheckpoint=0")
+        .execute(&mut conn)
+        .await
+        .unwrap();
+    sqlx::query("CREATE TABLE kv (k TEXT PRIMARY KEY, v TEXT NOT NULL)")
+        .execute(&mut conn)
+        .await
+        .unwrap();
+    sqlx::query("INSERT INTO kv (k, v) VALUES ('channel', 'stable')")
+        .execute(&mut conn)
+        .await
+        .unwrap();
+    sqlx::query("PRAGMA wal_checkpoint(TRUNCATE)")
+        .execute(&mut conn)
+        .await
+        .unwrap();
+    let snapshot = tokio::fs::read(&live).await.unwrap();
+
+    // Write a post-snapshot change that lands in the WAL (not checkpointed),
+    // and capture the populated -wal while the connection is still open.
+    sqlx::query("UPDATE kv SET v = 'beta' WHERE k = 'channel'")
+        .execute(&mut conn)
+        .await
+        .unwrap();
+    let wal = tokio::fs::read(sidecar(&live, "-wal")).await.unwrap();
+    assert!(
+        !wal.is_empty(),
+        "expected a populated -wal carrying the post-snapshot change"
+    );
+    conn.close().await.unwrap();
+    let _ = tokio::fs::remove_file(&live).await;
+    let _ = tokio::fs::remove_file(sidecar(&live, "-wal")).await;
+    let _ = tokio::fs::remove_file(sidecar(&live, "-shm")).await;
+
+    // --- Control: snapshot + stale WAL, no marker → SQLite recovers the
+    //     WAL and 'beta' resurfaces. Proves the failure this guard fixes. ---
+    let ctrl = dir.join(format!("wardnet-wal-ctrl-{}.db", Uuid::new_v4()));
+    tokio::fs::write(&ctrl, &snapshot).await.unwrap();
+    tokio::fs::write(sidecar(&ctrl, "-wal"), &wal)
+        .await
+        .unwrap();
+    assert_eq!(
+        read_channel(&ctrl).await,
+        "beta",
+        "control: stale WAL is recovered without the restore marker"
+    );
+
+    // --- Fix: same triple plus the marker → the guard discards the
+    //     sidecars and the snapshot's 'stable' wins. ---
+    let fixed = dir.join(format!("wardnet-wal-fixed-{}.db", Uuid::new_v4()));
+    tokio::fs::write(&fixed, &snapshot).await.unwrap();
+    tokio::fs::write(sidecar(&fixed, "-wal"), &wal)
+        .await
+        .unwrap();
+    // A stale -shm too, to prove the guard clears it.
+    tokio::fs::write(sidecar(&fixed, "-shm"), b"stale")
+        .await
+        .unwrap();
+    tokio::fs::write(restore_pending_marker_path(&fixed), b"")
+        .await
+        .unwrap();
+
+    discard_stale_wal_for_restore(&fixed);
+
+    assert!(!sidecar(&fixed, "-wal").exists(), "guard must remove -wal");
+    assert!(!sidecar(&fixed, "-shm").exists(), "guard must remove -shm");
+    assert!(
+        !restore_pending_marker_path(&fixed).exists(),
+        "guard must consume the restore marker"
+    );
+    assert_eq!(
+        read_channel(&fixed).await,
+        "stable",
+        "restored snapshot must win after the guard discards the stale WAL"
+    );
+
+    for p in [&ctrl, &fixed] {
+        let _ = tokio::fs::remove_file(p).await;
+        let _ = tokio::fs::remove_file(sidecar(p, "-wal")).await;
+        let _ = tokio::fs::remove_file(sidecar(p, "-shm")).await;
+    }
+}
+
+#[tokio::test]
+async fn discard_stale_wal_is_a_noop_without_the_marker() {
+    // Without the sentinel a normal crash must keep its WAL so SQLite can
+    // recover it — the guard must leave the sidecars untouched.
+    let dir = std::env::temp_dir();
+    let db = dir.join(format!("wardnet-wal-noop-{}.db", Uuid::new_v4()));
+    tokio::fs::write(&db, b"main").await.unwrap();
+    tokio::fs::write(sidecar(&db, "-wal"), b"wal")
+        .await
+        .unwrap();
+
+    discard_stale_wal_for_restore(&db);
+
+    assert!(
+        sidecar(&db, "-wal").exists(),
+        "no marker → WAL must be preserved for normal crash recovery"
+    );
+
+    let _ = tokio::fs::remove_file(&db).await;
+    let _ = tokio::fs::remove_file(sidecar(&db, "-wal")).await;
 }
 
 #[tokio::test]

--- a/source/daemon/crates/wardnetd-data/src/tests/db.rs
+++ b/source/daemon/crates/wardnetd-data/src/tests/db.rs
@@ -5,8 +5,8 @@ use sqlx::{ConnectOptions, Connection};
 use uuid::Uuid;
 
 use crate::db::{
-    discard_stale_wal_for_restore, init_pool, init_pool_from_connection_string,
-    restore_pending_marker_path,
+    discard_stale_wal_for_restore, init_db_pools_from_connection_string, init_pool,
+    init_pool_from_connection_string, restore_pending_marker_path,
 };
 
 /// Sibling sidecar path (`-wal` / `-shm`) for a database file.
@@ -180,6 +180,52 @@ async fn restore_marker_discards_stale_wal_so_snapshot_wins() {
         let _ = tokio::fs::remove_file(sidecar(p, "-wal")).await;
         let _ = tokio::fs::remove_file(sidecar(p, "-shm")).await;
     }
+}
+
+#[tokio::test]
+async fn init_db_pools_with_file_path_creates_migrates_and_runs_the_restore_guard() {
+    // Exercises the on-disk (file) branch — including the restore-WAL
+    // guard call — rather than the `:memory:` branch the other tests use.
+    let dir = std::env::temp_dir();
+    let db = dir.join(format!("wardnet-init-file-{}.db", Uuid::new_v4()));
+
+    let pools = init_db_pools_from_connection_string(db.to_str().unwrap())
+        .await
+        .expect("file-based pool creation should succeed");
+
+    let table_count: i64 =
+        sqlx::query_scalar("SELECT COUNT(*) FROM sqlite_master WHERE type='table'")
+            .fetch_one(&pools.read)
+            .await
+            .expect("sqlite_master query should succeed");
+    assert!(table_count > 0, "migrations should have created tables");
+
+    pools.write.close().await;
+    pools.read.close().await;
+    for s in ["", "-wal", "-shm"] {
+        let _ = tokio::fs::remove_file(sidecar(&db, s)).await;
+    }
+}
+
+#[tokio::test]
+async fn discard_stale_wal_tolerates_unremovable_sidecar_and_marker() {
+    // The guard must never panic on filesystem errors. Make both the
+    // `-wal` sidecar and the marker directories so `remove_file` fails
+    // with a non-NotFound error, and leave `-shm` absent so the NotFound
+    // arm is exercised too.
+    let dir = std::env::temp_dir();
+    let db = dir.join(format!("wardnet-wal-err-{}.db", Uuid::new_v4()));
+    std::fs::create_dir(restore_pending_marker_path(&db)).unwrap();
+    std::fs::create_dir(sidecar(&db, "-wal")).unwrap();
+
+    discard_stale_wal_for_restore(&db);
+
+    // Errors were swallowed; the unremovable entries remain.
+    assert!(sidecar(&db, "-wal").exists());
+    assert!(restore_pending_marker_path(&db).exists());
+
+    let _ = std::fs::remove_dir_all(sidecar(&db, "-wal"));
+    let _ = std::fs::remove_dir_all(restore_pending_marker_path(&db));
 }
 
 #[tokio::test]

--- a/source/daemon/crates/wardnetd-services/src/backup/service.rs
+++ b/source/daemon/crates/wardnetd-services/src/backup/service.rs
@@ -50,6 +50,7 @@ use wardnet_common::backup::{
     RestorePhase, SnapshotKind,
 };
 use wardnetd_data::database_dumper::DatabaseDumper;
+use wardnetd_data::db::restore_pending_marker_path;
 use wardnetd_data::repository::SystemConfigRepository;
 use wardnetd_data::secret_store::{SecretEntry, SecretStore};
 
@@ -392,6 +393,18 @@ impl BackupServiceImpl {
             self.secret_store
                 .restore_from_backup(&pending.contents.secrets)
                 .await?;
+
+            // Signal the next startup to discard the pre-restore WAL/SHM
+            // sidecars. The live WAL-mode pool keeps writing the old
+            // database's frames into `<db>-wal` until we restart (this
+            // method's restart-pending write, the graceful-shutdown
+            // record, …); without this marker SQLite would recover that
+            // WAL onto the freshly restored snapshot and resurrect
+            // pre-restore state. Written last so any failure above rolls
+            // back; removed again on the rollback path below.
+            tokio::fs::write(restore_pending_marker_path(&self.database_path), b"")
+                .await
+                .map_err(|e| anyhow::anyhow!("failed to write restore-pending marker: {e}"))?;
             Ok(())
         }
         .await;
@@ -410,6 +423,10 @@ impl BackupServiceImpl {
                 let _ = tokio::fs::rename(&config_hold, &self.config_path).await;
             }
             let _ = tokio::fs::remove_file(&staged_config).await;
+            // Drop the restore marker if we got far enough to write it —
+            // the original DB (and its live WAL) are back in place and
+            // must recover normally on the next boot.
+            let _ = tokio::fs::remove_file(restore_pending_marker_path(&self.database_path)).await;
             // Replay pre-restore secrets — the `restore_from_backup`
             // contract is "replace store contents with these entries",
             // so re-applying the captured list reverts the store.

--- a/source/daemon/crates/wardnetd-services/src/backup/tests/service.rs
+++ b/source/daemon/crates/wardnetd-services/src/backup/tests/service.rs
@@ -23,6 +23,7 @@ use wardnet_common::api::{ApplyImportRequest, ExportBackupRequest};
 use wardnet_common::auth::AuthContext;
 use wardnet_common::backup::{BackupStatus, BundleManifest, CURRENT_BUNDLE_FORMAT_VERSION};
 use wardnetd_data::database_dumper::DatabaseDumper;
+use wardnetd_data::db::restore_pending_marker_path;
 use wardnetd_data::repository::SystemConfigRepository;
 use wardnetd_data::secret_store::{FileSecretStore, SecretStore};
 
@@ -629,6 +630,86 @@ async fn status_reflects_failed_export_when_dumper_errors() {
 // Status transitions to `Failed` when the preview archiver rejects a
 // garbage payload.
 // ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn apply_import_rolls_back_and_leaves_no_restore_marker_on_failure() {
+    // When the install fails mid-apply, run_apply_import must roll the
+    // live database back and not leave a restore-pending marker behind
+    // (the marker would make the next boot discard a legitimate WAL).
+    struct RestoreFailsDumper {
+        dump_bytes: Vec<u8>,
+        schema_version: i64,
+    }
+    #[async_trait]
+    impl DatabaseDumper for RestoreFailsDumper {
+        async fn dump(&self) -> anyhow::Result<Vec<u8>> {
+            Ok(self.dump_bytes.clone())
+        }
+        async fn restore(&self, _bytes: &[u8]) -> anyhow::Result<i64> {
+            anyhow::bail!("restore boom")
+        }
+        async fn current_schema_version(&self) -> anyhow::Result<i64> {
+            Ok(self.schema_version)
+        }
+    }
+
+    let tempdir = std::env::temp_dir().join(format!("wardnet-backup-test-{}", Uuid::new_v4()));
+    std::fs::create_dir_all(&tempdir).unwrap();
+    let database_path = tempdir.join("wardnet.db");
+    let config_path = tempdir.join("wardnet.toml");
+    std::fs::write(&database_path, b"live db").unwrap();
+    std::fs::write(&config_path, b"live config").unwrap();
+
+    let secret_store: Arc<dyn SecretStore> = Arc::new(FileSecretStore::new(tempdir.join("sec")));
+    let svc = BackupServiceImpl::new(
+        Arc::new(AgeArchiver::new()),
+        Arc::new(RestoreFailsDumper {
+            dump_bytes: b"snapshot bytes".to_vec(),
+            schema_version: 42,
+        }),
+        secret_store,
+        Arc::new(MockSystemConfig::new()),
+        database_path.clone(),
+        config_path.clone(),
+        "0.2.0-test",
+        "test-host",
+    );
+
+    let passphrase = "correct-horse-battery-staple".to_owned();
+    let bundle = auth_context::with_context(
+        admin_ctx(),
+        svc.export(ExportBackupRequest {
+            passphrase: passphrase.clone(),
+        }),
+    )
+    .await
+    .unwrap();
+    let preview = auth_context::with_context(admin_ctx(), svc.preview_import(bundle, passphrase))
+        .await
+        .unwrap();
+
+    let err = auth_context::with_context(
+        admin_ctx(),
+        svc.apply_import(ApplyImportRequest {
+            preview_token: preview.preview_token,
+        }),
+    )
+    .await
+    .unwrap_err();
+    assert!(matches!(err, AppError::Internal(_)));
+
+    // Rollback restored the original database, and no restore marker
+    // survives to mislead the next startup.
+    assert_eq!(
+        tokio::fs::read(&database_path).await.unwrap(),
+        b"live db",
+        "rollback should restore the original database"
+    );
+    assert!(
+        !restore_pending_marker_path(&database_path).exists(),
+        "no restore-pending marker should remain after a rolled-back apply"
+    );
+}
 
 #[tokio::test]
 async fn preview_import_sets_failed_status_on_archiver_error() {

--- a/source/end2end-tests/web-ui/README.md
+++ b/source/end2end-tests/web-ui/README.md
@@ -86,6 +86,16 @@ the `wardnet_session` cookie (built from the login token). The
 `user-app` is unauthenticated (device-keyed); from the mgmt-side runner
 it shows the no-device state.
 
+## Spec ordering (`stateful/`)
+
+The suite runs single-worker against one shared daemon, and Playwright
+runs spec files in lexicographic path order. Specs that **restart the
+daemon** (currently `power.spec.ts` and `backups.spec.ts`) live under
+`tests/admin-site/stateful/`, whose path sorts after every read-only
+spec — so the destructive restarts run last and a slow/flaky restart
+can't cascade into the read-only specs. Put any future restart/reboot/
+shutdown spec there too; keep order-independent specs at the top level.
+
 ## Local overrides
 
 - `WARDNET_UI_BASE_URL` — daemon base URL the browser hits (default

--- a/source/end2end-tests/web-ui/fixtures/system.ts
+++ b/source/end2end-tests/web-ui/fixtures/system.ts
@@ -1,0 +1,41 @@
+import { expect, type Page } from "@playwright/test";
+import { ADMIN_PASSWORD, ADMIN_USERNAME } from "./seed";
+import { loginViaUi } from "./ui";
+
+/**
+ * Shared helpers for the admin-site System-area specs (settings / power /
+ * backups, #623). Pure UI-action helpers in the spirit of `ui.ts` —
+ * label/role assertions belong in the calling spec.
+ */
+
+/**
+ * Open the release-channel select on the Settings page and pick the
+ * option by its label ("Stable channel" / "Beta channel"). The select is
+ * controlled by the update-status query, which `useUpdateConfig` refreshes
+ * via `setQueryData` on success, so the trigger reflects the new value
+ * once the mutation settles — the caller asserts that.
+ */
+export async function setChannel(page: Page, label: string): Promise<void> {
+  await page.getByTestId("update-channel-trigger").click();
+  await page.getByRole("option", { name: label }).click();
+}
+
+/**
+ * Settle the RestartProgressDialog after a daemon restart: dismiss the
+ * success state, or — if the session was invalidated — re-login via the
+ * UI so the current spec (and any later spec) keeps an authenticated
+ * context. Sessions are DB-backed (validated by token-hash lookup), so on
+ * a restart that preserves/restores the database the cookie stays valid
+ * and the signed-out branch shouldn't fire; we handle it defensively.
+ */
+export async function recoverSession(page: Page): Promise<void> {
+  const signIn = page.getByTestId("restart-signin");
+  if (await signIn.isVisible().catch(() => false)) {
+    await signIn.click();
+    await loginViaUi(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+    await expect(page).toHaveURL(/\/admin(\/|$)/);
+  } else {
+    await page.getByTestId("progress-dismiss").click();
+    await expect(page.getByTestId("progress-dialog")).toBeHidden();
+  }
+}

--- a/source/end2end-tests/web-ui/tests/admin-site/settings.spec.ts
+++ b/source/end2end-tests/web-ui/tests/admin-site/settings.spec.ts
@@ -1,0 +1,109 @@
+import { expect, test } from "@playwright/test";
+import { setChannel } from "../../fixtures/system.js";
+
+/**
+ * Admin-site Settings page coverage (A8, #623): the read-only System
+ * Information card and the Updates card (release channel, auto-update
+ * toggle, "check for updates"). Runs in the `admin-site` project
+ * (seeded daemon + admin storageState).
+ *
+ * Note on scope: the issue's original wording mentioned password change
+ * and theme/language persistence, but the shipped Settings page has none
+ * of that (the Account card is a "future release" placeholder, theme is
+ * OS-driven, there is no language switcher). This spec covers what the
+ * page actually exposes.
+ *
+ * Selectors follow the suite's `data-testid` convention (README.md →
+ * "Selector convention"). Each test navigates fresh and normalises the
+ * state it touches (channel left on stable, auto-update restored), so
+ * behaviour doesn't depend on spec order on the shared single-worker
+ * daemon.
+ */
+
+test("the system information card shows live daemon details", async ({
+  page,
+}) => {
+  await page.goto("./settings");
+  await expect(page).toHaveURL(/\/admin\/settings$/);
+  await expect(page.getByTestId("page-title")).toHaveText("Settings");
+
+  const info = page.getByTestId("system-info");
+  await expect(info).toBeVisible();
+  // Version is sourced from the daemon and must render a real value.
+  await expect(page.getByTestId("system-version")).not.toHaveText("");
+  // The read-only stat grid renders its labels.
+  await expect(info).toContainText("Uptime");
+  await expect(info).toContainText("Database size");
+});
+
+test("the release channel can be changed and persists across reload", async ({
+  page,
+}) => {
+  await page.goto("./settings");
+
+  const trigger = page.getByTestId("update-channel-trigger");
+  await expect(trigger).toBeVisible();
+
+  // Normalise to stable first so the transition below is deterministic.
+  await setChannel(page, "Stable channel");
+  await expect(trigger).toContainText("Stable channel");
+
+  // Switch to beta and confirm it sticks across a reload — this exercises
+  // the PUT /api/config/updates round-trip, not just local UI state.
+  await setChannel(page, "Beta channel");
+  await expect(trigger).toContainText("Beta channel");
+  await page.reload();
+  await expect(page.getByTestId("update-channel-trigger")).toContainText(
+    "Beta channel",
+  );
+
+  // Leave the channel on stable for the next spec.
+  await setChannel(page, "Stable channel");
+  await expect(page.getByTestId("update-channel-trigger")).toContainText(
+    "Stable channel",
+  );
+});
+
+test("the auto-update toggle flips and persists across reload", async ({
+  page,
+}) => {
+  await page.goto("./settings");
+
+  const toggle = page.getByTestId("update-auto-toggle");
+  await expect(toggle).toBeVisible();
+
+  const initial = await toggle.getAttribute("aria-checked");
+  const flipped = initial === "true" ? "false" : "true";
+
+  // Flip to the opposite state and confirm it survives a reload (backed by
+  // PUT /api/config/updates).
+  await toggle.click();
+  await expect(toggle).toHaveAttribute("aria-checked", flipped);
+  await page.reload();
+  await expect(page.getByTestId("update-auto-toggle")).toHaveAttribute(
+    "aria-checked",
+    flipped,
+  );
+
+  // Restore the original state.
+  await page.getByTestId("update-auto-toggle").click();
+  await expect(page.getByTestId("update-auto-toggle")).toHaveAttribute(
+    "aria-checked",
+    initial ?? "false",
+  );
+});
+
+test("checking for updates settles to a terminal state", async ({ page }) => {
+  await page.goto("./settings");
+
+  const check = page.getByTestId("update-check");
+  await expect(check).toBeEnabled();
+  await check.click();
+
+  // The offline test environment may not reach a release server, so we
+  // don't assert a specific result — only that the action settles: the
+  // button re-enables once the check resolves (success or failure) and
+  // the page stays intact (no crash / error boundary).
+  await expect(check).toBeEnabled({ timeout: 30_000 });
+  await expect(page.getByTestId("page-title")).toHaveText("Settings");
+});

--- a/source/end2end-tests/web-ui/tests/admin-site/stateful/backups.spec.ts
+++ b/source/end2end-tests/web-ui/tests/admin-site/stateful/backups.spec.ts
@@ -1,0 +1,93 @@
+import { expect, test, type Page } from "@playwright/test";
+import { recoverSession, setChannel } from "../../../fixtures/system.js";
+
+/**
+ * Admin-site Backups page coverage (A8, #623): a real export → restore
+ * round-trip. Runs in the `admin-site` project (seeded daemon + admin
+ * storageState).
+ *
+ * Stateful: the restore restarts the daemon, so this lives under
+ * `tests/admin-site/stateful/` (sorts after every read-only spec; the
+ * single-worker suite runs it among the destructive specs at the end).
+ *
+ * Round-trip strategy (baseline-anchored so it's safe on the shared
+ * single-worker daemon):
+ *   1. Normalise a backed-up, UI-visible marker — the update channel — to
+ *      `stable`, then export the current state to a bundle.
+ *   2. Flip the marker to `beta` (a real change to system_config).
+ *   3. Restore the exported bundle (preview → apply → daemon restart).
+ *   4. Assert the marker reverted to `stable` — proving the restore
+ *      genuinely replaced the database, not a no-op.
+ * The net effect converges back to the exported baseline, and the bundle
+ * captured the live (DB-backed) session, so the cookie stays valid after
+ * the post-restore restart and other specs are unaffected.
+ */
+
+/** ≥12 chars to satisfy MIN_PASSPHRASE_LEN on both export and restore. */
+const PASSPHRASE = "e2e-backup-passphrase";
+
+/** Set the release channel and confirm it persisted across a reload — a
+ *  fresh GET returning the new value proves the DB write committed. */
+async function setChannelPersisted(page: Page, label: string): Promise<void> {
+  await page.goto("./settings");
+  await setChannel(page, label);
+  await expect(page.getByTestId("update-channel-trigger")).toContainText(label);
+  await page.reload();
+  await expect(page.getByTestId("update-channel-trigger")).toContainText(label);
+}
+
+test("export and restore round-trip reverts a configuration change", async ({
+  page,
+}, testInfo) => {
+  // Export, mutate, restore, restart, verify — give the flow room.
+  test.setTimeout(180_000);
+
+  // 1. Baseline: channel = stable, then export the current state.
+  await setChannelPersisted(page, "Stable channel");
+
+  await page.goto("./backups");
+  await expect(page).toHaveURL(/\/admin\/backups$/);
+  await expect(page.getByTestId("page-title")).toHaveText("Backups");
+
+  await page.getByTestId("backup-export-open").click();
+  await page.getByTestId("backup-passphrase").fill(PASSPHRASE);
+  await page.getByTestId("backup-passphrase-confirm").fill(PASSPHRASE);
+  const downloadPromise = page.waitForEvent("download");
+  await page.getByTestId("backup-export-submit").click();
+  const download = await downloadPromise;
+  const bundlePath = testInfo.outputPath("backup.wardnet.age");
+  await download.saveAs(bundlePath);
+
+  // 2. Mutate the marker: flip channel to beta (persisted to the live DB).
+  await setChannelPersisted(page, "Beta channel");
+
+  // 3. Restore the baseline bundle.
+  await page.goto("./backups");
+  await page.getByTestId("backup-restore-open").click();
+  await page.getByTestId("backup-bundle").setInputFiles(bundlePath);
+  await page.getByTestId("restore-passphrase").fill(PASSPHRASE);
+  await page.getByTestId("backup-preview-submit").click();
+
+  // The preview manifest renders; the bundle is from this same daemon so
+  // it must be compatible.
+  const preview = page.getByTestId("restore-preview");
+  await expect(preview).toBeVisible();
+  await expect(preview).toContainText("Schema version");
+  await expect(preview).not.toContainText("Bundle incompatible");
+
+  // Apply → the daemon restarts to pick up the restored files.
+  await page.getByTestId("backup-apply-submit").click();
+
+  await expect(page.getByTestId("progress-dialog")).toBeVisible();
+  await expect(page.getByTestId("progress-title")).toHaveText(
+    /Daemon is back online|Daemon restarted, session expired/,
+    { timeout: 90_000 },
+  );
+  await recoverSession(page);
+
+  // 4. The restore reverted the marker: channel is back to stable.
+  await page.goto("./settings");
+  await expect(page.getByTestId("update-channel-trigger")).toContainText(
+    "Stable channel",
+  );
+});

--- a/source/end2end-tests/web-ui/tests/admin-site/stateful/power.spec.ts
+++ b/source/end2end-tests/web-ui/tests/admin-site/stateful/power.spec.ts
@@ -1,0 +1,48 @@
+import { expect, test } from "@playwright/test";
+import { recoverSession } from "../../../fixtures/system.js";
+
+/**
+ * Admin-site Power page coverage (A8, #623): the "Restart daemon" flow —
+ * confirm dialog → progress dialog → recovery. Runs in the `admin-site`
+ * project (seeded daemon + admin storageState).
+ *
+ * Stateful: this really restarts the daemon, so it lives under
+ * `tests/admin-site/stateful/`, which sorts after every read-only spec —
+ * the suite runs single-worker in lexicographic path order, so the
+ * destructive restart specs run last (honouring the issue's "order this
+ * last" intent and keeping the blast radius off the read-only specs).
+ *
+ * The daemon runs as systemd PID 1 in the compose container and the
+ * state volume persists, so it comes back and the progress dialog reaches
+ * its terminal success state. Sessions are DB-backed (validated by
+ * token-hash lookup, no in-memory signing key), so the cookie stays valid
+ * across the restart and the expected outcome is "Daemon is back online";
+ * `recoverSession` still handles the signed-out branch defensively.
+ *
+ * Only the restart-daemon control is exercised — NOT reboot/shutdown,
+ * which wouldn't recover the container cleanly inside the suite.
+ */
+
+test("restarting the daemon shows progress and recovers", async ({ page }) => {
+  // Restart + come-back can take a while; give the whole flow room.
+  test.setTimeout(120_000);
+
+  await page.goto("./power");
+  await expect(page).toHaveURL(/\/admin\/power$/);
+  await expect(page.getByTestId("page-title")).toHaveText("Power");
+
+  // Trigger restart-daemon and confirm in the AlertModal.
+  await page.getByTestId("power-restart-daemon").click();
+  await page.getByTestId("power-restart-confirm").click();
+
+  // The progress dialog opens (inescapable while in-progress).
+  await expect(page.getByTestId("progress-dialog")).toBeVisible();
+
+  // It walks to a terminal success state once the daemon is back.
+  await expect(page.getByTestId("progress-title")).toHaveText(
+    /Daemon is back online|Daemon restarted, session expired/,
+    { timeout: 90_000 },
+  );
+
+  await recoverSession(page);
+});


### PR DESCRIPTION
Closes #623 (A8, parent epic #614).

Adds Playwright e2e coverage for the admin-site **System area**, and fixes a real backup-restore data-loss bug that the round-trip spec uncovered.

## Specs

- **`settings.spec.ts`** — System Information card + Updates card: release-channel persistence across reload (`PUT /api/config/updates`), auto-update toggle persistence, check-for-updates settling to a terminal state (tolerant of the offline test env).
- **`stateful/power.spec.ts`** — restart-daemon flow: confirm dialog → progress dialog → recovery to "Daemon is back online".
- **`stateful/backups.spec.ts`** — real export → restore round-trip: export the baseline, flip a backed-up marker (update channel → `beta`), restore the bundle (preview → apply → restart), then assert the marker reverted to `stable`.

## Bug found & fixed: stale WAL survives a restore

The backups round-trip initially failed: after restoring a `stable` bundle, the channel came back `beta`. Root cause — the database runs in **WAL mode**, and `DatabaseDumper::restore` swapped `wardnet.db` for the snapshot but left the live `wardnet.db-wal`/`-shm` sidecars. The live pool keeps writing the pre-restore DB's frames there until restart (the restart-pending write, the graceful-shutdown record), and on the next boot SQLite recovered that WAL **onto** the restored snapshot — silently resurrecting pre-restore state. **A real restore could lose data.** No test exercised restore-revert across a process restart, so it went unnoticed.

Fix (`fix(backup): discard stale WAL on restore`):
- `apply_import` drops a `<db>.restore-pending` sentinel after laying down the snapshot (removed on rollback).
- `init_db_pools_from_connection_string` discards the `-wal`/`-shm` sidecars before opening any pool when the sentinel is present. Gated so a normal crash still recovers its WAL; the restored snapshot is self-contained, so dropping its leftover WAL is correct.
- Regression test whose **control reproduces** the stale-WAL recovery (`beta`) and whose **fix path** confirms the snapshot wins (`stable`), plus a no-op-without-marker guard test.

## Scope notes (resolved with the issue author)

- `settings.spec.ts`: the issue's password/theme/language items don't exist in the UI yet (Account card is a placeholder, theme is OS-driven). The spec covers what the page actually ships.
- **`remote-access.spec.ts` is deferred** to a follow-up (#694): the DDNS flow can't run offline without bridge/ACME test infra.

## Design points

- **Ordering:** restart-bearing specs live under `tests/admin-site/stateful/`, which sorts after every read-only spec, so daemon restarts run last (`playwright --list` confirms power runs dead last). Documented in the README.
- **Session safety:** sessions are DB-backed (token-hash lookup, no in-memory signing key), so a restart on the persistent state volume keeps the cookie valid.
- Shared `setChannel` / `recoverSession` helpers in `fixtures/system.ts`; adds the `data-testid`s the specs target.

## Verification

- `make check-daemon` green (fmt + clippy + full workspace tests, incl. the new WAL regression tests).
- `make check-web` green; e2e `type-check` exit 0; prettier clean.
- Full e2e suite runs in CI on Docker (local podman can't boot the privileged systemd daemon container).

https://claude.ai/code/session_01A9ABpFErcKnhFDy2ftEhuW