### PR TITLE
feat(tunnel): per-tunnel speed test with direct-vs-tunnel comparison (#239)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ LINUX_TARGET := $(CURDIR)/.target-linux
 
 # Coverage: files excluded from cargo-llvm-cov.  Single source of truth —
 # CI calls `make coverage-daemon` with COV_FMT overridden for LCOV output.
-COV_IGNORE := (main\.rs|noop_.*\.rs|db\.rs|web\.rs|api/mod\.rs|auth_context\.rs|command\.rs|policy_router_netlink\.rs|firewall_netlink\.rs|route_monitor\.rs|mdns_advertiser\.rs|pnet_network_probe\.rs|garp_pnet\.rs|tunnel_exit_probe\.rs|linux_watchdog\.rs|wardnet-test-agent/.*|wardnetd-mock/src/events\.rs|wardnetd-data/src/lib\.rs)
+COV_IGNORE := (main\.rs|noop_.*\.rs|db\.rs|web\.rs|api/mod\.rs|auth_context\.rs|command\.rs|policy_router_netlink\.rs|firewall_netlink\.rs|route_monitor\.rs|mdns_advertiser\.rs|pnet_network_probe\.rs|garp_pnet\.rs|tunnel_exit_probe\.rs|tunnel_throughput_tester\.rs|tunnel_latency_prober\.rs|linux_watchdog\.rs|wardnet-test-agent/.*|wardnetd-mock/src/events\.rs|wardnetd-data/src/lib\.rs)
 # Default: human-readable summary.  CI overrides:
 #   make coverage-daemon COV_FMT="--lcov --output-path ../../coverage/daemon-lcov.info"
 COV_FMT    ?= --summary-only

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -16539,6 +16539,376 @@
         ]
       }
     },
+    "/api/tunnels/{id}/speed-test": {
+      "post": {
+        "tags": [
+          "tunnels"
+        ],
+        "description": "Start a speed test for this tunnel. Returns immediately with a job id (202); the background job measures throughput, latency and jitter twice — once over the direct (WAN) path and once through the tunnel — so the result shows how much of the line the VPN preserves. If the tunnel is down it is brought up for the run and torn back down after. Poll `GET /api/jobs/{job_id}` for progress. A concurrent run (or an overlapping test) on the same tunnel returns 409. Admin only.",
+        "operationId": "start_speed_test",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Tunnel ID",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Speed test job dispatched",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JobDispatchedResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthenticated — session cookie or API key missing/invalid",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "description": "Standard API error response.",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "detail": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "error": {
+                      "type": "string"
+                    },
+                    "request_id": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "description": "Request ID for correlation with server logs."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden — caller is not an admin",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "description": "Standard API error response.",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "detail": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "error": {
+                      "type": "string"
+                    },
+                    "request_id": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "description": "Request ID for correlation with server logs."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Resource not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "description": "Standard API error response.",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "detail": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "error": {
+                      "type": "string"
+                    },
+                    "request_id": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "description": "Request ID for correlation with server logs."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflicting concurrent operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "description": "Standard API error response.",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "detail": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "error": {
+                      "type": "string"
+                    },
+                    "request_id": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "description": "Request ID for correlation with server logs."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "description": "Standard API error response.",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "detail": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "error": {
+                      "type": "string"
+                    },
+                    "request_id": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "description": "Request ID for correlation with server logs."
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "session_cookie": []
+          },
+          {
+            "bearer_auth": []
+          }
+        ]
+      }
+    },
+    "/api/tunnels/{id}/speed-test/results": {
+      "get": {
+        "tags": [
+          "tunnels"
+        ],
+        "description": "List recent speed test results for this tunnel, newest first (last few runs). Each result carries both the direct (WAN) and tunnel measurements for throughput, latency and jitter. Admin only.",
+        "operationId": "list_speed_tests",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Tunnel ID",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Speed test history",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TunnelSpeedTestHistoryResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthenticated — session cookie or API key missing/invalid",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "description": "Standard API error response.",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "detail": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "error": {
+                      "type": "string"
+                    },
+                    "request_id": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "description": "Request ID for correlation with server logs."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden — caller is not an admin",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "description": "Standard API error response.",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "detail": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "error": {
+                      "type": "string"
+                    },
+                    "request_id": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "description": "Request ID for correlation with server logs."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Resource not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "description": "Standard API error response.",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "detail": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "error": {
+                      "type": "string"
+                    },
+                    "request_id": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "description": "Request ID for correlation with server logs."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "description": "Standard API error response.",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "detail": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "error": {
+                      "type": "string"
+                    },
+                    "request_id": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "description": "Request ID for correlation with server logs."
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "session_cookie": []
+          },
+          {
+            "bearer_auth": []
+          }
+        ]
+      }
+    },
     "/api/tunnels/{id}/test": {
       "post": {
         "tags": [
@@ -20216,7 +20586,8 @@
         "type": "string",
         "description": "Discriminator for what kind of work a job represents. The kind is fixed\nat job creation time; new kinds get new variants here.",
         "enum": [
-          "blocklist_refresh"
+          "blocklist_refresh",
+          "speed_test"
         ]
       },
       "JobStatus": {
@@ -21629,6 +22000,80 @@
             "items": {
               "$ref": "#/components/schemas/Device"
             }
+          }
+        }
+      },
+      "TunnelSpeedTestHistoryResponse": {
+        "type": "object",
+        "description": "History of recent speed tests for one tunnel, newest first.",
+        "required": [
+          "results"
+        ],
+        "properties": {
+          "results": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/TunnelSpeedTestResult"
+            }
+          }
+        }
+      },
+      "TunnelSpeedTestResult": {
+        "type": "object",
+        "description": "One completed speed test: the direct (WAN) baseline and the tunnel result,\nmeasured back-to-back in a single run.",
+        "required": [
+          "id",
+          "tunnel_id",
+          "direct_throughput_mbps",
+          "tunnel_throughput_mbps",
+          "direct_latency_ms",
+          "tunnel_latency_ms",
+          "direct_jitter_ms",
+          "tunnel_jitter_ms",
+          "tested_at"
+        ],
+        "properties": {
+          "direct_jitter_ms": {
+            "type": "number",
+            "format": "double",
+            "description": "Latency jitter (sample standard deviation) over the direct path, in ms."
+          },
+          "direct_latency_ms": {
+            "type": "number",
+            "format": "double",
+            "description": "Median ICMP round-trip latency over the direct path, in milliseconds."
+          },
+          "direct_throughput_mbps": {
+            "type": "number",
+            "format": "double",
+            "description": "Download throughput over the direct (unbound/WAN) path, in megabits/s."
+          },
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "tested_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "tunnel_id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "tunnel_jitter_ms": {
+            "type": "number",
+            "format": "double",
+            "description": "Latency jitter (sample standard deviation) through the tunnel, in ms."
+          },
+          "tunnel_latency_ms": {
+            "type": "number",
+            "format": "double",
+            "description": "Median ICMP round-trip latency through the tunnel, in milliseconds."
+          },
+          "tunnel_throughput_mbps": {
+            "type": "number",
+            "format": "double",
+            "description": "Download throughput through the tunnel interface, in megabits/s."
           }
         }
       },

--- a/source/admin-app/src/pages/Tunnels.tsx
+++ b/source/admin-app/src/pages/Tunnels.tsx
@@ -1,5 +1,5 @@
-import { memo } from "react";
-import { RotateCcwIcon } from "lucide-react";
+import { memo, useState } from "react";
+import { ChevronDownIcon, RotateCcwIcon, ZapIcon } from "lucide-react";
 import { Card, Text, Heading } from "@wardnet/web";
 import { Sparkline } from "@wardnet/web";
 import {
@@ -9,15 +9,128 @@ import {
   useRebuildTunnel,
   useTunnelStats,
   useCombinedTunnelStats,
+  useSpeedTestResults,
+  useStartSpeedTest,
   countryFlag,
   formatBytes,
+  retentionPct,
   timeAgo,
   TunnelStatusPill,
 } from "@wardnet/web";
 import { useOnlineStatusContext } from "@/context/OnlineStatusContext";
-import type { Device, Tunnel } from "@wardnet/js";
+import type { Device, Tunnel, TunnelSpeedTestResult } from "@wardnet/js";
 
 const BUCKET_SECS = 60;
+
+/** Compact mobile speed-test panel: a run button, the latest direct-vs-tunnel
+ *  result inline, and tap-to-expand for the last-5 history (no detail route). */
+const SpeedTestPanel = memo(function SpeedTestPanel({
+  tunnelId,
+}: {
+  tunnelId: string;
+}) {
+  const startSpeedTest = useStartSpeedTest();
+  const [requested, setRequested] = useState(false);
+  const [expanded, setExpanded] = useState(false);
+  const running =
+    startSpeedTest.isRunning && startSpeedTest.activeTunnelId === tunnelId;
+  // Only fetch history once the user runs a test on this card (or while one is
+  // in flight) — avoids one request per card across the tunnels list on load.
+  const { data } = useSpeedTestResults(tunnelId, requested || running);
+
+  const results = data?.results ?? [];
+  const latest: TunnelSpeedTestResult | undefined = results[0];
+
+  return (
+    <div className="flex flex-col gap-2 border-t border-line pt-3">
+      <button
+        data-testid="tunnel-speed-test-button"
+        onClick={() => {
+          setRequested(true);
+          startSpeedTest.start(tunnelId);
+        }}
+        disabled={running}
+        className="flex h-9 items-center justify-center gap-1.5 rounded-lg bg-sunken text-ink-2 transition-colors duration-snap active:bg-line disabled:opacity-50"
+      >
+        <ZapIcon size={14} className={running ? "animate-pulse" : undefined} />
+        <Text as="span" size="sm" weight="medium">
+          {running ? `Testing ${startSpeedTest.percentage}%` : "Speed test"}
+        </Text>
+      </button>
+
+      {latest && (
+        <div
+          data-testid="tunnel-speed-test-result"
+          className="flex flex-col rounded-lg bg-sunken"
+        >
+          <button
+            onClick={() => setExpanded((v) => !v)}
+            className="flex flex-col gap-1 px-3 py-2 text-left"
+          >
+            <div className="flex items-center justify-between">
+              <Text as="span" size="xs" className="text-ink-3">
+                ↓ tun / direct
+              </Text>
+              <div className="flex items-center gap-2">
+                <Text as="span" size="sm" weight="medium" className="font-mono text-ink">
+                  {latest.tunnel_throughput_mbps.toFixed(1)} /{" "}
+                  {latest.direct_throughput_mbps.toFixed(1)} Mbps
+                </Text>
+                <Text as="span" size="xs" weight="medium" className="text-ink-2">
+                  {retentionPct(
+                    latest.direct_throughput_mbps,
+                    latest.tunnel_throughput_mbps,
+                  )}
+                  % kept
+                </Text>
+              </div>
+            </div>
+            <div className="flex items-center justify-between">
+              <Text as="span" size="xs" className="text-ink-3">
+                ◷ tun / direct
+              </Text>
+              <div className="flex items-center gap-2">
+                <Text as="span" size="sm" className="font-mono text-ink">
+                  {Math.round(latest.tunnel_latency_ms)} /{" "}
+                  {Math.round(latest.direct_latency_ms)} ms
+                </Text>
+                <ChevronDownIcon
+                  size={14}
+                  className={`text-ink-3 transition-transform duration-snap ${
+                    expanded ? "rotate-180" : ""
+                  }`}
+                />
+              </div>
+            </div>
+            <Text as="span" size="2xs" className="text-ink-3">
+              tested {timeAgo(latest.tested_at)}
+            </Text>
+          </button>
+
+          {expanded && results.length > 1 && (
+            <div className="flex flex-col gap-1 border-t border-line px-3 py-2">
+              {results.slice(1).map((r) => (
+                <div key={r.id} className="flex items-center justify-between">
+                  <Text as="span" size="xs" className="font-mono text-ink-2">
+                    {r.tunnel_throughput_mbps.toFixed(1)} /{" "}
+                    {r.direct_throughput_mbps.toFixed(1)} Mbps
+                  </Text>
+                  <Text as="span" size="xs" className="text-ink-3">
+                    {retentionPct(
+                      r.direct_throughput_mbps,
+                      r.tunnel_throughput_mbps,
+                    )}
+                    % · {timeAgo(r.tested_at)}
+                  </Text>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+});
 
 function deviceCount(
   tunnelId: string,
@@ -130,6 +243,8 @@ const TunnelCard = memo(function TunnelCard({
             <Text as="span" size="xs" className="text-ink-3">↑ {formatBytes(txRate)}/s</Text>
           </div>
         )}
+
+        <SpeedTestPanel tunnelId={tunnel.id} />
       </div>
     </Card>
   );

--- a/source/admin-site/src/components/compound/TunnelCard.tsx
+++ b/source/admin-site/src/components/compound/TunnelCard.tsx
@@ -1,6 +1,7 @@
 import {
   ArrowDown,
   ArrowUp,
+  Gauge,
   Loader2,
   RotateCcw,
   SlidersHorizontal,
@@ -10,14 +11,101 @@ import { Link } from "react-router";
 import { Button } from "@wardnet/web";
 import { Text } from "@wardnet/web";
 import { StatusBadge } from "./StatusBadge";
-import { countryFlag, formatBytes, timeAgo } from "@wardnet/web";
-import { useTestTunnel, useRebuildTunnel } from "@wardnet/web";
+import {
+  countryFlag,
+  formatBytes,
+  formatMbps,
+  formatMs,
+  retentionPct,
+  timeAgo,
+} from "@wardnet/web";
+import {
+  useTestTunnel,
+  useRebuildTunnel,
+  useSpeedTestResults,
+  useStartSpeedTest,
+} from "@wardnet/web";
 import type {
   Tunnel,
   TunnelStatus,
   ProviderInfo,
   TunnelTestResult,
+  TunnelSpeedTestResult,
 } from "@wardnet/js";
+
+/**
+ * Direct-vs-tunnel comparison grid. A raw tunnel number is meaningless on its
+ * own, so each row shows the direct (WAN) baseline beside the tunnel value
+ * plus the delta — the only honest read on VPN quality.
+ */
+function SpeedTestComparison({ result }: { result: TunnelSpeedTestResult }) {
+  const kept = retentionPct(
+    result.direct_throughput_mbps,
+    result.tunnel_throughput_mbps,
+  );
+  const latencyOverhead = result.tunnel_latency_ms - result.direct_latency_ms;
+  const jitterOverhead = result.tunnel_jitter_ms - result.direct_jitter_ms;
+
+  return (
+    <div
+      data-testid="tunnel-speed-test-result"
+      className="col gap-4 rounded-[var(--radius-md)] border border-[var(--line)] bg-[var(--bg-sunken)] px-3 py-2 text-xs"
+    >
+      <div className="row text-ink-3">
+        <Text as="span" size="2xs" weight="medium">
+          Speed test
+        </Text>
+        <span className="ml-auto">tested {timeAgo(result.tested_at)}</span>
+      </div>
+      <div
+        className="grid items-center gap-x-3 gap-y-1"
+        style={{ gridTemplateColumns: "auto 1fr 1fr auto" }}
+      >
+        <span className="text-ink-3" />
+        <Text as="span" size="2xs" weight="medium" className="text-ink-3">
+          Direct
+        </Text>
+        <Text as="span" size="2xs" weight="medium" className="text-ink-3">
+          Tunnel
+        </Text>
+        <span className="text-ink-3" />
+
+        <span className="text-ink-3">Download</span>
+        <span className="mono">
+          {formatMbps(result.direct_throughput_mbps)}
+        </span>
+        <span className="mono" data-testid="tunnel-speed-test-download">
+          {formatMbps(result.tunnel_throughput_mbps)}
+        </span>
+        <Text
+          as="span"
+          weight="medium"
+          className={kept >= 80 ? "text-[var(--success-ink)]" : "text-ink-2"}
+        >
+          {kept}% kept
+        </Text>
+
+        <span className="text-ink-3">Latency</span>
+        <span className="mono">{formatMs(result.direct_latency_ms)}</span>
+        <span className="mono" data-testid="tunnel-speed-test-latency">
+          {formatMs(result.tunnel_latency_ms)}
+        </span>
+        <span className="text-ink-2">
+          {latencyOverhead >= 0 ? "+" : ""}
+          {formatMs(latencyOverhead)}
+        </span>
+
+        <span className="text-ink-3">Jitter</span>
+        <span className="mono">{formatMs(result.direct_jitter_ms)}</span>
+        <span className="mono">{formatMs(result.tunnel_jitter_ms)}</span>
+        <span className="text-ink-2">
+          {jitterOverhead >= 0 ? "+" : ""}
+          {formatMs(jitterOverhead)}
+        </span>
+      </div>
+    </div>
+  );
+}
 
 function statusTone(status: TunnelStatus): "success" | "neutral" | "danger" {
   switch (status) {
@@ -79,9 +167,30 @@ export function TunnelCard({ tunnel, providers, onDelete }: TunnelCardProps) {
 
   const testTunnel = useTestTunnel();
   const rebuildTunnel = useRebuildTunnel();
+  const startSpeedTest = useStartSpeedTest();
+  // Only fetch this tunnel's speed-test history once the user has run a test
+  // on this card (avoids one request per card across the whole tunnels grid on
+  // load — persisted history lives on the tunnel detail page). A run in flight
+  // also enables it so the prior result shows while the new test runs.
+  const [speedTestRequested, setSpeedTestRequested] = useState(false);
+  const speedTestRunning =
+    startSpeedTest.isRunning && startSpeedTest.activeTunnelId === tunnel.id;
+  const speedTestResults = useSpeedTestResults(
+    tunnel.id,
+    speedTestRequested || speedTestRunning,
+  );
+  const latestSpeedTest = speedTestResults.data?.results[0] ?? null;
   const [testResult, setTestResult] = useState<TunnelTestResult | null>(null);
   const [testError, setTestError] = useState<string | null>(null);
   const [testedAt, setTestedAt] = useState<string | null>(null);
+
+  const onSpeedTestClick = (e: React.MouseEvent) => {
+    // Card is wrapped in <Link>; don't navigate when clicking Speed test.
+    e.preventDefault();
+    e.stopPropagation();
+    setSpeedTestRequested(true);
+    startSpeedTest.start(tunnel.id);
+  };
 
   const onTestClick = (e: React.MouseEvent) => {
     // Card is wrapped in <Link>; don't navigate when clicking Test.
@@ -215,7 +324,28 @@ export function TunnelCard({ tunnel, providers, onDelete }: TunnelCardProps) {
         </div>
       )}
 
+      {latestSpeedTest && <SpeedTestComparison result={latestSpeedTest} />}
+
       <div className="row gap-8" style={{ justifyContent: "flex-end" }}>
+        <Button
+          size="sm"
+          variant="outline"
+          data-testid="tunnel-speed-test-button"
+          disabled={speedTestRunning}
+          onClick={onSpeedTestClick}
+        >
+          {speedTestRunning ? (
+            <>
+              <Loader2 className="mr-1 size-3 animate-spin" aria-hidden />
+              Testing {startSpeedTest.percentage}%
+            </>
+          ) : (
+            <>
+              <Gauge className="mr-1 size-3" aria-hidden />
+              Speed test
+            </>
+          )}
+        </Button>
         <Button
           size="sm"
           variant="outline"

--- a/source/admin-site/src/pages/TunnelDetail.tsx
+++ b/source/admin-site/src/pages/TunnelDetail.tsx
@@ -16,12 +16,63 @@ import {
   useDeleteTunnel,
   useSetTunnelDnsOverride,
   useRebuildTunnel,
+  useSpeedTestResults,
 } from "@wardnet/web";
 import { useTunnelStats, RANGES, type StatsRange } from "@wardnet/web";
 import { type ZoomRange } from "@/hooks/useChartZoom";
 import { countryFlag } from "@wardnet/web";
-import { timeAgo } from "@wardnet/web";
+import { retentionPct, timeAgo } from "@wardnet/web";
 import type { TunnelStatus } from "@wardnet/js";
+
+/** Last-5 speed test history: each row pairs the tunnel value with its
+ *  direct (WAN) baseline so the comparison is visible at a glance. */
+function SpeedTestHistory({ tunnelId }: { tunnelId: string }) {
+  const { data } = useSpeedTestResults(tunnelId);
+  const results = data?.results ?? [];
+  if (results.length === 0) return null;
+
+  return (
+    <Card data-testid="tunnel-speed-test-history">
+      <CardHeader>
+        <CardTitle>Speed test history</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="text-left text-ink-3">
+              <th className="pb-2 font-medium">Tested at</th>
+              <th className="pb-2 font-medium">Download (tun / direct)</th>
+              <th className="pb-2 font-medium">Latency (tun / direct)</th>
+              <th className="pb-2 font-medium">Kept</th>
+            </tr>
+          </thead>
+          <tbody>
+            {results.map((r) => (
+              <tr key={r.id} className="border-t border-[var(--line)]">
+                <td className="py-2">{timeAgo(r.tested_at)}</td>
+                <td className="py-2 mono">
+                  {r.tunnel_throughput_mbps.toFixed(1)} /{" "}
+                  {r.direct_throughput_mbps.toFixed(1)} Mbps
+                </td>
+                <td className="py-2 mono">
+                  {Math.round(r.tunnel_latency_ms)} /{" "}
+                  {Math.round(r.direct_latency_ms)} ms
+                </td>
+                <td className="py-2">
+                  {retentionPct(
+                    r.direct_throughput_mbps,
+                    r.tunnel_throughput_mbps,
+                  )}
+                  %
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </CardContent>
+    </Card>
+  );
+}
 
 function statusTone(status: TunnelStatus): "success" | "neutral" | "danger" {
   switch (status) {
@@ -213,6 +264,8 @@ export default function TunnelDetail() {
       </div>
 
       <TunnelDevicesTable tunnelId={tunnel.id} />
+
+      <SpeedTestHistory tunnelId={tunnel.id} />
 
       <div className="row justify-end gap-8">
         <Button

--- a/source/daemon/crates/wardnet-common/src/config.rs
+++ b/source/daemon/crates/wardnet-common/src/config.rs
@@ -344,6 +344,15 @@ pub struct TunnelConfig {
     /// `key=value` document including `ip=` and `loc=`. Overriding this
     /// requires the same response shape.
     pub test_probe_url: String,
+    /// URL the speed test downloads from to measure throughput. The default
+    /// is Cloudflare's `__down` endpoint requesting a 10 MB payload. The
+    /// download runs twice per speed test — once unbound (direct/WAN) and
+    /// once bound to the tunnel interface (`SO_BINDTODEVICE`) — so the
+    /// endpoint must serve the requested byte count over plain HTTPS.
+    pub speed_test_url: String,
+    /// Number of ICMP echo samples taken per leg of a speed test to derive
+    /// median latency and jitter. Defaults to 5.
+    pub speed_test_latency_samples: u32,
 }
 
 impl Default for TunnelConfig {
@@ -355,6 +364,8 @@ impl Default for TunnelConfig {
             latency_probe_interval_secs: 60,
             latency_probe_target: "1.1.1.1".to_owned(),
             test_probe_url: "https://1.1.1.1/cdn-cgi/trace".to_owned(),
+            speed_test_url: "https://speed.cloudflare.com/__down?bytes=10000000".to_owned(),
+            speed_test_latency_samples: 5,
         }
     }
 }

--- a/source/daemon/crates/wardnet-common/src/jobs.rs
+++ b/source/daemon/crates/wardnet-common/src/jobs.rs
@@ -14,6 +14,7 @@ use uuid::Uuid;
 #[serde(rename_all = "snake_case")]
 pub enum JobKind {
     BlocklistRefresh,
+    SpeedTest,
 }
 
 /// Lifecycle state of a [`Job`]. Jobs start as `Pending`, move to `Running`

--- a/source/daemon/crates/wardnet-common/src/lib.rs
+++ b/source/daemon/crates/wardnet-common/src/lib.rs
@@ -12,6 +12,7 @@ pub mod net;
 pub mod routing;
 pub mod rule_request;
 pub mod serde_util;
+pub mod speed_test;
 pub mod stats;
 pub mod tunnel;
 pub mod update;

--- a/source/daemon/crates/wardnet-common/src/speed_test.rs
+++ b/source/daemon/crates/wardnet-common/src/speed_test.rs
@@ -1,0 +1,39 @@
+//! Per-tunnel speed test result types.
+//!
+//! A speed test measures throughput, latency and jitter twice per run — once
+//! over the **direct** (unbound/WAN) path and once **through the tunnel** — so
+//! the admin can see how much of their line the VPN preserves (retention)
+//! rather than an isolated tunnel number. Both legs are persisted in a single
+//! [`TunnelSpeedTestResult`] row so the comparison stays apples-to-apples
+//! (measured seconds apart under the same line conditions).
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+/// One completed speed test: the direct (WAN) baseline and the tunnel result,
+/// measured back-to-back in a single run.
+#[derive(Debug, Clone, Serialize, Deserialize, utoipa::ToSchema)]
+pub struct TunnelSpeedTestResult {
+    pub id: Uuid,
+    pub tunnel_id: Uuid,
+    /// Download throughput over the direct (unbound/WAN) path, in megabits/s.
+    pub direct_throughput_mbps: f64,
+    /// Download throughput through the tunnel interface, in megabits/s.
+    pub tunnel_throughput_mbps: f64,
+    /// Median ICMP round-trip latency over the direct path, in milliseconds.
+    pub direct_latency_ms: f64,
+    /// Median ICMP round-trip latency through the tunnel, in milliseconds.
+    pub tunnel_latency_ms: f64,
+    /// Latency jitter (sample standard deviation) over the direct path, in ms.
+    pub direct_jitter_ms: f64,
+    /// Latency jitter (sample standard deviation) through the tunnel, in ms.
+    pub tunnel_jitter_ms: f64,
+    pub tested_at: DateTime<Utc>,
+}
+
+/// History of recent speed tests for one tunnel, newest first.
+#[derive(Debug, Clone, Serialize, Deserialize, utoipa::ToSchema)]
+pub struct TunnelSpeedTestHistoryResponse {
+    pub results: Vec<TunnelSpeedTestResult>,
+}

--- a/source/daemon/crates/wardnetd-api/src/api/tests/devices.rs
+++ b/source/daemon/crates/wardnetd-api/src/api/tests/devices.rs
@@ -197,6 +197,18 @@ impl TunnelService for MockTunnelService {
     async fn probe_latencies(&self) -> Result<(), AppError> {
         unimplemented!()
     }
+    async fn start_speed_test(
+        self: Arc<Self>,
+        _id: uuid::Uuid,
+    ) -> Result<wardnet_common::jobs::JobDispatchedResponse, AppError> {
+        unimplemented!()
+    }
+    async fn list_speed_tests(
+        &self,
+        _id: uuid::Uuid,
+    ) -> Result<wardnet_common::speed_test::TunnelSpeedTestHistoryResponse, AppError> {
+        unimplemented!()
+    }
 }
 
 #[async_trait]

--- a/source/daemon/crates/wardnetd-api/src/api/tests/tunnels.rs
+++ b/source/daemon/crates/wardnetd-api/src/api/tests/tunnels.rs
@@ -223,6 +223,18 @@ impl TunnelService for MockTunnelService {
     async fn probe_latencies(&self) -> Result<(), AppError> {
         Ok(())
     }
+    async fn start_speed_test(
+        self: Arc<Self>,
+        _id: uuid::Uuid,
+    ) -> Result<wardnet_common::jobs::JobDispatchedResponse, AppError> {
+        unimplemented!()
+    }
+    async fn list_speed_tests(
+        &self,
+        _id: uuid::Uuid,
+    ) -> Result<wardnet_common::speed_test::TunnelSpeedTestHistoryResponse, AppError> {
+        unimplemented!()
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/source/daemon/crates/wardnetd-api/src/api/tests/tunnels.rs
+++ b/source/daemon/crates/wardnetd-api/src/api/tests/tunnels.rs
@@ -227,13 +227,27 @@ impl TunnelService for MockTunnelService {
         self: Arc<Self>,
         _id: uuid::Uuid,
     ) -> Result<wardnet_common::jobs::JobDispatchedResponse, AppError> {
-        unimplemented!()
+        Ok(wardnet_common::jobs::JobDispatchedResponse {
+            job_id: Uuid::parse_str("00000000-0000-0000-0000-0000000000aa").unwrap(),
+        })
     }
     async fn list_speed_tests(
         &self,
-        _id: uuid::Uuid,
+        id: uuid::Uuid,
     ) -> Result<wardnet_common::speed_test::TunnelSpeedTestHistoryResponse, AppError> {
-        unimplemented!()
+        Ok(wardnet_common::speed_test::TunnelSpeedTestHistoryResponse {
+            results: vec![wardnet_common::speed_test::TunnelSpeedTestResult {
+                id: Uuid::parse_str("00000000-0000-0000-0000-0000000000bb").unwrap(),
+                tunnel_id: id,
+                direct_throughput_mbps: 94.0,
+                tunnel_throughput_mbps: 85.0,
+                direct_latency_ms: 11.0,
+                tunnel_latency_ms: 23.0,
+                direct_jitter_ms: 2.0,
+                tunnel_jitter_ms: 4.0,
+                tested_at: chrono::Utc::now(),
+            }],
+        })
     }
 }
 
@@ -317,6 +331,14 @@ fn tunnel_router(state: AppState) -> Router {
         .route(
             "/api/tunnels/{id}/rebuild",
             axum::routing::post(crate::api::tunnels::rebuild_tunnel),
+        )
+        .route(
+            "/api/tunnels/{id}/speed-test",
+            axum::routing::post(crate::api::tunnels::start_speed_test),
+        )
+        .route(
+            "/api/tunnels/{id}/speed-test/results",
+            get(crate::api::tunnels::list_speed_tests),
         )
         .with_state(state)
 }
@@ -936,4 +958,40 @@ async fn rebuild_tunnel_unauthorized_without_session() {
         .unwrap();
 
     assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+}
+
+// ---------------------------------------------------------------------------
+// Speed test endpoints
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn start_speed_test_returns_accepted_with_job_id() {
+    let state = build_state(MockTunnelService::empty());
+    let app = tunnel_router(state);
+
+    let (status, json) = post_json(
+        app,
+        "/api/tunnels/00000000-0000-0000-0000-000000000010/speed-test",
+        "",
+    )
+    .await;
+    assert_eq!(status, StatusCode::ACCEPTED);
+    assert!(json["job_id"].is_string());
+}
+
+#[tokio::test]
+async fn list_speed_test_results_returns_history() {
+    let state = build_state(MockTunnelService::empty());
+    let app = tunnel_router(state);
+
+    let (status, json) = get_json(
+        app,
+        "/api/tunnels/00000000-0000-0000-0000-000000000010/speed-test/results",
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    let results = json["results"].as_array().unwrap();
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0]["tunnel_throughput_mbps"], 85.0);
+    assert_eq!(results[0]["direct_throughput_mbps"], 94.0);
 }

--- a/source/daemon/crates/wardnetd-api/src/api/tunnels.rs
+++ b/source/daemon/crates/wardnetd-api/src/api/tunnels.rs
@@ -9,6 +9,8 @@ use wardnet_common::api::{
     RebuildTunnelResponse, TunnelDetailResponse, TunnelDevicesResponse, TunnelTestResponse,
     UpdateTunnelDnsOverrideRequest, UpdateTunnelDnsOverrideResponse,
 };
+use wardnet_common::jobs::JobDispatchedResponse;
+use wardnet_common::speed_test::TunnelSpeedTestHistoryResponse;
 
 use crate::api::middleware::AdminAuth;
 use crate::api::responses::{AuthErrors, BadRequest, Conflict, NotFound, UpstreamUnavailable};
@@ -22,6 +24,8 @@ pub fn register(router: OpenApiRouter<AppState>) -> OpenApiRouter<AppState> {
         .routes(routes!(get_tunnel, delete_tunnel))
         .routes(routes!(list_tunnel_devices))
         .routes(routes!(test_tunnel))
+        .routes(routes!(start_speed_test))
+        .routes(routes!(list_speed_tests))
         .routes(routes!(update_tunnel_dns_override))
         .routes(routes!(rebuild_tunnel))
 }
@@ -184,6 +188,65 @@ pub async fn test_tunnel(
 ) -> Result<Json<TunnelTestResponse>, AppError> {
     let result = state.tunnel_service().test_tunnel(id).await?;
     Ok(Json(TunnelTestResponse { result }))
+}
+
+#[utoipa::path(
+    post,
+    path = "/api/tunnels/{id}/speed-test",
+    tag = "tunnels",
+    description = "Start a speed test for this tunnel. Returns immediately with a job \
+                   id (202); the background job measures throughput, latency and jitter \
+                   twice — once over the direct (WAN) path and once through the tunnel — \
+                   so the result shows how much of the line the VPN preserves. If the \
+                   tunnel is down it is brought up for the run and torn back down after. \
+                   Poll `GET /api/jobs/{job_id}` for progress. A concurrent run (or an \
+                   overlapping test) on the same tunnel returns 409. Admin only.",
+    params(("id" = Uuid, Path, description = "Tunnel ID")),
+    responses(
+        (status = 202, description = "Speed test job dispatched", body = JobDispatchedResponse),
+        AuthErrors,
+        NotFound,
+        Conflict,
+    ),
+    security(
+        ("session_cookie" = []),
+        ("bearer_auth" = []),
+    ),
+)]
+pub async fn start_speed_test(
+    State(state): State<AppState>,
+    _auth: AdminAuth,
+    Path(id): Path<Uuid>,
+) -> Result<(StatusCode, Json<JobDispatchedResponse>), AppError> {
+    let response = state.tunnel_service_arc().start_speed_test(id).await?;
+    Ok((StatusCode::ACCEPTED, Json(response)))
+}
+
+#[utoipa::path(
+    get,
+    path = "/api/tunnels/{id}/speed-test/results",
+    tag = "tunnels",
+    description = "List recent speed test results for this tunnel, newest first \
+                   (last few runs). Each result carries both the direct (WAN) and \
+                   tunnel measurements for throughput, latency and jitter. Admin only.",
+    params(("id" = Uuid, Path, description = "Tunnel ID")),
+    responses(
+        (status = 200, description = "Speed test history", body = TunnelSpeedTestHistoryResponse),
+        AuthErrors,
+        NotFound,
+    ),
+    security(
+        ("session_cookie" = []),
+        ("bearer_auth" = []),
+    ),
+)]
+pub async fn list_speed_tests(
+    State(state): State<AppState>,
+    _auth: AdminAuth,
+    Path(id): Path<Uuid>,
+) -> Result<Json<TunnelSpeedTestHistoryResponse>, AppError> {
+    let response = state.tunnel_service().list_speed_tests(id).await?;
+    Ok(Json(response))
 }
 
 #[utoipa::path(

--- a/source/daemon/crates/wardnetd-api/src/state.rs
+++ b/source/daemon/crates/wardnetd-api/src/state.rs
@@ -221,6 +221,14 @@ impl AppState {
         self.inner.tunnel_service.as_ref()
     }
 
+    /// Owned handle to the tunnel service, for methods whose receiver is
+    /// `Arc<Self>` (e.g. [`TunnelService::start_speed_test`], which moves a
+    /// clone into a background job).
+    #[must_use]
+    pub fn tunnel_service_arc(&self) -> Arc<dyn TunnelService> {
+        self.inner.tunnel_service.clone()
+    }
+
     /// Access the auto-update service.
     #[must_use]
     pub fn update_service(&self) -> &dyn UpdateService {

--- a/source/daemon/crates/wardnetd-api/src/tests/stubs.rs
+++ b/source/daemon/crates/wardnetd-api/src/tests/stubs.rs
@@ -782,6 +782,18 @@ impl TunnelService for StubTunnelService {
     async fn probe_latencies(&self) -> Result<(), AppError> {
         Ok(())
     }
+    async fn start_speed_test(
+        self: Arc<Self>,
+        _id: uuid::Uuid,
+    ) -> Result<wardnet_common::jobs::JobDispatchedResponse, AppError> {
+        unimplemented!("not used in api stub tests")
+    }
+    async fn list_speed_tests(
+        &self,
+        _id: uuid::Uuid,
+    ) -> Result<wardnet_common::speed_test::TunnelSpeedTestHistoryResponse, AppError> {
+        unimplemented!("not used in api stub tests")
+    }
 }
 
 pub struct StubLogService;

--- a/source/daemon/crates/wardnetd-data/migrations/20260628000000_tunnel_speed_tests.sql
+++ b/source/daemon/crates/wardnetd-data/migrations/20260628000000_tunnel_speed_tests.sql
@@ -1,0 +1,21 @@
+-- Per-tunnel speed test results (issue #239). Each row is one completed run
+-- that measured throughput, latency and jitter twice: once over the direct
+-- (unbound/WAN) path and once through the tunnel. Storing both legs in one row
+-- keeps the comparison apples-to-apples (measured seconds apart). Kept in a
+-- separate table — not extra columns on the hot `tunnels` row — to avoid
+-- nullable columns there and keep history append-only.
+CREATE TABLE IF NOT EXISTS tunnel_speed_test_results (
+    id                       TEXT PRIMARY KEY NOT NULL,
+    tunnel_id                TEXT NOT NULL REFERENCES tunnels(id) ON DELETE CASCADE,
+    direct_throughput_mbps   REAL NOT NULL,
+    tunnel_throughput_mbps   REAL NOT NULL,
+    direct_latency_ms        REAL NOT NULL,
+    tunnel_latency_ms        REAL NOT NULL,
+    direct_jitter_ms         REAL NOT NULL,
+    tunnel_jitter_ms         REAL NOT NULL,
+    tested_at                TEXT NOT NULL
+);
+
+-- History queries fetch the most-recent N for one tunnel: ORDER BY tested_at DESC.
+CREATE INDEX IF NOT EXISTS idx_speed_tests_tunnel_tested
+    ON tunnel_speed_test_results(tunnel_id, tested_at DESC);

--- a/source/daemon/crates/wardnetd-data/src/lib.rs
+++ b/source/daemon/crates/wardnetd-data/src/lib.rs
@@ -21,8 +21,8 @@ use repository::{
     SqliteDnsFilterRepository, SqliteDnsLocalRepository, SqliteDnsRepository,
     SqliteMaintenanceRepository, SqliteRuleRequestRepository, SqliteSessionRepository,
     SqliteStatsRepository, SqliteSystemConfigRepository, SqliteTunnelRepository,
-    SqliteUpdateRepository, StatsRepository, SystemConfigRepository, TunnelRepository,
-    UpdateRepository,
+    SqliteTunnelSpeedTestRepository, SqliteUpdateRepository, StatsRepository,
+    SystemConfigRepository, TunnelRepository, TunnelSpeedTestRepository, UpdateRepository,
 };
 use sqlx::SqlitePool;
 
@@ -41,6 +41,7 @@ pub trait RepositoryFactory: Send + Sync {
     fn dns_filter(&self) -> Arc<dyn DnsFilterRepository>;
     fn dns_local(&self) -> Arc<dyn DnsLocalRepository>;
     fn tunnel(&self) -> Arc<dyn TunnelRepository>;
+    fn tunnel_speed_tests(&self) -> Arc<dyn TunnelSpeedTestRepository>;
     fn stats(&self) -> Arc<dyn StatsRepository>;
     fn update(&self) -> Arc<dyn UpdateRepository>;
     fn maintenance(&self) -> Arc<dyn MaintenanceRepository>;
@@ -169,6 +170,12 @@ impl RepositoryFactory for SqliteRepositoryFactory {
 
     fn tunnel(&self) -> Arc<dyn TunnelRepository> {
         Arc::new(SqliteTunnelRepository::new_pools(self.pools.clone()))
+    }
+
+    fn tunnel_speed_tests(&self) -> Arc<dyn TunnelSpeedTestRepository> {
+        Arc::new(SqliteTunnelSpeedTestRepository::new_pools(
+            self.pools.clone(),
+        ))
     }
 
     fn stats(&self) -> Arc<dyn StatsRepository> {

--- a/source/daemon/crates/wardnetd-data/src/repository/mod.rs
+++ b/source/daemon/crates/wardnetd-data/src/repository/mod.rs
@@ -13,6 +13,7 @@ pub mod sqlite;
 pub mod stats;
 pub mod system_config;
 pub mod tunnel;
+pub mod tunnel_speed_test;
 pub mod update;
 
 pub use admin::AdminRepository;
@@ -37,11 +38,12 @@ pub use sqlite::{
     SqliteDnsEventsRepository, SqliteDnsFilterRepository, SqliteDnsLocalRepository,
     SqliteDnsRepository, SqliteMaintenanceRepository, SqliteRuleRequestRepository,
     SqliteSessionRepository, SqliteStatsRepository, SqliteSystemConfigRepository,
-    SqliteTunnelRepository, SqliteUpdateRepository,
+    SqliteTunnelRepository, SqliteTunnelSpeedTestRepository, SqliteUpdateRepository,
 };
 pub use stats::{DailyStatRow, HourlyStatRow, IntradayStatRow, StatsRepository};
 pub use system_config::{LastShutdownInfo, SystemConfigRepository};
 pub use tunnel::{TunnelRepository, TunnelRow};
+pub use tunnel_speed_test::{SpeedTestRow, TunnelSpeedTestRepository};
 pub use update::{UpdateHistoryRow, UpdateRepository};
 
 #[cfg(test)]

--- a/source/daemon/crates/wardnetd-data/src/repository/sqlite/mod.rs
+++ b/source/daemon/crates/wardnetd-data/src/repository/sqlite/mod.rs
@@ -17,6 +17,7 @@ pub mod session;
 pub mod stats;
 pub mod system_config;
 pub mod tunnel;
+pub mod tunnel_speed_test;
 pub mod update;
 
 pub use admin::SqliteAdminRepository;
@@ -33,6 +34,7 @@ pub use session::SqliteSessionRepository;
 pub use stats::SqliteStatsRepository;
 pub use system_config::SqliteSystemConfigRepository;
 pub use tunnel::SqliteTunnelRepository;
+pub use tunnel_speed_test::SqliteTunnelSpeedTestRepository;
 pub use update::SqliteUpdateRepository;
 
 #[cfg(test)]

--- a/source/daemon/crates/wardnetd-data/src/repository/sqlite/tests/mod.rs
+++ b/source/daemon/crates/wardnetd-data/src/repository/sqlite/tests/mod.rs
@@ -1,1 +1,2 @@
 mod maintenance;
+mod tunnel_speed_test;

--- a/source/daemon/crates/wardnetd-data/src/repository/sqlite/tests/tunnel_speed_test.rs
+++ b/source/daemon/crates/wardnetd-data/src/repository/sqlite/tests/tunnel_speed_test.rs
@@ -1,0 +1,131 @@
+use sqlx::SqlitePool;
+use sqlx::sqlite::SqlitePoolOptions;
+use uuid::Uuid;
+
+use crate::repository::TunnelSpeedTestRepository;
+use crate::repository::sqlite::tunnel_speed_test::SqliteTunnelSpeedTestRepository;
+use crate::repository::tunnel_speed_test::SpeedTestRow;
+
+/// In-memory pool with the full schema applied. A single connection is used so
+/// the in-memory database persists across the repository's read/write pools.
+async fn make_pool() -> SqlitePool {
+    let pool = SqlitePoolOptions::new()
+        .max_connections(1)
+        .connect("sqlite::memory:")
+        .await
+        .expect("open in-memory db");
+    sqlx::migrate!("./migrations")
+        .run(&pool)
+        .await
+        .expect("run migrations");
+    pool
+}
+
+/// Insert a minimal parent tunnel so the speed-test FK is satisfied. The
+/// interface name is derived from the id (the column is UNIQUE).
+async fn seed_tunnel(pool: &SqlitePool, id: &str) {
+    sqlx::query(
+        "INSERT INTO tunnels (id, label, country_code, interface_name, endpoint) \
+         VALUES (?, 'test', 'NL', ?, '198.51.100.1:51820')",
+    )
+    .bind(id)
+    .bind(format!("wg_{}", &id[..8]))
+    .execute(pool)
+    .await
+    .expect("seed tunnel");
+}
+
+fn row(tunnel_id: &str, tested_at: &str, tunnel_mbps: f64) -> SpeedTestRow {
+    SpeedTestRow {
+        id: Uuid::new_v4().to_string(),
+        tunnel_id: tunnel_id.to_owned(),
+        direct_throughput_mbps: 94.0,
+        tunnel_throughput_mbps: tunnel_mbps,
+        direct_latency_ms: 11.0,
+        tunnel_latency_ms: 23.0,
+        direct_jitter_ms: 2.0,
+        tunnel_jitter_ms: 4.0,
+        tested_at: tested_at.to_owned(),
+    }
+}
+
+#[tokio::test]
+async fn insert_round_trips_all_fields() {
+    let pool = make_pool().await;
+    let tunnel = Uuid::new_v4().to_string();
+    seed_tunnel(&pool, &tunnel).await;
+    let repo = SqliteTunnelSpeedTestRepository::new(pool);
+    repo.insert(&row(&tunnel, "2026-06-28T10:00:00Z", 85.0))
+        .await
+        .unwrap();
+
+    let results = repo.find_recent(&tunnel, 5).await.unwrap();
+    assert_eq!(results.len(), 1);
+    let r = &results[0];
+    assert_eq!(r.tunnel_id.to_string(), tunnel);
+    assert!((r.direct_throughput_mbps - 94.0).abs() < f64::EPSILON);
+    assert!((r.tunnel_throughput_mbps - 85.0).abs() < f64::EPSILON);
+    assert!((r.direct_latency_ms - 11.0).abs() < f64::EPSILON);
+    assert!((r.tunnel_latency_ms - 23.0).abs() < f64::EPSILON);
+    assert!((r.direct_jitter_ms - 2.0).abs() < f64::EPSILON);
+    assert!((r.tunnel_jitter_ms - 4.0).abs() < f64::EPSILON);
+}
+
+#[tokio::test]
+async fn find_recent_orders_newest_first_and_applies_limit() {
+    let pool = make_pool().await;
+    let tunnel = Uuid::new_v4().to_string();
+    seed_tunnel(&pool, &tunnel).await;
+    let repo = SqliteTunnelSpeedTestRepository::new(pool);
+    // Six runs at increasing timestamps; tunnel throughput encodes the order.
+    for i in 0..6 {
+        repo.insert(&row(
+            &tunnel,
+            &format!("2026-06-28T10:0{i}:00Z"),
+            80.0 + f64::from(i),
+        ))
+        .await
+        .unwrap();
+    }
+
+    let results = repo.find_recent(&tunnel, 5).await.unwrap();
+    assert_eq!(results.len(), 5, "limit of 5 is applied");
+    // Newest first: the i=5 row (85.0) leads, the i=0 row (80.0) is dropped.
+    assert!((results[0].tunnel_throughput_mbps - 85.0).abs() < f64::EPSILON);
+    for pair in results.windows(2) {
+        assert!(
+            pair[0].tested_at >= pair[1].tested_at,
+            "results must be ordered newest-first",
+        );
+    }
+}
+
+#[tokio::test]
+async fn find_recent_filters_by_tunnel() {
+    let pool = make_pool().await;
+    let a = Uuid::new_v4().to_string();
+    let b = Uuid::new_v4().to_string();
+    seed_tunnel(&pool, &a).await;
+    seed_tunnel(&pool, &b).await;
+    let repo = SqliteTunnelSpeedTestRepository::new(pool);
+    repo.insert(&row(&a, "2026-06-28T10:00:00Z", 85.0))
+        .await
+        .unwrap();
+    repo.insert(&row(&b, "2026-06-28T10:01:00Z", 70.0))
+        .await
+        .unwrap();
+
+    let results = repo.find_recent(&a, 5).await.unwrap();
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].tunnel_id.to_string(), a);
+}
+
+#[tokio::test]
+async fn find_recent_empty_for_unknown_tunnel() {
+    let repo = SqliteTunnelSpeedTestRepository::new(make_pool().await);
+    let results = repo
+        .find_recent(&Uuid::new_v4().to_string(), 5)
+        .await
+        .unwrap();
+    assert!(results.is_empty());
+}

--- a/source/daemon/crates/wardnetd-data/src/repository/sqlite/tunnel_speed_test.rs
+++ b/source/daemon/crates/wardnetd-data/src/repository/sqlite/tunnel_speed_test.rs
@@ -1,0 +1,100 @@
+use async_trait::async_trait;
+use sqlx::SqlitePool;
+use wardnet_common::speed_test::TunnelSpeedTestResult;
+
+use super::super::TunnelSpeedTestRepository;
+use super::super::tunnel_speed_test::SpeedTestRow;
+use crate::db::DbPools;
+
+/// SQLite-backed implementation of [`TunnelSpeedTestRepository`].
+pub struct SqliteTunnelSpeedTestRepository {
+    pools: DbPools,
+}
+
+impl SqliteTunnelSpeedTestRepository {
+    /// Create a new repository backed by the given connection pool.
+    #[must_use]
+    pub fn new(pool: SqlitePool) -> Self {
+        Self::new_pools(DbPools::single(pool))
+    }
+
+    /// Create a new repository with split reader/writer pools.
+    #[must_use]
+    pub fn new_pools(pools: DbPools) -> Self {
+        Self { pools }
+    }
+}
+
+/// Raw row from the `tunnel_speed_test_results` table used for internal mapping.
+#[derive(sqlx::FromRow)]
+struct DbSpeedTestRow {
+    id: String,
+    tunnel_id: String,
+    direct_throughput_mbps: f64,
+    tunnel_throughput_mbps: f64,
+    direct_latency_ms: f64,
+    tunnel_latency_ms: f64,
+    direct_jitter_ms: f64,
+    tunnel_jitter_ms: f64,
+    tested_at: String,
+}
+
+impl DbSpeedTestRow {
+    /// Convert the raw database row into a domain [`TunnelSpeedTestResult`].
+    fn into_result(self) -> anyhow::Result<TunnelSpeedTestResult> {
+        Ok(TunnelSpeedTestResult {
+            id: self.id.parse()?,
+            tunnel_id: self.tunnel_id.parse()?,
+            direct_throughput_mbps: self.direct_throughput_mbps,
+            tunnel_throughput_mbps: self.tunnel_throughput_mbps,
+            direct_latency_ms: self.direct_latency_ms,
+            tunnel_latency_ms: self.tunnel_latency_ms,
+            direct_jitter_ms: self.direct_jitter_ms,
+            tunnel_jitter_ms: self.tunnel_jitter_ms,
+            tested_at: self.tested_at.parse()?,
+        })
+    }
+}
+
+#[async_trait]
+impl TunnelSpeedTestRepository for SqliteTunnelSpeedTestRepository {
+    async fn insert(&self, row: &SpeedTestRow) -> anyhow::Result<()> {
+        sqlx::query(
+            "INSERT INTO tunnel_speed_test_results (id, tunnel_id, \
+             direct_throughput_mbps, tunnel_throughput_mbps, \
+             direct_latency_ms, tunnel_latency_ms, \
+             direct_jitter_ms, tunnel_jitter_ms, tested_at) \
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        )
+        .bind(&row.id)
+        .bind(&row.tunnel_id)
+        .bind(row.direct_throughput_mbps)
+        .bind(row.tunnel_throughput_mbps)
+        .bind(row.direct_latency_ms)
+        .bind(row.tunnel_latency_ms)
+        .bind(row.direct_jitter_ms)
+        .bind(row.tunnel_jitter_ms)
+        .bind(&row.tested_at)
+        .execute(&self.pools.write)
+        .await?;
+        Ok(())
+    }
+
+    async fn find_recent(
+        &self,
+        tunnel_id: &str,
+        limit: i64,
+    ) -> anyhow::Result<Vec<TunnelSpeedTestResult>> {
+        let rows = sqlx::query_as::<_, DbSpeedTestRow>(
+            "SELECT id, tunnel_id, direct_throughput_mbps, tunnel_throughput_mbps, \
+             direct_latency_ms, tunnel_latency_ms, direct_jitter_ms, tunnel_jitter_ms, \
+             tested_at FROM tunnel_speed_test_results \
+             WHERE tunnel_id = ? ORDER BY tested_at DESC LIMIT ?",
+        )
+        .bind(tunnel_id)
+        .bind(limit)
+        .fetch_all(&self.pools.read)
+        .await?;
+        rows.into_iter().map(DbSpeedTestRow::into_result).collect()
+    }
+}

--- a/source/daemon/crates/wardnetd-data/src/repository/tunnel_speed_test.rs
+++ b/source/daemon/crates/wardnetd-data/src/repository/tunnel_speed_test.rs
@@ -1,0 +1,47 @@
+use async_trait::async_trait;
+use wardnet_common::speed_test::TunnelSpeedTestResult;
+
+/// Insert-only data transfer object for a completed speed test.
+///
+/// All fields map directly to columns on `tunnel_speed_test_results`. The
+/// service layer constructs this after measuring both the direct (WAN) and
+/// tunnel legs of a run.
+#[derive(Debug, Clone)]
+pub struct SpeedTestRow {
+    /// UUID primary key.
+    pub id: String,
+    /// Owning tunnel UUID.
+    pub tunnel_id: String,
+    /// Direct (unbound/WAN) download throughput, megabits/s.
+    pub direct_throughput_mbps: f64,
+    /// Through-tunnel download throughput, megabits/s.
+    pub tunnel_throughput_mbps: f64,
+    /// Direct median round-trip latency, milliseconds.
+    pub direct_latency_ms: f64,
+    /// Through-tunnel median round-trip latency, milliseconds.
+    pub tunnel_latency_ms: f64,
+    /// Direct latency jitter (sample stddev), milliseconds.
+    pub direct_jitter_ms: f64,
+    /// Through-tunnel latency jitter (sample stddev), milliseconds.
+    pub tunnel_jitter_ms: f64,
+    /// ISO 8601 timestamp of when the test completed.
+    pub tested_at: String,
+}
+
+/// Data access for per-tunnel speed test history.
+///
+/// Append-only: rows are inserted by the speed test job and never updated.
+/// History is not trimmed — [`find_recent`](Self::find_recent) bounds reads
+/// instead, so the table stays small in practice without discarding data.
+#[async_trait]
+pub trait TunnelSpeedTestRepository: Send + Sync {
+    /// Insert a completed speed test result.
+    async fn insert(&self, row: &SpeedTestRow) -> anyhow::Result<()>;
+
+    /// Return the most recent `limit` results for a tunnel, newest first.
+    async fn find_recent(
+        &self,
+        tunnel_id: &str,
+        limit: i64,
+    ) -> anyhow::Result<Vec<TunnelSpeedTestResult>>;
+}

--- a/source/daemon/crates/wardnetd-mock/src/backends/mod.rs
+++ b/source/daemon/crates/wardnetd-mock/src/backends/mod.rs
@@ -20,5 +20,6 @@ pub mod noop_network_probe;
 pub mod noop_power_ops;
 pub mod noop_remote_access;
 pub mod noop_routing;
+pub mod noop_throughput_tester;
 pub mod noop_tunnel;
 pub mod noop_watchdog;

--- a/source/daemon/crates/wardnetd-mock/src/backends/noop_latency_prober.rs
+++ b/source/daemon/crates/wardnetd-mock/src/backends/noop_latency_prober.rs
@@ -28,11 +28,13 @@ impl Default for NoopLatencyProber {
 
 #[async_trait]
 impl TunnelLatencyProber for NoopLatencyProber {
-    async fn probe(&self, interface_name: &str) -> Result<u64, LatencyProbeError> {
+    async fn probe(&self, interface_name: Option<&str>) -> Result<u64, LatencyProbeError> {
         // 10 ms feigned send time so back-to-back probes don't all
         // resolve in the same tokio poll.
         tokio::time::sleep(Duration::from_millis(10)).await;
-        Ok(synthetic_rtt(interface_name))
+        // `None` is the direct/WAN leg of a speed test; give it a stable
+        // low-ish baseline so the tunnel always looks slightly slower.
+        Ok(synthetic_rtt(interface_name.unwrap_or("<direct>")))
     }
 }
 

--- a/source/daemon/crates/wardnetd-mock/src/backends/noop_throughput_tester.rs
+++ b/source/daemon/crates/wardnetd-mock/src/backends/noop_throughput_tester.rs
@@ -1,0 +1,54 @@
+//! Deterministic [`ThroughputTester`] implementation for the mock server.
+//!
+//! Returns stable, plausible throughput numbers so the frontend's speed
+//! test UI has data to render without performing a real download (which
+//! `make run-dev` cannot do meaningfully on macOS). The direct (WAN) leg
+//! reports a higher number than the tunnel leg so the comparison always
+//! shows the tunnel keeping most — but not all — of the line.
+
+use std::time::Duration;
+
+use async_trait::async_trait;
+
+use wardnetd_services::tunnel::throughput_tester::{
+    ThroughputError, ThroughputMeasurement, ThroughputTester,
+};
+
+/// Synthetic direct (WAN) throughput, megabits/s.
+const DIRECT_MBPS: f64 = 94.0;
+/// Synthetic through-tunnel throughput, megabits/s (≈90% of direct).
+const TUNNEL_MBPS: f64 = 85.0;
+
+/// Synthetic-throughput tester for the mock daemon.
+pub struct NoopThroughputTester;
+
+impl NoopThroughputTester {
+    #[must_use]
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for NoopThroughputTester {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl ThroughputTester for NoopThroughputTester {
+    async fn download(
+        &self,
+        interface: Option<&str>,
+    ) -> Result<ThroughputMeasurement, ThroughputError> {
+        // Brief feigned download so the job spends visible time per leg and
+        // the UI's progress bar has something to show.
+        tokio::time::sleep(Duration::from_millis(200)).await;
+        let mbps = if interface.is_some() {
+            TUNNEL_MBPS
+        } else {
+            DIRECT_MBPS
+        };
+        Ok(ThroughputMeasurement { mbps })
+    }
+}

--- a/source/daemon/crates/wardnetd-mock/src/main.rs
+++ b/source/daemon/crates/wardnetd-mock/src/main.rs
@@ -34,6 +34,7 @@ use wardnetd_mock::backends::noop_remote_access::{
     MockDdnsService, MockRemoteAccessState, MockTlsService,
 };
 use wardnetd_mock::backends::noop_routing::{NoopFirewallManager, NoopPolicyRouter};
+use wardnetd_mock::backends::noop_throughput_tester::NoopThroughputTester;
 use wardnetd_mock::backends::noop_tunnel::NoopTunnelInterface;
 use wardnetd_mock::backends::noop_watchdog::NoopWatchdog;
 use wardnetd_mock::events::FakeEventEmitter;
@@ -249,6 +250,7 @@ async fn run(
         tunnel_interface: Arc::new(NoopTunnelInterface),
         tunnel_exit_probe: Arc::new(NoopExitProbe::new(factory.tunnel())),
         tunnel_latency_prober: Arc::new(NoopLatencyProber::new()),
+        tunnel_throughput_tester: Arc::new(NoopThroughputTester::new()),
         policy_router: Arc::new(NoopPolicyRouter),
         firewall: Arc::new(NoopFirewallManager),
         packet_capture: Arc::new(NoopPacketCapture),

--- a/source/daemon/crates/wardnetd-services/src/lib.rs
+++ b/source/daemon/crates/wardnetd-services/src/lib.rs
@@ -110,6 +110,11 @@ pub struct Backends {
     /// production (Linux-only) and to a deterministic mock in
     /// `wardnetd-mock`.
     pub tunnel_latency_prober: Arc<dyn tunnel::TunnelLatencyProber>,
+    /// Downloads a fixed payload to measure throughput, either unbound
+    /// (direct/WAN) or bound to a tunnel interface (`SO_BINDTODEVICE`).
+    /// Wired to a reqwest-based downloader in production and a fixed-value
+    /// stub in the mock.
+    pub tunnel_throughput_tester: Arc<dyn tunnel::ThroughputTester>,
     pub policy_router: Arc<dyn routing::PolicyRouter>,
     pub firewall: Arc<dyn routing::FirewallManager>,
     pub packet_capture: Arc<dyn device::PacketCapture>,
@@ -404,6 +409,7 @@ fn create_services(
     let dns_local_repo = repo_factory.dns_local();
     let maintenance_repo = repo_factory.maintenance();
     let tunnel_repo = repo_factory.tunnel();
+    let tunnel_speed_test_repo = repo_factory.tunnel_speed_tests();
     let update_repo = repo_factory.update();
     let stats_repo = repo_factory.stats();
 
@@ -513,10 +519,14 @@ fn create_services(
         backends.tunnel_interface.clone(),
         backends.tunnel_exit_probe.clone(),
         backends.tunnel_latency_prober.clone(),
+        backends.tunnel_throughput_tester.clone(),
         backends.secret_store.clone(),
         event_publisher.clone(),
         stats_meter.clone(),
         registry.clone(),
+        job_service.clone(),
+        tunnel_speed_test_repo.clone(),
+        config.tunnel.speed_test_latency_samples,
     ));
 
     let vpn_provider_service: Arc<dyn VpnProviderService> = Arc::new(VpnProviderServiceImpl::new(

--- a/source/daemon/crates/wardnetd-services/src/routing/tests/routing.rs
+++ b/source/daemon/crates/wardnetd-services/src/routing/tests/routing.rs
@@ -364,6 +364,20 @@ impl TunnelService for MockTunnelService {
     async fn probe_latencies(&self) -> Result<(), AppError> {
         Ok(())
     }
+
+    async fn start_speed_test(
+        self: Arc<Self>,
+        _id: Uuid,
+    ) -> Result<wardnet_common::jobs::JobDispatchedResponse, AppError> {
+        unimplemented!("not used in routing tests")
+    }
+
+    async fn list_speed_tests(
+        &self,
+        _id: Uuid,
+    ) -> Result<wardnet_common::speed_test::TunnelSpeedTestHistoryResponse, AppError> {
+        unimplemented!("not used in routing tests")
+    }
 }
 
 // -- Mock PolicyRouter --------------------------------------------------------

--- a/source/daemon/crates/wardnetd-services/src/tests/init.rs
+++ b/source/daemon/crates/wardnetd-services/src/tests/init.rs
@@ -26,6 +26,7 @@ use crate::system::SystemPowerOps;
 use crate::tunnel::exit_probe::{ExitInfo, ProbeError, TunnelExitProbe};
 use crate::tunnel::interface::{CreateTunnelParams, TunnelInterface, TunnelStats};
 use crate::tunnel::latency_prober::{LatencyProbeError, TunnelLatencyProber};
+use crate::tunnel::throughput_tester::{ThroughputError, ThroughputMeasurement, ThroughputTester};
 use crate::{init_services, init_services_with_factory};
 use wardnet_common::config::AdminConfig;
 
@@ -66,10 +67,23 @@ impl TunnelExitProbe for StubTunnelExitProbe {
     }
 }
 
+struct StubThroughputTester;
+#[async_trait]
+impl ThroughputTester for StubThroughputTester {
+    async fn download(
+        &self,
+        _interface: Option<&str>,
+    ) -> Result<ThroughputMeasurement, ThroughputError> {
+        Err(ThroughputError::Unsupported(
+            "stub throughput tester in init test".to_owned(),
+        ))
+    }
+}
+
 struct StubTunnelLatencyProber;
 #[async_trait]
 impl TunnelLatencyProber for StubTunnelLatencyProber {
-    async fn probe(&self, _interface: &str) -> Result<u64, LatencyProbeError> {
+    async fn probe(&self, _interface: Option<&str>) -> Result<u64, LatencyProbeError> {
         Err(LatencyProbeError::Unsupported(
             "stub latency prober in init test".to_owned(),
         ))
@@ -204,6 +218,7 @@ fn stub_backends() -> Backends {
         tunnel_interface: Arc::new(StubTunnelInterface),
         tunnel_exit_probe: Arc::new(StubTunnelExitProbe),
         tunnel_latency_prober: Arc::new(StubTunnelLatencyProber),
+        tunnel_throughput_tester: Arc::new(StubThroughputTester),
         policy_router: Arc::new(StubPolicyRouter),
         firewall: Arc::new(StubFirewall),
         packet_capture: Arc::new(StubPacketCapture),

--- a/source/daemon/crates/wardnetd-services/src/tunnel/latency_prober.rs
+++ b/source/daemon/crates/wardnetd-services/src/tunnel/latency_prober.rs
@@ -19,15 +19,16 @@ pub enum LatencyProbeError {
     Unsupported(String),
 }
 
-/// Sends a single ICMP echo through a specific network interface and
-/// returns the observed round-trip time.
+/// Sends a single ICMP echo and returns the observed round-trip time.
 ///
-/// Implementations must bind the outbound socket to `interface_name`
-/// (Linux: `SO_BINDTODEVICE`) so the probe traverses the tunnel rather
-/// than the default route.
+/// When `interface_name` is `Some`, implementations must bind the outbound
+/// socket to it (Linux: `SO_BINDTODEVICE`) so the probe traverses that tunnel
+/// rather than the default route. When `None`, the probe is sent **unbound**
+/// over the default route (the direct/WAN path) — used by the speed test to
+/// establish a baseline to compare the tunnel against.
 #[async_trait]
 pub trait TunnelLatencyProber: Send + Sync {
-    /// Probe `interface_name` and return the round-trip time in
-    /// milliseconds.
-    async fn probe(&self, interface_name: &str) -> Result<u64, LatencyProbeError>;
+    /// Probe `interface_name` (or the direct/WAN path when `None`) and return
+    /// the round-trip time in milliseconds.
+    async fn probe(&self, interface_name: Option<&str>) -> Result<u64, LatencyProbeError>;
 }

--- a/source/daemon/crates/wardnetd-services/src/tunnel/mod.rs
+++ b/source/daemon/crates/wardnetd-services/src/tunnel/mod.rs
@@ -3,12 +3,14 @@ pub mod interface;
 pub mod key_store;
 pub mod latency_prober;
 pub mod service;
+pub mod throughput_tester;
 
 pub use exit_probe::{ExitInfo, ProbeError, TunnelExitProbe};
 pub use interface::{CreateTunnelParams, TunnelConfig, TunnelInterface, TunnelStats};
 pub use key_store::{KeyStore, KeyStoreAdapter};
 pub use latency_prober::{LatencyProbeError, TunnelLatencyProber};
 pub use service::{TunnelService, TunnelServiceImpl};
+pub use throughput_tester::{ThroughputError, ThroughputMeasurement, ThroughputTester};
 
 #[cfg(test)]
 mod tests;

--- a/source/daemon/crates/wardnetd-services/src/tunnel/service.rs
+++ b/source/daemon/crates/wardnetd-services/src/tunnel/service.rs
@@ -1449,3 +1449,42 @@ impl TunnelService for TunnelServiceImpl {
         Ok(TunnelSpeedTestHistoryResponse { results })
     }
 }
+
+#[cfg(test)]
+mod summarize_latency_tests {
+    use super::summarize_latency;
+
+    fn approx(a: f64, b: f64) -> bool {
+        (a - b).abs() < 1e-9
+    }
+
+    #[test]
+    fn empty_is_zero() {
+        let (median, jitter) = summarize_latency(&[]);
+        assert!(approx(median, 0.0));
+        assert!(approx(jitter, 0.0));
+    }
+
+    #[test]
+    fn single_sample_has_no_jitter() {
+        let (median, jitter) = summarize_latency(&[42]);
+        assert!(approx(median, 42.0));
+        assert!(approx(jitter, 0.0));
+    }
+
+    #[test]
+    fn odd_count_takes_middle_and_sample_stddev() {
+        // Sorted: [10, 20, 30] -> median 20; mean 20, sample variance
+        // (100 + 0 + 100) / 2 = 100 -> stddev 10.
+        let (median, jitter) = summarize_latency(&[10, 30, 20]);
+        assert!(approx(median, 20.0));
+        assert!(approx(jitter, 10.0));
+    }
+
+    #[test]
+    fn even_count_averages_the_two_middles() {
+        // Sorted: [10, 20, 30, 40] -> median midpoint(20, 30) = 25.
+        let (median, _) = summarize_latency(&[40, 10, 30, 20]);
+        assert!(approx(median, 25.0));
+    }
+}

--- a/source/daemon/crates/wardnetd-services/src/tunnel/service.rs
+++ b/source/daemon/crates/wardnetd-services/src/tunnel/service.rs
@@ -10,21 +10,26 @@ use wardnet_common::api::{
     TunnelDevicesResponse, TunnelTestResult,
 };
 use wardnet_common::event::WardnetEvent;
+use wardnet_common::jobs::{JobDispatchedResponse, JobKind};
+use wardnet_common::speed_test::TunnelSpeedTestHistoryResponse;
 use wardnet_common::tunnel::{Tunnel, TunnelStatus};
 use wardnet_common::wireguard_config;
 
 use crate::auth_context;
 use crate::error::AppError;
 use crate::event::EventPublisher;
+use crate::jobs::{JobService, JobServiceExt, ProgressReporter};
 use crate::stats::meter::Meter;
 use crate::tunnel::exit_probe::{ProbeError, TunnelExitProbe};
 use crate::tunnel::interface::{
     CreateTunnelParams, TunnelConfig as TiTunnelConfig, TunnelInterface,
 };
 use crate::tunnel::latency_prober::{LatencyProbeError, TunnelLatencyProber};
+use crate::tunnel::throughput_tester::ThroughputTester;
 use crate::vpn::resolver::{EmptyServerListError, ServerResolver};
 use wardnetd_data::repository::TunnelRepository;
 use wardnetd_data::repository::tunnel::TunnelRow;
+use wardnetd_data::repository::tunnel_speed_test::{SpeedTestRow, TunnelSpeedTestRepository};
 use wardnetd_data::secret_store::SecretStore;
 
 use crate::tunnel::key_store::{KeyStore, KeyStoreAdapter};
@@ -120,6 +125,22 @@ pub trait TunnelService: Send + Sync {
     /// Used by the tunnel monitor background task. No auth guard — called from
     /// background task context.
     async fn probe_latencies(&self) -> Result<(), AppError>;
+
+    /// Start an asynchronous speed test for a tunnel and return the job id.
+    ///
+    /// The handler returns immediately (202); the background job measures
+    /// throughput, latency and jitter twice — once over the direct (WAN)
+    /// path and once through the tunnel — and persists a single result row.
+    /// If the tunnel is `Down` it is brought up for the run and torn back
+    /// down afterwards. A concurrent run for the same tunnel (or an in-flight
+    /// [`test_tunnel`](Self::test_tunnel)) returns `AppError::Conflict`; the
+    /// in-flight slot is held for the full job duration.
+    async fn start_speed_test(self: Arc<Self>, id: Uuid)
+    -> Result<JobDispatchedResponse, AppError>;
+
+    /// List the most recent speed test results for a tunnel, newest first
+    /// (bounded to the last few runs).
+    async fn list_speed_tests(&self, id: Uuid) -> Result<TunnelSpeedTestHistoryResponse, AppError>;
 }
 
 /// Default implementation of [`TunnelService`].
@@ -129,10 +150,16 @@ pub struct TunnelServiceImpl {
     tunnel_interface: Arc<dyn TunnelInterface>,
     exit_probe: Arc<dyn TunnelExitProbe>,
     latency_prober: Arc<dyn TunnelLatencyProber>,
+    throughput_tester: Arc<dyn ThroughputTester>,
     keys: Arc<dyn KeyStore>,
     events: Arc<dyn EventPublisher>,
     meter: Arc<Meter>,
     server_resolver: Arc<dyn ServerResolver>,
+    jobs: Arc<dyn JobService>,
+    speed_test_repo: Arc<dyn TunnelSpeedTestRepository>,
+    /// Number of ICMP samples taken per leg of a speed test to derive median
+    /// latency and jitter. From `config.tunnel.speed_test_latency_samples`.
+    speed_test_latency_samples: u32,
     /// Last cumulative `(bytes_tx, bytes_rx)` observed per tunnel.
     /// Used by `collect_stats` to compute positive deltas to feed into
     /// the generic stats pipeline. A counter that goes *down* means the
@@ -160,13 +187,55 @@ fn parse_port(endpoint: Option<&str>) -> u16 {
     }
 }
 
+/// Number of recent speed test results returned by `list_speed_tests`.
+const SPEED_TEST_HISTORY_LIMIT: i64 = 5;
+
+/// One leg of a speed test (direct or tunnel).
+struct LegMeasurement {
+    throughput_mbps: f64,
+    latency_ms: f64,
+    jitter_ms: f64,
+}
+
+/// Reduce a set of ICMP RTT samples (ms) to `(median, jitter)`, where jitter
+/// is the sample standard deviation. Returns `(0.0, 0.0)` for an empty slice
+/// (callers reject empty sample sets before this point).
+fn summarize_latency(samples: &[u64]) -> (f64, f64) {
+    if samples.is_empty() {
+        return (0.0, 0.0);
+    }
+    let mut sorted: Vec<u64> = samples.to_vec();
+    sorted.sort_unstable();
+    let mid = sorted.len() / 2;
+    #[allow(clippy::cast_precision_loss)]
+    let median = if sorted.len().is_multiple_of(2) {
+        f64::midpoint(sorted[mid - 1] as f64, sorted[mid] as f64)
+    } else {
+        sorted[mid] as f64
+    };
+
+    #[allow(clippy::cast_precision_loss)]
+    let n = samples.len() as f64;
+    #[allow(clippy::cast_precision_loss)]
+    let mean = samples.iter().map(|&s| s as f64).sum::<f64>() / n;
+    let jitter = if samples.len() > 1 {
+        #[allow(clippy::cast_precision_loss)]
+        let variance = samples
+            .iter()
+            .map(|&s| {
+                let d = s as f64 - mean;
+                d * d
+            })
+            .sum::<f64>()
+            / (n - 1.0);
+        variance.sqrt()
+    } else {
+        0.0
+    };
+    (median, jitter)
+}
+
 impl TunnelServiceImpl {
-    /// Create a new tunnel service wired to the daemon's [`SecretStore`].
-    ///
-    /// `WireGuard` private keys are stored through a [`KeyStoreAdapter`]
-    /// built internally — callers outside this crate only need to hand
-    /// in a secret store; the key-store facade never escapes the tunnel
-    /// module.
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         tunnels: Arc<dyn TunnelRepository>,
@@ -174,10 +243,14 @@ impl TunnelServiceImpl {
         tunnel_interface: Arc<dyn TunnelInterface>,
         exit_probe: Arc<dyn TunnelExitProbe>,
         latency_prober: Arc<dyn TunnelLatencyProber>,
+        throughput_tester: Arc<dyn ThroughputTester>,
         secret_store: Arc<dyn SecretStore>,
         events: Arc<dyn EventPublisher>,
         meter: Arc<Meter>,
         server_resolver: Arc<dyn ServerResolver>,
+        jobs: Arc<dyn JobService>,
+        speed_test_repo: Arc<dyn TunnelSpeedTestRepository>,
+        speed_test_latency_samples: u32,
     ) -> Self {
         let keys: Arc<dyn KeyStore> = Arc::new(KeyStoreAdapter::new(secret_store));
         Self {
@@ -186,20 +259,19 @@ impl TunnelServiceImpl {
             tunnel_interface,
             exit_probe,
             latency_prober,
+            throughput_tester,
             keys,
             events,
             meter,
             server_resolver,
+            jobs,
+            speed_test_repo,
+            speed_test_latency_samples,
             last_bytes: Mutex::new(HashMap::new()),
             tests_in_flight: Arc::new(std::sync::Mutex::new(HashSet::new())),
         }
     }
 
-    /// Test-only constructor that accepts a pre-built [`KeyStore`] mock.
-    ///
-    /// Kept `pub(crate)` so nothing outside `wardnetd-services` can
-    /// depend on the narrower interface — production code must go
-    /// through [`Self::new`] with a [`SecretStore`].
     #[cfg(test)]
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn with_key_store(
@@ -208,10 +280,14 @@ impl TunnelServiceImpl {
         tunnel_interface: Arc<dyn TunnelInterface>,
         exit_probe: Arc<dyn TunnelExitProbe>,
         latency_prober: Arc<dyn TunnelLatencyProber>,
+        throughput_tester: Arc<dyn ThroughputTester>,
         keys: Arc<dyn KeyStore>,
         events: Arc<dyn EventPublisher>,
         meter: Arc<Meter>,
         server_resolver: Arc<dyn ServerResolver>,
+        jobs: Arc<dyn JobService>,
+        speed_test_repo: Arc<dyn TunnelSpeedTestRepository>,
+        speed_test_latency_samples: u32,
     ) -> Self {
         Self {
             tunnels,
@@ -219,10 +295,14 @@ impl TunnelServiceImpl {
             tunnel_interface,
             exit_probe,
             latency_prober,
+            throughput_tester,
             keys,
             events,
             meter,
             server_resolver,
+            jobs,
+            speed_test_repo,
+            speed_test_latency_samples,
             last_bytes: Mutex::new(HashMap::new()),
             tests_in_flight: Arc::new(std::sync::Mutex::new(HashSet::new())),
         }
@@ -706,6 +786,99 @@ impl TunnelServiceImpl {
             timestamp: chrono::Utc::now(),
         });
 
+        Ok(())
+    }
+
+    /// Measure one leg of a speed test: a single throughput download plus
+    /// `speed_test_latency_samples` ICMP probes. `interface` is `Some(iface)`
+    /// for the tunnel leg (binds the socket) or `None` for the direct/WAN
+    /// baseline. A leg fails (whole test fails) if the download errors or
+    /// every latency probe fails — a half-measurement is meaningless.
+    async fn measure_leg(&self, interface: Option<&str>) -> Result<LegMeasurement, AppError> {
+        let throughput = self
+            .throughput_tester
+            .download(interface)
+            .await
+            .map_err(|e| {
+                AppError::UpstreamUnavailable(format!("throughput download failed: {e}"))
+            })?;
+
+        let samples_wanted = self.speed_test_latency_samples.max(1);
+        let mut samples = Vec::with_capacity(samples_wanted as usize);
+        for _ in 0..samples_wanted {
+            if let Ok(rtt_ms) = self.latency_prober.probe(interface).await {
+                samples.push(rtt_ms);
+            }
+        }
+        if samples.is_empty() {
+            return Err(AppError::UpstreamUnavailable(
+                "all latency probes failed".to_owned(),
+            ));
+        }
+        let (latency_ms, jitter_ms) = summarize_latency(&samples);
+        Ok(LegMeasurement {
+            throughput_mbps: throughput.mbps,
+            latency_ms,
+            jitter_ms,
+        })
+    }
+
+    /// Body of the speed test job. Measures the direct (WAN) baseline, then
+    /// the tunnel (bringing it up first if it was `Down`), persists one row
+    /// with both legs, and restores the prior tunnel state before returning.
+    async fn run_speed_test(&self, id: Uuid, reporter: &ProgressReporter) -> Result<(), AppError> {
+        let tunnel = self.require_tunnel(id).await?;
+        let was_down = tunnel.status == TunnelStatus::Down;
+        let interface_name = tunnel.interface_name.clone();
+        reporter.set_progress(5).await;
+
+        // Direct (WAN) baseline first. The two legs run sequentially — both
+        // ultimately traverse the same physical uplink, so measuring them at
+        // once would split the pipe and corrupt both numbers.
+        let direct = self.measure_leg(None).await;
+        reporter.set_progress(40).await;
+
+        // Bring the tunnel up if needed, wait for a fresh handshake, then
+        // measure through it. Wrapped so a failure still hits the teardown
+        // path below instead of leaking a tunnel we brought up.
+        let through = async {
+            if was_down {
+                self.bring_up_core(id).await?;
+                self.await_fresh_handshake(&interface_name, std::time::Duration::from_millis(3500))
+                    .await?;
+            }
+            self.measure_leg(Some(&interface_name)).await
+        }
+        .await;
+        reporter.set_progress(90).await;
+
+        if was_down && let Err(e) = self.tear_down_core(id, "speed test completed").await {
+            tracing::warn!(
+                tunnel_id = %id,
+                error = %e,
+                "speed test: failed to tear down tunnel after run; leaving best-effort"
+            );
+        }
+
+        let direct = direct?;
+        let through = through?;
+
+        let row = SpeedTestRow {
+            id: Uuid::new_v4().to_string(),
+            tunnel_id: id.to_string(),
+            direct_throughput_mbps: direct.throughput_mbps,
+            tunnel_throughput_mbps: through.throughput_mbps,
+            direct_latency_ms: direct.latency_ms,
+            tunnel_latency_ms: through.latency_ms,
+            direct_jitter_ms: direct.jitter_ms,
+            tunnel_jitter_ms: through.jitter_ms,
+            tested_at: chrono::Utc::now().to_rfc3339(),
+        };
+        self.speed_test_repo
+            .insert(&row)
+            .await
+            .map_err(AppError::Internal)?;
+        reporter.set_progress(100).await;
         Ok(())
     }
 }
@@ -1203,7 +1376,11 @@ impl TunnelService for TunnelServiceImpl {
             .collect();
 
         for tunnel in active_tunnels {
-            match self.latency_prober.probe(&tunnel.interface_name).await {
+            match self
+                .latency_prober
+                .probe(Some(&tunnel.interface_name))
+                .await
+            {
                 Ok(rtt_ms) => {
                     let labels = format!(r#"{{"tunnel_id":"{}"}}"#, tunnel.id);
                     #[allow(clippy::cast_precision_loss)]
@@ -1231,5 +1408,44 @@ impl TunnelService for TunnelServiceImpl {
             }
         }
         Ok(())
+    }
+
+    async fn start_speed_test(
+        self: Arc<Self>,
+        id: Uuid,
+    ) -> Result<JobDispatchedResponse, AppError> {
+        auth_context::require_admin()?;
+
+        // Claim the in-flight slot synchronously so a concurrent run (or an
+        // overlapping `test_tunnel`) is rejected with 409 immediately, before
+        // any state changes. The guard is then moved into the job closure so
+        // the slot is held for the full job duration, not just this handler.
+        let guard = self.acquire_in_flight(id)?;
+
+        // Fail fast if the tunnel doesn't exist, rather than 202-then-fail.
+        self.require_tunnel(id).await?;
+
+        let me = Arc::clone(&self);
+        let job_id = self
+            .jobs
+            .dispatch(JobKind::SpeedTest, move |reporter| async move {
+                let _guard = guard;
+                me.run_speed_test(id, &reporter)
+                    .await
+                    .map_err(|e| anyhow::anyhow!("{e}"))
+            })
+            .await;
+        Ok(JobDispatchedResponse { job_id })
+    }
+
+    async fn list_speed_tests(&self, id: Uuid) -> Result<TunnelSpeedTestHistoryResponse, AppError> {
+        auth_context::require_admin()?;
+        self.require_tunnel(id).await?;
+        let results = self
+            .speed_test_repo
+            .find_recent(&id.to_string(), SPEED_TEST_HISTORY_LIMIT)
+            .await
+            .map_err(AppError::Internal)?;
+        Ok(TunnelSpeedTestHistoryResponse { results })
     }
 }

--- a/source/daemon/crates/wardnetd-services/src/tunnel/tests/mod.rs
+++ b/source/daemon/crates/wardnetd-services/src/tunnel/tests/mod.rs
@@ -1,2 +1,3 @@
 mod key_store;
+mod speed_test;
 mod tunnel;

--- a/source/daemon/crates/wardnetd-services/src/tunnel/tests/speed_test.rs
+++ b/source/daemon/crates/wardnetd-services/src/tunnel/tests/speed_test.rs
@@ -1,0 +1,179 @@
+//! Service-level tests for the per-tunnel speed test (`start_speed_test` /
+//! `list_speed_tests`). Reuses the tunnel test harness; the speed test job
+//! runs in the background via the real in-memory `JobService`, so each test
+//! dispatches then polls the job to completion.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use uuid::Uuid;
+use wardnet_common::jobs::{Job, JobStatus};
+use wardnet_common::tunnel::TunnelStatus;
+
+use crate::TunnelService;
+use crate::auth_context;
+use crate::error::AppError;
+use crate::jobs::JobService;
+use crate::tunnel::interface::TunnelStats;
+use wardnetd_data::repository::TunnelRepository;
+
+use super::tunnel::{admin_ctx, build_harness, imported_tunnel_id};
+
+/// Poll a job until it reaches a terminal state, or panic after a generous
+/// budget (the mock throughput tester adds at most a few hundred ms).
+async fn await_job(jobs: &Arc<dyn JobService>, job_id: Uuid) -> Job {
+    for _ in 0..250 {
+        if let Some(job) = jobs.get(job_id).await
+            && job.status.is_terminal()
+        {
+            return job;
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+    panic!("speed test job {job_id} did not terminate in time");
+}
+
+/// A fresh handshake so `await_fresh_handshake` clears immediately when the
+/// job brings a tunnel up.
+fn fresh_stats() -> TunnelStats {
+    TunnelStats {
+        bytes_tx: 0,
+        bytes_rx: 0,
+        last_handshake: Some(chrono::Utc::now()),
+    }
+}
+
+#[tokio::test]
+async fn speed_test_persists_both_legs() {
+    let h = build_harness();
+    let id = imported_tunnel_id(&h).await;
+    // Already up: the job measures both legs without bringing it up.
+    h.tunnels
+        .update_status(&id.to_string(), "up")
+        .await
+        .unwrap();
+    h.tunnel_iface.set_stats(fresh_stats());
+
+    let resp = auth_context::with_context(admin_ctx(), h.svc.clone().start_speed_test(id))
+        .await
+        .expect("start_speed_test should dispatch");
+    let job = await_job(&h.jobs, resp.job_id).await;
+    assert_eq!(
+        job.status,
+        JobStatus::Succeeded,
+        "job error: {:?}",
+        job.error
+    );
+
+    // One row, both legs populated; mock reports direct 94 / tunnel 85 Mbps.
+    assert_eq!(h.speed_test_repo.count(), 1);
+    let rows = h.speed_test_repo.rows();
+    let row = &rows[0];
+    assert_eq!(row.tunnel_id, id.to_string());
+    assert!((row.direct_throughput_mbps - 94.0).abs() < f64::EPSILON);
+    assert!((row.tunnel_throughput_mbps - 85.0).abs() < f64::EPSILON);
+    assert!(row.direct_latency_ms > 0.0);
+    assert!(row.tunnel_latency_ms > 0.0);
+
+    // Direct leg measured first (unbound), then the tunnel leg (bound).
+    let calls = h.throughput_tester.calls();
+    assert_eq!(calls.len(), 2);
+    assert_eq!(calls[0], None, "direct leg should be unbound");
+    assert!(calls[1].is_some(), "tunnel leg should bind the interface");
+
+    // History surfaces the persisted run.
+    let history = auth_context::with_context(admin_ctx(), h.svc.list_speed_tests(id))
+        .await
+        .unwrap();
+    assert_eq!(history.results.len(), 1);
+    assert_eq!(history.results[0].tunnel_id, id);
+}
+
+#[tokio::test]
+async fn speed_test_brings_up_down_tunnel_then_tears_down() {
+    let h = build_harness();
+    let id = imported_tunnel_id(&h).await; // imported tunnels start Down
+    h.tunnel_iface.set_stats(fresh_stats());
+
+    let resp = auth_context::with_context(admin_ctx(), h.svc.clone().start_speed_test(id))
+        .await
+        .unwrap();
+    let job = await_job(&h.jobs, resp.job_id).await;
+    assert_eq!(
+        job.status,
+        JobStatus::Succeeded,
+        "job error: {:?}",
+        job.error
+    );
+
+    assert!(
+        h.tunnel_iface.created_count() >= 1,
+        "expected the tunnel to be brought up for the run"
+    );
+    assert!(
+        h.tunnel_iface.torn_down_count() >= 1,
+        "expected the tunnel to be torn back down after the run"
+    );
+    // Final state restored to Down.
+    let tunnel = h
+        .tunnels
+        .find_by_id(&id.to_string())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(tunnel.status, TunnelStatus::Down);
+    assert_eq!(h.speed_test_repo.count(), 1);
+}
+
+#[tokio::test]
+async fn speed_test_concurrent_run_returns_conflict() {
+    let h = build_harness();
+    let id = imported_tunnel_id(&h).await;
+    h.tunnels
+        .update_status(&id.to_string(), "up")
+        .await
+        .unwrap();
+    h.tunnel_iface.set_stats(fresh_stats());
+    // Hold the first run's download open long enough to overlap.
+    h.throughput_tester.set_delay(300);
+
+    let first = auth_context::with_context(admin_ctx(), h.svc.clone().start_speed_test(id))
+        .await
+        .expect("first run dispatches");
+
+    // The background job has acquired the in-flight slot; a second request
+    // for the same tunnel must be rejected.
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    let second = auth_context::with_context(admin_ctx(), h.svc.clone().start_speed_test(id)).await;
+    assert!(
+        matches!(second, Err(AppError::Conflict(_))),
+        "expected Conflict on concurrent run, got {second:?}"
+    );
+
+    // Drain the first job so the test doesn't leak a task.
+    await_job(&h.jobs, first.job_id).await;
+}
+
+#[tokio::test]
+async fn speed_test_leg_failure_fails_job() {
+    let h = build_harness();
+    let id = imported_tunnel_id(&h).await;
+    h.tunnels
+        .update_status(&id.to_string(), "up")
+        .await
+        .unwrap();
+    h.tunnel_iface.set_stats(fresh_stats());
+    // The tunnel leg's download fails — the whole test must fail, no row.
+    h.throughput_tester.set_fail_tunnel(true);
+
+    let resp = auth_context::with_context(admin_ctx(), h.svc.clone().start_speed_test(id))
+        .await
+        .unwrap();
+    let job = await_job(&h.jobs, resp.job_id).await;
+    assert_eq!(job.status, JobStatus::Failed);
+    assert_eq!(
+        h.speed_test_repo.count(),
+        0,
+        "a failed run must not persist a half-result"
+    );
+}

--- a/source/daemon/crates/wardnetd-services/src/tunnel/tests/speed_test.rs
+++ b/source/daemon/crates/wardnetd-services/src/tunnel/tests/speed_test.rs
@@ -15,6 +15,7 @@ use crate::auth_context;
 use crate::error::AppError;
 use crate::jobs::JobService;
 use crate::tunnel::interface::TunnelStats;
+use crate::tunnel::latency_prober::LatencyProbeError;
 use wardnetd_data::repository::TunnelRepository;
 
 use super::tunnel::{admin_ctx, build_harness, imported_tunnel_id};
@@ -176,4 +177,25 @@ async fn speed_test_leg_failure_fails_job() {
         0,
         "a failed run must not persist a half-result"
     );
+}
+
+#[tokio::test]
+async fn speed_test_fails_when_all_latency_probes_fail() {
+    let h = build_harness();
+    let id = imported_tunnel_id(&h).await;
+    h.tunnels
+        .update_status(&id.to_string(), "up")
+        .await
+        .unwrap();
+    h.tunnel_iface.set_stats(fresh_stats());
+    // Throughput succeeds but every ICMP probe times out — a leg with no
+    // usable latency samples must fail the whole run, with no row persisted.
+    h.latency_prober.set_err(LatencyProbeError::Timeout(1500));
+
+    let resp = auth_context::with_context(admin_ctx(), h.svc.clone().start_speed_test(id))
+        .await
+        .unwrap();
+    let job = await_job(&h.jobs, resp.job_id).await;
+    assert_eq!(job.status, JobStatus::Failed);
+    assert_eq!(h.speed_test_repo.count(), 0);
 }

--- a/source/daemon/crates/wardnetd-services/src/tunnel/tests/tunnel.rs
+++ b/source/daemon/crates/wardnetd-services/src/tunnel/tests/tunnel.rs
@@ -16,20 +16,24 @@ use wardnet_common::routing::RoutingRule;
 use crate::auth_context;
 use crate::error::AppError;
 use crate::event::EventPublisher;
+use crate::jobs::{JobService, JobServiceImpl};
 use crate::stats::buffer::StatsBuffer;
 use crate::stats::meter::Meter;
 use crate::tunnel::exit_probe::{ExitInfo, ProbeError, TunnelExitProbe};
 use crate::tunnel::interface::{CreateTunnelParams, TunnelInterface, TunnelStats};
 use crate::tunnel::key_store::KeyStore;
 use crate::tunnel::latency_prober::{LatencyProbeError, TunnelLatencyProber};
+use crate::tunnel::throughput_tester::{ThroughputError, ThroughputMeasurement, ThroughputTester};
 use crate::vpn::resolver::{EmptyServerListError, ServerResolver};
 use crate::{TunnelService, TunnelServiceImpl};
+use wardnet_common::speed_test::TunnelSpeedTestResult;
 use wardnet_common::tunnel::BestServerSelector;
 use wardnetd_data::repository::tunnel::TunnelRow;
+use wardnetd_data::repository::tunnel_speed_test::{SpeedTestRow, TunnelSpeedTestRepository};
 use wardnetd_data::repository::{DeviceRepository, TunnelRepository};
 
 /// Helper to create an admin auth context for tests.
-fn admin_ctx() -> AuthContext {
+pub(super) fn admin_ctx() -> AuthContext {
     AuthContext::Admin {
         admin_id: Uuid::new_v4(),
     }
@@ -61,7 +65,7 @@ struct TunnelStatsRow {
     last_handshake: Option<chrono::DateTime<chrono::Utc>>,
 }
 
-struct MockTunnelRepo {
+pub(super) struct MockTunnelRepo {
     rows: Mutex<Vec<TunnelRow>>,
     stats: Mutex<std::collections::HashMap<String, TunnelStatsRow>>,
 }
@@ -285,7 +289,7 @@ enum StatsBehavior {
 }
 
 /// Records calls to tunnel interface operations for assertion.
-struct MockTunnelInterface {
+pub(super) struct MockTunnelInterface {
     created: Mutex<Vec<String>>,
     brought_up: Mutex<Vec<String>>,
     torn_down: Mutex<Vec<String>>,
@@ -308,8 +312,16 @@ impl MockTunnelInterface {
         }
     }
 
-    fn set_stats(&self, stats: TunnelStats) {
+    pub(super) fn set_stats(&self, stats: TunnelStats) {
         *self.stats_behavior.lock().unwrap() = StatsBehavior::Some(stats);
+    }
+
+    pub(super) fn created_count(&self) -> usize {
+        self.created.lock().unwrap().len()
+    }
+
+    pub(super) fn torn_down_count(&self) -> usize {
+        self.torn_down.lock().unwrap().len()
     }
 
     fn set_stats_error(&self) {
@@ -473,8 +485,11 @@ impl MockTunnelLatencyProber {
 
 #[async_trait]
 impl TunnelLatencyProber for MockTunnelLatencyProber {
-    async fn probe(&self, interface: &str) -> Result<u64, LatencyProbeError> {
-        self.calls.lock().unwrap().push(interface.to_owned());
+    async fn probe(&self, interface: Option<&str>) -> Result<u64, LatencyProbeError> {
+        self.calls
+            .lock()
+            .unwrap()
+            .push(interface.unwrap_or("<direct>").to_owned());
         match &*self.behavior.lock().unwrap() {
             LatencyBehavior::Ok(rtt) => Ok(*rtt),
             LatencyBehavior::Err(LatencyProbeError::Probe(m)) => {
@@ -487,6 +502,141 @@ impl TunnelLatencyProber for MockTunnelLatencyProber {
                 Err(LatencyProbeError::Unsupported(m.clone()))
             }
         }
+    }
+}
+
+// -- Mock ThroughputTester ------------------------------------------------
+
+/// Deterministic throughput tester. Records each leg (interface = `None`
+/// for direct, `Some(iface)` for tunnel) and can be made to fail a chosen
+/// leg or delay so an in-flight run overlaps with a second request.
+pub(super) struct MockThroughputTester {
+    direct_mbps: Mutex<f64>,
+    tunnel_mbps: Mutex<f64>,
+    fail_direct: Mutex<bool>,
+    fail_tunnel: Mutex<bool>,
+    delay_ms: Mutex<u64>,
+    calls: Mutex<Vec<Option<String>>>,
+}
+
+impl MockThroughputTester {
+    pub(super) fn new() -> Self {
+        Self {
+            direct_mbps: Mutex::new(94.0),
+            tunnel_mbps: Mutex::new(85.0),
+            fail_direct: Mutex::new(false),
+            fail_tunnel: Mutex::new(false),
+            delay_ms: Mutex::new(0),
+            calls: Mutex::new(Vec::new()),
+        }
+    }
+
+    pub(super) fn set_fail_tunnel(&self, v: bool) {
+        *self.fail_tunnel.lock().unwrap() = v;
+    }
+
+    pub(super) fn set_delay(&self, ms: u64) {
+        *self.delay_ms.lock().unwrap() = ms;
+    }
+
+    pub(super) fn calls(&self) -> Vec<Option<String>> {
+        self.calls.lock().unwrap().clone()
+    }
+}
+
+#[async_trait]
+impl ThroughputTester for MockThroughputTester {
+    async fn download(
+        &self,
+        interface: Option<&str>,
+    ) -> Result<ThroughputMeasurement, ThroughputError> {
+        self.calls
+            .lock()
+            .unwrap()
+            .push(interface.map(str::to_owned));
+        let delay = *self.delay_ms.lock().unwrap();
+        if delay > 0 {
+            tokio::time::sleep(std::time::Duration::from_millis(delay)).await;
+        }
+        let is_tunnel = interface.is_some();
+        let fail = if is_tunnel {
+            *self.fail_tunnel.lock().unwrap()
+        } else {
+            *self.fail_direct.lock().unwrap()
+        };
+        if fail {
+            return Err(ThroughputError::Download("mock leg failure".to_owned()));
+        }
+        let mbps = if is_tunnel {
+            *self.tunnel_mbps.lock().unwrap()
+        } else {
+            *self.direct_mbps.lock().unwrap()
+        };
+        Ok(ThroughputMeasurement { mbps })
+    }
+}
+
+// -- Mock TunnelSpeedTestRepository ---------------------------------------
+
+/// In-memory speed test repository capturing inserted rows.
+pub(super) struct MockSpeedTestRepo {
+    rows: Mutex<Vec<SpeedTestRow>>,
+}
+
+impl MockSpeedTestRepo {
+    pub(super) fn new() -> Self {
+        Self {
+            rows: Mutex::new(Vec::new()),
+        }
+    }
+
+    pub(super) fn count(&self) -> usize {
+        self.rows.lock().unwrap().len()
+    }
+
+    pub(super) fn rows(&self) -> Vec<SpeedTestRow> {
+        self.rows.lock().unwrap().clone()
+    }
+}
+
+#[async_trait]
+impl TunnelSpeedTestRepository for MockSpeedTestRepo {
+    async fn insert(&self, row: &SpeedTestRow) -> anyhow::Result<()> {
+        self.rows.lock().unwrap().push(row.clone());
+        Ok(())
+    }
+
+    async fn find_recent(
+        &self,
+        tunnel_id: &str,
+        limit: i64,
+    ) -> anyhow::Result<Vec<TunnelSpeedTestResult>> {
+        let mut rows: Vec<SpeedTestRow> = self
+            .rows
+            .lock()
+            .unwrap()
+            .iter()
+            .filter(|r| r.tunnel_id == tunnel_id)
+            .cloned()
+            .collect();
+        // Newest first.
+        rows.sort_by(|a, b| b.tested_at.cmp(&a.tested_at));
+        rows.truncate(usize::try_from(limit).unwrap_or(0));
+        rows.into_iter()
+            .map(|r| {
+                Ok(TunnelSpeedTestResult {
+                    id: r.id.parse()?,
+                    tunnel_id: r.tunnel_id.parse()?,
+                    direct_throughput_mbps: r.direct_throughput_mbps,
+                    tunnel_throughput_mbps: r.tunnel_throughput_mbps,
+                    direct_latency_ms: r.direct_latency_ms,
+                    tunnel_latency_ms: r.tunnel_latency_ms,
+                    direct_jitter_ms: r.direct_jitter_ms,
+                    tunnel_jitter_ms: r.tunnel_jitter_ms,
+                    tested_at: r.tested_at.parse()?,
+                })
+            })
+            .collect()
     }
 }
 
@@ -746,18 +896,21 @@ impl ServerResolver for FakeServerResolver {
     }
 }
 
-struct TestHarness {
-    svc: TunnelServiceImpl,
-    tunnels: Arc<MockTunnelRepo>,
-    tunnel_iface: Arc<MockTunnelInterface>,
+pub(super) struct TestHarness {
+    pub(super) svc: Arc<TunnelServiceImpl>,
+    pub(super) tunnels: Arc<MockTunnelRepo>,
+    pub(super) tunnel_iface: Arc<MockTunnelInterface>,
     events: Arc<MockEventPublisher>,
     keys: Arc<MockKeyStore>,
     stats_buffer: Arc<StatsBuffer>,
     exit_probe: Arc<MockTunnelExitProbe>,
     latency_prober: Arc<MockTunnelLatencyProber>,
+    pub(super) throughput_tester: Arc<MockThroughputTester>,
+    pub(super) speed_test_repo: Arc<MockSpeedTestRepo>,
+    pub(super) jobs: Arc<dyn JobService>,
 }
 
-fn build_harness() -> TestHarness {
+pub(super) fn build_harness() -> TestHarness {
     let repo = Arc::new(MockTunnelRepo::new());
     let device_repo: Arc<dyn DeviceRepository> = Arc::new(MockDeviceRepoForTunnel);
     let tunnel_iface = Arc::new(MockTunnelInterface::new());
@@ -769,20 +922,28 @@ fn build_harness() -> TestHarness {
     let meter = Arc::new(Meter::new(stats_buffer.clone()));
     let server_resolver: Arc<dyn ServerResolver> = Arc::new(MockServerResolver);
 
+    let throughput_tester = Arc::new(MockThroughputTester::new());
+    let speed_test_repo = Arc::new(MockSpeedTestRepo::new());
+    let jobs: Arc<dyn JobService> = JobServiceImpl::new();
+
     let svc = TunnelServiceImpl::with_key_store(
         repo.clone(),
         device_repo,
         tunnel_iface.clone(),
         exit_probe.clone(),
         latency_prober.clone(),
+        throughput_tester.clone(),
         keys.clone(),
         events.clone(),
         meter,
         server_resolver,
+        jobs.clone(),
+        speed_test_repo.clone(),
+        3,
     );
 
     TestHarness {
-        svc,
+        svc: Arc::new(svc),
         tunnels: repo,
         tunnel_iface,
         events,
@@ -790,6 +951,9 @@ fn build_harness() -> TestHarness {
         stats_buffer,
         exit_probe,
         latency_prober,
+        throughput_tester,
+        speed_test_repo,
+        jobs,
     }
 }
 
@@ -804,20 +968,28 @@ fn build_harness_with_device_repo(device_repo: Arc<dyn DeviceRepository>) -> Tes
     let meter = Arc::new(Meter::new(stats_buffer.clone()));
     let server_resolver: Arc<dyn ServerResolver> = Arc::new(MockServerResolver);
 
+    let throughput_tester = Arc::new(MockThroughputTester::new());
+    let speed_test_repo = Arc::new(MockSpeedTestRepo::new());
+    let jobs: Arc<dyn JobService> = JobServiceImpl::new();
+
     let svc = TunnelServiceImpl::with_key_store(
         repo.clone(),
         device_repo,
         tunnel_iface.clone(),
         exit_probe.clone(),
         latency_prober.clone(),
+        throughput_tester.clone(),
         keys.clone(),
         events.clone(),
         meter,
         server_resolver,
+        jobs.clone(),
+        speed_test_repo.clone(),
+        3,
     );
 
     TestHarness {
-        svc,
+        svc: Arc::new(svc),
         tunnels: repo,
         tunnel_iface,
         events,
@@ -825,6 +997,9 @@ fn build_harness_with_device_repo(device_repo: Arc<dyn DeviceRepository>) -> Tes
         stats_buffer,
         exit_probe,
         latency_prober,
+        throughput_tester,
+        speed_test_repo,
+        jobs,
     }
 }
 
@@ -839,20 +1014,28 @@ fn build_harness_with_resolver(server_resolver: Arc<dyn ServerResolver>) -> Test
     let stats_buffer = StatsBuffer::new();
     let meter = Arc::new(Meter::new(stats_buffer.clone()));
 
+    let throughput_tester = Arc::new(MockThroughputTester::new());
+    let speed_test_repo = Arc::new(MockSpeedTestRepo::new());
+    let jobs: Arc<dyn JobService> = JobServiceImpl::new();
+
     let svc = TunnelServiceImpl::with_key_store(
         repo.clone(),
         device_repo,
         tunnel_iface.clone(),
         exit_probe.clone(),
         latency_prober.clone(),
+        throughput_tester.clone(),
         keys.clone(),
         events.clone(),
         meter,
         server_resolver,
+        jobs.clone(),
+        speed_test_repo.clone(),
+        3,
     );
 
     TestHarness {
-        svc,
+        svc: Arc::new(svc),
         tunnels: repo,
         tunnel_iface,
         events,
@@ -860,6 +1043,9 @@ fn build_harness_with_resolver(server_resolver: Arc<dyn ServerResolver>) -> Test
         stats_buffer,
         exit_probe,
         latency_prober,
+        throughput_tester,
+        speed_test_repo,
+        jobs,
     }
 }
 
@@ -2237,7 +2423,7 @@ async fn list_tunnel_devices_anonymous_forbidden() {
 // -- test_tunnel ----------------------------------------------------------
 
 /// Helper: import a tunnel and return its id.
-async fn imported_tunnel_id(h: &TestHarness) -> Uuid {
+pub(super) async fn imported_tunnel_id(h: &TestHarness) -> Uuid {
     let resp = auth_context::with_context(admin_ctx(), h.svc.import_tunnel(sample_request()))
         .await
         .unwrap();

--- a/source/daemon/crates/wardnetd-services/src/tunnel/tests/tunnel.rs
+++ b/source/daemon/crates/wardnetd-services/src/tunnel/tests/tunnel.rs
@@ -454,7 +454,7 @@ enum LatencyBehavior {
     Err(LatencyProbeError),
 }
 
-struct MockTunnelLatencyProber {
+pub(super) struct MockTunnelLatencyProber {
     behavior: Mutex<LatencyBehavior>,
     calls: Mutex<Vec<String>>,
 }
@@ -473,7 +473,7 @@ impl MockTunnelLatencyProber {
     }
 
     #[allow(dead_code)]
-    fn set_err(&self, err: LatencyProbeError) {
+    pub(super) fn set_err(&self, err: LatencyProbeError) {
         *self.behavior.lock().unwrap() = LatencyBehavior::Err(err);
     }
 
@@ -904,7 +904,7 @@ pub(super) struct TestHarness {
     keys: Arc<MockKeyStore>,
     stats_buffer: Arc<StatsBuffer>,
     exit_probe: Arc<MockTunnelExitProbe>,
-    latency_prober: Arc<MockTunnelLatencyProber>,
+    pub(super) latency_prober: Arc<MockTunnelLatencyProber>,
     pub(super) throughput_tester: Arc<MockThroughputTester>,
     pub(super) speed_test_repo: Arc<MockSpeedTestRepo>,
     pub(super) jobs: Arc<dyn JobService>,

--- a/source/daemon/crates/wardnetd-services/src/tunnel/throughput_tester.rs
+++ b/source/daemon/crates/wardnetd-services/src/tunnel/throughput_tester.rs
@@ -1,0 +1,46 @@
+use async_trait::async_trait;
+
+/// Failure modes for [`ThroughputTester::download`].
+#[derive(Debug, thiserror::Error)]
+pub enum ThroughputError {
+    /// The download could not be started or completed (socket error, no
+    /// route, connection reset, non-success HTTP status).
+    #[error("throughput download failed: {0}")]
+    Download(String),
+
+    /// The download did not finish inside the time budget.
+    #[error("throughput download timed out after {0} ms")]
+    Timeout(u64),
+
+    /// The tester is not implemented for this build/platform. Binding a
+    /// socket to a tunnel interface (`SO_BINDTODEVICE`) is Linux-only;
+    /// macOS/Windows builds only ever see this through the mock backend.
+    #[error("throughput testing unsupported on this platform: {0}")]
+    Unsupported(String),
+}
+
+/// Result of a single throughput download.
+#[derive(Debug, Clone, Copy)]
+pub struct ThroughputMeasurement {
+    /// Measured download throughput in megabits per second.
+    pub mbps: f64,
+}
+
+/// Downloads a fixed payload and measures the achieved throughput.
+///
+/// The download URL is fixed at construction (mirroring
+/// [`TunnelExitProbe`](crate::tunnel::exit_probe::TunnelExitProbe) and
+/// [`TunnelLatencyProber`](crate::tunnel::latency_prober::TunnelLatencyProber)).
+/// When `interface_name` is `Some`, implementations bind the outbound socket
+/// to it (Linux: `SO_BINDTODEVICE`) so the download traverses that tunnel;
+/// when `None`, the download runs **unbound** over the default route — the
+/// direct/WAN baseline the speed test compares the tunnel against.
+#[async_trait]
+pub trait ThroughputTester: Send + Sync {
+    /// Download the configured payload through `interface_name` (or the
+    /// direct/WAN path when `None`) and return the measured throughput.
+    async fn download(
+        &self,
+        interface_name: Option<&str>,
+    ) -> Result<ThroughputMeasurement, ThroughputError>;
+}

--- a/source/daemon/crates/wardnetd-services/src/vpn/tests/provider.rs
+++ b/source/daemon/crates/wardnetd-services/src/vpn/tests/provider.rs
@@ -252,6 +252,20 @@ impl TunnelService for MockTunnelService {
     async fn probe_latencies(&self) -> Result<(), AppError> {
         Ok(())
     }
+
+    async fn start_speed_test(
+        self: Arc<Self>,
+        _id: Uuid,
+    ) -> Result<wardnet_common::jobs::JobDispatchedResponse, AppError> {
+        unimplemented!("not used in vpn provider tests")
+    }
+
+    async fn list_speed_tests(
+        &self,
+        _id: Uuid,
+    ) -> Result<wardnet_common::speed_test::TunnelSpeedTestHistoryResponse, AppError> {
+        unimplemented!("not used in vpn provider tests")
+    }
 }
 
 // -- Helpers ------------------------------------------------------------------

--- a/source/daemon/crates/wardnetd/src/lib.rs
+++ b/source/daemon/crates/wardnetd/src/lib.rs
@@ -11,6 +11,7 @@ pub mod policy_router_netlink;
 pub mod tunnel_exit_probe;
 pub mod tunnel_interface_wireguard;
 pub mod tunnel_latency_prober;
+pub mod tunnel_throughput_tester;
 
 // DHCP/DNS server implementations.
 pub mod dhcp;

--- a/source/daemon/crates/wardnetd/src/main.rs
+++ b/source/daemon/crates/wardnetd/src/main.rs
@@ -43,6 +43,7 @@ use wardnetd::tunnel_idle::IdleTunnelWatcher;
 use wardnetd::tunnel_interface_wireguard::WireGuardTunnelInterface;
 use wardnetd::tunnel_latency_prober::SurgePingTunnelLatencyProber;
 use wardnetd::tunnel_monitor::TunnelMonitor;
+use wardnetd::tunnel_throughput_tester::HttpThroughputTester;
 use wardnetd::watchdog::{HardwareWatchdogRunner, Notifier, SdNotifier, SoftWatchdogRunner};
 use wardnetd_api::state::AppState;
 use wardnetd_services::HealthMonitor;
@@ -314,6 +315,9 @@ async fn run(
                 .latency_probe_target
                 .parse()
                 .expect("tunnel.latency_probe_target must be a valid IP address"),
+        )),
+        tunnel_throughput_tester: Arc::new(HttpThroughputTester::new(
+            config.tunnel.speed_test_url.clone(),
         )),
         policy_router: Arc::new(
             NetlinkPolicyRouter::new(executor.clone())

--- a/source/daemon/crates/wardnetd/src/tests/stubs.rs
+++ b/source/daemon/crates/wardnetd/src/tests/stubs.rs
@@ -400,6 +400,18 @@ impl TunnelService for StubTunnelService {
     async fn probe_latencies(&self) -> Result<(), AppError> {
         unimplemented!()
     }
+    async fn start_speed_test(
+        self: std::sync::Arc<Self>,
+        _id: uuid::Uuid,
+    ) -> Result<wardnet_common::jobs::JobDispatchedResponse, AppError> {
+        unimplemented!()
+    }
+    async fn list_speed_tests(
+        &self,
+        _id: uuid::Uuid,
+    ) -> Result<wardnet_common::speed_test::TunnelSpeedTestHistoryResponse, AppError> {
+        unimplemented!()
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/source/daemon/crates/wardnetd/src/tests/tunnel_idle.rs
+++ b/source/daemon/crates/wardnetd/src/tests/tunnel_idle.rs
@@ -124,6 +124,18 @@ impl TunnelService for MockTunnelService {
     async fn probe_latencies(&self) -> Result<(), AppError> {
         Ok(())
     }
+    async fn start_speed_test(
+        self: std::sync::Arc<Self>,
+        _id: uuid::Uuid,
+    ) -> Result<wardnet_common::jobs::JobDispatchedResponse, AppError> {
+        unimplemented!()
+    }
+    async fn list_speed_tests(
+        &self,
+        _id: uuid::Uuid,
+    ) -> Result<wardnet_common::speed_test::TunnelSpeedTestHistoryResponse, AppError> {
+        unimplemented!()
+    }
 }
 
 // -- Mock RoutingService --------------------------------------------------

--- a/source/daemon/crates/wardnetd/src/tests/tunnel_monitor.rs
+++ b/source/daemon/crates/wardnetd/src/tests/tunnel_monitor.rs
@@ -140,6 +140,18 @@ impl TunnelService for MockTunnelService {
         }
         Ok(())
     }
+    async fn start_speed_test(
+        self: std::sync::Arc<Self>,
+        _id: uuid::Uuid,
+    ) -> Result<wardnet_common::jobs::JobDispatchedResponse, AppError> {
+        unimplemented!()
+    }
+    async fn list_speed_tests(
+        &self,
+        _id: uuid::Uuid,
+    ) -> Result<wardnet_common::speed_test::TunnelSpeedTestHistoryResponse, AppError> {
+        unimplemented!()
+    }
 }
 
 // -- Tests -------------------------------------------------------------------

--- a/source/daemon/crates/wardnetd/src/tunnel_latency_prober.rs
+++ b/source/daemon/crates/wardnetd/src/tunnel_latency_prober.rs
@@ -42,14 +42,21 @@ impl SurgePingTunnelLatencyProber {
 #[async_trait]
 impl TunnelLatencyProber for SurgePingTunnelLatencyProber {
     #[cfg(target_os = "linux")]
-    async fn probe(&self, interface: &str) -> Result<u64, LatencyProbeError> {
+    async fn probe(&self, interface: Option<&str>) -> Result<u64, LatencyProbeError> {
         use surge_ping::{Client, Config, ICMP, PingIdentifier, PingSequence};
 
         let kind = match self.target {
             IpAddr::V4(_) => ICMP::V4,
             IpAddr::V6(_) => ICMP::V6,
         };
-        let config = Config::builder().kind(kind).interface(interface).build();
+        // `Some` binds the socket to the tunnel (SO_BINDTODEVICE); `None`
+        // leaves it unbound so the probe egresses the default WAN route — the
+        // direct baseline leg of a speed test.
+        let mut builder = Config::builder().kind(kind);
+        if let Some(iface) = interface {
+            builder = builder.interface(iface);
+        }
+        let config = builder.build();
 
         let client = Client::new(&config)
             .map_err(|e| LatencyProbeError::Probe(format!("client build failed: {e}")))?;
@@ -77,7 +84,7 @@ impl TunnelLatencyProber for SurgePingTunnelLatencyProber {
     }
 
     #[cfg(not(target_os = "linux"))]
-    async fn probe(&self, _interface: &str) -> Result<u64, LatencyProbeError> {
+    async fn probe(&self, _interface: Option<&str>) -> Result<u64, LatencyProbeError> {
         Err(LatencyProbeError::Unsupported(
             "SO_BINDTODEVICE is Linux-only; tunnel latency probe requires Linux".to_owned(),
         ))

--- a/source/daemon/crates/wardnetd/src/tunnel_throughput_tester.rs
+++ b/source/daemon/crates/wardnetd/src/tunnel_throughput_tester.rs
@@ -1,0 +1,111 @@
+//! Real `ThroughputTester` impl: times a fixed HTTP download to derive
+//! throughput, optionally bound to a tunnel interface.
+//!
+//! Linux uses `SO_BINDTODEVICE` (via `reqwest::ClientBuilder::interface`) to
+//! force the outbound socket onto the tunnel interface for the tunnel leg;
+//! the direct leg builds an unbound client so it egresses the default (WAN)
+//! route. Other platforms return [`ThroughputError::Unsupported`] — the
+//! production daemon only runs on Linux; macOS/Windows builds reach the mock
+//! backend instead.
+
+use std::time::{Duration, Instant};
+
+use async_trait::async_trait;
+
+use wardnetd_services::tunnel::throughput_tester::{
+    ThroughputError, ThroughputMeasurement, ThroughputTester,
+};
+
+/// 30 s download budget — the acceptance target is "completes in under 30 s
+/// on a 100 Mbps tunnel", and a 10 MB payload at 100 Mbps takes under a
+/// second, so this only trips on a stalled or very slow link.
+const DOWNLOAD_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Downloads `download_url` and measures throughput. The URL is fixed at
+/// construction from `tunnel.speed_test_url` (default: Cloudflare's `__down`
+/// endpoint requesting 10 MB).
+pub struct HttpThroughputTester {
+    download_url: String,
+}
+
+impl HttpThroughputTester {
+    #[must_use]
+    pub fn new(download_url: String) -> Self {
+        Self { download_url }
+    }
+}
+
+#[async_trait]
+impl ThroughputTester for HttpThroughputTester {
+    #[cfg(target_os = "linux")]
+    async fn download(
+        &self,
+        interface: Option<&str>,
+    ) -> Result<ThroughputMeasurement, ThroughputError> {
+        let mut builder = reqwest::Client::builder().timeout(DOWNLOAD_TIMEOUT);
+        // `Some` binds the socket to the tunnel (tunnel leg); `None` leaves it
+        // unbound so it egresses the default WAN route (direct baseline).
+        if let Some(iface) = interface {
+            builder = builder.interface(iface);
+        }
+        let client = builder
+            .build()
+            .map_err(|e| ThroughputError::Download(format!("client build failed: {e}")))?;
+
+        let started = Instant::now();
+        let resp = client.get(&self.download_url).send().await.map_err(|e| {
+            if e.is_timeout() {
+                ThroughputError::Timeout(
+                    u64::try_from(DOWNLOAD_TIMEOUT.as_millis()).unwrap_or(u64::MAX),
+                )
+            } else {
+                ThroughputError::Download(e.to_string())
+            }
+        })?;
+
+        if !resp.status().is_success() {
+            return Err(ThroughputError::Download(format!(
+                "download returned HTTP {}",
+                resp.status()
+            )));
+        }
+
+        let body = resp.bytes().await.map_err(|e| {
+            if e.is_timeout() {
+                ThroughputError::Timeout(
+                    u64::try_from(DOWNLOAD_TIMEOUT.as_millis()).unwrap_or(u64::MAX),
+                )
+            } else {
+                ThroughputError::Download(format!("read body failed: {e}"))
+            }
+        })?;
+
+        let elapsed = started.elapsed().as_secs_f64();
+        let bytes = body.len();
+        if bytes == 0 {
+            return Err(ThroughputError::Download(
+                "download returned an empty body".to_owned(),
+            ));
+        }
+        if elapsed <= 0.0 {
+            return Err(ThroughputError::Download(
+                "download completed in zero time".to_owned(),
+            ));
+        }
+
+        // Megabits per second: bytes → bits (×8) → megabits (÷1e6) ÷ seconds.
+        #[allow(clippy::cast_precision_loss)]
+        let mbps = (bytes as f64 * 8.0) / 1_000_000.0 / elapsed;
+        Ok(ThroughputMeasurement { mbps })
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    async fn download(
+        &self,
+        _interface: Option<&str>,
+    ) -> Result<ThroughputMeasurement, ThroughputError> {
+        Err(ThroughputError::Unsupported(
+            "SO_BINDTODEVICE is Linux-only; speed test requires Linux".to_owned(),
+        ))
+    }
+}

--- a/source/sdk/wardnet-js/src/index.ts
+++ b/source/sdk/wardnet-js/src/index.ts
@@ -126,6 +126,8 @@ export type {
   TunnelDevicesResponse,
   TunnelTestResult,
   TunnelTestResponse,
+  TunnelSpeedTestResult,
+  TunnelSpeedTestHistoryResponse,
   ListProvidersResponse,
   ValidateCredentialsRequest,
   ValidateCredentialsResponse,

--- a/source/sdk/wardnet-js/src/services/tunnels.ts
+++ b/source/sdk/wardnet-js/src/services/tunnels.ts
@@ -7,10 +7,12 @@ import type {
   RebuildTunnelResponse,
   TunnelDetailResponse,
   TunnelDevicesResponse,
+  TunnelSpeedTestHistoryResponse,
   TunnelTestResponse,
   UpdateTunnelDnsOverrideRequest,
   UpdateTunnelDnsOverrideResponse,
 } from "../types/api.js";
+import type { JobDispatchedResponse } from "../types/jobs.js";
 
 /** Tunnel management service for the Wardnet daemon. */
 export class TunnelService {
@@ -83,5 +85,26 @@ export class TunnelService {
     return this.client.request<RebuildTunnelResponse>(`/tunnels/${id}/rebuild`, {
       method: "POST",
     });
+  }
+
+  /**
+   * Start a speed test for a tunnel (admin only). Returns a job id (202);
+   * poll `jobs.get(job_id)` for progress. The background job measures
+   * throughput, latency and jitter twice — once over the direct (WAN) path
+   * and once through the tunnel — so the result shows how much of the line
+   * the VPN preserves. A concurrent run on the same tunnel returns 409.
+   */
+  async startSpeedTest(id: string): Promise<JobDispatchedResponse> {
+    return this.client.request<JobDispatchedResponse>(`/tunnels/${id}/speed-test`, {
+      method: "POST",
+    });
+  }
+
+  /**
+   * List recent speed test results for a tunnel, newest first (admin only).
+   * Each result carries both the direct (WAN) and tunnel measurements.
+   */
+  async getSpeedTestResults(id: string): Promise<TunnelSpeedTestHistoryResponse> {
+    return this.client.request<TunnelSpeedTestHistoryResponse>(`/tunnels/${id}/speed-test/results`);
   }
 }

--- a/source/sdk/wardnet-js/src/types/api.ts
+++ b/source/sdk/wardnet-js/src/types/api.ts
@@ -119,6 +119,35 @@ export interface TunnelTestResponse {
   result: TunnelTestResult;
 }
 
+/**
+ * One completed speed test: the direct (WAN) baseline and the tunnel result,
+ * measured back-to-back so retention (how much of the line the VPN keeps) is
+ * an apples-to-apples comparison.
+ */
+export interface TunnelSpeedTestResult {
+  id: string;
+  tunnel_id: string;
+  /** Download throughput over the direct (unbound/WAN) path, megabits/s. */
+  direct_throughput_mbps: number;
+  /** Download throughput through the tunnel interface, megabits/s. */
+  tunnel_throughput_mbps: number;
+  /** Median round-trip latency over the direct path, milliseconds. */
+  direct_latency_ms: number;
+  /** Median round-trip latency through the tunnel, milliseconds. */
+  tunnel_latency_ms: number;
+  /** Latency jitter (sample stddev) over the direct path, milliseconds. */
+  direct_jitter_ms: number;
+  /** Latency jitter (sample stddev) through the tunnel, milliseconds. */
+  tunnel_jitter_ms: number;
+  /** ISO 8601 timestamp of when the test completed. */
+  tested_at: string;
+}
+
+/** Response for GET /api/tunnels/:id/speed-test/results — newest first. */
+export interface TunnelSpeedTestHistoryResponse {
+  results: TunnelSpeedTestResult[];
+}
+
 /** Request body for PUT /api/tunnels/:id/dns-override. */
 export interface UpdateTunnelDnsOverrideRequest {
   /**

--- a/source/sdk/wardnet-js/src/types/jobs.ts
+++ b/source/sdk/wardnet-js/src/types/jobs.ts
@@ -1,5 +1,5 @@
 /** Discriminator for what kind of background work a job represents. */
-export type JobKind = "blocklist_refresh";
+export type JobKind = "blocklist_refresh" | "speed_test";
 
 /** Lifecycle state of a background job. */
 export type JobStatus = "PENDING" | "RUNNING" | "SUCCEED" | "TERMINATED_WITH_ERRORS";

--- a/source/web/src/hooks/useTunnels.ts
+++ b/source/web/src/hooks/useTunnels.ts
@@ -1,7 +1,9 @@
+import { useEffect, useState } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
-import type { CreateTunnelRequest } from "@wardnet/js";
-import { tunnelService } from "../lib/sdk";
+import type { CreateTunnelRequest, Job } from "@wardnet/js";
+import { isJobTerminal } from "@wardnet/js";
+import { jobsService, tunnelService } from "../lib/sdk";
 
 export function useTunnels() {
   return useQuery({
@@ -99,4 +101,82 @@ export function useSetTunnelDnsOverride() {
     },
     onError: () => toast.error("Failed to update DNS override"),
   });
+}
+
+/** Recent speed test results for a tunnel (newest first). */
+export function useSpeedTestResults(id: string, enabled = true) {
+  return useQuery({
+    queryKey: ["tunnels", id, "speed-test"],
+    queryFn: () => tunnelService.getSpeedTestResults(id),
+    enabled: !!id && enabled,
+  });
+}
+
+/**
+ * Start a speed test for a tunnel and track the background job to completion.
+ *
+ * The server dispatches a job and returns immediately with its id; this hook
+ * polls the job (exposing `percentage` for an inline progress bar) and, on
+ * success, invalidates the tunnel's speed-test history so the new result
+ * renders. Each card uses its own instance, so one in-flight run is tracked
+ * per card. A 409 (run already in progress) surfaces as a dedicated toast.
+ *
+ * Mirrors the job-polling shape of `useRefreshBlocklist`; kept inline rather
+ * than extracting a shared poller so the existing blocklist hook is untouched.
+ */
+export function useStartSpeedTest() {
+  const qc = useQueryClient();
+  const [active, setActive] = useState<{
+    jobId: string;
+    tunnelId: string;
+  } | null>(null);
+
+  const dispatch = useMutation({
+    mutationFn: async (tunnelId: string) => {
+      const res = await tunnelService.startSpeedTest(tunnelId);
+      return { tunnelId, jobId: res.job_id };
+    },
+    onSuccess: ({ tunnelId, jobId }) => setActive({ jobId, tunnelId }),
+    onError: (error) => {
+      const message =
+        error instanceof Error ? error.message : "Speed test failed";
+      if (/already|conflict/i.test(message)) {
+        toast.error("Speed test already in progress");
+      } else {
+        toast.error(message);
+      }
+    },
+  });
+
+  const jobQuery = useQuery<Job>({
+    queryKey: ["job", active?.jobId],
+    queryFn: () => jobsService.get(active!.jobId),
+    enabled: !!active,
+    refetchInterval: (q) => {
+      const s = q.state.data?.status;
+      return s && isJobTerminal(s) ? false : 1000;
+    },
+  });
+
+  useEffect(() => {
+    const job = jobQuery.data;
+    if (!job || !active) return;
+    if (job.status === "SUCCEED") {
+      qc.invalidateQueries({
+        queryKey: ["tunnels", active.tunnelId, "speed-test"],
+      });
+      // eslint-disable-next-line react-hooks/set-state-in-effect
+      setActive(null);
+    } else if (job.status === "TERMINATED_WITH_ERRORS") {
+      toast.error(job.error || "Speed test failed");
+      setActive(null);
+    }
+  }, [jobQuery.data, active, qc]);
+
+  return {
+    start: dispatch.mutate,
+    activeTunnelId: active?.tunnelId ?? null,
+    percentage: jobQuery.data?.percentage_done ?? 0,
+    isRunning: dispatch.isPending || !!active,
+  };
 }

--- a/source/web/src/index.ts
+++ b/source/web/src/index.ts
@@ -30,6 +30,9 @@ export {
 export {
   cn,
   formatBytes,
+  formatMbps,
+  formatMs,
+  retentionPct,
   formatUptime,
   formatDate,
   formatTime,
@@ -101,6 +104,8 @@ export {
   useTestTunnel,
   useRebuildTunnel,
   useSetTunnelDnsOverride,
+  useSpeedTestResults,
+  useStartSpeedTest,
 } from "./hooks/useTunnels";
 
 // Hooks — providers

--- a/source/web/src/lib/utils.ts
+++ b/source/web/src/lib/utils.ts
@@ -22,6 +22,25 @@ export function formatBytes(bytes: number): string {
   return `${value.toFixed(i === 0 ? 0 : 1)} ${units[i]}`;
 }
 
+/** Format a throughput value in megabits/s (e.g. "85.0 Mbps"). */
+export function formatMbps(mbps: number): string {
+  return `${mbps.toFixed(1)} Mbps`;
+}
+
+/** Format a latency/jitter value in milliseconds, rounded (e.g. "23 ms"). */
+export function formatMs(ms: number): string {
+  return `${Math.round(ms)} ms`;
+}
+
+/**
+ * Percentage of the direct (WAN) line a tunnel retains — the speed-test
+ * headline. `direct` of 0 yields 0 to avoid divide-by-zero.
+ */
+export function retentionPct(direct: number, tunnel: number): number {
+  if (direct <= 0) return 0;
+  return Math.round((tunnel / direct) * 100);
+}
+
 /** Format seconds into a human-readable uptime string (e.g. "2d 5h 30m"). */
 export function formatUptime(seconds: number): string {
   const d = Math.floor(seconds / 86400);


### PR DESCRIPTION
Closes #239

## What

Built-in **speed test** that measures real throughput through each configured VPN exit, surfaced on the tunnel card. Every run measures **both** the **direct** (WAN, unbound) connection **and** the **tunnel** connection back-to-back and stores both in a single result row, so the UI shows **retention** — how much of the line the VPN keeps — instead of an isolated tunnel number that an admin can't interpret on its own.

## Why the scope grew beyond the issue

A raw tunnel figure ("85 Mbps") can't tell you whether your *provider* is bad or your *home line* is just slow. The only honest signal of VPN quality is the comparison against a contemporaneous direct baseline (measured seconds apart, same conditions). So each run does direct → tunnel **sequentially** (both traverse the same physical uplink; parallel would split the pipe) and the UI annotates the delta (e.g. `92% kept`, `+12 ms`).

## Changes

**Daemon**
- `JobKind::SpeedTest`; `speed_test` result types; `TunnelConfig` gains `speed_test_url` (default Cloudflare `__down?bytes=10000000`) and `speed_test_latency_samples` (default 5).
- New `tunnel_speed_test_results` table (both legs in one row; separate table avoids nullable columns on the hot `tunnels` row) + repository.
- `ThroughputTester` trait; `TunnelService::start_speed_test` (202 + `job_id`, background job via the existing `JobService`, `InFlightGuard` held for the full job → **409 on concurrent runs**, brings a `Down` tunnel up/runs/tears it back down) and `list_speed_tests`.
- `TunnelLatencyProber` gains an unbound (direct/WAN) probe path.
- Real `HttpThroughputTester` (reqwest `SO_BINDTODEVICE`) + mock `NoopThroughputTester`.
- `POST /api/tunnels/{id}/speed-test`, `GET .../speed-test/results`; `docs/openapi.json` regenerated.

**SDK + Web UI**
- `startSpeedTest` / `getSpeedTestResults` + speed-test types.
- admin-site `TunnelCard` (button + inline progress + direct/tunnel grid) and `TunnelDetail` history table; admin-app compact result with tap-to-expand last-5.
- Shared retention/throughput formatters consolidated into `@wardnet/web` (design system untouched).

## Failure semantics

Both legs are required — if either the direct or tunnel leg fails, the **job fails** with a descriptive error (a half-comparison is meaningless).

## Tests

- New service tests (`tunnel/tests/speed_test.rs`): happy path persists both legs, 409 on concurrent run, Down-tunnel up/run/down lifecycle, leg-failure fails the job.
- Full workspace green in the Linux container: `cargo fmt --check && cargo clippy --all-targets -D warnings && cargo test --workspace`. `make check-web` / `make check-sdk` green.

## Out of scope

End-to-end Playwright coverage is tracked in **#691** — the e2e harness has no live tunnel and no guaranteed internet egress, so it needs a deterministic stub seam in the real daemon (its own infra change).

## Merge Commit Message

```
feat(tunnel): per-tunnel speed test with direct-vs-tunnel comparison (#239)

Measures throughput/latency/jitter through each VPN exit and over the direct
WAN path back-to-back, surfacing retention on the tunnel card and a history
table in tunnel detail. Adds the SpeedTest job, ThroughputTester backend,
tunnel_speed_test_results table, API endpoints, SDK methods, and UI.

Closes #239.
```

https://claude.ai/code/session_01U242u5FMU51XsKufvMh2EN