### PR TITLE
ci(site): add manual workflow_dispatch deploy for marketing site

### DIFF
--- a/.github/workflows/deploy-site-manual.yml
+++ b/.github/workflows/deploy-site-manual.yml
@@ -1,0 +1,57 @@
+name: Deploy Site (manual)
+
+# Manual GitHub Pages deploy for the marketing site.
+#
+# The normal deploy path is release.yml on a tag push — marketing
+# content ships in lockstep with daemon releases. This workflow exists
+# for the off-cycle case: shipping a marketing-content change to Pages
+# without cutting a release.
+#
+# It composes the same reusable leaves as the release path:
+#   build-site   — lint + release build + `site-dist` artifact
+#   deploy-site  — wrap `site-dist` into a pages-artifact and publish
+#
+# Note: unlike release.yml this does NOT run the release-manifest
+# refresh. The bundle's /releases/{stable,beta}.json are whatever
+# `make build-site` generated from the GitHub Releases API at build
+# time — correct for a content-only deploy, since no new release is
+# being cut here.
+#
+# Run it with: `gh workflow run deploy-site-manual.yml` (or the
+# "Run workflow" button on the Actions tab).
+
+on:
+  workflow_dispatch:
+
+# Workflow-level permissions stay read-only. Each leaf elevates to the
+# writes it actually needs via its own `permissions:` block — Scorecard's
+# Token-Permissions check rewards this scoping.
+permissions:
+  contents: read
+
+# No top-level `concurrency` here: the deploy-site.yml leaf already
+# pins the shared `pages` group, so a manual run and a release deploy
+# still serialize at the publish step. Mirroring release.yml, which
+# also leaves the caller-level concurrency unset.
+
+jobs:
+  build-site:
+    name: Build Site
+    # Read @wardnet/{brand,styles} from GitHub Packages during yarn install.
+    permissions:
+      contents: read
+      packages: read
+    uses: ./.github/workflows/build-site.yml
+    secrets: inherit
+
+  deploy-site:
+    name: Deploy Site
+    needs: build-site
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+    uses: ./.github/workflows/deploy-site.yml
+    with:
+      bundle-artifact: site-dist
+    secrets: inherit

--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -6,8 +6,9 @@ name: Deploy Site
 # publishes it. No build step here — deploy-site.yml is strictly about
 # shipping, so `bundle-artifact` is a required input.
 #
-# Callers: ci.yml (on push to main, when site changed), release.yml
-# (on every tag). Manual redeploy: `gh workflow run ci.yml`.
+# Callers: release.yml (on every tag) and deploy-site-manual.yml
+# (off-cycle, on demand). Manual redeploy:
+# `gh workflow run deploy-site-manual.yml`.
 
 on:
   workflow_call:


### PR DESCRIPTION
## Summary

The marketing site only ships to GitHub Pages via `release.yml` on a tag push, so there's no way to deploy a content-only change off-cycle. (The `deploy-site.yml` header even claimed you could redeploy with `gh workflow run ci.yml`, but `ci.yml` has no deploy job — that comment was stale.)

This PR adds **`deploy-site-manual.yml`**, a `workflow_dispatch` orchestrator you can trigger on demand from the Actions tab or with `gh workflow run deploy-site-manual.yml`.

## How it works

- Composes the same two reusable leaves the release path uses: `build-site.yml` → `deploy-site.yml`.
- Pages publishing stays serialized via `deploy-site.yml`'s own `pages` concurrency group, so a manual run can't collide with a release deploy.
- **No manifest refresh** (unlike `release.yml`): no release is being cut, so the bundle ships whatever `make build-site` generated from the Releases API at build time — correct for a content-only deploy.

Also updates the now-accurate `deploy-site.yml` header comment to point at the new workflow.

## Testing

- `actionlint` passes on the new workflow.
- Composition mirrors `release.yml`'s proven `build-site` → `deploy-site` wiring (permissions, `secrets: inherit`, `bundle-artifact: site-dist`).

## Merge Commit Message

ci(site): add manual workflow_dispatch deploy for marketing site

https://claude.ai/code/session_01FzyhnuFtcfcEVhTzqfEykn