### PR TITLE
test(e2e): user-app LAN runner + PWA shell & identity specs (#626)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -503,13 +503,16 @@ e2e-ui: build-web
 	        $(CONTAINER_RT) inspect "$$cid" >> '"$$REPORTS"'/inspect.json 2>&1 || true; \
 	      done; \
 	      $(CONTAINER_RT) compose -f $(E2E_UI_COMPOSE) down -v --remove-orphans' EXIT; \
-	$(CONTAINER_RT) compose -f $(E2E_UI_COMPOSE) up -d --build --wait wardnetd-ui wardnetd-ui-fresh tls_proxy blocklist_server; \
+	$(CONTAINER_RT) compose -f $(E2E_UI_COMPOSE) up -d --build --wait wardnetd-ui wardnetd-ui-fresh tls_proxy tls_proxy_lan blocklist_server; \
 	$(CONTAINER_RT) compose -f $(E2E_UI_COMPOSE) up -d --build --wait test_debian || \
 	    echo "warning: test_debian (LAN client) not healthy; running playwright anyway so failures surface as assertions"; \
 	echo "::group::compose ps before playwright"; \
 	$(CONTAINER_RT) compose -f $(E2E_UI_COMPOSE) ps -a; \
 	echo "::endgroup::"; \
-	$(CONTAINER_RT) compose -f $(E2E_UI_COMPOSE) run --rm ui_runner
+	rc=0; \
+	$(CONTAINER_RT) compose -f $(E2E_UI_COMPOSE) run --rm ui_runner || rc=$$?; \
+	$(CONTAINER_RT) compose -f $(E2E_UI_COMPOSE) run --rm ui_runner_lan || rc=$$?; \
+	exit $$rc
 
 # Run both end-to-end suites: daemon (Vitest API/kernel) then web-ui
 # (Playwright). Sequential so the two stacks never share host bridges.

--- a/source/end2end-tests/web-ui/Caddyfile.lan
+++ b/source/end2end-tests/web-ui/Caddyfile.lan
@@ -1,0 +1,34 @@
+# LAN-side TLS-terminating reverse proxy for the user-app e2e runner.
+#
+# The user-app (`/`) is device-keyed: the daemon classifies
+# `GET /api/devices/me` by the request's *source IP*
+# (`wardnetd-api/.../middleware.rs::resolve_auth_context` — raw TCP peer
+# via `ConnectInfo`, no `X-Forwarded-For` trust). A caller is a "device"
+# only if its source IP matches a discovered LAN device.
+#
+# But the PWA-shell specs need a *secure context* (service workers only
+# register over HTTPS), which forces a TLS proxy — and an L7 proxy
+# re-originates the TCP connection, so the daemon sees the PROXY's IP,
+# not the browser-runner's. We turn that into a feature: this proxy lives
+# only on `wardnet_lan` with a fixed IP, the upstream is the daemon's
+# pinned LAN IP `10.91.0.1` (an explicit IP — not the service name —
+# forces the proxy→daemon hop over `wardnet_lan` so the daemon observes
+# this proxy's LAN source IP), and the harness seeds THIS proxy's IP as a
+# discovered device. The user-app project then sees a real HTTPS origin
+# AND a non-null `devices/me`. (The non-LAN/null case is exercised by
+# navigating the same runner to the mgmt proxy `wardnetd-ui-tls`.)
+#
+# Self-signed (`tls internal`); Playwright trusts it via
+# `ignoreHTTPSErrors` + `--ignore-certificate-errors`.
+{
+	admin off
+	auto_https disable_redirects
+	# Self-signed CA generated in-container; never trusted outside the
+	# e2e stack (Playwright uses ignoreHTTPSErrors).
+	local_certs
+}
+
+https://wardnetd-ui-lan-tls {
+	tls internal
+	reverse_proxy 10.91.0.1:7411
+}

--- a/source/end2end-tests/web-ui/README.md
+++ b/source/end2end-tests/web-ui/README.md
@@ -24,10 +24,37 @@ make e2e-ui      # build web → real-asset daemon image → compose → run sui
 make e2e-all     # daemon (Vitest) + web-ui (Playwright)
 ```
 
-The suite runs inside the `ui_runner` container against a dedicated,
-self-seeded `wardnetd-ui` instance (`compose.ui.yaml`) — isolated from
-the API/kernel Vitest suite under `../daemon`. JUnit + an HTML report are
-written to `reports/`.
+The suite runs against a dedicated, self-seeded `wardnetd-ui` instance
+(`compose.ui.yaml`) — isolated from the API/kernel Vitest suite under
+`../daemon` — across **two runner containers**:
+
+- `ui_runner` (wardnet_mgmt) drives the **admin-site** and **admin-app**
+  projects; its report lands in `reports/`.
+- `ui_runner_lan` (wardnet_lan + wardnet_mgmt) drives the device-keyed
+  **user-app** project through the LAN-side TLS proxy; its report lands
+  in `reports/lan/` (`REPORT_SUBDIR=lan`).
+
+`make e2e-ui` runs them sequentially against the one shared daemon and
+fails if either does.
+
+### LAN-side runner + proxy (`ui_runner_lan` / `tls_proxy_lan`, C1 #626)
+
+The user-app (`/`) is **device-keyed**: the daemon resolves
+`GET /api/devices/me` from the request's *source IP*
+(`middleware.rs::resolve_auth_context` — raw TCP peer, no
+`X-Forwarded-For` trust). But service workers only register over HTTPS,
+and an L7 TLS proxy re-originates the connection, so the daemon would see
+the proxy's IP, not the browser-runner's.
+
+We turn that into the mechanism: `tls_proxy_lan` lives only on
+`wardnet_lan` at a fixed IP (`10.91.0.20`) and forwards to the daemon's
+LAN IP, so every user-app request reaches the daemon from that one IP.
+The `seed-lan-device` setup project warms the proxy (a throwaway request
+forces a proxy→daemon hop that packet-capture discovery observes) and
+polls until `10.91.0.20` is a discovered device. The user-app then sees a
+real HTTPS origin **and** a non-null `devices/me`. The no-device/null
+case (`identity.spec.ts`) is exercised by navigating the same runner to
+the mgmt proxy origin (`wardnetd-ui-tls`), whose IP is not a device.
 
 ### LAN client (`test_debian`)
 
@@ -88,8 +115,9 @@ REST API (plain `fetch` — see `fixtures/seed.ts` for why not the
 source-only `@wardnet/js` SDK), then writes `.auth/admin.json` carrying
 the `wardnet_session` cookie (built from the login token). The
 `admin-site` and `admin-app` projects reuse it via `storageState`.
-`user-app` is unauthenticated (device-keyed); from the mgmt-side runner
-it shows the no-device state.
+`user-app` is unauthenticated (device-keyed); it runs on the LAN-side
+runner and depends on the `seed-lan-device` project instead (see "LAN-side
+runner + proxy" above).
 
 ## Spec ordering (`stateful/`)
 

--- a/source/end2end-tests/web-ui/compose.ui.yaml
+++ b/source/end2end-tests/web-ui/compose.ui.yaml
@@ -1,12 +1,17 @@
 # Web-UI end-to-end test topology (Playwright).
 #
 # A dedicated, self-seeded daemon (`wardnetd-ui`) built with the real
-# embedded frontends (`WEB_DIST=real`), plus a Playwright runner on
-# wardnet_mgmt that drives the three surfaces over HTTP. Deliberately
-# separate from the API/kernel Vitest stack (../daemon/compose.yaml):
-# different project name + its own daemon + its own seeded state, so the
-# two suites never couple. The LAN-side runner for the device-keyed
-# user-app arrives in C1 (#626).
+# embedded frontends (`WEB_DIST=real`), driven by two Playwright runners:
+#   - `ui_runner` on wardnet_mgmt — the admin-site + admin-app projects.
+#   - `ui_runner_lan` on wardnet_lan + wardnet_mgmt — the device-keyed
+#     user-app project (C1, #626). It reaches the daemon through a
+#     LAN-side TLS proxy (`tls_proxy_lan`) whose own LAN IP is seeded as a
+#     discovered device, so `GET /api/devices/me` (classified by source
+#     IP) resolves non-null; the null case is exercised by navigating to
+#     the mgmt proxy origin.
+# Deliberately separate from the API/kernel Vitest stack
+# (../daemon/compose.yaml): different project name + its own daemon + its
+# own seeded state, so the two suites never couple.
 #
 # Networks mirror the daemon stack; `make` runs the two suites
 # sequentially (each tears its stack down), so the shared subnets don't
@@ -174,6 +179,41 @@ services:
       retries: 30
       start_period: 10s
 
+  # LAN-side TLS proxy for the device-keyed user-app (C1, #626). Lives
+  # ONLY on wardnet_lan with a fixed IP and reverse-proxies to the
+  # daemon's pinned LAN IP (10.91.0.1) — see Caddyfile.lan. The harness
+  # seeds THIS proxy's LAN IP as a discovered device, so the user-app's
+  # `GET /api/devices/me` (classified by source IP, no XFF trust) resolves
+  # non-null while still being served over a real HTTPS origin (required
+  # for service-worker registration). The static IP sits OUTSIDE the
+  # wardnet_lan IPAM ip_range (10.91.0.0/28 → .0-.15) so it never collides
+  # with auto-assigned containers, and inside the /24 so discovery's
+  # subnet filter accepts it.
+  tls_proxy_lan:
+    image: caddy:2.10.0-alpine@sha256:ae4458638da8e1a91aafffb231c5f8778e964bca650c8a8cb23a7e8ac557aa3c
+    depends_on:
+      wardnetd-ui:
+        condition: service_healthy
+    volumes:
+      - ./Caddyfile.lan:/etc/caddy/Caddyfile:ro
+    networks:
+      wardnet_lan:
+        # The browser/seed reach the proxy by this hostname (the Caddyfile
+        # vhost + WARDNET_UI_LAN_BASE_URL); it differs from the service name,
+        # so it must be a network alias or DNS won't resolve it — mirrors
+        # tls_proxy's `wardnetd-ui-tls` alias.
+        aliases:
+          - wardnetd-ui-lan-tls
+        ipv4_address: 10.91.0.20
+    healthcheck:
+      # BusyBox wget in the Caddy Alpine image has no HTTPS support; check
+      # the TLS port is accepting connections instead (mirrors tls_proxy).
+      test: ["CMD-SHELL", "nc -z 127.0.0.1 443 || exit 1"]
+      interval: 5s
+      timeout: 3s
+      retries: 30
+      start_period: 10s
+
   # Real LAN client used by the DHCP-leases spec (A3, #618). Runs the
   # wardnet-test-agent HTTP server on :3001; the spec drives its
   # /dhcp/renew to make `wardnetd-ui`'s DHCP server hand out a lease,
@@ -272,6 +312,19 @@ services:
       WARDNET_API_BASE_URL: "http://wardnetd-ui:7411/api"
       WARDNET_TEST_DEBIAN_AGENT: "http://test_debian:3001"
       WARDNET_BLOCKLIST_FIXTURE_URL: "http://10.90.0.20/hosts.txt"
+    # The mgmt runner drives the admin surfaces only; the device-keyed
+    # user-app moved to `ui_runner_lan` (C1, #626). `--project` is
+    # include-only, so the mgmt projects are listed explicitly (the
+    # `setup` project runs automatically as their dependency).
+    command:
+      - yarn
+      - test
+      - --project
+      - admin-site
+      - --project
+      - admin-site-setup
+      - --project
+      - admin-app
     # Reports bind-mounted (not a named volume) to the same host dir the
     # Makefile trap writes compose-logs.txt / inspect.json into, so the
     # JUnit + HTML report land alongside them in the CI artefact.
@@ -280,8 +333,46 @@ services:
     networks:
       wardnet_mgmt:
         ipv4_address: 10.90.0.10
-      # Attached now (no static IP) to keep the topology stable for the
-      # LAN-side user-app runner added in C1.
+      # Also on wardnet_lan to reach the `test_debian` LAN client agent
+      # (http://test_debian:3001) used by the DHCP-leases spec.
+      wardnet_lan: {}
+
+  # LAN-side runner for the device-keyed user-app (C1, #626). On BOTH
+  # networks: it drives the user-app over the LAN proxy
+  # (`wardnetd-ui-lan-tls`, source IP → seeded device → non-null
+  # `devices/me`) and, for the null/no-device case, navigates to the mgmt
+  # proxy origin (`wardnetd-ui-tls`, source IP not a device). Runs only
+  # the `user-app` project; Playwright auto-runs its `seed-lan-device`
+  # dependency first (warms the LAN proxy so discovery observes
+  # 10.91.0.20, then polls until that device exists). Writes its report
+  # under reports/lan so it doesn't clobber the mgmt runner's report.
+  ui_runner_lan:
+    build:
+      context: ../../..
+      dockerfile: source/end2end-tests/web-ui/Dockerfile.ui-runner
+    image: wardnet-e2e-ui-runner:dev
+    depends_on:
+      wardnetd-ui:
+        condition: service_healthy
+      tls_proxy:
+        condition: service_healthy
+      tls_proxy_lan:
+        condition: service_healthy
+    environment:
+      WARDNET_UI_LAN_BASE_URL: "https://wardnetd-ui-lan-tls"
+      WARDNET_UI_BASE_URL: "https://wardnetd-ui-tls"
+      WARDNET_API_BASE_URL: "http://wardnetd-ui:7411/api"
+      # Keep this runner's JUnit + HTML report out of the mgmt runner's.
+      REPORT_SUBDIR: "lan"
+    command:
+      - yarn
+      - test
+      - --project
+      - user-app
+    volumes:
+      - ./reports:/work/source/end2end-tests/web-ui/reports
+    networks:
+      wardnet_mgmt: {}
       wardnet_lan: {}
 
 volumes:

--- a/source/end2end-tests/web-ui/fixtures/lan-device.setup.ts
+++ b/source/end2end-tests/web-ui/fixtures/lan-device.setup.ts
@@ -1,0 +1,85 @@
+import { request, test as setup } from "@playwright/test";
+
+import {
+  API_BASE_URL,
+  LAN_PROXY_IP,
+  UI_LAN_BASE_URL,
+  api,
+  ensureAdminSetup,
+  waitForReady,
+} from "./seed.js";
+
+/**
+ * LAN-device bootstrap for the user-app project (C1, #626) — runs before
+ * the user-app specs via Playwright `dependencies`.
+ *
+ * The user-app is device-keyed: the daemon classifies `GET /api/devices/me`
+ * by the request's source IP (`middleware.rs::resolve_auth_context` — raw
+ * TCP peer, no `X-Forwarded-For` trust). Requests reach the daemon through
+ * the LAN-side TLS proxy (`tls_proxy_lan`), so the daemon sees the proxy's
+ * fixed LAN IP (`LAN_PROXY_IP`). For `devices/me` to resolve non-null, that
+ * IP must be a *discovered* device.
+ *
+ * There is no create-device API — the daemon only materializes a device row
+ * when packet-capture discovery observes LAN traffic for a MAC in-subnet
+ * (`device/discovery.rs`). So instead of spoofing an ARP frame at the
+ * proxy's IP (which it actively uses — that would risk ARP conflicts), we
+ * make the proxy itself talk to the daemon: a throwaway `GET /api/info`
+ * through the LAN proxy forces a proxy→daemon connection over wardnet_lan,
+ * which discovery observes (the proxy's real MAC at `LAN_PROXY_IP`). We
+ * re-poke and poll `/api/devices` until that device appears.
+ *
+ * The proxy request uses a Playwright request context with
+ * `ignoreHTTPSErrors` so the self-signed `tls_proxy_lan` cert is trusted
+ * (Node's bare `fetch`, used elsewhere here against plain HTTP, can't).
+ */
+
+interface SeededDevice {
+  id: string;
+  mac: string;
+  last_ip: string;
+}
+
+interface ListDevicesResponse {
+  devices: SeededDevice[];
+}
+
+setup("seed LAN-proxy device", async () => {
+  await waitForReady();
+  const token = await ensureAdminSetup();
+
+  // Trust the self-signed LAN proxy so the warm-up request goes through.
+  const proxy = await request.newContext({ ignoreHTTPSErrors: true });
+  try {
+    const found = async (): Promise<SeededDevice | undefined> => {
+      const { devices } = await api<ListDevicesResponse>("/devices", { token });
+      return devices.find((d) => d.last_ip === LAN_PROXY_IP);
+    };
+
+    const existing = await found();
+    if (existing) return;
+
+    const timeoutMs = 60_000;
+    const deadline = Date.now() + timeoutMs;
+    let lastErr: unknown;
+    while (Date.now() < deadline) {
+      try {
+        // Forces tls_proxy_lan → daemon traffic over wardnet_lan, which
+        // packet-capture discovery observes. The response itself is
+        // irrelevant; we only need the connection to happen.
+        await proxy.get(`${UI_LAN_BASE_URL}/api/info`);
+        if (await found()) return;
+      } catch (err) {
+        lastErr = err;
+      }
+      await new Promise((resolve) => setTimeout(resolve, 3_000));
+    }
+    throw new Error(
+      `LAN proxy device ${LAN_PROXY_IP} was not discovered within ${timeoutMs}ms ` +
+        `(${API_BASE_URL}) — packet capture may not be reaching wardnet_lan in ` +
+        `this environment${lastErr ? `: ${String(lastErr)}` : ""}`,
+    );
+  } finally {
+    await proxy.dispose();
+  }
+});

--- a/source/end2end-tests/web-ui/fixtures/seed.ts
+++ b/source/end2end-tests/web-ui/fixtures/seed.ts
@@ -36,6 +36,24 @@ export const UI_FRESH_BASE_URL =
   process.env.WARDNET_UI_FRESH_BASE_URL ?? "https://wardnetd-ui-fresh-tls";
 
 /**
+ * Browser base URL of the LAN-side TLS proxy (`tls_proxy_lan`) used by the
+ * device-keyed user-app (C1, #626). The proxy lives on wardnet_lan and
+ * forwards to the daemon's LAN IP, so the daemon classifies requests from
+ * this origin as coming from `LAN_PROXY_IP` — seeded as a discovered
+ * device so `GET /api/devices/me` resolves non-null.
+ */
+export const UI_LAN_BASE_URL =
+  process.env.WARDNET_UI_LAN_BASE_URL ?? "https://wardnetd-ui-lan-tls";
+
+/**
+ * The LAN-side proxy's fixed wardnet_lan IP (compose `tls_proxy_lan`).
+ * This is the source IP the daemon sees for user-app requests over the
+ * LAN proxy, and the IP the harness seeds as a discovered device. Outside
+ * the wardnet_lan IPAM `ip_range` (10.91.0.0/28) and inside the /24.
+ */
+export const LAN_PROXY_IP = "10.91.0.20";
+
+/**
  * API base for Node-side seeding (global.setup). Hits the daemon's
  * plain-HTTP port DIRECTLY (not through the proxy): seeding reads the
  * login token from the response body, never relies on the cookie, and

--- a/source/end2end-tests/web-ui/playwright.config.ts
+++ b/source/end2end-tests/web-ui/playwright.config.ts
@@ -4,7 +4,15 @@ import {
   STORAGE_STATE,
   UI_BASE_URL,
   UI_FRESH_BASE_URL,
+  UI_LAN_BASE_URL,
 } from "./fixtures/seed.js";
+
+// Two runners share one bind-mounted `reports/` dir; the LAN runner sets
+// REPORT_SUBDIR=lan so its JUnit/HTML report lands in `reports/lan/` and
+// doesn't clobber the mgmt runner's.
+const REPORT_DIR = process.env.REPORT_SUBDIR
+  ? `reports/${process.env.REPORT_SUBDIR}`
+  : "reports";
 
 /**
  * Playwright harness for Wardnet's three web surfaces, each embedded in
@@ -58,10 +66,10 @@ export default defineConfig({
   expect: { timeout: 15_000 },
   reporter: [
     ["list"],
-    ["junit", { outputFile: "reports/junit.xml" }],
+    ["junit", { outputFile: `${REPORT_DIR}/junit.xml` }],
     // `open:'never'` — the HTML reporter otherwise spawns a server and
     // hangs the container/CI run on completion.
-    ["html", { outputFolder: "reports/html", open: "never" }],
+    ["html", { outputFolder: `${REPORT_DIR}/html`, open: "never" }],
   ],
   use: {
     // Trust the proxy's self-signed cert.
@@ -73,6 +81,9 @@ export default defineConfig({
     // Runs first: seeds the admin via the SDK and writes the admin
     // session into STORAGE_STATE for the authed surfaces to reuse.
     { name: "setup", testMatch: "fixtures/global.setup.ts" },
+    // Discovers the LAN proxy's IP as a device so the user-app's
+    // source-IP-classified `devices/me` resolves non-null (C1, #626).
+    { name: "seed-lan-device", testMatch: "fixtures/lan-device.setup.ts" },
     {
       name: "admin-site",
       testMatch: "tests/admin-site/**/*.spec.ts",
@@ -111,16 +122,19 @@ export default defineConfig({
       },
     },
     {
-      // Device-keyed, no login. From the mgmt-side runner the source IP
-      // is not a discovered LAN device, so the app renders its
-      // no-device state. Real device flows arrive with the LAN-side
-      // runner in C1 (#626).
+      // Device-keyed, no login (C1, #626). Driven by `ui_runner_lan`
+      // through the LAN-side TLS proxy, whose IP `seed-lan-device` seeds
+      // as a discovered device — so `devices/me` (classified by source
+      // IP) resolves non-null and the app renders the device. The
+      // null/no-device case is exercised within identity.spec by
+      // navigating to the mgmt proxy origin (UI_BASE_URL), whose IP is
+      // not a device.
       name: "user-app",
       testMatch: "tests/user-app/**/*.spec.ts",
-      dependencies: ["setup"],
+      dependencies: ["seed-lan-device"],
       use: {
         ...devices["Pixel 7"],
-        baseURL: `${UI_BASE_URL}/`,
+        baseURL: `${UI_LAN_BASE_URL}/`,
         launchOptions: { args: CHROMIUM_ARGS },
       },
     },

--- a/source/end2end-tests/web-ui/tests/user-app/identity.spec.ts
+++ b/source/end2end-tests/web-ui/tests/user-app/identity.spec.ts
@@ -1,0 +1,50 @@
+import { expect, test } from "@playwright/test";
+
+import { UI_BASE_URL } from "../../fixtures/seed.js";
+
+/**
+ * user-app device identity (epic #614 → C1, #626).
+ *
+ * The user-app is device-keyed: the daemon resolves `GET /api/devices/me`
+ * from the request's source IP (`middleware.rs::resolve_auth_context`).
+ * This spec asserts both ends of that contract from one runner:
+ *
+ *  - From the LAN context (the project's baseURL = the `tls_proxy_lan`
+ *    origin, whose IP `seed-lan-device` seeded as a discovered device), the
+ *    app resolves a non-null device and renders its identity.
+ *  - From a non-LAN context (the mgmt proxy origin, whose IP is not a
+ *    device), the app shows the null-device fallback.
+ *
+ * Selectors follow the suite's `data-testid` convention (README →
+ * "Selector convention"): testids locate, human-facing text is additionally
+ * asserted where meaningful.
+ */
+
+test("renders the resolved device from the LAN context", async ({ page }) => {
+  await page.goto("./");
+
+  // Non-null device → the identity header renders with a level-1 heading
+  // (the device's display name; its exact value depends on what discovery
+  // recorded for the proxy, so we assert structure, not a literal name).
+  const identity = page.getByTestId("device-identity");
+  await expect(identity).toBeVisible();
+  await expect(identity.getByRole("heading", { level: 1 })).toBeVisible();
+
+  // The no-device fallback must NOT be shown.
+  await expect(page.getByTestId("no-device")).toHaveCount(0);
+});
+
+test("shows the no-device fallback from a non-LAN context", async ({ page }) => {
+  // Navigate to the mgmt proxy origin: the daemon sees that proxy's IP,
+  // which is not a discovered device, so `devices/me` returns null.
+  await page.goto(`${UI_BASE_URL}/`);
+
+  const fallback = page.getByTestId("no-device");
+  await expect(fallback).toBeVisible();
+  await expect(
+    page.getByRole("heading", { level: 1, name: "Device not detected" }),
+  ).toBeVisible();
+
+  // The resolved-device header must NOT be shown.
+  await expect(page.getByTestId("device-identity")).toHaveCount(0);
+});

--- a/source/end2end-tests/web-ui/tests/user-app/pwa-shell.spec.ts
+++ b/source/end2end-tests/web-ui/tests/user-app/pwa-shell.spec.ts
@@ -1,0 +1,85 @@
+import { expect, test } from "@playwright/test";
+
+/**
+ * user-app PWA shell coverage (epic #614 → C1, #626): the web-app manifest
+ * + installability criteria and the service-worker offline shell, for the
+ * device-keyed user PWA served at the root scope (`/`).
+ *
+ * Runs in the `user-app` project — Pixel 7 viewport, driven by the LAN-side
+ * runner over the `tls_proxy_lan` HTTPS origin (a secure context is required
+ * for service workers to register; see playwright.config.ts / Caddyfile.lan).
+ * Mirrors `admin-app/pwa-shell.spec.ts`, minus the tab-bar/login coverage
+ * (the user-app has no login and its nav is out of scope for #626).
+ */
+
+test.describe("manifest + installability", () => {
+  test("serves a manifest and meets the installable criteria", async ({
+    page,
+  }) => {
+    await page.goto("./");
+
+    // The document advertises a manifest; resolve its href against the page
+    // URL and fetch it through the browser context so the self-signed TLS
+    // proxy is honoured.
+    const href = await page
+      .locator('link[rel="manifest"]')
+      .getAttribute("href");
+    expect(href, "a <link rel=manifest> is present").toBeTruthy();
+    const manifestUrl = new URL(href!, page.url()).toString();
+
+    const res = await page.request.get(manifestUrl);
+    expect(res.ok(), `manifest fetch ${manifestUrl} → ${res.status()}`).toBe(
+      true,
+    );
+    const manifest = await res.json();
+
+    // Core installability fields: a name, the root-scoped start URL + scope
+    // (the user-app owns the whole origin, so both are exactly "/"),
+    // standalone display, and the 192/512 icons Chrome requires to offer
+    // installation.
+    expect(manifest.name).toBeTruthy();
+    expect(manifest.start_url).toBe("/");
+    expect(manifest.scope).toBe("/");
+    expect(manifest.display).toBe("standalone");
+    const iconSizes: string[] = (manifest.icons ?? []).map(
+      (icon: { sizes: string }) => icon.sizes,
+    );
+    expect(iconSizes).toContain("192x192");
+    expect(iconSizes).toContain("512x512");
+
+    // The remaining install-gate components: a registered service worker on
+    // a secure origin. (headless Chromium does not reliably fire
+    // `beforeinstallprompt`, so we verify the criteria that produce it.)
+    await page.evaluate(() => navigator.serviceWorker.ready.then(() => {}));
+    expect(new URL(page.url()).protocol).toBe("https:");
+  });
+});
+
+test("service worker serves the cached app shell offline", async ({
+  page,
+  context,
+}) => {
+  await page.goto("./");
+
+  // Wait for the SW to install/activate, then reload so it controls the
+  // page (sw.ts does not call clients.claim(), so the first load is
+  // uncontrolled).
+  await page.evaluate(() => navigator.serviceWorker.ready.then(() => {}));
+  await page.reload();
+  await page.waitForFunction(() => Boolean(navigator.serviceWorker.controller));
+
+  // Cut the network and reload. The SW's NavigationRoute must answer the
+  // navigation from the precache; otherwise the reload would surface a
+  // browser network-error page.
+  await context.setOffline(true);
+  try {
+    await page.reload();
+
+    // The title and #root both live in the cached static index.html, so
+    // their presence proves the shell was served from the SW cache offline.
+    await expect(page).toHaveTitle(/Wardnet/i);
+    await expect(page.locator("#root")).toBeAttached();
+  } finally {
+    await context.setOffline(false);
+  }
+});

--- a/source/end2end-tests/web-ui/tests/user-app/smoke.spec.ts
+++ b/source/end2end-tests/web-ui/tests/user-app/smoke.spec.ts
@@ -1,12 +1,11 @@
 import { expect, test } from "@playwright/test";
 
 /**
- * Scaffold smoke: the user-app PWA shell loads without throwing. Driven
- * from the mgmt-side runner, whose source IP is not a discovered LAN
- * device, so the daemon's `/api/devices/me` returns `{device:null}` and
- * the app shows its no-device state — we only assert the shell mounts.
- * Real device-keyed flows (and the LAN-side runner) arrive in C1/C2
- * (#626/#627).
+ * Smoke canary: the user-app PWA shell loads without throwing. Driven from
+ * the LAN-side runner over the `tls_proxy_lan` origin (C1, #626), so the
+ * daemon resolves a device — but this spec only asserts the shell mounts.
+ * Manifest/offline and device-identity coverage live in `pwa-shell.spec.ts`
+ * and `identity.spec.ts`.
  */
 test("user-app shell renders", async ({ page }) => {
   const pageErrors: string[] = [];

--- a/source/sdk/wardnet-js/package.json
+++ b/source/sdk/wardnet-js/package.json
@@ -20,7 +20,7 @@
     "format:check": "prettier --check src/"
   },
   "devDependencies": {
-    "prettier": "3.8.4",
+    "prettier": "3.8.5",
     "typescript": "6.0.3"
   },
   "packageManager": "yarn@4.17.0",

--- a/source/user-app/src/pages/Home.tsx
+++ b/source/user-app/src/pages/Home.tsx
@@ -308,7 +308,10 @@ export default function Home() {
 
   if (!device) {
     return (
-      <div className="flex flex-col items-center gap-4 px-5 py-16 text-center">
+      <div
+        data-testid="no-device"
+        className="flex flex-col items-center gap-4 px-5 py-16 text-center"
+      >
         <WifiOffIcon className="size-12 text-ink-3/50" />
         <Text as="h1" size="lg" weight="semibold" className="text-ink">
           Device not detected
@@ -324,7 +327,7 @@ export default function Home() {
 
   return (
     <div className="flex flex-col gap-6 p-5">
-      <div className="flex items-center gap-3">
+      <div data-testid="device-identity" className="flex items-center gap-3">
         <DeviceIcon
           type={device.device_type}
           size={28}

--- a/source/yarn.lock
+++ b/source/yarn.lock
@@ -4848,7 +4848,7 @@ __metadata:
   resolution: "@wardnet/js@workspace:sdk/wardnet-js"
   dependencies:
     consola: "npm:^3.4.2"
-    prettier: "npm:3.8.4"
+    prettier: "npm:3.8.5"
     typescript: "npm:6.0.3"
   languageName: unknown
   linkType: soft
@@ -8436,6 +8436,15 @@ __metadata:
   bin:
     prettier: bin/prettier.cjs
   checksum: 10c0/b90a0cbe75b88ac0af9c13fe0f359bd19926fabccd88483227b21f71f0c1cc42da056fc1ac3a361e665577c568371d5ccfb2c62c31c8a1186f8d1bd531a063e9
+  languageName: node
+  linkType: hard
+
+"prettier@npm:3.8.5":
+  version: 3.8.5
+  resolution: "prettier@npm:3.8.5"
+  bin:
+    prettier: bin/prettier.cjs
+  checksum: 10c0/57ba3cd8ddc0cebcb31038f09081da5c8633ff1823ff5e5cf3496918b3b839f76a21e06050fd1a2c41547f44fedea2c28d7a4a26f0b2ed40eb60428c54c297ea
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## What & why

Playwright C1 (#626, epic #614): end-to-end coverage for the device-keyed
**user-app** PWA (`/`) — which the existing harness couldn't reach.

Two constraints collide:

1. The daemon classifies `GET /api/devices/me` by the **raw TCP peer IP**
   (`middleware.rs::resolve_auth_context` — no `X-Forwarded-For` trust). A
   caller is a "device" only if its source IP is a discovered LAN device.
2. The PWA-shell specs need a **secure context** (service workers register
   only over HTTPS → a TLS proxy). An L7 proxy re-originates the TCP
   connection, so the daemon would see the *proxy's* IP, not the runner's.

**Resolution:** make a LAN-only TLS proxy the discovered device.

## Changes

- **`tls_proxy_lan`** (Caddy, `wardnet_lan`, fixed `10.91.0.20`) terminates
  TLS and forwards to the daemon's LAN IP (`Caddyfile.lan`), so every
  user-app request reaches the daemon from one known LAN IP over a real
  HTTPS origin.
- **`ui_runner_lan`** (on `wardnet_lan` + `wardnet_mgmt`) runs the
  `user-app` project against the LAN proxy; the mgmt `ui_runner` now runs
  only the admin surfaces (`--project` lists).
- **`seed-lan-device`** setup project warms the proxy (a throwaway request
  forces a proxy→daemon hop that packet-capture discovery observes) and
  polls `/api/devices` until `10.91.0.20` is discovered — so `devices/me`
  resolves non-null before the browser loads.
- **Specs** (`tests/user-app/`): `pwa-shell.spec.ts` (manifest/installability
  + offline service-worker shell) and `identity.spec.ts` (non-null device
  from the LAN origin; null/no-device fallback from the mgmt proxy origin).
  Minimal `device-identity` / `no-device` testids added to the user-app
  `Home` page per the suite's selector convention.
- **Makefile** runs both runners sequentially and fails if either does;
  reports split via `REPORT_SUBDIR` (`reports/` vs `reports/lan/`).
- Folds in **#727** (prettier `3.8.4`→`3.8.5` in the JS SDK; `source/yarn.lock`
  updated to keep `yarn install --immutable` green).

This mirrors the established `admin-app/pwa-shell.spec.ts` approach.

## Verification

- `yarn type-check` (web-ui e2e package) — passes.
- `podman compose -f compose.ui.yaml config` — valid (8 services).
- `make e2e-ui` — full stack run (mgmt + LAN runners). _(running locally; CI runs the same suite.)_

## Merge Commit Message

```
test(e2e): user-app LAN runner + PWA shell & identity specs (#626)

LAN-side Playwright runner + LAN TLS proxy (the discovered device) so the
device-keyed user-app's source-IP-classified devices/me resolves non-null
over a secure HTTPS origin. Adds pwa-shell + identity specs, user-app
testids, sequential two-runner Makefile flow, and folds in #727 (prettier
3.8.4->3.8.5 in the JS SDK).

Closes #626. Closes #727.
```

Closes #626. Closes #727.

https://claude.ai/code/session_01FzyhnuFtcfcEVhTzqfEykn
