### PR TITLE
test(e2e): admin-app Pages specs — dashboard, devices, tunnels, dns, system (#625)

### DIFF
--- a/source/admin-app/src/components/BusyOverlay.tsx
+++ b/source/admin-app/src/components/BusyOverlay.tsx
@@ -24,7 +24,10 @@ export function BusyOverlay({ phase, action }: Props) {
   const { title, subtitle } = COPY[action][phase];
 
   return (
-    <div className="fixed inset-0 z-[60] flex flex-col items-center justify-center gap-5 bg-side text-white">
+    <div
+      data-testid="system-busy-overlay"
+      className="fixed inset-0 z-[60] flex flex-col items-center justify-center gap-5 bg-side text-white"
+    >
       {phase === "working" ? (
         <div className="h-[46px] w-[46px] animate-spin rounded-full border-[3px] border-white/15 border-t-accent" />
       ) : (

--- a/source/admin-app/src/components/ConfirmDialog.tsx
+++ b/source/admin-app/src/components/ConfirmDialog.tsx
@@ -23,6 +23,7 @@ export function ConfirmDialog({
     <Drawer open={open} onOpenChange={onOpenChange}>
       <DrawerContent
           side="bottom"
+          data-testid="confirm-dialog"
           onPointerDownOutside={(e) => e.preventDefault()}
           onEscapeKeyDown={(e) => e.preventDefault()}
         >
@@ -38,7 +39,7 @@ export function ConfirmDialog({
         </div>
 
         {/* Buttons */}
-        <div data-testid="confirm-dialog" className="flex flex-col gap-2 px-4 pb-10">
+        <div className="flex flex-col gap-2 px-4 pb-10">
           <button
             data-testid="confirm-dialog-confirm"
             onClick={onConfirm}

--- a/source/admin-app/src/components/ConfirmDialog.tsx
+++ b/source/admin-app/src/components/ConfirmDialog.tsx
@@ -38,8 +38,9 @@ export function ConfirmDialog({
         </div>
 
         {/* Buttons */}
-        <div className="flex flex-col gap-2 px-4 pb-10">
+        <div data-testid="confirm-dialog" className="flex flex-col gap-2 px-4 pb-10">
           <button
+            data-testid="confirm-dialog-confirm"
             onClick={onConfirm}
             className={`w-full rounded-2xl py-[15px] text-[15px] font-semibold tracking-tight ${
               variant === "danger"

--- a/source/admin-app/src/components/DeviceRoutingSheet.tsx
+++ b/source/admin-app/src/components/DeviceRoutingSheet.tsx
@@ -120,7 +120,6 @@ export function DeviceRoutingSheet({ device, tunnels, open, onOpenChange }: Prop
                 active={current === tunnel.id}
                 disabled={updateDevice.isPending}
                 onSelect={() => handleSelect({ type: "tunnel", tunnel_id: tunnel.id })}
-                testId={`device-routing-tunnel-${tunnel.id}`}
               />
             );
           })}

--- a/source/admin-app/src/components/DeviceRoutingSheet.tsx
+++ b/source/admin-app/src/components/DeviceRoutingSheet.tsx
@@ -31,19 +31,21 @@ function tunnelSublabel(status: Tunnel["status"]): { label: string; tone: Tunnel
   }
 }
 
-function OptionRow({ label, sublabel, sublabelTone, active, disabled, onSelect }: {
+function OptionRow({ label, sublabel, sublabelTone, active, disabled, onSelect, testId }: {
   label: string;
   sublabel?: string;
   sublabelTone?: TunnelTone;
   active: boolean;
   disabled: boolean;
   onSelect: () => void;
+  testId?: string;
 }) {
   const sublabelClass =
     sublabelTone === "danger" ? "text-danger" :
     sublabelTone === "warn"   ? "text-warn"   : "text-ink-3";
   return (
     <button
+      data-testid={testId}
       onClick={onSelect}
       disabled={disabled}
       className="flex w-full items-center gap-3 px-4 py-3.5 text-left transition-colors duration-snap active:bg-sunken disabled:pointer-events-none disabled:opacity-40"
@@ -89,16 +91,22 @@ export function DeviceRoutingSheet({ device, tunnels, open, onOpenChange }: Prop
         <DrawerTitle className="px-4 pb-1 text-[11px] font-semibold uppercase tracking-wider text-ink-3">
           Route: {deviceLabel}
         </DrawerTitle>
-        <div className="flex flex-col" style={{ paddingBottom: "max(24px, env(safe-area-inset-bottom))" }}>
+        <div
+          data-testid="device-routing-sheet"
+          className="flex flex-col"
+          style={{ paddingBottom: "max(24px, env(safe-area-inset-bottom))" }}
+        >
           <OptionRow
             label="Default" sublabel="Follow gateway policy"
             active={current === "default"} disabled={updateDevice.isPending}
             onSelect={() => handleSelect({ type: "default" })}
+            testId="device-routing-default"
           />
           <OptionRow
             label="Direct" sublabel="No VPN"
             active={current === "direct"} disabled={updateDevice.isPending}
             onSelect={() => handleSelect({ type: "direct" })}
+            testId="device-routing-direct"
           />
           {tunnels.length > 0 && <div className="mx-4 my-2 h-px bg-line" />}
           {tunnels.map((tunnel) => {
@@ -112,6 +120,7 @@ export function DeviceRoutingSheet({ device, tunnels, open, onOpenChange }: Prop
                 active={current === tunnel.id}
                 disabled={updateDevice.isPending}
                 onSelect={() => handleSelect({ type: "tunnel", tunnel_id: tunnel.id })}
+                testId={`device-routing-tunnel-${tunnel.id}`}
               />
             );
           })}

--- a/source/admin-app/src/features/dashboard/DevicesCard.tsx
+++ b/source/admin-app/src/features/dashboard/DevicesCard.tsx
@@ -22,7 +22,7 @@ export function DevicesCard({ deviceCount, devices, defaultPolicy }: Props) {
     }).length ?? null;
 
   return (
-    <Link to="/devices" className="block">
+    <Link to="/devices" className="block" data-testid="dashboard-devices-card">
       <Card className="card--flush">
         <div className="flex items-center gap-3 px-2 py-3">
           <div

--- a/source/admin-app/src/features/dashboard/DnsCard.tsx
+++ b/source/admin-app/src/features/dashboard/DnsCard.tsx
@@ -11,7 +11,7 @@ interface Props {
 
 export function DnsQueriesCard({ data, isLoading }: Props) {
   return (
-    <Link to="/dns" className="block">
+    <Link to="/dns" className="block" data-testid="dashboard-dns-queries-card">
       <Card className="card--flush">
         <div className="flex items-center gap-3 px-2 py-3">
           <div
@@ -51,7 +51,7 @@ export function BlockedCard({ data, isLoading }: Props) {
       : undefined;
 
   return (
-    <Link to="/dns" className="block">
+    <Link to="/dns" className="block" data-testid="dashboard-blocked-card">
       <Card className="card--flush">
         <div className="flex items-center gap-3 px-2 py-3">
           <div

--- a/source/admin-app/src/features/dashboard/StatusCard.tsx
+++ b/source/admin-app/src/features/dashboard/StatusCard.tsx
@@ -10,6 +10,7 @@ export function StatusCard({ reachable, uptimeSeconds }: Props) {
 
   return (
     <div
+      data-testid="dashboard-status-card"
       className="rounded-xl px-4 py-4 flex flex-col gap-4"
       style={{
         background: `radial-gradient(ellipse at 75% 40%, color-mix(in srgb, ${statusColor} 18%, transparent) 0%, transparent 60%), var(--color-side)`,

--- a/source/admin-app/src/features/dashboard/TunnelsCard.tsx
+++ b/source/admin-app/src/features/dashboard/TunnelsCard.tsx
@@ -15,7 +15,7 @@ export function TunnelsCard({ tunnelCount, tunnelActiveCount, tunnels }: Props) 
   const primary = activeTunnels[0];
 
   return (
-    <Link to="/tunnels" className="block">
+    <Link to="/tunnels" className="block" data-testid="dashboard-tunnels-card">
       <Card className="card--flush">
       <div className="flex items-center gap-3 px-2 py-3">
         <div

--- a/source/admin-app/src/pages/Devices.tsx
+++ b/source/admin-app/src/pages/Devices.tsx
@@ -51,6 +51,7 @@ const DeviceRow = memo(function DeviceRow({
 }) {
   return (
     <button
+      data-testid="device-row"
       onClick={() => onSelect(device.id)}
       className="flex w-full items-center gap-3 px-4 py-3 text-left transition-colors duration-snap active:bg-sunken first:rounded-t-xl last:rounded-b-xl"
     >
@@ -163,6 +164,7 @@ export default function Devices() {
           {(["all", "online", "vpn"] as Filter[]).map((id) => (
             <button
               key={id}
+              data-testid={`device-filter-${id}`}
               onClick={() => setFilter(id)}
               className={[
                 "shrink-0 rounded-full px-3.5 py-1.5 text-[13px] font-medium transition-colors duration-snap",

--- a/source/admin-app/src/pages/Dns.tsx
+++ b/source/admin-app/src/pages/Dns.tsx
@@ -83,7 +83,7 @@ export default function Dns() {
                 />
                 <Text as="span" size="lg" weight="semibold" className="text-ink">DNS Server</Text>
                 <div className="ml-auto">
-                  <Pill variant={isRunning ? "ok" : "down"}>
+                  <Pill variant={isRunning ? "ok" : "down"} data-testid="dns-status-pill">
                     <span className="mr-1" aria-hidden>●</span>
                     {isRunning ? "Running" : "Stopped"}
                   </Pill>
@@ -148,6 +148,7 @@ export default function Dns() {
               {/* Flush cache action */}
               <div className="mt-4 flex justify-end border-t border-line pt-4">
                 <button
+                  data-testid="dns-flush-cache"
                   onClick={() => flushCache.mutate()}
                   disabled={flushCache.isPending}
                   className="flex items-center gap-1.5 text-[13px] font-medium text-ink-3 disabled:opacity-40 active:text-ink"
@@ -180,6 +181,7 @@ export default function Dns() {
                   onCheckedChange={() => setDnsToggleConfirmOpen(true)}
                   disabled={toggleDns.isPending}
                   aria-label="Toggle DNS server"
+                  data-testid="dns-toggle"
                 />
               </div>
 
@@ -196,6 +198,7 @@ export default function Dns() {
                   onCheckedChange={() => setFilterToggleConfirmOpen(true)}
                   disabled={updateConfig.isPending}
                   aria-label="Toggle DNS filtering"
+                  data-testid="dns-filter-toggle"
                 />
               </div>
             </div>
@@ -204,7 +207,7 @@ export default function Dns() {
           {/* ── Top blocked domains ── */}
           <div>
             <SectionLabel>Top Blocked Domains · 24h</SectionLabel>
-            <div className="rounded-xl border border-line bg-card">
+            <div data-testid="dns-top-blocked" className="rounded-xl border border-line bg-card">
               {topEntries.length === 0 ? (
                 <Text as="p" size="sm" className="py-8 text-center text-ink-3">
                   No blocked queries in the last 24 hours.

--- a/source/admin-app/src/pages/System.tsx
+++ b/source/admin-app/src/pages/System.tsx
@@ -120,7 +120,7 @@ export default function System() {
                 />
                 <Text as="span" size="lg" weight="semibold" className="text-ink">Wardnet</Text>
                 <div className="ml-auto">
-                  <Pill variant={daemonStatus?.reachable ? "ok" : "warn"}>
+                  <Pill variant={daemonStatus?.reachable ? "ok" : "warn"} data-testid="system-status-pill">
                     <span className="mr-1" aria-hidden>●</span>
                     {daemonStatus?.reachable ? "Running" : "Unreachable"}
                   </Pill>
@@ -233,6 +233,7 @@ export default function System() {
             <SectionLabel>Power</SectionLabel>
             <div className="flex flex-col gap-2">
               <button
+                data-testid="system-restart-daemon"
                 onClick={() => setConfirmAction("restart")}
                 className="flex w-full items-center gap-3 rounded-xl border border-line bg-card px-4 py-3.5 text-left active:bg-sunken"
               >
@@ -247,6 +248,7 @@ export default function System() {
               </button>
 
               <button
+                data-testid="system-reboot-device"
                 onClick={() => setConfirmAction("reboot")}
                 className="flex w-full items-center gap-3 rounded-xl border border-line bg-card px-4 py-3.5 text-left active:bg-sunken"
               >
@@ -270,6 +272,7 @@ export default function System() {
         <div className="flex flex-col gap-2">
           <a
             href="/admin/"
+            data-testid="system-open-desktop"
             className="flex w-full items-center gap-3 rounded-xl border border-line bg-card px-4 py-3.5 active:bg-sunken"
           >
             <div className="flex size-10 shrink-0 items-center justify-center rounded-xl bg-sunken">
@@ -282,6 +285,7 @@ export default function System() {
             <ChevronRightIcon size={16} className="shrink-0 text-ink-4" />
           </a>
           <button
+            data-testid="system-logout"
             onClick={() => {
               logout();
               biometric.unregister();

--- a/source/admin-app/src/pages/Tunnels.tsx
+++ b/source/admin-app/src/pages/Tunnels.tsx
@@ -176,7 +176,7 @@ const TunnelCard = memo(function TunnelCard({
 
   return (
     <Card className="card--flush">
-      <div className="flex flex-col gap-3 p-4">
+      <div data-testid="tunnel-card" className="flex flex-col gap-3 p-4">
         {/* Header row */}
         <div className="flex items-start gap-2">
           <Text as="span" size="2xl" className="leading-none" aria-hidden>
@@ -191,6 +191,7 @@ const TunnelCard = memo(function TunnelCard({
           <div className="flex shrink-0 items-center gap-2">
             <TunnelStatusPill status={tunnel.status} />
             <button
+              data-testid="tunnel-rebuild"
               onClick={() => onRebuild(tunnel.id)}
               disabled={isRebuilding}
               className="flex h-7 w-7 items-center justify-center rounded-lg bg-sunken text-ink-3 transition-colors duration-snap active:bg-line disabled:opacity-40"
@@ -294,7 +295,7 @@ export default function Tunnels() {
 
       {/* Summary header */}
       <Card className="card--flush">
-        <div className="flex items-center gap-3 p-4">
+        <div data-testid="tunnels-summary" className="flex items-center gap-3 p-4">
           <div className="min-w-0 shrink-0">
             <Text as="div" size="2xs" weight="semibold" className="uppercase tracking-wider text-ink-3">
               Tunnels Up

--- a/source/end2end-tests/web-ui/tests/admin-app/pages.spec.ts
+++ b/source/end2end-tests/web-ui/tests/admin-app/pages.spec.ts
@@ -6,8 +6,6 @@ import {
   seedDiscoveredDevice,
   seedTunnel,
 } from "../../fixtures/devices.js";
-import { ADMIN_PASSWORD, ADMIN_USERNAME } from "../../fixtures/seed.js";
-import { loginViaUi } from "../../fixtures/ui.js";
 
 /**
  * admin-app PWA page coverage (epic #614 → B2, #625): each of the five
@@ -30,7 +28,9 @@ import { loginViaUi } from "../../fixtures/ui.js";
  *     server enabled and filtering at its original state.
  *   - Device routing: set to a tunnel, then restored to Default on the
  *     seeded device.
- *   - Daemon restart: really fired (it recovers — see the stateful describe).
+ * The daemon-restart flow really restarts the daemon, so per the suite README
+ * ("Spec ordering (stateful/)") it lives in its own stateful/restart.spec.ts —
+ * which sorts last — rather than here, keeping its blast radius off these specs.
  * Two actions are NOT fired, for hard infra reasons documented at their tests:
  *   - Device *reboot* can't recover the compose container (mirrors the
  *     admin-site power.spec, which also avoids reboot/shutdown) — open + cancel.
@@ -99,9 +99,17 @@ test.describe("devices", () => {
     for (const f of ["all", "online", "vpn"] as const) {
       const pill = page.getByTestId(`device-filter-${f}`);
       await pill.click();
-      const label = (await pill.textContent()) ?? "";
-      const count = Number(label.match(/\((\d+)\)/)?.[1] ?? "-1");
-      await expect(page.getByTestId("device-row")).toHaveCount(count);
+      // Re-read the pill's count and the row count together on each poll: the
+      // "online" count is time-derived and a background refetch can move both,
+      // so a one-shot snapshot could leave `toHaveCount` chasing a value that
+      // no longer occurs. Comparing fresh reads converges once the page settles.
+      await expect
+        .poll(async () => {
+          const label = (await pill.textContent()) ?? "";
+          const expected = Number(label.match(/\((\d+)\)/)?.[1] ?? "-1");
+          return (await page.getByTestId("device-row").count()) === expected;
+        })
+        .toBe(true);
     }
   });
 
@@ -255,48 +263,4 @@ test("an unknown route redirects to the dashboard", async ({ page }) => {
   await page.goto("./this-route-does-not-exist");
   await expect(page).toHaveURL(/\/admin-app\/?$/);
   await expect(page.getByTestId("tab-home")).toBeVisible();
-});
-
-test.describe("daemon restart (stateful)", () => {
-  // Really restarts the daemon, so it is declared last — the suite runs
-  // single-worker in declaration order, keeping the blast radius off the
-  // read-only / restore-after tests above. The daemon runs as systemd PID 1
-  // in the compose container with a persistent state volume, so it comes
-  // back; DB-backed sessions stay valid across the restart (the cookie
-  // survives), so the expected outcome is an in-place recovery. The
-  // signed-out branch is handled defensively.
-  test("the restart flow shows the busy overlay and recovers", async ({
-    page,
-  }) => {
-    test.setTimeout(120_000);
-
-    await page.goto("./system");
-
-    // Confirm restart.
-    await page.getByTestId("system-restart-daemon").click();
-    await expect(page.getByText("Restart daemon?", { exact: true })).toBeVisible();
-    await page.getByTestId("confirm-dialog-confirm").click();
-
-    // The full-screen busy overlay appears while the daemon is down, then
-    // tears itself down once the daemon is back and the app reconnects.
-    await expect(page.getByTestId("system-busy-overlay")).toBeVisible();
-    await expect(page.getByTestId("system-busy-overlay")).toBeHidden({
-      timeout: 90_000,
-    });
-
-    // Recover: normally the session survives and we're still in the shell;
-    // if the daemon came back signed-out, re-authenticate so later specs
-    // keep an authenticated context.
-    if (/\/admin-app\/login/.test(page.url())) {
-      await loginViaUi(page, ADMIN_USERNAME, ADMIN_PASSWORD);
-      const declineBiometric = page.getByTestId("biometric-setup-decline");
-      if (await declineBiometric.isVisible().catch(() => false)) {
-        await declineBiometric.click();
-      }
-      await expect(page).toHaveURL(/\/admin-app\/?$/);
-    } else {
-      await page.goto("./system");
-      await expect(page.getByTestId("system-status-pill")).toBeVisible();
-    }
-  });
 });

--- a/source/end2end-tests/web-ui/tests/admin-app/pages.spec.ts
+++ b/source/end2end-tests/web-ui/tests/admin-app/pages.spec.ts
@@ -182,20 +182,29 @@ test.describe("dns", () => {
     await expect(statusPill).toBeVisible();
     await expect(statusPill).toHaveText(/Running|Stopped/);
 
+    // Confirm the open dialog, then wait for it to fully unmount before the
+    // next flip. The Drawer keeps the closing dialog mounted through its
+    // slide-out animation, so opening the next one too soon would leave two
+    // confirm buttons in the DOM (strict-mode violation).
+    const confirmDialog = async () => {
+      await page.getByTestId("confirm-dialog-confirm").click();
+      await expect(page.getByTestId("confirm-dialog")).toHaveCount(0);
+    };
+
     // DNS server toggle — each flip goes through a confirm dialog. Normalise
     // to enabled, disable, then re-enable, leaving the server enabled.
     const dnsToggle = page.getByTestId("dns-toggle");
     if ((await dnsToggle.getAttribute("aria-checked")) !== "true") {
       await dnsToggle.click();
-      await page.getByTestId("confirm-dialog-confirm").click();
+      await confirmDialog();
       await expect(dnsToggle).toHaveAttribute("aria-checked", "true");
     }
     await dnsToggle.click();
     await expect(page.getByText("Disable DNS server?", { exact: true })).toBeVisible();
-    await page.getByTestId("confirm-dialog-confirm").click();
+    await confirmDialog();
     await expect(dnsToggle).toHaveAttribute("aria-checked", "false");
     await dnsToggle.click();
-    await page.getByTestId("confirm-dialog-confirm").click();
+    await confirmDialog();
     await expect(dnsToggle).toHaveAttribute("aria-checked", "true");
 
     // Filtering toggle — flip and flip back to the original state.
@@ -203,10 +212,10 @@ test.describe("dns", () => {
     const initial = await filterToggle.getAttribute("aria-checked");
     const flipped = initial === "true" ? "false" : "true";
     await filterToggle.click();
-    await page.getByTestId("confirm-dialog-confirm").click();
+    await confirmDialog();
     await expect(filterToggle).toHaveAttribute("aria-checked", flipped);
     await filterToggle.click();
-    await page.getByTestId("confirm-dialog-confirm").click();
+    await confirmDialog();
     await expect(filterToggle).toHaveAttribute("aria-checked", initial ?? "false");
 
     // Top-blocked section renders (list or empty state).

--- a/source/end2end-tests/web-ui/tests/admin-app/pages.spec.ts
+++ b/source/end2end-tests/web-ui/tests/admin-app/pages.spec.ts
@@ -1,0 +1,302 @@
+import { expect, test } from "@playwright/test";
+
+import {
+  SEED_DEVICE_IP,
+  SEED_DEVICE_MAC,
+  seedDiscoveredDevice,
+  seedTunnel,
+} from "../../fixtures/devices.js";
+import { ADMIN_PASSWORD, ADMIN_USERNAME } from "../../fixtures/seed.js";
+import { loginViaUi } from "../../fixtures/ui.js";
+
+/**
+ * admin-app PWA page coverage (epic #614 → B2, #625): each of the five
+ * sections — dashboard, devices, tunnels, DNS, system — renders its content
+ * and supports its primary actions in the mobile viewport, and an unknown
+ * route redirects to "/".
+ *
+ * Runs in the `admin-app` project — Pixel 7 viewport, seeded daemon, admin
+ * `storageState` (see playwright.config.ts). The shell (manifest, service
+ * worker, tab-bar navigation, h1 headings, login) is covered by
+ * pwa-shell.spec.ts; this spec deliberately exercises page *content* and
+ * *actions* instead. Selectors follow the suite's `data-testid` convention
+ * (README.md → "Selector convention"): testids locate, human-facing
+ * label/role/text is additionally asserted where meaningful.
+ *
+ * State discipline (single-worker shared daemon): destructive primary
+ * actions are fired and then restored so behaviour doesn't depend on spec
+ * order —
+ *   - DNS server / filtering toggles: flipped and flipped back, leaving the
+ *     server enabled and filtering at its original state.
+ *   - Device routing: set to a tunnel, then restored to Default on the
+ *     seeded device.
+ *   - Daemon restart: really fired (it recovers — see the stateful describe).
+ * Two actions are NOT fired, for hard infra reasons documented at their tests:
+ *   - Device *reboot* can't recover the compose container (mirrors the
+ *     admin-site power.spec, which also avoids reboot/shutdown) — open + cancel.
+ *   - Tunnel *rebuild* / *speed test* would run against the only seedable
+ *     tunnel, a non-functional dummy (status down, throwaway WireGuard keys),
+ *     so firing them is meaningless and flaky — presence + enabled is the
+ *     contract.
+ */
+
+const TUNNEL_LABEL = "E2E Test Tunnel";
+
+// Both fixtures are idempotent and shared with the admin-site Devices spec;
+// by the time the admin-app project runs they are typically already present,
+// so this resolves quickly. Hard preconditions — a missing device means
+// packet capture isn't reaching wardnet_lan, which should fail the run.
+test.beforeAll(async () => {
+  await seedDiscoveredDevice();
+  await seedTunnel(TUNNEL_LABEL);
+});
+
+test.describe("dashboard", () => {
+  test("renders the status and summary cards and links into a section", async ({
+    page,
+  }) => {
+    await page.goto("./");
+
+    // The dashboard has no <h1> (pwa-shell asserts that contract); its
+    // content is the status card plus the four summary cards.
+    await expect(page.getByTestId("dashboard-status-card")).toBeVisible();
+    await expect(page.getByTestId("dashboard-devices-card")).toBeVisible();
+    await expect(page.getByTestId("dashboard-tunnels-card")).toBeVisible();
+    await expect(page.getByTestId("dashboard-dns-queries-card")).toBeVisible();
+    await expect(page.getByTestId("dashboard-blocked-card")).toBeVisible();
+
+    // Each summary card is a link; the primary action is drilling into its
+    // section. Tapping Devices navigates there.
+    await page.getByTestId("dashboard-devices-card").click();
+    await expect(page).toHaveURL(/\/admin-app\/devices$/);
+  });
+});
+
+test.describe("devices", () => {
+  test("lists the discovered LAN client", async ({ page }) => {
+    await page.goto("./devices");
+
+    // Unmanaged, hostname-less device: the row falls back to the MAC and
+    // shows last_ip alongside its route label. Scope by IP, assert the MAC.
+    const row = page.getByTestId("device-row").filter({ hasText: SEED_DEVICE_IP });
+    await expect(row).toBeVisible();
+    await expect(row).toContainText(SEED_DEVICE_MAC);
+  });
+
+  test("the filter pills narrow the visible set", async ({ page }) => {
+    await page.goto("./devices");
+
+    // The seeded device is listed under "All".
+    await expect(page.getByTestId("device-filter-all")).toContainText("All");
+    await expect(
+      page.getByTestId("device-row").filter({ hasText: SEED_DEVICE_IP }),
+    ).toBeVisible();
+
+    // Each pill carries a count ("Label (N)"); selecting it must show exactly
+    // that many rows. Asserting against the pill's own count keeps this
+    // independent of whatever route an earlier spec left the device in (the
+    // admin-site Devices spec leaves it on a tunnel, i.e. "On VPN").
+    for (const f of ["all", "online", "vpn"] as const) {
+      const pill = page.getByTestId(`device-filter-${f}`);
+      await pill.click();
+      const label = (await pill.textContent()) ?? "";
+      const count = Number(label.match(/\((\d+)\)/)?.[1] ?? "-1");
+      await expect(page.getByTestId("device-row")).toHaveCount(count);
+    }
+  });
+
+  test("the device routing rule can be changed to a tunnel and restored", async ({
+    page,
+  }) => {
+    await page.goto("./devices");
+
+    const row = page.getByTestId("device-row").filter({ hasText: SEED_DEVICE_IP });
+
+    // Tap the device → the routing sheet opens with the routing options.
+    await row.click();
+    const sheet = page.getByTestId("device-routing-sheet");
+    await expect(sheet).toBeVisible();
+    await expect(page.getByTestId("device-routing-default")).toBeVisible();
+    await expect(page.getByTestId("device-routing-direct")).toBeVisible();
+
+    // Pick the seeded tunnel (the option's accessible name carries the flag
+    // glyph + label; match the label substring). The sheet closes on success
+    // and the row's route label reflects the new target.
+    await sheet.getByRole("button", { name: new RegExp(TUNNEL_LABEL) }).click();
+    await expect(sheet).toBeHidden();
+    await expect(row).toContainText(TUNNEL_LABEL);
+
+    // Restore to Default so later specs see the device unrouted.
+    await row.click();
+    await expect(page.getByTestId("device-routing-sheet")).toBeVisible();
+    await page.getByTestId("device-routing-default").click();
+    await expect(page.getByTestId("device-routing-sheet")).toBeHidden();
+    await expect(row).toContainText("Default");
+  });
+});
+
+test.describe("tunnels", () => {
+  test("renders the summary and the seeded tunnel card with its controls", async ({
+    page,
+  }) => {
+    await page.goto("./tunnels");
+
+    // Summary header with the up/total count.
+    await expect(page.getByTestId("tunnels-summary")).toContainText("Tunnels Up");
+
+    // The seeded tunnel's card surfaces its endpoint (from the imported
+    // WireGuard config).
+    const card = page.getByTestId("tunnel-card").filter({ hasText: TUNNEL_LABEL });
+    await expect(card).toBeVisible();
+    await expect(card).toContainText("198.51.100.1");
+
+    // Primary actions are present and actionable. They are NOT fired: the
+    // only seedable tunnel is a non-functional dummy (status down, throwaway
+    // keys), so a real rebuild / speed test against it is meaningless and
+    // flaky — the contract here is that the controls are wired and enabled.
+    const speedTest = card.getByTestId("tunnel-speed-test-button");
+    await expect(speedTest).toBeVisible();
+    await expect(speedTest).toBeEnabled();
+    const rebuild = card.getByTestId("tunnel-rebuild");
+    await expect(rebuild).toBeVisible();
+    await expect(rebuild).toBeEnabled();
+  });
+});
+
+test.describe("dns", () => {
+  test("renders status and supports toggles, filtering and cache flush", async ({
+    page,
+  }) => {
+    await page.goto("./dns");
+
+    // Status pill reflects a real running state (Running|Stopped).
+    const statusPill = page.getByTestId("dns-status-pill");
+    await expect(statusPill).toBeVisible();
+    await expect(statusPill).toHaveText(/Running|Stopped/);
+
+    // DNS server toggle — each flip goes through a confirm dialog. Normalise
+    // to enabled, disable, then re-enable, leaving the server enabled.
+    const dnsToggle = page.getByTestId("dns-toggle");
+    if ((await dnsToggle.getAttribute("aria-checked")) !== "true") {
+      await dnsToggle.click();
+      await page.getByTestId("confirm-dialog-confirm").click();
+      await expect(dnsToggle).toHaveAttribute("aria-checked", "true");
+    }
+    await dnsToggle.click();
+    await expect(page.getByText("Disable DNS server?", { exact: true })).toBeVisible();
+    await page.getByTestId("confirm-dialog-confirm").click();
+    await expect(dnsToggle).toHaveAttribute("aria-checked", "false");
+    await dnsToggle.click();
+    await page.getByTestId("confirm-dialog-confirm").click();
+    await expect(dnsToggle).toHaveAttribute("aria-checked", "true");
+
+    // Filtering toggle — flip and flip back to the original state.
+    const filterToggle = page.getByTestId("dns-filter-toggle");
+    const initial = await filterToggle.getAttribute("aria-checked");
+    const flipped = initial === "true" ? "false" : "true";
+    await filterToggle.click();
+    await page.getByTestId("confirm-dialog-confirm").click();
+    await expect(filterToggle).toHaveAttribute("aria-checked", flipped);
+    await filterToggle.click();
+    await page.getByTestId("confirm-dialog-confirm").click();
+    await expect(filterToggle).toHaveAttribute("aria-checked", initial ?? "false");
+
+    // Top-blocked section renders (list or empty state).
+    await expect(page.getByTestId("dns-top-blocked")).toBeVisible();
+
+    // Cache flush surfaces a success toast.
+    await page.getByTestId("dns-flush-cache").click();
+    await expect(page.getByText(/Cache flushed/i)).toBeVisible();
+  });
+});
+
+test.describe("system", () => {
+  test("renders daemon health and account actions", async ({ page }) => {
+    await page.goto("./system");
+
+    const statusPill = page.getByTestId("system-status-pill");
+    await expect(statusPill).toBeVisible();
+    await expect(statusPill).toHaveText(/Running|Unreachable/);
+
+    // Daemon health tiles.
+    await expect(page.getByText("Version", { exact: true })).toBeVisible();
+    await expect(page.getByText("Uptime", { exact: true })).toBeVisible();
+    await expect(page.getByText("CPU", { exact: true })).toBeVisible();
+    await expect(page.getByText("Memory", { exact: true })).toBeVisible();
+
+    // Account section: the desktop-admin link points at /admin/, and log-out
+    // is present (not fired — it would end the shared session).
+    await expect(page.getByTestId("system-open-desktop")).toHaveAttribute(
+      "href",
+      "/admin/",
+    );
+    await expect(page.getByTestId("system-logout")).toBeVisible();
+  });
+
+  test("reboot asks for confirmation and can be cancelled", async ({ page }) => {
+    await page.goto("./system");
+
+    // Reboot is intentionally NOT fired: a real reboot wouldn't recover the
+    // compose container cleanly (the admin-site power.spec avoids it for the
+    // same reason). Verify the confirm dialog is wired, then cancel.
+    await page.getByTestId("system-reboot-device").click();
+    const dialog = page.getByTestId("confirm-dialog");
+    await expect(dialog).toBeVisible();
+    await expect(page.getByText("Reboot device?", { exact: true })).toBeVisible();
+    await dialog.getByRole("button", { name: "Cancel" }).click();
+    await expect(dialog).toBeHidden();
+  });
+});
+
+test("an unknown route redirects to the dashboard", async ({ page }) => {
+  // App.tsx routes `*` to <Navigate to="/" replace />, so any unknown path
+  // under /admin-app/ lands back on the dashboard (the authed tab bar mounts
+  // only inside AppLayout, so its presence confirms the redirect resolved).
+  await page.goto("./this-route-does-not-exist");
+  await expect(page).toHaveURL(/\/admin-app\/?$/);
+  await expect(page.getByTestId("tab-home")).toBeVisible();
+});
+
+test.describe("daemon restart (stateful)", () => {
+  // Really restarts the daemon, so it is declared last — the suite runs
+  // single-worker in declaration order, keeping the blast radius off the
+  // read-only / restore-after tests above. The daemon runs as systemd PID 1
+  // in the compose container with a persistent state volume, so it comes
+  // back; DB-backed sessions stay valid across the restart (the cookie
+  // survives), so the expected outcome is an in-place recovery. The
+  // signed-out branch is handled defensively.
+  test("the restart flow shows the busy overlay and recovers", async ({
+    page,
+  }) => {
+    test.setTimeout(120_000);
+
+    await page.goto("./system");
+
+    // Confirm restart.
+    await page.getByTestId("system-restart-daemon").click();
+    await expect(page.getByText("Restart daemon?", { exact: true })).toBeVisible();
+    await page.getByTestId("confirm-dialog-confirm").click();
+
+    // The full-screen busy overlay appears while the daemon is down, then
+    // tears itself down once the daemon is back and the app reconnects.
+    await expect(page.getByTestId("system-busy-overlay")).toBeVisible();
+    await expect(page.getByTestId("system-busy-overlay")).toBeHidden({
+      timeout: 90_000,
+    });
+
+    // Recover: normally the session survives and we're still in the shell;
+    // if the daemon came back signed-out, re-authenticate so later specs
+    // keep an authenticated context.
+    if (/\/admin-app\/login/.test(page.url())) {
+      await loginViaUi(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+      const declineBiometric = page.getByTestId("biometric-setup-decline");
+      if (await declineBiometric.isVisible().catch(() => false)) {
+        await declineBiometric.click();
+      }
+      await expect(page).toHaveURL(/\/admin-app\/?$/);
+    } else {
+      await page.goto("./system");
+      await expect(page.getByTestId("system-status-pill")).toBeVisible();
+    }
+  });
+});

--- a/source/end2end-tests/web-ui/tests/admin-app/stateful/restart.spec.ts
+++ b/source/end2end-tests/web-ui/tests/admin-app/stateful/restart.spec.ts
@@ -1,0 +1,57 @@
+import { expect, test } from "@playwright/test";
+
+import { ADMIN_PASSWORD, ADMIN_USERNAME } from "../../../fixtures/seed.js";
+import { loginViaUi } from "../../../fixtures/ui.js";
+
+/**
+ * admin-app PWA daemon-restart coverage (epic #614 → B2, #625): the System
+ * page's restart flow really restarts the daemon and shows the busy overlay
+ * until the app reconnects.
+ *
+ * Stateful: this really restarts the daemon, so — per the suite README,
+ * "Spec ordering (stateful/)" — it lives under `tests/admin-app/stateful/`,
+ * whose path sorts after every read-only admin-app spec (pages / pwa-shell /
+ * smoke). That keeps a slow or flaky restart from cascading into them, the
+ * same isolation the admin-site power.spec gets under `tests/admin-site/
+ * stateful/`. Runs in the `admin-app` project — Pixel 7 viewport, seeded
+ * daemon, admin storageState (see playwright.config.ts).
+ *
+ * The daemon runs as systemd PID 1 in the compose container with a
+ * persistent state volume, so it comes back; DB-backed sessions stay valid
+ * across the restart (the cookie survives), so the expected outcome is an
+ * in-place recovery. The signed-out branch is handled defensively.
+ */
+test("the restart flow shows the busy overlay and recovers", async ({
+  page,
+}) => {
+  test.setTimeout(120_000);
+
+  await page.goto("./system");
+
+  // Confirm restart.
+  await page.getByTestId("system-restart-daemon").click();
+  await expect(page.getByText("Restart daemon?", { exact: true })).toBeVisible();
+  await page.getByTestId("confirm-dialog-confirm").click();
+
+  // The full-screen busy overlay appears while the daemon is down, then
+  // tears itself down once the daemon is back and the app reconnects.
+  await expect(page.getByTestId("system-busy-overlay")).toBeVisible();
+  await expect(page.getByTestId("system-busy-overlay")).toBeHidden({
+    timeout: 90_000,
+  });
+
+  // Recover: normally the session survives and we're still in the shell; if
+  // the daemon came back signed-out, re-authenticate so later specs keep an
+  // authenticated context.
+  if (/\/admin-app\/login/.test(page.url())) {
+    await loginViaUi(page, ADMIN_USERNAME, ADMIN_PASSWORD);
+    const declineBiometric = page.getByTestId("biometric-setup-decline");
+    if (await declineBiometric.isVisible().catch(() => false)) {
+      await declineBiometric.click();
+    }
+    await expect(page).toHaveURL(/\/admin-app\/?$/);
+  } else {
+    await page.goto("./system");
+    await expect(page.getByTestId("system-status-pill")).toBeVisible();
+  }
+});


### PR DESCRIPTION
## Summary
Closes #625 
Implements **#625** (epic #614 → B2): a Playwright `pages.spec.ts` for the admin-app PWA covering the five sections — **dashboard, devices, tunnels, DNS, system** — in the Pixel 7 mobile viewport. Each page is asserted to render its content and support its primary actions, and an unknown route is verified to redirect to `/`.

The existing `pwa-shell.spec.ts` (#693) owns the shell contract (manifest, service worker, tab-bar nav, h1 headings, login), so this spec deliberately drives **page content and actions** instead of re-testing navigation.

## What's in the diff

- **New spec:** `source/end2end-tests/web-ui/tests/admin-app/pages.spec.ts`.
- **Component instrumentation:** stable `data-testid`s added to the admin-app components the spec asserts on — dashboard cards, device filters / rows / routing sheet, tunnel summary / card / rebuild, DNS status pill / toggles / flush / top-blocked, system status pill / power / account, the busy overlay, and the shared confirm dialog. Every testid is anchored on a native element (`div`/`button`/`a`/`Link`) or on `Pill`/`Toggle` (which provably forward `data-testid`, per the admin-site DNS spec), so none are silently dropped by an unverified `@wardnet/ui` primitive.

## Test-state discipline (single-worker shared daemon)

Destructive primary actions are **fired and restored** so behaviour doesn't depend on spec order:
- DNS server + filtering toggles (flipped and flipped back; server left enabled),
- device routing (set to a tunnel, restored to Default on the seeded device),
- daemon restart (really fired — it recovers; declared last, in a stateful `describe`).

Two actions are intentionally **not fired**, for hard infra reasons documented at their tests:
- **Device reboot** — wouldn't recover the compose container cleanly (mirrors the admin-site `power.spec`, which avoids reboot/shutdown). The spec opens the confirm dialog and cancels.
- **Tunnel rebuild / speed test** — the only seedable tunnel is a non-functional dummy (status `down`, throwaway WireGuard keys), so firing them is meaningless and flaky. The spec asserts the controls are present + enabled.

The device-filter test asserts the visible row count against **each pill's own count**, keeping it independent of whatever route an earlier spec (the admin-site Devices spec leaves the device on a tunnel) left the seeded device in.

## Validation

- `yarn type-check` passes for both `@wardnet/admin-app` (component edits) and the e2e package (spec).
- The dockerized Playwright suite (`make e2e-ui`) was not run locally (Docker unavailable in this environment); it will run in CI.

## Merge Commit Message

test(e2e): admin-app Pages specs — dashboard, devices, tunnels, dns, system (#625)

Add tests/admin-app/pages.spec.ts covering the five admin-app PWA sections in the mobile viewport (render + primary actions) and unknown-route redirect. Instrument the asserted components with stable data-testids. Destructive actions are fired-and-restored except reboot and the dummy-tunnel rebuild/speed-test, which are non-recoverable/non-functional and so are verified by open+cancel / presence.

https://claude.ai/code/session_01FzyhnuFtcfcEVhTzqfEykn