### PR TITLE
test(e2e): admin-site DNS advanced Playwright specs — local, logs, filter (#620)

### DIFF
--- a/source/admin-site/src/components/features/ConditionalForwardingCard.tsx
+++ b/source/admin-site/src/components/features/ConditionalForwardingCard.tsx
@@ -128,11 +128,14 @@ export function ConditionalForwardingCard() {
           emptyMessage="No forwarding rules yet."
           addLabel="Add rule"
           onAdd={openCreate}
+          addTestId="fwd-add"
+          rowActionsTestId="fwd-row-menu"
           rowActions={(row) => (
             <>
               <RowAction
                 onSelect={() => openEdit(row)}
                 icon={<Pencil aria-hidden />}
+                testId="fwd-edit"
               >
                 Edit
               </RowAction>
@@ -140,6 +143,7 @@ export function ConditionalForwardingCard() {
                 onSelect={() => setDeleteId(row.id)}
                 destructive
                 icon={<Trash2 aria-hidden />}
+                testId="fwd-delete"
               >
                 Delete
               </RowAction>
@@ -215,6 +219,7 @@ function RuleForm({
             >
               <Input
                 id="fwd-domain"
+                data-testid="fwd-domain"
                 value={domain}
                 onChange={(e) => setDomain(e.target.value)}
                 placeholder="corp.internal"
@@ -234,6 +239,7 @@ function RuleForm({
             >
               <Input
                 id="fwd-upstream"
+                data-testid="fwd-upstream"
                 value={upstream}
                 onChange={(e) => setUpstream(e.target.value)}
                 placeholder="10.0.0.1"
@@ -255,7 +261,7 @@ function RuleForm({
           >
             Cancel
           </Button>
-          <Button type="submit" disabled={isSaving}>
+          <Button type="submit" disabled={isSaving} data-testid="fwd-submit">
             {rule ? "Save changes" : "Add rule"}
           </Button>
         </CardFooter>

--- a/source/admin-site/src/components/features/DnsZonesCard.tsx
+++ b/source/admin-site/src/components/features/DnsZonesCard.tsx
@@ -142,11 +142,14 @@ export function DnsZonesCard() {
           emptyMessage="No zones yet."
           addLabel="Add zone"
           onAdd={openCreate}
+          addTestId="zone-add"
+          rowActionsTestId="zone-row-menu"
           rowActions={(row) => (
             <>
               <RowAction
                 onSelect={() => openEdit(row)}
                 icon={<Pencil aria-hidden />}
+                testId="zone-edit"
               >
                 Edit
               </RowAction>
@@ -157,6 +160,7 @@ export function DnsZonesCard() {
                   onSelect={() => setDeleteId(row.id)}
                   destructive
                   icon={<Trash2 aria-hidden />}
+                  testId="zone-delete"
                 >
                   Delete
                 </RowAction>
@@ -225,6 +229,7 @@ function ZoneForm({
           >
             <Input
               id="zone-name"
+              data-testid="zone-name"
               value={name}
               onChange={(e) => setName(e.target.value)}
               placeholder="home"
@@ -253,7 +258,7 @@ function ZoneForm({
           >
             Cancel
           </Button>
-          <Button type="submit" disabled={isSaving}>
+          <Button type="submit" disabled={isSaving} data-testid="zone-submit">
             {zone ? "Save changes" : "Add zone"}
           </Button>
         </CardFooter>

--- a/source/admin-site/src/components/features/LocalRecordsCard.tsx
+++ b/source/admin-site/src/components/features/LocalRecordsCard.tsx
@@ -183,11 +183,14 @@ export function LocalRecordsCard() {
           emptyMessage="No custom records yet."
           addLabel="Add record"
           onAdd={openCreate}
+          addTestId="local-record-add"
+          rowActionsTestId="local-record-row-menu"
           rowActions={(row) => (
             <>
               <RowAction
                 onSelect={() => openEdit(row)}
                 icon={<Pencil aria-hidden />}
+                testId="local-record-edit"
               >
                 Edit
               </RowAction>
@@ -195,6 +198,7 @@ export function LocalRecordsCard() {
                 onSelect={() => setDeleteId(row.id)}
                 destructive
                 icon={<Trash2 aria-hidden />}
+                testId="local-record-delete"
               >
                 Delete
               </RowAction>
@@ -294,6 +298,7 @@ function RecordForm({
             >
               <Input
                 id="rec-domain"
+                data-testid="rec-domain"
                 value={domain}
                 onChange={(e) => setDomain(e.target.value)}
                 placeholder="printer.lan"
@@ -333,6 +338,7 @@ function RecordForm({
             >
               <Input
                 id="rec-value"
+                data-testid="rec-value"
                 value={value}
                 onChange={(e) => setValue(e.target.value)}
                 placeholder="192.168.1.50"
@@ -352,6 +358,7 @@ function RecordForm({
             >
               <Input
                 id="rec-ttl"
+                data-testid="rec-ttl"
                 type="number"
                 min={0}
                 value={ttl}
@@ -390,7 +397,11 @@ function RecordForm({
           >
             Cancel
           </Button>
-          <Button type="submit" disabled={isSaving}>
+          <Button
+            type="submit"
+            disabled={isSaving}
+            data-testid="local-record-submit"
+          >
             {record ? "Save changes" : "Add record"}
           </Button>
         </CardFooter>

--- a/source/admin-site/src/pages/DnsFilterProfile.tsx
+++ b/source/admin-site/src/pages/DnsFilterProfile.tsx
@@ -163,7 +163,12 @@ function ProfileIdentityCard({
         <CardTitle>Identity</CardTitle>
         {!editing && !builtin && (
           <CardAction>
-            <Button variant="outline" size="sm" onClick={startEdit}>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={startEdit}
+              data-testid="profile-edit"
+            >
               Edit
             </Button>
           </CardAction>
@@ -176,6 +181,7 @@ function ProfileIdentityCard({
             <Field label="Name" htmlFor="profile-name">
               <Input
                 id="profile-name"
+                data-testid="profile-edit-name"
                 value={draft}
                 onChange={(e) => setDraft(e.target.value)}
               />
@@ -183,6 +189,7 @@ function ProfileIdentityCard({
             <Field label="Description (optional)" htmlFor="profile-desc">
               <Input
                 id="profile-desc"
+                data-testid="profile-edit-desc"
                 value={draftDesc}
                 onChange={(e) => setDraftDesc(e.target.value)}
                 placeholder="e.g. Strict — for kids' devices"
@@ -201,6 +208,7 @@ function ProfileIdentityCard({
               className="text-danger hover:text-danger"
               onClick={() => setConfirmDelete(true)}
               disabled={builtin || update.isPending || del.isPending}
+              data-testid="profile-delete"
             >
               Delete profile
             </Button>
@@ -212,7 +220,11 @@ function ProfileIdentityCard({
               >
                 Cancel
               </Button>
-              <Button onClick={handleSave} disabled={saveDisabled}>
+              <Button
+                onClick={handleSave}
+                disabled={saveDisabled}
+                data-testid="profile-save"
+              >
                 {update.isPending ? "Saving…" : "Save"}
               </Button>
             </div>

--- a/source/admin-site/src/pages/DnsLogs.tsx
+++ b/source/admin-site/src/pages/DnsLogs.tsx
@@ -227,7 +227,10 @@ export default function DnsLogs() {
           setPage(0);
         }}
       >
-        <SelectTrigger className="select-trigger--md w-40">
+        <SelectTrigger
+          className="select-trigger--md w-40"
+          data-testid="dns-log-result-filter"
+        >
           <SelectValue />
         </SelectTrigger>
         <SelectContent>
@@ -248,7 +251,12 @@ export default function DnsLogs() {
   const liveTailAction = (
     <Text as="label" size="sm" className="flex items-center gap-2 text-ink-3">
       <span>Live tail{liveConnected ? "" : " (offline)"}</span>
-      <Toggle id="live-tail" checked={liveTail} onCheckedChange={setLiveTail} />
+      <Toggle
+        id="live-tail"
+        data-testid="live-tail"
+        checked={liveTail}
+        onCheckedChange={setLiveTail}
+      />
     </Text>
   );
 

--- a/source/end2end-tests/web-ui/README.md
+++ b/source/end2end-tests/web-ui/README.md
@@ -67,7 +67,10 @@ fail only the leases spec, not abort the whole suite. The IPAM range
 (`.2–.15`) sits below the pool the spec sets (`.100–.150`), so any `.100+`
 address is unambiguously daemon-issued. Agent helpers in `fixtures/dhcp.ts`
 are ported from `source/end2end-tests/daemon/tests/helpers.ts` because this
-harness deliberately avoids importing the daemon package.
+harness deliberately avoids importing the daemon package. The DNS query-log
+spec (`dns-logs.spec.ts`) also drives it — `fixtures/dns-logs.ts:resolveViaAgent`
+calls `/dns/resolve` against the daemon's LAN IP (`10.91.0.1`) so the daemon
+resolves and therefore logs the query.
 
 ### Blocklist fixture server (`blocklist_server`)
 

--- a/source/end2end-tests/web-ui/fixtures/dns-filter.ts
+++ b/source/end2end-tests/web-ui/fixtures/dns-filter.ts
@@ -24,6 +24,21 @@ export const BLOCKLIST_FIXTURE_URL =
 /** Name of the profile the ad-blocking spec creates through the UI. */
 export const TEST_PROFILE_NAME = "e2e-adblock";
 
+/**
+ * Name of the profile the filter-lifecycle spec (A5, #620) creates, edits, and
+ * deletes. Distinct from `TEST_PROFILE_NAME` so the two DNS-filter specs never
+ * collide on the daemon's UNIQUE profile-name constraint when they share a
+ * persisted state volume.
+ */
+export const PROFILE_MGMT_NAME = "e2e-profile-mgmt";
+
+/**
+ * The name the lifecycle spec renames the profile to during its edit step.
+ * Cleaned up alongside `PROFILE_MGMT_NAME` so a mid-test failure (which could
+ * leave the profile under either name) doesn't wedge the next run.
+ */
+export const PROFILE_MGMT_RENAMED = "e2e-profile-mgmt-renamed";
+
 interface FilterProfile {
   id: string;
   name: string;

--- a/source/end2end-tests/web-ui/fixtures/dns-local.ts
+++ b/source/end2end-tests/web-ui/fixtures/dns-local.ts
@@ -1,0 +1,80 @@
+/**
+ * Local-DNS seeding helpers for the admin-site local-DNS spec (A5, #620).
+ *
+ * The spec creates its records/zones/forwarding rules *through the UI* (real
+ * coverage of the create flows), so the only seeding here is *cleanup*: a
+ * re-run against a persisted state volume would otherwise accumulate leftover
+ * rows (and record/zone names are effectively unique per fixture). Each helper
+ * deletes any leftover entity the spec creates, up front, so the UI-create
+ * flow starts from a clean slate. Uses the plain-`fetch` `api`/`ensureAdminSetup`
+ * path as the other fixtures (see seed.ts for why this harness avoids the
+ * source-only SDK).
+ */
+
+import { api, ensureAdminSetup } from "./seed";
+
+/** Custom A record the local-DNS spec creates through the UI. */
+export const TEST_RECORD_DOMAIN = "e2e-record.test";
+/** Authoritative zone the local-DNS spec creates (single label, non-public). */
+export const TEST_ZONE_NAME = "e2e-zone";
+/** Conditional-forwarding domain the local-DNS spec creates. */
+export const TEST_FORWARD_DOMAIN = "e2e-forward.test";
+
+interface CustomDnsRecord {
+  id: string;
+  domain: string;
+  source: string;
+}
+interface DnsZone {
+  id: string;
+  name: string;
+  source: string;
+}
+interface ForwardingRule {
+  id: string;
+  domain: string;
+}
+
+/**
+ * Delete any leftover records/zones/forwarding rules the local-DNS spec owns,
+ * so its UI-create steps are deterministic. Idempotent: missing entities are a
+ * no-op; only manual/non-system rows matching the test names are touched.
+ */
+export async function cleanupLocalDns(): Promise<void> {
+  const token = await ensureAdminSetup();
+
+  const { records } = await api<{ records: CustomDnsRecord[] }>(
+    "/dns/local/records",
+    { token },
+  );
+  for (const r of records) {
+    if (r.domain === TEST_RECORD_DOMAIN && r.source === "manual") {
+      await api(`/dns/local/records/${r.id}`, { method: "DELETE", token });
+    }
+  }
+
+  const { rules } = await api<{ rules: ForwardingRule[] }>(
+    "/dns/local/forwarding",
+    { token },
+  );
+  for (const rule of rules) {
+    if (rule.domain === TEST_FORWARD_DOMAIN) {
+      await api(`/dns/local/forwarding/${rule.id}`, {
+        method: "DELETE",
+        token,
+      });
+    }
+  }
+
+  // Delete zones last: records may reference a zone, and the daemon keeps a
+  // zone's records (they become unzoned) on delete, so order only matters for
+  // tidiness. System zones (the seeded `.lan`) are never touched.
+  const { zones } = await api<{ zones: DnsZone[] }>("/dns/local/zones", {
+    token,
+  });
+  for (const z of zones) {
+    if (z.name === TEST_ZONE_NAME && z.source !== "system") {
+      await api(`/dns/local/zones/${z.id}`, { method: "DELETE", token });
+    }
+  }
+}

--- a/source/end2end-tests/web-ui/fixtures/dns-logs.ts
+++ b/source/end2end-tests/web-ui/fixtures/dns-logs.ts
@@ -1,0 +1,107 @@
+/**
+ * DNS query-log seeding for the admin-site query-log spec (A5, #620).
+ *
+ * The query log only records queries the daemon actually resolves, so both the
+ * live-tail and history coverage are seeded by driving *real* DNS queries
+ * through the `test_debian` LAN client's `/dns/resolve` probe — the same probe
+ * the daemon `dns-resolve` spec uses — pointed at the daemon's own LAN IP
+ * (10.91.0.1). Querying the daemon (rather than the client's system resolver)
+ * is what makes it log the request as a client query.
+ *
+ * `enableDnsAndQueryLog` guarantees the server + query logging are on first.
+ * Like the other fixtures, this talks to the daemon over plain `fetch` against
+ * the REST API rather than the source-only `@wardnet/js` SDK (see seed.ts for
+ * why).
+ */
+
+import { api, ensureAdminSetup } from "./seed";
+import { TEST_DEBIAN_AGENT } from "./dhcp";
+
+/**
+ * The daemon's LAN IP — the DNS server the agent probe queries, so the
+ * wardnetd-ui daemon (not the client container's system resolver) is the one
+ * that resolves and therefore logs the query.
+ */
+const DAEMON_LAN_IP = "10.91.0.1";
+
+interface DnsConfig {
+  enabled: boolean;
+  query_log_enabled: boolean;
+}
+
+/**
+ * Ensure the DNS server and query logging are both on so driven resolves get
+ * persisted. Idempotent: reads the current config and only writes when a flag
+ * is off. Server enable goes through the dedicated toggle endpoint; query
+ * logging is a plain config field (`PUT /dns/config` accepts partial updates).
+ */
+export async function enableDnsAndQueryLog(): Promise<void> {
+  const token = await ensureAdminSetup();
+  const { config } = await api<{ config: DnsConfig }>("/dns/config", { token });
+  if (!config.enabled) {
+    await api("/dns/config/toggle", {
+      method: "POST",
+      token,
+      body: JSON.stringify({ enabled: true }),
+    });
+  }
+  if (!config.query_log_enabled) {
+    await api("/dns/config", {
+      method: "PUT",
+      token,
+      body: JSON.stringify({ query_log_enabled: true }),
+    });
+  }
+}
+
+/**
+ * Drive a single DNS query for `name` from the `test_debian` LAN client against
+ * the daemon (10.91.0.1). Resolves regardless of the answer — an NXDOMAIN or
+ * upstream error is still logged — so callers can assert the domain shows up in
+ * the query log. Throws only if the agent probe itself is unreachable.
+ */
+export async function resolveViaAgent(name: string): Promise<void> {
+  const params = `name=${encodeURIComponent(name)}&server=${DAEMON_LAN_IP}`;
+  const res = await fetch(`${TEST_DEBIAN_AGENT}/dns/resolve?${params}`);
+  if (!res.ok) {
+    throw new Error(
+      `agent GET /dns/resolve?${params} failed: ${res.status} ${await res.text()}`,
+    );
+  }
+}
+
+interface QueryLogEntry {
+  domain: string;
+}
+
+/**
+ * Poll `/dns/log` until an entry whose domain contains `needle` is persisted,
+ * so the history assertions don't race the daemon's write path. Throws on
+ * timeout — a missing entry means the driven resolve wasn't logged, which is a
+ * real failure, not a skip.
+ */
+export async function waitForQueryLog(
+  needle: string,
+  timeoutMs = 15_000,
+): Promise<void> {
+  const token = await ensureAdminSetup();
+  const deadline = Date.now() + timeoutMs;
+  const path = `/dns/log?domain=${encodeURIComponent(needle)}&limit=50`;
+  let lastErr: unknown;
+  while (Date.now() < deadline) {
+    try {
+      const { entries } = await api<{ entries: QueryLogEntry[] }>(path, {
+        token,
+      });
+      if (entries.some((e) => e.domain.includes(needle))) return;
+    } catch (err) {
+      lastErr = err;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 500));
+  }
+  throw new Error(
+    `query log did not record a domain containing "${needle}" within ${timeoutMs}ms${
+      lastErr ? `: ${String(lastErr)}` : ""
+    }`,
+  );
+}

--- a/source/end2end-tests/web-ui/tests/admin-site/dns-filter.spec.ts
+++ b/source/end2end-tests/web-ui/tests/admin-site/dns-filter.spec.ts
@@ -73,7 +73,10 @@ test("filter profile: create, list, edit, set default, delete", async ({
   await expect(defaultToggle).toHaveAttribute("aria-checked", "true");
 
   // ── Delete it ──────────────────────────────────────────────────────
+  // "Delete profile" lives in the identity card's edit mode, so open the
+  // profile and enter edit before deleting.
   await renamedRow.click();
+  await page.getByTestId("profile-edit").click();
   await page.getByTestId("profile-delete").click();
   await page.getByTestId("confirm-dialog-confirm").click();
   await expect(page).toHaveURL(/\/admin\/dns\/filter$/);

--- a/source/end2end-tests/web-ui/tests/admin-site/dns-filter.spec.ts
+++ b/source/end2end-tests/web-ui/tests/admin-site/dns-filter.spec.ts
@@ -1,0 +1,83 @@
+import { expect, test } from "@playwright/test";
+
+import { api, ensureAdminSetup } from "../../fixtures/seed.js";
+import {
+  PROFILE_MGMT_NAME,
+  PROFILE_MGMT_RENAMED,
+  deleteTestProfiles,
+} from "../../fixtures/dns-filter.js";
+
+/**
+ * Admin-site DNS filter-profile lifecycle coverage (A5, #620).
+ *
+ * A4's `adblocking.spec.ts` covers a profile's *content* (blocklists,
+ * allowlists, custom rules); this spec owns the profile *lifecycle* it
+ * deferred: create via the `/new` form, see it in the list, edit its identity,
+ * mark it as a default profile, and delete it.
+ *
+ * Runs in the `admin-site` project (seeded daemon + admin storageState).
+ * Selectors follow the suite's `data-testid` convention (README.md).
+ */
+
+// Profile names are UNIQUE in the daemon schema, so a re-run against a
+// persisted state volume would collide on create. Clear both names this spec
+// may leave behind (a mid-test failure could leave the profile renamed), and
+// enable global filtering so the list's default-profile toggle is interactive.
+test.beforeAll(async () => {
+  await deleteTestProfiles(PROFILE_MGMT_NAME);
+  await deleteTestProfiles(PROFILE_MGMT_RENAMED);
+  const token = await ensureAdminSetup();
+  await api("/dns/filter/config", {
+    method: "PUT",
+    token,
+    body: JSON.stringify({ enabled: true }),
+  });
+});
+
+test("filter profile: create, list, edit, set default, delete", async ({
+  page,
+}) => {
+  // ── Create via the /new form ───────────────────────────────────────
+  await page.goto("./dns/filter");
+  await page.getByTestId("filter-add-profile").click();
+  await expect(page).toHaveURL(/\/admin\/dns\/filter\/profiles\/new$/);
+
+  // Submit is gated on a non-empty name.
+  await expect(page.getByTestId("profile-create-submit")).toBeDisabled();
+  await page.getByTestId("profile-name").fill(PROFILE_MGMT_NAME);
+  await page.getByTestId("profile-create-submit").click();
+  await expect(page).toHaveURL(/\/admin\/dns\/filter\/profiles\/[0-9a-f-]+$/);
+
+  // ── It appears in the list ─────────────────────────────────────────
+  await page.goto("./dns/filter");
+  const listRow = page.getByRole("row").filter({ hasText: PROFILE_MGMT_NAME });
+  await expect(listRow).toBeVisible();
+
+  // ── Edit its identity (rename + description) ───────────────────────
+  await listRow.click();
+  await expect(page).toHaveURL(/\/admin\/dns\/filter\/profiles\/[0-9a-f-]+$/);
+  await page.getByTestId("profile-edit").click();
+  await page.getByTestId("profile-edit-name").fill(PROFILE_MGMT_RENAMED);
+  await page.getByTestId("profile-edit-desc").fill("Renamed by A5 e2e");
+  await page.getByTestId("profile-save").click();
+  await expect(page.getByText(PROFILE_MGMT_RENAMED).first()).toBeVisible();
+
+  // ── Mark it as a default profile from the list ─────────────────────
+  await page.goto("./dns/filter");
+  const renamedRow = page
+    .getByRole("row")
+    .filter({ hasText: PROFILE_MGMT_RENAMED });
+  const defaultToggle = renamedRow.getByRole("switch");
+  await expect(defaultToggle).toHaveAttribute("aria-checked", "false");
+  await defaultToggle.click();
+  await expect(defaultToggle).toHaveAttribute("aria-checked", "true");
+
+  // ── Delete it ──────────────────────────────────────────────────────
+  await renamedRow.click();
+  await page.getByTestId("profile-delete").click();
+  await page.getByTestId("confirm-dialog-confirm").click();
+  await expect(page).toHaveURL(/\/admin\/dns\/filter$/);
+  await expect(
+    page.getByRole("row").filter({ hasText: PROFILE_MGMT_RENAMED }),
+  ).toHaveCount(0);
+});

--- a/source/end2end-tests/web-ui/tests/admin-site/dns-local.spec.ts
+++ b/source/end2end-tests/web-ui/tests/admin-site/dns-local.spec.ts
@@ -1,0 +1,101 @@
+import { expect, test } from "@playwright/test";
+
+import {
+  TEST_FORWARD_DOMAIN,
+  TEST_RECORD_DOMAIN,
+  TEST_ZONE_NAME,
+  cleanupLocalDns,
+} from "../../fixtures/dns-local.js";
+
+/**
+ * Admin-site local-DNS coverage (A5, #620) for `/admin/dns/local`.
+ *
+ * Each of the page's three interactive cards — custom Records, authoritative
+ * Zones, and Conditional forwarding — is exercised through its real UI
+ * create/edit/delete flow. State is created and removed within each test so the
+ * shared seeded daemon is left as found.
+ *
+ * Runs in the `admin-site` project (seeded daemon + admin storageState).
+ * Selectors follow the suite's `data-testid` convention (README.md); table rows
+ * are located by their unique text and deletes go through the shared
+ * `confirm-dialog-confirm` control.
+ */
+
+// Record/zone/forwarding names are effectively unique per fixture, so a re-run
+// against a persisted state volume would accumulate leftovers. Clear them up
+// front so every create step starts from a clean slate.
+test.beforeAll(async () => {
+  await cleanupLocalDns();
+});
+
+test("local DNS: create, edit, toggle, and delete a custom record", async ({
+  page,
+}) => {
+  await page.goto("./dns/local");
+  await expect(page.getByTestId("page-title")).toHaveText("Local DNS");
+
+  // ── Create an A record ─────────────────────────────────────────────
+  await page.getByTestId("local-record-add").click();
+  await page.getByTestId("rec-domain").fill(TEST_RECORD_DOMAIN);
+  await page.getByTestId("rec-value").fill("192.168.1.50");
+  await page.getByTestId("local-record-submit").click();
+
+  const row = page.getByRole("row").filter({ hasText: TEST_RECORD_DOMAIN });
+  await expect(row).toBeVisible();
+  await expect(row).toContainText("192.168.1.50");
+
+  // ── Edit its value ─────────────────────────────────────────────────
+  await row.getByTestId("local-record-row-menu").click();
+  await page.getByTestId("local-record-edit").click();
+  await page.getByTestId("rec-value").fill("192.168.1.51");
+  await page.getByTestId("local-record-submit").click();
+  await expect(row).toContainText("192.168.1.51");
+
+  // ── Toggle it off (starts enabled) ─────────────────────────────────
+  const enabledToggle = row.getByRole("switch");
+  await expect(enabledToggle).toHaveAttribute("aria-checked", "true");
+  await enabledToggle.click();
+  await expect(enabledToggle).toHaveAttribute("aria-checked", "false");
+
+  // ── Delete it ──────────────────────────────────────────────────────
+  await row.getByTestId("local-record-row-menu").click();
+  await page.getByTestId("local-record-delete").click();
+  await page.getByTestId("confirm-dialog-confirm").click();
+  await expect(row).toHaveCount(0);
+});
+
+test("local DNS: create and delete an authoritative zone", async ({ page }) => {
+  await page.goto("./dns/local");
+
+  await page.getByTestId("zone-add").click();
+  await page.getByTestId("zone-name").fill(TEST_ZONE_NAME);
+  await page.getByTestId("zone-submit").click();
+
+  const row = page.getByRole("row").filter({ hasText: TEST_ZONE_NAME });
+  await expect(row).toBeVisible();
+
+  await row.getByTestId("zone-row-menu").click();
+  await page.getByTestId("zone-delete").click();
+  await page.getByTestId("confirm-dialog-confirm").click();
+  await expect(row).toHaveCount(0);
+});
+
+test("local DNS: create and delete a conditional-forwarding rule", async ({
+  page,
+}) => {
+  await page.goto("./dns/local");
+
+  await page.getByTestId("fwd-add").click();
+  await page.getByTestId("fwd-domain").fill(TEST_FORWARD_DOMAIN);
+  await page.getByTestId("fwd-upstream").fill("10.0.0.1");
+  await page.getByTestId("fwd-submit").click();
+
+  const row = page.getByRole("row").filter({ hasText: TEST_FORWARD_DOMAIN });
+  await expect(row).toBeVisible();
+  await expect(row).toContainText("10.0.0.1");
+
+  await row.getByTestId("fwd-row-menu").click();
+  await page.getByTestId("fwd-delete").click();
+  await page.getByTestId("confirm-dialog-confirm").click();
+  await expect(row).toHaveCount(0);
+});

--- a/source/end2end-tests/web-ui/tests/admin-site/dns-logs.spec.ts
+++ b/source/end2end-tests/web-ui/tests/admin-site/dns-logs.spec.ts
@@ -1,0 +1,84 @@
+import { expect, test } from "@playwright/test";
+
+import {
+  enableDnsAndQueryLog,
+  resolveViaAgent,
+  waitForQueryLog,
+} from "../../fixtures/dns-logs.js";
+
+/**
+ * Admin-site DNS query-log coverage (A5, #620) for `/admin/dns/logs`.
+ *
+ * The query log is populated by real resolution, so both paths are seeded by
+ * driving DNS queries through the `test_debian` LAN client against the daemon
+ * (see fixtures/dns-logs.ts):
+ *  - **live tail** — with the stream connected, a freshly driven query must
+ *    appear in the table in real time (WebSocket coverage);
+ *  - **history** — with live tail off, the paginated table renders persisted
+ *    queries, narrows by the domain search, and honours the result filter.
+ *
+ * Runs in the `admin-site` project (seeded daemon + admin storageState).
+ */
+
+// Query logging (and the DNS server) must be on for resolves to be recorded.
+test.beforeAll(async () => {
+  await enableDnsAndQueryLog();
+});
+
+test("query log: a live query streams into the table", async ({ page }) => {
+  // Unique label so the assertion can't match an unrelated pre-existing row.
+  const label = `a5live${Date.now()}`;
+  const domain = `${label}.example.org`;
+
+  await page.goto("./dns/logs");
+  await expect(page.getByTestId("page-title")).toHaveText("DNS query log");
+
+  // Live tail is the default view; wait for the stream to connect (the label
+  // drops its "(offline)" suffix) before driving a query into it.
+  await expect(page.getByTestId("live-tail")).toHaveAttribute(
+    "aria-checked",
+    "true",
+  );
+  await expect(page.getByText("(offline)")).toHaveCount(0, { timeout: 15_000 });
+
+  await resolveViaAgent(domain);
+
+  await expect(page.getByRole("row").filter({ hasText: label })).toBeVisible({
+    timeout: 15_000,
+  });
+});
+
+test("query log: history table filters by domain and result", async ({
+  page,
+}) => {
+  const label = `a5hist${Date.now()}`;
+  const domain = `${label}.example.org`;
+
+  // Seed a persisted entry and wait until the daemon has written it, so the
+  // history query below isn't racing the log write path.
+  await resolveViaAgent(domain);
+  await waitForQueryLog(label);
+
+  await page.goto("./dns/logs");
+
+  // Switch to the historical (paginated) view.
+  const liveTail = page.getByTestId("live-tail");
+  await liveTail.click();
+  await expect(liveTail).toHaveAttribute("aria-checked", "false");
+
+  // Domain search narrows the history to our seeded query.
+  await page.getByPlaceholder("Search domain…").fill(label);
+  const row = page.getByRole("row").filter({ hasText: label });
+  await expect(row).toBeVisible();
+
+  // Result filter: the seeded query was never "blocked", so filtering by
+  // Blocked hides it; resetting to Any brings it back. Deterministic
+  // regardless of whether the upstream answered or NXDOMAIN'd.
+  await page.getByTestId("dns-log-result-filter").click();
+  await page.getByRole("option", { name: "Blocked", exact: true }).click();
+  await expect(row).toHaveCount(0);
+
+  await page.getByTestId("dns-log-result-filter").click();
+  await page.getByRole("option", { name: "Any result", exact: true }).click();
+  await expect(row).toBeVisible();
+});


### PR DESCRIPTION
Closes #620.

Playwright A5 (epic #614): DNS advanced coverage for the admin-site surface — local zones/records, query logs, and filter profiles. Threads `data-testid`s through the backing components as A4 (#619) did.

## Specs
- **`dns-local.spec.ts`** (`/admin/dns/local`): custom record create → edit → toggle-enabled → delete; authoritative zone create/delete; conditional-forwarding rule create/delete — each through the real UI flow.
- **`dns-logs.spec.ts`** (`/admin/dns/logs`): a live query **streams into the table over the WebSocket**, and the history table filters by domain search + result. Both are seeded by driving real DNS queries through the `test_debian` LAN client's `/dns/resolve` against the daemon's LAN IP (`10.91.0.1`), so the daemon resolves and logs them.
- **`dns-filter.spec.ts`**: the filter-profile **lifecycle** A4 deferred — create via the `/new` form (submit gated on a non-empty name), see it in the list, edit its identity, mark it as a default profile, and delete it. Does not re-test blocklist/allowlist/rule content (A4 owns those).

## Fixtures
- **`fixtures/dns-logs.ts`** (new): `enableDnsAndQueryLog` (server + query logging on), `resolveViaAgent`, `waitForQueryLog`.
- **`fixtures/dns-local.ts`** (new): idempotent cleanup so re-runs against a persisted state volume start clean.
- **`fixtures/dns-filter.ts`**: adds `PROFILE_MGMT_NAME` / `PROFILE_MGMT_RENAMED` so the lifecycle spec never collides with `adblocking.spec.ts`'s profile on the daemon's `UNIQUE` name constraint.

## Selector threading
The local-DNS/logs/profile-identity components carried only `id=` (or nothing), so this threads `data-testid`s through `LocalRecordsCard`, `DnsZonesCard`, `ConditionalForwardingCard`, `DnsLogs`, and `ProfileIdentityCard`, per the suite's authoritative convention. Deletes reuse the existing `confirm-dialog-confirm` control. **No new compose service** is needed (`test_debian` + the shared daemon already exist).

## Verification
- `admin-site` type-check + lint + `format:check` — green.
- e2e package `type-check` + prettier on the new/changed files — green.
- The full `make e2e-ui` Playwright run needs Docker, so it runs in the CI `tests-e2e.yml` job rather than locally (as with A4).

## Merge Commit Message
test(e2e): admin-site DNS advanced Playwright specs — local, logs, filter (#620)