### PR TITLE
test(e2e): unify LocalRecordsCard testid prefix to local-record-*

### DIFF
--- a/source/admin-site/src/components/features/LocalRecordsCard.tsx
+++ b/source/admin-site/src/components/features/LocalRecordsCard.tsx
@@ -298,7 +298,7 @@ function RecordForm({
             >
               <Input
                 id="rec-domain"
-                data-testid="rec-domain"
+                data-testid="local-record-domain"
                 value={domain}
                 onChange={(e) => setDomain(e.target.value)}
                 placeholder="printer.lan"
@@ -338,7 +338,7 @@ function RecordForm({
             >
               <Input
                 id="rec-value"
-                data-testid="rec-value"
+                data-testid="local-record-value"
                 value={value}
                 onChange={(e) => setValue(e.target.value)}
                 placeholder="192.168.1.50"
@@ -358,7 +358,7 @@ function RecordForm({
             >
               <Input
                 id="rec-ttl"
-                data-testid="rec-ttl"
+                data-testid="local-record-ttl"
                 type="number"
                 min={0}
                 value={ttl}

--- a/source/end2end-tests/web-ui/tests/admin-site/dns-local.spec.ts
+++ b/source/end2end-tests/web-ui/tests/admin-site/dns-local.spec.ts
@@ -36,8 +36,8 @@ test("local DNS: create, edit, toggle, and delete a custom record", async ({
 
   // ── Create an A record ─────────────────────────────────────────────
   await page.getByTestId("local-record-add").click();
-  await page.getByTestId("rec-domain").fill(TEST_RECORD_DOMAIN);
-  await page.getByTestId("rec-value").fill("192.168.1.50");
+  await page.getByTestId("local-record-domain").fill(TEST_RECORD_DOMAIN);
+  await page.getByTestId("local-record-value").fill("192.168.1.50");
   await page.getByTestId("local-record-submit").click();
 
   const row = page.getByRole("row").filter({ hasText: TEST_RECORD_DOMAIN });
@@ -47,7 +47,7 @@ test("local DNS: create, edit, toggle, and delete a custom record", async ({
   // ── Edit its value ─────────────────────────────────────────────────
   await row.getByTestId("local-record-row-menu").click();
   await page.getByTestId("local-record-edit").click();
-  await page.getByTestId("rec-value").fill("192.168.1.51");
+  await page.getByTestId("local-record-value").fill("192.168.1.51");
   await page.getByTestId("local-record-submit").click();
   await expect(row).toContainText("192.168.1.51");
 


### PR DESCRIPTION
Follow-up cleanup to #734 (Playwright A5), from a code review of that PR.

`LocalRecordsCard` used two `data-testid` area-prefixes within one component: the form inputs were `rec-domain` / `rec-value` / `rec-ttl` while the add/edit/delete/row-menu/submit controls were `local-record-*`. The sibling cards added in #734 each use a single prefix per component (`ConditionalForwardingCard` all `fwd-`, `DnsZonesCard` all `zone-`), matching the suite's selector convention (`source/end2end-tests/web-ui/README.md`). The split prefix invites a future spec author to guess the wrong one and get a silently-non-matching locator.

## Change
- Rename the field testids to `local-record-domain` / `-value` / `-ttl` (the `id="rec-*"` attributes stay — the `Field` labels reference them).
- Update `dns-local.spec.ts` to match.

## Verification
- `admin-site` type-check + lint + `format:check` — green.
- e2e `type-check` + prettier — green.
- Full Playwright run happens in the CI `tests-e2e.yml` job (needs Docker).

## Merge Commit Message
test(e2e): unify LocalRecordsCard testid prefix to local-record-*