### PR TITLE
refactor(admin-site,web): render text through DS Heading/Text (#729)

### DIFF
--- a/source/admin-site/src/components/compound/DetailPageHeader.tsx
+++ b/source/admin-site/src/components/compound/DetailPageHeader.tsx
@@ -1,7 +1,7 @@
 import { Link } from "react-router";
 import { ChevronRight } from "lucide-react";
 import type { ReactNode } from "react";
-import { Text } from "@wardnet/web";
+import { Heading, Text } from "@wardnet/web";
 
 interface DetailPageHeaderProps {
   /** The resource list label (e.g. "Tunnels"). */
@@ -25,7 +25,7 @@ interface DetailPageHeaderProps {
  * Established by the tunnel detail page; other detail pages should adopt
  * this header as part of the routed-detail refactor (issue #316).
  *
- * Forge mapping (T3-δ): title uses `.h-title`, meta line uses `.h-sub`,
+ * Forge mapping (T3-δ): title is a `<Heading>`, meta line a `<Text>`,
  * layout rows use `.row`/`.col` helpers. Breadcrumb mirrors the
  * `.topbar__crumbs` pattern (ink-3 trail, ink current segment) without
  * the topbar chrome, since this lives in the page body, not the chrome.
@@ -55,10 +55,16 @@ export function DetailPageHeader({
             {icon}
           </span>
         ) : null}
-        <h1 className="h-title">{itemLabel}</h1>
+        <Heading level={1} size="3xl" className="text-ink">
+          {itemLabel}
+        </Heading>
         {status}
       </div>
-      {meta ? <p className="h-sub">{meta}</p> : null}
+      {meta ? (
+        <Text as="p" size="sm" className="mt-1 text-ink-3">
+          {meta}
+        </Text>
+      ) : null}
     </header>
   );
 }

--- a/source/admin-site/src/components/compound/LogViewer.tsx
+++ b/source/admin-site/src/components/compound/LogViewer.tsx
@@ -103,11 +103,11 @@ export function LogViewer({
         </div>
       )}
       {entries.length === 0 ? (
-        <p className="logrow is-info">
+        <div className="logrow is-info">
           <span className="m">
             {connected ? "Waiting for log entries…" : "Not connected"}
           </span>
-        </p>
+        </div>
       ) : (
         entries.map((entry, i) => (
           <div key={i} className={`logrow is-${levelModifier(entry.level)}`}>

--- a/source/admin-site/src/components/compound/PageHeader.tsx
+++ b/source/admin-site/src/components/compound/PageHeader.tsx
@@ -1,4 +1,5 @@
 import type { ReactNode } from "react";
+import { Heading, Text } from "@wardnet/web";
 
 interface PageHeaderProps {
   title: string;
@@ -12,10 +13,19 @@ export function PageHeader({ title, description, actions }: PageHeaderProps) {
   return (
     <div className="row mb-6 justify-between">
       <div>
-        <h2 className="h-title" data-testid="page-title">
+        <Heading
+          level={2}
+          size="3xl"
+          className="text-ink"
+          data-testid="page-title"
+        >
           {title}
-        </h2>
-        {description && <p className="h-sub">{description}</p>}
+        </Heading>
+        {description && (
+          <Text as="p" size="sm" className="mt-1 text-ink-3">
+            {description}
+          </Text>
+        )}
       </div>
       {actions && <div className="row gap-8">{actions}</div>}
     </div>

--- a/source/admin-site/src/components/features/RemoteAccessProgress.tsx
+++ b/source/admin-site/src/components/features/RemoteAccessProgress.tsx
@@ -24,7 +24,7 @@ export function RemoteAccessProgress({
         <Text as="p" weight="medium" className="text-ink">
           Issuing certificate…
         </Text>
-        <p className="mt-1 text-ink-3">
+        <Text as="p" className="mt-1 text-ink-3">
           {domain ? (
             <>
               Provisioning HTTPS for <span className="font-mono">{domain}</span>
@@ -34,7 +34,7 @@ export function RemoteAccessProgress({
           ) : (
             "Provisioning HTTPS. This can take a minute."
           )}
-        </p>
+        </Text>
       </Text>
     );
   }
@@ -49,7 +49,7 @@ export function RemoteAccessProgress({
         <Text as="p" weight="medium" className="text-accent-soft-ink">
           Remote access is live
         </Text>
-        <p className="mt-1 text-ink-2">
+        <Text as="p" className="mt-1 text-ink-2">
           {domain && (
             <>
               <span className="font-mono">{domain}</span> has a valid
@@ -57,7 +57,7 @@ export function RemoteAccessProgress({
               {not_after && <> until {formatDate(not_after)}</>}.
             </>
           )}
-        </p>
+        </Text>
       </Text>
     );
   }
@@ -72,10 +72,10 @@ export function RemoteAccessProgress({
         <Text as="p" weight="medium" className="text-danger-soft-ink">
           Certificate issuance failed
         </Text>
-        <p className="mt-1 text-ink-2">
+        <Text as="p" className="mt-1 text-ink-2">
           {error ?? "The daemon could not issue a certificate."} You can retry
           later from Settings — the daemon also retries automatically.
-        </p>
+        </Text>
       </Text>
     );
   }

--- a/source/admin-site/src/pages/DeviceDetail.tsx
+++ b/source/admin-site/src/pages/DeviceDetail.tsx
@@ -1,6 +1,7 @@
 import { Link, useParams } from "react-router";
 import { DetailPageHeader } from "@/components/compound/DetailPageHeader";
 import { DeviceIcon } from "@wardnet/web";
+import { Heading, Text } from "@wardnet/web";
 import { StatusBadge } from "@/components/compound/StatusBadge";
 import { DeviceDnsFilterCard } from "@/components/features/DeviceDnsFilterCard";
 import { DeviceDnsCaptureCard } from "@/components/features/DeviceDnsCaptureCard";
@@ -35,7 +36,9 @@ export default function DeviceDetail() {
   if (isLoading) {
     return (
       <div className="col gap-20">
-        <p className="text-ink-3">Loading…</p>
+        <Text as="p" className="text-ink-3">
+          Loading…
+        </Text>
       </div>
     );
   }
@@ -43,10 +46,12 @@ export default function DeviceDetail() {
   if (isError || !data) {
     return (
       <div className="col gap-8">
-        <h1 className="h-title">Device not found</h1>
-        <p className="h-sub">
+        <Heading level={1} size="3xl" className="text-ink">
+          Device not found
+        </Heading>
+        <Text as="p" size="sm" className="mt-1 text-ink-3">
           The device you're looking for may have been removed.
-        </p>
+        </Text>
         <Link to="/devices" className="text-accent">
           Back to Devices
         </Link>

--- a/source/admin-site/src/pages/NotFound.tsx
+++ b/source/admin-site/src/pages/NotFound.tsx
@@ -1,5 +1,6 @@
 import { useNavigate } from "react-router";
 import { Button } from "@wardnet/web";
+import { Heading, Text } from "@wardnet/web";
 
 /** 404 page shown for unknown routes. Renders as a full-page Forge `.empty` block. */
 export default function NotFound() {
@@ -10,11 +11,19 @@ export default function NotFound() {
       className="empty col items-center justify-center gap-4"
       data-testid="notfound-page"
     >
-      <p className="h-title text-6xl">404</p>
-      <h2 className="h-title">Page not found</h2>
-      <p className="h-sub max-w-md">
+      <Text
+        as="p"
+        weight="semibold"
+        className="text-6xl tracking-tight text-ink"
+      >
+        404
+      </Text>
+      <Heading level={2} size="3xl" className="text-ink">
+        Page not found
+      </Heading>
+      <Text as="p" size="sm" className="mt-1 max-w-md text-ink-3">
         The page you're looking for doesn't exist or has been moved.
-      </p>
+      </Text>
       <Button
         variant="outline"
         onClick={() => navigate("/")}

--- a/source/admin-site/src/pages/TunnelDetail.tsx
+++ b/source/admin-site/src/pages/TunnelDetail.tsx
@@ -5,7 +5,7 @@ import { Button } from "@wardnet/web";
 import { Field } from "@wardnet/web";
 import { Toggle } from "@wardnet/web";
 import { Tabs, TabsList, TabsTrigger } from "@wardnet/web";
-import { Text } from "@wardnet/web";
+import { Heading, Text } from "@wardnet/web";
 import { DetailPageHeader } from "@/components/compound/DetailPageHeader";
 import { StatusBadge } from "@/components/compound/StatusBadge";
 import { TunnelDevicesTable } from "@/components/features/TunnelDevicesTable";
@@ -125,10 +125,12 @@ export default function TunnelDetail() {
   if (isError || !data) {
     return (
       <div className="col gap-8">
-        <h1 className="h-title">Tunnel not found</h1>
-        <p className="h-sub">
+        <Heading level={1} size="3xl" className="text-ink">
+          Tunnel not found
+        </Heading>
+        <Text as="p" size="sm" className="mt-1 text-ink-3">
           The tunnel you're looking for may have been deleted.
-        </p>
+        </Text>
       </div>
     );
   }

--- a/source/admin-site/src/pages/setup/Step1Admin.tsx
+++ b/source/admin-site/src/pages/setup/Step1Admin.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import { WardnetApiError } from "@wardnet/js";
 import { Button } from "@wardnet/web";
+import { Heading, Text } from "@wardnet/web";
 import { Field } from "@wardnet/web";
 import { Form, Validator } from "@wardnet/web";
 import { Input } from "@wardnet/web";
@@ -64,11 +65,13 @@ export default function Step1Admin() {
   return (
     <div>
       <div className="mb-5 flex flex-col gap-1">
-        <h2 className="h-title">Create admin account</h2>
-        <p className="h-sub">
+        <Heading level={2} size="3xl" className="text-ink">
+          Create admin account
+        </Heading>
+        <Text as="p" size="sm" className="mt-1 text-ink-3">
           Set up your administrator credentials. You'll use these to sign in to
           Wardnet.
-        </p>
+        </Text>
       </div>
       <Form
         values={{ username, password, confirmPassword }}
@@ -142,9 +145,9 @@ export default function Step1Admin() {
         />
 
         {formError && (
-          <p role="alert" className="text-sm text-danger">
+          <Text as="p" role="alert" size="sm" className="text-danger">
             {formError}
-          </p>
+          </Text>
         )}
         <Button
           type="submit"

--- a/source/admin-site/src/pages/setup/Step2Network.tsx
+++ b/source/admin-site/src/pages/setup/Step2Network.tsx
@@ -1,6 +1,6 @@
 import { AlertTriangleIcon } from "lucide-react";
 import { Button } from "@wardnet/web";
-import { Text } from "@wardnet/web";
+import { Heading, Text } from "@wardnet/web";
 import { useAdvanceWizard } from "@wardnet/web";
 import { useNetworkStatus } from "@wardnet/web";
 
@@ -19,11 +19,13 @@ export default function Step2Network() {
   return (
     <div className="flex flex-col gap-5">
       <div className="flex flex-col gap-1">
-        <h2 className="h-title">Confirm network</h2>
-        <p className="h-sub">
+        <Heading level={2} size="3xl" className="text-ink">
+          Confirm network
+        </Heading>
+        <Text as="p" size="sm" className="mt-1 text-ink-3">
           Wardnet should have a stable LAN IP so opted-in devices keep pointing
           at it across reboots.
-        </p>
+        </Text>
       </div>
 
       <dl className="grid grid-cols-[auto_1fr] gap-x-4 gap-y-2 rounded-lg border border-line bg-sunken p-4 text-sm">
@@ -63,14 +65,14 @@ export default function Step2Network() {
             <Text as="p" weight="medium">
               Your IP isn't pinned
             </Text>
-            <p>
+            <Text as="p">
               The router is currently leasing this address — it may change on
               the next reboot. Re-run <code>install.sh</code> with{" "}
               <code>--static-ip {data?.ip ?? "&lt;cidr&gt;"}/24</code> (or
               another IP from your subnet) to write{" "}
               <code>/etc/dhcpcd.conf.d/wardnet.conf</code> and pin it. You can
               continue without this, but devices may need reconfiguring later.
-            </p>
+            </Text>
           </Text>
         </div>
       )}

--- a/source/admin-site/src/pages/setup/Step3DhcpOnboarding.tsx
+++ b/source/admin-site/src/pages/setup/Step3DhcpOnboarding.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import type { WizardMode } from "@wardnet/js";
 import { Button } from "@wardnet/web";
-import { Text } from "@wardnet/web";
+import { Heading, Text } from "@wardnet/web";
 import { Field } from "@wardnet/web";
 import {
   Select,
@@ -59,8 +59,12 @@ export default function Step3DhcpOnboarding({
   return (
     <div className="flex flex-col gap-5">
       <div className="flex flex-col gap-1">
-        <h2 className="h-title">DHCP onboarding</h2>
-        <p className="h-sub">Choose how Wardnet handles DHCP on your LAN.</p>
+        <Heading level={2} size="3xl" className="text-ink">
+          DHCP onboarding
+        </Heading>
+        <Text as="p" size="sm" className="mt-1 text-ink-3">
+          Choose how Wardnet handles DHCP on your LAN.
+        </Text>
       </div>
 
       <div className="flex flex-col gap-2">
@@ -181,15 +185,15 @@ export default function Step3DhcpOnboarding({
           size="sm"
           className="flex flex-col gap-2 rounded-md border border-line bg-sunken p-4 text-ink-3"
         >
-          <p>
+          <Text as="p">
             Configure each opted-in device's network settings to use Wardnet as
             its gateway and DNS server. Other devices on the LAN keep their
             normal connectivity.
-          </p>
-          <p>
+          </Text>
+          <Text as="p">
             On the next page Wardnet will show a live counter of devices it sees
             using it as a gateway.
-          </p>
+          </Text>
         </Text>
       )}
 

--- a/source/admin-site/src/pages/setup/Step4RouterMac.tsx
+++ b/source/admin-site/src/pages/setup/Step4RouterMac.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 import { Button } from "@wardnet/web";
-import { Text } from "@wardnet/web";
+import { Heading, Text } from "@wardnet/web";
 import { Field } from "@wardnet/web";
 import { Form, Validator } from "@wardnet/web";
 import { Input } from "@wardnet/web";
@@ -47,11 +47,13 @@ export default function Step4RouterMac() {
   return (
     <div className="flex flex-col gap-5">
       <div className="flex flex-col gap-1">
-        <h2 className="h-title">Router MAC</h2>
-        <p className="h-sub">
+        <Heading level={2} size="3xl" className="text-ink">
+          Router MAC
+        </Heading>
+        <Text as="p" size="sm" className="mt-1 text-ink-3">
           Wardnet uses the upstream router's MAC address for diagnostics and
           packet-capture filtering.
-        </p>
+        </Text>
       </div>
 
       {probe.isPending && !probedMac && (
@@ -69,7 +71,9 @@ export default function Step4RouterMac() {
           <Text as="p" weight="medium" className="text-ink">
             {probedSource === "arp" ? "Discovered via ARP" : "Recorded"}
           </Text>
-          <p className="mono mt-1">{probedMac}</p>
+          <Text as="p" className="mono mt-1">
+            {probedMac}
+          </Text>
         </Text>
       )}
 

--- a/source/admin-site/src/pages/setup/Step5Tunnel.tsx
+++ b/source/admin-site/src/pages/setup/Step5Tunnel.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { Button } from "@wardnet/web";
-import { Text } from "@wardnet/web";
+import { Heading, Text } from "@wardnet/web";
 import { CreateTunnelInline } from "@/components/features/CreateTunnelInline";
 import { useAdvanceWizard } from "@wardnet/web";
 import { useTunnels } from "@wardnet/web";
@@ -31,12 +31,14 @@ export default function Step5Tunnel() {
   return (
     <div className="flex flex-col gap-5">
       <div className="flex flex-col gap-1">
-        <h2 className="h-title">First VPN tunnel</h2>
-        <p className="h-sub">
+        <Heading level={2} size="3xl" className="text-ink">
+          First VPN tunnel
+        </Heading>
+        <Text as="p" size="sm" className="mt-1 text-ink-3">
           Optional — connect a VPN provider so opted-in devices can route
           through it. You can add more from the Tunnels page once setup is
           complete.
-        </p>
+        </Text>
       </div>
 
       {hasTunnel ? (

--- a/source/admin-site/src/pages/setup/Step6Policy.tsx
+++ b/source/admin-site/src/pages/setup/Step6Policy.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { Button } from "@wardnet/web";
-import { Text } from "@wardnet/web";
+import { Heading, Text } from "@wardnet/web";
 import { RoutingSelector } from "@wardnet/web";
 import { useAdvanceWizard } from "@wardnet/web";
 import { useDefaultPolicy, useSetDefaultPolicy } from "@wardnet/web";
@@ -49,11 +49,13 @@ export default function Step6Policy() {
   return (
     <div className="flex flex-col gap-5">
       <div className="flex flex-col gap-1">
-        <h2 className="h-title">Default routing</h2>
-        <p className="h-sub">
+        <Heading level={2} size="3xl" className="text-ink">
+          Default routing
+        </Heading>
+        <Text as="p" size="sm" className="mt-1 text-ink-3">
           Pick how new devices route by default. You can override per-device
           later from the Devices page.
-        </p>
+        </Text>
       </div>
 
       <div className="flex flex-col gap-2">

--- a/source/admin-site/src/pages/setup/Step7RemoteAccess.tsx
+++ b/source/admin-site/src/pages/setup/Step7RemoteAccess.tsx
@@ -1,4 +1,4 @@
-import { Button, Text } from "@wardnet/web";
+import { Button, Heading, Text } from "@wardnet/web";
 import { WardnetApiError } from "@wardnet/js";
 import { useAdvanceWizard, useTlsStatus } from "@wardnet/web";
 import { RemoteAccessProgress } from "@/components/features/RemoteAccessProgress";
@@ -106,11 +106,13 @@ export default function Step7RemoteAccess() {
     return (
       <div className="flex flex-col gap-5">
         <div className="flex flex-col gap-1">
-          <h2 className="h-title">Remote access</h2>
-          <p className="h-sub">
+          <Heading level={2} size="3xl" className="text-ink">
+            Remote access
+          </Heading>
+          <Text as="p" size="sm" className="mt-1 text-ink-3">
             Your hostname is registered. The certificate is being issued in the
             background — you can wait here or finish setup; it'll keep going.
-          </p>
+          </Text>
         </div>
 
         {tlsStatus ? (
@@ -153,10 +155,12 @@ export default function Step7RemoteAccess() {
     return (
       <div className="flex flex-col gap-5">
         <div className="flex flex-col gap-1">
-          <h2 className="h-title">Remote access (HTTPS)</h2>
-          <p className="h-sub">
+          <Heading level={2} size="3xl" className="text-ink">
+            Remote access (HTTPS)
+          </Heading>
+          <Text as="p" size="sm" className="mt-1 text-ink-3">
             Wardnet couldn't reach the {serviceName} right now.
-          </p>
+          </Text>
         </div>
 
         <Text
@@ -196,12 +200,14 @@ export default function Step7RemoteAccess() {
   return (
     <div className="flex flex-col gap-5">
       <div className="flex flex-col gap-1">
-        <h2 className="h-title">Remote access (HTTPS)</h2>
-        <p className="h-sub">
+        <Heading level={2} size="3xl" className="text-ink">
+          Remote access (HTTPS)
+        </Heading>
+        <Text as="p" size="sm" className="mt-1 text-ink-3">
           Give Wardnet a public hostname and a valid certificate so you can
           reach it securely from anywhere. This step is optional, you can skip
           and set this up later from Settings.
-        </p>
+        </Text>
       </div>
 
       <div className="flex flex-col gap-2">

--- a/source/admin-site/src/pages/setup/Step8Confirm.tsx
+++ b/source/admin-site/src/pages/setup/Step8Confirm.tsx
@@ -1,5 +1,6 @@
 import { useNavigate } from "react-router";
 import { Button } from "@wardnet/web";
+import { Heading, Text } from "@wardnet/web";
 
 /**
  * Step 8 — wizard finished.
@@ -15,11 +16,13 @@ export default function Step8Confirm() {
   return (
     <div className="flex flex-col gap-5">
       <div className="flex flex-col gap-1">
-        <h2 className="h-title">All set</h2>
-        <p className="h-sub">
+        <Heading level={2} size="3xl" className="text-ink">
+          All set
+        </Heading>
+        <Text as="p" size="sm" className="mt-1 text-ink-3">
           Wardnet is configured. You can manage devices, tunnels, DHCP, and DNS
           filtering from the dashboard.
-        </p>
+        </Text>
       </div>
       <Button
         onClick={() => navigate("/")}

--- a/source/web/src/components/ApiErrorAlert.tsx
+++ b/source/web/src/components/ApiErrorAlert.tsx
@@ -1,5 +1,6 @@
 import { apiErrorMessage, apiRequestId } from "../lib/utils";
 import { CircleAlertIcon } from "lucide-react";
+import { Text } from "@wardnet/ui";
 
 interface ApiErrorAlertProps {
   error: unknown;
@@ -15,9 +16,13 @@ export function ApiErrorAlert({ error, fallback }: ApiErrorAlertProps) {
     <div role="alert" className="api-error-alert">
       <CircleAlertIcon className="api-error-alert__icon" />
       <div className="api-error-alert__body">
-        <p className="api-error-alert__message">{message}</p>
+        <Text as="p" className="api-error-alert__message">
+          {message}
+        </Text>
         {requestId && (
-          <p className="api-error-alert__request-id">Request ID: {requestId}</p>
+          <Text as="p" className="api-error-alert__request-id">
+            Request ID: {requestId}
+          </Text>
         )}
       </div>
     </div>

--- a/source/web/src/components/ConnectionGate.tsx
+++ b/source/web/src/components/ConnectionGate.tsx
@@ -1,6 +1,6 @@
 import { useRef } from "react";
 import { RefreshCw } from "lucide-react";
-import { Button } from "@wardnet/ui";
+import { Button, Heading, Text } from "@wardnet/ui";
 import { useDaemonStatus } from "../hooks/useDaemonStatus";
 
 /**
@@ -65,11 +65,13 @@ interface ConnectionErrorProps {
 function ConnectionError({ onRetry, retrying }: ConnectionErrorProps) {
   return (
     <div role="alert" className="empty col items-center justify-center gap-4">
-      <h2 className="h-title">Can&rsquo;t reach Wardnet</h2>
-      <p className="h-sub max-w-md">
+      <Heading level={2} size="3xl" className="text-ink">
+        Can&rsquo;t reach Wardnet
+      </Heading>
+      <Text as="p" size="sm" className="mt-1 max-w-md text-ink-3">
         The Wardnet daemon isn&rsquo;t responding. Make sure it&rsquo;s running
         and that you&rsquo;re on the same network, then try again.
-      </p>
+      </Text>
       <Button variant="outline" onClick={onRetry} disabled={retrying}>
         <RefreshCw
           size={15}

--- a/source/web/src/components/LoginForm.tsx
+++ b/source/web/src/components/LoginForm.tsx
@@ -4,6 +4,7 @@ import { Button } from "@wardnet/ui";
 import { Field } from "@wardnet/ui";
 import { Form, Validator } from "@wardnet/ui";
 import { Input } from "@wardnet/ui";
+import { Text } from "@wardnet/ui";
 
 interface LoginFormProps {
   /** Injected login action — callers supply this from their auth store or hook. */
@@ -112,9 +113,14 @@ export function LoginForm({
       )}
 
       {formError && (
-        <p role="alert" data-testid="login-error" className="login-form__error">
+        <Text
+          as="p"
+          role="alert"
+          data-testid="login-error"
+          className="login-form__error"
+        >
           {formError}
-        </p>
+        </Text>
       )}
       <Button
         type="submit"
@@ -124,9 +130,9 @@ export function LoginForm({
       >
         {loading ? "Signing in…" : "Log in"}
       </Button>
-      <p className="login-form__hint">
+      <Text as="p" className="login-form__hint">
         Credentials are set during initial daemon setup.
-      </p>
+      </Text>
     </Form>
   );
 }

--- a/source/web/src/components/RoutingSelector.tsx
+++ b/source/web/src/components/RoutingSelector.tsx
@@ -4,6 +4,7 @@ import {
   SelectItem,
   SelectTrigger,
   SelectValue,
+  Text,
 } from "@wardnet/ui";
 import { Link } from "react-router";
 import { WifiOffIcon } from "lucide-react";
@@ -72,7 +73,7 @@ export function RoutingSelector({
             </SelectItem>
           </SelectContent>
         </Select>
-        <p className="text-sm text-ink-3">
+        <Text as="p" size="sm" className="text-ink-3">
           No tunnels configured.{" "}
           {isAdmin ? (
             <Link to="/tunnels" className="text-accent underline">
@@ -81,7 +82,7 @@ export function RoutingSelector({
           ) : (
             "Contact your network admin."
           )}
-        </p>
+        </Text>
       </div>
     );
   }


### PR DESCRIPTION
## Summary

Finishes the design-system typography migration (#729): all remaining raw `<h1>/<h2>/<p>` typographic tags in **admin-site** and **web** now render through the DS `Heading`/`Text` primitives from `@wardnet/ui` (re-exported by `@wardnet/web`). `admin-app`/`user-app` were already migrated; `marketing-site` stays out of scope by decision.

## Mapping (visual output preserved)

The chosen variants match the size/weight/leading of the legacy classes:

| Legacy | Replacement |
| --- | --- |
| `<h1/h2 className="h-title">` (26px / 600 / ink) | `<Heading level={n} size="3xl" className="text-ink">` |
| `<p className="h-sub">` (13px / ink-3 / 4px top margin) | `<Text as="p" size="sm" className="mt-1 text-ink-3">` |
| BEM- / ad-hoc-classed and plain `<p>` | `<Text as="p" …>` preserving existing classes |
| `LogViewer` `<p className="logrow is-info">` (layout row) | `<div>` — matches its sibling row, layout-only |

`size="3xl"` is set explicitly because the bare DS `h1`/`h2` variants are 22px/18px, whereas the legacy `.h-title` is 26px (`--text-3xl`); this keeps titles visually unchanged.

## Files

- **admin-site** (15 files): `PageHeader`, `DetailPageHeader`, `RemoteAccessProgress`, `LogViewer`, `DeviceDetail`, `TunnelDetail`, `NotFound`, and setup steps 1–8.
- **web** (4 files): `LoginForm`, `ApiErrorAlert`, `RoutingSelector`, `ConnectionGate`.

## Verification

- `yarn type-check` (admin-site) ✅ · `yarn lint` (admin-site) ✅
- `tsc --noEmit` (web) ✅ · `prettier --check` on touched files ✅
- `grep '\b<(h1|h2|h3|h4|p)\b'` across `admin-site`/`web` app code returns no matches (only a comment reference in `CronSchedulePicker`).

## Merge Commit Message

refactor(admin-site,web): render text through DS Heading/Text (#729)

https://claude.ai/code/session_01HPZRtVWVCMVXW1nUzVCiZi