### PR TITLE
refactor(admin-site): adopt shared SegmentedTabs for DataTable group control (#631)

### DIFF
--- a/source/admin-app/package.json
+++ b/source/admin-app/package.json
@@ -13,7 +13,7 @@
     "@tanstack/react-query": "5.101.1",
     "@wardnet/js": "workspace:*",
     "@wardnet/styles": "^0.1.0",
-    "@wardnet/ui": "^0.2.0",
+    "@wardnet/ui": "^0.3.0",
     "@wardnet/web": "workspace:*",
     "lucide-react": "1.21.0",
     "react": "19.2.7",

--- a/source/admin-site/package.json
+++ b/source/admin-site/package.json
@@ -19,7 +19,7 @@
     "@tanstack/react-table": "8.21.3",
     "@wardnet/js": "workspace:*",
     "@wardnet/styles": "^0.1.0",
-    "@wardnet/ui": "^0.2.0",
+    "@wardnet/ui": "^0.3.0",
     "@wardnet/web": "workspace:*",
     "class-variance-authority": "0.7.1",
     "clsx": "2.1.1",

--- a/source/admin-site/src/components/core/ui/data-table.tsx
+++ b/source/admin-site/src/components/core/ui/data-table.tsx
@@ -22,6 +22,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@wardnet/web";
+import { SegmentedTabs } from "@wardnet/web";
 import { cn } from "@wardnet/web";
 
 declare module "@tanstack/react-table" {
@@ -194,29 +195,18 @@ export function DataTable<TData, TValue>({
         <div className="tbl-toolbar">
           {groups && groups.length > 0 && (
             <>
-              {/* Desktop wrapper — segmented pill control. Wrapped in
-                  a plain div because Forge's unlayered `.tabs {
-                  display: inline-flex }` would otherwise beat
-                  Tailwind's layered `.hidden { display: none }`. */}
+              {/* Desktop wrapper — shared segmented pill control. Wrapped
+                  in a plain div because Forge's unlayered `.tabs {
+                  display: inline-flex }` would otherwise beat Tailwind's
+                  layered `.hidden { display: none }`. `DataTableGroup` is
+                  structurally a `SegmentedTab` (id/label/count/testId), so
+                  the groups pass straight through. */}
               <div className="hidden md:block">
-                <div className="tabs" role="tablist">
-                  {groups.map((g) => (
-                    <button
-                      key={g.id}
-                      type="button"
-                      role="tab"
-                      aria-selected={g.id === activeGroup}
-                      data-state={g.id === activeGroup ? "active" : "inactive"}
-                      data-testid={g.testId}
-                      onClick={() => onGroupChange?.(g.id)}
-                    >
-                      {g.label}
-                      {g.count !== undefined && (
-                        <span className="count">{g.count}</span>
-                      )}
-                    </button>
-                  ))}
-                </div>
+                <SegmentedTabs
+                  tabs={groups}
+                  activeId={activeGroup ?? ""}
+                  onChange={(id) => onGroupChange?.(id)}
+                />
               </div>
               {/* Mobile wrapper — same data as a Select that collapses
                   long group lists to a single 34px trigger. Same

--- a/source/user-app/package.json
+++ b/source/user-app/package.json
@@ -15,7 +15,7 @@
     "@tanstack/react-query": "5.101.1",
     "@wardnet/js": "workspace:*",
     "@wardnet/styles": "^0.1.0",
-    "@wardnet/ui": "^0.2.0",
+    "@wardnet/ui": "^0.3.0",
     "@wardnet/web": "workspace:*",
     "leaflet": "^1.9.4",
     "lucide-react": "1.21.0",

--- a/source/web/package.json
+++ b/source/web/package.json
@@ -20,7 +20,7 @@
     "format:check": "prettier --check \"src/**/*.{ts,tsx}\""
   },
   "dependencies": {
-    "@wardnet/ui": "^0.2.0",
+    "@wardnet/ui": "^0.3.0",
     "clsx": "2.1.1",
     "cronstrue": "3.21.0",
     "tailwind-merge": "3.6.0"

--- a/source/yarn.lock
+++ b/source/yarn.lock
@@ -4891,7 +4891,7 @@ __metadata:
     "@vitejs/plugin-react": "npm:6.0.3"
     "@wardnet/js": "workspace:*"
     "@wardnet/styles": "npm:^0.1.0"
-    "@wardnet/ui": "npm:^0.2.0"
+    "@wardnet/ui": "npm:^0.3.0"
     "@wardnet/web": "workspace:*"
     lucide-react: "npm:1.21.0"
     react: "npm:19.2.7"
@@ -4924,7 +4924,7 @@ __metadata:
     "@vitejs/plugin-react": "npm:6.0.3"
     "@wardnet/js": "workspace:*"
     "@wardnet/styles": "npm:^0.1.0"
-    "@wardnet/ui": "npm:^0.2.0"
+    "@wardnet/ui": "npm:^0.3.0"
     "@wardnet/web": "workspace:*"
     class-variance-authority: "npm:0.7.1"
     clsx: "npm:2.1.1"
@@ -5030,9 +5030,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wardnet/ui@npm:^0.2.0":
-  version: 0.2.0
-  resolution: "@wardnet/ui@npm:0.2.0::__archiveUrl=https%3A%2F%2Fnpm.pkg.github.com%2Fdownload%2F%40wardnet%2Fui%2F0.2.0%2Ffc92ca9a57dfa3f63539bf4734d187d58239dfa6"
+"@wardnet/ui@npm:^0.3.0":
+  version: 0.3.0
+  resolution: "@wardnet/ui@npm:0.3.0::__archiveUrl=https%3A%2F%2Fnpm.pkg.github.com%2Fdownload%2F%40wardnet%2Fui%2F0.3.0%2F1a3035fed039ce856849123364bc07ddd9d7da81"
   dependencies:
     "@wardnet/styles": "npm:^0.1.0"
     class-variance-authority: "npm:0.7.1"
@@ -5044,7 +5044,7 @@ __metadata:
     lucide-react: ">=1.0.0"
     react: ^19.0.0
     react-dom: ^19.0.0
-  checksum: 10c0/1b158502f6bfeadea737c1bef118a2e671245c1021ebe836fa31c33071e98ebe1333c20ea2b4f8645d497c1f79157870ac8d3c3c333b6b338decdb1626029ff2
+  checksum: 10c0/bb8364e21777ec0a3b097f8d1b98f96f2d052d89559361cee9ea30fd319761a9ed6ec43077ab28c9ec5594e62aca526a76d120419ad53569363e4d5c0ca204d8
   languageName: node
   linkType: hard
 
@@ -5063,7 +5063,7 @@ __metadata:
     "@vitejs/plugin-react": "npm:6.0.3"
     "@wardnet/js": "workspace:*"
     "@wardnet/styles": "npm:^0.1.0"
-    "@wardnet/ui": "npm:^0.2.0"
+    "@wardnet/ui": "npm:^0.3.0"
     "@wardnet/web": "workspace:*"
     leaflet: "npm:^1.9.4"
     lucide-react: "npm:1.21.0"
@@ -5086,7 +5086,7 @@ __metadata:
   resolution: "@wardnet/web@workspace:web"
   dependencies:
     "@eslint/js": "npm:10.0.1"
-    "@wardnet/ui": "npm:^0.2.0"
+    "@wardnet/ui": "npm:^0.3.0"
     clsx: "npm:2.1.1"
     cronstrue: "npm:3.21.0"
     eslint: "npm:10.4.1"


### PR DESCRIPTION
Closes #631.

## Summary

Replaces the hand-rolled desktop `.tabs` segmented button row in the admin-site `DataTable` toolbar with the canonical `SegmentedTabs` control from `@wardnet/ui` (imported via `@wardnet/web`). The mobile `Select` fallback is untouched.

`DataTableGroup` is structurally identical to the (now extended) `SegmentedTab` — `{ id, label, count?, testId? }` — so `groups` pass straight through and every per-tab `data-testid` (e.g. `dhcp-group-leases`) is preserved. No changes to `DhcpEntryTable`, `DeviceTable`, `Devices.tsx`, or e2e specs.

**Audit:** `data-table.tsx` was the only remaining hand-rolled `.tabs` / `role="tablist"` control in admin-site — `RuleRequests.tsx` already uses `SegmentedTabs`. Nothing else to migrate.

## Dependency (⚠️ blocks green CI)

Needs `@wardnet/ui` **0.3.0**, which adds the optional per-tab `testId` (see wardnet/wardnet-design-system#7). This PR bumps `@wardnet/ui` `^0.2.0 → ^0.3.0` across the four consumers (`admin-app`, `admin-site`, `user-app`, `web`).

**CI will stay red until 0.3.0 is published to GitHub Packages** (merge DS#7 → merge its Version Packages PR → push the `@wardnet/ui@0.3.0` tag). Once published, refresh `yarn.lock` and CI goes green — no further code changes expected.

## Verification

- Structural: `DataTableGroup` ⊆ `SegmentedTab`; `@wardnet/web` re-exports `SegmentedTabs` (`export * from "@wardnet/ui"`), the same path `RuleRequests.tsx` already compiles against.
- Full type-check/build deferred to CI post-publish (local install can't resolve unpublished 0.3.0; dev disk near-full).

## Merge Commit Message

refactor(admin-site): adopt shared SegmentedTabs for DataTable group control (#631)