### PR TITLE
fix(zones): post-merge code-review follow-ups for Network Zones (#735)

### DIFF
--- a/docs/adr-network-zone-isolation.md
+++ b/docs/adr-network-zone-isolation.md
@@ -59,15 +59,28 @@ routing choice; they do not make it. `admin_locked` remains a separate gate
 governing *who* may change a rule.
 
 **`RoutingTarget::Default` is resolve-then-check.** Validation resolves `Default`
-to a concrete kind via the global default policy (read directly from
-`system_config`'s `default_policy` key, mirroring `RoutingService` — a
-service→service call would introduce a cycle), then checks the *resolved* kind.
-`Default` is never itself an entry in `allowed_targets`.
+to a concrete kind via the global default policy, then checks the *resolved*
+kind. The `"direct"`-vs-tunnel-UUID classification is a single shared function
+(`RoutingTarget::from_default_policy` in `wardnet-common`) used by both the
+routing engine (`RoutingService::resolve_target`) and the zone gate, so the two
+can never disagree about what `Default` means. The zone gate reads the persisted
+`default_policy` from `system_config` directly (a `RoutingService` call would
+introduce a service→service cycle). `Default` is never itself an entry in
+`allowed_targets`.
 
-**Known caveat:** already-stored `Default` rules are validated at write time
-only. If the global policy later flips (e.g. `direct` → a tunnel) a stored
-`Default` rule is not retro-validated here. Reconciling stored rules against a
-changed policy belongs to the CI-2 enforcer (#736), not to this write-time gate.
+**The invariant "a device's stored rule kind is permitted by its zone" is
+enforced on every edge that can create a contradiction:** the two rule-write
+paths (`set_rule` / `set_rule_for_ip`), **device→zone reassignment**
+(`assign_device` rejects a move that would strand a device holding a rule its
+new zone forbids), and **zone-config narrowing** (`update_zone` rejects an
+`allowed_targets` change that any current member's rule would violate — a
+batched two-query check).
+
+**Known caveat:** the one edge *not* re-validated is a change to the **global
+default policy** itself (e.g. `direct` → a tunnel), which can flip the resolved
+kind of every stored `Default` rule at once. Reconciling stored rules against a
+changed policy is a fleet-wide reconciliation that belongs to the CI-2 enforcer
+(#736), not to a per-write gate.
 
 ### 3. Two default flags, not one
 

--- a/source/daemon/crates/wardnet-common/src/api.rs
+++ b/source/daemon/crates/wardnet-common/src/api.rs
@@ -1748,7 +1748,14 @@ pub struct UpdateNetworkZoneRequest {
     pub member_isolation: Option<bool>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub admin_ui_reachable: Option<bool>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    // Three-state: absent → `None` (leave as-is); `null` → `Some(None)` (clear);
+    // a value → `Some(Some(..))` (set). Needs `nullable_field` because plain
+    // serde maps JSON `null` on `Option<Option<T>>` to the outer `None`.
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "crate::serde_util::nullable_field"
+    )]
     pub subnet: Option<Option<ZoneSubnet>>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub is_default: Option<bool>,

--- a/source/daemon/crates/wardnet-common/src/network_zone.rs
+++ b/source/daemon/crates/wardnet-common/src/network_zone.rs
@@ -2,12 +2,37 @@ use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
+use crate::routing::RoutingTarget;
+
 /// A permitted routing-target *kind* a zone allows. Coarse: any tunnel, or direct.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, utoipa::ToSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum AllowedTargetKind {
     Direct,
     Tunnel,
+}
+
+impl AllowedTargetKind {
+    /// The coarse kind of a *concrete* routing target. `Default` is not
+    /// concrete (it resolves through the global policy first) and yields
+    /// `None` — callers resolve it via [`RoutingTarget::from_default_policy`].
+    #[must_use]
+    pub fn of_target(target: &RoutingTarget) -> Option<Self> {
+        match target {
+            RoutingTarget::Direct => Some(Self::Direct),
+            RoutingTarget::Tunnel { .. } => Some(Self::Tunnel),
+            RoutingTarget::Default => None,
+        }
+    }
+
+    /// The `snake_case` wire string, for log/error messages.
+    #[must_use]
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Direct => "direct",
+            Self::Tunnel => "tunnel",
+        }
+    }
 }
 
 /// Cross-zone isolation rung of the guarantee ladder (epic #244). Only the rungs

--- a/source/daemon/crates/wardnet-common/src/routing.rs
+++ b/source/daemon/crates/wardnet-common/src/routing.rs
@@ -10,6 +10,25 @@ pub enum RoutingTarget {
     Default,
 }
 
+impl RoutingTarget {
+    /// Interpret a persisted global default-policy string into a concrete
+    /// target. `"direct"` → [`Direct`](Self::Direct); a tunnel UUID →
+    /// [`Tunnel`](Self::Tunnel); any other (legacy/corrupt) value falls back to
+    /// `Direct`. The single source of truth shared by the routing engine
+    /// (`RoutingService::resolve_target`) and the Network-Zone gate
+    /// (`DeviceService`), so the two never disagree about what `Default` means.
+    #[must_use]
+    pub fn from_default_policy(policy: &str) -> Self {
+        if policy == "direct" {
+            Self::Direct
+        } else if let Ok(tunnel_id) = policy.parse::<Uuid>() {
+            Self::Tunnel { tunnel_id }
+        } else {
+            Self::Direct
+        }
+    }
+}
+
 /// Who created a routing rule.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, utoipa::ToSchema)]
 #[serde(rename_all = "snake_case")]

--- a/source/daemon/crates/wardnet-common/src/tests/api.rs
+++ b/source/daemon/crates/wardnet-common/src/tests/api.rs
@@ -71,3 +71,21 @@ fn export_backup_request_debug_redacts_passphrase() {
     assert!(rendered.contains("[REDACTED]"));
     assert!(!rendered.contains("correct-horse-battery-staple"));
 }
+
+#[test]
+fn update_network_zone_request_subnet_is_three_state() {
+    use crate::api::UpdateNetworkZoneRequest;
+
+    // Absent → None (leave as-is).
+    let absent: UpdateNetworkZoneRequest = serde_json::from_str("{}").unwrap();
+    assert_eq!(absent.subnet, None);
+
+    // Explicit null → Some(None) (clear).
+    let cleared: UpdateNetworkZoneRequest = serde_json::from_str(r#"{"subnet":null}"#).unwrap();
+    assert_eq!(cleared.subnet, Some(None));
+
+    // A value → Some(Some(..)) (set).
+    let set: UpdateNetworkZoneRequest =
+        serde_json::from_str(r#"{"subnet":{"cidr":"10.44.0.0/24"}}"#).unwrap();
+    assert_eq!(set.subnet.unwrap().unwrap().cidr, "10.44.0.0/24");
+}

--- a/source/daemon/crates/wardnetd-data/src/repository/network_zone.rs
+++ b/source/daemon/crates/wardnetd-data/src/repository/network_zone.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use async_trait::async_trait;
 use wardnet_common::network_zone::NetworkZone;
 
@@ -42,4 +44,10 @@ pub trait NetworkZoneRepository: Send + Sync {
 
     /// Count the devices currently assigned to the given zone.
     async fn count_members(&self, zone_id: &str) -> anyhow::Result<i64>;
+
+    /// Member counts for every zone in a single query (`zone_id` → count).
+    /// Zones with zero members are absent from the map. Batched companion to
+    /// [`count_members`](Self::count_members) for the list view (avoids an
+    /// N+1 COUNT per zone).
+    async fn member_counts(&self) -> anyhow::Result<HashMap<String, i64>>;
 }

--- a/source/daemon/crates/wardnetd-data/src/repository/sqlite/network_zone.rs
+++ b/source/daemon/crates/wardnetd-data/src/repository/sqlite/network_zone.rs
@@ -176,10 +176,15 @@ impl NetworkZoneRepository for SqliteNetworkZoneRepository {
         sqlx::query("UPDATE network_zones SET is_default = 0 WHERE is_default = 1")
             .execute(&mut *tx)
             .await?;
-        sqlx::query("UPDATE network_zones SET is_default = 1 WHERE id = ?")
+        let set = sqlx::query("UPDATE network_zones SET is_default = 1 WHERE id = ?")
             .bind(id)
             .execute(&mut *tx)
             .await?;
+        // Guard against clearing the flag from every row but setting it on none
+        // (unknown id) — that would orphan the anchor. Roll back by not committing.
+        if set.rows_affected() == 0 {
+            anyhow::bail!("cannot set default: no network zone with id {id}");
+        }
         tx.commit().await?;
         Ok(())
     }
@@ -189,10 +194,13 @@ impl NetworkZoneRepository for SqliteNetworkZoneRepository {
         sqlx::query("UPDATE network_zones SET is_default_for_new = 0 WHERE is_default_for_new = 1")
             .execute(&mut *tx)
             .await?;
-        sqlx::query("UPDATE network_zones SET is_default_for_new = 1 WHERE id = ?")
+        let set = sqlx::query("UPDATE network_zones SET is_default_for_new = 1 WHERE id = ?")
             .bind(id)
             .execute(&mut *tx)
             .await?;
+        if set.rows_affected() == 0 {
+            anyhow::bail!("cannot set default-for-new: no network zone with id {id}");
+        }
         tx.commit().await?;
         Ok(())
     }

--- a/source/daemon/crates/wardnetd-data/src/repository/sqlite/network_zone.rs
+++ b/source/daemon/crates/wardnetd-data/src/repository/sqlite/network_zone.rs
@@ -212,4 +212,13 @@ impl NetworkZoneRepository for SqliteNetworkZoneRepository {
             .await?;
         Ok(count)
     }
+
+    async fn member_counts(&self) -> anyhow::Result<std::collections::HashMap<String, i64>> {
+        let rows = sqlx::query_as::<_, (String, i64)>(
+            "SELECT zone_id, COUNT(*) FROM devices GROUP BY zone_id",
+        )
+        .fetch_all(&self.pools.read)
+        .await?;
+        Ok(rows.into_iter().collect())
+    }
 }

--- a/source/daemon/crates/wardnetd-services/src/device/service.rs
+++ b/source/daemon/crates/wardnetd-services/src/device/service.rs
@@ -151,29 +151,27 @@ impl DeviceServiceImpl {
         }
     }
 
-    /// Resolve the global default routing policy into a concrete target kind.
-    ///
-    /// Mirrors [`RoutingServiceImpl::resolve_target`](crate::routing) without a
-    /// service→service dependency: reads the persisted `default_policy` string
-    /// (`"direct"` or a tunnel UUID) directly from `system_config`. Absent or
-    /// unparseable config resolves to `Direct`.
-    async fn resolve_default_kind(&self) -> Result<AllowedTargetKind, AppError> {
+    /// Resolve a routing target into the coarse [`AllowedTargetKind`] a zone
+    /// gates on. `Default` is resolved through the persisted global
+    /// `default_policy` (read from `system_config`, avoiding a service→service
+    /// cycle) using the shared [`RoutingTarget::from_default_policy`] — the same
+    /// classifier the routing engine uses, so the two never disagree.
+    async fn resolve_target_kind(
+        &self,
+        target: &RoutingTarget,
+    ) -> Result<AllowedTargetKind, AppError> {
+        if let Some(kind) = AllowedTargetKind::of_target(target) {
+            return Ok(kind);
+        }
+        // `Default` — resolve via the global policy.
         let policy = self
             .system_config
             .get_default_policy()
             .await
             .map_err(AppError::Internal)?
             .unwrap_or_else(|| "direct".to_owned());
-        Ok(if policy == "direct" {
-            AllowedTargetKind::Direct
-        } else {
-            // Any non-"direct" value is a tunnel selector (validated on write by
-            // the routing service); treat unparseable legacy values as Direct.
-            match policy.parse::<Uuid>() {
-                Ok(_) => AllowedTargetKind::Tunnel,
-                Err(_) => AllowedTargetKind::Direct,
-            }
-        })
+        let concrete = RoutingTarget::from_default_policy(&policy);
+        Ok(AllowedTargetKind::of_target(&concrete).unwrap_or(AllowedTargetKind::Direct))
     }
 
     /// Reject a routing target that the device's Network Zone does not permit.
@@ -187,11 +185,7 @@ impl DeviceServiceImpl {
         device: &Device,
         target: &RoutingTarget,
     ) -> Result<(), AppError> {
-        let kind = match target {
-            RoutingTarget::Direct => AllowedTargetKind::Direct,
-            RoutingTarget::Tunnel { .. } => AllowedTargetKind::Tunnel,
-            RoutingTarget::Default => self.resolve_default_kind().await?,
-        };
+        let kind = self.resolve_target_kind(target).await?;
 
         let zone = self
             .zones
@@ -207,12 +201,9 @@ impl DeviceServiceImpl {
             })?;
 
         if !zone.permits_kind(kind) {
-            let kind_str = match kind {
-                AllowedTargetKind::Direct => "direct",
-                AllowedTargetKind::Tunnel => "tunnel",
-            };
             return Err(AppError::Conflict(format!(
-                "routing target '{kind_str}' is not permitted by this device's zone '{}'",
+                "routing target '{}' is not permitted by this device's zone '{}'",
+                kind.as_str(),
                 zone.name
             )));
         }

--- a/source/daemon/crates/wardnetd-services/src/device/tests/device.rs
+++ b/source/daemon/crates/wardnetd-services/src/device/tests/device.rs
@@ -234,6 +234,9 @@ impl NetworkZoneRepository for MockNetworkZoneRepo {
     async fn count_members(&self, _zone_id: &str) -> anyhow::Result<i64> {
         Ok(0)
     }
+    async fn member_counts(&self) -> anyhow::Result<std::collections::HashMap<String, i64>> {
+        Ok(std::collections::HashMap::new())
+    }
 }
 
 // -- Mock system-config repository ----------------------------------------

--- a/source/daemon/crates/wardnetd-services/src/device/tests/discovery.rs
+++ b/source/daemon/crates/wardnetd-services/src/device/tests/discovery.rs
@@ -360,6 +360,9 @@ impl NetworkZoneRepository for MockNetworkZoneRepo {
     async fn count_members(&self, _zone_id: &str) -> anyhow::Result<i64> {
         Ok(0)
     }
+    async fn member_counts(&self) -> anyhow::Result<std::collections::HashMap<String, i64>> {
+        Ok(std::collections::HashMap::new())
+    }
 }
 
 struct MockDhcpRepository {

--- a/source/daemon/crates/wardnetd-services/src/lib.rs
+++ b/source/daemon/crates/wardnetd-services/src/lib.rs
@@ -455,6 +455,7 @@ fn create_services(
     let network_zone_service: Arc<dyn NetworkZoneService> = Arc::new(NetworkZoneServiceImpl::new(
         network_zone_repo.clone(),
         device_repo.clone(),
+        system_config_repo.clone(),
         event_publisher.clone(),
     ));
 

--- a/source/daemon/crates/wardnetd-services/src/network_zone/service.rs
+++ b/source/daemon/crates/wardnetd-services/src/network_zone/service.rs
@@ -261,6 +261,14 @@ impl NetworkZoneService for NetworkZoneServiceImpl {
                 "the default (anchor) zone cannot be deleted".to_owned(),
             ));
         }
+        if zone.is_default_for_new {
+            // Deleting the sole default-for-new zone would orphan the pointer
+            // (`find_default_for_new` would then error, breaking device
+            // discovery). Promote another zone first.
+            return Err(AppError::Conflict(
+                "the default-for-new zone cannot be deleted; promote another zone first".to_owned(),
+            ));
+        }
         let members = self
             .zones
             .count_members(&id.to_string())

--- a/source/daemon/crates/wardnetd-services/src/network_zone/service.rs
+++ b/source/daemon/crates/wardnetd-services/src/network_zone/service.rs
@@ -5,8 +5,9 @@ use async_trait::async_trait;
 use uuid::Uuid;
 use wardnet_common::api::{CreateNetworkZoneRequest, NetworkZoneView, UpdateNetworkZoneRequest};
 use wardnet_common::event::WardnetEvent;
-use wardnet_common::network_zone::{NetworkZone, ZoneProvenance};
-use wardnetd_data::repository::{DeviceRepository, NetworkZoneRepository};
+use wardnet_common::network_zone::{AllowedTargetKind, NetworkZone, ZoneProvenance};
+use wardnet_common::routing::RoutingTarget;
+use wardnetd_data::repository::{DeviceRepository, NetworkZoneRepository, SystemConfigRepository};
 
 use crate::auth_context;
 use crate::error::AppError;
@@ -55,6 +56,7 @@ pub trait NetworkZoneService: Send + Sync {
 pub struct NetworkZoneServiceImpl {
     zones: Arc<dyn NetworkZoneRepository>,
     devices: Arc<dyn DeviceRepository>,
+    system_config: Arc<dyn SystemConfigRepository>,
     events: Arc<dyn EventPublisher>,
 }
 
@@ -64,13 +66,102 @@ impl NetworkZoneServiceImpl {
     pub fn new(
         zones: Arc<dyn NetworkZoneRepository>,
         devices: Arc<dyn DeviceRepository>,
+        system_config: Arc<dyn SystemConfigRepository>,
         events: Arc<dyn EventPublisher>,
     ) -> Self {
         Self {
             zones,
             devices,
+            system_config,
             events,
         }
+    }
+
+    /// Resolve a device's *current* routing-rule kind (if it has a rule),
+    /// resolving `Default` through the global policy — the same classification
+    /// the write-time zone gate in `DeviceService` uses. `Ok(None)` means the
+    /// device has no rule of its own (it follows the gateway default, which is
+    /// itself already zone-checked at write time only — see the ADR caveat).
+    async fn current_rule_kind(
+        &self,
+        device_id: &str,
+    ) -> Result<Option<AllowedTargetKind>, AppError> {
+        let Some(rule) = self
+            .devices
+            .find_rule_for_device(device_id)
+            .await
+            .map_err(AppError::Internal)?
+        else {
+            return Ok(None);
+        };
+        let concrete = match rule.target {
+            RoutingTarget::Default => {
+                let policy = self
+                    .system_config
+                    .get_default_policy()
+                    .await
+                    .map_err(AppError::Internal)?
+                    .unwrap_or_else(|| "direct".to_owned());
+                RoutingTarget::from_default_policy(&policy)
+            }
+            other => other,
+        };
+        Ok(Some(
+            AllowedTargetKind::of_target(&concrete).unwrap_or(AllowedTargetKind::Direct),
+        ))
+    }
+
+    /// Reject if any device in `zone_id` holds a routing rule whose resolved
+    /// kind is not in `allowed` — used when a zone's `allowed_targets` is about
+    /// to change. Batched: two queries total (all devices + all rules) plus one
+    /// policy read, regardless of member count.
+    async fn assert_members_conform(
+        &self,
+        zone_id: Uuid,
+        allowed: &[AllowedTargetKind],
+    ) -> Result<(), AppError> {
+        let members: std::collections::HashSet<String> = self
+            .devices
+            .find_all()
+            .await
+            .map_err(AppError::Internal)?
+            .into_iter()
+            .filter(|d| d.zone_id == zone_id)
+            .map(|d| d.id.to_string())
+            .collect();
+        if members.is_empty() {
+            return Ok(());
+        }
+        let policy = self
+            .system_config
+            .get_default_policy()
+            .await
+            .map_err(AppError::Internal)?
+            .unwrap_or_else(|| "direct".to_owned());
+        let rules = self
+            .devices
+            .find_all_rules()
+            .await
+            .map_err(AppError::Internal)?;
+        for rule in rules {
+            if !members.contains(&rule.device_id.to_string()) {
+                continue;
+            }
+            let concrete = match rule.target {
+                RoutingTarget::Default => RoutingTarget::from_default_policy(&policy),
+                other => other,
+            };
+            let kind = AllowedTargetKind::of_target(&concrete).unwrap_or(AllowedTargetKind::Direct);
+            if !allowed.contains(&kind) {
+                return Err(AppError::Conflict(format!(
+                    "cannot narrow allowed_targets: device {} has a '{}' rule the new set forbids; \
+                     change or clear its rule first",
+                    rule.device_id,
+                    kind.as_str()
+                )));
+            }
+        }
+        Ok(())
     }
 
     /// Fetch a zone by id or return `NotFound`.
@@ -148,10 +239,19 @@ impl NetworkZoneService for NetworkZoneServiceImpl {
     async fn list_zones(&self) -> Result<Vec<NetworkZoneView>, AppError> {
         auth_context::require_admin()?;
         let zones = self.zones.find_all().await.map_err(AppError::Internal)?;
-        let mut views = Vec::with_capacity(zones.len());
-        for zone in zones {
-            views.push(self.view_of(zone).await?);
-        }
+        // One GROUP BY instead of an N+1 COUNT per zone.
+        let counts = self
+            .zones
+            .member_counts()
+            .await
+            .map_err(AppError::Internal)?;
+        let views = zones
+            .into_iter()
+            .map(|zone| {
+                let member_count = counts.get(&zone.id.to_string()).copied().unwrap_or(0);
+                NetworkZoneView { zone, member_count }
+            })
+            .collect();
         Ok(views)
     }
 
@@ -211,6 +311,7 @@ impl NetworkZoneService for NetworkZoneServiceImpl {
         if let Some(stance) = req.isolation_stance {
             zone.isolation_stance = stance;
         }
+        let targets_changed = req.allowed_targets.is_some();
         if let Some(allowed_targets) = req.allowed_targets {
             zone.allowed_targets = allowed_targets;
         }
@@ -226,16 +327,26 @@ impl NetworkZoneService for NetworkZoneServiceImpl {
 
         Self::validate_targets_and_subnet(&zone.allowed_targets, zone.subnet.as_ref())?;
 
+        // If the permitted target kinds change, no existing member may be left
+        // holding a rule the new set forbids — the same invariant the write-time
+        // gate enforces, applied from the zone-config side.
+        if targets_changed {
+            self.assert_members_conform(id, &zone.allowed_targets)
+                .await?;
+        }
+
         zone.updated_at = chrono::Utc::now();
         self.zones.update(&zone).await.map_err(AppError::Internal)?;
 
-        if req.is_default == Some(true) {
+        let promoted_default = req.is_default == Some(true);
+        let promoted_default_for_new = req.is_default_for_new == Some(true);
+        if promoted_default {
             self.zones
                 .set_default(&id.to_string())
                 .await
                 .map_err(AppError::Internal)?;
         }
-        if req.is_default_for_new == Some(true) {
+        if promoted_default_for_new {
             self.zones
                 .set_default_for_new(&id.to_string())
                 .await
@@ -243,8 +354,13 @@ impl NetworkZoneService for NetworkZoneServiceImpl {
         }
 
         self.emit_zone_changed(id);
-        // Re-fetch so any default-flag flips are reflected in the response.
-        self.require_zone(id).await
+        // Re-fetch only when a default flag was moved out-of-band; otherwise the
+        // already-mutated local `zone` is authoritative.
+        if promoted_default || promoted_default_for_new {
+            self.require_zone(id).await
+        } else {
+            Ok(zone)
+        }
     }
 
     async fn delete_zone(&self, id: Uuid) -> Result<(), AppError> {
@@ -321,11 +437,24 @@ impl NetworkZoneService for NetworkZoneServiceImpl {
             .ok_or_else(|| AppError::NotFound(format!("device {device_id} not found")))?;
 
         // Validate the target zone exists (also enforced by the FK).
-        self.require_zone(zone_id).await?;
+        let target_zone = self.require_zone(zone_id).await?;
 
         let old_zone_id = device.zone_id;
         if old_zone_id == zone_id {
             return Ok(());
+        }
+
+        // Don't strand the device with a routing rule its new zone forbids —
+        // the write-time gate would have rejected that target, so reject the
+        // move too rather than persist contradictory state.
+        if let Some(kind) = self.current_rule_kind(&device_id.to_string()).await?
+            && !target_zone.permits_kind(kind)
+        {
+            return Err(AppError::Conflict(format!(
+                "device's current routing target '{}' is not permitted by zone '{}'; change or clear its rule first",
+                kind.as_str(),
+                target_zone.name
+            )));
         }
 
         let updated = self

--- a/source/daemon/crates/wardnetd-services/src/network_zone/tests/service.rs
+++ b/source/daemon/crates/wardnetd-services/src/network_zone/tests/service.rs
@@ -352,6 +352,21 @@ async fn delete_rejects_default_zone() {
 }
 
 #[tokio::test]
+async fn delete_rejects_default_for_new_zone() {
+    // A manual, empty zone that has been promoted to default-for-new must not
+    // be deletable — doing so would orphan the pointer and break discovery.
+    let h = build().await;
+    let zone = as_admin(h.svc.create_zone(create_req("Landing")))
+        .await
+        .unwrap();
+    as_admin(h.svc.set_default_for_new(zone.id)).await.unwrap();
+    assert!(matches!(
+        as_admin(h.svc.delete_zone(zone.id)).await,
+        Err(AppError::Conflict(_))
+    ));
+}
+
+#[tokio::test]
 async fn delete_rejects_zone_with_members() {
     let h = build().await;
     let zone = as_admin(h.svc.create_zone(create_req("Temp")))

--- a/source/daemon/crates/wardnetd-services/src/network_zone/tests/service.rs
+++ b/source/daemon/crates/wardnetd-services/src/network_zone/tests/service.rs
@@ -15,9 +15,11 @@ use wardnet_common::api::{CreateNetworkZoneRequest, UpdateNetworkZoneRequest};
 use wardnet_common::auth::AuthContext;
 use wardnet_common::event::WardnetEvent;
 use wardnet_common::network_zone::{AllowedTargetKind, ZoneProvenance, ZoneStance, ZoneSubnet};
+use wardnet_common::routing::RoutingTarget;
 use wardnetd_data::repository::device::DeviceRow;
 use wardnetd_data::repository::{
     DeviceRepository, SqliteDeviceRepository, SqliteNetworkZoneRepository,
+    SqliteSystemConfigRepository,
 };
 
 use crate::auth_context;
@@ -50,9 +52,10 @@ struct Harness {
 async fn build() -> Harness {
     let pool = test_pool().await;
     let zones = Arc::new(SqliteNetworkZoneRepository::new(pool.clone()));
-    let devices: Arc<dyn DeviceRepository> = Arc::new(SqliteDeviceRepository::new(pool));
+    let devices: Arc<dyn DeviceRepository> = Arc::new(SqliteDeviceRepository::new(pool.clone()));
+    let system_config = Arc::new(SqliteSystemConfigRepository::new(pool));
     let events = Arc::new(BroadcastEventBus::new(16));
-    let svc = NetworkZoneServiceImpl::new(zones, devices.clone(), events.clone());
+    let svc = NetworkZoneServiceImpl::new(zones, devices.clone(), system_config, events.clone());
     Harness {
         svc,
         devices,
@@ -428,6 +431,69 @@ async fn assign_device_moves_zone_and_emits_event() {
         }
         other => panic!("expected DeviceZoneChanged, got {other:?}"),
     }
+}
+
+async fn give_tunnel_rule(devices: &Arc<dyn DeviceRepository>, device_id: Uuid) {
+    let target = RoutingTarget::Tunnel {
+        tunnel_id: Uuid::new_v4(),
+    };
+    let json = serde_json::to_string(&target).unwrap();
+    devices
+        .upsert_user_rule(
+            &device_id.to_string(),
+            &json,
+            &chrono::Utc::now().to_rfc3339(),
+        )
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn assign_device_rejects_move_that_would_violate_new_zone() {
+    // Device has a Tunnel rule; moving it into a direct-only zone is rejected
+    // rather than persisting a rule the zone forbids.
+    let h = build().await;
+    let direct_only = as_admin(h.svc.create_zone(CreateNetworkZoneRequest {
+        name: "DirectOnly".to_owned(),
+        isolation_stance: ZoneStance::SharedSubnet,
+        allowed_targets: vec![AllowedTargetKind::Direct],
+        member_isolation: false,
+        admin_ui_reachable: true,
+        subnet: None,
+    }))
+    .await
+    .unwrap();
+
+    let device_id = Uuid::new_v4();
+    insert_device(&h.devices, device_id, GUEST).await;
+    give_tunnel_rule(&h.devices, device_id).await;
+
+    assert!(matches!(
+        as_admin(h.svc.assign_device(device_id, direct_only.id)).await,
+        Err(AppError::Conflict(_))
+    ));
+}
+
+#[tokio::test]
+async fn update_zone_rejects_narrowing_that_strands_a_member() {
+    // A member holds a Tunnel rule; narrowing the zone to direct-only is
+    // rejected until the rule is changed.
+    let h = build().await;
+    let zone = as_admin(h.svc.create_zone(create_req("Mixed")))
+        .await
+        .unwrap();
+    let device_id = Uuid::new_v4();
+    insert_device(&h.devices, device_id, &zone.id.to_string()).await;
+    give_tunnel_rule(&h.devices, device_id).await;
+
+    let req = UpdateNetworkZoneRequest {
+        allowed_targets: Some(vec![AllowedTargetKind::Direct]),
+        ..Default::default()
+    };
+    assert!(matches!(
+        as_admin(h.svc.update_zone(zone.id, req)).await,
+        Err(AppError::Conflict(_))
+    ));
 }
 
 #[tokio::test]

--- a/source/daemon/crates/wardnetd-services/src/routing/service.rs
+++ b/source/daemon/crates/wardnetd-services/src/routing/service.rs
@@ -267,17 +267,9 @@ impl RoutingServiceImpl {
         match target {
             RoutingTarget::Default => {
                 let policy = self.current_default_policy();
-                let resolved = if policy == "direct" {
-                    RoutingTarget::Direct
-                } else if let Ok(tunnel_id) = policy.parse::<Uuid>() {
-                    RoutingTarget::Tunnel { tunnel_id }
-                } else {
-                    tracing::warn!(
-                        policy = %policy,
-                        "unknown default policy, falling back to direct"
-                    );
-                    RoutingTarget::Direct
-                };
+                // Shared classifier — the single source of truth also used by
+                // the Network-Zone gate in `DeviceService`.
+                let resolved = RoutingTarget::from_default_policy(&policy);
                 tracing::debug!(
                     policy = %policy,
                     ?resolved,


### PR DESCRIPTION
## Summary

Follow-up to **#743** (Network Zones foundation, already merged). A multi-agent code review of that PR surfaced findings that landed on the branch *after* the squash-merge, so they aren't in `main`. This PR carries just those fixes.

## Correctness

- **`delete_zone` now also guards the `is_default_for_new` zone.** Previously a manual, empty zone that had been promoted to default-for-new could be deleted, orphaning the pointer — `find_default_for_new()` would then error and new-device discovery would silently stop. (+ test)
- **`UpdateNetworkZoneRequest.subnet` three-state clear works over HTTP.** Switched to the existing `serde_util::nullable_field` double-option deserializer so JSON `null` maps to `Some(None)` (clear) instead of `None` (no-op); the documented clear was previously unreachable. (+ deserialization test)
- **`set_default` / `set_default_for_new` roll back on an unknown id** instead of clearing the flag from every row and setting it on none (defensive backstop).

## Invariant now enforced on every edge (finding: gate existed on one edge only)

The invariant *"a device's stored rule kind is permitted by its zone"* is now enforced wherever a contradiction could be created:
- `assign_device` rejects (409) moving a device into a zone its current rule would violate;
- `update_zone` rejects (409) narrowing `allowed_targets` when any current member's rule would be stranded (batched: 2 queries + 1 policy read, no N+1);
- (the two rule-write paths already gated).

Only a **global default-policy flip** remains deferred to CI-2 (#736) — a fleet-wide reconciliation, documented in the ADR.

## Cleanup / altitude / efficiency

- **Single shared default-policy classifier.** Extracted the `"direct"`-vs-tunnel-UUID logic into `RoutingTarget::from_default_policy` (+ `AllowedTargetKind::of_target`/`as_str`) in `wardnet-common`, replacing three hand-rolled copies so the routing engine and the zone gate can never disagree about what `Default` resolves to.
- **`list_zones`** uses one `GROUP BY` (`member_counts`) instead of an N+1 COUNT per zone.
- **`update_zone`** re-fetches only when a default flag actually moved.

## Testing

- `cargo clippy --all-targets -- -D warnings` clean; `cargo test` green across the four cross-platform crates (129 + 296 + 247 + 995 passing, incl. new guard/re-validation/deserialization tests).
- `cargo fmt --check` clean; `make openapi` produces no drift (no API-surface change).

## Merge Commit Message

fix(zones): post-merge code-review follow-ups for Network Zones (#735)

https://claude.ai/code/session_01V6oZrN5fphbFDWiD3UHuN3