### PR TITLE
feat(daemon): wire up session cleanup runner for expired sessions (#491)

### DIFF
--- a/source/daemon/crates/wardnetd-api/src/api/tests/auth.rs
+++ b/source/daemon/crates/wardnetd-api/src/api/tests/auth.rs
@@ -80,6 +80,9 @@ impl AuthService for MockAuthService {
     async fn refresh_session(&self, _token: &str) -> Result<LoginResult, AppError> {
         unimplemented!()
     }
+    async fn cleanup_expired_sessions(&self) -> Result<u64, AppError> {
+        unimplemented!()
+    }
 }
 
 /// Mock auth service for refresh endpoint tests.
@@ -128,6 +131,9 @@ impl AuthService for MockRefreshAuthService {
                 "session not found or not refreshable".to_owned(),
             )),
         }
+    }
+    async fn cleanup_expired_sessions(&self) -> Result<u64, AppError> {
+        unimplemented!()
     }
 }
 

--- a/source/daemon/crates/wardnetd-api/src/api/tests/backup.rs
+++ b/source/daemon/crates/wardnetd-api/src/api/tests/backup.rs
@@ -78,6 +78,9 @@ impl AuthService for AlwaysAuthService {
     async fn refresh_session(&self, _token: &str) -> Result<LoginResult, AppError> {
         unimplemented!()
     }
+    async fn cleanup_expired_sessions(&self) -> Result<u64, AppError> {
+        unimplemented!()
+    }
 }
 
 struct NeverAuthService;
@@ -111,6 +114,9 @@ impl AuthService for NeverAuthService {
         unimplemented!()
     }
     async fn refresh_session(&self, _token: &str) -> Result<LoginResult, AppError> {
+        unimplemented!()
+    }
+    async fn cleanup_expired_sessions(&self) -> Result<u64, AppError> {
         unimplemented!()
     }
 }

--- a/source/daemon/crates/wardnetd-api/src/api/tests/ddns.rs
+++ b/source/daemon/crates/wardnetd-api/src/api/tests/ddns.rs
@@ -68,6 +68,9 @@ impl AuthService for AlwaysAdminAuth {
     async fn refresh_session(&self, _token: &str) -> Result<LoginResult, AppError> {
         unimplemented!()
     }
+    async fn cleanup_expired_sessions(&self) -> Result<u64, AppError> {
+        unimplemented!()
+    }
 }
 
 /// DDNS mock returning canned availability + status.

--- a/source/daemon/crates/wardnetd-api/src/api/tests/devices.rs
+++ b/source/daemon/crates/wardnetd-api/src/api/tests/devices.rs
@@ -73,6 +73,9 @@ impl AuthService for MockAuthService {
     async fn refresh_session(&self, _token: &str) -> Result<LoginResult, AppError> {
         unimplemented!()
     }
+    async fn cleanup_expired_sessions(&self) -> Result<u64, AppError> {
+        unimplemented!()
+    }
 }
 
 /// Mock `DeviceService` returning configurable responses.

--- a/source/daemon/crates/wardnetd-api/src/api/tests/dhcp.rs
+++ b/source/daemon/crates/wardnetd-api/src/api/tests/dhcp.rs
@@ -78,6 +78,9 @@ impl AuthService for MockAuthService {
     async fn refresh_session(&self, _token: &str) -> Result<LoginResult, AppError> {
         unimplemented!()
     }
+    async fn cleanup_expired_sessions(&self) -> Result<u64, AppError> {
+        unimplemented!()
+    }
 }
 
 /// Mock DHCP service that returns default config and empty collections.

--- a/source/daemon/crates/wardnetd-api/src/api/tests/dns_capture.rs
+++ b/source/daemon/crates/wardnetd-api/src/api/tests/dns_capture.rs
@@ -39,6 +39,9 @@ impl wardnetd_services::AuthService for MockAuthService {
             max_age_seconds: 3600,
         })
     }
+    async fn cleanup_expired_sessions(&self) -> Result<u64, AppError> {
+        unimplemented!()
+    }
     async fn validate_session(&self, _token: &str) -> Result<Option<Uuid>, AppError> {
         Ok(Some(
             Uuid::parse_str("00000000-0000-0000-0000-000000000099").unwrap(),

--- a/source/daemon/crates/wardnetd-api/src/api/tests/dns_events.rs
+++ b/source/daemon/crates/wardnetd-api/src/api/tests/dns_events.rs
@@ -65,6 +65,9 @@ impl wardnetd_services::AuthService for MockAuthService {
             max_age_seconds: 3600,
         })
     }
+    async fn cleanup_expired_sessions(&self) -> Result<u64, AppError> {
+        unimplemented!()
+    }
     async fn validate_session(&self, _token: &str) -> Result<Option<Uuid>, AppError> {
         Ok(Some(
             Uuid::parse_str("00000000-0000-0000-0000-000000000099").unwrap(),

--- a/source/daemon/crates/wardnetd-api/src/api/tests/dns_filter.rs
+++ b/source/daemon/crates/wardnetd-api/src/api/tests/dns_filter.rs
@@ -88,6 +88,9 @@ impl AuthService for MockAuthService {
     async fn refresh_session(&self, _token: &str) -> Result<LoginResult, AppError> {
         unimplemented!()
     }
+    async fn cleanup_expired_sessions(&self) -> Result<u64, AppError> {
+        unimplemented!()
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/source/daemon/crates/wardnetd-api/src/api/tests/dns_local.rs
+++ b/source/daemon/crates/wardnetd-api/src/api/tests/dns_local.rs
@@ -233,6 +233,9 @@ impl AuthService for AlwaysAdminAuth {
     async fn refresh_session(&self, _token: &str) -> Result<LoginResult, AppError> {
         unimplemented!()
     }
+    async fn cleanup_expired_sessions(&self) -> Result<u64, AppError> {
+        unimplemented!()
+    }
 }
 
 // ── Harness ───────────────────────────────────────────────────────────────────

--- a/source/daemon/crates/wardnetd-api/src/api/tests/jobs.rs
+++ b/source/daemon/crates/wardnetd-api/src/api/tests/jobs.rs
@@ -59,6 +59,9 @@ impl AuthService for AlwaysAdminAuth {
     async fn refresh_session(&self, _token: &str) -> Result<LoginResult, AppError> {
         unimplemented!()
     }
+    async fn cleanup_expired_sessions(&self) -> Result<u64, AppError> {
+        unimplemented!()
+    }
 }
 
 /// Fake job service with one preloaded job — lets us exercise the 200 path

--- a/source/daemon/crates/wardnetd-api/src/api/tests/logs_ws.rs
+++ b/source/daemon/crates/wardnetd-api/src/api/tests/logs_ws.rs
@@ -62,6 +62,9 @@ impl AuthService for AlwaysAuthService {
     async fn refresh_session(&self, _token: &str) -> Result<LoginResult, AppError> {
         unimplemented!()
     }
+    async fn cleanup_expired_sessions(&self) -> Result<u64, AppError> {
+        unimplemented!()
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/source/daemon/crates/wardnetd-api/src/api/tests/middleware.rs
+++ b/source/daemon/crates/wardnetd-api/src/api/tests/middleware.rs
@@ -80,6 +80,9 @@ impl AuthService for MockAuthService {
     async fn refresh_session(&self, _token: &str) -> Result<LoginResult, AppError> {
         unimplemented!()
     }
+    async fn cleanup_expired_sessions(&self) -> Result<u64, AppError> {
+        unimplemented!()
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/source/daemon/crates/wardnetd-api/src/api/tests/network.rs
+++ b/source/daemon/crates/wardnetd-api/src/api/tests/network.rs
@@ -71,6 +71,9 @@ impl AuthService for AlwaysAuthService {
     async fn refresh_session(&self, _token: &str) -> Result<LoginResult, AppError> {
         unimplemented!()
     }
+    async fn cleanup_expired_sessions(&self) -> Result<u64, AppError> {
+        unimplemented!()
+    }
 }
 
 struct NeverAuthService;
@@ -104,6 +107,9 @@ impl AuthService for NeverAuthService {
         unimplemented!()
     }
     async fn refresh_session(&self, _token: &str) -> Result<LoginResult, AppError> {
+        unimplemented!()
+    }
+    async fn cleanup_expired_sessions(&self) -> Result<u64, AppError> {
         unimplemented!()
     }
 }

--- a/source/daemon/crates/wardnetd-api/src/api/tests/network_zone.rs
+++ b/source/daemon/crates/wardnetd-api/src/api/tests/network_zone.rs
@@ -66,6 +66,9 @@ impl AuthService for MockAuthService {
     async fn refresh_session(&self, _token: &str) -> Result<LoginResult, AppError> {
         unimplemented!()
     }
+    async fn cleanup_expired_sessions(&self) -> Result<u64, AppError> {
+        unimplemented!()
+    }
 }
 
 fn sample_zone() -> NetworkZone {

--- a/source/daemon/crates/wardnetd-api/src/api/tests/providers.rs
+++ b/source/daemon/crates/wardnetd-api/src/api/tests/providers.rs
@@ -73,6 +73,9 @@ impl AuthService for MockAuthService {
     async fn refresh_session(&self, _token: &str) -> Result<LoginResult, AppError> {
         unimplemented!()
     }
+    async fn cleanup_expired_sessions(&self) -> Result<u64, AppError> {
+        unimplemented!()
+    }
 }
 
 /// Mock `VpnProviderService` with configurable responses.

--- a/source/daemon/crates/wardnetd-api/src/api/tests/rule_requests.rs
+++ b/source/daemon/crates/wardnetd-api/src/api/tests/rule_requests.rs
@@ -34,6 +34,9 @@ impl wardnetd_services::AuthService for MockAuthService {
     async fn login(&self, _u: &str, _p: &str, _remember_me: bool) -> Result<LoginResult, AppError> {
         unimplemented!()
     }
+    async fn cleanup_expired_sessions(&self) -> Result<u64, AppError> {
+        unimplemented!()
+    }
     async fn validate_session(&self, _token: &str) -> Result<Option<Uuid>, AppError> {
         Ok(Some(
             Uuid::parse_str("00000000-0000-0000-0000-000000000099").unwrap(),

--- a/source/daemon/crates/wardnetd-api/src/api/tests/setup.rs
+++ b/source/daemon/crates/wardnetd-api/src/api/tests/setup.rs
@@ -92,6 +92,9 @@ impl AuthService for MockSetupAuthService {
     async fn refresh_session(&self, _token: &str) -> Result<LoginResult, AppError> {
         unimplemented!()
     }
+    async fn cleanup_expired_sessions(&self) -> Result<u64, AppError> {
+        unimplemented!()
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/source/daemon/crates/wardnetd-api/src/api/tests/system.rs
+++ b/source/daemon/crates/wardnetd-api/src/api/tests/system.rs
@@ -69,6 +69,9 @@ impl AuthService for AlwaysAuthService {
     async fn refresh_session(&self, _token: &str) -> Result<LoginResult, AppError> {
         unimplemented!()
     }
+    async fn cleanup_expired_sessions(&self) -> Result<u64, AppError> {
+        unimplemented!()
+    }
 }
 
 /// Mock auth service that always rejects.
@@ -103,6 +106,9 @@ impl AuthService for NeverAuthService {
         unimplemented!()
     }
     async fn refresh_session(&self, _token: &str) -> Result<LoginResult, AppError> {
+        unimplemented!()
+    }
+    async fn cleanup_expired_sessions(&self) -> Result<u64, AppError> {
         unimplemented!()
     }
 }

--- a/source/daemon/crates/wardnetd-api/src/api/tests/tunnels.rs
+++ b/source/daemon/crates/wardnetd-api/src/api/tests/tunnels.rs
@@ -71,6 +71,9 @@ impl AuthService for MockAuthService {
     async fn refresh_session(&self, _token: &str) -> Result<LoginResult, AppError> {
         unimplemented!()
     }
+    async fn cleanup_expired_sessions(&self) -> Result<u64, AppError> {
+        unimplemented!()
+    }
 }
 
 /// Mock `TunnelService` with configurable tunnel list.

--- a/source/daemon/crates/wardnetd-api/src/tests/stubs.rs
+++ b/source/daemon/crates/wardnetd-api/src/tests/stubs.rs
@@ -73,6 +73,9 @@ impl AuthService for StubAuthService {
     async fn refresh_session(&self, _token: &str) -> Result<LoginResult, AppError> {
         unimplemented!()
     }
+    async fn cleanup_expired_sessions(&self) -> Result<u64, AppError> {
+        unimplemented!()
+    }
 }
 
 pub struct StubDeviceService;

--- a/source/daemon/crates/wardnetd-services/src/auth/mod.rs
+++ b/source/daemon/crates/wardnetd-services/src/auth/mod.rs
@@ -1,6 +1,8 @@
 pub mod service;
+pub mod session_cleanup_runner;
 
 pub use service::{AuthService, AuthServiceImpl, LoginResult};
+pub use session_cleanup_runner::SessionCleanupRunner;
 
 #[cfg(test)]
 mod tests;

--- a/source/daemon/crates/wardnetd-services/src/auth/service.rs
+++ b/source/daemon/crates/wardnetd-services/src/auth/service.rs
@@ -101,6 +101,14 @@ pub trait AuthService: Send + Sync {
         to_step: WizardStep,
         mode: Option<WizardMode>,
     ) -> Result<WizardState, AppError>;
+
+    /// Delete all sessions whose `expires_at` is in the past.
+    ///
+    /// Intended for the periodic
+    /// [`SessionCleanupRunner`](crate::auth::SessionCleanupRunner); reads
+    /// already filter expired rows, so this only reclaims dead storage.
+    /// Returns the number of rows removed.
+    async fn cleanup_expired_sessions(&self) -> Result<u64, AppError>;
 }
 
 /// Maximum lifetime of a `remember_me` session regardless of sliding-window refreshes.
@@ -291,6 +299,16 @@ impl AuthService for AuthServiceImpl {
             }
             None => Ok(None),
         }
+    }
+
+    async fn cleanup_expired_sessions(&self) -> Result<u64, AppError> {
+        auth_context::require_admin()?;
+
+        let now = chrono::Utc::now().to_rfc3339();
+        self.sessions
+            .delete_expired(&now)
+            .await
+            .map_err(AppError::Internal)
     }
 
     async fn validate_api_key(&self, key: &str) -> Result<Option<Uuid>, AppError> {

--- a/source/daemon/crates/wardnetd-services/src/auth/session_cleanup_runner.rs
+++ b/source/daemon/crates/wardnetd-services/src/auth/session_cleanup_runner.rs
@@ -1,0 +1,104 @@
+//! Background runner that periodically purges expired admin-session rows.
+//!
+//! Reads always filter on `expires_at > now`, so expired sessions are never
+//! honored — but the rows would otherwise accumulate indefinitely. This
+//! runner calls the auth-gated [`AuthService::cleanup_expired_sessions`] on a
+//! fixed interval (hourly in production) to reclaim that dead storage.
+//!
+//! Lifecycle mirrors the other daemon runners: spawned at boot, stopped via
+//! the cancellation token on shutdown. Like [`DnsQueryLogRunner`], the
+//! immediate first interval tick is consumed so the first cleanup fires one
+//! interval after startup rather than at boot.
+//!
+//! [`DnsQueryLogRunner`]: crate::dns::query_log_runner::DnsQueryLogRunner
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use tokio_util::sync::CancellationToken;
+use tracing::Instrument;
+use uuid::Uuid;
+use wardnet_common::auth::AuthContext;
+
+use crate::AuthService;
+use crate::auth_context;
+
+/// Production cleanup interval.
+const CLEANUP_INTERVAL: Duration = Duration::from_hours(1);
+
+/// Background runner purging expired sessions via [`AuthService`].
+pub struct SessionCleanupRunner {
+    cancel: CancellationToken,
+    handle: tokio::task::JoinHandle<()>,
+}
+
+impl SessionCleanupRunner {
+    /// Start the runner with the production ([`CLEANUP_INTERVAL`]) cadence.
+    ///
+    /// The `parent` span is used as the parent for the
+    /// `session_cleanup_runner` child span, ensuring all log output includes
+    /// the root version field.
+    pub fn start(service: Arc<dyn AuthService>, parent: &tracing::Span) -> Self {
+        Self::start_with_interval(service, CLEANUP_INTERVAL, parent)
+    }
+
+    /// Start the runner with a custom interval. Production callers use
+    /// [`Self::start`]; tests pass a shorter interval to exercise the loop
+    /// without waiting.
+    pub fn start_with_interval(
+        service: Arc<dyn AuthService>,
+        interval: Duration,
+        parent: &tracing::Span,
+    ) -> Self {
+        let cancel = CancellationToken::new();
+        let span = tracing::info_span!(parent: parent, "session_cleanup_runner");
+
+        let handle = tokio::spawn(runner_loop(service, interval, cancel.clone()).instrument(span));
+
+        Self { cancel, handle }
+    }
+
+    /// Cancel the background task and wait for it to finish.
+    pub async fn shutdown(self) {
+        self.cancel.cancel();
+        let _ = self.handle.await;
+        tracing::info!("session cleanup runner shut down");
+    }
+}
+
+async fn runner_loop(service: Arc<dyn AuthService>, interval: Duration, cancel: CancellationToken) {
+    let admin_ctx = AuthContext::Admin {
+        admin_id: Uuid::nil(),
+    };
+
+    let mut ticker = tokio::time::interval(interval);
+    ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+    ticker.tick().await; // skip the immediate first tick
+
+    loop {
+        tokio::select! {
+            () = cancel.cancelled() => {
+                tracing::info!("session cleanup runner cancellation received");
+                break;
+            }
+            _ = ticker.tick() => {
+                match auth_context::with_context(
+                    admin_ctx.clone(),
+                    service.cleanup_expired_sessions(),
+                )
+                .await
+                {
+                    Ok(deleted) if deleted > 0 => {
+                        tracing::info!(deleted, "purged expired sessions: deleted={deleted}");
+                    }
+                    Ok(_) => {
+                        tracing::debug!("no expired sessions to purge");
+                    }
+                    Err(e) => {
+                        tracing::error!(error = %e, "failed to purge expired sessions: error={e}");
+                    }
+                }
+            }
+        }
+    }
+}

--- a/source/daemon/crates/wardnetd-services/src/auth/tests/auth.rs
+++ b/source/daemon/crates/wardnetd-services/src/auth/tests/auth.rs
@@ -293,6 +293,29 @@ async fn is_setup_completed_delegates() {
 }
 
 #[tokio::test]
+async fn cleanup_expired_sessions_requires_admin() {
+    // No auth context → require_admin rejects before touching the repo.
+    let svc = make_auth_service(None, None, None, vec![]);
+    let result = svc.cleanup_expired_sessions().await;
+    assert!(matches!(result, Err(AppError::Forbidden(_))));
+}
+
+#[tokio::test]
+async fn cleanup_expired_sessions_delegates_under_admin_context() {
+    // Under an admin context it delegates to SessionRepository::delete_expired
+    // and returns the row count (MockSessionRepo returns 0).
+    let svc = make_auth_service(None, None, None, vec![]);
+    let result = auth_context::with_context(
+        AuthContext::Admin {
+            admin_id: Uuid::nil(),
+        },
+        async { svc.cleanup_expired_sessions().await },
+    )
+    .await;
+    assert_eq!(result.unwrap(), 0);
+}
+
+#[tokio::test]
 async fn refresh_session_success() {
     // Session exists and was created as remember_me=true → rotates token and extends expiry.
     let admin_uuid = "00000000-0000-0000-0000-000000000001";

--- a/source/daemon/crates/wardnetd-services/src/auth/tests/mod.rs
+++ b/source/daemon/crates/wardnetd-services/src/auth/tests/mod.rs
@@ -1,3 +1,4 @@
 mod auth;
+mod session_cleanup_runner;
 mod setup;
 mod wizard;

--- a/source/daemon/crates/wardnetd-services/src/auth/tests/session_cleanup_runner.rs
+++ b/source/daemon/crates/wardnetd-services/src/auth/tests/session_cleanup_runner.rs
@@ -1,0 +1,250 @@
+//! Tests for [`SessionCleanupRunner`]. Drives the runner with a recording
+//! mock [`AuthService`] and asserts it calls `cleanup_expired_sessions` on
+//! its interval (under an admin context), skips the immediate first tick, and
+//! stops on shutdown.
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::Duration;
+
+use async_trait::async_trait;
+use uuid::Uuid;
+use wardnet_common::api::{WizardMode, WizardStep};
+
+use crate::auth::SessionCleanupRunner;
+use crate::auth::service::{LoginResult, WizardState};
+use crate::error::AppError;
+use crate::{AuthService, auth_context};
+
+/// Mock service that records every `cleanup_expired_sessions` call and whether
+/// it observed an admin auth context, and returns a configurable outcome. All
+/// other trait methods are unreachable in these tests.
+struct MockAuthService {
+    calls: AtomicU64,
+    /// Incremented only when the call ran under a valid admin context.
+    admin_calls: AtomicU64,
+    /// Row count returned by a successful `cleanup_expired_sessions`.
+    return_count: u64,
+    /// When true, `cleanup_expired_sessions` returns an error.
+    fail: bool,
+}
+
+impl MockAuthService {
+    /// Succeeds returning `0` deleted rows.
+    fn new() -> Self {
+        Self::with_outcome(0, false)
+    }
+
+    /// Succeeds returning `count` deleted rows (exercises the "deleted" log).
+    fn returning(count: u64) -> Self {
+        Self::with_outcome(count, false)
+    }
+
+    /// Fails every call (exercises the error log + loop resilience).
+    fn failing() -> Self {
+        Self::with_outcome(0, true)
+    }
+
+    fn with_outcome(return_count: u64, fail: bool) -> Self {
+        Self {
+            calls: AtomicU64::new(0),
+            admin_calls: AtomicU64::new(0),
+            return_count,
+            fail,
+        }
+    }
+}
+
+#[async_trait]
+impl AuthService for MockAuthService {
+    async fn login(
+        &self,
+        _username: &str,
+        _password: &str,
+        _remember_me: bool,
+    ) -> Result<LoginResult, AppError> {
+        unimplemented!()
+    }
+    async fn refresh_session(&self, _token: &str) -> Result<LoginResult, AppError> {
+        unimplemented!()
+    }
+    async fn validate_session(&self, _token: &str) -> Result<Option<Uuid>, AppError> {
+        unimplemented!()
+    }
+    async fn validate_api_key(&self, _key: &str) -> Result<Option<Uuid>, AppError> {
+        unimplemented!()
+    }
+    async fn setup_admin(&self, _username: &str, _password: &str) -> Result<(), AppError> {
+        unimplemented!()
+    }
+    async fn is_setup_completed(&self) -> Result<bool, AppError> {
+        unimplemented!()
+    }
+    async fn wizard_state(&self) -> Result<WizardState, AppError> {
+        unimplemented!()
+    }
+    async fn advance_wizard(
+        &self,
+        _to_step: WizardStep,
+        _mode: Option<WizardMode>,
+    ) -> Result<WizardState, AppError> {
+        unimplemented!()
+    }
+    async fn cleanup_expired_sessions(&self) -> Result<u64, AppError> {
+        if auth_context::require_admin().is_ok() {
+            self.admin_calls.fetch_add(1, Ordering::SeqCst);
+        }
+        self.calls.fetch_add(1, Ordering::SeqCst);
+        if self.fail {
+            return Err(AppError::Internal(anyhow::anyhow!(
+                "simulated cleanup failure"
+            )));
+        }
+        Ok(self.return_count)
+    }
+}
+
+/// Poll `f` up to `tries` times with a short sleep between attempts, returning
+/// as soon as it is true.
+async fn wait_until(tries: u32, mut f: impl FnMut() -> bool) -> bool {
+    for _ in 0..tries {
+        if f() {
+            return true;
+        }
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+    f()
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn runs_cleanup_on_tick_under_admin_context() {
+    let service = Arc::new(MockAuthService::new());
+    let parent = tracing::Span::none();
+
+    let runner = SessionCleanupRunner::start_with_interval(
+        Arc::clone(&service) as Arc<dyn AuthService>,
+        Duration::from_millis(10),
+        &parent,
+    );
+
+    let fired = wait_until(50, || service.calls.load(Ordering::SeqCst) > 0).await;
+    assert!(fired, "cleanup should have run at least once");
+    assert!(
+        service.admin_calls.load(Ordering::SeqCst) > 0,
+        "cleanup should run under an admin auth context"
+    );
+
+    runner.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn skips_immediate_startup_tick() {
+    let service = Arc::new(MockAuthService::new());
+    let parent = tracing::Span::none();
+
+    // Long interval: the only tick that could fire quickly is the immediate
+    // first one, which the runner consumes. So no call should be observed.
+    let runner = SessionCleanupRunner::start_with_interval(
+        Arc::clone(&service) as Arc<dyn AuthService>,
+        Duration::from_hours(1),
+        &parent,
+    );
+
+    // Give the task a chance to run to its first `ticker.tick().await`.
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    assert_eq!(
+        service.calls.load(Ordering::SeqCst),
+        0,
+        "the immediate first tick must be skipped"
+    );
+
+    runner.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn shutdown_stops_the_loop() {
+    let service = Arc::new(MockAuthService::new());
+    let parent = tracing::Span::none();
+
+    let runner = SessionCleanupRunner::start_with_interval(
+        Arc::clone(&service) as Arc<dyn AuthService>,
+        Duration::from_millis(10),
+        &parent,
+    );
+
+    assert!(
+        wait_until(50, || service.calls.load(Ordering::SeqCst) > 0).await,
+        "cleanup should have run before shutdown"
+    );
+
+    runner.shutdown().await;
+    let after_shutdown = service.calls.load(Ordering::SeqCst);
+
+    // No further calls once the loop has been cancelled and joined.
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    assert_eq!(
+        service.calls.load(Ordering::SeqCst),
+        after_shutdown,
+        "no cleanup should run after shutdown"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn logs_deleted_count_when_rows_removed() {
+    // A non-zero row count exercises the "purged expired sessions" info branch.
+    let service = Arc::new(MockAuthService::returning(3));
+    let parent = tracing::Span::none();
+
+    let runner = SessionCleanupRunner::start_with_interval(
+        Arc::clone(&service) as Arc<dyn AuthService>,
+        Duration::from_millis(10),
+        &parent,
+    );
+
+    assert!(
+        wait_until(50, || service.calls.load(Ordering::SeqCst) > 0).await,
+        "cleanup should have run at least once"
+    );
+
+    runner.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn continues_running_after_cleanup_error() {
+    // A failing service exercises the error branch; the loop must keep ticking.
+    let service = Arc::new(MockAuthService::failing());
+    let parent = tracing::Span::none();
+
+    let runner = SessionCleanupRunner::start_with_interval(
+        Arc::clone(&service) as Arc<dyn AuthService>,
+        Duration::from_millis(10),
+        &parent,
+    );
+
+    // At least two calls proves the loop survived the first error.
+    assert!(
+        wait_until(50, || service.calls.load(Ordering::SeqCst) >= 2).await,
+        "runner should keep ticking after an error"
+    );
+
+    runner.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn production_start_skips_immediate_tick() {
+    // Exercises the production `start()` wrapper (hourly interval). The first
+    // tick is consumed, so no cleanup fires before we shut down.
+    let service = Arc::new(MockAuthService::new());
+    let parent = tracing::Span::none();
+
+    let runner = SessionCleanupRunner::start(Arc::clone(&service) as Arc<dyn AuthService>, &parent);
+
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    assert_eq!(
+        service.calls.load(Ordering::SeqCst),
+        0,
+        "hourly runner must not fire immediately"
+    );
+
+    runner.shutdown().await;
+}

--- a/source/daemon/crates/wardnetd/src/main.rs
+++ b/source/daemon/crates/wardnetd/src/main.rs
@@ -49,6 +49,7 @@ use wardnetd::watchdog::{HardwareWatchdogRunner, Notifier, SdNotifier, SoftWatch
 use wardnetd_api::state::AppState;
 use wardnetd_services::HealthMonitor;
 use wardnetd_services::TlsRenewalRunner;
+use wardnetd_services::auth::SessionCleanupRunner;
 use wardnetd_services::db_maintenance_runner::DbMaintenanceRunner;
 use wardnetd_services::ddns::runner::DdnsUpdateRunner;
 use wardnetd_services::dhcp::runner::DhcpRunner;
@@ -611,6 +612,10 @@ async fn run(
         &root_span,
     );
 
+    // Periodically purge expired admin-session rows (reads already filter on
+    // expiry; this reclaims the dead storage). Hourly cadence.
+    let session_cleanup_runner = SessionCleanupRunner::start(services.auth.clone(), &root_span);
+
     // Drain the DNS query log persistence channel into SQLite and trim the
     // table once a day. The receiver is taken out of `Services` exactly
     // once at startup; the sink stays in `Services` so the API layer can
@@ -934,6 +939,7 @@ async fn run(
     dns_runner.shutdown().await;
     dns_filter_runner.shutdown().await;
     dhcp_lan_runner.shutdown().await;
+    session_cleanup_runner.shutdown().await;
     dns_query_log_runner.shutdown().await;
     dns_capture_runner.shutdown().await;
     db_maintenance_runner.shutdown().await;

--- a/source/daemon/crates/wardnetd/src/tests/stubs.rs
+++ b/source/daemon/crates/wardnetd/src/tests/stubs.rs
@@ -120,6 +120,9 @@ impl AuthService for StubAuthService {
     async fn refresh_session(&self, _token: &str) -> Result<LoginResult, AppError> {
         unimplemented!()
     }
+    async fn cleanup_expired_sessions(&self) -> Result<u64, AppError> {
+        unimplemented!()
+    }
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

`SessionRepository::delete_expired` was fully implemented but never called, so expired admin-session rows accumulated in the database indefinitely — they were only filtered out on reads (`expires_at > now`). This becomes meaningful with the upcoming 30-day `remember_me` sessions (#476), where rows live much longer.

This wires up a periodic background runner that purges expired sessions **hourly**, going through the auth-gated service layer (not the repository directly).

Closes #491.

## Changes

- **`AuthService::cleanup_expired_sessions()`** — new trait method; opens with `auth_context::require_admin()?` then delegates to `SessionRepository::delete_expired(now)` (RFC3339 timestamp matching how `expires_at` is stored). Mirrors `DhcpService::cleanup_expired`.
- **`SessionCleanupRunner`** — new `auth/session_cleanup_runner.rs`. Hourly `tokio::time::interval`, skips the immediate first tick, calls the service under a synthetic `AuthContext::Admin { admin_id: Uuid::nil() }`. Same struct / `start` / `start_with_interval` / `shutdown` shape as `DnsQueryLogRunner`.
- **`main.rs`** — started alongside the other background runners and shut down in the teardown sequence.
- **Test mocks** — stub the new trait method across the existing `AuthService` mocks/stubs.

## Design notes

- **Through the service, not the repo**: keeps DB access behind the auth-gated service boundary, consistent with the DHCP cleanup runner.
- **No new trait method on `SessionRepository`, no migration** — `delete_expired` already existed.
- **First cleanup fires 1h after boot** (immediate tick skipped), matching `DnsQueryLogRunner`.

## Tests

- Runner: fires on tick under an admin context, skips the startup tick, stops after shutdown.
- Service: `cleanup_expired_sessions` requires admin and delegates to `delete_expired`.
- `cargo test -p wardnetd-services --lib auth::` → 41 passed; `wardnetd-api` compiles + auth tests pass; `fmt --check` and `clippy` clean.

> Note: the `wardnetd` binary crate can't compile on macOS (`netlink-sys` is Linux-only, targets the Pi); `main.rs` wiring will be validated by CI on Linux.

## Merge Commit Message

`feat(daemon): wire up session cleanup runner for expired sessions (#491)`

https://claude.ai/code/session_013RRE9MvuwSDR1h4kX7XDMF