### PR TITLE
feat(dhcp): handle pool-range changes without stranding devices (#227)

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -3593,6 +3593,173 @@
         ]
       }
     },
+    "/api/dhcp/config/preview": {
+      "post": {
+        "tags": [
+          "dhcp"
+        ],
+        "description": "Dry-run a pool-range change: report the active leases that would be revoked because their IP would fall outside the proposed pool (and are not pinned by a reservation). Mutates nothing — used to warn the admin before saving. Admin only.",
+        "operationId": "preview_config",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PreviewDhcpConfigRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Leases that would be revoked",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PreviewDhcpConfigResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Malformed or invalid request body",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "description": "Standard API error response.",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "detail": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "error": {
+                      "type": "string"
+                    },
+                    "request_id": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "description": "Request ID for correlation with server logs."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthenticated — session cookie or API key missing/invalid",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "description": "Standard API error response.",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "detail": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "error": {
+                      "type": "string"
+                    },
+                    "request_id": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "description": "Request ID for correlation with server logs."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden — caller is not an admin",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "description": "Standard API error response.",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "detail": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "error": {
+                      "type": "string"
+                    },
+                    "request_id": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "description": "Request ID for correlation with server logs."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "description": "Standard API error response.",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "detail": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "error": {
+                      "type": "string"
+                    },
+                    "request_id": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "description": "Request ID for correlation with server logs."
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "session_cookie": []
+          },
+          {
+            "bearer_auth": []
+          }
+        ]
+      }
+    },
     "/api/dhcp/config/toggle": {
       "post": {
         "tags": [
@@ -22814,6 +22981,38 @@
           }
         ],
         "description": "A Network Zone plus its current member count. Enriched view returned by the\nzone list/detail endpoints."
+      },
+      "PreviewDhcpConfigRequest": {
+        "type": "object",
+        "description": "Request body for POST /api/dhcp/config/preview.\n\nA dry-run that reports which active leases would be revoked if the pool\nwere changed to `pool_start`–`pool_end`, so the admin can be warned before\nsaving. Mutates nothing.",
+        "required": [
+          "pool_start",
+          "pool_end"
+        ],
+        "properties": {
+          "pool_end": {
+            "type": "string"
+          },
+          "pool_start": {
+            "type": "string"
+          }
+        }
+      },
+      "PreviewDhcpConfigResponse": {
+        "type": "object",
+        "description": "Response for POST /api/dhcp/config/preview.",
+        "required": [
+          "affected"
+        ],
+        "properties": {
+          "affected": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/DhcpLease"
+            },
+            "description": "Active leases whose IP would fall outside the proposed pool and are not\npinned by a reservation. These devices would be forced to re-acquire an\nin-range lease on their next renewal."
+          }
+        }
       },
       "ProviderAuthMethod": {
         "type": "string",

--- a/source/admin-site/src/components/compound/DhcpConfigCard.tsx
+++ b/source/admin-site/src/components/compound/DhcpConfigCard.tsx
@@ -14,14 +14,29 @@ import { Text } from "@wardnet/web";
 import { Ipv4Input } from "@/components/core/ui/ipv4-input";
 import { isCompleteIpv4, ipv4ToInt } from "@wardnet/js";
 import { ApiErrorAlert } from "@wardnet/web";
-import { useUpdateDhcpConfig } from "@wardnet/web";
+import { useUpdateDhcpConfig, usePreviewDhcpConfig } from "@wardnet/web";
 import { useDnsConfig } from "@wardnet/web";
-import type { DhcpConfig } from "@wardnet/js";
+import type { DhcpConfig, DhcpLease } from "@wardnet/js";
+import { ConfirmDialog } from "@/components/compound/ConfirmDialog";
 
 function formatDuration(secs: number): string {
   if (secs < 3600) return `${Math.floor(secs / 60)}m`;
   if (secs < 86400) return `${Math.floor(secs / 3600)}h`;
   return `${Math.floor(secs / 86400)}d`;
+}
+
+/** Human-readable warning listing the devices a pool change would strand. */
+function affectedDescription(leases: DhcpLease[]): string {
+  const shown = leases
+    .slice(0, 5)
+    .map((l) => `${l.hostname || l.mac_address} (${l.ip_address})`);
+  const more = leases.length > 5 ? `, and ${leases.length - 5} more` : "";
+  const count = leases.length;
+  return (
+    `${count} device${count === 1 ? "" : "s"} currently hold ` +
+    `out-of-range leases and will reconnect within ~10 minutes: ` +
+    `${shown.join(", ")}${more}.`
+  );
 }
 
 interface DhcpConfigCardProps {
@@ -35,10 +50,13 @@ interface DhcpConfigCardProps {
  *  and show "Wardnet DNS" in the read view to match reality. */
 export function DhcpConfigCard({ config }: DhcpConfigCardProps) {
   const updateConfig = useUpdateDhcpConfig();
+  const previewConfig = usePreviewDhcpConfig();
   const { data: dnsConfigData } = useDnsConfig();
   const dnsEnabled = dnsConfigData?.config.enabled ?? false;
 
   const [editing, setEditing] = useState(false);
+  const [confirmOpen, setConfirmOpen] = useState(false);
+  const [affected, setAffected] = useState<DhcpLease[]>([]);
   const [poolStart, setPoolStart] = useState(config.pool_start);
   const [poolEnd, setPoolEnd] = useState(config.pool_end);
   const [subnetMask, setSubnetMask] = useState(config.subnet_mask);
@@ -84,8 +102,7 @@ export function DhcpConfigCard({ config }: DhcpConfigCardProps) {
     return null;
   }, [editing, poolStart, poolEnd, subnetMask, routerIp]);
 
-  async function handleSave() {
-    if (validationError) return;
+  async function doSave() {
     await updateConfig.mutateAsync({
       pool_start: poolStart,
       pool_end: poolEnd,
@@ -98,6 +115,38 @@ export function DhcpConfigCard({ config }: DhcpConfigCardProps) {
       router_ip: routerIp || undefined,
     });
     setEditing(false);
+  }
+
+  async function handleSave() {
+    if (validationError) return;
+
+    // Only a pool-range change can strand existing leases, so dry-run the new
+    // range and warn before saving when devices would be forced to reconnect
+    // (issue #227). Preview is best-effort: if it fails, fall through to save.
+    const poolChanged =
+      poolStart !== config.pool_start || poolEnd !== config.pool_end;
+    if (poolChanged) {
+      try {
+        const res = await previewConfig.mutateAsync({
+          pool_start: poolStart,
+          pool_end: poolEnd,
+        });
+        if (res.affected.length > 0) {
+          setAffected(res.affected);
+          setConfirmOpen(true);
+          return;
+        }
+      } catch {
+        // Ignore — the warning is a nicety, not a gate on saving.
+      }
+    }
+
+    await doSave();
+  }
+
+  function confirmSave() {
+    setConfirmOpen(false);
+    void doSave();
   }
 
   return (
@@ -230,15 +279,32 @@ export function DhcpConfigCard({ config }: DhcpConfigCardProps) {
             secondaryLabel="Cancel"
             secondaryProps={{
               onClick: cancelEdit,
-              disabled: updateConfig.isPending,
+              disabled: updateConfig.isPending || previewConfig.isPending,
               "data-testid": "dhcp-config-cancel",
             }}
-            primaryLabel={updateConfig.isPending ? "Saving…" : "Save"}
+            primaryLabel={
+              previewConfig.isPending
+                ? "Checking…"
+                : updateConfig.isPending
+                  ? "Saving…"
+                  : "Save"
+            }
             primaryProps={{
               onClick: handleSave,
-              disabled: updateConfig.isPending || validationError !== null,
+              disabled:
+                updateConfig.isPending ||
+                previewConfig.isPending ||
+                validationError !== null,
               "data-testid": "dhcp-config-save",
             }}
+          />
+          <ConfirmDialog
+            open={confirmOpen}
+            onOpenChange={setConfirmOpen}
+            title="Devices will reconnect"
+            description={affectedDescription(affected)}
+            confirmLabel="Save and revoke"
+            onConfirm={confirmSave}
           />
         </>
       ) : (

--- a/source/daemon/crates/wardnet-common/src/api.rs
+++ b/source/daemon/crates/wardnet-common/src/api.rs
@@ -849,6 +849,26 @@ pub struct ToggleDhcpRequest {
     pub enabled: bool,
 }
 
+/// Request body for POST /api/dhcp/config/preview.
+///
+/// A dry-run that reports which active leases would be revoked if the pool
+/// were changed to `pool_start`–`pool_end`, so the admin can be warned before
+/// saving. Mutates nothing.
+#[derive(Debug, Deserialize, utoipa::ToSchema)]
+pub struct PreviewDhcpConfigRequest {
+    pub pool_start: String,
+    pub pool_end: String,
+}
+
+/// Response for POST /api/dhcp/config/preview.
+#[derive(Debug, Serialize, utoipa::ToSchema)]
+pub struct PreviewDhcpConfigResponse {
+    /// Active leases whose IP would fall outside the proposed pool and are not
+    /// pinned by a reservation. These devices would be forced to re-acquire an
+    /// in-range lease on their next renewal.
+    pub affected: Vec<DhcpLease>,
+}
+
 /// Response for GET /api/dhcp/leases.
 #[derive(Debug, Serialize, utoipa::ToSchema)]
 pub struct ListDhcpLeasesResponse {

--- a/source/daemon/crates/wardnetd-api/src/api/dhcp.rs
+++ b/source/daemon/crates/wardnetd-api/src/api/dhcp.rs
@@ -7,7 +7,8 @@ use uuid::Uuid;
 use wardnet_common::api::{
     CreateDhcpReservationRequest, CreateDhcpReservationResponse, DeleteDhcpReservationResponse,
     DhcpConfigResponse, DhcpStatusResponse, ListDhcpLeasesResponse, ListDhcpReservationsResponse,
-    RevokeDhcpLeaseResponse, ToggleDhcpRequest, UpdateDhcpConfigRequest,
+    PreviewDhcpConfigRequest, PreviewDhcpConfigResponse, RevokeDhcpLeaseResponse,
+    ToggleDhcpRequest, UpdateDhcpConfigRequest,
 };
 
 use crate::api::middleware::AdminAuth;
@@ -19,6 +20,7 @@ use wardnetd_services::error::AppError;
 pub fn register(router: OpenApiRouter<AppState>) -> OpenApiRouter<AppState> {
     router
         .routes(routes!(get_config, update_config))
+        .routes(routes!(preview_config))
         .routes(routes!(toggle))
         .routes(routes!(list_leases))
         .routes(routes!(revoke_lease))
@@ -29,6 +31,7 @@ pub fn register(router: OpenApiRouter<AppState>) -> OpenApiRouter<AppState> {
 
 const TAG: &str = "dhcp";
 const PATH_CONFIG: &str = "/api/dhcp/config";
+const PATH_PREVIEW: &str = "/api/dhcp/config/preview";
 const PATH_TOGGLE: &str = "/api/dhcp/config/toggle";
 const PATH_LEASES: &str = "/api/dhcp/leases";
 const PATH_LEASE_ITEM: &str = "/api/dhcp/leases/{id}";
@@ -83,6 +86,44 @@ pub async fn update_config(
     Json(body): Json<UpdateDhcpConfigRequest>,
 ) -> Result<Json<DhcpConfigResponse>, AppError> {
     let response = state.dhcp_service().update_config(body).await?;
+
+    // Hot-reload the running server so the new pool/options take effect without
+    // a daemon restart (issue #227). The swap is cheap and safe whether or not
+    // the server is currently running. Mirrors the toggle handler, which
+    // start/stops the same shared `DhcpServer` instance directly.
+    state
+        .dhcp_server()
+        .update_config(response.config.clone())
+        .await;
+
+    Ok(Json(response))
+}
+
+#[utoipa::path(
+    post,
+    path = PATH_PREVIEW,
+    tag = TAG,
+    description = "Dry-run a pool-range change: report the active leases that would be \
+                   revoked because their IP would fall outside the proposed pool (and \
+                   are not pinned by a reservation). Mutates nothing — used to warn the \
+                   admin before saving. Admin only.",
+    request_body = PreviewDhcpConfigRequest,
+    responses(
+        (status = 200, description = "Leases that would be revoked", body = PreviewDhcpConfigResponse),
+        AuthErrors,
+        BadRequest,
+    ),
+    security(
+        ("session_cookie" = []),
+        ("bearer_auth" = []),
+    ),
+)]
+pub async fn preview_config(
+    State(state): State<AppState>,
+    _auth: AdminAuth,
+    Json(body): Json<PreviewDhcpConfigRequest>,
+) -> Result<Json<PreviewDhcpConfigResponse>, AppError> {
+    let response = state.dhcp_service().preview_config(body).await?;
     Ok(Json(response))
 }
 

--- a/source/daemon/crates/wardnetd-api/src/api/tests/devices.rs
+++ b/source/daemon/crates/wardnetd-api/src/api/tests/devices.rs
@@ -332,6 +332,14 @@ impl DhcpService for MockDhcpService {
     ) -> Result<wardnet_common::api::DhcpConfigResponse, AppError> {
         unimplemented!()
     }
+    async fn preview_config(
+        &self,
+        _req: wardnet_common::api::PreviewDhcpConfigRequest,
+    ) -> Result<wardnet_common::api::PreviewDhcpConfigResponse, AppError> {
+        Ok(wardnet_common::api::PreviewDhcpConfigResponse {
+            affected: Vec::new(),
+        })
+    }
     async fn toggle(
         &self,
         _r: wardnet_common::api::ToggleDhcpRequest,

--- a/source/daemon/crates/wardnetd-api/src/api/tests/dhcp.rs
+++ b/source/daemon/crates/wardnetd-api/src/api/tests/dhcp.rs
@@ -18,7 +18,8 @@ use uuid::Uuid;
 use wardnet_common::api::{
     CreateDhcpReservationRequest, CreateDhcpReservationResponse, DeleteDhcpReservationResponse,
     DhcpConfigResponse, DhcpStatusResponse, ListDhcpLeasesResponse, ListDhcpReservationsResponse,
-    RevokeDhcpLeaseResponse, ToggleDhcpRequest, UpdateDhcpConfigRequest,
+    PreviewDhcpConfigRequest, PreviewDhcpConfigResponse, RevokeDhcpLeaseResponse,
+    ToggleDhcpRequest, UpdateDhcpConfigRequest,
 };
 use wardnet_common::dhcp::{DhcpConfig, DhcpLease, DhcpReservation};
 
@@ -105,6 +106,15 @@ impl DhcpService for MockDhcpService {
         _req: UpdateDhcpConfigRequest,
     ) -> Result<DhcpConfigResponse, AppError> {
         self.get_config().await
+    }
+
+    async fn preview_config(
+        &self,
+        _req: PreviewDhcpConfigRequest,
+    ) -> Result<PreviewDhcpConfigResponse, AppError> {
+        Ok(PreviewDhcpConfigResponse {
+            affected: Vec::new(),
+        })
     }
 
     async fn toggle(&self, _req: ToggleDhcpRequest) -> Result<DhcpConfigResponse, AppError> {

--- a/source/daemon/crates/wardnetd-api/src/tests/stubs.rs
+++ b/source/daemon/crates/wardnetd-api/src/tests/stubs.rs
@@ -162,6 +162,14 @@ impl DhcpService for StubDhcpService {
     ) -> Result<DhcpConfigResponse, AppError> {
         unimplemented!()
     }
+    async fn preview_config(
+        &self,
+        _req: PreviewDhcpConfigRequest,
+    ) -> Result<PreviewDhcpConfigResponse, AppError> {
+        Ok(PreviewDhcpConfigResponse {
+            affected: Vec::new(),
+        })
+    }
     async fn toggle(&self, _r: ToggleDhcpRequest) -> Result<DhcpConfigResponse, AppError> {
         unimplemented!()
     }
@@ -892,6 +900,7 @@ impl DhcpServer for StubDhcpServer {
     fn is_running(&self) -> bool {
         false
     }
+    async fn update_config(&self, _config: wardnet_common::dhcp::DhcpConfig) {}
 }
 
 pub struct StubDnsServer;

--- a/source/daemon/crates/wardnetd-mock/src/backends/noop_dhcp.rs
+++ b/source/daemon/crates/wardnetd-mock/src/backends/noop_dhcp.rs
@@ -32,4 +32,8 @@ impl DhcpServer for NoopDhcpServer {
     fn is_running(&self) -> bool {
         self.running.load(Ordering::SeqCst)
     }
+
+    async fn update_config(&self, _config: wardnet_common::dhcp::DhcpConfig) {
+        tracing::debug!("mock DHCP server update_config");
+    }
 }

--- a/source/daemon/crates/wardnetd-services/src/dhcp/server.rs
+++ b/source/daemon/crates/wardnetd-services/src/dhcp/server.rs
@@ -1,6 +1,7 @@
 use std::net::SocketAddr;
 
 use async_trait::async_trait;
+use wardnet_common::dhcp::DhcpConfig;
 
 use crate::error::AppError;
 
@@ -39,4 +40,9 @@ pub trait DhcpServer: Send + Sync {
 
     /// Whether the server is currently running.
     fn is_running(&self) -> bool;
+
+    /// Replace the configuration the running server serves, so pool/option
+    /// changes take effect without a daemon restart (issue #227). A no-op-safe
+    /// swap: callers may invoke it whether or not the server is running.
+    async fn update_config(&self, config: DhcpConfig);
 }

--- a/source/daemon/crates/wardnetd-services/src/dhcp/service.rs
+++ b/source/daemon/crates/wardnetd-services/src/dhcp/service.rs
@@ -6,7 +6,8 @@ use uuid::Uuid;
 use wardnet_common::api::{
     CreateDhcpReservationRequest, CreateDhcpReservationResponse, DeleteDhcpReservationResponse,
     DhcpConfigResponse, DhcpStatusResponse, ListDhcpLeasesResponse, ListDhcpReservationsResponse,
-    RevokeDhcpLeaseResponse, ToggleDhcpRequest, UpdateDhcpConfigRequest,
+    PreviewDhcpConfigRequest, PreviewDhcpConfigResponse, RevokeDhcpLeaseResponse,
+    ToggleDhcpRequest, UpdateDhcpConfigRequest,
 };
 use wardnet_common::dhcp::{DhcpConfig, DhcpLease, DhcpLeaseStatus};
 
@@ -33,6 +34,14 @@ pub trait DhcpService: Send + Sync {
         &self,
         req: UpdateDhcpConfigRequest,
     ) -> Result<DhcpConfigResponse, AppError>;
+
+    /// Dry-run a pool-range change: report the active leases that would be
+    /// revoked because their IP would fall outside the proposed pool (and are
+    /// not pinned by a reservation). Mutates nothing.
+    async fn preview_config(
+        &self,
+        req: PreviewDhcpConfigRequest,
+    ) -> Result<PreviewDhcpConfigResponse, AppError>;
 
     /// Enable or disable the DHCP server.
     async fn toggle(&self, req: ToggleDhcpRequest) -> Result<DhcpConfigResponse, AppError>;
@@ -265,6 +274,27 @@ impl DhcpServiceImpl {
         n >= u32::from(config.pool_start) && n <= u32::from(config.pool_end)
     }
 
+    /// Parse and validate a proposed DHCP pool range: both endpoints must be
+    /// valid IPv4 addresses and `pool_end >= pool_start`. Shared by
+    /// `update_config` and `preview_config` so the rule lives in one place.
+    fn parse_pool_range(
+        pool_start: &str,
+        pool_end: &str,
+    ) -> Result<(Ipv4Addr, Ipv4Addr), AppError> {
+        let start: Ipv4Addr = pool_start
+            .parse()
+            .map_err(|_| AppError::BadRequest("invalid pool_start IP address".to_owned()))?;
+        let end: Ipv4Addr = pool_end
+            .parse()
+            .map_err(|_| AppError::BadRequest("invalid pool_end IP address".to_owned()))?;
+        if u32::from(end) < u32::from(start) {
+            return Err(AppError::BadRequest(
+                "pool_end must be >= pool_start".to_owned(),
+            ));
+        }
+        Ok((start, end))
+    }
+
     /// Look up the active lease for `mac` and confirm it still reflects
     /// the current configuration. A lease is valid when either a reservation
     /// for the same MAC points to its IP, or no reservation exists for the
@@ -334,6 +364,87 @@ impl DhcpServiceImpl {
             .map_err(AppError::Internal)?;
         Ok(None)
     }
+
+    /// Active leases whose IP falls outside `[pool_start, pool_end]` and are
+    /// not pinned by a reservation for the same MAC. A reservation is a
+    /// deliberate static pin, so it survives a pool change even when its IP
+    /// sits outside the dynamic pool — mirroring `lease_if_still_valid`.
+    async fn leases_outside_pool(
+        &self,
+        pool_start: Ipv4Addr,
+        pool_end: Ipv4Addr,
+    ) -> Result<Vec<DhcpLease>, AppError> {
+        let leases = self
+            .dhcp
+            .list_active_leases()
+            .await
+            .map_err(AppError::Internal)?;
+        let reservations = self
+            .dhcp
+            .list_reservations()
+            .await
+            .map_err(AppError::Internal)?;
+
+        // Map each reserved MAC to its pinned IP. Casing is canonicalised at
+        // the repository boundary (issue #312) so a direct comparison is safe.
+        let reserved: std::collections::HashMap<String, Ipv4Addr> = reservations
+            .into_iter()
+            .map(|r| (r.mac_address, r.ip_address))
+            .collect();
+
+        let start = u32::from(pool_start);
+        let end = u32::from(pool_end);
+        Ok(leases
+            .into_iter()
+            .filter(|l| {
+                let n = u32::from(l.ip_address);
+                let in_pool = n >= start && n <= end;
+                let pinned = reserved.get(&l.mac_address) == Some(&l.ip_address);
+                !in_pool && !pinned
+            })
+            .collect())
+    }
+
+    /// Expire every active lease outside `[pool_start, pool_end]` (skipping
+    /// reservation-pinned ones) and write an audit-log row for each. Returns
+    /// the number of leases revoked.
+    async fn revoke_leases_outside_pool(
+        &self,
+        pool_start: Ipv4Addr,
+        pool_end: Ipv4Addr,
+    ) -> Result<u64, AppError> {
+        let stranded = self.leases_outside_pool(pool_start, pool_end).await?;
+        let mut revoked = 0u64;
+        for lease in stranded {
+            self.dhcp
+                .update_lease_status(&lease.id.to_string(), "expired")
+                .await
+                .map_err(AppError::Internal)?;
+            self.dhcp
+                .insert_lease_log(&DhcpLeaseLogRow {
+                    lease_id: lease.id.to_string(),
+                    mac_address: lease.mac_address.clone(),
+                    event_type: "expired".to_owned(),
+                    details: Some(format!(
+                        "out of range after pool change: ip {} outside {pool_start}-{pool_end}",
+                        lease.ip_address
+                    )),
+                })
+                .await
+                .map_err(AppError::Internal)?;
+            let mac = &lease.mac_address;
+            let ip = lease.ip_address;
+            let lease_id = lease.id;
+            tracing::info!(
+                %mac,
+                %ip,
+                %lease_id,
+                "expiring lease stranded outside new DHCP pool: mac={mac}, ip={ip}, lease_id={lease_id}"
+            );
+            revoked += 1;
+        }
+        Ok(revoked)
+    }
 }
 
 #[async_trait]
@@ -351,24 +462,11 @@ impl DhcpService for DhcpServiceImpl {
         auth_context::require_admin()?;
 
         // Validate IP addresses.
-        let pool_start: Ipv4Addr = req
-            .pool_start
-            .parse()
-            .map_err(|_| AppError::BadRequest("invalid pool_start IP address".to_owned()))?;
-        let pool_end: Ipv4Addr = req
-            .pool_end
-            .parse()
-            .map_err(|_| AppError::BadRequest("invalid pool_end IP address".to_owned()))?;
+        let (pool_start, pool_end) = Self::parse_pool_range(&req.pool_start, &req.pool_end)?;
         let _subnet_mask: Ipv4Addr = req
             .subnet_mask
             .parse()
             .map_err(|_| AppError::BadRequest("invalid subnet_mask IP address".to_owned()))?;
-
-        if u32::from(pool_end) < u32::from(pool_start) {
-            return Err(AppError::BadRequest(
-                "pool_end must be >= pool_start".to_owned(),
-            ));
-        }
 
         for dns in &req.upstream_dns {
             let _: Ipv4Addr = dns.parse().map_err(|_| {
@@ -424,8 +522,38 @@ impl DhcpService for DhcpServiceImpl {
             .await
             .map_err(AppError::Internal)?;
 
+        // Revoke leases stranded outside the new pool (issue #227). A device
+        // holding an out-of-range IP would otherwise keep it — with routing
+        // rules still targeting the old address — until its lease happened to
+        // expire. Expiring them now, plus the DHCPNAK path in `evaluate_renewal`,
+        // forces each device to re-acquire an in-range lease at its next
+        // renewal. Reservations are left untouched: a static pin is deliberate
+        // even when it sits outside the dynamic pool.
+        let revoked = self
+            .revoke_leases_outside_pool(pool_start, pool_end)
+            .await?;
+        if revoked > 0 {
+            tracing::info!(
+                revoked,
+                %pool_start,
+                %pool_end,
+                "revoked {revoked} DHCP leases outside new pool range {pool_start}-{pool_end}"
+            );
+        }
+
         let config = self.load_config().await?;
         Ok(DhcpConfigResponse { config })
+    }
+
+    async fn preview_config(
+        &self,
+        req: PreviewDhcpConfigRequest,
+    ) -> Result<PreviewDhcpConfigResponse, AppError> {
+        auth_context::require_admin()?;
+
+        let (pool_start, pool_end) = Self::parse_pool_range(&req.pool_start, &req.pool_end)?;
+        let affected = self.leases_outside_pool(pool_start, pool_end).await?;
+        Ok(PreviewDhcpConfigResponse { affected })
     }
 
     async fn toggle(&self, req: ToggleDhcpRequest) -> Result<DhcpConfigResponse, AppError> {

--- a/source/daemon/crates/wardnetd-services/src/dhcp/tests/dhcp.rs
+++ b/source/daemon/crates/wardnetd-services/src/dhcp/tests/dhcp.rs
@@ -6,7 +6,8 @@ use async_trait::async_trait;
 use chrono::Utc;
 use uuid::Uuid;
 use wardnet_common::api::{
-    CreateDhcpReservationRequest, ToggleDhcpRequest, UpdateDhcpConfigRequest,
+    CreateDhcpReservationRequest, PreviewDhcpConfigRequest, ToggleDhcpRequest,
+    UpdateDhcpConfigRequest,
 };
 use wardnet_common::auth::AuthContext;
 use wardnet_common::dhcp::{DhcpLease, DhcpLeaseLog, DhcpLeaseStatus, DhcpReservation};
@@ -1825,4 +1826,118 @@ async fn renew_lease_publishes_event_with_updated_hostname() {
         }
         other => panic!("expected DhcpLeaseRenewed, got {other:?}"),
     }
+}
+
+// =========================================================================
+// Pool-range change: out-of-range lease revocation (issue #227)
+// =========================================================================
+
+/// Build an `UpdateDhcpConfigRequest` for the given pool with fixed defaults
+/// for the unrelated fields.
+fn update_req(pool_start: &str, pool_end: &str) -> UpdateDhcpConfigRequest {
+    UpdateDhcpConfigRequest {
+        pool_start: pool_start.to_owned(),
+        pool_end: pool_end.to_owned(),
+        subnet_mask: "255.255.255.0".to_owned(),
+        upstream_dns: vec!["1.1.1.1".to_owned()],
+        lease_duration_secs: 86400,
+        router_ip: None,
+    }
+}
+
+/// Current stored status of the lease with `id`, if present.
+fn lease_status(dhcp: &MockDhcpRepository, id: &str) -> Option<String> {
+    dhcp.leases
+        .lock()
+        .unwrap()
+        .iter()
+        .find(|r| r.id == id)
+        .map(|r| r.status.clone())
+}
+
+#[tokio::test]
+async fn update_config_revokes_only_out_of_range_unreserved_leases() {
+    let (svc, dhcp, _cfg) = build_service_with_deps();
+
+    // New pool is 192.168.1.150-200.
+    let in_range = seed_active_lease(&dhcp, "aa:bb:cc:dd:ee:01", "192.168.1.160");
+    let out_of_range = seed_active_lease(&dhcp, "aa:bb:cc:dd:ee:02", "192.168.1.50");
+    // Out of the pool but pinned by a reservation -> deliberate, must survive.
+    seed_reservation(&dhcp, "aa:bb:cc:dd:ee:03", "192.168.1.10");
+    let reserved = seed_active_lease(&dhcp, "aa:bb:cc:dd:ee:03", "192.168.1.10");
+
+    auth_context::with_context(
+        admin_ctx(),
+        svc.update_config(update_req("192.168.1.150", "192.168.1.200")),
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(lease_status(&dhcp, &in_range).as_deref(), Some("active"));
+    assert_eq!(lease_status(&dhcp, &reserved).as_deref(), Some("active"));
+    assert_eq!(
+        lease_status(&dhcp, &out_of_range).as_deref(),
+        Some("expired")
+    );
+
+    // An audit-log row explains why the stranded lease was revoked.
+    let logs = dhcp.logs.lock().unwrap();
+    let expired_log = logs
+        .iter()
+        .find(|l| l.event_type == "expired")
+        .expect("expired log row");
+    assert!(
+        expired_log
+            .details
+            .as_deref()
+            .unwrap_or_default()
+            .contains("out of range")
+    );
+}
+
+#[tokio::test]
+async fn preview_config_reports_affected_without_mutating() {
+    let (svc, dhcp, _cfg) = build_service_with_deps();
+
+    let in_range = seed_active_lease(&dhcp, "aa:bb:cc:dd:ee:01", "192.168.1.160");
+    let out_of_range = seed_active_lease(&dhcp, "aa:bb:cc:dd:ee:02", "192.168.1.50");
+    seed_reservation(&dhcp, "aa:bb:cc:dd:ee:03", "192.168.1.10");
+    let reserved = seed_active_lease(&dhcp, "aa:bb:cc:dd:ee:03", "192.168.1.10");
+
+    let resp = auth_context::with_context(
+        admin_ctx(),
+        svc.preview_config(PreviewDhcpConfigRequest {
+            pool_start: "192.168.1.150".to_owned(),
+            pool_end: "192.168.1.200".to_owned(),
+        }),
+    )
+    .await
+    .unwrap();
+
+    // Only the out-of-range, unreserved lease is reported.
+    assert_eq!(resp.affected.len(), 1);
+    assert_eq!(resp.affected[0].ip_address.to_string(), "192.168.1.50");
+
+    // Nothing was mutated: every lease stays active and no log rows appear.
+    assert_eq!(lease_status(&dhcp, &in_range).as_deref(), Some("active"));
+    assert_eq!(
+        lease_status(&dhcp, &out_of_range).as_deref(),
+        Some("active")
+    );
+    assert_eq!(lease_status(&dhcp, &reserved).as_deref(), Some("active"));
+    assert!(dhcp.logs.lock().unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn preview_config_rejects_inverted_range() {
+    let (svc, _dhcp, _cfg) = build_service_with_deps();
+    let result = auth_context::with_context(
+        admin_ctx(),
+        svc.preview_config(PreviewDhcpConfigRequest {
+            pool_start: "192.168.1.200".to_owned(),
+            pool_end: "192.168.1.100".to_owned(),
+        }),
+    )
+    .await;
+    assert!(matches!(result, Err(AppError::BadRequest(_))));
 }

--- a/source/daemon/crates/wardnetd-services/src/dhcp/tests/runner.rs
+++ b/source/daemon/crates/wardnetd-services/src/dhcp/tests/runner.rs
@@ -7,7 +7,8 @@ use uuid::Uuid;
 use wardnet_common::api::{
     CreateDhcpReservationRequest, CreateDhcpReservationResponse, DeleteDhcpReservationResponse,
     DhcpConfigResponse, DhcpStatusResponse, ListDhcpLeasesResponse, ListDhcpReservationsResponse,
-    RevokeDhcpLeaseResponse, ToggleDhcpRequest, UpdateDhcpConfigRequest,
+    PreviewDhcpConfigRequest, PreviewDhcpConfigResponse, RevokeDhcpLeaseResponse,
+    ToggleDhcpRequest, UpdateDhcpConfigRequest,
 };
 use wardnet_common::dhcp::{DhcpConfig, DhcpLease};
 
@@ -55,6 +56,8 @@ impl DhcpServer for MockDhcpServer {
     fn is_running(&self) -> bool {
         self.started.load(Ordering::SeqCst)
     }
+
+    async fn update_config(&self, _config: wardnet_common::dhcp::DhcpConfig) {}
 }
 
 // ---------------------------------------------------------------------------
@@ -86,6 +89,14 @@ impl DhcpService for MockRunnerDhcpService {
         _r: UpdateDhcpConfigRequest,
     ) -> Result<DhcpConfigResponse, AppError> {
         unimplemented!()
+    }
+    async fn preview_config(
+        &self,
+        _req: PreviewDhcpConfigRequest,
+    ) -> Result<PreviewDhcpConfigResponse, AppError> {
+        Ok(PreviewDhcpConfigResponse {
+            affected: Vec::new(),
+        })
     }
     async fn toggle(&self, _r: ToggleDhcpRequest) -> Result<DhcpConfigResponse, AppError> {
         unimplemented!()
@@ -346,6 +357,7 @@ async fn runner_handles_start_failure_gracefully() {
         fn is_running(&self) -> bool {
             false
         }
+        async fn update_config(&self, _config: wardnet_common::dhcp::DhcpConfig) {}
     }
 
     let service: Arc<dyn DhcpService> = Arc::new(MockRunnerDhcpService::new(true));
@@ -385,6 +397,14 @@ async fn runner_handles_config_load_failure() {
             _r: UpdateDhcpConfigRequest,
         ) -> Result<DhcpConfigResponse, AppError> {
             unimplemented!()
+        }
+        async fn preview_config(
+            &self,
+            _req: PreviewDhcpConfigRequest,
+        ) -> Result<PreviewDhcpConfigResponse, AppError> {
+            Ok(PreviewDhcpConfigResponse {
+                affected: Vec::new(),
+            })
         }
         async fn toggle(&self, _r: ToggleDhcpRequest) -> Result<DhcpConfigResponse, AppError> {
             unimplemented!()

--- a/source/daemon/crates/wardnetd-services/src/dns/dhcp_lan_runner/tests.rs
+++ b/source/daemon/crates/wardnetd-services/src/dns/dhcp_lan_runner/tests.rs
@@ -77,6 +77,14 @@ impl DhcpService for MockDhcp {
     ) -> Result<wardnet_common::api::DhcpConfigResponse, AppError> {
         unimplemented!()
     }
+    async fn preview_config(
+        &self,
+        _req: wardnet_common::api::PreviewDhcpConfigRequest,
+    ) -> Result<wardnet_common::api::PreviewDhcpConfigResponse, AppError> {
+        Ok(wardnet_common::api::PreviewDhcpConfigResponse {
+            affected: Vec::new(),
+        })
+    }
     async fn toggle(
         &self,
         _req: wardnet_common::api::ToggleDhcpRequest,

--- a/source/daemon/crates/wardnetd-services/src/tests/health_checks.rs
+++ b/source/daemon/crates/wardnetd-services/src/tests/health_checks.rs
@@ -197,6 +197,14 @@ impl DhcpService for MockDhcpService {
     ) -> Result<wardnet_common::api::DhcpConfigResponse, AppError> {
         unimplemented!()
     }
+    async fn preview_config(
+        &self,
+        _req: wardnet_common::api::PreviewDhcpConfigRequest,
+    ) -> Result<wardnet_common::api::PreviewDhcpConfigResponse, AppError> {
+        Ok(wardnet_common::api::PreviewDhcpConfigResponse {
+            affected: Vec::new(),
+        })
+    }
     async fn toggle(
         &self,
         _r: wardnet_common::api::ToggleDhcpRequest,
@@ -270,6 +278,7 @@ impl DhcpServer for MockDhcpServer {
     fn is_running(&self) -> bool {
         self.running.load(Ordering::SeqCst)
     }
+    async fn update_config(&self, _config: wardnet_common::dhcp::DhcpConfig) {}
 }
 
 fn dhcp_check(enabled: bool, running: bool, fail: bool) -> DhcpServerHealthCheck {

--- a/source/daemon/crates/wardnetd/src/dhcp/server.rs
+++ b/source/daemon/crates/wardnetd/src/dhcp/server.rs
@@ -1,9 +1,9 @@
-use std::net::SocketAddr;
+use std::net::{Ipv4Addr, SocketAddr};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 
 use async_trait::async_trait;
-use dhcproto::v4::{DhcpOption, Flags, Message, MessageType, Opcode};
+use dhcproto::v4::{DhcpOption, Flags, Message, MessageType, Opcode, OptionCode};
 use dhcproto::{Decodable, Decoder, Encodable, Encoder};
 use tokio::net::UdpSocket;
 use tokio::sync::{Mutex, RwLock};
@@ -135,11 +135,6 @@ impl UdpDhcpServer {
     pub(crate) fn local_addr(&self) -> Option<SocketAddr> {
         *self.local_addr.lock().expect("local_addr mutex poisoned")
     }
-
-    /// Update the stored configuration (called when config changes).
-    pub async fn update_config(&self, config: DhcpConfig) {
-        *self.config.write().await = config;
-    }
 }
 
 #[async_trait]
@@ -212,6 +207,14 @@ impl DhcpServer for UdpDhcpServer {
 
     fn is_running(&self) -> bool {
         self.running.load(Ordering::SeqCst)
+    }
+
+    /// Swap the config the running `server_loop` reads on each packet. The
+    /// loop holds the same `Arc<RwLock<DhcpConfig>>`, so the new options
+    /// (pool, mask, lease time, DNS, router) take effect on the next request
+    /// without a restart.
+    async fn update_config(&self, config: DhcpConfig) {
+        *self.config.write().await = config;
     }
 }
 
@@ -336,7 +339,13 @@ pub(crate) async fn handle_discover(
     Ok(build_response(msg, MessageType::Offer, &lease, config))
 }
 
-/// Handle a DHCPREQUEST message: renew the lease and build an ACK response.
+/// Handle a DHCPREQUEST message.
+///
+/// Delegates to [`DhcpService::evaluate_renewal`], which decides whether the
+/// client may keep the IP it asked for. A legitimate renewal produces a
+/// DHCPACK; a request for an IP the configuration no longer justifies (e.g.
+/// the pool moved out from under it) produces a DHCPNAK, forcing the client
+/// back to DISCOVER so it picks up an in-range lease (issue #227).
 pub(crate) async fn handle_request(
     service: &Arc<dyn DhcpService>,
     msg: &Message,
@@ -347,9 +356,28 @@ pub(crate) async fn handle_request(
         admin_id: Uuid::nil(),
     };
     let hostname = extract_hostname(msg);
+    let requested_ip = extract_requested_ip(msg);
+
     let lease =
         auth_context::with_context(admin_ctx, service.renew_lease(mac, hostname.as_deref()))
             .await?;
+
+    // If the client asked to keep a specific IP but the service assigned a
+    // different one, its old address is no longer valid (e.g. the pool moved
+    // out from under it). A renewing client expects either an ACK for the same
+    // IP or a NAK — silently ACKing a different IP is a protocol violation, so
+    // NAK to force it back through DISCOVER, where it picks up the in-range
+    // lease that `renew_lease` just prepared. See issue #227.
+    if !requested_ip.is_unspecified() && lease.ip_address != requested_ip {
+        let new_ip = lease.ip_address;
+        tracing::info!(
+            %mac,
+            %requested_ip,
+            %new_ip,
+            "sending DHCPNAK: mac={mac} requested out-of-range ip={requested_ip}, assigned new_ip={new_ip}",
+        );
+        return Ok(build_nak(msg, config));
+    }
 
     tracing::info!(
         %mac,
@@ -361,6 +389,41 @@ pub(crate) async fn handle_request(
     );
 
     Ok(build_response(msg, MessageType::Ack, &lease, config))
+}
+
+/// Extract the IP address a DHCPREQUEST client wants to keep. In RENEWING /
+/// REBINDING the client already holds the address, so it appears in `ciaddr`;
+/// in SELECTING / INIT-REBOOT it is carried in the Requested-IP option (50).
+/// Returns `0.0.0.0` when neither is present.
+fn extract_requested_ip(msg: &Message) -> Ipv4Addr {
+    let ciaddr = msg.ciaddr();
+    if !ciaddr.is_unspecified() {
+        return ciaddr;
+    }
+    if let Some(DhcpOption::RequestedIpAddress(ip)) = msg.opts().get(OptionCode::RequestedIpAddress)
+    {
+        return *ip;
+    }
+    Ipv4Addr::UNSPECIFIED
+}
+
+/// Build a DHCPNAK response. A NAK carries no address; it just tells the client
+/// its request was rejected and it must restart the handshake.
+pub(crate) fn build_nak(request: &Message, config: &DhcpConfig) -> Message {
+    let server_ip = config.gateway_ip;
+
+    let mut response = Message::default();
+    response
+        .set_opcode(Opcode::BootReply)
+        .set_xid(request.xid())
+        .set_flags(Flags::default().set_broadcast())
+        .set_chaddr(request.chaddr());
+
+    let opts = response.opts_mut();
+    opts.insert(DhcpOption::MessageType(MessageType::Nak));
+    opts.insert(DhcpOption::ServerIdentifier(server_ip));
+
+    response
 }
 
 /// Build an OFFER or ACK response message.

--- a/source/daemon/crates/wardnetd/src/dhcp/tests/server.rs
+++ b/source/daemon/crates/wardnetd/src/dhcp/tests/server.rs
@@ -11,7 +11,8 @@ use uuid::Uuid;
 use wardnet_common::api::{
     CreateDhcpReservationRequest, CreateDhcpReservationResponse, DeleteDhcpReservationResponse,
     DhcpConfigResponse, DhcpStatusResponse, ListDhcpLeasesResponse, ListDhcpReservationsResponse,
-    RevokeDhcpLeaseResponse, ToggleDhcpRequest, UpdateDhcpConfigRequest,
+    PreviewDhcpConfigRequest, PreviewDhcpConfigResponse, RevokeDhcpLeaseResponse,
+    ToggleDhcpRequest, UpdateDhcpConfigRequest,
 };
 use wardnet_common::dhcp::{DhcpConfig, DhcpLease, DhcpLeaseStatus};
 
@@ -139,6 +140,14 @@ impl DhcpService for MockDhcpService {
         _r: UpdateDhcpConfigRequest,
     ) -> Result<DhcpConfigResponse, AppError> {
         unimplemented!()
+    }
+    async fn preview_config(
+        &self,
+        _req: PreviewDhcpConfigRequest,
+    ) -> Result<PreviewDhcpConfigResponse, AppError> {
+        Ok(PreviewDhcpConfigResponse {
+            affected: Vec::new(),
+        })
     }
     async fn toggle(&self, _r: ToggleDhcpRequest) -> Result<DhcpConfigResponse, AppError> {
         unimplemented!()
@@ -547,6 +556,48 @@ async fn handle_request_calls_renew_lease_and_returns_ack() {
 }
 
 #[tokio::test]
+async fn handle_request_naks_when_assigned_ip_differs_from_requested() {
+    // Client renews from an out-of-range address (ciaddr) but the service
+    // hands back a different, in-range lease — meaning the requested IP is no
+    // longer valid. The server must NAK, not ACK a surprise IP (issue #227).
+    let lease = test_lease(); // ip 192.168.1.100
+    let mock = Arc::new(MockDhcpService::new(lease.clone()));
+    let service: Arc<dyn DhcpService> = Arc::clone(&mock) as Arc<dyn DhcpService>;
+
+    let mut msg = build_request([0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff]);
+    msg.set_ciaddr(Ipv4Addr::new(192, 168, 1, 50)); // old, now out-of-range IP
+    let config = test_config();
+
+    let response = server::handle_request(&service, &msg, "aa:bb:cc:dd:ee:ff", &config)
+        .await
+        .unwrap();
+
+    assert_eq!(response.opts().msg_type(), Some(MessageType::Nak));
+    // A NAK carries no address assignment.
+    assert_eq!(response.yiaddr(), Ipv4Addr::UNSPECIFIED);
+}
+
+#[tokio::test]
+async fn handle_request_acks_when_requested_ip_matches_assigned() {
+    // A normal renewal: the client asks to keep exactly the IP the service
+    // returns, so the server ACKs it.
+    let lease = test_lease(); // ip 192.168.1.100
+    let mock = Arc::new(MockDhcpService::new(lease.clone()));
+    let service: Arc<dyn DhcpService> = Arc::clone(&mock) as Arc<dyn DhcpService>;
+
+    let mut msg = build_request([0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff]);
+    msg.set_ciaddr(lease.ip_address);
+    let config = test_config();
+
+    let response = server::handle_request(&service, &msg, "aa:bb:cc:dd:ee:ff", &config)
+        .await
+        .unwrap();
+
+    assert_eq!(response.opts().msg_type(), Some(MessageType::Ack));
+    assert_eq!(response.yiaddr(), lease.ip_address);
+}
+
+#[tokio::test]
 async fn handle_request_preserves_xid() {
     let lease = test_lease();
     let service: Arc<dyn DhcpService> = Arc::new(MockDhcpService::new(lease));
@@ -576,6 +627,14 @@ async fn handle_discover_returns_error_when_service_fails() {
             _r: UpdateDhcpConfigRequest,
         ) -> Result<DhcpConfigResponse, AppError> {
             unimplemented!()
+        }
+        async fn preview_config(
+            &self,
+            _req: PreviewDhcpConfigRequest,
+        ) -> Result<PreviewDhcpConfigResponse, AppError> {
+            Ok(PreviewDhcpConfigResponse {
+                affected: Vec::new(),
+            })
         }
         async fn toggle(&self, _r: ToggleDhcpRequest) -> Result<DhcpConfigResponse, AppError> {
             unimplemented!()
@@ -652,6 +711,14 @@ async fn handle_request_returns_error_when_service_fails() {
             _r: UpdateDhcpConfigRequest,
         ) -> Result<DhcpConfigResponse, AppError> {
             unimplemented!()
+        }
+        async fn preview_config(
+            &self,
+            _req: PreviewDhcpConfigRequest,
+        ) -> Result<PreviewDhcpConfigResponse, AppError> {
+            Ok(PreviewDhcpConfigResponse {
+                affected: Vec::new(),
+            })
         }
         async fn toggle(&self, _r: ToggleDhcpRequest) -> Result<DhcpConfigResponse, AppError> {
             unimplemented!()
@@ -1196,6 +1263,14 @@ async fn server_loop_handles_discover_error_gracefully() {
         ) -> Result<DhcpConfigResponse, AppError> {
             unimplemented!()
         }
+        async fn preview_config(
+            &self,
+            _req: PreviewDhcpConfigRequest,
+        ) -> Result<PreviewDhcpConfigResponse, AppError> {
+            Ok(PreviewDhcpConfigResponse {
+                affected: Vec::new(),
+            })
+        }
         async fn toggle(&self, _r: ToggleDhcpRequest) -> Result<DhcpConfigResponse, AppError> {
             unimplemented!()
         }
@@ -1280,6 +1355,14 @@ async fn server_loop_handles_request_error_gracefully() {
             _r: UpdateDhcpConfigRequest,
         ) -> Result<DhcpConfigResponse, AppError> {
             unimplemented!()
+        }
+        async fn preview_config(
+            &self,
+            _req: PreviewDhcpConfigRequest,
+        ) -> Result<PreviewDhcpConfigResponse, AppError> {
+            Ok(PreviewDhcpConfigResponse {
+                affected: Vec::new(),
+            })
         }
         async fn toggle(&self, _r: ToggleDhcpRequest) -> Result<DhcpConfigResponse, AppError> {
             unimplemented!()

--- a/source/daemon/crates/wardnetd/src/tests/stubs.rs
+++ b/source/daemon/crates/wardnetd/src/tests/stubs.rs
@@ -27,7 +27,8 @@ use wardnet_common::tunnel::Tunnel;
 use wardnet_common::api::{
     CreateDhcpReservationRequest, CreateDhcpReservationResponse, DeleteDhcpReservationResponse,
     DhcpConfigResponse, DhcpStatusResponse, ListDhcpLeasesResponse, ListDhcpReservationsResponse,
-    RevokeDhcpLeaseResponse, ToggleDhcpRequest, UpdateDhcpConfigRequest,
+    PreviewDhcpConfigRequest, PreviewDhcpConfigResponse, RevokeDhcpLeaseResponse,
+    ToggleDhcpRequest, UpdateDhcpConfigRequest,
 };
 use wardnet_common::api::{WizardMode, WizardStep};
 use wardnet_common::dhcp::{DhcpConfig, DhcpLease};
@@ -557,6 +558,14 @@ impl DhcpService for StubDhcpService {
     ) -> Result<DhcpConfigResponse, AppError> {
         unimplemented!()
     }
+    async fn preview_config(
+        &self,
+        _req: PreviewDhcpConfigRequest,
+    ) -> Result<PreviewDhcpConfigResponse, AppError> {
+        Ok(PreviewDhcpConfigResponse {
+            affected: Vec::new(),
+        })
+    }
     async fn toggle(&self, _r: ToggleDhcpRequest) -> Result<DhcpConfigResponse, AppError> {
         unimplemented!()
     }
@@ -1069,6 +1078,7 @@ impl wardnetd_services::dhcp::server::DhcpServer for StubDhcpServer {
     fn is_running(&self) -> bool {
         false
     }
+    async fn update_config(&self, _config: wardnet_common::dhcp::DhcpConfig) {}
 }
 
 // ---------------------------------------------------------------------------

--- a/source/sdk/wardnet-js/src/index.ts
+++ b/source/sdk/wardnet-js/src/index.ts
@@ -107,6 +107,8 @@ export type {
   DhcpReservation,
   DhcpConfigResponse,
   UpdateDhcpConfigRequest,
+  PreviewDhcpConfigRequest,
+  PreviewDhcpConfigResponse,
   ToggleDhcpRequest,
   ListDhcpLeasesResponse,
   ListDhcpReservationsResponse,

--- a/source/sdk/wardnet-js/src/services/dhcp.ts
+++ b/source/sdk/wardnet-js/src/services/dhcp.ts
@@ -2,6 +2,8 @@ import type { WardnetClient } from "../client.js";
 import type {
   DhcpConfigResponse,
   UpdateDhcpConfigRequest,
+  PreviewDhcpConfigRequest,
+  PreviewDhcpConfigResponse,
   ToggleDhcpRequest,
   ListDhcpLeasesResponse,
   ListDhcpReservationsResponse,
@@ -25,6 +27,18 @@ export class DhcpService {
   async updateConfig(body: UpdateDhcpConfigRequest): Promise<DhcpConfigResponse> {
     return this.client.request<DhcpConfigResponse>("/dhcp/config", {
       method: "PUT",
+      body: JSON.stringify(body),
+    });
+  }
+
+  /**
+   * Dry-run a pool-range change: report the active leases that would be
+   * revoked if the pool were changed to the given range (admin only). Mutates
+   * nothing — used to warn before saving.
+   */
+  async previewConfig(body: PreviewDhcpConfigRequest): Promise<PreviewDhcpConfigResponse> {
+    return this.client.request<PreviewDhcpConfigResponse>("/dhcp/config/preview", {
+      method: "POST",
       body: JSON.stringify(body),
     });
   }

--- a/source/sdk/wardnet-js/src/types/dhcp.ts
+++ b/source/sdk/wardnet-js/src/types/dhcp.ts
@@ -59,6 +59,20 @@ export interface ToggleDhcpRequest {
   enabled: boolean;
 }
 
+/** Request body for POST /api/dhcp/config/preview. */
+export interface PreviewDhcpConfigRequest {
+  pool_start: string;
+  pool_end: string;
+}
+
+/**
+ * Response for POST /api/dhcp/config/preview: the active leases that would be
+ * revoked (IP outside the proposed pool, not pinned by a reservation).
+ */
+export interface PreviewDhcpConfigResponse {
+  affected: DhcpLease[];
+}
+
 /** Response for GET /api/dhcp/leases. */
 export interface ListDhcpLeasesResponse {
   leases: DhcpLease[];

--- a/source/web/src/hooks/useDhcp.ts
+++ b/source/web/src/hooks/useDhcp.ts
@@ -7,6 +7,8 @@ import type {
   ListDhcpLeasesResponse,
   ListDhcpReservationsResponse,
   UpdateDhcpConfigRequest,
+  PreviewDhcpConfigRequest,
+  PreviewDhcpConfigResponse,
   CreateDhcpReservationRequest,
 } from "@wardnet/js";
 
@@ -51,6 +53,17 @@ export function useToggleDhcp() {
       qc.invalidateQueries({ queryKey: ["dhcp"] });
     },
     onError: () => toast.error("Failed to toggle DHCP server"),
+  });
+}
+
+export function usePreviewDhcpConfig() {
+  return useMutation<
+    PreviewDhcpConfigResponse,
+    Error,
+    PreviewDhcpConfigRequest
+  >({
+    mutationFn: (body: PreviewDhcpConfigRequest) =>
+      dhcpService.previewConfig(body),
   });
 }
 

--- a/source/web/src/index.ts
+++ b/source/web/src/index.ts
@@ -232,6 +232,7 @@ export {
   useDhcpReservations,
   useToggleDhcp,
   useUpdateDhcpConfig,
+  usePreviewDhcpConfig,
   useCreateReservation,
   useDeleteReservation,
   useRevokeLease,


### PR DESCRIPTION
Closes #227.

## Context

Changing the DHCP pool range via `PUT /api/dhcp/config` was an undefined footgun. When the admin narrows or moves the pool, devices holding a lease outside the new range were left stranded: the lease row stayed `active`, the running server kept advertising the *old* options (subnet mask / lease time / DNS / router) until a daemon restart, and — worst — a renewing client could be silently ACKed a *different* IP, a DHCP protocol violation many clients reject.

## What changed

- **Immediate revocation on save** — `update_config` expires the active leases now outside the pool (skipping reservation-pinned ones), each with an audit-log row, and reloads the running server's config.
- **Forced re-DISCOVER via DHCPNAK** — `handle_request` compares the client's requested IP (`ciaddr` / requested-IP option) against what the service would assign; on mismatch it sends a **DHCPNAK**, pushing the client back through DISCOVER→OFFER onto an in-range lease instead of ACKing a surprise IP.
- **Hot-reload without restart** — `update_config` added to the `DhcpServer` trait; the API handler pushes the new config into the same shared server `Arc` (mirroring the existing toggle start/stop wiring), so changes take effect without a daemon restart.
- **Pre-save warning** — new `POST /api/dhcp/config/preview` dry-run endpoint (+ SDK `previewConfig` + `usePreviewDhcpConfig` hook) computes the affected leases; `DhcpConfigCard` shows a confirm dialog ("N devices … reconnect within ~10 minutes") before saving.

Routing stays correct via the existing ARP-discovery → `DeviceIpChanged` → `routing_listener` path (DHCP leases carry no `device_id`).

### Design notes
- The NAK decision lives in the server layer as an assigned-vs-requested IP compare, reusing the service's existing `renew_lease` / `lease_if_still_valid` validity logic rather than duplicating it. Renewals that send `ciaddr=0` (the common case) are unaffected.
- Config hot-reload is wired directly in the API handler because the toggle handler already start/stops the same shared `DhcpServer` there; no new event type was needed.

## Testing

- Daemon: containerized `make check-daemon` — `cargo fmt --check`, `cargo clippy --all-targets -D warnings`, `cargo test --workspace` (2056 passed, 0 failed), including 5 new tests: out-of-range revocation (reserved/in-range untouched), `preview_config` reports-without-mutating, inverted-range rejection, and NAK-vs-ACK on renewal.
- SDK / web / admin-site: typecheck + lint + format clean.
- `docs/openapi.json` regenerated for the new endpoint.

## Merge Commit Message

feat(dhcp): handle pool-range changes without stranding devices (#227)

Revoke out-of-range leases on pool-config save, NAK renewals for now-invalid IPs to force a clean re-DISCOVER, hot-reload the running DHCP server without a daemon restart, and add a preview endpoint powering a pre-save warning of affected devices.

https://claude.ai/code/session_01VHUZsNZcfhKTv4Z7mK2jje