### PR TITLE
Config hardening: reject unknown TOML fields and use absolute-path DB default

### DIFF
--- a/source/daemon/crates/wardnet-common/src/config.rs
+++ b/source/daemon/crates/wardnet-common/src/config.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 /// Loaded from a TOML file by the daemon, or constructed with defaults
 /// by the mock server. All sub-crates receive this via dependency injection.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(default)]
+#[serde(default, deny_unknown_fields)]
 pub struct ApplicationConfiguration {
     pub server: ServerConfig,
     pub database: DatabaseConfig,
@@ -107,7 +107,7 @@ impl ApplicationConfiguration {
 
 /// HTTP server configuration.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(default)]
+#[serde(default, deny_unknown_fields)]
 pub struct ServerConfig {
     pub host: String,
     /// Plain-HTTP port — the pre-provisioning fallback surface and the LAN admin
@@ -142,11 +142,17 @@ pub enum DatabaseProvider {
 
 /// Database configuration.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(default)]
+#[serde(default, deny_unknown_fields)]
 pub struct DatabaseConfig {
     /// Database provider. Only `sqlite` is supported for now.
     pub provider: DatabaseProvider,
     /// Connection string. For `SQLite` this is the file path.
+    ///
+    /// Defaults to the absolute `/var/lib/wardnet/wardnet.db` (matching the
+    /// systemd `ReadWritePaths=/var/lib/wardnet` and what `deploy/install.sh`
+    /// writes) so a zero-config daemon under `WorkingDirectory=/` doesn't try
+    /// to create `/wardnet.db`. Explicit relative paths are still honoured and
+    /// resolved against the working directory via [`Self::to_file_path`].
     pub connection_string: String,
 }
 
@@ -154,7 +160,7 @@ impl Default for DatabaseConfig {
     fn default() -> Self {
         Self {
             provider: DatabaseProvider::Sqlite,
-            connection_string: "./wardnet.db".to_owned(),
+            connection_string: "/var/lib/wardnet/wardnet.db".to_owned(),
         }
     }
 }
@@ -203,7 +209,7 @@ pub enum LogRotation {
 
 /// Logging configuration.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(default)]
+#[serde(default, deny_unknown_fields)]
 pub struct LoggingConfig {
     /// Log output format (console or json).
     pub format: LogFormat,
@@ -265,7 +271,7 @@ impl LoggingConfig {
 
 /// Network / LAN configuration.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(default)]
+#[serde(default, deny_unknown_fields)]
 pub struct NetworkConfig {
     pub lan_interface: String,
     pub default_policy: String,
@@ -282,7 +288,7 @@ impl Default for NetworkConfig {
 
 /// Authentication settings.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(default)]
+#[serde(default, deny_unknown_fields)]
 pub struct AuthConfig {
     pub session_expiry_hours: u64,
     /// Session lifetime when `remember_me = true` (default 30 days = 720 h).
@@ -303,6 +309,7 @@ impl Default for AuthConfig {
 /// Optional in the TOML file. When present, `bootstrap_admin` uses these
 /// instead of generating random credentials.
 #[derive(Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct AdminConfig {
     pub username: String,
     pub password: String,
@@ -325,7 +332,7 @@ impl std::fmt::Debug for AdminConfig {
 /// top-level [`SecretStoreConfig`]. Tunnel creation refuses to operate
 /// when no secret store is configured.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(default)]
+#[serde(default, deny_unknown_fields)]
 pub struct TunnelConfig {
     pub idle_timeout_secs: u64,
     pub health_check_interval_secs: u64,
@@ -383,6 +390,10 @@ impl Default for TunnelConfig {
 /// provider = "file_system"
 /// path = "/var/lib/wardnet/secrets"
 /// ```
+// NOTE: no `deny_unknown_fields` here — serde rejects it on internally-tagged
+// enums (`tag = "provider"`) at compile time. Unknown keys *inside* a variant
+// (e.g. a stray field under `[secret_store]`) are therefore not caught; unknown
+// top-level sections still are, via `ApplicationConfiguration`.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(tag = "provider", rename_all = "snake_case")]
 pub enum SecretStoreConfig {
@@ -396,7 +407,7 @@ pub enum SecretStoreConfig {
 
 /// Device detection settings.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(default)]
+#[serde(default, deny_unknown_fields)]
 pub struct DetectionConfig {
     pub enabled: bool,
     pub departure_timeout_secs: u64,
@@ -419,7 +430,7 @@ impl Default for DetectionConfig {
 
 /// OpenTelemetry OTLP export configuration.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(default)]
+#[serde(default, deny_unknown_fields)]
 pub struct OtelConfig {
     pub enabled: bool,
     pub endpoint: String,
@@ -446,7 +457,7 @@ impl Default for OtelConfig {
 
 /// `OTel` trace export settings.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(default)]
+#[serde(default, deny_unknown_fields)]
 pub struct OtelTracesConfig {
     pub enabled: bool,
 }
@@ -459,7 +470,7 @@ impl Default for OtelTracesConfig {
 
 /// `OTel` log export settings.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(default)]
+#[serde(default, deny_unknown_fields)]
 pub struct OtelLogsConfig {
     pub enabled: bool,
 }
@@ -480,7 +491,7 @@ impl Default for OtelLogsConfig {
 /// nordvpn = false
 /// ```
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
-#[serde(default)]
+#[serde(default, deny_unknown_fields)]
 pub struct VpnProvidersConfig {
     /// Map of provider ID to enabled flag. Providers not listed here are
     /// treated as enabled.
@@ -495,7 +506,7 @@ pub struct VpnProvidersConfig {
 
 /// OpenTelemetry metrics collection configuration.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(default)]
+#[serde(default, deny_unknown_fields)]
 pub struct OtelMetricsConfig {
     pub enabled: bool,
     pub enabled_metrics: EnabledMetrics,
@@ -513,7 +524,7 @@ impl Default for OtelMetricsConfig {
 /// Per-metric enable/disable toggles for the metrics collector.
 #[allow(clippy::struct_excessive_bools)]
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(default)]
+#[serde(default, deny_unknown_fields)]
 pub struct EnabledMetrics {
     pub system_cpu_utilization: bool,
     pub system_memory_usage: bool,
@@ -551,7 +562,7 @@ impl Default for EnabledMetrics {
 /// here are the deploy-time knobs: where to fetch releases from, how often
 /// to check, and the binary layout paths.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(default)]
+#[serde(default, deny_unknown_fields)]
 pub struct UpdateConfig {
     /// HTTPS base URL for the release manifest server.
     ///
@@ -595,7 +606,7 @@ impl Default for UpdateConfig {
 /// without knowing the LAN IP. Disable via `enabled = false` if the
 /// LAN already has another mDNS responder owning the name.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(default)]
+#[serde(default, deny_unknown_fields)]
 pub struct MdnsConfig {
     /// When `false`, the daemon does not start the mDNS advertiser.
     pub enabled: bool,
@@ -624,7 +635,7 @@ impl Default for MdnsConfig {
 /// All three fields are `serde` defaults so an existing `wardnet.toml` needs
 /// no `[health]` section.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(default)]
+#[serde(default, deny_unknown_fields)]
 pub struct HealthConfig {
     /// How often the monitor re-runs every check, in seconds.
     pub refresh_interval_secs: u64,
@@ -653,7 +664,7 @@ impl Default for HealthConfig {
 /// Covers both the hardware `/dev/watchdog` (ungated kernel-reboot backstop)
 /// and the health-gated soft restart driven by `sd_notify(WATCHDOG=1)`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(default)]
+#[serde(default, deny_unknown_fields)]
 pub struct WatchdogConfig {
     /// Master switch for the hardware `/dev/watchdog` runner. When `false`
     /// the daemon never opens the device (e.g. boards without a watchdog).
@@ -686,7 +697,7 @@ impl Default for WatchdogConfig {
 
 /// Pyroscope continuous profiling agent configuration.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(default)]
+#[serde(default, deny_unknown_fields)]
 pub struct PyroscopeConfig {
     pub enabled: bool,
     pub endpoint: String,

--- a/source/daemon/crates/wardnet-common/src/tests/config.rs
+++ b/source/daemon/crates/wardnet-common/src/tests/config.rs
@@ -10,7 +10,10 @@ fn defaults_when_file_missing() {
         .expect("should return defaults");
     assert_eq!(config.server.host, "0.0.0.0");
     assert_eq!(config.server.port, 7411);
-    assert_eq!(config.database.connection_string, "./wardnet.db");
+    assert_eq!(
+        config.database.connection_string,
+        "/var/lib/wardnet/wardnet.db"
+    );
     assert_eq!(config.logging.format, LogFormat::Console);
     assert_eq!(config.logging.level, "info");
     assert_eq!(
@@ -89,6 +92,60 @@ path = "/var/lib/wardnet/secrets"
             assert_eq!(path, &PathBuf::from("/var/lib/wardnet/secrets"));
         }
     }
+
+    let _ = std::fs::remove_file(&path);
+}
+
+#[test]
+fn unknown_top_level_key_is_rejected() {
+    let dir = std::env::temp_dir().join("wardnet-config-unknown-top-level-test");
+    let _ = std::fs::create_dir_all(&dir);
+    let path = dir.join("wardnet-unknown-top-level.toml");
+    // `databse` is a typo of the `[database]` section: it must fail loudly,
+    // naming the offending key, rather than being silently dropped.
+    std::fs::write(
+        &path,
+        r#"
+[server]
+port = 8080
+
+[databse]
+connection_string = "/tmp/x.db"
+"#,
+    )
+    .unwrap();
+
+    let err =
+        ApplicationConfiguration::load(&path).expect_err("unknown top-level key must be rejected");
+    assert!(
+        err.to_string().contains("databse"),
+        "error should name the offending key, got: {err}"
+    );
+
+    let _ = std::fs::remove_file(&path);
+}
+
+#[test]
+fn unknown_nested_key_is_rejected() {
+    let dir = std::env::temp_dir().join("wardnet-config-unknown-nested-test");
+    let _ = std::fs::create_dir_all(&dir);
+    let path = dir.join("wardnet-unknown-nested.toml");
+    // `porrt` is a typo of `port` inside an otherwise-valid section.
+    std::fs::write(
+        &path,
+        r"
+[server]
+porrt = 8080
+",
+    )
+    .unwrap();
+
+    let err =
+        ApplicationConfiguration::load(&path).expect_err("unknown nested key must be rejected");
+    assert!(
+        err.to_string().contains("porrt"),
+        "error should name the offending key, got: {err}"
+    );
 
     let _ = std::fs::remove_file(&path);
 }

--- a/source/daemon/crates/wardnetd/src/main.rs
+++ b/source/daemon/crates/wardnetd/src/main.rs
@@ -821,12 +821,20 @@ async fn run(
     )
     .parse()?;
 
+    // Show the *resolved absolute* database path (relative paths joined onto
+    // the working directory) so a misconfigured path is obvious in journalctl.
+    // The `:memory:` sentinel has no on-disk path, so fall back to the raw
+    // connection string there.
+    let database_display = config.database.to_file_path().map_or_else(
+        || config.database.connection_string.clone(),
+        |p| p.display().to_string(),
+    );
     println!(
         "\n  Wardnet daemon v{}\n  Listening on http://{} (plain) and https://{} (TLS)\n  Database: {}\n",
         env!("WARDNET_VERSION"),
         addr,
         https_addr,
-        config.database.connection_string,
+        database_display,
     );
 
     let _pidfile = match wardnetd::pidfile::PidfileGuard::write(&config.pidfile_path) {

--- a/source/marketing-site/content/docs/configuration.md
+++ b/source/marketing-site/content/docs/configuration.md
@@ -11,7 +11,7 @@ the file keeps its defaults.
 ```toml
 # /etc/wardnet/wardnet.toml — minimal file written by the installer
 [database]
-path = "/var/lib/wardnet/wardnet.db"
+connection_string = "/var/lib/wardnet/wardnet.db"
 
 [logging]
 path = "/var/log/wardnet/wardnetd.log"
@@ -48,7 +48,7 @@ writable by the `wardnet` user.
 | Key | Default | Notes |
 | --- | --- | --- |
 | `provider` | `"sqlite"` | Only `sqlite` is supported. |
-| `connection_string` | `"./wardnet.db"` | Installer overrides this to `/var/lib/wardnet/wardnet.db`. |
+| `connection_string` | `"/var/lib/wardnet/wardnet.db"` | Absolute path. Relative paths are resolved against the daemon's working directory. |
 
 ## `[logging]`
 


### PR DESCRIPTION
Closes: #283

## Problem

`wardnet-common::config::ApplicationConfiguration` and its nested structs used `#[serde(default)]` without `deny_unknown_fields`, with two consequences:

1. **Silent field drops.** Any TOML key that didn't match the schema was silently ignored and the field fell back to its serde default. Renames and typos were invisible to operators.
2. **Relative-path default.** `DatabaseConfig::default()` used `./wardnet.db` — the only relative default. Under systemd's `WorkingDirectory=/` that resolves to `/wardnet.db`, which the daemon (running `ProtectSystem=strict`, RW only on `/var/lib/wardnet`) can't create; sqlx then surfaced the misleading `(code: 14) unable to open database file` (the historical #281 incident).

## Changes

- Add `#[serde(deny_unknown_fields)]` to `ApplicationConfiguration` and every nested plain config struct, so unknown keys fail loudly at startup naming the offending field.
- `SecretStoreConfig` is intentionally left undecorated — serde rejects `deny_unknown_fields` on internally-tagged enums (`tag = "provider"`) at compile time; a code comment records this, and unknown top-level sections are still caught by the parent struct.
- Change the DB default `connection_string` to the absolute `/var/lib/wardnet/wardnet.db`, matching the systemd `ReadWritePaths` and what `deploy/install.sh` already writes. Explicit relative paths are still honoured and resolved via `to_file_path()`.
- Startup banner now logs the **resolved absolute** database path so a misconfigured path is obvious in `journalctl`.
- Fix `configuration.md`: it documented `[database] path = ...` (an unknown key that would now hard-fail to parse) instead of the real `connection_string`, and refresh the stated default.

## Tests

- New `unknown_top_level_key_is_rejected` and `unknown_nested_key_is_rejected` assert the error names the offending key.
- Updated `defaults_when_file_missing` for the new absolute default.
- Existing valid full/partial-config tests still pass, guarding against over-strict attributes.

## Verification

- `cargo test -p wardnet-common config` — 31 pass, including the 2 new rejection tests.
- `cargo clippy -p wardnet-common` clean; `cargo fmt --check` clean.
- Confirmed the config `deploy/install.sh` and the e2e fixtures write only valid keys, so `deny_unknown_fields` won't break existing deployments.

> Note: `wardnetd` is a Linux-only daemon (netlink) and cannot be built natively on macOS; the `main.rs` banner change is exercised in CI/Linux. The full pre-push gate (fmt/clippy/nextest for the whole daemon) runs there.

## Out of scope

- A config-migration framework (per the issue). Future renames get an explicit migration step, not silent fallback.
- Restructuring `[secret_store]` to catch its intra-variant unknown keys.

## Merge Commit Message

feat(config): reject unknown TOML fields and use absolute-path DB default

Add `deny_unknown_fields` to every config struct so unknown/misspelled TOML keys fail loudly at startup, and change the DB default to the absolute `/var/lib/wardnet/wardnet.db` so a zero-config daemon under `WorkingDirectory=/` doesn't try to create an unwritable `/wardnet.db`. Startup banner logs the resolved absolute DB path; docs corrected to `connection_string`.

https://claude.ai/code/session_015T9f4KijhxSbnFwk7y62UX