### PR TITLE
feat(dhcp): show reservation description under hostname in leases table

### DIFF
--- a/source/admin-site/src/components/compound/DhcpEntryTable.tsx
+++ b/source/admin-site/src/components/compound/DhcpEntryTable.tsx
@@ -198,20 +198,33 @@ export function DhcpEntryTable({
     return [...fromReservations, ...fromLeases];
   }, [leases, reservations, reservationIndex]);
 
+  // A reserved MAC gets both a static reservation and (while the device
+  // is online) a dynamic lease. In the "All" view we collapse those to a
+  // single row — the reservation — so the device isn't listed twice; the
+  // Leases tab still shows the underlying lease.
+  const reservedLeaseCount = useMemo(
+    () =>
+      leases.filter((l) => reservationIndex.has(l.mac_address.toLowerCase()))
+        .length,
+    [leases, reservationIndex],
+  );
+
   const counts = useMemo(
     () => ({
-      all: entries.length,
+      all: entries.length - reservedLeaseCount,
       reservations: reservations.length,
       leases: leases.length,
     }),
-    [entries.length, reservations.length, leases.length],
+    [entries.length, reservedLeaseCount, reservations.length, leases.length],
   );
 
   const filtered = useMemo(() => {
     const byGroup = entries.filter((e) => {
       if (activeGroup === "reservations") return e.kind === "reservation";
       if (activeGroup === "leases") return e.kind === "lease";
-      return true;
+      // "all": hide a lease whose MAC already has a reservation so the
+      // reserved device appears once, as its static reservation.
+      return !(e.kind === "lease" && reservationIndex.has(e.mac.toLowerCase()));
     });
     const q = searchValue.trim().toLowerCase();
     if (!q) return byGroup;
@@ -222,7 +235,7 @@ export function DhcpEntryTable({
         e.ip.toLowerCase().includes(q) ||
         (e.description ?? "").toLowerCase().includes(q),
     );
-  }, [entries, activeGroup, searchValue]);
+  }, [entries, activeGroup, searchValue, reservationIndex]);
 
   const columns = useMemo(() => buildColumns(deviceIndex), [deviceIndex]);
 

--- a/source/admin-site/src/components/compound/DhcpEntryTable.tsx
+++ b/source/admin-site/src/components/compound/DhcpEntryTable.tsx
@@ -34,6 +34,14 @@ interface DhcpEntry {
   reservation: DhcpReservation | null;
 }
 
+/** Collapse a null / empty / whitespace-only description to null so only
+ *  meaningful annotations render as a subline. */
+function normalizeDescription(
+  description: string | null | undefined,
+): string | null {
+  return description?.trim() ? description : null;
+}
+
 /** Kind + status as two separate pills. They stack vertically on
  *  mobile so the column doesn't push the row wider than the
  *  viewport, and sit inline at `md+` where there's room. */
@@ -67,11 +75,7 @@ function buildColumns(
         const entry = row.original;
         const device = deviceIndex.get(entry.mac.toLowerCase());
         const primary =
-          device?.name ??
-          entry.description ??
-          entry.hostname ??
-          device?.hostname ??
-          entry.mac;
+          device?.name ?? entry.hostname ?? device?.hostname ?? entry.mac;
         const secondary = primary === entry.mac ? null : entry.mac;
         const fallbackIcon =
           entry.kind === "reservation" ? (
@@ -88,6 +92,7 @@ function buildColumns(
           <HostCell
             primary={primary}
             secondary={secondary}
+            note={entry.description}
             icon={icon}
             // The IP column is hidden below md so we surface the
             // address inside the Host cell on mobile instead.
@@ -114,14 +119,6 @@ function buildColumns(
           ? reservationTypeBadge()
           : leaseTypeBadge(row.original.leaseStatus ?? "active"),
     },
-    {
-      id: "description",
-      header: "Description",
-      meta: { className: "hidden md:table-cell" },
-      cell: ({ row }) => (
-        <span className="text-ink-3">{row.original.description ?? "—"}</span>
-      ),
-    },
   ];
 }
 
@@ -145,7 +142,8 @@ interface DhcpEntryTableProps {
 
 /** Combined DHCP entries table — reservations and leases share one
  *  surface with a group filter (All / Reservations / Leases), a
- *  search field (MAC · hostname · IP), and an Add reservation CTA. */
+ *  search field (MAC · hostname · IP · description), and an Add
+ *  reservation CTA. */
 export function DhcpEntryTable({
   leases,
   reservations,
@@ -162,6 +160,16 @@ export function DhcpEntryTable({
 }: DhcpEntryTableProps) {
   const deviceIndex = useMemo(() => buildDeviceIndex(devices), [devices]);
 
+  // MAC-keyed reservation index so a dynamic lease can surface the
+  // description of the reservation it fulfils. MACs are canonical
+  // lowercase server-side (issue #312); we lowercase keys/lookups
+  // defensively to stay robust to any un-normalised input.
+  const reservationIndex = useMemo(() => {
+    const map = new Map<string, DhcpReservation>();
+    for (const r of reservations) map.set(r.mac_address.toLowerCase(), r);
+    return map;
+  }, [reservations]);
+
   const entries = useMemo<DhcpEntry[]>(() => {
     const fromReservations: DhcpEntry[] = reservations.map((r) => ({
       kind: "reservation",
@@ -169,7 +177,7 @@ export function DhcpEntryTable({
       mac: r.mac_address,
       ip: r.ip_address,
       hostname: r.hostname,
-      description: r.description,
+      description: normalizeDescription(r.description),
       leaseStatus: null,
       lease: null,
       reservation: r,
@@ -180,13 +188,15 @@ export function DhcpEntryTable({
       mac: l.mac_address,
       ip: l.ip_address,
       hostname: l.hostname,
-      description: null,
+      description: normalizeDescription(
+        reservationIndex.get(l.mac_address.toLowerCase())?.description,
+      ),
       leaseStatus: l.status,
       lease: l,
       reservation: null,
     }));
     return [...fromReservations, ...fromLeases];
-  }, [leases, reservations]);
+  }, [leases, reservations, reservationIndex]);
 
   const counts = useMemo(
     () => ({
@@ -209,7 +219,8 @@ export function DhcpEntryTable({
       (e) =>
         e.mac.toLowerCase().includes(q) ||
         (e.hostname ?? "").toLowerCase().includes(q) ||
-        e.ip.toLowerCase().includes(q),
+        e.ip.toLowerCase().includes(q) ||
+        (e.description ?? "").toLowerCase().includes(q),
     );
   }, [entries, activeGroup, searchValue]);
 
@@ -236,7 +247,7 @@ export function DhcpEntryTable({
   if (entries.length === 0) {
     return (
       <DiscoveryPlaceholder
-        cols={4}
+        cols={3}
         message="Waiting for DHCP activity"
         hint="Leases and reservations will appear here as devices come online."
       />
@@ -252,7 +263,7 @@ export function DhcpEntryTable({
       onGroupChange={(id) => onGroupChange(id as DhcpGroupId)}
       searchValue={searchValue}
       onSearchChange={onSearchChange}
-      searchPlaceholder="Search by MAC, hostname or IP"
+      searchPlaceholder="Search by MAC, hostname, IP or description"
       searchTestId="dhcp-search"
       addLabel="Add reservation"
       onAdd={onAddReservation}

--- a/source/admin-site/src/components/compound/HostCell.tsx
+++ b/source/admin-site/src/components/compound/HostCell.tsx
@@ -17,18 +17,24 @@ export function buildDeviceIndex(devices: Device[]): Map<string, Device> {
  * an icon on the left, then a primary identifier with a smaller secondary
  * line beneath. Keeps tabular layouts visually consistent.
  *
- * `extra` is rendered under the secondary line — useful for collapsing a
- * sibling column into this cell on narrow viewports (e.g. DHCP's IP
- * column dropping into the Host cell on mobile via `md:hidden`).
+ * `note` is an optional muted annotation rendered under the secondary line —
+ * DHCP uses it to surface a reservation's description ("why this reservation
+ * exists") directly in the row.
+ *
+ * `extra` is rendered under the note — useful for collapsing a sibling column
+ * into this cell on narrow viewports (e.g. DHCP's IP column dropping into the
+ * Host cell on mobile via `md:hidden`).
  */
 export function HostCell({
   primary,
   secondary,
+  note,
   extra,
   icon,
 }: {
   primary: string;
   secondary: string | null;
+  note?: string | null;
   extra?: React.ReactNode;
   icon: React.ReactNode;
 }) {
@@ -38,6 +44,7 @@ export function HostCell({
       <div className="col">
         <div className="name">{primary}</div>
         {secondary && <div className="mac mono">{secondary}</div>}
+        {note && <div className="text-ink-3 text-xs">{note}</div>}
         {extra}
       </div>
     </div>


### PR DESCRIPTION
## Summary

Surfaces a DHCP reservation's `description` as a small muted line beneath the hostname in the unified DHCP entries table, so an operator can see *why* a reservation exists at a glance (e.g. "Kids' tablet — force safe DNS").

Also fixes a pre-existing bug found while verifying: reserved devices were listed twice under the **All** filter.

Closes #83

## Changes

- **`HostCell.tsx`** — added an optional `note` prop that renders a muted subline (`text-ink-3 text-xs`) below the MAC line. The prop is optional, so the cell's other consumers (Devices, DeviceSelect, TunnelDevicesTable, DeviceTable) are unaffected.
- **`DhcpEntryTable.tsx`**:
  - MAC-keyed reservation index so a dynamic **lease** row inherits the description of the reservation it fulfils (there was no lease→reservation join before).
  - Description dropped from the Host cell's primary-name fallback chain (it now renders as the subline instead of being consumed as the name).
  - Removed the separate `md+`-only **Description column** in favour of the all-viewport subline.
  - Empty/whitespace descriptions normalise to `null` so no empty subline renders.
  - Added description to the search predicate + updated the placeholder.
  - **De-duplicate reserved devices in the All view**: a reserved MAC has both a static reservation and (while online) a dynamic lease, and the table concatenated both lists — so the device appeared twice under **All**. The lease row is now hidden when a reservation already represents its MAC (the device shows once, as its **Static** reservation), and the All count reflects the collapse. The **Leases** and **Reservations** tabs are unchanged.

Note: the admin-app has no DHCP reservation surface, so no change is needed there.

## Verification

- `yarn type-check`, `yarn lint`, and `yarn build` for admin-site all pass.
- Verified live against `make run-dev` (mock daemon seeds a `smart-plug-kitchen` reservation + matching lease): the description subline shows on both the reservation and its lease, and the device now appears once under All.
- Existing e2e (`dhcp-leases.spec.ts`) does not assert on the removed column, so it remains green.

## Merge Commit Message

feat(dhcp): show reservation description under hostname in leases table

Surface a DHCP reservation's description as a muted subline beneath the hostname in the unified DHCP entries table; lease rows inherit the matching reservation's description via a MAC-keyed lookup. Replaces the separate md-only Description column with an all-viewport subline and adds description to search. Also de-duplicates reserved devices in the All view (a reserved MAC no longer shows as both a reservation and a lease). Closes #83.

https://claude.ai/code/session_01XFtvtSBhdneSo1vLiH7zBV
