### PR TITLE
test(e2e): admin-site Tunnels & Providers Playwright specs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -503,7 +503,7 @@ e2e-ui: build-web
 	        $(CONTAINER_RT) inspect "$$cid" >> '"$$REPORTS"'/inspect.json 2>&1 || true; \
 	      done; \
 	      $(CONTAINER_RT) compose -f $(E2E_UI_COMPOSE) down -v --remove-orphans' EXIT; \
-	$(CONTAINER_RT) compose -f $(E2E_UI_COMPOSE) up -d --build --wait wardnetd-ui wardnetd-ui-fresh tls_proxy tls_proxy_lan blocklist_server; \
+	$(CONTAINER_RT) compose -f $(E2E_UI_COMPOSE) up -d --build --wait wardnetd-ui wardnetd-ui-fresh tls_proxy tls_proxy_lan blocklist_server nordvpn_mock; \
 	$(CONTAINER_RT) compose -f $(E2E_UI_COMPOSE) up -d --build --wait test_debian || \
 	    echo "warning: test_debian (LAN client) not healthy; running playwright anyway so failures surface as assertions"; \
 	echo "::group::compose ps before playwright"; \

--- a/source/admin-site/src/components/compound/TunnelCard.tsx
+++ b/source/admin-site/src/components/compound/TunnelCard.tsx
@@ -216,7 +216,7 @@ export function TunnelCard({ tunnel, providers, onDelete }: TunnelCardProps) {
   else if (tunnel.provider) subParts.push(tunnel.provider);
 
   return (
-    <div className="tcard">
+    <div className="tcard" data-testid="tunnel-card">
       <Link
         to={`/tunnels/${tunnel.id}`}
         className="col gap-16 rounded-[var(--radius-lg)] focus:outline-none focus-visible:ring-2 focus-visible:ring-accent"
@@ -384,6 +384,7 @@ export function TunnelCard({ tunnel, providers, onDelete }: TunnelCardProps) {
         <Button
           size="sm"
           variant="destructive"
+          data-testid="tunnel-delete"
           onClick={(e) => {
             // Card is wrapped in <Link>; don't navigate when clicking delete.
             e.preventDefault();

--- a/source/admin-site/src/components/compound/TunnelGrid.tsx
+++ b/source/admin-site/src/components/compound/TunnelGrid.tsx
@@ -39,6 +39,7 @@ export function TunnelGrid({
         hint="Add a WireGuard tunnel to route device traffic through a VPN provider."
         actionLabel={onAdd ? "Add tunnel" : undefined}
         onAction={onAdd}
+        actionTestId="tunnel-add"
       />
     );
   }

--- a/source/admin-site/src/components/features/CreateTunnelInline.tsx
+++ b/source/admin-site/src/components/features/CreateTunnelInline.tsx
@@ -35,8 +35,12 @@ export function CreateTunnelInline({
   const body = (
     <Tabs defaultValue="manual">
       <TabsList>
-        <TabsTrigger value="manual">Manual</TabsTrigger>
-        <TabsTrigger value="provider">Provider</TabsTrigger>
+        <TabsTrigger value="manual" data-testid="tunnel-tab-manual">
+          Manual
+        </TabsTrigger>
+        <TabsTrigger value="provider" data-testid="tunnel-tab-provider">
+          Provider
+        </TabsTrigger>
       </TabsList>
       <TabsContent value="manual" className="mt-4">
         <ManualTunnelTab onSuccess={onClose} />

--- a/source/admin-site/src/components/features/ManualTunnelTab.tsx
+++ b/source/admin-site/src/components/features/ManualTunnelTab.tsx
@@ -54,6 +54,7 @@ export function ManualTunnelTab({ onSuccess }: ManualTunnelTabProps) {
         <Field label="Label" htmlFor="tunnel-label" name="label">
           <Input
             id="tunnel-label"
+            data-testid="tunnel-label"
             value={label}
             onChange={(e) => setLabel(e.target.value)}
             placeholder="US West"
@@ -64,6 +65,7 @@ export function ManualTunnelTab({ onSuccess }: ManualTunnelTabProps) {
         <Field label="Country code" htmlFor="tunnel-country" name="countryCode">
           <Input
             id="tunnel-country"
+            data-testid="tunnel-country"
             value={countryCode}
             onChange={(e) => setCountryCode(e.target.value)}
             placeholder="US"
@@ -106,6 +108,7 @@ export function ManualTunnelTab({ onSuccess }: ManualTunnelTabProps) {
         >
           <Textarea
             id="tunnel-config"
+            data-testid="tunnel-config"
             value={config}
             onChange={(e) => setConfig(e.target.value)}
             placeholder="Paste your .conf file contents here…"
@@ -126,7 +129,11 @@ export function ManualTunnelTab({ onSuccess }: ManualTunnelTabProps) {
         />
       )}
       <div className="flex justify-end">
-        <Button type="submit" disabled={createTunnel.isPending}>
+        <Button
+          type="submit"
+          data-testid="tunnel-create-submit"
+          disabled={createTunnel.isPending}
+        >
           {createTunnel.isPending ? "Creating…" : "Create tunnel"}
         </Button>
       </div>

--- a/source/admin-site/src/components/features/ProviderTunnelTab.tsx
+++ b/source/admin-site/src/components/features/ProviderTunnelTab.tsx
@@ -186,7 +186,7 @@ export function ProviderTunnelTab({ onSuccess }: ProviderTunnelTabProps) {
               );
             }}
           >
-            <SelectTrigger className="w-full">
+            <SelectTrigger className="w-full" data-testid="provider-select">
               <SelectValue placeholder="Select a provider" />
             </SelectTrigger>
             <SelectContent>
@@ -236,6 +236,7 @@ export function ProviderTunnelTab({ onSuccess }: ProviderTunnelTabProps) {
             >
               <Input
                 id="prov-token"
+                data-testid="provider-token"
                 type="password"
                 value={token}
                 onChange={(e) => {
@@ -280,6 +281,7 @@ export function ProviderTunnelTab({ onSuccess }: ProviderTunnelTabProps) {
             )}
             <Button
               variant="secondary"
+              data-testid="provider-validate"
               onClick={handleValidate}
               disabled={!credsReady || validateCreds.isPending}
             >
@@ -369,6 +371,7 @@ export function ProviderTunnelTab({ onSuccess }: ProviderTunnelTabProps) {
           <Field label="Label (optional)" htmlFor="prov-label">
             <Input
               id="prov-label"
+              data-testid="provider-label"
               value={labelOverride}
               onChange={(e) => setLabelOverride(e.target.value)}
               placeholder="Auto-generated from server"
@@ -380,7 +383,11 @@ export function ProviderTunnelTab({ onSuccess }: ProviderTunnelTabProps) {
           )}
 
           <div className="flex justify-end">
-            <Button onClick={handleSetup} disabled={setupTunnel.isPending}>
+            <Button
+              data-testid="provider-setup-submit"
+              onClick={handleSetup}
+              disabled={setupTunnel.isPending}
+            >
               {setupTunnel.isPending ? "Setting up…" : "Create tunnel"}
             </Button>
           </div>

--- a/source/admin-site/src/pages/TunnelDetail.tsx
+++ b/source/admin-site/src/pages/TunnelDetail.tsx
@@ -279,6 +279,7 @@ export default function TunnelDetail() {
         </Button>
         <Button
           variant="destructive"
+          data-testid="tunnel-detail-delete"
           onClick={() => {
             deleteTunnel.mutate(tunnel.id, {
               onSuccess: () => navigate("/tunnels"),

--- a/source/admin-site/src/pages/Tunnels.tsx
+++ b/source/admin-site/src/pages/Tunnels.tsx
@@ -32,7 +32,9 @@ export default function Tunnels() {
         description="WireGuard tunnels you can route device traffic through, e.g. to a VPN provider or your own server."
         actions={
           hasTunnels && !creating ? (
-            <Button onClick={() => setCreating(true)}>Add tunnel</Button>
+            <Button data-testid="tunnel-add" onClick={() => setCreating(true)}>
+              Add tunnel
+            </Button>
           ) : undefined
         }
       />

--- a/source/end2end-tests/web-ui/compose.ui.yaml
+++ b/source/end2end-tests/web-ui/compose.ui.yaml
@@ -71,6 +71,19 @@ services:
         else
           echo "wardnetd-ui e2e fixture: WARNING no NIC holds 10.91.0.1; leaving lan_interface as-is" >&2
         fi
+        # Point the NordVPN provider at the nordvpn_mock container instead of
+        # the real api.nordvpn.com (issue #248), so the admin-site providers
+        # spec can drive the wizard offline. Mirrors ../daemon/compose.yaml:
+        # idempotent on the nordvpn_api_url key, injecting under an existing
+        # [vpn_providers] table or appending a fresh one.
+        if ! grep -q '^nordvpn_api_url' /etc/wardnet/wardnet.toml; then
+          if grep -q '^\[vpn_providers\]' /etc/wardnet/wardnet.toml; then
+            sed -i '/^\[vpn_providers\]/a nordvpn_api_url = "http://10.92.0.52:8080"' /etc/wardnet/wardnet.toml
+          else
+            printf '\n[vpn_providers]\nnordvpn_api_url = "http://10.92.0.52:8080"\n' >> /etc/wardnet/wardnet.toml
+          fi
+          echo "wardnetd-ui e2e fixture: pinned nordvpn_api_url=http://10.92.0.52:8080" >&2
+        fi
         exec /lib/systemd/systemd --log-target=console --log-level=debug --show-status=yes
     networks:
       wardnet_mgmt:
@@ -281,6 +294,33 @@ services:
       retries: 30
       start_period: 5s
 
+  # NordVPN API mock (issue #248) for the admin-site providers spec (A7,
+  # #622). Reuses the daemon stack's mock image/fixtures verbatim (a
+  # dependency-free Node HTTP server backed by fixtures/nordvpn JSON) — do
+  # not duplicate them. Pinned to 10.92.0.52 on wardnet_wan so the
+  # wardnetd-ui config's nordvpn_api_url can reference a stable URL. The
+  # provider wizard's validate/list/setup calls hit this instead of the real
+  # api.nordvpn.com, which is unreachable inside the isolated compose net.
+  nordvpn_mock:
+    build:
+      context: ../daemon/mocks/nordvpn
+      dockerfile: Dockerfile
+    image: wardnet-nordvpn-mock:dev
+    volumes:
+      - ../daemon/fixtures/nordvpn:/fixtures:ro
+    networks:
+      wardnet_wan:
+        ipv4_address: 10.92.0.52
+    healthcheck:
+      # node:22-slim ships neither curl nor wget; probe with node itself.
+      test:
+        - "CMD-SHELL"
+        - "node -e \"require('http').get('http://127.0.0.1:8080/health',r=>process.exit(r.statusCode===200?0:1)).on('error',()=>process.exit(1))\""
+      interval: 3s
+      timeout: 2s
+      retries: 10
+      start_period: 3s
+
   ui_runner:
     build:
       context: ../../..
@@ -305,6 +345,11 @@ services:
       # The ad-blocking spec needs this up before it forces a blocklist
       # refresh; gate the runner on it being healthy.
       blocklist_server:
+        condition: service_healthy
+      # The providers spec drives the NordVPN wizard against this mock; gate
+      # the runner on it being healthy (the mock is a firm invariant — the
+      # spec hard-fails, not skips, if the provider can't be reached).
+      nordvpn_mock:
         condition: service_healthy
     environment:
       WARDNET_UI_BASE_URL: "https://wardnetd-ui-tls"

--- a/source/end2end-tests/web-ui/fixtures/devices.ts
+++ b/source/end2end-tests/web-ui/fixtures/devices.ts
@@ -22,6 +22,10 @@
 
 import { api, ensureAdminSetup } from "./seed";
 import { TEST_DEBIAN_AGENT } from "./dhcp";
+import {
+  TUNNEL_CONFIG,
+  type ListTunnelsResponse,
+} from "./tunnels";
 
 /**
  * Synthetic LAN client we conjure for the Devices specs. The MAC is
@@ -44,15 +48,6 @@ interface SeededDevice {
 
 interface ListDevicesResponse {
   devices: SeededDevice[];
-}
-
-interface TunnelSummary {
-  id: string;
-  label: string;
-}
-
-interface ListTunnelsResponse {
-  tunnels: TunnelSummary[];
 }
 
 /** POST JSON to a test-agent serve URL. Throws on non-2xx. */
@@ -135,31 +130,11 @@ export async function seedDiscoveredDevice(
 }
 
 /**
- * A deterministic, syntactically-valid WireGuard config. The daemon's
- * parser (`wardnet-common/src/wireguard_config.rs`) only requires
- * `[Interface] PrivateKey` and `[Peer] PublicKey` and does not validate
- * the key material, so these throwaway base64 blobs are fine — the tunnel
- * is never brought up.
- */
-const SEED_TUNNEL_CONFIG = [
-  "[Interface]",
-  "PrivateKey = SHFlsItPbjj4u4nNZbR8Ej2cTSDDTNeWiR+ej8a4tEM=",
-  "Address = 10.99.0.2/32",
-  "DNS = 1.1.1.1",
-  "",
-  "[Peer]",
-  "PublicKey = HIgo9xNzJMWLKASShiTqIybxZ0U3wGLiUeJ1PKf8ykw=",
-  "Endpoint = 198.51.100.1:51820",
-  "AllowedIPs = 0.0.0.0/0",
-  "",
-].join("\n");
-
-/**
  * Ensure a tunnel exists so the device routing selector offers a
  * non-Direct option. Idempotent: returns the existing tunnel's label if
- * one with this label is already configured, otherwise imports the
- * deterministic config above. Returns the label so the spec can match the
- * selector option by its accessible name.
+ * one with this label is already configured, otherwise imports the shared
+ * deterministic `TUNNEL_CONFIG` (see ./tunnels). Returns the label so the
+ * spec can match the selector option by its accessible name.
  */
 export async function seedTunnel(
   label = "E2E Test Tunnel",
@@ -176,7 +151,7 @@ export async function seedTunnel(
     body: JSON.stringify({
       label,
       country_code: countryCode,
-      config: SEED_TUNNEL_CONFIG,
+      config: TUNNEL_CONFIG,
     }),
   });
   return label;

--- a/source/end2end-tests/web-ui/fixtures/tunnels.ts
+++ b/source/end2end-tests/web-ui/fixtures/tunnels.ts
@@ -1,0 +1,103 @@
+/**
+ * Tunnel seeding + cleanup helpers for the admin-site Tunnels & Providers
+ * specs (A7, #622).
+ *
+ * `tunnels.spec.ts` creates a tunnel through the UI (real coverage of the
+ * `.conf` paste-import flow) and `providers.spec.ts` creates one through the
+ * NordVPN wizard, so the only seeding done here is *cleanup* plus a
+ * deterministic API import for the list-page delete case. Tunnel labels are
+ * NOT unique in the daemon schema (unlike filter-profile names), so a re-run
+ * against the persisted state volume wouldn't collide — but leftover
+ * `e2e-tunnel-*` rows would accumulate and make list assertions ambiguous.
+ * `deleteTestTunnels` removes every row matching the given labels up front.
+ *
+ * Uses the same plain-`fetch` `api`/`ensureAdminSetup` path as the other
+ * fixtures (see seed.ts for why this harness avoids the source-only SDK).
+ */
+
+import { api, ensureAdminSetup } from "./seed";
+
+/** Label the import→detail→delete lifecycle test creates through the UI. */
+export const TUNNEL_IMPORT_LABEL = "e2e-tunnel-import";
+
+/**
+ * Label the list-page delete test seeds via the API then deletes through the
+ * ConfirmDialog. Distinct from `TUNNEL_IMPORT_LABEL` so the two tunnel tests
+ * never see each other's rows in the shared daemon.
+ */
+export const TUNNEL_LIST_DELETE_LABEL = "e2e-tunnel-list-delete";
+
+/** Label the NordVPN provider wizard test's tunnel is created under. */
+export const TUNNEL_PROVIDER_LABEL = "e2e-tunnel-nordvpn";
+
+/**
+ * A deterministic, syntactically-valid WireGuard config. The daemon's parser
+ * (`wardnet-common/src/wireguard_config.rs`) only requires `[Interface]
+ * PrivateKey` and `[Peer] PublicKey` and does not validate the key material,
+ * so these throwaway base64 blobs are fine — import only parses and persists
+ * the definition (status `Down`, no interface brought up), so it has no
+ * WireGuard kernel dependency in the compose stack.
+ */
+export const TUNNEL_CONFIG = [
+  "[Interface]",
+  "PrivateKey = SHFlsItPbjj4u4nNZbR8Ej2cTSDDTNeWiR+ej8a4tEM=",
+  "Address = 10.99.0.2/32",
+  "DNS = 1.1.1.1",
+  "",
+  "[Peer]",
+  "PublicKey = HIgo9xNzJMWLKASShiTqIybxZ0U3wGLiUeJ1PKf8ykw=",
+  "Endpoint = 198.51.100.1:51820",
+  "AllowedIPs = 0.0.0.0/0",
+  "",
+].join("\n");
+
+export interface TunnelSummary {
+  id: string;
+  label: string;
+}
+
+export interface ListTunnelsResponse {
+  tunnels: TunnelSummary[];
+}
+
+/**
+ * Delete every tunnel whose label matches one of `labels`, so a spec starts
+ * from a clean slate. Idempotent: a missing tunnel (already deleted) is a
+ * no-op. Matching is by label because these specs own their labels and never
+ * know the daemon-assigned id up front; all matches are removed since labels
+ * are not unique.
+ */
+export async function deleteTestTunnels(...labels: string[]): Promise<void> {
+  const token = await ensureAdminSetup();
+  const wanted = new Set(labels);
+  const { tunnels } = await api<ListTunnelsResponse>("/tunnels", { token });
+  for (const t of tunnels) {
+    if (wanted.has(t.label)) {
+      await api(`/tunnels/${t.id}`, { method: "DELETE", token });
+    }
+  }
+}
+
+/**
+ * Import a tunnel via the API so a spec has an existing row to act on (used by
+ * the list-page delete test). Always POSTs a fresh row (the caller is expected
+ * to clean up its label in `beforeAll`); for an idempotent skip-if-present
+ * variant see `seedTunnel` in ./devices. Returns the label so the spec can
+ * locate the card by its accessible text.
+ */
+export async function importTunnel(
+  label: string,
+  countryCode = "de",
+): Promise<string> {
+  const token = await ensureAdminSetup();
+  await api("/tunnels", {
+    method: "POST",
+    token,
+    body: JSON.stringify({
+      label,
+      country_code: countryCode,
+      config: TUNNEL_CONFIG,
+    }),
+  });
+  return label;
+}

--- a/source/end2end-tests/web-ui/tests/admin-site/providers.spec.ts
+++ b/source/end2end-tests/web-ui/tests/admin-site/providers.spec.ts
@@ -1,0 +1,81 @@
+import { expect, test } from "@playwright/test";
+
+import { TUNNEL_PROVIDER_LABEL, deleteTestTunnels } from "../../fixtures/tunnels.js";
+
+/**
+ * Admin-site VPN-provider wizard coverage (A7, #622).
+ *
+ * Drives the "Provider" tab of the add-tunnel panel end to end against the
+ * NordVPN provider, backed by the `nordvpn_mock` compose service (#248) which
+ * `compose.ui.yaml` wires into this stack. The mock is a firm invariant here:
+ * these tests HARD-FAIL (not skip) if the provider can't be reached — the
+ * runner gates on `nordvpn_mock` being healthy.
+ *
+ * NordVPN is token-only (`auth_methods: [Token]`), so the wizard shows the
+ * access-token field directly with no auth-method selector. The mock's
+ * `/v1/servers/recommendations` returns its server fixture regardless of
+ * country, so the happy path can create a tunnel without selecting a
+ * country/server — the daemon auto-selects the lowest-load server.
+ *
+ * Runs in the `admin-site` project (seeded daemon + admin storageState).
+ */
+
+/** The mock accepts exactly this token (NORDVPN_VALID_TOKEN default). */
+const VALID_TOKEN = "valid-nordvpn-token";
+
+test.beforeAll(async () => {
+  await deleteTestTunnels(TUNNEL_PROVIDER_LABEL);
+});
+
+// Unlike tunnels.spec (which deletes everything it creates), the happy-path
+// test here leaves a tunnel behind. Clean it up so it can't leak into other
+// admin-site specs sharing this daemon.
+test.afterAll(async () => {
+  await deleteTestTunnels(TUNNEL_PROVIDER_LABEL);
+});
+
+test("provider: NordVPN wizard validates token and creates a tunnel", async ({
+  page,
+}) => {
+  await page.goto("./tunnels");
+  await page.getByTestId("tunnel-add").click();
+  await page.getByTestId("tunnel-tab-provider").click();
+
+  // ── Step 1: select the NordVPN provider ────────────────────────────
+  await page.getByTestId("provider-select").click();
+  await page.getByRole("option", { name: "NordVPN", exact: true }).click();
+
+  // ── Step 2: validate the access token against the mock ──────────────
+  await page.getByTestId("provider-token").fill(VALID_TOKEN);
+  await page.getByTestId("provider-validate").click();
+
+  // Validation success reveals the country/server + label step.
+  const labelField = page.getByTestId("provider-label");
+  await expect(labelField).toBeVisible();
+  await labelField.fill(TUNNEL_PROVIDER_LABEL);
+
+  // ── Step 3: create the tunnel (auto-select best server) ─────────────
+  await page.getByTestId("provider-setup-submit").click();
+
+  // ── It appears in the list attributed to our label ─────────────────
+  await expect(
+    page.getByTestId("tunnel-card").filter({ hasText: TUNNEL_PROVIDER_LABEL }),
+  ).toBeVisible();
+});
+
+test("provider: NordVPN wizard rejects an invalid token", async ({ page }) => {
+  await page.goto("./tunnels");
+  await page.getByTestId("tunnel-add").click();
+  await page.getByTestId("tunnel-tab-provider").click();
+
+  await page.getByTestId("provider-select").click();
+  await page.getByRole("option", { name: "NordVPN", exact: true }).click();
+
+  await page.getByTestId("provider-token").fill("not-a-valid-token");
+  await page.getByTestId("provider-validate").click();
+
+  // The daemon reports the credentials as invalid (mock 401 → valid:false).
+  await expect(page.getByText("credentials are invalid")).toBeVisible();
+  // The country/server + setup step stays hidden while creds are invalid.
+  await expect(page.getByTestId("provider-setup-submit")).toHaveCount(0);
+});

--- a/source/end2end-tests/web-ui/tests/admin-site/tunnels.spec.ts
+++ b/source/end2end-tests/web-ui/tests/admin-site/tunnels.spec.ts
@@ -1,0 +1,93 @@
+import { expect, test } from "@playwright/test";
+
+import {
+  TUNNEL_CONFIG,
+  TUNNEL_IMPORT_LABEL,
+  TUNNEL_LIST_DELETE_LABEL,
+  deleteTestTunnels,
+  importTunnel,
+} from "../../fixtures/tunnels.js";
+
+/**
+ * Admin-site Tunnels lifecycle coverage (A7, #622).
+ *
+ * Covers the WireGuard `.conf` import flow (the "Manual" tab is a textarea
+ * paste, not a file upload), seeing the tunnel in the list, drilling into its
+ * detail page, and both delete paths: the detail page deletes immediately and
+ * redirects, while the list page routes through a ConfirmDialog.
+ *
+ * Runs in the `admin-site` project (seeded daemon + admin storageState).
+ * Selectors follow the suite's `data-testid` convention (README.md); the
+ * tunnel components carried almost none before this issue, so this PR adds
+ * them alongside the specs.
+ */
+
+// Tunnel labels are not UNIQUE in the daemon, but leftover `e2e-tunnel-*` rows
+// from a prior run (or a mid-test failure) would make the list assertions
+// ambiguous. Clear both labels this spec owns up front.
+test.beforeAll(async () => {
+  await deleteTestTunnels(TUNNEL_IMPORT_LABEL, TUNNEL_LIST_DELETE_LABEL);
+});
+
+test("tunnel: import .conf, see in list, open detail, delete from detail", async ({
+  page,
+}) => {
+  // ── Import via the Manual (.conf paste) tab ────────────────────────
+  await page.goto("./tunnels");
+  await page.getByTestId("tunnel-add").click();
+  // Manual is the default tab; select it explicitly so the test is robust
+  // to a future default change.
+  await page.getByTestId("tunnel-tab-manual").click();
+  await page.getByTestId("tunnel-label").fill(TUNNEL_IMPORT_LABEL);
+  await page.getByTestId("tunnel-country").fill("de");
+  await page.getByTestId("tunnel-config").fill(TUNNEL_CONFIG);
+  await page.getByTestId("tunnel-create-submit").click();
+
+  // ── It appears in the list ─────────────────────────────────────────
+  const card = page
+    .getByTestId("tunnel-card")
+    .filter({ hasText: TUNNEL_IMPORT_LABEL });
+  await expect(card).toBeVisible();
+
+  // ── Open the detail page ───────────────────────────────────────────
+  await card.getByRole("link").click();
+  await expect(page).toHaveURL(/\/admin\/tunnels\/[0-9a-f-]+$/);
+  await expect(page.getByText(TUNNEL_IMPORT_LABEL).first()).toBeVisible();
+
+  // ── Delete from detail (no confirm dialog) → redirect to list ──────
+  await page.getByTestId("tunnel-detail-delete").click();
+  await expect(page).toHaveURL(/\/admin\/tunnels$/);
+  await expect(
+    page.getByTestId("tunnel-card").filter({ hasText: TUNNEL_IMPORT_LABEL }),
+  ).toHaveCount(0);
+});
+
+test("tunnel: delete from list via confirm dialog (cancel then confirm)", async ({
+  page,
+}) => {
+  // Seed via the API so this test owns a deterministic row to delete.
+  await importTunnel(TUNNEL_LIST_DELETE_LABEL);
+
+  await page.goto("./tunnels");
+  const card = page
+    .getByTestId("tunnel-card")
+    .filter({ hasText: TUNNEL_LIST_DELETE_LABEL });
+  await expect(card).toBeVisible();
+
+  // ── Cancel keeps the tunnel ────────────────────────────────────────
+  await card.getByTestId("tunnel-delete").click();
+  await page.getByTestId("confirm-dialog-cancel").click();
+  // Wait for the dialog to fully tear down before reopening it, so the
+  // reopen click can't race the Radix overlay's close transition.
+  await expect(page.getByTestId("confirm-dialog-confirm")).toHaveCount(0);
+  await expect(card).toBeVisible();
+
+  // ── Confirm removes it ─────────────────────────────────────────────
+  await card.getByTestId("tunnel-delete").click();
+  await page.getByTestId("confirm-dialog-confirm").click();
+  await expect(
+    page
+      .getByTestId("tunnel-card")
+      .filter({ hasText: TUNNEL_LIST_DELETE_LABEL }),
+  ).toHaveCount(0);
+});


### PR DESCRIPTION
Closes #622.

Adds admin-site end-to-end (Playwright) coverage for the Tunnels & Providers surface (A7 of the #614 epic).

## What

- **`tunnels.spec.ts`** — import a WireGuard `.conf` via the Manual tab textarea, see the tunnel in the list, open its detail page, and delete it via **both** paths: the detail page (immediate delete + redirect) and the list `ConfirmDialog` (cancel keeps it, confirm removes it).
- **`providers.spec.ts`** — drive the NordVPN provider wizard end to end (select provider → validate token → create tunnel), plus an invalid-token rejection path.

## Infra

- Wire the `nordvpn_mock` service into `compose.ui.yaml`, **reusing** the daemon stack's image + fixtures (`../daemon/mocks/nordvpn`, `../daemon/fixtures/nordvpn`) rather than duplicating them, and inject the `nordvpn_api_url` override into `wardnetd-ui` so the wizard runs offline. `ui_runner` gates on the mock being healthy — these tests **hard-fail** (not skip) if the provider is unreachable, since the mock is now a firm invariant of the stack.
- `make e2e-ui` pre-builds `nordvpn_mock` in its `up --wait` batch.

## Notes / decisions

- The issue mentions ".conf file upload", but the Manual tab is a paste-into-textarea flow (no file input exists); the spec fills the textarea accordingly. No product file-input was added.
- `setup_tunnel` reuses `import_tunnel`, which only persists the definition (status `Down`) — no interface bring-up — so the web-ui stack needs only `nordvpn_mock`, not `wg_gateway`.
- Added the `data-testid`s the specs need to the tunnel/provider components (per the suite's selector ADR), and de-duplicated the shared WireGuard config + list-response types between the `tunnels` and `devices` fixtures.

## Verification

- `yarn type-check` (web-ui suite) passes.
- `compose.ui.yaml` validated; `nordvpn_mock` reachable from `wardnetd-ui` on `wardnet_wan`.
- Full `make e2e-ui` run (Docker + built frontends) is the remaining end-to-end confirmation.

## Merge Commit Message

test(e2e): admin-site Tunnels & Providers Playwright specs (#622)