### PR TITLE
fix(security): resolve RUSTSEC-2026-0173 and RUSTSEC-2026-0190

### DIFF
--- a/.github/scripts/audit-ignore-staleness.py
+++ b/.github/scripts/audit-ignore-staleness.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""Warn when a suppressed advisory's crate has left the dependency graph.
+
+`.cargo/audit.toml` (cargo-audit) and `osv-scanner.toml` (OpenSSF Scorecard's
+vulnerability check) both carry a hand-justified ignore list for advisories
+with no upstream fix. Nothing expires those entries, so an ignore silently
+outlives its justification once the offending crate leaves the tree.
+
+This check resolves each ignored advisory to its crate via the local RustSec
+advisory database and asks `cargo tree -i <crate>` whether the crate is still
+present. If it is gone, *neither* scanner can match the advisory, so the ignore
+is definitively stale and should be deleted. We deliberately key on crate
+presence rather than on cargo-audit's own match set: cargo-audit and osv-scanner
+use different version matchers and disagree on some advisories (e.g. the
+hickory-proto and memmap2 entries), so a "no longer matched by cargo-audit"
+signal would raise false alarms. Crate presence is scanner-agnostic.
+
+Non-blocking: emits GitHub `::warning::` annotations and always exits 0.
+"""
+from __future__ import annotations
+
+import os
+import sys
+import tomllib
+from pathlib import Path
+
+DAEMON = Path(__file__).resolve().parents[2] / "source" / "daemon"
+AUDIT_TOML = DAEMON / ".cargo" / "audit.toml"
+OSV_TOML = DAEMON / "osv-scanner.toml"
+# Every Cargo.lock osv-scanner walks; a crate lingering in any of them keeps
+# the advisory reachable, so union them for the presence check.
+LOCKFILES = [DAEMON / "Cargo.lock", DAEMON / "fuzz" / "Cargo.lock"]
+
+
+def ignored_ids() -> dict[str, list[str]]:
+    """Map advisory id -> list of config files that ignore it."""
+    ids: dict[str, list[str]] = {}
+    if AUDIT_TOML.exists():
+        cfg = tomllib.loads(AUDIT_TOML.read_text())
+        for adv in cfg.get("advisories", {}).get("ignore", []):
+            ids.setdefault(adv, []).append(".cargo/audit.toml")
+    if OSV_TOML.exists():
+        cfg = tomllib.loads(OSV_TOML.read_text())
+        for entry in cfg.get("IgnoredVulns", []):
+            if "id" in entry:
+                ids.setdefault(entry["id"], []).append("osv-scanner.toml")
+    return ids
+
+
+def advisory_db() -> Path:
+    cargo_home = os.environ.get("CARGO_HOME") or str(Path.home() / ".cargo")
+    return Path(cargo_home) / "advisory-db"
+
+
+def crate_for(adv_id: str, db: Path) -> str | None:
+    matches = list(db.glob(f"crates/*/{adv_id}.md"))
+    return matches[0].parent.name if matches else None
+
+
+def locked_crates() -> set[str]:
+    """Every package name across the scanned lockfiles.
+
+    Keying on presence-in-lockfile mirrors exactly what cargo-audit and
+    osv-scanner read (the whole Cargo.lock, all dependency kinds, all
+    versions), and sidesteps `cargo tree -i` ambiguity when a crate appears at
+    multiple versions. It is intentionally version-agnostic: it flags an ignore
+    stale only once the crate is *entirely gone*, never on a version-scoped
+    fix — the safe direction, since re-deriving affected ranges is the very
+    work the scanners already do.
+    """
+    names: set[str] = set()
+    for lock in LOCKFILES:
+        if not lock.exists():
+            continue
+        cfg = tomllib.loads(lock.read_text())
+        names.update(pkg["name"] for pkg in cfg.get("package", []))
+    return names
+
+
+def warn(msg: str) -> None:
+    print(f"::warning::{msg}")
+
+
+def main() -> int:
+    db = advisory_db()
+    if not db.exists():
+        warn(f"RustSec advisory-db not found at {db}; skipping staleness check")
+        return 0
+
+    ids = ignored_ids()
+    if not ids:
+        print("No ignored advisories configured.")
+        return 0
+
+    present = locked_crates()
+    stale, unknown, active = [], [], []
+    for adv_id, files in sorted(ids.items()):
+        crate = crate_for(adv_id, db)
+        if crate is None:
+            unknown.append(adv_id)
+            continue
+        if crate in present:
+            active.append((adv_id, crate))
+        else:
+            stale.append((adv_id, crate, files))
+
+    for adv_id, crate, files in stale:
+        warn(
+            f"{adv_id}: ignored crate '{crate}' is no longer in the dependency "
+            f"graph — remove the ignore from {', '.join(sorted(set(files)))}."
+        )
+    for adv_id in unknown:
+        warn(
+            f"{adv_id}: could not resolve a crate in the advisory-db; verify the "
+            f"id is still current (withdrawn/renamed advisories can be dropped)."
+        )
+
+    print(f"\nSummary: {len(active)} active, {len(stale)} stale, {len(unknown)} unresolved.")
+    for adv_id, crate in active:
+        print(f"  active  {adv_id} -> {crate} (still present)")
+    for adv_id, crate, _ in stale:
+        print(f"  STALE   {adv_id} -> {crate} (gone)")
+    for adv_id in unknown:
+        print(f"  ??      {adv_id} (unresolved)")
+
+    # Non-blocking by design.
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -5,14 +5,18 @@ on:
     branches: [main]
     paths:
       - "source/daemon/**/Cargo.toml"
-      - "source/daemon/Cargo.lock"
+      - "source/daemon/**/Cargo.lock"
       - "source/daemon/.cargo/audit.toml"
+      - "source/daemon/osv-scanner.toml"
+      - ".github/scripts/audit-ignore-staleness.py"
   pull_request:
     branches: [main]
     paths:
       - "source/daemon/**/Cargo.toml"
-      - "source/daemon/Cargo.lock"
+      - "source/daemon/**/Cargo.lock"
       - "source/daemon/.cargo/audit.toml"
+      - "source/daemon/osv-scanner.toml"
+      - ".github/scripts/audit-ignore-staleness.py"
   schedule:
     # Run daily at 06:00 UTC to catch newly disclosed advisories
     - cron: "0 6 * * *"
@@ -44,3 +48,23 @@ jobs:
 
       - name: Run cargo-audit
         run: cd source/daemon && cargo audit
+
+  ignore-staleness:
+    name: Audit Ignore Staleness
+    runs-on: ubuntu-latest
+    # Non-blocking watchdog: warns (never fails) when a suppressed advisory's
+    # crate has left the dependency graph, so ignores in .cargo/audit.toml and
+    # osv-scanner.toml don't outlive their justification. See wardnet#758.
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+
+      - name: Fetch RustSec advisory database
+        run: git clone --depth 1 https://github.com/rustsec/advisory-db.git "$HOME/.cargo/advisory-db"
+
+      - name: Check for stale advisory ignores
+        run: python3 .github/scripts/audit-ignore-staleness.py

--- a/source/daemon/.cargo/audit.toml
+++ b/source/daemon/.cargo/audit.toml
@@ -40,8 +40,10 @@
 # RUSTSEC-2026-0173: proc-macro-error2 unmaintained.
 # Compile-time proc-macro pulled in via i18n-embed-fl (through age) and
 # tabled_derive (through wctl's tabled). Not a CVE — the author stopped
-# publishing updates. Zero runtime footprint. Re-evaluate when age and
-# tabled migrate off proc-macro-error2.
+# publishing updates. Zero runtime footprint. Blocked on age →
+# i18n-embed-fl migrating off proc-macro-error2 (the tabled/wctl path is
+# removable but not sufficient alone). Tracked in wardnet/wardnet#758;
+# remove this entry when `cargo tree -i proc-macro-error2` returns nothing.
 #
 # RUSTSEC-2026-0186: memmap2 unchecked pointer offset.
 # Transitive via pyroscope (continuous-profiling client) and

--- a/source/daemon/fuzz/Cargo.lock
+++ b/source/daemon/fuzz/Cargo.lock
@@ -87,9 +87,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "arbitrary"

--- a/source/daemon/osv-scanner.toml
+++ b/source/daemon/osv-scanner.toml
@@ -54,3 +54,26 @@ to encode DHCPv4 packets, which carry at most a single FQDN (option
 81), so the quadratic blow-up isn't reachable. No 0.25.x backport.
 Re-evaluate when dhcproto upgrades.
 """
+
+[[IgnoredVulns]]
+id = "RUSTSEC-2026-0173"
+reason = """
+proc-macro-error2 unmaintained. Compile-time proc-macro pulled in via
+i18n-embed-fl (through age) and tabled_derive (through wctl's tabled).
+Not a CVE — the author stopped publishing updates. Zero runtime
+footprint. Blocked on age → i18n-embed-fl migrating off
+proc-macro-error2 (the tabled/wctl path is removable but not
+sufficient alone). Tracked in wardnet/wardnet#758; remove this entry
+when `cargo tree -i proc-macro-error2` returns nothing.
+"""
+
+[[IgnoredVulns]]
+id = "RUSTSEC-2026-0186"
+reason = """
+memmap2 unchecked pointer offset. Transitive via pyroscope
+(continuous-profiling client) and symbolic-common (its demangler). The
+unsoundness is in memmap2's offset API; pyroscope only memory-maps its
+own profiling buffers with in-bounds offsets, so the unchecked path
+isn't reachable in our usage. No fixed release yet. Re-evaluate when
+pyroscope bumps memmap2.
+"""


### PR DESCRIPTION
## Summary

The branch's Scorecard / code-scanning run flagged two Rust advisories. This PR resolves both and adds a watchdog so suppressed advisories don't silently outlive their justification.

### RUSTSEC-2026-0190 — `anyhow` unsound `downcast_mut` (< 1.0.103)
A real patch exists. The **main** lockfile was already at `1.0.103`; only the **fuzz** lockfile still pinned the vulnerable `1.0.102`. Bumped it (surgical version + checksum edit — the fuzz lock is independently stale vs its manifest, so a full `cargo update` would have ballooned the diff).

### RUSTSEC-2026-0173 — `proc-macro-error2` unmaintained
No upstream fix exists. It was **already justified-and-ignored** in `.cargo/audit.toml`, but the mirror in `osv-scanner.toml` (what OpenSSF Scorecard/osv-scanner actually reads) had drifted — which is why `cargo audit` was green while the code-scanning alert fired. Added the entry to `osv-scanner.toml`, and synced `RUSTSEC-2026-0186` too to close the same drift.

The crate enters transitively via two paths:
```
proc-macro-error2
├── i18n-embed-fl → age → wardnetd-services   [BLOCKING]
└── tabled_derive → tabled → wctl             [removable, but not sufficient alone]
```
`age` hard-depends on `i18n-embed-fl` (non-optional, no feature gate) and even the latest `i18n-embed-fl 0.10.0` still uses `proc-macro-error2`, so suppression is the only available action until upstream migrates. Removing the `tabled` path alone wouldn't clear the advisory. Tracked in #758 (with an upstream `i18n-embed-fl` issue to be linked there); the tracking URL is embedded in both reason blocks.

### New: non-blocking ignore-staleness watchdog
`.github/scripts/audit-ignore-staleness.py` + a scheduled `ignore-staleness` job in `security.yml`. It resolves each ignored advisory to its crate via the RustSec DB and warns (never fails) when that crate has left the lockfile — so an ignore can't outlive its justification. Keyed on **crate-presence-in-lockfile**, not cargo-audit's match set, because the two scanners disagree on which advisories match our versions (`0118/0119/0186`), which would otherwise produce false alarms. Verified locally: all 7 current ignores report active.

## Test plan
- `cargo audit` (main lockfile): clean.
- `osv-scanner.toml`: valid TOML, 7 ignore ids.
- Staleness script: 7 active / 0 stale locally; stale branch verified against a known-absent crate; exits 0 (non-blocking).
- Definitive confirmation is the Scorecard re-run in CI on this branch.

## Notes
- Fuzz lock is pre-existingly out of sync with its manifest (unrelated to this change; regenerated on nightly fuzz builds).
- Aside: `cargo audit` doesn't match `0118/0119/0186` against our versions while osv-scanner does — those ignores are effectively cargo-audit no-ops but correct to keep for osv-scanner.

## Merge Commit Message
```
fix(security): resolve RUSTSEC-2026-0173 and RUSTSEC-2026-0190 (#758)

Bump anyhow to 1.0.103 in the fuzz lockfile (0190), sync the
proc-macro-error2 (0173) and memmap2 (0186) ignores into osv-scanner.toml
to close audit.toml drift, and add a non-blocking CI watchdog that warns
when a suppressed advisory's crate has left the lockfile.
```

https://claude.ai/code/session_01FiVJZHQSaxBGeFpwum3qe6
