### PR TITLE
feat(zones): off-by-default new-device quarantine with admin approval

### DIFF
--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -423,4 +423,19 @@ is recorded in the ADR.
 never sees it on a flat L2 segment (the AP's job, or the isolate-members rung
 #737).
 
+### New-device quarantine (issue #738)
+
+An off-by-default `quarantine_new_devices` `system_config` toggle (owned by
+`NetworkZoneService`, exposed at `GET/PUT /api/network/quarantine-new-devices`).
+It is **notification-only**: placement is unchanged — every new device already
+lands in the `is_default_for_new` zone unconditionally (`DeviceDiscoveryServiceImpl::insert_new_device`),
+and enforcement already reacts to `DeviceDiscovered`. When the toggle is on, the
+**truly-first-ever** discovery path (only `insert_new_device`, never the reappear
+path — so idempotent by construction) publishes a dedicated
+`WardnetEvent::NewDeviceQuarantined`; `PushService` turns it into an admin
+"approve this device" push. A real quarantine is achieved by pointing
+`is_default_for_new` at a restrictive Guest zone (the #735 lever). Approve =
+existing `PUT /api/devices/{id}/zone`. Note `DeviceDiscovered` is **not** a
+valid first-ever signal (it also fires on every reconnect).
+
 [`NetworkZone`]: ../source/daemon/crates/wardnet-common/src/network_zone.rs

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -12856,6 +12856,296 @@
         ]
       }
     },
+    "/api/network/quarantine-new-devices": {
+      "get": {
+        "tags": [
+          "network_zones"
+        ],
+        "description": "Read the new-device quarantine toggle (issue #738). When on, a freshly-discovered device lands in the default-for-new zone (as always) and admins get a push to approve it. Off by default. Admin only.",
+        "operationId": "get_quarantine_new_devices",
+        "responses": {
+          "200": {
+            "description": "Current toggle state",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/QuarantineNewDevicesResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthenticated — session cookie or API key missing/invalid",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "description": "Standard API error response.",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "detail": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "error": {
+                      "type": "string"
+                    },
+                    "request_id": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "description": "Request ID for correlation with server logs."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden — caller is not an admin",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "description": "Standard API error response.",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "detail": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "error": {
+                      "type": "string"
+                    },
+                    "request_id": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "description": "Request ID for correlation with server logs."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "description": "Standard API error response.",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "detail": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "error": {
+                      "type": "string"
+                    },
+                    "request_id": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "description": "Request ID for correlation with server logs."
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "session_cookie": []
+          },
+          {
+            "bearer_auth": []
+          }
+        ]
+      },
+      "put": {
+        "tags": [
+          "network_zones"
+        ],
+        "description": "Enable or disable new-device quarantine (issue #738). Placement is unchanged either way (new devices always land in the default-for-new zone); the toggle only controls whether admins are notified to approve. Admin only.",
+        "operationId": "set_quarantine_new_devices",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SetQuarantineNewDevicesRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Updated toggle state",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/QuarantineNewDevicesResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Malformed or invalid request body",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "description": "Standard API error response.",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "detail": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "error": {
+                      "type": "string"
+                    },
+                    "request_id": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "description": "Request ID for correlation with server logs."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthenticated — session cookie or API key missing/invalid",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "description": "Standard API error response.",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "detail": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "error": {
+                      "type": "string"
+                    },
+                    "request_id": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "description": "Request ID for correlation with server logs."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden — caller is not an admin",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "description": "Standard API error response.",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "detail": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "error": {
+                      "type": "string"
+                    },
+                    "request_id": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "description": "Request ID for correlation with server logs."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "description": "Standard API error response.",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "detail": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "error": {
+                      "type": "string"
+                    },
+                    "request_id": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "description": "Request ID for correlation with server logs."
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "session_cookie": []
+          },
+          {
+            "bearer_auth": []
+          }
+        ]
+      }
+    },
     "/api/network/status": {
       "get": {
         "tags": [
@@ -24098,6 +24388,19 @@
           }
         }
       },
+      "QuarantineNewDevicesResponse": {
+        "type": "object",
+        "description": "Response for GET /api/network/quarantine-new-devices (issue #738).",
+        "required": [
+          "enabled"
+        ],
+        "properties": {
+          "enabled": {
+            "type": "boolean",
+            "description": "Whether new-device quarantine is on. Off by default."
+          }
+        }
+      },
       "RebuildTunnelResponse": {
         "type": "object",
         "description": "Response for POST /api/tunnels/:id/rebuild.",
@@ -24536,6 +24839,18 @@
           },
           "target": {
             "$ref": "#/components/schemas/RoutingTarget"
+          }
+        }
+      },
+      "SetQuarantineNewDevicesRequest": {
+        "type": "object",
+        "description": "Request body for PUT /api/network/quarantine-new-devices (issue #738).",
+        "required": [
+          "enabled"
+        ],
+        "properties": {
+          "enabled": {
+            "type": "boolean"
           }
         }
       },

--- a/source/daemon/crates/wardnet-common/src/api.rs
+++ b/source/daemon/crates/wardnet-common/src/api.rs
@@ -1834,6 +1834,19 @@ pub struct AssignDeviceZoneRequest {
     pub zone_id: Uuid,
 }
 
+/// Response for GET /api/network/quarantine-new-devices (issue #738).
+#[derive(Debug, Serialize, Deserialize, utoipa::ToSchema)]
+pub struct QuarantineNewDevicesResponse {
+    /// Whether new-device quarantine is on. Off by default.
+    pub enabled: bool,
+}
+
+/// Request body for PUT /api/network/quarantine-new-devices (issue #738).
+#[derive(Debug, Serialize, Deserialize, utoipa::ToSchema)]
+pub struct SetQuarantineNewDevicesRequest {
+    pub enabled: bool,
+}
+
 // --- Zone Exceptions (epic #244, issue #737) -------------------------------
 
 /// Response for GET /api/network/zones/exceptions.

--- a/source/daemon/crates/wardnet-common/src/event.rs
+++ b/source/daemon/crates/wardnet-common/src/event.rs
@@ -248,6 +248,19 @@ pub enum WardnetEvent {
         policy: String,
         timestamp: DateTime<Utc>,
     },
+    /// A previously-unseen device was discovered while new-device quarantine is
+    /// enabled (issue #738). Fires exactly once per device — only from the
+    /// truly-new insert path, never on reconnect — so it is a valid "first-ever"
+    /// signal. The push subsystem consumes it to notify admins to approve the
+    /// device; other listeners ignore it. Placement/enforcement are unaffected
+    /// (the device already landed in the default-for-new zone via
+    /// `DeviceDiscovered`).
+    NewDeviceQuarantined {
+        device_id: Uuid,
+        mac: String,
+        zone_name: String,
+        timestamp: DateTime<Utc>,
+    },
 }
 
 /// What kind of DNS filtering change happened. Carried by

--- a/source/daemon/crates/wardnetd-api/src/api/network_zone.rs
+++ b/source/daemon/crates/wardnetd-api/src/api/network_zone.rs
@@ -12,8 +12,8 @@ use utoipa_axum::routes;
 use uuid::Uuid;
 use wardnet_common::api::{
     CreateNetworkZoneRequest, CreateNetworkZoneResponse, DeleteNetworkZoneResponse,
-    GetNetworkZoneResponse, ListNetworkZonesResponse, UpdateNetworkZoneRequest,
-    UpdateNetworkZoneResponse,
+    GetNetworkZoneResponse, ListNetworkZonesResponse, QuarantineNewDevicesResponse,
+    SetQuarantineNewDevicesRequest, UpdateNetworkZoneRequest, UpdateNetworkZoneResponse,
 };
 
 use crate::api::middleware::AdminAuth;
@@ -24,6 +24,10 @@ use wardnetd_services::error::AppError;
 pub fn register(router: OpenApiRouter<AppState>) -> OpenApiRouter<AppState> {
     router
         .routes(routes!(list_zones, create_zone))
+        .routes(routes!(
+            get_quarantine_new_devices,
+            set_quarantine_new_devices
+        ))
         .routes(routes!(get_zone, update_zone, delete_zone))
 }
 
@@ -149,4 +153,59 @@ pub async fn delete_zone(
 ) -> Result<Json<DeleteNetworkZoneResponse>, AppError> {
     state.network_zone_service().delete_zone(id).await?;
     Ok(Json(DeleteNetworkZoneResponse { deleted: true }))
+}
+
+#[utoipa::path(
+    get,
+    path = "/api/network/quarantine-new-devices",
+    tag = "network_zones",
+    description = "Read the new-device quarantine toggle (issue #738). When on, a \
+                   freshly-discovered device lands in the default-for-new zone (as \
+                   always) and admins get a push to approve it. Off by default. \
+                   Admin only.",
+    responses(
+        (status = 200, description = "Current toggle state", body = QuarantineNewDevicesResponse),
+        AuthErrors,
+    ),
+    security(("session_cookie" = []), ("bearer_auth" = [])),
+)]
+pub async fn get_quarantine_new_devices(
+    State(state): State<AppState>,
+    _auth: AdminAuth,
+) -> Result<Json<QuarantineNewDevicesResponse>, AppError> {
+    let enabled = state
+        .network_zone_service()
+        .get_quarantine_new_devices()
+        .await?;
+    Ok(Json(QuarantineNewDevicesResponse { enabled }))
+}
+
+#[utoipa::path(
+    put,
+    path = "/api/network/quarantine-new-devices",
+    tag = "network_zones",
+    description = "Enable or disable new-device quarantine (issue #738). Placement \
+                   is unchanged either way (new devices always land in the \
+                   default-for-new zone); the toggle only controls whether admins \
+                   are notified to approve. Admin only.",
+    request_body = SetQuarantineNewDevicesRequest,
+    responses(
+        (status = 200, description = "Updated toggle state", body = QuarantineNewDevicesResponse),
+        AuthErrors,
+        BadRequest,
+    ),
+    security(("session_cookie" = []), ("bearer_auth" = [])),
+)]
+pub async fn set_quarantine_new_devices(
+    State(state): State<AppState>,
+    _auth: AdminAuth,
+    Json(body): Json<SetQuarantineNewDevicesRequest>,
+) -> Result<Json<QuarantineNewDevicesResponse>, AppError> {
+    state
+        .network_zone_service()
+        .set_quarantine_new_devices(body.enabled)
+        .await?;
+    Ok(Json(QuarantineNewDevicesResponse {
+        enabled: body.enabled,
+    }))
 }

--- a/source/daemon/crates/wardnetd-api/src/api/tests/network_zone.rs
+++ b/source/daemon/crates/wardnetd-api/src/api/tests/network_zone.rs
@@ -129,6 +129,12 @@ impl NetworkZoneService for MockNetworkZoneService {
     async fn assign_device(&self, _device_id: Uuid, _zone_id: Uuid) -> Result<(), AppError> {
         Ok(())
     }
+    async fn get_quarantine_new_devices(&self) -> Result<bool, AppError> {
+        Ok(true)
+    }
+    async fn set_quarantine_new_devices(&self, _enabled: bool) -> Result<(), AppError> {
+        Ok(())
+    }
 }
 
 fn connect_info() -> ConnectInfo<SocketAddr> {
@@ -179,6 +185,11 @@ fn zone_router() -> Router {
                 .put(crate::api::network_zone::update_zone)
                 .delete(crate::api::network_zone::delete_zone),
         )
+        .route(
+            "/api/network/quarantine-new-devices",
+            get(crate::api::network_zone::get_quarantine_new_devices)
+                .put(crate::api::network_zone::set_quarantine_new_devices),
+        )
         .with_state(build_state())
 }
 
@@ -220,6 +231,26 @@ async fn get_zone_returns_view() {
     let (status, json) = send("GET", &format!("/api/network/zones/{TRUSTED}"), None).await;
     assert_eq!(status, StatusCode::OK);
     assert_eq!(json["zone"]["member_count"], 3);
+}
+
+#[tokio::test]
+async fn get_quarantine_new_devices_returns_enabled() {
+    // The mock reports the toggle as on.
+    let (status, json) = send("GET", "/api/network/quarantine-new-devices", None).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(json["enabled"], true);
+}
+
+#[tokio::test]
+async fn set_quarantine_new_devices_echoes_request() {
+    let (status, json) = send(
+        "PUT",
+        "/api/network/quarantine-new-devices",
+        Some(r#"{"enabled":false}"#),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(json["enabled"], false);
 }
 
 #[tokio::test]

--- a/source/daemon/crates/wardnetd-api/src/tests/stubs.rs
+++ b/source/daemon/crates/wardnetd-api/src/tests/stubs.rs
@@ -726,6 +726,12 @@ impl NetworkZoneService for StubNetworkZoneService {
     async fn assign_device(&self, _device_id: Uuid, _zone_id: Uuid) -> Result<(), AppError> {
         Ok(())
     }
+    async fn get_quarantine_new_devices(&self) -> Result<bool, AppError> {
+        Ok(false)
+    }
+    async fn set_quarantine_new_devices(&self, _enabled: bool) -> Result<(), AppError> {
+        Ok(())
+    }
 }
 
 pub struct StubZoneExceptionService;

--- a/source/daemon/crates/wardnetd-data/src/repository/system_config.rs
+++ b/source/daemon/crates/wardnetd-data/src/repository/system_config.rs
@@ -131,6 +131,22 @@ pub trait SystemConfigRepository: Send + Sync {
         self.set("setup_completed", value).await
     }
 
+    /// Check whether new-device quarantine is enabled (issue #738).
+    ///
+    /// When on, a freshly-discovered device triggers an admin push to approve
+    /// it. Reads the `quarantine_new_devices` key; returns `false` if the key is
+    /// missing or set to any value other than `"true"` (off by default).
+    async fn is_quarantine_new_devices(&self) -> anyhow::Result<bool> {
+        let value = self.get("quarantine_new_devices").await?;
+        Ok(value.as_deref() == Some("true"))
+    }
+
+    /// Enable or disable new-device quarantine (issue #738).
+    async fn set_quarantine_new_devices(&self, enabled: bool) -> anyhow::Result<()> {
+        let value = if enabled { "true" } else { "false" };
+        self.set("quarantine_new_devices", value).await
+    }
+
     /// Read the global default routing policy.
     ///
     /// Stored as either `"direct"` or a tunnel UUID (as plain string).

--- a/source/daemon/crates/wardnetd-services/src/device/discovery.rs
+++ b/source/daemon/crates/wardnetd-services/src/device/discovery.rs
@@ -19,6 +19,7 @@ use wardnetd_data::oui;
 use wardnetd_data::repository::DeviceRepository;
 use wardnetd_data::repository::DhcpRepository;
 use wardnetd_data::repository::NetworkZoneRepository;
+use wardnetd_data::repository::SystemConfigRepository;
 use wardnetd_data::repository::device::DeviceRow;
 
 /// In-memory tracking state for a device.
@@ -110,6 +111,9 @@ pub struct DeviceDiscoveryServiceImpl {
     devices: Arc<dyn DeviceRepository>,
     zones: Arc<dyn NetworkZoneRepository>,
     dhcp: Arc<dyn DhcpRepository>,
+    /// Read-only: the `quarantine_new_devices` toggle (#738). Gates the
+    /// `NewDeviceQuarantined` admin-notification event on truly-new devices.
+    system_config: Arc<dyn SystemConfigRepository>,
     events: Arc<dyn EventPublisher>,
     resolver: Arc<dyn HostnameResolver>,
     /// LAN subnet — only observations from IPs within this range are processed.
@@ -125,6 +129,7 @@ impl DeviceDiscoveryServiceImpl {
         devices: Arc<dyn DeviceRepository>,
         zones: Arc<dyn NetworkZoneRepository>,
         dhcp: Arc<dyn DhcpRepository>,
+        system_config: Arc<dyn SystemConfigRepository>,
         events: Arc<dyn EventPublisher>,
         resolver: Arc<dyn HostnameResolver>,
         lan_subnet: ipnetwork::Ipv4Network,
@@ -133,6 +138,7 @@ impl DeviceDiscoveryServiceImpl {
             devices,
             zones,
             dhcp,
+            system_config,
             events,
             resolver,
             lan_subnet,
@@ -259,6 +265,32 @@ impl DeviceDiscoveryServiceImpl {
             hostname: None,
             timestamp: chrono::Utc::now(),
         });
+
+        // New-device quarantine (#738): this is the only truly-first-ever path
+        // (reached solely when the MAC had no prior DB row), so gating the
+        // notification here is idempotent by construction — a reconnecting
+        // device never reaches this. Placement already happened above (the
+        // device landed in the default-for-new zone); the toggle only controls
+        // whether admins are nudged to approve. A read failure must not block
+        // discovery, so it degrades to "no notification".
+        match self.system_config.is_quarantine_new_devices().await {
+            Ok(true) => {
+                self.events.publish(WardnetEvent::NewDeviceQuarantined {
+                    device_id,
+                    mac: obs.mac.clone(),
+                    zone_name: zone.name.clone(),
+                    timestamp: chrono::Utc::now(),
+                });
+            }
+            Ok(false) => {}
+            Err(e) => {
+                tracing::warn!(
+                    error = %e,
+                    mac = %obs.mac,
+                    "failed to read quarantine_new_devices toggle; skipping notification",
+                );
+            }
+        }
 
         Ok(ObservationResult::NewDevice {
             device_id,

--- a/source/daemon/crates/wardnetd-services/src/device/tests/discovery.rs
+++ b/source/daemon/crates/wardnetd-services/src/device/tests/discovery.rs
@@ -24,7 +24,7 @@ use crate::event::EventPublisher;
 use wardnetd_data::repository::device::DeviceRow;
 use wardnetd_data::repository::{
     DeviceRepository, DhcpLeaseLogRow, DhcpLeaseRow, DhcpRepository, DhcpReservationRow,
-    NetworkZoneRepository,
+    NetworkZoneRepository, SystemConfigRepository,
 };
 
 /// Helper to create an admin auth context for tests.
@@ -487,10 +487,56 @@ fn sample_observation(mac: &str, ip: &str) -> ObservedDevice {
     }
 }
 
+/// In-memory `SystemConfigRepository` for discovery tests. Only the generic
+/// key-value surface is backed; the typed helpers (incl. the #738 quarantine
+/// toggle) come from the trait's default impls over `get`/`set`.
+#[derive(Default)]
+struct MockSystemConfig {
+    values: Mutex<HashMap<String, String>>,
+}
+
+impl MockSystemConfig {
+    /// Flip the `quarantine_new_devices` toggle for a test.
+    fn set_quarantine(&self, enabled: bool) {
+        self.values.lock().unwrap().insert(
+            "quarantine_new_devices".to_owned(),
+            if enabled { "true" } else { "false" }.to_owned(),
+        );
+    }
+}
+
+#[async_trait]
+impl SystemConfigRepository for MockSystemConfig {
+    async fn get(&self, key: &str) -> anyhow::Result<Option<String>> {
+        Ok(self.values.lock().unwrap().get(key).cloned())
+    }
+    async fn set(&self, key: &str, value: &str) -> anyhow::Result<()> {
+        self.values
+            .lock()
+            .unwrap()
+            .insert(key.to_owned(), value.to_owned());
+        Ok(())
+    }
+    async fn delete(&self, key: &str) -> anyhow::Result<()> {
+        self.values.lock().unwrap().remove(key);
+        Ok(())
+    }
+    async fn device_count(&self) -> anyhow::Result<i64> {
+        Ok(0)
+    }
+    async fn tunnel_count(&self) -> anyhow::Result<i64> {
+        Ok(0)
+    }
+    async fn db_size_bytes(&self) -> anyhow::Result<u64> {
+        Ok(0)
+    }
+}
+
 struct TestHarness {
     svc: DeviceDiscoveryServiceImpl,
     repo: Arc<MockDeviceRepo>,
     events: Arc<MockEventPublisher>,
+    system_config: Arc<MockSystemConfig>,
 }
 
 fn build_harness() -> TestHarness {
@@ -502,16 +548,23 @@ fn build_harness_with_devices(devices: Vec<Device>) -> TestHarness {
     let dhcp = Arc::new(MockDhcpRepository::empty());
     let events = Arc::new(MockEventPublisher::new());
     let resolver = Arc::new(MockHostnameResolver::new());
+    let system_config = Arc::new(MockSystemConfig::default());
     let svc = DeviceDiscoveryServiceImpl::new(
         repo.clone(),
         Arc::new(MockNetworkZoneRepo),
         dhcp,
+        system_config.clone(),
         events.clone(),
         resolver,
         "192.168.1.0/24".parse().unwrap(),
     );
 
-    TestHarness { svc, repo, events }
+    TestHarness {
+        svc,
+        repo,
+        events,
+        system_config,
+    }
 }
 
 fn build_harness_with_resolver(
@@ -529,16 +582,23 @@ fn build_harness_with_resolver_and_dhcp(
     let repo = Arc::new(MockDeviceRepo::with_devices(devices));
     let events = Arc::new(MockEventPublisher::new());
     let resolver = Arc::new(MockHostnameResolver::with_mappings(resolver_mappings));
+    let system_config = Arc::new(MockSystemConfig::default());
     let svc = DeviceDiscoveryServiceImpl::new(
         repo.clone(),
         Arc::new(MockNetworkZoneRepo),
         Arc::new(dhcp),
+        system_config.clone(),
         events.clone(),
         resolver,
         "192.168.1.0/24".parse().unwrap(),
     );
 
-    TestHarness { svc, repo, events }
+    TestHarness {
+        svc,
+        repo,
+        events,
+        system_config,
+    }
 }
 
 // -- Tests ----------------------------------------------------------------
@@ -1212,4 +1272,80 @@ async fn process_observation_reappear_from_db_not_memory() {
     let events = h.events.published_events();
     assert_eq!(events.len(), 1);
     assert!(matches!(&events[0], WardnetEvent::DeviceDiscovered { .. }));
+}
+
+// -- New-device quarantine (#738) -----------------------------------------
+
+/// Toggle ON + a brand-new MAC ⇒ a `NewDeviceQuarantined` event is published
+/// (alongside the usual `DeviceDiscovered`), carrying the default-for-new zone
+/// name so the admin push can say where the device landed.
+#[tokio::test]
+async fn quarantine_on_new_device_publishes_event() {
+    let h = build_harness();
+    h.system_config.set_quarantine(true);
+
+    let obs = sample_observation("aa:bb:cc:dd:ee:01", "192.168.1.10");
+    let result = h.svc.process_observation(&obs).await.unwrap();
+    assert!(matches!(result, ObservationResult::NewDevice { .. }));
+
+    let events = h.events.published_events();
+    // DeviceDiscovered (enforcement) is emitted before the quarantine nudge.
+    assert!(matches!(&events[0], WardnetEvent::DeviceDiscovered { .. }));
+    let quarantined = events
+        .iter()
+        .find(|e| matches!(e, WardnetEvent::NewDeviceQuarantined { .. }))
+        .expect("expected a NewDeviceQuarantined event");
+    assert!(matches!(
+        quarantined,
+        WardnetEvent::NewDeviceQuarantined { mac, zone_name, .. }
+            if mac == "aa:bb:cc:dd:ee:01" && zone_name == "Trusted"
+    ));
+}
+
+/// Toggle OFF (the default) ⇒ a brand-new MAC behaves exactly as today: no
+/// `NewDeviceQuarantined` event.
+#[tokio::test]
+async fn quarantine_off_new_device_publishes_no_quarantine_event() {
+    let h = build_harness();
+    // Toggle left at its default (off).
+
+    let obs = sample_observation("aa:bb:cc:dd:ee:01", "192.168.1.10");
+    h.svc.process_observation(&obs).await.unwrap();
+
+    let events = h.events.published_events();
+    assert!(
+        !events
+            .iter()
+            .any(|e| matches!(e, WardnetEvent::NewDeviceQuarantined { .. })),
+        "expected no NewDeviceQuarantined event, got {events:?}"
+    );
+}
+
+/// Toggle ON but the MAC already has a DB row (a previously-approved device
+/// reconnecting) ⇒ it takes the reappear path, never `insert_new_device`, so it
+/// is never re-quarantined.
+#[tokio::test]
+async fn quarantine_on_reappearing_device_is_not_requarantined() {
+    let existing = sample_device(
+        "00000000-0000-0000-0000-0000000000aa",
+        "aa:bb:cc:dd:ee:01",
+        "192.168.1.10",
+    );
+    let h = build_harness_with_devices(vec![existing]);
+    h.system_config.set_quarantine(true);
+
+    let obs = sample_observation("aa:bb:cc:dd:ee:01", "192.168.1.10");
+    let result = h.svc.process_observation(&obs).await.unwrap();
+    assert!(
+        matches!(result, ObservationResult::Reappeared(_)),
+        "expected Reappeared, got {result:?}"
+    );
+
+    let events = h.events.published_events();
+    assert!(
+        !events
+            .iter()
+            .any(|e| matches!(e, WardnetEvent::NewDeviceQuarantined { .. })),
+        "a reconnecting device must not be re-quarantined, got {events:?}"
+    );
 }

--- a/source/daemon/crates/wardnetd-services/src/lib.rs
+++ b/source/daemon/crates/wardnetd-services/src/lib.rs
@@ -568,7 +568,7 @@ fn create_services(
         Arc::new(MaintenanceServiceImpl::new(maintenance_repo));
 
     let system_service: Arc<dyn SystemService> = Arc::new(SystemServiceImpl::new(
-        system_config_repo,
+        system_config_repo.clone(),
         tunnel_repo.clone(),
         started_at,
         backends.shutdown_token.clone(),
@@ -608,6 +608,7 @@ fn create_services(
         device_repo.clone(),
         network_zone_repo.clone(),
         dhcp_repo,
+        system_config_repo,
         event_publisher.clone(),
         backends.hostname_resolver,
         lan_ip,
@@ -704,6 +705,7 @@ fn build_discovery_service(
     device_repo: Arc<dyn wardnetd_data::repository::DeviceRepository>,
     network_zone_repo: Arc<dyn wardnetd_data::repository::NetworkZoneRepository>,
     dhcp_repo: Arc<dyn wardnetd_data::repository::DhcpRepository>,
+    system_config_repo: Arc<dyn wardnetd_data::repository::SystemConfigRepository>,
     event_publisher: Arc<dyn EventPublisher>,
     hostname_resolver: Arc<dyn device::HostnameResolver>,
     lan_ip: std::net::Ipv4Addr,
@@ -716,6 +718,7 @@ fn build_discovery_service(
         device_repo,
         network_zone_repo,
         dhcp_repo,
+        system_config_repo,
         event_publisher,
         hostname_resolver,
         lan_subnet,

--- a/source/daemon/crates/wardnetd-services/src/lib.rs
+++ b/source/daemon/crates/wardnetd-services/src/lib.rs
@@ -831,9 +831,10 @@ fn build_backup_service(
 
 /// Fresh handle to the `system_config` repo for the update service.
 ///
-/// `system_config_repo` has already been moved into `SystemService`, so we
-/// ask the factory for another instance. Each repo trait object wraps an
-/// `Arc<SqlitePool>`, so this is cheap.
+/// `system_config_repo` has already been consumed upstream (cloned into
+/// `SystemService`, moved into the discovery service), so we ask the factory
+/// for another instance. Each repo trait object wraps an `Arc<SqlitePool>`, so
+/// this is cheap.
 fn system_config_for_update(
     repo_factory: &dyn RepositoryFactory,
 ) -> Arc<dyn wardnetd_data::repository::SystemConfigRepository> {

--- a/source/daemon/crates/wardnetd-services/src/network_zone/service.rs
+++ b/source/daemon/crates/wardnetd-services/src/network_zone/service.rs
@@ -50,6 +50,13 @@ pub trait NetworkZoneService: Send + Sync {
 
     /// Reassign a device to a different zone.
     async fn assign_device(&self, device_id: Uuid, zone_id: Uuid) -> Result<(), AppError>;
+
+    /// Read the new-device quarantine toggle (issue #738). When on, a
+    /// freshly-discovered device triggers an admin push to approve it.
+    async fn get_quarantine_new_devices(&self) -> Result<bool, AppError>;
+
+    /// Enable or disable new-device quarantine (issue #738).
+    async fn set_quarantine_new_devices(&self, enabled: bool) -> Result<(), AppError>;
 }
 
 /// Default implementation of [`NetworkZoneService`].
@@ -476,5 +483,21 @@ impl NetworkZoneService for NetworkZoneServiceImpl {
             timestamp: chrono::Utc::now(),
         });
         Ok(())
+    }
+
+    async fn get_quarantine_new_devices(&self) -> Result<bool, AppError> {
+        auth_context::require_admin()?;
+        self.system_config
+            .is_quarantine_new_devices()
+            .await
+            .map_err(AppError::Internal)
+    }
+
+    async fn set_quarantine_new_devices(&self, enabled: bool) -> Result<(), AppError> {
+        auth_context::require_admin()?;
+        self.system_config
+            .set_quarantine_new_devices(enabled)
+            .await
+            .map_err(AppError::Internal)
     }
 }

--- a/source/daemon/crates/wardnetd-services/src/network_zone/tests/service.rs
+++ b/source/daemon/crates/wardnetd-services/src/network_zone/tests/service.rs
@@ -138,6 +138,31 @@ async fn every_method_rejects_non_admin() {
         h.svc.set_default(IOT.parse().unwrap()).await,
         Err(AppError::Forbidden(_))
     ));
+    assert!(matches!(
+        h.svc.get_quarantine_new_devices().await,
+        Err(AppError::Forbidden(_))
+    ));
+    assert!(matches!(
+        h.svc.set_quarantine_new_devices(true).await,
+        Err(AppError::Forbidden(_))
+    ));
+}
+
+#[tokio::test]
+async fn quarantine_toggle_defaults_off_and_round_trips() {
+    let h = build().await;
+    // Off by default (key absent).
+    assert!(!as_admin(h.svc.get_quarantine_new_devices()).await.unwrap());
+    // Enable, then read back.
+    as_admin(h.svc.set_quarantine_new_devices(true))
+        .await
+        .unwrap();
+    assert!(as_admin(h.svc.get_quarantine_new_devices()).await.unwrap());
+    // Disable again.
+    as_admin(h.svc.set_quarantine_new_devices(false))
+        .await
+        .unwrap();
+    assert!(!as_admin(h.svc.get_quarantine_new_devices()).await.unwrap());
 }
 
 // ── Create ─────────────────────────────────────────────────────────────────

--- a/source/daemon/crates/wardnetd-services/src/push/mod.rs
+++ b/source/daemon/crates/wardnetd-services/src/push/mod.rs
@@ -398,6 +398,23 @@ impl PushService for PushServiceImpl {
                 .await;
             }
 
+            // A previously-unseen device landed in the quarantine (default-for-new)
+            // zone while new-device quarantine is on (#738). Nudge the admins to
+            // approve it; approving = reassigning its zone via
+            // `PUT /api/devices/{id}/zone`.
+            WardnetEvent::NewDeviceQuarantined {
+                device_id,
+                zone_name,
+                ..
+            } => {
+                let name = self.device_name(&device_id.to_string()).await;
+                self.deliver_to_admins(Notification {
+                    title: "New device",
+                    body: format!("New device {name} joined, in {zone_name}. Approve in the app."),
+                })
+                .await;
+            }
+
             _ => {}
         }
         Ok(())

--- a/source/daemon/crates/wardnetd-services/src/push/tests.rs
+++ b/source/daemon/crates/wardnetd-services/src/push/tests.rs
@@ -698,3 +698,42 @@ async fn delivery_is_dropped_when_vapid_key_is_corrupt() {
     assert!(h.sender.sent.lock().unwrap().is_empty());
     assert_eq!(h.push_repo.list_admins().await.unwrap().len(), 1);
 }
+
+#[tokio::test]
+async fn new_device_quarantined_notifies_admins() {
+    let h = build(SendOutcome::Delivered).await;
+    let device_id = Uuid::new_v4();
+    insert_device(
+        &h.devices,
+        device_id,
+        "aa:bb:cc:dd:ee:01",
+        Some("Kid's iPad"),
+    )
+    .await;
+    seed(
+        &h.push_repo,
+        OWNER_KIND_ADMIN,
+        "admin-1",
+        "https://push/admin",
+    )
+    .await;
+
+    handle(
+        &h.service,
+        WardnetEvent::NewDeviceQuarantined {
+            device_id,
+            mac: "aa:bb:cc:dd:ee:01".to_owned(),
+            zone_name: "Guest".to_owned(),
+            timestamp: Utc::now(),
+        },
+    )
+    .await;
+
+    let sent = h.sender.sent.lock().unwrap();
+    assert_eq!(sent.len(), 1);
+    assert_eq!(sent[0].endpoint, "https://push/admin");
+    // Uses the device's human name and the landing zone.
+    assert!(sent[0].payload.contains("Kid's iPad"));
+    assert!(sent[0].payload.contains("Guest"));
+    assert!(sent[0].payload.contains("Approve"));
+}

--- a/source/daemon/crates/wardnetd/src/routing_listener.rs
+++ b/source/daemon/crates/wardnetd/src/routing_listener.rs
@@ -230,6 +230,8 @@ async fn handle_event(event: WardnetEvent, routing: &dyn RoutingService) {
         | WardnetEvent::NetworkZoneChanged { .. }
         | WardnetEvent::DeviceZoneChanged { .. }
         | WardnetEvent::ZoneExceptionsChanged { .. }
+        // New-device quarantine (#738) is a push-notification concern only.
+        | WardnetEvent::NewDeviceQuarantined { .. }
         | WardnetEvent::DefaultPolicyChanged { .. } => {}
     }
 }

--- a/source/daemon/crates/wardnetd/src/tests/stubs.rs
+++ b/source/daemon/crates/wardnetd/src/tests/stubs.rs
@@ -541,6 +541,12 @@ impl NetworkZoneService for StubNetworkZoneService {
     async fn assign_device(&self, _device_id: Uuid, _zone_id: Uuid) -> Result<(), AppError> {
         unimplemented!()
     }
+    async fn get_quarantine_new_devices(&self) -> Result<bool, AppError> {
+        unimplemented!()
+    }
+    async fn set_quarantine_new_devices(&self, _enabled: bool) -> Result<(), AppError> {
+        unimplemented!()
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/source/daemon/crates/wardnetd/src/zone_enforcement_listener.rs
+++ b/source/daemon/crates/wardnetd/src/zone_enforcement_listener.rs
@@ -176,6 +176,9 @@ async fn handle_event(event: WardnetEvent, enforcer: &dyn ZoneEnforcementService
         | WardnetEvent::UpdateCompleted { .. }
         | WardnetEvent::UpdateFailed { .. }
         | WardnetEvent::DeviceCaptureSettingsChanged { .. }
+        // New-device quarantine (#738) only drives an admin push; the device
+        // already landed in the default-for-new zone via `DeviceDiscovered`.
+        | WardnetEvent::NewDeviceQuarantined { .. }
         | WardnetEvent::DnsEventInserted { .. } => {}
 
         // A cross-zone exception changed — rebuild the L3 isolation state so its


### PR DESCRIPTION
Closes #738 — Network Zones epic #244, Phase 3.

## What & why
Adds an off-by-default `quarantine_new_devices` toggle. When on, a **previously-unseen** device joining the LAN nudges admins with a push to approve it (approve = reassign its zone).

Key insight from the merged code (this shaped the design): new devices **already** land in the `is_default_for_new` zone unconditionally (`DeviceDiscoveryServiceImpl::insert_new_device`), and enforcement **already** reacts to `DeviceDiscovered`. So placement and enforcement need no change — the toggle's only behavioral delta is **the admin notification**. A real quarantine is achieved by pointing `is_default_for_new` at a restrictive Guest zone (the #735 lever). Approve reuses the existing `PUT /api/devices/{id}/zone`.

## How
- **Setting**: `quarantine_new_devices` in `system_config` (default false) with typed `is_/set_quarantine_new_devices` helpers.
- **Service + API**: `NetworkZoneService::get/set_quarantine_new_devices` (both `require_admin`) exposed at `GET/PUT /api/network/quarantine-new-devices`; `docs/openapi.json` regenerated.
- **Event**: new `WardnetEvent::NewDeviceQuarantined { device_id, mac, zone_name, timestamp }`. It fires **only** from `insert_new_device` — the only truly-first-ever path (reached solely when the MAC has no prior DB row) — so it is **idempotent by construction**: a reconnecting device takes the reappear path and is never re-quarantined. `DeviceDiscovered` is deliberately *not* used (it also fires on every reconnect).
- **Discovery**: `DeviceDiscoveryServiceImpl` gains a read-only `SystemConfigRepository` dep to gate the event on the toggle. A toggle-read failure degrades to "no notification" and never blocks discovery.
- **Push**: `PushServiceImpl::handle_event` turns `NewDeviceQuarantined` into `deliver_to_admins("New device X joined, in <zone>. Approve in the app.")`.

## Tests (all green under `make check-daemon`)
- Discovery gating: toggle on ⇒ event published for a brand-new MAC; toggle off ⇒ not; reconnecting device ⇒ never re-quarantined.
- Zone service: get/set round-trip + non-admin rejection.
- Push: `NewDeviceQuarantined` delivers to admin subscriptions with the right body.
- API plumbing: GET/PUT handlers.

## Verification
- `make check-daemon` exits 0 (fmt + clippy `-D warnings` + full workspace test suite).
- `docs/openapi.json` regenerated in-container; diff is scoped to the new route + two schemas (nothing removed).

## Out of scope (→ #739)
- wardnet-js SDK method + admin-PWA toggle UI and the tap-to-deep-link "Approve" flow.
- Any push-payload schema change (kept bare `{title, body}`).

## Merge Commit Message
`feat(zones): off-by-default new-device quarantine with admin approval`

https://claude.ai/code/session_01V6oZrN5fphbFDWiD3UHuN3