### PR TITLE
ci: harden Scorecard findings — scope token perms and pin base images

### DIFF
--- a/.github/workflows/update-visual-snapshots.yml
+++ b/.github/workflows/update-visual-snapshots.yml
@@ -25,11 +25,11 @@ name: Update Visual Snapshots
 on:
   workflow_dispatch:
 
+# Workflow-level permissions stay read-only. The single job elevates to the
+# writes it actually needs via its own `permissions:` block — keeps
+# Scorecard's Token-Permissions check from flagging a top-level write.
 permissions:
-  # Commit the regenerated baselines back to the branch.
-  contents: write
-  # `make build-web` pulls @wardnet/{ui,styles,brand} from GitHub Packages.
-  packages: read
+  contents: read
 
 env:
   CARGO_TERM_COLOR: always
@@ -39,6 +39,12 @@ jobs:
   update-snapshots:
     name: Regenerate visual baselines
     runs-on: ubuntu-latest
+    permissions:
+      # `contents: write` scoped to this job — commits the regenerated
+      # baselines back to the branch (`git push` in the final step).
+      contents: write
+      # `make build-web` pulls @wardnet/{ui,styles,brand} from GitHub Packages.
+      packages: read
     # Matches the e2e-ui job: a real-asset wardnetd-ui image is compiled in
     # Docker (~7-10 min cold) before the Playwright run.
     timeout-minutes: 40

--- a/source/end2end-tests/daemon/mocks/nordvpn/Dockerfile
+++ b/source/end2end-tests/daemon/mocks/nordvpn/Dockerfile
@@ -1,7 +1,7 @@
 # nordvpn_mock image. Build context is this directory. Fixtures are NOT copied
 # in — they are bind-mounted read-only at runtime (see compose.yaml) so the
 # JSON can be edited without an image rebuild.
-FROM node:22-slim
+FROM node:22-slim@sha256:813a7480f28fdadac1f7f5c824bcdad435b5bc1322a5968bbbdef8d058f9dff4
 
 WORKDIR /app
 COPY server.mjs /app/server.mjs

--- a/source/end2end-tests/daemon/mocks/wg-gateway/Dockerfile
+++ b/source/end2end-tests/daemon/mocks/wg-gateway/Dockerfile
@@ -1,6 +1,6 @@
 # WireGuard exit-gateway image for the E2E VPN routing topology (issue #248).
 # Build context is this directory.
-FROM alpine:3.20
+FROM alpine:3.20@sha256:d9e853e87e55526f6b2917df91a2115c36dd7c696a35be12163d44e6e2a4b6bc
 
 # wireguard-tools brings wg + wg-quick; iptables provides the NAT/forward
 # rules the entrypoint installs. The WireGuard data path is the host kernel


### PR DESCRIPTION
## What

Resolves the three **code-fixable** OpenSSF Scorecard code-scanning alerts.

| Alert | File | Finding | Fix |
|-------|------|---------|-----|
| [476](https://github.com/wardnet/wardnet/security/code-scanning/476) | `update-visual-snapshots.yml` | top-level `contents: write` | Move to job level; top-level now `contents: read` |
| [469](https://github.com/wardnet/wardnet/security/code-scanning/469) | `mocks/wg-gateway/Dockerfile` | `FROM alpine:3.20` unpinned | Pin `@sha256:d9e853e8…` |
| [468](https://github.com/wardnet/wardnet/security/code-scanning/468) | `mocks/nordvpn/Dockerfile` | `FROM node:22-slim` unpinned | Pin `@sha256:813a7480…` |

The `update-visual-snapshots.yml` change brings it in line with every other
workflow, which already keep the workflow-level token read-only and elevate
per-job. The digest pins were captured from the current Docker Hub index
manifests for each tag.

## Not addressed here (by design)

The other 11 open Scorecard alerts are **not** code-fixable:

- **470–475** — job-level `security-events` / `packages` / `contents` writes
  that SARIF upload, image publish, and release creation genuinely require.
  Already scoped to the minimum. Being dismissed as *won't fix*.
- **157** — `Dockerfile.client` `FROM ${WARDNETD_TEST_IMAGE}` is a
  locally-built tag with no registry digest to pin.
- **1, 36, 37, 42** — branch-protection / CII-badge / code-review /
  dependency-vulnerability findings that are repo-settings, not code.

## Testing

- `actionlint` parses the reworked workflow cleanly (only a pre-existing
  SC2046 shellcheck warning, unrelated to this change).
- Digest pins verified against `registry-1.docker.io` index manifests.

## Merge Commit Message

ci: harden Scorecard findings — scope token perms and pin base images

https://claude.ai/code/session_01X51mubVBLDiPJ25RxLitQo