### PR TITLE
chore(ci): point Dependabot npm updates at the yarn workspace root

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,8 +13,15 @@ updates:
     cooldown:
       default-days: 3
 
+  # The web codebase is a Yarn-workspaces monorepo with a SINGLE lockfile
+  # at /source/yarn.lock. Dependabot must point at the workspace ROOT so
+  # every version bump also regenerates the lockfile — per-workspace
+  # entries (e.g. /source/admin-site) edit only that package.json, leave
+  # yarn.lock stale, and every PR fails CI's `yarn install --immutable`.
+  # This one entry covers the root manifest plus all workspaces
+  # (sdk/wardnet-js, web, admin-site, admin-app, user-app, marketing-site).
   - package-ecosystem: "npm"
-    directory: "/source/admin-site"
+    directory: "/source"
     schedule:
       interval: "weekly"
     commit-message:
@@ -22,49 +29,8 @@ updates:
     cooldown:
       default-days: 3
 
-  - package-ecosystem: "npm"
-    directory: "/source/admin-app"
-    schedule:
-      interval: "weekly"
-    commit-message:
-      prefix: "chore(deps):"
-    cooldown:
-      default-days: 3
-
-  - package-ecosystem: "npm"
-    directory: "/source/user-app"
-    schedule:
-      interval: "weekly"
-    commit-message:
-      prefix: "chore(deps):"
-    cooldown:
-      default-days: 3
-
-  - package-ecosystem: "npm"
-    directory: "/source/web"
-    schedule:
-      interval: "weekly"
-    commit-message:
-      prefix: "chore(deps):"
-    cooldown:
-      default-days: 3
-
-  - package-ecosystem: "npm"
-    directory: "/source/marketing-site"
-    schedule:
-      interval: "weekly"
-    commit-message:
-      prefix: "chore(deps):"
-    cooldown:
-      default-days: 3
-
-  - package-ecosystem: npm
-    directory: /source/sdk/wardnet-js
-    schedule:
-      interval: daily
-    cooldown:
-      default-days: 3
-
+  # Standalone package with its own yarn.lock — not part of the /source
+  # workspace, so it keeps its own entry.
   - package-ecosystem: "npm"
     directory: "/source/end2end-tests/daemon"
     schedule:


### PR DESCRIPTION
## Problem

Every npm Dependabot PR (e.g. #767) fails CI. The web codebase is a Yarn-workspaces monorepo with a **single lockfile** at `source/yarn.lock`, but `dependabot.yml` had one npm entry per workspace package (`/source/admin-site`, `/source/sdk/wardnet-js`, …). Dependabot therefore bumped only that package's `package.json` and never regenerated the root lockfile, so every build job died with:

```
YN0028: The lockfile would have been modified by this install, which is explicitly forbidden.
```

(from `yarn install --immutable`).

## Fix

Collapse the six per-workspace npm entries into a single entry at `/source` — the workspace root where `yarn.lock` lives — so Dependabot resolves the workspace and updates the lockfile alongside the manifests. This also normalizes the sdk entry, which was `daily` and missing the `chore(deps):` commit prefix.

`source/end2end-tests/daemon` keeps its own entry: it has its own `yarn.lock` outside the workspace.

## Follow-up

Once this merges, the open per-workspace Dependabot PRs (like #767) belong to removed config entries — Dependabot will close them on its next run, and re-open equivalent bumps from the `/source` entry with a proper lockfile update.

## Merge Commit Message

chore(ci): point Dependabot npm updates at the yarn workspace root so lockfile updates are included and PRs stop failing `yarn install --immutable`

https://claude.ai/code/session_01C4Cn68AYrKUX2GiPExCBv3