### PR TITLE
feat(cloud): dial the per-scope gateways and sign PoP over prefixed paths

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -78,7 +78,9 @@
 
 **Region slug** — A short identifier for a wardnet region (e.g. `use1`). It selects which regional **DDNS service** endpoint the daemon talks to (resolved through the **region catalog**) and is returned at registration for display.
 
-**Region catalog** — The built-in, daemon-shipped table mapping each **region slug** to its regional **DDNS service** base URL (an `ddns.svc.<…>.wardnet.network` FQDN). The cloud cannot supply this (each regional service is region-specific), so the daemon must already know it. At registration the daemon probes every catalogued region's health endpoint and registers against the lowest-latency one. (The production FQDNs are a daemon constant pending infra confirmation.)
+**Region catalog** — The built-in, daemon-shipped table mapping each **region slug** to its regional **cloud gateway** base URL (an `api.<region-slug>.wardnet.network` FQDN). The cloud cannot supply this (each regional gateway is region-specific), so the daemon must already know it. At registration the daemon probes every catalogued region's health endpoint and registers against the lowest-latency one. (The production FQDNs are a daemon constant pending infra confirmation.)
+
+**Cloud gateway** — The per-scope north-south edge the daemon HTTPS-es into to reach wardnet-cloud (wardnet-cloud ADR-0014 / inforge ADR-0032): one **global** gateway fronting the **tenants service**, and one gateway per region fronting that region's **regional plane** (DDNS + Tunneler). The target service is the first path segment (`/tenants/…`, `/ddns/…`, `/tunneller/…`) and the gateway forwards the path unmodified, so the daemon's Ed25519 **PoP** signature is computed over the full prefixed path it puts on the wire. TLS is an ordinary public server certificate; the daemon presents no client certificate (the cloud's internal mesh mTLS is invisible to it).
 
 **Vanity name** — A user's chosen slug (e.g. `alice`) forming the flat, region-free user host `<vanity>.my.wardnet.services`. Validated `[a-z0-9-]`, 3–32 chars. The region is deliberately *not* in the name (it lives in the record's value and in infra names only), so a user can be migrated between regions without changing their host, bookmarks, or certificate. Per-service hosts nest under it: `<service>.<vanity>.my.wardnet.services`. See [adr-two-domain-strategy.md](docs/adr-two-domain-strategy.md).
 
@@ -140,7 +142,7 @@
 
 **Slug** — A tenant's chosen vanity label (e.g. `happy-einstein`) forming the flat, region-free host `<slug>.my.wardnet.services`. Validated `[a-z0-9-]`, 3–32 chars, no leading/trailing hyphen, unreserved. (Synonym for the older **vanity name**.)
 
-**Enrollment code** — A one-time code emailed to a **tenant**'s account address that the daemon requests on the operator's behalf (`POST /api/ddns/enrollment-code` → tenants `POST /v1/verification-codes {email, purpose:"enrollment"}`). Submitting it to *enroll* binds the **daemon identity** to the tenant. Replaces the old reinstall **magic-link**: a fresh box wipes-and-re-enrolls (no migration).
+**Enrollment code** — A one-time code emailed to a **tenant**'s account address that the daemon requests on the operator's behalf (`POST /api/ddns/enrollment-code` → tenants `POST /tenants/v1/verification-codes {email, purpose:"enrollment"}`). Submitting it to *enroll* binds the **daemon identity** to the tenant. Replaces the old reinstall **magic-link**: a fresh box wipes-and-re-enrolls (no migration).
 
 **Daemon identity** — The per-box cloud identity: an **Ed25519** seed in the daemon `SecretStore` (`SECRET_DAEMON_KEY`, generated at *enroll*), an in-memory cached **identity JWT**, and the shared **entitlement** flag. Authenticates every cloud call as this box; see [adr-daemon-cloud-auth.md](docs/adr-daemon-cloud-auth.md).
 
@@ -152,9 +154,9 @@
 
 ## Service decomposition
 
-**Tenants service** — The *global* service and database (at `account.wardnet.network`). Owns **tenants**, billing/Stripe linkage, the **global naming authority** (slug allocation), enrollment (verification codes, identity binding), and **identity JWT** minting. Lowest-traffic, most security-sensitive — isolating it from the internet-facing planes is the primary reason to split, ahead of scaling.
+**Tenants service** — The *global* service and database, reached through the global **cloud gateway** under `/tenants/…`. Owns **tenants**, billing/Stripe linkage, the **global naming authority** (slug allocation), enrollment (verification codes, identity binding), and **identity JWT** minting. Lowest-traffic, most security-sensitive — isolating it from the internet-facing planes is the primary reason to split, ahead of scaling.
 
-**Per-service cloud client** — The daemon's `cloud/` module: a `TenantsClient` (bound to the global tenants endpoint) and a `DdnsClient` (bound to a regional **DDNS service** endpoint from the **region catalog**), each addressing its own origin but sharing one **daemon identity**. See [adr-per-service-cloud-clients.md](docs/adr-per-service-cloud-clients.md).
+**Per-service cloud client** — The daemon's `cloud/` module: a `TenantsClient` (bound to the global **cloud gateway**) and a `DdnsClient` (bound to a regional gateway from the **region catalog**), each addressing its own service by path prefix but sharing one **daemon identity**. See [adr-per-service-cloud-clients.md](docs/adr-per-service-cloud-clients.md).
 
 **Regional plane** — The **DDNS** and **Tunneler** services, deployed per region behind the **edge SNI demux**. The daemon pins a region at registration (lowest-latency probe) and stays. Each holds only regional/operational state and authorizes calls by the **identity JWT** bearer rather than the global DB. DDNS writes into the global Cloudflare zone; the Tunneler accepts the daemon's relay connection at its PoP.
 

--- a/docs/adr-daemon-cloud-auth.md
+++ b/docs/adr-daemon-cloud-auth.md
@@ -10,7 +10,8 @@
 ## Context
 
 The daemon talks to a decomposed wardnet-cloud: a global **tenants** service
-(account + naming authority, at `account.wardnet.network`) and per-region
+(account + naming authority, reached via the global gateway under
+`/tenants/…`) and per-region
 **ddns** services. The daemon needs (a) a way to authenticate every cloud call
 as *this* enrolled box, and (b) a signal for whether the box's subscription is
 active, so it can self-degrade into Suspended mode.

--- a/docs/adr-per-service-cloud-clients.md
+++ b/docs/adr-per-service-cloud-clients.md
@@ -11,15 +11,18 @@
 ## Context
 
 wardnet-cloud is decomposed into a **global tenants** service (accounts, billing
-linkage, the global naming authority — one instance, at
-`account.wardnet.network`) and **per-region ddns** services (network
-registration, A-record publishing, ACME DNS-01 — one instance per region, behind
-region-specific FQDNs). The daemon must reach both.
+linkage, the global naming authority — one instance) and **per-region ddns**
+services (network registration, A-record publishing, ACME DNS-01 — one instance
+per region). Daemons reach them through per-scope north-south **gateways**
+(wardnet-cloud ADR-0014 / inforge ADR-0032): the global gateway fronts tenants,
+each region's gateway fronts that region's services, and the target service is
+the first path segment (`/tenants/…`, `/ddns/…`). The daemon must reach both
+scopes.
 
 A single monolithic "cloud client" pointed at one base URL no longer fits: the
-two services live at different origins, scale independently, and a network is
-pinned to a *specific* region's ddns endpoint after registration. The daemon
-needs to address each by its own URL while still presenting one identity.
+two scopes live at different origins, scale independently, and a network is
+pinned to a *specific* region's gateway after registration. The daemon needs to
+address each by its own URL while still presenting one identity.
 
 ## Decision
 
@@ -28,12 +31,14 @@ needs to address each by its own URL while still presenting one identity.
 The daemon's `cloud/` module exposes a **`TenantsClient`** (global endpoint) and
 a **`DdnsClient`** (regional endpoint), constructed independently:
 
-- `TenantsClient` is bound to the **global** `TENANTS_BASE_URL`
-  (`account.wardnet.network`). It owns enrollment, verification-code requests,
-  slug availability, network registration, JWT minting, and per-daemon removal.
-- `DdnsClient` is bound to a **regional** ddns control base URL resolved from a
-  **hardcoded region catalog** (region slug → `ddns.svc.<...>.wardnet.network`).
-  It owns A-record publishing and the ACME DNS-01 challenge.
+- `TenantsClient` is bound to the **global** gateway `GLOBAL_GATEWAY_URL`
+  (`api.wardnet.network`) and prefixes every path with `/tenants`. It owns
+  enrollment, verification-code requests, slug availability, network
+  registration, JWT minting, and per-daemon removal.
+- `DdnsClient` is bound to a **regional** gateway base URL resolved from a
+  **hardcoded region catalog** (region slug → `api.<slug>.wardnet.network`) and
+  prefixes every path with `/ddns`. It owns A-record publishing and the ACME
+  DNS-01 challenge.
 
 The clients share the pooled `reqwest::Client` (connection reuse) but nothing
 else; each is cheap to build per use.

--- a/docs/adr-provider-based-ddns.md
+++ b/docs/adr-provider-based-ddns.md
@@ -42,7 +42,7 @@ the certificate lifecycle and the key never leaving the Pi under either provider
     directly with their token.
 - **Multi-region via a daemon-side catalog.** A built-in region-slug → bridge
   endpoint catalog ships in the daemon (`ddns/region.rs`); at registration the
-  daemon probes each region's `/v1/health` and picks the lowest-latency one. The
+  daemon probes each region's `/ddns/v1/health` and picks the lowest-latency one. The
   bridge cannot supply this list (it is itself region-bound), so the catalog is the
   daemon's. Adding a region is a one-line catalog change.
 - The **daemon**, not the bridge, owns issuance and renewal — it calls the provider

--- a/source/daemon/crates/wardnetd-services/src/cloud/ddns.rs
+++ b/source/daemon/crates/wardnetd-services/src/cloud/ddns.rs
@@ -1,10 +1,13 @@
 //! Client for the **ddns** service — the regional report-IP + ACME DNS-01 proxy
 //! — and the [`WardnetDnsProvider`] that adapts it to the [`DnsProvider`] trait.
 //!
-//! ddns is **regional**: its base URL comes from the region catalog
-//! (`https://ddns.svc.<region>…` — the daemon dials the FQDN directly, so TLS SNI
-//! is the hostname automatically). Every call is network-scoped JWT + `PoP`; the
-//! network is taken from the JWT `net` claim, so paths carry no id.
+//! ddns is **regional**, reached through the region's north-south **gateway**
+//! (cloud ADR-0014 / inforge ADR-0032): the base URL from the region catalog is
+//! the gateway host (`https://api.<region-slug>…`), and the `/ddns/` path prefix
+//! selects the service. The gateway is path-preserving, so the prefixed path is
+//! also what the cloud verifies the `PoP` signature against. Every call is
+//! network-scoped JWT + `PoP`; the network is taken from the JWT `net` claim, so
+//! paths carry no id.
 //!
 //! [`WardnetDnsProvider`] is the wardnet-managed sibling of the BYOD
 //! [`CloudflareProvider`](crate::ddns::cloudflare::CloudflareProvider): publish A
@@ -24,21 +27,27 @@ use super::request::{self, Auth};
 use super::tenants::TenantsClient;
 use crate::ddns::provider::DnsProvider;
 
-/// A client for a region's ddns service at `base_url`.
+/// Gateway path-routing prefix: the first path segment selecting the ddns
+/// service. Prepended once, in [`DdnsClient::send`], so every call is prefixed
+/// (and therefore `PoP`-signed) structurally rather than per literal.
+const SERVICE_PREFIX: &str = "/ddns";
+
+/// A client for a region's ddns service behind the regional gateway at
+/// `base_url`.
 pub struct DdnsClient {
     http: reqwest::Client,
     base_url: String,
 }
 
 impl DdnsClient {
-    /// Build a client sharing the pooled `http` and pointed at the region's ddns
-    /// `base_url` (e.g. `https://ddns.svc.prd.use1.wardnet.network`).
+    /// Build a client sharing the pooled `http` and pointed at the region's
+    /// gateway `base_url` (e.g. `https://api.use1.wardnet.network`).
     #[must_use]
     pub fn new(http: reqwest::Client, base_url: String) -> Self {
         Self { http, base_url }
     }
 
-    /// Publish the network's public **A** record (`PUT /v1/ip`).
+    /// Publish the network's public **A** record (`PUT /ddns/v1/ip`).
     pub async fn report_ip(
         &self,
         identity: &DaemonIdentity,
@@ -50,7 +59,7 @@ impl DdnsClient {
         request::ok(resp).await.map(drop)
     }
 
-    /// Publish the `_acme-challenge` TXT value(s) (`PUT /v1/acme-challenge`).
+    /// Publish the `_acme-challenge` TXT value(s) (`PUT /ddns/v1/acme-challenge`).
     pub async fn set_acme_challenge(
         &self,
         identity: &DaemonIdentity,
@@ -62,18 +71,17 @@ impl DdnsClient {
         request::ok(resp).await.map(drop)
     }
 
-    /// Remove the `_acme-challenge` TXT records (`DELETE /v1/acme-challenge`).
+    /// Remove the `_acme-challenge` TXT records (`DELETE /ddns/v1/acme-challenge`).
     /// Idempotent.
     pub async fn clear_acme_challenge(&self, identity: &DaemonIdentity) -> Result<(), CloudError> {
-        let resp = request::send(
-            &self.http,
-            &self.base_url,
-            Auth::Full(identity),
-            reqwest::Method::DELETE,
-            "/v1/acme-challenge",
-            None,
-        )
-        .await?;
+        let resp = self
+            .send(
+                reqwest::Method::DELETE,
+                "/v1/acme-challenge",
+                identity,
+                None,
+            )
+            .await?;
         request::ok(resp).await.map(drop)
     }
 
@@ -83,12 +91,28 @@ impl DdnsClient {
         identity: &DaemonIdentity,
         body: Option<Vec<u8>>,
     ) -> Result<reqwest::Response, CloudError> {
+        self.send(reqwest::Method::PUT, path, identity, body).await
+    }
+
+    /// Send `{SERVICE_PREFIX}{path_and_query}` — the single funnel every ddns
+    /// call goes through, so a new endpoint cannot forget the gateway prefix
+    /// (a valid signature over an un-prefixed path would misroute at the
+    /// gateway). The prefixed string is built once and passed whole to
+    /// [`request::send`], preserving its "sign exactly what you send"
+    /// invariant.
+    async fn send(
+        &self,
+        method: reqwest::Method,
+        path_and_query: &str,
+        identity: &DaemonIdentity,
+        body: Option<Vec<u8>>,
+    ) -> Result<reqwest::Response, CloudError> {
         request::send(
             &self.http,
             &self.base_url,
             Auth::Full(identity),
-            reqwest::Method::PUT,
-            path,
+            method,
+            &format!("{SERVICE_PREFIX}{path_and_query}"),
             body,
         )
         .await

--- a/source/daemon/crates/wardnetd-services/src/cloud/mod.rs
+++ b/source/daemon/crates/wardnetd-services/src/cloud/mod.rs
@@ -2,10 +2,14 @@
 //!
 //! wardnet-cloud is a service mesh — `tenants` (global identity/account
 //! authority), `ddns` and `tunneller` (regional), with `billing`/`subscriptions`
-//! internal to `tenants`. The daemon consumes `tenants` and `ddns`; each gets its
-//! **own** client with an **independently configured endpoint** so the current
-//! co-location (and any future split onto separate hosts) is a config change, not
-//! a code change.
+//! internal to `tenants`. Daemons reach it through per-scope north-south
+//! **gateways** (cloud ADR-0014 / inforge ADR-0032): the global gateway fronts
+//! `tenants`, each region's gateway fronts that region's `ddns` + `tunneller`,
+//! and the target service is the **first path segment** (`/tenants/v1/…`,
+//! `/ddns/v1/…`). The gateway is path-preserving, so the `PoP` signature covers
+//! that same prefixed path. The daemon consumes `tenants` and `ddns`; each gets
+//! its **own** client with an **independently configured gateway base URL**, so
+//! a topology change stays a config change, not a code change.
 //!
 //! Shared concerns live here:
 //!

--- a/source/daemon/crates/wardnetd-services/src/cloud/pop.rs
+++ b/source/daemon/crates/wardnetd-services/src/cloud/pop.rs
@@ -12,6 +12,12 @@
 //! `"<METHOD>\n<path_and_query>\n<timestamp>\n<hex-sha256(body)>"`. The two repos
 //! are separate workspaces, so [`tests`](super::tests) pins this format by
 //! constructing a signature and verifying its bytes.
+//!
+//! `path_and_query` is the **full gateway-facing path including the
+//! `/<service>/` prefix and any query string** (e.g. `/ddns/v1/ip`): the
+//! gateway is path-preserving and the cloud verifies against the original,
+//! un-stripped request URI (`OriginalUri`), so a signature over an un-prefixed
+//! path is rejected with `401`.
 
 use base64::Engine as _;
 use ed25519_dalek::{Signer, SigningKey};

--- a/source/daemon/crates/wardnetd-services/src/cloud/request.rs
+++ b/source/daemon/crates/wardnetd-services/src/cloud/request.rs
@@ -29,7 +29,11 @@ pub(crate) enum Auth<'a> {
 ///
 /// `path_and_query` is used **verbatim** both for the URL and for the signed
 /// payload, so callers must pre-encode any query string (our slugs/ids are
-/// already `[a-z0-9-]`). Returns the raw response; use [`ok`] to classify status.
+/// already `[a-z0-9-]`) and must pass the **full gateway-facing path including
+/// the `/<service>/` prefix** — the cloud verifies the `PoP` over the original,
+/// un-stripped URI, and this single-argument design is what makes "sign exactly
+/// what you send" structural. Returns the raw response; use [`ok`] to classify
+/// status.
 pub(crate) async fn send(
     http: &reqwest::Client,
     base_url: &str,

--- a/source/daemon/crates/wardnetd-services/src/cloud/tenants.rs
+++ b/source/daemon/crates/wardnetd-services/src/cloud/tenants.rs
@@ -5,8 +5,12 @@
 //! the network plane (slug availability, network registration, per-daemon
 //! removal). Account/SPA/OAuth endpoints are not the daemon's concern.
 //!
-//! tenants is **global** (one deployment), so its base URL is a single constant,
-//! unlike the per-region [`DdnsClient`](super::ddns::DdnsClient).
+//! tenants is **global** (one deployment) behind the global north-south
+//! **gateway** (cloud ADR-0014 / inforge ADR-0032), so its base URL is a single
+//! constant, unlike the per-region [`DdnsClient`](super::ddns::DdnsClient). The
+//! gateway routes by the first path segment, so every path here carries the
+//! `/tenants/` prefix — and, because the gateway is path-preserving, that full
+//! prefixed path is exactly what the cloud verifies the `PoP` signature against.
 
 use serde::{Deserialize, Serialize};
 
@@ -14,10 +18,14 @@ use super::CloudError;
 use super::identity::DaemonIdentity;
 use super::request::{self, Auth};
 
-/// Code-request endpoint. Targets the converged `POST /v1/verification-codes`
-/// resource from wardnet-cloud #20, which supersedes `POST /v1/enrollment-codes`
-/// (today's live path). Kept as a single constant so the coordinated switch is a
-/// one-line change; the daemon release lands with #20.
+/// Gateway path-routing prefix: the first path segment selecting the tenants
+/// service. Prepended once, in [`TenantsClient::send`], so every call is
+/// prefixed (and therefore `PoP`-signed) structurally rather than per literal.
+const SERVICE_PREFIX: &str = "/tenants";
+
+/// Code-request endpoint: the converged `POST /v1/verification-codes` resource
+/// from wardnet-cloud #20 (supersedes `POST /v1/enrollment-codes`). Kept as a
+/// single constant so a path change stays one line.
 const ENROLLMENT_CODE_PATH: &str = "/v1/verification-codes";
 /// The `purpose` discriminator bound into the requested code (prevents a code
 /// issued for enrollment being spent on signup/reset).
@@ -45,10 +53,35 @@ pub struct TenantsClient {
 
 impl TenantsClient {
     /// Build a client sharing the pooled `http` and pointed at `base_url`
-    /// (production: the global `account.wardnet.network`; tests: a wiremock URL).
+    /// (production: the global gateway `api.wardnet.network`; tests: a wiremock
+    /// URL).
     #[must_use]
     pub fn new(http: reqwest::Client, base_url: String) -> Self {
         Self { http, base_url }
+    }
+
+    /// Send `{SERVICE_PREFIX}{path_and_query}` — the single funnel every
+    /// tenants call goes through, so a new endpoint cannot forget the gateway
+    /// prefix (a valid signature over an un-prefixed path would misroute at
+    /// the gateway). The prefixed string is built once and passed whole to
+    /// [`request::send`], preserving its "sign exactly what you send"
+    /// invariant.
+    async fn send(
+        &self,
+        auth: Auth<'_>,
+        method: reqwest::Method,
+        path_and_query: &str,
+        body: Option<Vec<u8>>,
+    ) -> Result<reqwest::Response, CloudError> {
+        request::send(
+            &self.http,
+            &self.base_url,
+            auth,
+            method,
+            &format!("{SERVICE_PREFIX}{path_and_query}"),
+            body,
+        )
+        .await
     }
 
     // ── bootstrap plane (no JWT) ────────────────────────────────────────────
@@ -61,15 +94,14 @@ impl TenantsClient {
             purpose: ENROLLMENT_CODE_PURPOSE,
         })
         .map_err(|e| CloudError::Upstream(e.into()))?;
-        let resp = request::send(
-            &self.http,
-            &self.base_url,
-            Auth::Public,
-            reqwest::Method::POST,
-            ENROLLMENT_CODE_PATH,
-            Some(body),
-        )
-        .await?;
+        let resp = self
+            .send(
+                Auth::Public,
+                reqwest::Method::POST,
+                ENROLLMENT_CODE_PATH,
+                Some(body),
+            )
+            .await?;
         request::ok(resp).await.map(drop)
     }
 
@@ -81,15 +113,14 @@ impl TenantsClient {
             public_key: public_key_b64,
         })
         .map_err(|e| CloudError::Upstream(e.into()))?;
-        let resp = request::send(
-            &self.http,
-            &self.base_url,
-            Auth::Public,
-            reqwest::Method::POST,
-            "/v1/enroll",
-            Some(body),
-        )
-        .await?;
+        let resp = self
+            .send(
+                Auth::Public,
+                reqwest::Method::POST,
+                "/v1/enroll",
+                Some(body),
+            )
+            .await?;
         let parsed: EnrollResponse = request::json(request::ok(resp).await?).await?;
         Ok(parsed.tenant_id)
     }
@@ -106,15 +137,14 @@ impl TenantsClient {
             public_key: identity.public_key_b64(),
         })
         .map_err(|e| CloudError::Upstream(e.into()))?;
-        let resp = request::send(
-            &self.http,
-            &self.base_url,
-            Auth::Pop(identity),
-            reqwest::Method::POST,
-            "/v1/token",
-            Some(body),
-        )
-        .await?;
+        let resp = self
+            .send(
+                Auth::Pop(identity),
+                reqwest::Method::POST,
+                "/v1/token",
+                Some(body),
+            )
+            .await?;
         if request::is(&resp, reqwest::StatusCode::FORBIDDEN) {
             identity.mark_unentitled();
             return Err(CloudError::EntitlementLost);
@@ -137,15 +167,14 @@ impl TenantsClient {
         identity: &DaemonIdentity,
         slug: &str,
     ) -> Result<bool, CloudError> {
-        let resp = request::send(
-            &self.http,
-            &self.base_url,
-            Auth::Full(identity),
-            reqwest::Method::GET,
-            &format!("/v1/availability?slug={slug}"),
-            None,
-        )
-        .await?;
+        let resp = self
+            .send(
+                Auth::Full(identity),
+                reqwest::Method::GET,
+                &format!("/v1/availability?slug={slug}"),
+                None,
+            )
+            .await?;
         let parsed: AvailabilityResponse = request::json(request::ok(resp).await?).await?;
         Ok(parsed.available)
     }
@@ -166,15 +195,14 @@ impl TenantsClient {
             region,
         })
         .map_err(|e| CloudError::Upstream(e.into()))?;
-        let resp = request::send(
-            &self.http,
-            &self.base_url,
-            Auth::Full(identity),
-            reqwest::Method::POST,
-            "/v1/networks",
-            Some(body),
-        )
-        .await?;
+        let resp = self
+            .send(
+                Auth::Full(identity),
+                reqwest::Method::POST,
+                "/v1/networks",
+                Some(body),
+            )
+            .await?;
         let view: NetworkView = request::json(request::ok(resp).await?).await?;
         Ok(NetworkRegistration {
             network_id: view.id,
@@ -194,15 +222,14 @@ impl TenantsClient {
         identity: &DaemonIdentity,
         network_id: &str,
     ) -> Result<(), CloudError> {
-        let resp = request::send(
-            &self.http,
-            &self.base_url,
-            Auth::Full(identity),
-            reqwest::Method::DELETE,
-            &format!("/v1/networks/{network_id}/daemons/self"),
-            None,
-        )
-        .await?;
+        let resp = self
+            .send(
+                Auth::Full(identity),
+                reqwest::Method::DELETE,
+                &format!("/v1/networks/{network_id}/daemons/self"),
+                None,
+            )
+            .await?;
         request::ok(resp).await.map(drop)
     }
 }

--- a/source/daemon/crates/wardnetd-services/src/cloud/tests.rs
+++ b/source/daemon/crates/wardnetd-services/src/cloud/tests.rs
@@ -40,14 +40,16 @@ fn pop_canonical_payload_is_stable_and_verifies() {
     let timestamp = 1_700_000_000i64;
     let body = br#"{"ip":"203.0.113.5"}"#;
 
-    let payload = pop::canonical_payload("PUT", "/v1/ip", timestamp, body);
+    // The signed path is the full gateway-facing path, `/<service>/` prefix
+    // included — the cloud verifies against the un-stripped `OriginalUri`.
+    let payload = pop::canonical_payload("PUT", "/ddns/v1/ip", timestamp, body);
     let expected = format!(
-        "PUT\n/v1/ip\n{timestamp}\n{}",
+        "PUT\n/ddns/v1/ip\n{timestamp}\n{}",
         hex::encode(Sha256::digest(body))
     );
     assert_eq!(payload, expected, "canonical payload format must not drift");
 
-    let signature_b64 = pop::sign(&key, "PUT", "/v1/ip", timestamp, body);
+    let signature_b64 = pop::sign(&key, "PUT", "/ddns/v1/ip", timestamp, body);
     let signature_bytes = base64::engine::general_purpose::STANDARD
         .decode(signature_b64)
         .expect("standard base64");
@@ -58,13 +60,29 @@ fn pop_canonical_payload_is_stable_and_verifies() {
 
     // Cross-check the signer matches a hand-rolled signature over the same bytes.
     assert_eq!(signature, key.sign(expected.as_bytes()));
+
+    // The query string participates in the signed path: the cloud verifies the
+    // full `OriginalUri` including `?…`, so a payload that drops the query must
+    // not equal one that carries it.
+    let with_query =
+        pop::canonical_payload("GET", "/tenants/v1/availability?slug=alice", timestamp, b"");
+    let expected_with_query = format!(
+        "GET\n/tenants/v1/availability?slug=alice\n{timestamp}\n{}",
+        hex::encode(Sha256::digest(b""))
+    );
+    assert_eq!(with_query, expected_with_query);
+    assert_ne!(
+        with_query,
+        pop::canonical_payload("GET", "/tenants/v1/availability", timestamp, b""),
+        "dropping the query string must change the signed payload"
+    );
 }
 
 #[tokio::test]
 async fn request_enrollment_code_posts_email_and_purpose() {
     let server = MockServer::start().await;
     Mock::given(method("POST"))
-        .and(path("/v1/verification-codes"))
+        .and(path("/tenants/v1/verification-codes"))
         .and(body_json(
             json!({ "email": "a@b.com", "purpose": "enrollment" }),
         ))
@@ -81,7 +99,7 @@ async fn request_enrollment_code_posts_email_and_purpose() {
 async fn enroll_returns_tenant_id() {
     let server = MockServer::start().await;
     Mock::given(method("POST"))
-        .and(path("/v1/enroll"))
+        .and(path("/tenants/v1/enroll"))
         .and(body_json(json!({ "code": "ABC123", "public_key": "pk" })))
         .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "tenant_id": "t-1" })))
         .mount(&server)
@@ -95,7 +113,7 @@ async fn enroll_returns_tenant_id() {
 async fn mint_token_403_flags_entitlement_lost() {
     let server = MockServer::start().await;
     Mock::given(method("POST"))
-        .and(path("/v1/token"))
+        .and(path("/tenants/v1/token"))
         .and(header_exists(pop::SIGNATURE_HEADER))
         .respond_with(ResponseTemplate::new(403).set_body_string("subscription is not active"))
         .mount(&server)
@@ -115,7 +133,7 @@ async fn token_is_cached_and_minted_once() {
     let server = MockServer::start().await;
     let exp = chrono::Utc::now().timestamp() + 3600;
     Mock::given(method("POST"))
-        .and(path("/v1/token"))
+        .and(path("/tenants/v1/token"))
         .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "token": fake_jwt(exp) })))
         .expect(1) // second call must hit the cache, not the server
         .mount(&server)
@@ -133,12 +151,12 @@ async fn availability_sends_jwt_and_pop() {
     let server = MockServer::start().await;
     let exp = chrono::Utc::now().timestamp() + 3600;
     Mock::given(method("POST"))
-        .and(path("/v1/token"))
+        .and(path("/tenants/v1/token"))
         .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "token": fake_jwt(exp) })))
         .mount(&server)
         .await;
     Mock::given(method("GET"))
-        .and(path("/v1/availability"))
+        .and(path("/tenants/v1/availability"))
         .and(query_param("slug", "alice"))
         .and(header_exists("authorization"))
         .and(header_exists(pop::SIGNATURE_HEADER))
@@ -160,12 +178,12 @@ async fn register_network_maps_view() {
     let server = MockServer::start().await;
     let exp = chrono::Utc::now().timestamp() + 3600;
     Mock::given(method("POST"))
-        .and(path("/v1/token"))
+        .and(path("/tenants/v1/token"))
         .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "token": fake_jwt(exp) })))
         .mount(&server)
         .await;
     Mock::given(method("POST"))
-        .and(path("/v1/networks"))
+        .and(path("/tenants/v1/networks"))
         .and(body_json(json!({ "slug": "alice", "region": "use1" })))
         .respond_with(ResponseTemplate::new(200).set_body_json(json!({
             "id": "n-1",
@@ -195,19 +213,19 @@ async fn ddns_report_ip_and_clear_acme() {
     let server = MockServer::start().await;
     let exp = chrono::Utc::now().timestamp() + 3600;
     Mock::given(method("POST"))
-        .and(path("/v1/token"))
+        .and(path("/tenants/v1/token"))
         .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "token": fake_jwt(exp) })))
         .mount(&server)
         .await;
     Mock::given(method("PUT"))
-        .and(path("/v1/ip"))
+        .and(path("/ddns/v1/ip"))
         .and(body_json(json!({ "ip": "203.0.113.7" })))
         .and(header_exists(pop::SIGNATURE_HEADER))
         .respond_with(ResponseTemplate::new(204))
         .mount(&server)
         .await;
     Mock::given(method("DELETE"))
-        .and(path("/v1/acme-challenge"))
+        .and(path("/ddns/v1/acme-challenge"))
         .respond_with(ResponseTemplate::new(204))
         .mount(&server)
         .await;

--- a/source/daemon/crates/wardnetd-services/src/ddns/mod.rs
+++ b/source/daemon/crates/wardnetd-services/src/ddns/mod.rs
@@ -195,10 +195,11 @@ pub trait DdnsService: Send + Sync {
 
 /// Tunable base URLs, overridable in tests to point at wiremock servers.
 pub(crate) struct DdnsSettings {
-    /// Per-region `ddns` catalog (control + health URLs), probed for selection.
+    /// Per-region gateway catalog (control + health URLs), probed for selection.
     region_catalog: Vec<RegionEndpoint>,
-    /// Global `tenants` service base URL (enroll / token / availability / networks).
-    tenants_base_url: String,
+    /// Global gateway base URL — fronts `tenants` (enroll / token / availability
+    /// / networks under `/tenants/v1/…`).
+    global_gateway_url: String,
     /// Public-IP echo endpoints, tried in order.
     echo_endpoints: Vec<String>,
     /// Cloudflare API base URL.
@@ -211,7 +212,7 @@ impl Default for DdnsSettings {
     fn default() -> Self {
         Self {
             region_catalog: region::default_catalog(),
-            tenants_base_url: region::TENANTS_BASE_URL.to_owned(),
+            global_gateway_url: region::GLOBAL_GATEWAY_URL.to_owned(),
             echo_endpoints: public_ip::ECHO_ENDPOINTS
                 .iter()
                 .map(|s| (*s).to_owned())
@@ -305,9 +306,9 @@ impl DdnsServiceImpl {
             Some(PROVIDER_WARDNET) => {
                 let network_id = self.require_cfg(KEY_NETWORK_ID).await?;
                 let region = self.require_cfg(KEY_REGION).await?;
-                let ddns_base = self.ddns_base_for_region(&region)?;
+                let gateway_base = self.gateway_base_for_region(&region)?;
                 let (tenants, identity) = self.build_identity().await?;
-                let ddns = DdnsClient::new(self.http.clone(), ddns_base);
+                let ddns = DdnsClient::new(self.http.clone(), gateway_base);
                 Ok(Some(Box::new(WardnetDnsProvider::new(
                     ddns, tenants, identity, network_id,
                 ))))
@@ -340,7 +341,7 @@ impl DdnsServiceImpl {
     fn tenants_client(&self) -> Arc<TenantsClient> {
         Arc::new(TenantsClient::new(
             self.http.clone(),
-            self.settings.tenants_base_url.clone(),
+            self.settings.global_gateway_url.clone(),
         ))
     }
 
@@ -365,13 +366,13 @@ impl DdnsServiceImpl {
         Ok((tenants, identity))
     }
 
-    /// Resolve a region slug to its `ddns` control base URL from the catalog.
-    fn ddns_base_for_region(&self, slug: &str) -> Result<String, AppError> {
+    /// Resolve a region slug to its gateway base URL from the catalog.
+    fn gateway_base_for_region(&self, slug: &str) -> Result<String, AppError> {
         self.settings
             .region_catalog
             .iter()
             .find(|e| e.slug == slug)
-            .map(|e| e.ddns_base_url.clone())
+            .map(|e| e.gateway_base_url.clone())
             .ok_or_else(|| AppError::Internal(anyhow::anyhow!("unknown DDNS region slug '{slug}'")))
     }
 
@@ -505,7 +506,7 @@ impl DdnsServiceImpl {
 /// Whether `slug` is a syntactically valid vanity slug.
 ///
 /// **Security boundary:** the slug is interpolated into the tenants request URL
-/// (`/v1/availability?slug={slug}`) and signed as part of the `PoP`
+/// (`/tenants/v1/availability?slug={slug}`) and signed as part of the `PoP`
 /// `path_and_query`, so it must be validated **before** building that URL — an
 /// unchecked `/`, `?`, `.` or whitespace would let an admin reshape the request
 /// path. The cloud enforces the authoritative rules (incl. the reserved-name

--- a/source/daemon/crates/wardnetd-services/src/ddns/region.rs
+++ b/source/daemon/crates/wardnetd-services/src/ddns/region.rs
@@ -1,53 +1,58 @@
 //! The built-in **region catalog**, latency-based selection, and the global
-//! **tenants** endpoint.
+//! **gateway** endpoint.
 //!
-//! wardnet-cloud is split into a global `tenants` service (one deployment) and
-//! per-region `ddns` services. The daemon must already know a region's address to
-//! reach it, so the catalog ships in the daemon: a **region slug** mapped to that
-//! region's `ddns` control endpoint. At registration the daemon probes every
-//! known region's health endpoint and registers against the lowest-latency one,
-//! passing that slug as the network's `region`.
+//! wardnet-cloud sits behind per-scope north-south **gateways** (cloud ADR-0014 /
+//! inforge ADR-0032): one public edge per scope that daemons HTTPS into, with the
+//! target service selected by the **first path segment** (`/tenants/…`, `/ddns/…`,
+//! `/tunneller/…`). The global scope's gateway fronts `tenants`; each region's
+//! gateway fronts that region's `ddns` + `tunneller`. The daemon must already
+//! know a region's address to reach it, so the catalog ships in the daemon: a
+//! **region slug** mapped to that region's gateway. At registration the daemon
+//! probes every known region's health endpoint and registers against the
+//! lowest-latency one, passing that slug as the network's `region`.
 //!
 //! Two endpoints per region matter:
-//! * **control** (`https://ddns.svc.<region>…:443`) — TLS-terminated by the edge
-//!   ingress for the `ddns.svc` SNI; the daemon dials the FQDN directly so SNI is
-//!   the hostname automatically.
-//! * **health** (`http://ddns.svc.<region>…:81/v1/health`) — the edge ingress
-//!   exposes health on plain-HTTP `:81`, Host-demuxed by service FQDN.
+//! * **control** (`https://api.<region-slug>…:443`) — the regional gateway; TLS
+//!   is a normal public cert, requests are path-routed to the service.
+//! * **health** (`http://api.<region-slug>…:81/ddns/v1/health`) — the gateway
+//!   host exposes health on plain-HTTP `:81`.
 //!
-//! The `tenants` endpoint is **global**, so it is a single constant rather than a
-//! per-region catalog entry.
+//! The global gateway (`tenants`) is scope-wide, so it is a single constant
+//! rather than a per-region catalog entry.
 //!
 //! Today only `use1` exists, but the probe-and-pick mechanism is built in from
 //! the start so adding a region is a one-line catalog change.
 
 use std::time::{Duration, Instant};
 
-/// The global **tenants** service base URL (enroll / token / availability /
-/// networks). One deployment, region-independent.
+/// The **global gateway** base URL — the north-south edge fronting the global
+/// `tenants` service (enroll / token / availability / networks under
+/// `/tenants/v1/…`). One deployment, region-independent.
 ///
-/// FIXME(infra): confirm the daemon-facing tenants FQDN. This is the tenants
-/// ingress public vanity (`account.{BASE_DOMAIN}`); infra still marks it FIXME.
-pub const TENANTS_BASE_URL: &str = "https://account.wardnet.network";
+/// FIXME(infra): confirm the daemon-facing gateway FQDN once the gateway
+/// manifest lands in wardnet-infrastructure; ADR-0032's shape is
+/// `api.<slug>.<base>` with the global scope dropping the slug.
+pub const GLOBAL_GATEWAY_URL: &str = "https://api.wardnet.network";
 
 /// One entry in the built-in region catalog.
 #[derive(Debug, Clone)]
 pub struct RegionEndpoint {
     /// Short region slug, e.g. `use1`. Selects the region and is passed to
-    /// `POST /v1/networks` as `region`.
+    /// `POST /tenants/v1/networks` as `region`.
     pub slug: String,
-    /// `ddns` control base URL for this region (`https://ddns.svc.<region>…`).
-    pub ddns_base_url: String,
-    /// `ddns` health-probe URL for region selection
-    /// (`http://ddns.svc.<region>…:81/v1/health`, plain HTTP).
+    /// The region's **gateway** base URL (`https://api.<region-slug>…`) — fronts
+    /// the regional `ddns` and `tunneller` services by path prefix.
+    pub gateway_base_url: String,
+    /// Health-probe URL for region selection
+    /// (`http://api.<region-slug>…:81/ddns/v1/health`, plain HTTP).
     pub health_url: String,
 }
 
 impl RegionEndpoint {
-    fn new(slug: &str, ddns_base_url: &str, health_url: &str) -> Self {
+    fn new(slug: &str, gateway_base_url: &str, health_url: &str) -> Self {
         Self {
             slug: slug.to_owned(),
-            ddns_base_url: ddns_base_url.to_owned(),
+            gateway_base_url: gateway_base_url.to_owned(),
             health_url: health_url.to_owned(),
         }
     }
@@ -55,15 +60,15 @@ impl RegionEndpoint {
 
 /// The built-in catalog. Extend this to add regions.
 ///
-/// FIXME(infra): confirm the derived `.svc` FQDN format/segment order against
-/// inforge's record derivation (env `prd`, region slug `use1`). Kept as data here
-/// so confirming it is a one-line change.
+/// FIXME(infra): confirm the regional gateway FQDN against the gateway manifest
+/// once it lands in wardnet-infrastructure (ADR-0032 shape `api.<slug>.<base>`,
+/// region slug `use1`). Kept as data here so confirming it is a one-line change.
 #[must_use]
 pub fn default_catalog() -> Vec<RegionEndpoint> {
     vec![RegionEndpoint::new(
         "use1",
-        "https://ddns.svc.prd.use1.wardnet.network",
-        "http://ddns.svc.prd.use1.wardnet.network:81/v1/health",
+        "https://api.use1.wardnet.network",
+        "http://api.use1.wardnet.network:81/ddns/v1/health",
     )]
 }
 
@@ -71,8 +76,9 @@ pub fn default_catalog() -> Vec<RegionEndpoint> {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SelectedRegion {
     pub slug: String,
-    /// The region's `ddns` control base URL (steady-state report-IP / ACME).
-    pub ddns_base_url: String,
+    /// The region's gateway base URL (steady-state report-IP / ACME via
+    /// `/ddns/v1/…`).
+    pub gateway_base_url: String,
 }
 
 /// Probe every entry's health endpoint and return the lowest-latency reachable
@@ -122,7 +128,7 @@ pub(crate) async fn select_best(
                 elapsed,
                 SelectedRegion {
                     slug: entry.slug,
-                    ddns_base_url: entry.ddns_base_url,
+                    gateway_base_url: entry.gateway_base_url,
                 },
             ));
         }

--- a/source/daemon/crates/wardnetd-services/src/ddns/tests/region.rs
+++ b/source/daemon/crates/wardnetd-services/src/ddns/tests/region.rs
@@ -1,8 +1,8 @@
 //! Region selection tests: lowest-latency reachable region wins; unhealthy
 //! endpoints are skipped; all-unreachable is an error.
 //!
-//! Each region's `health_url` points at its wiremock server's `/v1/health`,
-//! while `ddns_base_url` is the server root — mirroring the production split
+//! Each region's `health_url` points at its wiremock server's `/ddns/v1/health`,
+//! while `gateway_base_url` is the server root — mirroring the production split
 //! between the plain-HTTP `:81` health probe and the `:443` control base.
 
 use std::time::Duration;
@@ -19,19 +19,19 @@ async fn health_server(delay: Option<Duration>, status: u16) -> MockServer {
         template = template.set_delay(delay);
     }
     Mock::given(method("GET"))
-        .and(path("/v1/health"))
+        .and(path("/ddns/v1/health"))
         .respond_with(template)
         .mount(&server)
         .await;
     server
 }
 
-/// A catalog entry whose health probe targets `server`'s `/v1/health`.
+/// A catalog entry whose health probe targets `server`'s `/ddns/v1/health`.
 fn entry(slug: &str, server: &MockServer) -> RegionEndpoint {
     RegionEndpoint {
         slug: slug.to_owned(),
-        ddns_base_url: server.uri(),
-        health_url: format!("{}/v1/health", server.uri()),
+        gateway_base_url: server.uri(),
+        health_url: format!("{}/ddns/v1/health", server.uri()),
     }
 }
 
@@ -45,7 +45,7 @@ async fn picks_lowest_latency() {
         .await
         .unwrap();
     assert_eq!(chosen.slug, "fast");
-    assert_eq!(chosen.ddns_base_url, fast.uri());
+    assert_eq!(chosen.gateway_base_url, fast.uri());
 }
 
 #[tokio::test]

--- a/source/daemon/crates/wardnetd-services/src/ddns/tests/service.rs
+++ b/source/daemon/crates/wardnetd-services/src/ddns/tests/service.rs
@@ -4,7 +4,7 @@
 //! exercised end to end.
 //!
 //! Every JWT + `PoP` call first mints a token via the tenants server's
-//! `POST /v1/token`; the [`mount_token`] helper answers it with a JWT-shaped
+//! `POST /tenants/v1/token`; the [`mount_token`] helper answers it with a JWT-shaped
 //! body (see `crate::cloud::tests` for the canonical pattern).
 
 use std::collections::HashMap;
@@ -114,12 +114,12 @@ fn fake_jwt(exp: i64) -> String {
     format!("header.{payload}.sig")
 }
 
-/// Mount `POST /v1/token` on a tenants server, answering with a fresh,
+/// Mount `POST /tenants/v1/token` on a tenants server, answering with a fresh,
 /// far-from-expiry JWT. Required by every JWT + `PoP` call the service makes.
 async fn mount_token(server: &MockServer) {
     let exp = chrono::Utc::now().timestamp() + 3600;
     Mock::given(method("POST"))
-        .and(path("/v1/token"))
+        .and(path("/tenants/v1/token"))
         .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "token": fake_jwt(exp) })))
         .mount(server)
         .await;
@@ -135,7 +135,7 @@ fn settings(
 ) -> DdnsSettings {
     DdnsSettings {
         region_catalog,
-        tenants_base_url: tenants_url,
+        global_gateway_url: tenants_url,
         echo_endpoints: echo,
         cf_base_url: String::new(),
         doh_resolvers: vec![],
@@ -146,8 +146,8 @@ fn settings(
 fn region_catalog(slug: &str, ddns: &MockServer) -> Vec<RegionEndpoint> {
     vec![RegionEndpoint {
         slug: slug.to_owned(),
-        ddns_base_url: ddns.uri(),
-        health_url: format!("{}/v1/health", ddns.uri()),
+        gateway_base_url: ddns.uri(),
+        health_url: format!("{}/ddns/v1/health", ddns.uri()),
     }]
 }
 
@@ -243,7 +243,7 @@ async fn request_enrollment_code_requires_admin() {
 async fn request_enrollment_code_posts_email_and_purpose() {
     let tenants = MockServer::start().await;
     Mock::given(method("POST"))
-        .and(path("/v1/verification-codes"))
+        .and(path("/tenants/v1/verification-codes"))
         .and(body_json(
             json!({ "email": "a@b.com", "purpose": "enrollment" }),
         ))
@@ -284,7 +284,7 @@ async fn request_enrollment_code_rejects_invalid_email_locally() {
 async fn enroll_persists_key_and_tenant_id() {
     let tenants = MockServer::start().await;
     Mock::given(method("POST"))
-        .and(path("/v1/enroll"))
+        .and(path("/tenants/v1/enroll"))
         .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "tenant_id": "t-1" })))
         .expect(1)
         .mount(&tenants)
@@ -335,7 +335,7 @@ async fn check_slug_returns_available() {
     let tenants = MockServer::start().await;
     mount_token(&tenants).await;
     Mock::given(method("GET"))
-        .and(path("/v1/availability"))
+        .and(path("/tenants/v1/availability"))
         .and(query_param("slug", "alice"))
         .and(header_exists("authorization"))
         .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "available": true })))
@@ -361,7 +361,7 @@ async fn check_slug_returns_taken() {
     let tenants = MockServer::start().await;
     mount_token(&tenants).await;
     Mock::given(method("GET"))
-        .and(path("/v1/availability"))
+        .and(path("/tenants/v1/availability"))
         .and(query_param("slug", "taken"))
         .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "available": false })))
         .mount(&tenants)
@@ -417,7 +417,7 @@ async fn register_network_persists_wardnet_provider() {
     let tenants = MockServer::start().await;
     mount_token(&tenants).await;
     Mock::given(method("POST"))
-        .and(path("/v1/networks"))
+        .and(path("/tenants/v1/networks"))
         .and(body_json(json!({ "slug": "alice", "region": "use1" })))
         .and(header_exists("authorization"))
         .respond_with(ResponseTemplate::new(200).set_body_json(json!({
@@ -437,7 +437,7 @@ async fn register_network_persists_wardnet_provider() {
     // The region health probe (`select_best`) must see a reachable region.
     let ddns = MockServer::start().await;
     Mock::given(method("GET"))
-        .and(path("/v1/health"))
+        .and(path("/ddns/v1/health"))
         .respond_with(ResponseTemplate::new(200))
         .mount(&ddns)
         .await;
@@ -504,7 +504,7 @@ async fn refresh_skips_when_ip_unchanged() {
     let tenants = MockServer::start().await;
     let ddns = MockServer::start().await;
     Mock::given(method("PUT"))
-        .and(path("/v1/ip"))
+        .and(path("/ddns/v1/ip"))
         .respond_with(ResponseTemplate::new(204))
         .expect(0) // must NOT be called when the IP is unchanged
         .mount(&ddns)
@@ -538,7 +538,7 @@ async fn refresh_publishes_when_ip_changed() {
     mount_token(&tenants).await;
     let ddns = MockServer::start().await;
     Mock::given(method("PUT"))
-        .and(path("/v1/ip"))
+        .and(path("/ddns/v1/ip"))
         .and(body_json(json!({ "ip": "9.9.9.9" })))
         .and(header_exists("authorization"))
         .respond_with(ResponseTemplate::new(204))
@@ -618,7 +618,7 @@ async fn set_acme_challenge_publishes_txt_via_ddns() {
     mount_token(&tenants).await;
     let ddns = MockServer::start().await;
     Mock::given(method("PUT"))
-        .and(path("/v1/acme-challenge"))
+        .and(path("/ddns/v1/acme-challenge"))
         .and(body_json(
             json!({ "values": ["apex-value", "wildcard-value"] }),
         ))
@@ -652,7 +652,7 @@ async fn clear_acme_challenge_deletes_txt_via_ddns() {
     mount_token(&tenants).await;
     let ddns = MockServer::start().await;
     Mock::given(method("DELETE"))
-        .and(path("/v1/acme-challenge"))
+        .and(path("/ddns/v1/acme-challenge"))
         .respond_with(ResponseTemplate::new(204))
         .expect(1)
         .mount(&ddns)
@@ -682,7 +682,7 @@ async fn token_403_surfaces_as_forbidden() {
     // the wizard can drive the Suspended state, not a generic outage.
     let tenants = MockServer::start().await;
     Mock::given(method("POST"))
-        .and(path("/v1/token"))
+        .and(path("/tenants/v1/token"))
         .respond_with(ResponseTemplate::new(403).set_body_string("subscription is not active"))
         .mount(&tenants)
         .await;
@@ -726,7 +726,7 @@ async fn cf_zones_server() -> MockServer {
 fn cloudflare_settings(cf: &MockServer) -> DdnsSettings {
     DdnsSettings {
         region_catalog: vec![],
-        tenants_base_url: String::new(),
+        global_gateway_url: String::new(),
         echo_endpoints: vec![],
         cf_base_url: cf.uri(),
         doh_resolvers: vec![],
@@ -875,7 +875,7 @@ async fn teardown_removes_daemon_and_wipes_state() {
     mount_token(&tenants).await;
     // The per-daemon removal endpoint must be hit exactly once.
     Mock::given(method("DELETE"))
-        .and(path("/v1/networks/net-1/daemons/self"))
+        .and(path("/tenants/v1/networks/net-1/daemons/self"))
         .respond_with(ResponseTemplate::new(204))
         .expect(1)
         .mount(&tenants)
@@ -968,7 +968,7 @@ async fn switching_to_cloudflare_deregisters_old_wardnet() {
     let tenants = MockServer::start().await;
     mount_token(&tenants).await;
     Mock::given(method("DELETE"))
-        .and(path("/v1/networks/net-1/daemons/self"))
+        .and(path("/tenants/v1/networks/net-1/daemons/self"))
         .respond_with(ResponseTemplate::new(204))
         .expect(1)
         .mount(&tenants)
@@ -985,7 +985,7 @@ async fn switching_to_cloudflare_deregisters_old_wardnet() {
         secrets.clone(),
         DdnsSettings {
             region_catalog: region_catalog("use1", &ddns),
-            tenants_base_url: tenants.uri(),
+            global_gateway_url: tenants.uri(),
             echo_endpoints: vec![],
             cf_base_url: cf.uri(),
             doh_resolvers: vec![],
@@ -1033,7 +1033,7 @@ async fn doh_server(status: u32, answer_ips: &[&str]) -> MockServer {
 fn resolution_settings(doh: &MockServer) -> DdnsSettings {
     DdnsSettings {
         region_catalog: vec![],
-        tenants_base_url: String::new(),
+        global_gateway_url: String::new(),
         echo_endpoints: vec![],
         cf_base_url: String::new(),
         doh_resolvers: vec![format!("{}/dns-query", doh.uri())],


### PR DESCRIPTION
## What

Adapts the daemon to wardnet-cloud's new deployment topology (cloud **ADR-0014** / inforge **ADR-0032**): daemon-facing endpoints moved behind per-scope north-south **gateways**, with the target service selected by the first path segment, and the cloud now verifies the Ed25519 PoP signature over the **full, un-stripped** `path_and_query`.

- **Gateway base URLs** — `GLOBAL_GATEWAY_URL` (`api.wardnet.network`, fronts tenants) replaces `TENANTS_BASE_URL`; the region catalog's per-region entry becomes that region's gateway (`api.use1.wardnet.network`, fronts ddns + tunneller), with the health probe at `:81/ddns/v1/health`. Config vocabulary renamed to gateway terms (`global_gateway_url`, `gateway_base_url`, `gateway_base_for_region`). `FIXME(infra)` markers kept — the gateway manifests haven't landed in wardnet-infrastructure yet.
- **Prefixed paths, structurally** — each client owns its `SERVICE_PREFIX` (`/tenants`, `/ddns`) and prepends it in a single private `send()` funnel, so every call is prefixed — and therefore PoP-signed over the prefixed path — by construction. `request::send`'s "sign exactly what you send" invariant is untouched (one string feeds both the URL and the signature).
- **Tests** — the pinned canonical-payload test now covers a prefixed path *and* a query-string case (the query participates in the signature); all wiremock route mocks updated. 1084 tests pass; `make check-daemon` green.
- **Docs** — `CONTEXT.md` gains a **Cloud gateway** glossary entry; the per-service-clients, daemon-cloud-auth, and provider-based-ddns ADRs updated to the gateway topology.

## Notes

- Per-scope (global + regional) gateway URLs, not one: inforge validates gateways as scope singletons routing only to same-scope services, and tenants is global while ddns/tunneller are regional.
- The reverse-tunnel WS client remains intentionally absent; its gateway-era requirements (dial `GET /tunneller/v1/tunnel`, sign the prefixed path, answer WS Pings, tolerate the extra proxy hops) are recorded on #266.

## Merge Commit Message

feat(cloud): dial the per-scope cloud gateways and sign PoP over the full `/service/`-prefixed paths (cloud ADR-0014 / inforge ADR-0032)

https://claude.ai/code/session_01RWfmY9rfbUKgynchyNFsbC