### PR TITLE
fix(deps): patch cmov RUSTSEC advisory (GHSA-3rjw-m598-pq24)

### DIFF
--- a/source/daemon/Cargo.lock
+++ b/source/daemon/Cargo.lock
@@ -819,9 +819,9 @@ dependencies = [
 
 [[package]]
 name = "cmov"
-version = "0.5.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f88a43d011fc4a6876cb7344703e297c71dda42494fee094d5f7c76bf13f746"
+checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
 
 [[package]]
 name = "coarsetime"


### PR DESCRIPTION
## Summary

Bumps `cmov` 0.5.3 → 0.5.4 in `source/daemon/Cargo.lock` to resolve [Dependabot alert #73](https://github.com/wardnet/wardnet/security/dependabot/73) ([GHSA-3rjw-m598-pq24](https://github.com/advisories/GHSA-3rjw-m598-pq24), moderate).

On **aarch64**, `Cmov`/`CmovEq` could produce wrong results when high bits of the compared registers are set. This applies to us directly: wardnetd targets Raspberry Pi (aarch64), and `cmov` sits in the crypto dependency chain — transitively via `ctutils` under `sha2`/`sha3`/`ml-dsa` (`superboring` → `jwt-simple` → `web-push-native` in `wardnetd-services`).

Lockfile-only change; `cargo update -p cmov` locked exactly one package.

## Merge Commit Message

fix(deps): bump cmov 0.5.3 → 0.5.4 to patch GHSA-3rjw-m598-pq24 (aarch64 Cmov/CmovEq miscomputation), closing Dependabot alert #73

https://claude.ai/code/session_01C4Cn68AYrKUX2GiPExCBv3