### PR TITLE
fix(cloud)!: dial prefix-free /v1 cloud paths + /readyz region probe

### DIFF
--- a/docs/adr-provider-based-ddns.md
+++ b/docs/adr-provider-based-ddns.md
@@ -42,7 +42,7 @@ the certificate lifecycle and the key never leaving the Pi under either provider
     directly with their token.
 - **Multi-region via a daemon-side catalog.** A built-in region-slug → bridge
   endpoint catalog ships in the daemon (`ddns/region.rs`); at registration the
-  daemon probes each region's `/ddns/v1/health` and picks the lowest-latency one. The
+  daemon probes each region's `/readyz` health endpoint and picks the lowest-latency one. The
   bridge cannot supply this list (it is itself region-bound), so the catalog is the
   daemon's. Adding a region is a one-line catalog change.
 - The **daemon**, not the bridge, owns issuance and renewal — it calls the provider

--- a/source/daemon/crates/wardnetd-services/src/cloud/ddns.rs
+++ b/source/daemon/crates/wardnetd-services/src/cloud/ddns.rs
@@ -27,11 +27,6 @@ use super::request::{self, Auth};
 use super::tenants::TenantsClient;
 use crate::ddns::provider::DnsProvider;
 
-/// Gateway path-routing prefix: the first path segment selecting the ddns
-/// service. Prepended once, in [`DdnsClient::send`], so every call is prefixed
-/// (and therefore `PoP`-signed) structurally rather than per literal.
-const SERVICE_PREFIX: &str = "/ddns";
-
 /// A client for a region's ddns service behind the regional gateway at
 /// `base_url`.
 pub struct DdnsClient {
@@ -47,7 +42,7 @@ impl DdnsClient {
         Self { http, base_url }
     }
 
-    /// Publish the network's public **A** record (`PUT /ddns/v1/ip`).
+    /// Publish the network's public **A** record (`PUT /v1/ip`).
     pub async fn report_ip(
         &self,
         identity: &DaemonIdentity,
@@ -59,7 +54,7 @@ impl DdnsClient {
         request::ok(resp).await.map(drop)
     }
 
-    /// Publish the `_acme-challenge` TXT value(s) (`PUT /ddns/v1/acme-challenge`).
+    /// Publish the `_acme-challenge` TXT value(s) (`PUT /v1/acme-challenge`).
     pub async fn set_acme_challenge(
         &self,
         identity: &DaemonIdentity,
@@ -71,7 +66,7 @@ impl DdnsClient {
         request::ok(resp).await.map(drop)
     }
 
-    /// Remove the `_acme-challenge` TXT records (`DELETE /ddns/v1/acme-challenge`).
+    /// Remove the `_acme-challenge` TXT records (`DELETE /v1/acme-challenge`).
     /// Idempotent.
     pub async fn clear_acme_challenge(&self, identity: &DaemonIdentity) -> Result<(), CloudError> {
         let resp = self
@@ -94,11 +89,11 @@ impl DdnsClient {
         self.send(reqwest::Method::PUT, path, identity, body).await
     }
 
-    /// Send `{SERVICE_PREFIX}{path_and_query}` — the single funnel every ddns
-    /// call goes through, so a new endpoint cannot forget the gateway prefix
-    /// (a valid signature over an un-prefixed path would misroute at the
-    /// gateway). The prefixed string is built once and passed whole to
-    /// [`request::send`], preserving its "sign exactly what you send"
+    /// Send `path_and_query` — the single funnel every ddns call goes through.
+    /// Cloud serves prefix-free `/v1/...` paths (cloud ADR-0015); the gateway
+    /// routes on the `X-Mesh-Target` header it derives per service, not on a
+    /// path prefix, so no service segment is prepended. The path is passed whole
+    /// to [`request::send`], preserving its "sign exactly what you send"
     /// invariant.
     async fn send(
         &self,
@@ -112,7 +107,7 @@ impl DdnsClient {
             &self.base_url,
             Auth::Full(identity),
             method,
-            &format!("{SERVICE_PREFIX}{path_and_query}"),
+            path_and_query,
             body,
         )
         .await

--- a/source/daemon/crates/wardnetd-services/src/cloud/mod.rs
+++ b/source/daemon/crates/wardnetd-services/src/cloud/mod.rs
@@ -3,13 +3,14 @@
 //! wardnet-cloud is a service mesh — `tenants` (global identity/account
 //! authority), `ddns` and `tunneller` (regional), with `billing`/`subscriptions`
 //! internal to `tenants`. Daemons reach it through per-scope north-south
-//! **gateways** (cloud ADR-0014 / inforge ADR-0032): the global gateway fronts
-//! `tenants`, each region's gateway fronts that region's `ddns` + `tunneller`,
-//! and the target service is the **first path segment** (`/tenants/v1/…`,
-//! `/ddns/v1/…`). The gateway is path-preserving, so the `PoP` signature covers
-//! that same prefixed path. The daemon consumes `tenants` and `ddns`; each gets
-//! its **own** client with an **independently configured gateway base URL**, so
-//! a topology change stays a config change, not a code change.
+//! **gateways** (cloud ADR-0014/ADR-0015 / inforge ADR-0032/ADR-0034): the global
+//! gateway fronts `tenants`, each region's gateway fronts that region's `ddns` +
+//! `tunneller`, and the gateway selects the target service from the `X-Mesh-Target`
+//! header it derives per service — **not** from a path prefix. Paths are prefix-free
+//! `/v1/…`. The gateway is path-preserving, so the `PoP` signature covers exactly
+//! that path. The daemon consumes `tenants` and `ddns`; each gets its **own** client
+//! with an **independently configured gateway base URL**, so a topology change stays
+//! a config change, not a code change.
 //!
 //! Shared concerns live here:
 //!

--- a/source/daemon/crates/wardnetd-services/src/cloud/pop.rs
+++ b/source/daemon/crates/wardnetd-services/src/cloud/pop.rs
@@ -13,11 +13,10 @@
 //! are separate workspaces, so [`tests`](super::tests) pins this format by
 //! constructing a signature and verifying its bytes.
 //!
-//! `path_and_query` is the **full gateway-facing path including the
-//! `/<service>/` prefix and any query string** (e.g. `/ddns/v1/ip`): the
-//! gateway is path-preserving and the cloud verifies against the original,
-//! un-stripped request URI (`OriginalUri`), so a signature over an un-prefixed
-//! path is rejected with `401`.
+//! `path_and_query` is the **gateway-facing path and any query string**, prefix-free
+//! `/v1/…` (e.g. `/v1/ip`, cloud ADR-0015): the gateway is path-preserving and the
+//! cloud verifies against the request URI it received, so the daemon must sign exactly
+//! the path it dials.
 
 use base64::Engine as _;
 use ed25519_dalek::{Signer, SigningKey};

--- a/source/daemon/crates/wardnetd-services/src/cloud/tenants.rs
+++ b/source/daemon/crates/wardnetd-services/src/cloud/tenants.rs
@@ -18,11 +18,6 @@ use super::CloudError;
 use super::identity::DaemonIdentity;
 use super::request::{self, Auth};
 
-/// Gateway path-routing prefix: the first path segment selecting the tenants
-/// service. Prepended once, in [`TenantsClient::send`], so every call is
-/// prefixed (and therefore `PoP`-signed) structurally rather than per literal.
-const SERVICE_PREFIX: &str = "/tenants";
-
 /// Code-request endpoint: the converged `POST /v1/verification-codes` resource
 /// from wardnet-cloud #20 (supersedes `POST /v1/enrollment-codes`). Kept as a
 /// single constant so a path change stays one line.
@@ -60,11 +55,11 @@ impl TenantsClient {
         Self { http, base_url }
     }
 
-    /// Send `{SERVICE_PREFIX}{path_and_query}` — the single funnel every
-    /// tenants call goes through, so a new endpoint cannot forget the gateway
-    /// prefix (a valid signature over an un-prefixed path would misroute at
-    /// the gateway). The prefixed string is built once and passed whole to
-    /// [`request::send`], preserving its "sign exactly what you send"
+    /// Send `path_and_query` — the single funnel every tenants call goes
+    /// through. Cloud serves prefix-free `/v1/...` paths (cloud ADR-0015); the
+    /// gateway routes on the `X-Mesh-Target` header it derives per service, not
+    /// on a path prefix, so no service segment is prepended. The path is passed
+    /// whole to [`request::send`], preserving its "sign exactly what you send"
     /// invariant.
     async fn send(
         &self,
@@ -78,7 +73,7 @@ impl TenantsClient {
             &self.base_url,
             auth,
             method,
-            &format!("{SERVICE_PREFIX}{path_and_query}"),
+            path_and_query,
             body,
         )
         .await

--- a/source/daemon/crates/wardnetd-services/src/cloud/tests.rs
+++ b/source/daemon/crates/wardnetd-services/src/cloud/tests.rs
@@ -64,8 +64,7 @@ fn pop_canonical_payload_is_stable_and_verifies() {
     // The query string participates in the signed path: the cloud verifies the
     // full request path including `?…`, so a payload that drops the query must
     // not equal one that carries it.
-    let with_query =
-        pop::canonical_payload("GET", "/v1/availability?slug=alice", timestamp, b"");
+    let with_query = pop::canonical_payload("GET", "/v1/availability?slug=alice", timestamp, b"");
     let expected_with_query = format!(
         "GET\n/v1/availability?slug=alice\n{timestamp}\n{}",
         hex::encode(Sha256::digest(b""))

--- a/source/daemon/crates/wardnetd-services/src/cloud/tests.rs
+++ b/source/daemon/crates/wardnetd-services/src/cloud/tests.rs
@@ -42,14 +42,14 @@ fn pop_canonical_payload_is_stable_and_verifies() {
 
     // The signed path is the full gateway-facing path, `/<service>/` prefix
     // included — the cloud verifies against the un-stripped `OriginalUri`.
-    let payload = pop::canonical_payload("PUT", "/ddns/v1/ip", timestamp, body);
+    let payload = pop::canonical_payload("PUT", "/v1/ip", timestamp, body);
     let expected = format!(
-        "PUT\n/ddns/v1/ip\n{timestamp}\n{}",
+        "PUT\n/v1/ip\n{timestamp}\n{}",
         hex::encode(Sha256::digest(body))
     );
     assert_eq!(payload, expected, "canonical payload format must not drift");
 
-    let signature_b64 = pop::sign(&key, "PUT", "/ddns/v1/ip", timestamp, body);
+    let signature_b64 = pop::sign(&key, "PUT", "/v1/ip", timestamp, body);
     let signature_bytes = base64::engine::general_purpose::STANDARD
         .decode(signature_b64)
         .expect("standard base64");
@@ -65,15 +65,15 @@ fn pop_canonical_payload_is_stable_and_verifies() {
     // full `OriginalUri` including `?…`, so a payload that drops the query must
     // not equal one that carries it.
     let with_query =
-        pop::canonical_payload("GET", "/tenants/v1/availability?slug=alice", timestamp, b"");
+        pop::canonical_payload("GET", "/v1/availability?slug=alice", timestamp, b"");
     let expected_with_query = format!(
-        "GET\n/tenants/v1/availability?slug=alice\n{timestamp}\n{}",
+        "GET\n/v1/availability?slug=alice\n{timestamp}\n{}",
         hex::encode(Sha256::digest(b""))
     );
     assert_eq!(with_query, expected_with_query);
     assert_ne!(
         with_query,
-        pop::canonical_payload("GET", "/tenants/v1/availability", timestamp, b""),
+        pop::canonical_payload("GET", "/v1/availability", timestamp, b""),
         "dropping the query string must change the signed payload"
     );
 }
@@ -82,7 +82,7 @@ fn pop_canonical_payload_is_stable_and_verifies() {
 async fn request_enrollment_code_posts_email_and_purpose() {
     let server = MockServer::start().await;
     Mock::given(method("POST"))
-        .and(path("/tenants/v1/verification-codes"))
+        .and(path("/v1/verification-codes"))
         .and(body_json(
             json!({ "email": "a@b.com", "purpose": "enrollment" }),
         ))
@@ -99,7 +99,7 @@ async fn request_enrollment_code_posts_email_and_purpose() {
 async fn enroll_returns_tenant_id() {
     let server = MockServer::start().await;
     Mock::given(method("POST"))
-        .and(path("/tenants/v1/enroll"))
+        .and(path("/v1/enroll"))
         .and(body_json(json!({ "code": "ABC123", "public_key": "pk" })))
         .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "tenant_id": "t-1" })))
         .mount(&server)
@@ -113,7 +113,7 @@ async fn enroll_returns_tenant_id() {
 async fn mint_token_403_flags_entitlement_lost() {
     let server = MockServer::start().await;
     Mock::given(method("POST"))
-        .and(path("/tenants/v1/token"))
+        .and(path("/v1/token"))
         .and(header_exists(pop::SIGNATURE_HEADER))
         .respond_with(ResponseTemplate::new(403).set_body_string("subscription is not active"))
         .mount(&server)
@@ -133,7 +133,7 @@ async fn token_is_cached_and_minted_once() {
     let server = MockServer::start().await;
     let exp = chrono::Utc::now().timestamp() + 3600;
     Mock::given(method("POST"))
-        .and(path("/tenants/v1/token"))
+        .and(path("/v1/token"))
         .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "token": fake_jwt(exp) })))
         .expect(1) // second call must hit the cache, not the server
         .mount(&server)
@@ -151,12 +151,12 @@ async fn availability_sends_jwt_and_pop() {
     let server = MockServer::start().await;
     let exp = chrono::Utc::now().timestamp() + 3600;
     Mock::given(method("POST"))
-        .and(path("/tenants/v1/token"))
+        .and(path("/v1/token"))
         .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "token": fake_jwt(exp) })))
         .mount(&server)
         .await;
     Mock::given(method("GET"))
-        .and(path("/tenants/v1/availability"))
+        .and(path("/v1/availability"))
         .and(query_param("slug", "alice"))
         .and(header_exists("authorization"))
         .and(header_exists(pop::SIGNATURE_HEADER))
@@ -178,12 +178,12 @@ async fn register_network_maps_view() {
     let server = MockServer::start().await;
     let exp = chrono::Utc::now().timestamp() + 3600;
     Mock::given(method("POST"))
-        .and(path("/tenants/v1/token"))
+        .and(path("/v1/token"))
         .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "token": fake_jwt(exp) })))
         .mount(&server)
         .await;
     Mock::given(method("POST"))
-        .and(path("/tenants/v1/networks"))
+        .and(path("/v1/networks"))
         .and(body_json(json!({ "slug": "alice", "region": "use1" })))
         .respond_with(ResponseTemplate::new(200).set_body_json(json!({
             "id": "n-1",
@@ -213,19 +213,19 @@ async fn ddns_report_ip_and_clear_acme() {
     let server = MockServer::start().await;
     let exp = chrono::Utc::now().timestamp() + 3600;
     Mock::given(method("POST"))
-        .and(path("/tenants/v1/token"))
+        .and(path("/v1/token"))
         .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "token": fake_jwt(exp) })))
         .mount(&server)
         .await;
     Mock::given(method("PUT"))
-        .and(path("/ddns/v1/ip"))
+        .and(path("/v1/ip"))
         .and(body_json(json!({ "ip": "203.0.113.7" })))
         .and(header_exists(pop::SIGNATURE_HEADER))
         .respond_with(ResponseTemplate::new(204))
         .mount(&server)
         .await;
     Mock::given(method("DELETE"))
-        .and(path("/ddns/v1/acme-challenge"))
+        .and(path("/v1/acme-challenge"))
         .respond_with(ResponseTemplate::new(204))
         .mount(&server)
         .await;

--- a/source/daemon/crates/wardnetd-services/src/cloud/tests.rs
+++ b/source/daemon/crates/wardnetd-services/src/cloud/tests.rs
@@ -40,8 +40,8 @@ fn pop_canonical_payload_is_stable_and_verifies() {
     let timestamp = 1_700_000_000i64;
     let body = br#"{"ip":"203.0.113.5"}"#;
 
-    // The signed path is the full gateway-facing path, `/<service>/` prefix
-    // included — the cloud verifies against the un-stripped `OriginalUri`.
+    // The signed path is the prefix-free gateway-facing path (`/v1/...`, cloud
+    // ADR-0015) — the daemon signs exactly what it dials.
     let payload = pop::canonical_payload("PUT", "/v1/ip", timestamp, body);
     let expected = format!(
         "PUT\n/v1/ip\n{timestamp}\n{}",
@@ -62,7 +62,7 @@ fn pop_canonical_payload_is_stable_and_verifies() {
     assert_eq!(signature, key.sign(expected.as_bytes()));
 
     // The query string participates in the signed path: the cloud verifies the
-    // full `OriginalUri` including `?…`, so a payload that drops the query must
+    // full request path including `?…`, so a payload that drops the query must
     // not equal one that carries it.
     let with_query =
         pop::canonical_payload("GET", "/v1/availability?slug=alice", timestamp, b"");

--- a/source/daemon/crates/wardnetd-services/src/ddns/mod.rs
+++ b/source/daemon/crates/wardnetd-services/src/ddns/mod.rs
@@ -198,7 +198,7 @@ pub(crate) struct DdnsSettings {
     /// Per-region gateway catalog (control + health URLs), probed for selection.
     region_catalog: Vec<RegionEndpoint>,
     /// Global gateway base URL — fronts `tenants` (enroll / token / availability
-    /// / networks under `/tenants/v1/…`).
+    /// / networks under `/v1/…`).
     global_gateway_url: String,
     /// Public-IP echo endpoints, tried in order.
     echo_endpoints: Vec<String>,
@@ -506,7 +506,7 @@ impl DdnsServiceImpl {
 /// Whether `slug` is a syntactically valid vanity slug.
 ///
 /// **Security boundary:** the slug is interpolated into the tenants request URL
-/// (`/tenants/v1/availability?slug={slug}`) and signed as part of the `PoP`
+/// (`/v1/availability?slug={slug}`) and signed as part of the `PoP`
 /// `path_and_query`, so it must be validated **before** building that URL — an
 /// unchecked `/`, `?`, `.` or whitespace would let an admin reshape the request
 /// path. The cloud enforces the authoritative rules (incl. the reserved-name

--- a/source/daemon/crates/wardnetd-services/src/ddns/region.rs
+++ b/source/daemon/crates/wardnetd-services/src/ddns/region.rs
@@ -1,10 +1,11 @@
 //! The built-in **region catalog**, latency-based selection, and the global
 //! **gateway** endpoint.
 //!
-//! wardnet-cloud sits behind per-scope north-south **gateways** (cloud ADR-0014 /
-//! inforge ADR-0032): one public edge per scope that daemons HTTPS into, with the
-//! target service selected by the **first path segment** (`/tenants/…`, `/ddns/…`,
-//! `/tunneller/…`). The global scope's gateway fronts `tenants`; each region's
+//! wardnet-cloud sits behind per-scope north-south **gateways** (cloud
+//! ADR-0014/ADR-0015 / inforge ADR-0032/ADR-0034): one public edge per scope that
+//! daemons HTTPS into, with the target service selected from the `X-Mesh-Target`
+//! header the gateway derives per service — **not** a path prefix; paths are
+//! prefix-free `/v1/…`. The global scope's gateway fronts `tenants`; each region's
 //! gateway fronts that region's `ddns` + `tunneller`. The daemon must already
 //! know a region's address to reach it, so the catalog ships in the daemon: a
 //! **region slug** mapped to that region's gateway. At registration the daemon
@@ -13,9 +14,9 @@
 //!
 //! Two endpoints per region matter:
 //! * **control** (`https://api.<region-slug>…:443`) — the regional gateway; TLS
-//!   is a normal public cert, requests are path-routed to the service.
-//! * **health** (`http://api.<region-slug>…:81/ddns/v1/health`) — the gateway
-//!   host exposes health on plain-HTTP `:81`.
+//!   is a normal public cert, requests route to the service by `X-Mesh-Target`.
+//! * **health** (`http://api.<region-slug>…:81/readyz`) — the gateway host exposes
+//!   the readiness probe on plain-HTTP `:81` (cloud ADR-0027).
 //!
 //! The global gateway (`tenants`) is scope-wide, so it is a single constant
 //! rather than a per-region catalog entry.
@@ -26,8 +27,8 @@
 use std::time::{Duration, Instant};
 
 /// The **global gateway** base URL — the north-south edge fronting the global
-/// `tenants` service (enroll / token / availability / networks under
-/// `/tenants/v1/…`). One deployment, region-independent.
+/// `tenants` service (enroll / token / availability / networks under prefix-free
+/// `/v1/…`, cloud ADR-0015). One deployment, region-independent.
 ///
 /// FIXME(infra): confirm the daemon-facing gateway FQDN once the gateway
 /// manifest lands in wardnet-infrastructure; ADR-0032's shape is
@@ -38,13 +39,14 @@ pub const GLOBAL_GATEWAY_URL: &str = "https://api.wardnet.network";
 #[derive(Debug, Clone)]
 pub struct RegionEndpoint {
     /// Short region slug, e.g. `use1`. Selects the region and is passed to
-    /// `POST /tenants/v1/networks` as `region`.
+    /// `POST /v1/networks` as `region`.
     pub slug: String,
     /// The region's **gateway** base URL (`https://api.<region-slug>…`) — fronts
-    /// the regional `ddns` and `tunneller` services by path prefix.
+    /// the regional `ddns` and `tunneller` services (routing on `X-Mesh-Target`,
+    /// cloud ADR-0015).
     pub gateway_base_url: String,
-    /// Health-probe URL for region selection
-    /// (`http://api.<region-slug>…:81/ddns/v1/health`, plain HTTP).
+    /// Health-probe URL for region selection — the cloud health tier's readiness
+    /// probe (`http://api.<region-slug>…:81/readyz`, plain HTTP; cloud ADR-0027).
     pub health_url: String,
 }
 
@@ -68,7 +70,7 @@ pub fn default_catalog() -> Vec<RegionEndpoint> {
     vec![RegionEndpoint::new(
         "use1",
         "https://api.use1.wardnet.network",
-        "http://api.use1.wardnet.network:81/ddns/v1/health",
+        "http://api.use1.wardnet.network:81/readyz",
     )]
 }
 
@@ -77,7 +79,7 @@ pub fn default_catalog() -> Vec<RegionEndpoint> {
 pub struct SelectedRegion {
     pub slug: String,
     /// The region's gateway base URL (steady-state report-IP / ACME via
-    /// `/ddns/v1/…`).
+    /// prefix-free `/v1/…`, cloud ADR-0015).
     pub gateway_base_url: String,
 }
 

--- a/source/daemon/crates/wardnetd-services/src/ddns/tests/region.rs
+++ b/source/daemon/crates/wardnetd-services/src/ddns/tests/region.rs
@@ -1,7 +1,7 @@
 //! Region selection tests: lowest-latency reachable region wins; unhealthy
 //! endpoints are skipped; all-unreachable is an error.
 //!
-//! Each region's `health_url` points at its wiremock server's `/ddns/v1/health`,
+//! Each region's `health_url` points at its wiremock server's `/readyz`,
 //! while `gateway_base_url` is the server root — mirroring the production split
 //! between the plain-HTTP `:81` health probe and the `:443` control base.
 
@@ -19,19 +19,19 @@ async fn health_server(delay: Option<Duration>, status: u16) -> MockServer {
         template = template.set_delay(delay);
     }
     Mock::given(method("GET"))
-        .and(path("/ddns/v1/health"))
+        .and(path("/readyz"))
         .respond_with(template)
         .mount(&server)
         .await;
     server
 }
 
-/// A catalog entry whose health probe targets `server`'s `/ddns/v1/health`.
+/// A catalog entry whose health probe targets `server`'s `/readyz`.
 fn entry(slug: &str, server: &MockServer) -> RegionEndpoint {
     RegionEndpoint {
         slug: slug.to_owned(),
         gateway_base_url: server.uri(),
-        health_url: format!("{}/ddns/v1/health", server.uri()),
+        health_url: format!("{}/readyz", server.uri()),
     }
 }
 

--- a/source/daemon/crates/wardnetd-services/src/ddns/tests/service.rs
+++ b/source/daemon/crates/wardnetd-services/src/ddns/tests/service.rs
@@ -4,7 +4,7 @@
 //! exercised end to end.
 //!
 //! Every JWT + `PoP` call first mints a token via the tenants server's
-//! `POST /tenants/v1/token`; the [`mount_token`] helper answers it with a JWT-shaped
+//! `POST /v1/token`; the [`mount_token`] helper answers it with a JWT-shaped
 //! body (see `crate::cloud::tests` for the canonical pattern).
 
 use std::collections::HashMap;
@@ -114,12 +114,12 @@ fn fake_jwt(exp: i64) -> String {
     format!("header.{payload}.sig")
 }
 
-/// Mount `POST /tenants/v1/token` on a tenants server, answering with a fresh,
+/// Mount `POST /v1/token` on a tenants server, answering with a fresh,
 /// far-from-expiry JWT. Required by every JWT + `PoP` call the service makes.
 async fn mount_token(server: &MockServer) {
     let exp = chrono::Utc::now().timestamp() + 3600;
     Mock::given(method("POST"))
-        .and(path("/tenants/v1/token"))
+        .and(path("/v1/token"))
         .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "token": fake_jwt(exp) })))
         .mount(server)
         .await;
@@ -147,7 +147,7 @@ fn region_catalog(slug: &str, ddns: &MockServer) -> Vec<RegionEndpoint> {
     vec![RegionEndpoint {
         slug: slug.to_owned(),
         gateway_base_url: ddns.uri(),
-        health_url: format!("{}/ddns/v1/health", ddns.uri()),
+        health_url: format!("{}/readyz", ddns.uri()),
     }]
 }
 
@@ -243,7 +243,7 @@ async fn request_enrollment_code_requires_admin() {
 async fn request_enrollment_code_posts_email_and_purpose() {
     let tenants = MockServer::start().await;
     Mock::given(method("POST"))
-        .and(path("/tenants/v1/verification-codes"))
+        .and(path("/v1/verification-codes"))
         .and(body_json(
             json!({ "email": "a@b.com", "purpose": "enrollment" }),
         ))
@@ -284,7 +284,7 @@ async fn request_enrollment_code_rejects_invalid_email_locally() {
 async fn enroll_persists_key_and_tenant_id() {
     let tenants = MockServer::start().await;
     Mock::given(method("POST"))
-        .and(path("/tenants/v1/enroll"))
+        .and(path("/v1/enroll"))
         .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "tenant_id": "t-1" })))
         .expect(1)
         .mount(&tenants)
@@ -335,7 +335,7 @@ async fn check_slug_returns_available() {
     let tenants = MockServer::start().await;
     mount_token(&tenants).await;
     Mock::given(method("GET"))
-        .and(path("/tenants/v1/availability"))
+        .and(path("/v1/availability"))
         .and(query_param("slug", "alice"))
         .and(header_exists("authorization"))
         .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "available": true })))
@@ -361,7 +361,7 @@ async fn check_slug_returns_taken() {
     let tenants = MockServer::start().await;
     mount_token(&tenants).await;
     Mock::given(method("GET"))
-        .and(path("/tenants/v1/availability"))
+        .and(path("/v1/availability"))
         .and(query_param("slug", "taken"))
         .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "available": false })))
         .mount(&tenants)
@@ -417,7 +417,7 @@ async fn register_network_persists_wardnet_provider() {
     let tenants = MockServer::start().await;
     mount_token(&tenants).await;
     Mock::given(method("POST"))
-        .and(path("/tenants/v1/networks"))
+        .and(path("/v1/networks"))
         .and(body_json(json!({ "slug": "alice", "region": "use1" })))
         .and(header_exists("authorization"))
         .respond_with(ResponseTemplate::new(200).set_body_json(json!({
@@ -437,7 +437,7 @@ async fn register_network_persists_wardnet_provider() {
     // The region health probe (`select_best`) must see a reachable region.
     let ddns = MockServer::start().await;
     Mock::given(method("GET"))
-        .and(path("/ddns/v1/health"))
+        .and(path("/readyz"))
         .respond_with(ResponseTemplate::new(200))
         .mount(&ddns)
         .await;
@@ -504,7 +504,7 @@ async fn refresh_skips_when_ip_unchanged() {
     let tenants = MockServer::start().await;
     let ddns = MockServer::start().await;
     Mock::given(method("PUT"))
-        .and(path("/ddns/v1/ip"))
+        .and(path("/v1/ip"))
         .respond_with(ResponseTemplate::new(204))
         .expect(0) // must NOT be called when the IP is unchanged
         .mount(&ddns)
@@ -538,7 +538,7 @@ async fn refresh_publishes_when_ip_changed() {
     mount_token(&tenants).await;
     let ddns = MockServer::start().await;
     Mock::given(method("PUT"))
-        .and(path("/ddns/v1/ip"))
+        .and(path("/v1/ip"))
         .and(body_json(json!({ "ip": "9.9.9.9" })))
         .and(header_exists("authorization"))
         .respond_with(ResponseTemplate::new(204))
@@ -618,7 +618,7 @@ async fn set_acme_challenge_publishes_txt_via_ddns() {
     mount_token(&tenants).await;
     let ddns = MockServer::start().await;
     Mock::given(method("PUT"))
-        .and(path("/ddns/v1/acme-challenge"))
+        .and(path("/v1/acme-challenge"))
         .and(body_json(
             json!({ "values": ["apex-value", "wildcard-value"] }),
         ))
@@ -652,7 +652,7 @@ async fn clear_acme_challenge_deletes_txt_via_ddns() {
     mount_token(&tenants).await;
     let ddns = MockServer::start().await;
     Mock::given(method("DELETE"))
-        .and(path("/ddns/v1/acme-challenge"))
+        .and(path("/v1/acme-challenge"))
         .respond_with(ResponseTemplate::new(204))
         .expect(1)
         .mount(&ddns)
@@ -682,7 +682,7 @@ async fn token_403_surfaces_as_forbidden() {
     // the wizard can drive the Suspended state, not a generic outage.
     let tenants = MockServer::start().await;
     Mock::given(method("POST"))
-        .and(path("/tenants/v1/token"))
+        .and(path("/v1/token"))
         .respond_with(ResponseTemplate::new(403).set_body_string("subscription is not active"))
         .mount(&tenants)
         .await;
@@ -875,7 +875,7 @@ async fn teardown_removes_daemon_and_wipes_state() {
     mount_token(&tenants).await;
     // The per-daemon removal endpoint must be hit exactly once.
     Mock::given(method("DELETE"))
-        .and(path("/tenants/v1/networks/net-1/daemons/self"))
+        .and(path("/v1/networks/net-1/daemons/self"))
         .respond_with(ResponseTemplate::new(204))
         .expect(1)
         .mount(&tenants)
@@ -968,7 +968,7 @@ async fn switching_to_cloudflare_deregisters_old_wardnet() {
     let tenants = MockServer::start().await;
     mount_token(&tenants).await;
     Mock::given(method("DELETE"))
-        .and(path("/tenants/v1/networks/net-1/daemons/self"))
+        .and(path("/v1/networks/net-1/daemons/self"))
         .respond_with(ResponseTemplate::new(204))
         .expect(1)
         .mount(&tenants)

--- a/source/end2end-tests/web-ui/tests/user-app/settings.spec.ts
+++ b/source/end2end-tests/web-ui/tests/user-app/settings.spec.ts
@@ -8,8 +8,8 @@ import { setMyCapture } from "../../fixtures/user-app.js";
  * The issue lists "theme/language; push-subscription UX"; the Settings tab
  * as built is the device's self-service controls: a DNS-capture toggle, the
  * admin-owned retention caps shown read-only, the device's own rule-change
- * requests, and a notifications placeholder (push is "coming soon"). This
- * spec covers what exists.
+ * requests, and a Web Push notifications toggle (#792). This spec covers
+ * what exists.
  *
  * Driven from the LAN runner. The capture toggle is the one stateful control
  * here — it flips the device's own `dns_capture_enabled` (device-keyed, no
@@ -52,15 +52,13 @@ test("the admin-owned retention caps are shown read-only", async ({ page }) => {
   ).toBeVisible();
 });
 
-test("the notifications placeholder advertises push as coming soon", async ({
+test("the notifications card offers a push-subscription toggle", async ({
   page,
 }) => {
   await page.goto("./settings");
 
   await expect(page.getByText("Notifications", { exact: true })).toBeVisible();
-  await expect(
-    page.getByText("Push notifications about your device are coming soon."),
-  ).toBeVisible();
+  await expect(page.getByTestId("notifications-toggle")).toBeVisible();
 });
 
 test("the my-requests card is absent when the device has no requests", async ({


### PR DESCRIPTION
## Summary

wardnet-cloud dropped its per-service URL prefix (cloud ADR-0015): services now serve prefix-free `/v1/<resource>` paths and the north-south gateway routes on the `X-Mesh-Target` header it derives per service — not on the first path segment (verified against inforge ADR-0034: routing is by declared path globs + `X-Mesh-Target`, paths forwarded byte-for-byte, no code assumes segment 1 = service name). This PR makes the daemon dial the new shape. Pairs with **wardnet-cloud PR #52**.

### What changed
- **Both cloud clients** (`cloud/tenants.rs`, `cloud/ddns.rs`) drop the `SERVICE_PREFIX` (`/tenants`, `/ddns`) prepend — `send` passes `path_and_query` whole. The per-endpoint literals were already `/v1/...`, so only the prefix funnel changes. **PoP is unaffected**: it signs exactly the `path_and_query` it dials (`cloud/request.rs`), so dropping the prefix from the dialed path drops it from the signature in lockstep — no signing-logic change.
- **Region health probe:** re-pointed from the removed `/ddns/v1/health` to the cloud health tier's **`/readyz`** (cloud ADR-0027, port 81). `select_best` already treats a non-2xx response as unhealthy, so readiness semantics are exactly right for "pick a region that's actually able to serve."
- **Tests:** updated every wiremock `path(...)` matcher and the **PoP canonical-payload pins** — the cross-repo contract test that asserts the daemon's signature bytes match the cloud verifier. Routing prose in the module docs (`cloud/mod.rs`, `cloud/pop.rs`, `ddns/region.rs`) corrected.

### Compatibility — hard cutover
No cloud environment is deployed and the daemon gateway FQDNs are still `FIXME(infra)` unconfirmed, so no field daemon reaches a live cloud API. No dual-path shim.

## Verification
- `cargo fmt --check` ✅
- `cargo test -p wardnetd-services` ✅ (1109 passed) · `cargo clippy -p wardnetd-services --all-targets -- -D warnings` ✅
- ⚠️ The **full** `make check-daemon` (whole workspace) was **not** run natively: the daemon's platform layer pulls the Linux-only `netlink-sys` (needs `sockaddr_nl`), which does not compile on macOS — that's exactly why the Makefile routes non-Linux hosts through `check-daemon-container`. All changes in this PR are confined to `wardnetd-services`, which builds and tests cleanly native; CI (Linux) covers the rest.

## Merge Commit Message

fix(cloud)!: dial prefix-free /v1 cloud paths + /readyz region probe

Drop the SERVICE_PREFIX prepend in both cloud clients so the daemon dials cloud's
new prefix-free /v1/... paths (cloud ADR-0015 / inforge ADR-0034 — gateway routes on
X-Mesh-Target, not a path prefix); PoP is unaffected since it signs what it dials.
Re-point the region-selection health probe at the health tier's /readyz. Hard cutover;
pairs with wardnet-cloud PR #52.

https://claude.ai/code/session_01YBULgoCuJ2cQ9RdMtAUawc