### PR TITLE
test(daemon,sdk): inbound-wg API tests + remote-access grant SDK (#811)

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -191,7 +191,7 @@
             }
           },
           "401": {
-            "description": "Unauthenticated — session cookie or API key missing/invalid",
+            "description": "Unauthenticated - session cookie or API key missing/invalid",
             "content": {
               "application/json": {
                 "schema": {
@@ -223,7 +223,7 @@
             }
           },
           "403": {
-            "description": "Forbidden — caller is not an admin",
+            "description": "Forbidden - caller is not an admin",
             "content": {
               "application/json": {
                 "schema": {
@@ -358,7 +358,7 @@
             }
           },
           "401": {
-            "description": "Unauthenticated — session cookie or API key missing/invalid",
+            "description": "Unauthenticated - session cookie or API key missing/invalid",
             "content": {
               "application/json": {
                 "schema": {
@@ -390,7 +390,7 @@
             }
           },
           "403": {
-            "description": "Forbidden — caller is not an admin",
+            "description": "Forbidden - caller is not an admin",
             "content": {
               "application/json": {
                 "schema": {
@@ -526,7 +526,7 @@
             }
           },
           "401": {
-            "description": "Unauthenticated — session cookie or API key missing/invalid",
+            "description": "Unauthenticated - session cookie or API key missing/invalid",
             "content": {
               "application/json": {
                 "schema": {
@@ -558,7 +558,7 @@
             }
           },
           "403": {
-            "description": "Forbidden — caller is not an admin",
+            "description": "Forbidden - caller is not an admin",
             "content": {
               "application/json": {
                 "schema": {
@@ -651,7 +651,7 @@
             }
           },
           "401": {
-            "description": "Unauthenticated — session cookie or API key missing/invalid",
+            "description": "Unauthenticated - session cookie or API key missing/invalid",
             "content": {
               "application/json": {
                 "schema": {
@@ -683,7 +683,7 @@
             }
           },
           "403": {
-            "description": "Forbidden — caller is not an admin",
+            "description": "Forbidden - caller is not an admin",
             "content": {
               "application/json": {
                 "schema": {
@@ -776,7 +776,7 @@
             }
           },
           "401": {
-            "description": "Unauthenticated — session cookie or API key missing/invalid",
+            "description": "Unauthenticated - session cookie or API key missing/invalid",
             "content": {
               "application/json": {
                 "schema": {
@@ -808,7 +808,7 @@
             }
           },
           "403": {
-            "description": "Forbidden — caller is not an admin",
+            "description": "Forbidden - caller is not an admin",
             "content": {
               "application/json": {
                 "schema": {
@@ -894,7 +894,7 @@
             "description": "Remote access torn down (or already absent)"
           },
           "401": {
-            "description": "Unauthenticated — session cookie or API key missing/invalid",
+            "description": "Unauthenticated - session cookie or API key missing/invalid",
             "content": {
               "application/json": {
                 "schema": {
@@ -926,7 +926,7 @@
             }
           },
           "403": {
-            "description": "Forbidden — caller is not an admin",
+            "description": "Forbidden - caller is not an admin",
             "content": {
               "application/json": {
                 "schema": {
@@ -1030,7 +1030,7 @@
             }
           },
           "401": {
-            "description": "Unauthenticated — session cookie or API key missing/invalid",
+            "description": "Unauthenticated - session cookie or API key missing/invalid",
             "content": {
               "application/json": {
                 "schema": {
@@ -1062,7 +1062,7 @@
             }
           },
           "403": {
-            "description": "Forbidden — caller is not an admin",
+            "description": "Forbidden - caller is not an admin",
             "content": {
               "application/json": {
                 "schema": {
@@ -1197,7 +1197,7 @@
             }
           },
           "401": {
-            "description": "Unauthenticated — session cookie or API key missing/invalid",
+            "description": "Unauthenticated - session cookie or API key missing/invalid",
             "content": {
               "application/json": {
                 "schema": {
@@ -1229,7 +1229,7 @@
             }
           },
           "403": {
-            "description": "Forbidden — caller is not an admin",
+            "description": "Forbidden - caller is not an admin",
             "content": {
               "application/json": {
                 "schema": {
@@ -1357,7 +1357,7 @@
             }
           },
           "401": {
-            "description": "Unauthenticated — session cookie or API key missing/invalid",
+            "description": "Unauthenticated - session cookie or API key missing/invalid",
             "content": {
               "application/json": {
                 "schema": {
@@ -1389,7 +1389,7 @@
             }
           },
           "403": {
-            "description": "Forbidden — caller is not an admin",
+            "description": "Forbidden - caller is not an admin",
             "content": {
               "application/json": {
                 "schema": {
@@ -1517,7 +1517,7 @@
             }
           },
           "401": {
-            "description": "Unauthenticated — session cookie or API key missing/invalid",
+            "description": "Unauthenticated - session cookie or API key missing/invalid",
             "content": {
               "application/json": {
                 "schema": {
@@ -1549,7 +1549,7 @@
             }
           },
           "403": {
-            "description": "Forbidden — caller is not an admin",
+            "description": "Forbidden - caller is not an admin",
             "content": {
               "application/json": {
                 "schema": {
@@ -1684,7 +1684,7 @@
             }
           },
           "401": {
-            "description": "Unauthenticated — session cookie or API key missing/invalid",
+            "description": "Unauthenticated - session cookie or API key missing/invalid",
             "content": {
               "application/json": {
                 "schema": {
@@ -1716,7 +1716,7 @@
             }
           },
           "403": {
-            "description": "Forbidden — caller is not an admin",
+            "description": "Forbidden - caller is not an admin",
             "content": {
               "application/json": {
                 "schema": {
@@ -1809,7 +1809,7 @@
             }
           },
           "401": {
-            "description": "Unauthenticated — session cookie or API key missing/invalid",
+            "description": "Unauthenticated - session cookie or API key missing/invalid",
             "content": {
               "application/json": {
                 "schema": {
@@ -1841,7 +1841,7 @@
             }
           },
           "403": {
-            "description": "Forbidden — caller is not an admin",
+            "description": "Forbidden - caller is not an admin",
             "content": {
               "application/json": {
                 "schema": {
@@ -1934,7 +1934,7 @@
             }
           },
           "401": {
-            "description": "Unauthenticated — session cookie or API key missing/invalid",
+            "description": "Unauthenticated - session cookie or API key missing/invalid",
             "content": {
               "application/json": {
                 "schema": {
@@ -1966,7 +1966,7 @@
             }
           },
           "403": {
-            "description": "Forbidden — caller is not an admin",
+            "description": "Forbidden - caller is not an admin",
             "content": {
               "application/json": {
                 "schema": {
@@ -2059,7 +2059,7 @@
             }
           },
           "401": {
-            "description": "Unauthenticated — session cookie or API key missing/invalid",
+            "description": "Unauthenticated - session cookie or API key missing/invalid",
             "content": {
               "application/json": {
                 "schema": {
@@ -2091,7 +2091,7 @@
             }
           },
           "403": {
-            "description": "Forbidden — caller is not an admin",
+            "description": "Forbidden - caller is not an admin",
             "content": {
               "application/json": {
                 "schema": {
@@ -2593,7 +2593,7 @@
             }
           },
           "401": {
-            "description": "Unauthenticated — session cookie or API key missing/invalid",
+            "description": "Unauthenticated - session cookie or API key missing/invalid",
             "content": {
               "application/json": {
                 "schema": {
@@ -2625,7 +2625,7 @@
             }
           },
           "403": {
-            "description": "Forbidden — caller is not an admin",
+            "description": "Forbidden - caller is not an admin",
             "content": {
               "application/json": {
                 "schema": {
@@ -2802,7 +2802,7 @@
             }
           },
           "401": {
-            "description": "Unauthenticated — session cookie or API key missing/invalid",
+            "description": "Unauthenticated - session cookie or API key missing/invalid",
             "content": {
               "application/json": {
                 "schema": {
@@ -2834,7 +2834,7 @@
             }
           },
           "403": {
-            "description": "Forbidden — caller is not an admin",
+            "description": "Forbidden - caller is not an admin",
             "content": {
               "application/json": {
                 "schema": {
@@ -3165,7 +3165,7 @@
             }
           },
           "401": {
-            "description": "Unauthenticated — session cookie or API key missing/invalid",
+            "description": "Unauthenticated - session cookie or API key missing/invalid",
             "content": {
               "application/json": {
                 "schema": {
@@ -3197,7 +3197,7 @@
             }
           },
           "403": {
-            "description": "Forbidden — caller is not an admin",
+            "description": "Forbidden - caller is not an admin",
             "content": {
               "application/json": {
                 "schema": {
@@ -3322,7 +3322,7 @@
             }
           },
           "401": {
-            "description": "Unauthenticated — session cookie or API key missing/invalid",
+            "description": "Unauthenticated - session cookie or API key missing/invalid",
             "content": {
               "application/json": {
                 "schema": {
@@ -3354,7 +3354,7 @@
             }
           },
           "403": {
-            "description": "Forbidden — caller is not an admin",
+            "description": "Forbidden - caller is not an admin",
             "content": {
               "application/json": {
                 "schema": {
@@ -3487,7 +3487,7 @@
             }
           },
           "401": {
-            "description": "Unauthenticated — session cookie or API key missing/invalid",
+            "description": "Unauthenticated - session cookie or API key missing/invalid",
             "content": {
               "application/json": {
                 "schema": {
@@ -3519,7 +3519,7 @@
             }
           },
           "403": {
-            "description": "Forbidden — caller is not an admin",
+            "description": "Forbidden - caller is not an admin",
             "content": {
               "application/json": {
                 "schema": {
@@ -3654,7 +3654,7 @@
             }
           },
           "401": {
-            "description": "Unauthenticated — session cookie or API key missing/invalid",
+            "description": "Unauthenticated - session cookie or API key missing/invalid",
             "content": {
               "application/json": {
                 "schema": {
@@ -3686,7 +3686,7 @@
             }
           },
           "403": {
-            "description": "Forbidden — caller is not an admin",
+            "description": "Forbidden - caller is not an admin",
             "content": {
               "application/json": {
                 "schema": {
@@ -3821,7 +3821,7 @@
             }
           },
           "401": {
-            "description": "Unauthenticated — session cookie or API key missing/invalid",
+            "description": "Unauthenticated - session cookie or API key missing/invalid",
             "content": {
               "application/json": {
                 "schema": {
@@ -3853,7 +3853,7 @@
             }
           },
           "403": {
-            "description": "Forbidden — caller is not an admin",
+            "description": "Forbidden - caller is not an admin",
             "content": {
               "application/json": {
                 "schema": {
@@ -3946,7 +3946,7 @@
             }
           },
           "401": {
-            "description": "Unauthenticated — session cookie or API key missing/invalid",
+            "description": "Unauthenticated - session cookie or API key missing/invalid",
             "content": {
               "application/json": {
                 "schema": {
@@ -3978,7 +3978,7 @@
             }
           },
           "403": {
-            "description": "Forbidden — caller is not an admin",
+            "description": "Forbidden - caller is not an admin",
             "content": {
               "application/json": {
                 "schema": {
@@ -4083,7 +4083,7 @@
             }
           },
           "401": {
-            "description": "Unauthenticated — session cookie or API key missing/invalid",
+            "description": "Unauthenticated - session cookie or API key missing/invalid",
             "content": {
               "application/json": {
                 "schema": {
@@ -4115,7 +4115,7 @@
             }
           },
           "403": {
-            "description": "Forbidden — caller is not an admin",
+            "description": "Forbidden - caller is not an admin",
             "content": {
               "application/json": {
                 "schema": {
@@ -4240,7 +4240,7 @@
             }
           },
           "401": {
-            "description": "Unauthenticated — session cookie or API key missing/invalid",
+            "description": "Unauthenticated - session cookie or API key missing/invalid",
             "content": {
               "application/json": {
                 "schema": {
@@ -4272,7 +4272,7 @@
             }
           },
           "403": {
-            "description": "Forbidden — caller is not an admin",
+            "description": "Forbidden - caller is not an admin",
             "content": {
               "application/json": {
                 "schema": {
@@ -4405,7 +4405,7 @@
             }
           },
           "401": {
-            "description": "Unauthenticated — session cookie or API key missing/invalid",
+            "description": "Unauthenticated - session cookie or API key missing/invalid",
             "content": {
               "application/json": {
                 "schema": {
@@ -4437,7 +4437,7 @@
             }
           },
           "403": {
-            "description": "Forbidden — caller is not an admin",
+            "description": "Forbidden - caller is not an admin",
             "content": {
               "application/json": {
                 "schema": {
@@ -4542,7 +4542,7 @@
             }
           },
           "401": {
-            "description": "Unauthenticated — session cookie or API key missing/invalid",
+            "description": "Unauthenticated - session cookie or API key missing/invalid",
             "content": {
               "application/json": {
                 "schema": {
@@ -4574,7 +4574,7 @@
             }
           },
           "403": {
-            "description": "Forbidden — caller is not an admin",
+            "description": "Forbidden - caller is not an admin",
             "content": {
               "application/json": {
                 "schema": {
@@ -4699,7 +4699,7 @@
             }
           },
           "401": {
-            "description": "Unauthenticated — session cookie or API key missing/invalid",
+            "description": "Unauthenticated - session cookie or API key missing/invalid",
             "content": {
               "application/json": {
                 "schema": {
@@ -4731,7 +4731,7 @@
             }
           },
           "403": {
-            "description": "Forbidden — caller is not an admin",
+            "description": "Forbidden - caller is not an admin",
             "content": {
               "application/json": {
                 "schema": {
@@ -4824,7 +4824,7 @@
             }
           },
           "401": {
-            "description": "Unauthenticated — session cookie or API key missing/invalid",
+            "description": "Unauthenticated - session cookie or API key missing/invalid",
             "content": {
               "application/json": {
                 "schema": {
@@ -4856,7 +4856,7 @@
             }
           },
           "403": {
-            "description": "Forbidden — caller is not an admin",
+            "description": "Forbidden - caller is not an admin",
             "content": {
               "application/json": {
                 "schema": {
@@ -4949,7 +4949,7 @@
             }
           },
           "401": {
-            "description": "Unauthenticated — session cookie or API key missing/invalid",
+            "description": "Unauthenticated - session cookie or API key missing/invalid",
             "content": {
               "application/json": {
                 "schema": {
@@ -4981,7 +4981,7 @@
             }
           },
           "403": {
-            "description": "Forbidden — caller is not an admin",
+            "description": "Forbidden - caller is not an admin",
             "content": {
               "application/json": {
                 "schema": {
@@ -5114,7 +5114,7 @@
             }
           },
           "401": {
-            "description": "Unauthenticated — session cookie or API key missing/invalid",
+            "description": "Unauthenticated - session cookie or API key missing/invalid",
             "content": {
               "application/json": {
                 "schema": {
@@ -5146,7 +5146,7 @@
             }
           },
           "403": {
-            "description": "Forbidden — caller is not an admin",
+            "description": "Forbidden - caller is not an admin",
             "content": {
               "application/json": {
                 "schema": {
@@ -5281,7 +5281,7 @@
             }
           },
           "401": {
-            "description": "Unauthenticated — session cookie or API key missing/invalid",
+            "description": "Unauthenticated - session cookie or API key missing/invalid",
             "content": {
               "application/json": {
                 "schema": {
@@ -5313,7 +5313,7 @@
             }
           },
           "403": {
-            "description": "Forbidden — caller is not an admin",
+            "description": "Forbidden - caller is not an admin",
             "content": {
               "application/json": {
                 "schema": {
@@ -5406,7 +5406,7 @@
             }
           },
           "401": {
-            "description": "Unauthenticated — session cookie or API key missing/invalid",
+            "description": "Unauthenticated - session cookie or API key missing/invalid",
             "content": {
               "application/json": {
                 "schema": {
@@ -5438,7 +5438,7 @@
             }
           },
           "403": {
-            "description": "Forbidden — caller is not an admin",
+            "description": "Forbidden - caller is not an admin",
             "content": {
               "application/json": {
                 "schema": {
@@ -5571,7 +5571,7 @@
             }
           },
           "401": {
-            "description": "Unauthenticated — session cookie or API key missing/invalid",
+            "description": "Unauthenticated - session cookie or API key missing/invalid",
             "content": {
               "application/json": {
                 "schema": {
@@ -5603,7 +5603,7 @@
             }
           },
           "403": {
-            "description": "Forbidden — caller is not an admin",
+            "description": "Forbidden - caller is not an admin",
             "content": {
               "application/json": {
                 "schema": {
@@ -5742,7 +5742,7 @@
             }
           },
           "401": {
-            "description": "Unauthenticated — session cookie or API key missing/invalid",
+            "description": "Unauthenticated - session cookie or API key missing/invalid",
             "content": {
               "application/json": {
                 "schema": {
@@ -5774,7 +5774,7 @@
             }
           },
           "403": {
-            "description": "Forbidden — caller is not an admin",
+            "description": "Forbidden - caller is not an admin",
             "content": {
               "application/json": {
                 "schema": {
@@ -5879,7 +5879,7 @@
             }
           },
           "401": {
-            "description": "Unauthenticated — session cookie or API key missing/invalid",
+            "description": "Unauthenticated - session cookie or API key missing/invalid",
             "content": {
               "application/json": {
                 "schema": {
@@ -5911,7 +5911,7 @@
             }
           },
           "403": {
-            "description": "Forbidden — caller is not an admin",
+            "description": "Forbidden - caller is not an admin",
             "content": {
               "application/json": {
                 "schema": {
@@ -6056,7 +6056,7 @@
             }
           },
           "401": {
-            "description": "Unauthenticated — session cookie or API key missing/invalid",
+            "description": "Unauthenticated - session cookie or API key missing/invalid",
             "content": {
               "application/json": {
                 "schema": {
@@ -6088,7 +6088,7 @@
             }
           },
           "403": {
-            "description": "Forbidden — caller is not an admin",
+            "description": "Forbidden - caller is not an admin",
             "content": {
               "application/json": {
                 "schema": {
@@ -6213,7 +6213,7 @@
             }
           },
           "401": {
-            "description": "Unauthenticated — session cookie or API key missing/invalid",
+            "description": "Unauthenticated - session cookie or API key missing/invalid",
             "content": {
               "application/json": {
                 "schema": {
@@ -6245,7 +6245,7 @@
             }
           },
           "403": {
-            "description": "Forbidden — caller is not an admin",
+            "description": "Forbidden - caller is not an admin",
             "content": {
               "application/json": {
                 "schema": {
@@ -6378,7 +6378,7 @@
             }
           },
           "401": {
-            "description": "Unauthenticated — session cookie or API key missing/invalid",
+            "description": "Unauthenticated - session cookie or API key missing/invalid",
             "content": {
               "application/json": {
                 "schema": {
@@ -6410,7 +6410,7 @@
             }
           },
           "403": {
-            "description": "Forbidden — caller is not an admin",
+            "description": "Forbidden - caller is not an admin",
             "content": {
               "application/json": {
                 "schema": {
@@ -6515,7 +6515,7 @@
             }
           },
           "401": {
-            "description": "Unauthenticated — session cookie or API key missing/invalid",
+            "description": "Unauthenticated - session cookie or API key missing/invalid",
             "content": {
               "application/json": {
                 "schema": {
@@ -6547,7 +6547,7 @@
             }
           },
           "403": {
-            "description": "Forbidden — caller is not an admin",
+            "description": "Forbidden - caller is not an admin",
             "content": {
               "application/json": {
                 "schema": {
@@ -6724,7 +6724,7 @@
             }
           },
           "401": {
-            "description": "Unauthenticated — session cookie or API key missing/invalid",
+            "description": "Unauthenticated - session cookie or API key missing/invalid",
             "content": {
               "application/json": {
                 "schema": {
@@ -6756,7 +6756,7 @@
             }
           },
           "403": {
-            "description": "Forbidden — caller is not an admin",
+            "description": "Forbidden - caller is not an admin",
             "content": {
               "application/json": {
                 "schema": {
@@ -6891,7 +6891,7 @@
             }
           },
           "401": {
-            "description": "Unauthenticated — session cookie or API key missing/invalid",
+            "description": "Unauthenticated - session cookie or API key missing/invalid",
             "content": {
               "application/json": {
                 "schema": {
@@ -6923,7 +6923,7 @@
             }
           },
           "403": {
-            "description": "Forbidden — caller is not an admin",
+            "description": "Forbidden - caller is not an admin",
             "content": {
               "application/json": {
                 "schema": {
@@ -7063,7 +7063,7 @@
             }
           },
           "401": {
-            "description": "Unauthenticated — session cookie or API key missing/invalid",
+            "description": "Unauthenticated - session cookie or API key missing/invalid",
             "content": {
               "application/json": {
                 "schema": {
@@ -7095,7 +7095,7 @@
             }
           },
           "403": {
-            "description": "Forbidden — caller is not an admin",
+            "description": "Forbidden - caller is not an admin",
             "content": {
               "application/json": {
                 "schema": {
@@ -7272,7 +7272,7 @@
             }
           },
           "401": {
-            "description": "Unauthenticated — session cookie or API key missing/invalid",
+            "description": "Unauthenticated - session cookie or API key missing/invalid",
             "content": {
               "application/json": {
                 "schema": {
@@ -7304,7 +7304,7 @@
             }
           },
           "403": {
-            "description": "Forbidden — caller is not an admin",
+            "description": "Forbidden - caller is not an admin",
             "content": {
               "application/json": {
                 "schema": {
@@ -7451,7 +7451,7 @@
             }
           },
           "401": {
-            "description": "Unauthenticated — session cookie or API key missing/invalid",
+            "description": "Unauthenticated - session cookie or API key missing/invalid",
             "content": {
               "application/json": {
                 "schema": {
@@ -7483,7 +7483,7 @@
             }
           },
           "403": {
-            "description": "Forbidden — caller is not an admin",
+            "description": "Forbidden - caller is not an admin",
             "content": {
               "application/json": {
                 "schema": {
@@ -7620,7 +7620,7 @@
             }
           },
           "401": {
-            "description": "Unauthenticated — session cookie or API key missing/invalid",
+            "description": "Unauthenticated - session cookie or API key missing/invalid",
             "content": {
               "application/json": {
                 "schema": {
@@ -7652,7 +7652,7 @@
             }
           },
           "403": {
-            "description": "Forbidden — caller is not an admin",
+            "description": "Forbidden - caller is not an admin",
             "content": {
               "application/json": {
                 "schema": {
@@ -7829,7 +7829,7 @@
             }
           },
           "401": {
-            "description": "Unauthenticated — session cookie or API key missing/invalid",
+            "description": "Unauthenticated - session cookie or API key missing/invalid",
             "content": {
               "application/json": {
                 "schema": {
@@ -7861,7 +7861,7 @@
             }
           },
           "403": {
-            "description": "Forbidden — caller is not an admin",
+            "description": "Forbidden - caller is not an admin",
             "content": {
               "application/json": {
                 "schema": {
@@ -8050,7 +8050,7 @@
             }
           },
           "401": {
-            "description": "Unauthenticated — session cookie or API key missing/invalid",
+            "description": "Unauthenticated - session cookie or API key missing/invalid",
             "content": {
               "application/json": {
                 "schema": {
@@ -8082,7 +8082,7 @@
             }
           },
           "403": {
-            "description": "Forbidden — caller is not an admin",
+            "description": "Forbidden - caller is not an admin",
             "content": {
               "application/json": {
                 "schema": {
@@ -8227,7 +8227,7 @@
             }
           },
           "401": {
-            "description": "Unauthenticated — session cookie or API key missing/invalid",
+            "description": "Unauthenticated - session cookie or API key missing/invalid",
             "content": {
               "application/json": {
                 "schema": {
@@ -8259,7 +8259,7 @@
             }
           },
           "403": {
-            "description": "Forbidden — caller is not an admin",
+            "description": "Forbidden - caller is not an admin",
             "content": {
               "application/json": {
                 "schema": {
@@ -8406,7 +8406,7 @@
             }
           },
           "401": {
-            "description": "Unauthenticated — session cookie or API key missing/invalid",
+            "description": "Unauthenticated - session cookie or API key missing/invalid",
             "content": {
               "application/json": {
                 "schema": {
@@ -8438,7 +8438,7 @@
             }
           },
           "403": {
-            "description": "Forbidden — caller is not an admin",
+            "description": "Forbidden - caller is not an admin",
             "content": {
               "application/json": {
                 "schema": {
@@ -8575,7 +8575,7 @@
             }
           },
           "401": {
-            "description": "Unauthenticated — session cookie or API key missing/invalid",
+            "description": "Unauthenticated - session cookie or API key missing/invalid",
             "content": {
               "application/json": {
                 "schema": {
@@ -8607,7 +8607,7 @@
             }
           },
           "403": {
-            "description": "Forbidden — caller is not an admin",
+            "description": "Forbidden - caller is not an admin",
             "content": {
               "application/json": {
                 "schema": {
@@ -8784,7 +8784,7 @@
             }
           },
           "401": {
-            "description": "Unauthenticated — session cookie or API key missing/invalid",
+            "description": "Unauthenticated - session cookie or API key missing/invalid",
             "content": {
               "application/json": {
                 "schema": {
@@ -8816,7 +8816,7 @@
             }
           },
           "403": {
-            "description": "Forbidden — caller is not an admin",
+            "description": "Forbidden - caller is not an admin",
             "content": {
               "application/json": {
                 "schema": {
@@ -9005,7 +9005,7 @@
             }
           },
           "401": {
-            "description": "Unauthenticated — session cookie or API key missing/invalid",
+            "description": "Unauthenticated - session cookie or API key missing/invalid",
             "content": {
               "application/json": {
                 "schema": {
@@ -9037,7 +9037,7 @@
             }
           },
           "403": {
-            "description": "Forbidden — caller is not an admin",
+            "description": "Forbidden - caller is not an admin",
             "content": {
               "application/json": {
                 "schema": {
@@ -9182,7 +9182,7 @@
             }
           },
           "401": {
-            "description": "Unauthenticated — session cookie or API key missing/invalid",
+            "description": "Unauthenticated - session cookie or API key missing/invalid",
             "content": {
               "application/json": {
                 "schema": {
@@ -9214,7 +9214,7 @@
             }
           },
           "403": {
-            "description": "Forbidden — caller is not an admin",
+            "description": "Forbidden - caller is not an admin",
             "content": {
               "application/json": {
                 "schema": {
@@ -9339,7 +9339,7 @@
             }
           },
           "401": {
-            "description": "Unauthenticated — session cookie or API key missing/invalid",
+            "description": "Unauthenticated - session cookie or API key missing/invalid",
             "content": {
               "application/json": {
                 "schema": {
@@ -9371,7 +9371,7 @@
             }
           },
           "403": {
-            "description": "Forbidden — caller is not an admin",
+            "description": "Forbidden - caller is not an admin",
             "content": {
               "application/json": {
                 "schema": {
@@ -9504,7 +9504,7 @@
             }
           },
           "401": {
-            "description": "Unauthenticated — session cookie or API key missing/invalid",
+            "description": "Unauthenticated - session cookie or API key missing/invalid",
             "content": {
               "application/json": {
                 "schema": {
@@ -9536,7 +9536,7 @@
             }
           },
           "403": {
-            "description": "Forbidden — caller is not an admin",
+            "description": "Forbidden - caller is not an admin",
             "content": {
               "application/json": {
                 "schema": {
@@ -9641,7 +9641,7 @@
             }
           },
           "401": {
-            "description": "Unauthenticated — session cookie or API key missing/invalid",
+            "description": "Unauthenticated - session cookie or API key missing/invalid",
             "content": {
               "application/json": {
                 "schema": {
@@ -9673,7 +9673,7 @@
             }
           },
           "403": {
-            "description": "Forbidden — caller is not an admin",
+            "description": "Forbidden - caller is not an admin",
             "content": {
               "application/json": {
                 "schema": {
@@ -9850,7 +9850,7 @@
             }
           },
           "401": {
-            "description": "Unauthenticated — session cookie or API key missing/invalid",
+            "description": "Unauthenticated - session cookie or API key missing/invalid",
             "content": {
               "application/json": {
                 "schema": {
@@ -9882,7 +9882,7 @@
             }
           },
           "403": {
-            "description": "Forbidden — caller is not an admin",
+            "description": "Forbidden - caller is not an admin",
             "content": {
               "application/json": {
                 "schema": {
@@ -10017,7 +10017,7 @@
             }
           },
           "401": {
-            "description": "Unauthenticated — session cookie or API key missing/invalid",
+            "description": "Unauthenticated - session cookie or API key missing/invalid",
             "content": {
               "application/json": {
                 "schema": {
@@ -10049,7 +10049,7 @@
             }
           },
           "403": {
-            "description": "Forbidden — caller is not an admin",
+            "description": "Forbidden - caller is not an admin",
             "content": {
               "application/json": {
                 "schema": {
@@ -10174,7 +10174,7 @@
             }
           },
           "401": {
-            "description": "Unauthenticated — session cookie or API key missing/invalid",
+            "description": "Unauthenticated - session cookie or API key missing/invalid",
             "content": {
               "application/json": {
                 "schema": {
@@ -10206,7 +10206,7 @@
             }
           },
           "403": {
-            "description": "Forbidden — caller is not an admin",
+            "description": "Forbidden - caller is not an admin",
             "content": {
               "application/json": {
                 "schema": {
@@ -10339,7 +10339,7 @@
             }
           },
           "401": {
-            "description": "Unauthenticated — session cookie or API key missing/invalid",
+            "description": "Unauthenticated - session cookie or API key missing/invalid",
             "content": {
               "application/json": {
                 "schema": {
@@ -10371,7 +10371,7 @@
             }
           },
           "403": {
-            "description": "Forbidden — caller is not an admin",
+            "description": "Forbidden - caller is not an admin",
             "content": {
               "application/json": {
                 "schema": {
@@ -10508,7 +10508,7 @@
             }
           },
           "401": {
-            "description": "Unauthenticated — session cookie or API key missing/invalid",
+            "description": "Unauthenticated - session cookie or API key missing/invalid",
             "content": {
               "application/json": {
                 "schema": {
@@ -10540,7 +10540,7 @@
             }
           },
           "403": {
-            "description": "Forbidden — caller is not an admin",
+            "description": "Forbidden - caller is not an admin",
             "content": {
               "application/json": {
                 "schema": {
@@ -10717,7 +10717,7 @@
             }
           },
           "401": {
-            "description": "Unauthenticated — session cookie or API key missing/invalid",
+            "description": "Unauthenticated - session cookie or API key missing/invalid",
             "content": {
               "application/json": {
                 "schema": {
@@ -10749,7 +10749,7 @@
             }
           },
           "403": {
-            "description": "Forbidden — caller is not an admin",
+            "description": "Forbidden - caller is not an admin",
             "content": {
               "application/json": {
                 "schema": {
@@ -10884,7 +10884,7 @@
             }
           },
           "401": {
-            "description": "Unauthenticated — session cookie or API key missing/invalid",
+            "description": "Unauthenticated - session cookie or API key missing/invalid",
             "content": {
               "application/json": {
                 "schema": {
@@ -10916,7 +10916,7 @@
             }
           },
           "403": {
-            "description": "Forbidden — caller is not an admin",
+            "description": "Forbidden - caller is not an admin",
             "content": {
               "application/json": {
                 "schema": {
@@ -11041,7 +11041,7 @@
             }
           },
           "401": {
-            "description": "Unauthenticated — session cookie or API key missing/invalid",
+            "description": "Unauthenticated - session cookie or API key missing/invalid",
             "content": {
               "application/json": {
                 "schema": {
@@ -11073,7 +11073,7 @@
             }
           },
           "403": {
-            "description": "Forbidden — caller is not an admin",
+            "description": "Forbidden - caller is not an admin",
             "content": {
               "application/json": {
                 "schema": {
@@ -11206,7 +11206,7 @@
             }
           },
           "401": {
-            "description": "Unauthenticated — session cookie or API key missing/invalid",
+            "description": "Unauthenticated - session cookie or API key missing/invalid",
             "content": {
               "application/json": {
                 "schema": {
@@ -11238,7 +11238,7 @@
             }
           },
           "403": {
-            "description": "Forbidden — caller is not an admin",
+            "description": "Forbidden - caller is not an admin",
             "content": {
               "application/json": {
                 "schema": {
@@ -11343,7 +11343,7 @@
             }
           },
           "401": {
-            "description": "Unauthenticated — session cookie or API key missing/invalid",
+            "description": "Unauthenticated - session cookie or API key missing/invalid",
             "content": {
               "application/json": {
                 "schema": {
@@ -11375,7 +11375,7 @@
             }
           },
           "403": {
-            "description": "Forbidden — caller is not an admin",
+            "description": "Forbidden - caller is not an admin",
             "content": {
               "application/json": {
                 "schema": {
@@ -11552,7 +11552,7 @@
             }
           },
           "401": {
-            "description": "Unauthenticated — session cookie or API key missing/invalid",
+            "description": "Unauthenticated - session cookie or API key missing/invalid",
             "content": {
               "application/json": {
                 "schema": {
@@ -11584,7 +11584,7 @@
             }
           },
           "403": {
-            "description": "Forbidden — caller is not an admin",
+            "description": "Forbidden - caller is not an admin",
             "content": {
               "application/json": {
                 "schema": {
@@ -11719,7 +11719,7 @@
             }
           },
           "401": {
-            "description": "Unauthenticated — session cookie or API key missing/invalid",
+            "description": "Unauthenticated - session cookie or API key missing/invalid",
             "content": {
               "application/json": {
                 "schema": {
@@ -11751,7 +11751,7 @@
             }
           },
           "403": {
-            "description": "Forbidden — caller is not an admin",
+            "description": "Forbidden - caller is not an admin",
             "content": {
               "application/json": {
                 "schema": {
@@ -11888,7 +11888,7 @@
             }
           },
           "401": {
-            "description": "Unauthenticated — session cookie or API key missing/invalid",
+            "description": "Unauthenticated - session cookie or API key missing/invalid",
             "content": {
               "application/json": {
                 "schema": {
@@ -11920,7 +11920,7 @@
             }
           },
           "403": {
-            "description": "Forbidden — caller is not an admin",
+            "description": "Forbidden - caller is not an admin",
             "content": {
               "application/json": {
                 "schema": {
@@ -12142,7 +12142,7 @@
             }
           },
           "401": {
-            "description": "Unauthenticated — session cookie or API key missing/invalid",
+            "description": "Unauthenticated - session cookie or API key missing/invalid",
             "content": {
               "application/json": {
                 "schema": {
@@ -12174,7 +12174,7 @@
             }
           },
           "403": {
-            "description": "Forbidden — caller is not an admin",
+            "description": "Forbidden - caller is not an admin",
             "content": {
               "application/json": {
                 "schema": {
@@ -12267,7 +12267,7 @@
             }
           },
           "401": {
-            "description": "Unauthenticated — session cookie or API key missing/invalid",
+            "description": "Unauthenticated - session cookie or API key missing/invalid",
             "content": {
               "application/json": {
                 "schema": {
@@ -12299,7 +12299,7 @@
             }
           },
           "403": {
-            "description": "Forbidden — caller is not an admin",
+            "description": "Forbidden - caller is not an admin",
             "content": {
               "application/json": {
                 "schema": {
@@ -12374,25 +12374,15 @@
       }
     },
     "/api/inbound-wg/config": {
-      "put": {
+      "get": {
         "tags": [
           "inbound-wg"
         ],
-        "description": "Enable or disable the inbound (multi-peer) WireGuard server and set its UDP listen port. On enable the daemon generates the server keypair (once), stands up the `wg_wardin0` interface, installs the NAT masquerade and listen-port accept firewall rules, and re-admits every enabled peer. On disable it removes those rules and tears the interface down; peer definitions are preserved. Admin only.",
-        "operationId": "set_config",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/InboundWgConfigRequest"
-              }
-            }
-          },
-          "required": true
-        },
+        "description": "Read the current inbound WireGuard server config (enabled, listen port, public key) without mutating anything. Admin only.",
+        "operationId": "get_config",
         "responses": {
           "200": {
-            "description": "Inbound WireGuard config applied",
+            "description": "Current inbound WireGuard config",
             "content": {
               "application/json": {
                 "schema": {
@@ -12402,7 +12392,7 @@
             }
           },
           "401": {
-            "description": "Unauthenticated — session cookie or API key missing/invalid",
+            "description": "Unauthenticated - session cookie or API key missing/invalid",
             "content": {
               "application/json": {
                 "schema": {
@@ -12434,7 +12424,140 @@
             }
           },
           "403": {
-            "description": "Forbidden — caller is not an admin",
+            "description": "Forbidden - caller is not an admin",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "description": "Standard API error response.",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "detail": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "error": {
+                      "type": "string"
+                    },
+                    "request_id": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "description": "Request ID for correlation with server logs."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "description": "Standard API error response.",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "detail": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "error": {
+                      "type": "string"
+                    },
+                    "request_id": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "description": "Request ID for correlation with server logs."
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "session_cookie": []
+          },
+          {
+            "bearer_auth": []
+          }
+        ]
+      },
+      "put": {
+        "tags": [
+          "inbound-wg"
+        ],
+        "description": "Enable or disable the inbound (multi-peer) WireGuard server and set its UDP listen port. On enable the daemon generates the server keypair (once), stands up the `wg_wardin0` interface, installs the NAT masquerade and listen-port accept firewall rules, and re-admits every enabled peer. On disable it removes those rules and tears the interface down; peer definitions are preserved. Admin only.",
+        "operationId": "set_config",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/InboundWgConfigRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Inbound WireGuard config applied",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InboundWgConfigResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthenticated - session cookie or API key missing/invalid",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "description": "Standard API error response.",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "detail": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "error": {
+                      "type": "string"
+                    },
+                    "request_id": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "description": "Request ID for correlation with server logs."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden - caller is not an admin",
             "content": {
               "application/json": {
                 "schema": {
@@ -12527,7 +12650,7 @@
             }
           },
           "401": {
-            "description": "Unauthenticated — session cookie or API key missing/invalid",
+            "description": "Unauthenticated - session cookie or API key missing/invalid",
             "content": {
               "application/json": {
                 "schema": {
@@ -12559,7 +12682,7 @@
             }
           },
           "403": {
-            "description": "Forbidden — caller is not an admin",
+            "description": "Forbidden - caller is not an admin",
             "content": {
               "application/json": {
                 "schema": {
@@ -12660,7 +12783,7 @@
             }
           },
           "401": {
-            "description": "Unauthenticated — session cookie or API key missing/invalid",
+            "description": "Unauthenticated - session cookie or API key missing/invalid",
             "content": {
               "application/json": {
                 "schema": {
@@ -12692,7 +12815,7 @@
             }
           },
           "403": {
-            "description": "Forbidden — caller is not an admin",
+            "description": "Forbidden - caller is not an admin",
             "content": {
               "application/json": {
                 "schema": {
@@ -12854,7 +12977,7 @@
             "description": "Peer removed"
           },
           "401": {
-            "description": "Unauthenticated — session cookie or API key missing/invalid",
+            "description": "Unauthenticated - session cookie or API key missing/invalid",
             "content": {
               "application/json": {
                 "schema": {
@@ -12886,7 +13009,184 @@
             }
           },
           "403": {
-            "description": "Forbidden — caller is not an admin",
+            "description": "Forbidden - caller is not an admin",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "description": "Standard API error response.",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "detail": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "error": {
+                      "type": "string"
+                    },
+                    "request_id": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "description": "Request ID for correlation with server logs."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Resource not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "description": "Standard API error response.",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "detail": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "error": {
+                      "type": "string"
+                    },
+                    "request_id": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "description": "Request ID for correlation with server logs."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "description": "Standard API error response.",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "detail": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "error": {
+                      "type": "string"
+                    },
+                    "request_id": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "description": "Request ID for correlation with server logs."
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "session_cookie": []
+          },
+          {
+            "bearer_auth": []
+          }
+        ]
+      },
+      "patch": {
+        "tags": [
+          "inbound-wg"
+        ],
+        "description": "Pause or resume an inbound WireGuard peer without deleting its credential: re-admits it onto the live interface (enable) or best-effort removes it (disable), then persists the flag. Distinct from DELETE, which revokes the credential permanently — a paused peer can be resumed without a fresh keypair or QR scan. Admin only.",
+        "operationId": "set_peer_enabled",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Peer ID",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SetInboundWgPeerEnabledRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Peer state applied",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InboundWgPeerSummary"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthenticated - session cookie or API key missing/invalid",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "description": "Standard API error response.",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "detail": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "error": {
+                      "type": "string"
+                    },
+                    "request_id": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "description": "Request ID for correlation with server logs."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden - caller is not an admin",
             "content": {
               "application/json": {
                 "schema": {
@@ -13057,7 +13357,7 @@
             }
           },
           "401": {
-            "description": "Unauthenticated — session cookie or API key missing/invalid",
+            "description": "Unauthenticated - session cookie or API key missing/invalid",
             "content": {
               "application/json": {
                 "schema": {
@@ -13089,7 +13389,7 @@
             }
           },
           "403": {
-            "description": "Forbidden — caller is not an admin",
+            "description": "Forbidden - caller is not an admin",
             "content": {
               "application/json": {
                 "schema": {
@@ -13214,7 +13514,7 @@
             }
           },
           "401": {
-            "description": "Unauthenticated — session cookie or API key missing/invalid",
+            "description": "Unauthenticated - session cookie or API key missing/invalid",
             "content": {
               "application/json": {
                 "schema": {
@@ -13246,7 +13546,7 @@
             }
           },
           "403": {
-            "description": "Forbidden — caller is not an admin",
+            "description": "Forbidden - caller is not an admin",
             "content": {
               "application/json": {
                 "schema": {
@@ -13359,7 +13659,7 @@
             }
           },
           "401": {
-            "description": "Unauthenticated — session cookie or API key missing/invalid",
+            "description": "Unauthenticated - session cookie or API key missing/invalid",
             "content": {
               "application/json": {
                 "schema": {
@@ -13391,7 +13691,7 @@
             }
           },
           "403": {
-            "description": "Forbidden — caller is not an admin",
+            "description": "Forbidden - caller is not an admin",
             "content": {
               "application/json": {
                 "schema": {
@@ -13494,7 +13794,7 @@
             }
           },
           "401": {
-            "description": "Unauthenticated — session cookie or API key missing/invalid",
+            "description": "Unauthenticated - session cookie or API key missing/invalid",
             "content": {
               "application/json": {
                 "schema": {
@@ -13526,7 +13826,7 @@
             }
           },
           "403": {
-            "description": "Forbidden — caller is not an admin",
+            "description": "Forbidden - caller is not an admin",
             "content": {
               "application/json": {
                 "schema": {
@@ -13659,7 +13959,7 @@
             }
           },
           "401": {
-            "description": "Unauthenticated — session cookie or API key missing/invalid",
+            "description": "Unauthenticated - session cookie or API key missing/invalid",
             "content": {
               "application/json": {
                 "schema": {
@@ -13691,7 +13991,7 @@
             }
           },
           "403": {
-            "description": "Forbidden — caller is not an admin",
+            "description": "Forbidden - caller is not an admin",
             "content": {
               "application/json": {
                 "schema": {
@@ -13784,7 +14084,7 @@
             }
           },
           "401": {
-            "description": "Unauthenticated — session cookie or API key missing/invalid",
+            "description": "Unauthenticated - session cookie or API key missing/invalid",
             "content": {
               "application/json": {
                 "schema": {
@@ -13816,7 +14116,7 @@
             }
           },
           "403": {
-            "description": "Forbidden — caller is not an admin",
+            "description": "Forbidden - caller is not an admin",
             "content": {
               "application/json": {
                 "schema": {
@@ -13909,7 +14209,7 @@
             }
           },
           "401": {
-            "description": "Unauthenticated — session cookie or API key missing/invalid",
+            "description": "Unauthenticated - session cookie or API key missing/invalid",
             "content": {
               "application/json": {
                 "schema": {
@@ -13941,7 +14241,7 @@
             }
           },
           "403": {
-            "description": "Forbidden — caller is not an admin",
+            "description": "Forbidden - caller is not an admin",
             "content": {
               "application/json": {
                 "schema": {
@@ -14074,7 +14374,7 @@
             }
           },
           "401": {
-            "description": "Unauthenticated — session cookie or API key missing/invalid",
+            "description": "Unauthenticated - session cookie or API key missing/invalid",
             "content": {
               "application/json": {
                 "schema": {
@@ -14106,7 +14406,7 @@
             }
           },
           "403": {
-            "description": "Forbidden — caller is not an admin",
+            "description": "Forbidden - caller is not an admin",
             "content": {
               "application/json": {
                 "schema": {
@@ -14209,7 +14509,7 @@
             }
           },
           "401": {
-            "description": "Unauthenticated — session cookie or API key missing/invalid",
+            "description": "Unauthenticated - session cookie or API key missing/invalid",
             "content": {
               "application/json": {
                 "schema": {
@@ -14241,7 +14541,7 @@
             }
           },
           "403": {
-            "description": "Forbidden — caller is not an admin",
+            "description": "Forbidden - caller is not an admin",
             "content": {
               "application/json": {
                 "schema": {
@@ -14374,7 +14674,7 @@
             }
           },
           "401": {
-            "description": "Unauthenticated — session cookie or API key missing/invalid",
+            "description": "Unauthenticated - session cookie or API key missing/invalid",
             "content": {
               "application/json": {
                 "schema": {
@@ -14406,7 +14706,7 @@
             }
           },
           "403": {
-            "description": "Forbidden — caller is not an admin",
+            "description": "Forbidden - caller is not an admin",
             "content": {
               "application/json": {
                 "schema": {
@@ -14511,7 +14811,7 @@
             }
           },
           "401": {
-            "description": "Unauthenticated — session cookie or API key missing/invalid",
+            "description": "Unauthenticated - session cookie or API key missing/invalid",
             "content": {
               "application/json": {
                 "schema": {
@@ -14543,7 +14843,7 @@
             }
           },
           "403": {
-            "description": "Forbidden — caller is not an admin",
+            "description": "Forbidden - caller is not an admin",
             "content": {
               "application/json": {
                 "schema": {
@@ -14720,7 +15020,7 @@
             }
           },
           "401": {
-            "description": "Unauthenticated — session cookie or API key missing/invalid",
+            "description": "Unauthenticated - session cookie or API key missing/invalid",
             "content": {
               "application/json": {
                 "schema": {
@@ -14752,7 +15052,7 @@
             }
           },
           "403": {
-            "description": "Forbidden — caller is not an admin",
+            "description": "Forbidden - caller is not an admin",
             "content": {
               "application/json": {
                 "schema": {
@@ -14887,7 +15187,7 @@
             }
           },
           "401": {
-            "description": "Unauthenticated — session cookie or API key missing/invalid",
+            "description": "Unauthenticated - session cookie or API key missing/invalid",
             "content": {
               "application/json": {
                 "schema": {
@@ -14919,7 +15219,7 @@
             }
           },
           "403": {
-            "description": "Forbidden — caller is not an admin",
+            "description": "Forbidden - caller is not an admin",
             "content": {
               "application/json": {
                 "schema": {
@@ -15056,7 +15356,7 @@
             }
           },
           "401": {
-            "description": "Unauthenticated — session cookie or API key missing/invalid",
+            "description": "Unauthenticated - session cookie or API key missing/invalid",
             "content": {
               "application/json": {
                 "schema": {
@@ -15088,7 +15388,7 @@
             }
           },
           "403": {
-            "description": "Forbidden — caller is not an admin",
+            "description": "Forbidden - caller is not an admin",
             "content": {
               "application/json": {
                 "schema": {
@@ -15265,7 +15565,7 @@
             }
           },
           "401": {
-            "description": "Unauthenticated — session cookie or API key missing/invalid",
+            "description": "Unauthenticated - session cookie or API key missing/invalid",
             "content": {
               "application/json": {
                 "schema": {
@@ -15297,7 +15597,7 @@
             }
           },
           "403": {
-            "description": "Forbidden — caller is not an admin",
+            "description": "Forbidden - caller is not an admin",
             "content": {
               "application/json": {
                 "schema": {
@@ -15442,7 +15742,7 @@
             }
           },
           "401": {
-            "description": "Unauthenticated — session cookie or API key missing/invalid",
+            "description": "Unauthenticated - session cookie or API key missing/invalid",
             "content": {
               "application/json": {
                 "schema": {
@@ -15474,7 +15774,7 @@
             }
           },
           "403": {
-            "description": "Forbidden — caller is not an admin",
+            "description": "Forbidden - caller is not an admin",
             "content": {
               "application/json": {
                 "schema": {
@@ -15609,7 +15909,7 @@
             }
           },
           "401": {
-            "description": "Unauthenticated — session cookie or API key missing/invalid",
+            "description": "Unauthenticated - session cookie or API key missing/invalid",
             "content": {
               "application/json": {
                 "schema": {
@@ -15641,7 +15941,7 @@
             }
           },
           "403": {
-            "description": "Forbidden — caller is not an admin",
+            "description": "Forbidden - caller is not an admin",
             "content": {
               "application/json": {
                 "schema": {
@@ -15745,7 +16045,7 @@
             }
           },
           "401": {
-            "description": "Unauthenticated — session cookie or API key missing/invalid",
+            "description": "Unauthenticated - session cookie or API key missing/invalid",
             "content": {
               "application/json": {
                 "schema": {
@@ -15777,7 +16077,7 @@
             }
           },
           "403": {
-            "description": "Forbidden — caller is not an admin",
+            "description": "Forbidden - caller is not an admin",
             "content": {
               "application/json": {
                 "schema": {
@@ -15955,7 +16255,7 @@
             }
           },
           "401": {
-            "description": "Unauthenticated — session cookie or API key missing/invalid",
+            "description": "Unauthenticated - session cookie or API key missing/invalid",
             "content": {
               "application/json": {
                 "schema": {
@@ -15987,7 +16287,7 @@
             }
           },
           "403": {
-            "description": "Forbidden — caller is not an admin",
+            "description": "Forbidden - caller is not an admin",
             "content": {
               "application/json": {
                 "schema": {
@@ -16165,7 +16465,7 @@
             }
           },
           "401": {
-            "description": "Unauthenticated — session cookie or API key missing/invalid",
+            "description": "Unauthenticated - session cookie or API key missing/invalid",
             "content": {
               "application/json": {
                 "schema": {
@@ -16197,7 +16497,7 @@
             }
           },
           "403": {
-            "description": "Forbidden — caller is not an admin",
+            "description": "Forbidden - caller is not an admin",
             "content": {
               "application/json": {
                 "schema": {
@@ -16375,7 +16675,7 @@
             }
           },
           "401": {
-            "description": "Unauthenticated — session cookie or API key missing/invalid",
+            "description": "Unauthenticated - session cookie or API key missing/invalid",
             "content": {
               "application/json": {
                 "schema": {
@@ -16407,7 +16707,7 @@
             }
           },
           "403": {
-            "description": "Forbidden — caller is not an admin",
+            "description": "Forbidden - caller is not an admin",
             "content": {
               "application/json": {
                 "schema": {
@@ -16548,7 +16848,7 @@
             }
           },
           "401": {
-            "description": "Unauthenticated — session cookie or API key missing/invalid",
+            "description": "Unauthenticated - session cookie or API key missing/invalid",
             "content": {
               "application/json": {
                 "schema": {
@@ -16580,7 +16880,7 @@
             }
           },
           "403": {
-            "description": "Forbidden — caller is not an admin",
+            "description": "Forbidden - caller is not an admin",
             "content": {
               "application/json": {
                 "schema": {
@@ -16649,7 +16949,7 @@
             }
           },
           "401": {
-            "description": "Unauthenticated — session cookie or API key missing/invalid",
+            "description": "Unauthenticated - session cookie or API key missing/invalid",
             "content": {
               "application/json": {
                 "schema": {
@@ -16681,7 +16981,7 @@
             }
           },
           "403": {
-            "description": "Forbidden — caller is not an admin",
+            "description": "Forbidden - caller is not an admin",
             "content": {
               "application/json": {
                 "schema": {
@@ -16927,7 +17227,7 @@
             }
           },
           "401": {
-            "description": "Unauthenticated — session cookie or API key missing/invalid",
+            "description": "Unauthenticated - session cookie or API key missing/invalid",
             "content": {
               "application/json": {
                 "schema": {
@@ -16959,7 +17259,7 @@
             }
           },
           "403": {
-            "description": "Forbidden — caller is not an admin",
+            "description": "Forbidden - caller is not an admin",
             "content": {
               "application/json": {
                 "schema": {
@@ -17083,7 +17383,7 @@
             }
           },
           "401": {
-            "description": "Unauthenticated — session cookie or API key missing/invalid",
+            "description": "Unauthenticated - session cookie or API key missing/invalid",
             "content": {
               "application/json": {
                 "schema": {
@@ -17115,7 +17415,7 @@
             }
           },
           "403": {
-            "description": "Forbidden — caller is not an admin",
+            "description": "Forbidden - caller is not an admin",
             "content": {
               "application/json": {
                 "schema": {
@@ -17324,7 +17624,7 @@
             }
           },
           "401": {
-            "description": "Unauthenticated — session cookie or API key missing/invalid",
+            "description": "Unauthenticated - session cookie or API key missing/invalid",
             "content": {
               "application/json": {
                 "schema": {
@@ -17356,7 +17656,7 @@
             }
           },
           "403": {
-            "description": "Forbidden — caller is not an admin",
+            "description": "Forbidden - caller is not an admin",
             "content": {
               "application/json": {
                 "schema": {
@@ -17550,7 +17850,7 @@
             }
           },
           "401": {
-            "description": "Unauthenticated — session cookie or API key missing/invalid",
+            "description": "Unauthenticated - session cookie or API key missing/invalid",
             "content": {
               "application/json": {
                 "schema": {
@@ -17582,7 +17882,7 @@
             }
           },
           "403": {
-            "description": "Forbidden — caller is not an admin",
+            "description": "Forbidden - caller is not an admin",
             "content": {
               "application/json": {
                 "schema": {
@@ -17722,7 +18022,7 @@
             }
           },
           "401": {
-            "description": "Unauthenticated — session cookie or API key missing/invalid",
+            "description": "Unauthenticated - session cookie or API key missing/invalid",
             "content": {
               "application/json": {
                 "schema": {
@@ -17754,7 +18054,7 @@
             }
           },
           "403": {
-            "description": "Forbidden — caller is not an admin",
+            "description": "Forbidden - caller is not an admin",
             "content": {
               "application/json": {
                 "schema": {
@@ -17847,7 +18147,7 @@
             }
           },
           "401": {
-            "description": "Unauthenticated — session cookie or API key missing/invalid",
+            "description": "Unauthenticated - session cookie or API key missing/invalid",
             "content": {
               "application/json": {
                 "schema": {
@@ -17879,7 +18179,7 @@
             }
           },
           "403": {
-            "description": "Forbidden — caller is not an admin",
+            "description": "Forbidden - caller is not an admin",
             "content": {
               "application/json": {
                 "schema": {
@@ -17990,7 +18290,7 @@
             }
           },
           "401": {
-            "description": "Unauthenticated — session cookie or API key missing/invalid",
+            "description": "Unauthenticated - session cookie or API key missing/invalid",
             "content": {
               "application/json": {
                 "schema": {
@@ -18022,7 +18322,7 @@
             }
           },
           "403": {
-            "description": "Forbidden — caller is not an admin",
+            "description": "Forbidden - caller is not an admin",
             "content": {
               "application/json": {
                 "schema": {
@@ -18115,7 +18415,7 @@
             }
           },
           "401": {
-            "description": "Unauthenticated — session cookie or API key missing/invalid",
+            "description": "Unauthenticated - session cookie or API key missing/invalid",
             "content": {
               "application/json": {
                 "schema": {
@@ -18147,7 +18447,7 @@
             }
           },
           "403": {
-            "description": "Forbidden — caller is not an admin",
+            "description": "Forbidden - caller is not an admin",
             "content": {
               "application/json": {
                 "schema": {
@@ -18245,7 +18545,7 @@
             }
           },
           "401": {
-            "description": "Unauthenticated — session cookie or API key missing/invalid",
+            "description": "Unauthenticated - session cookie or API key missing/invalid",
             "content": {
               "application/json": {
                 "schema": {
@@ -18277,7 +18577,7 @@
             }
           },
           "403": {
-            "description": "Forbidden — caller is not an admin",
+            "description": "Forbidden - caller is not an admin",
             "content": {
               "application/json": {
                 "schema": {
@@ -18364,7 +18664,7 @@
             "description": "Reboot scheduled"
           },
           "401": {
-            "description": "Unauthenticated — session cookie or API key missing/invalid",
+            "description": "Unauthenticated - session cookie or API key missing/invalid",
             "content": {
               "application/json": {
                 "schema": {
@@ -18396,7 +18696,7 @@
             }
           },
           "403": {
-            "description": "Forbidden — caller is not an admin",
+            "description": "Forbidden - caller is not an admin",
             "content": {
               "application/json": {
                 "schema": {
@@ -18483,7 +18783,7 @@
             "description": "Restart scheduled"
           },
           "401": {
-            "description": "Unauthenticated — session cookie or API key missing/invalid",
+            "description": "Unauthenticated - session cookie or API key missing/invalid",
             "content": {
               "application/json": {
                 "schema": {
@@ -18515,7 +18815,7 @@
             }
           },
           "403": {
-            "description": "Forbidden — caller is not an admin",
+            "description": "Forbidden - caller is not an admin",
             "content": {
               "application/json": {
                 "schema": {
@@ -18602,7 +18902,7 @@
             "description": "Shutdown scheduled"
           },
           "401": {
-            "description": "Unauthenticated — session cookie or API key missing/invalid",
+            "description": "Unauthenticated - session cookie or API key missing/invalid",
             "content": {
               "application/json": {
                 "schema": {
@@ -18634,7 +18934,7 @@
             }
           },
           "403": {
-            "description": "Forbidden — caller is not an admin",
+            "description": "Forbidden - caller is not an admin",
             "content": {
               "application/json": {
                 "schema": {
@@ -18721,7 +19021,7 @@
             "description": "Acknowledgement recorded"
           },
           "401": {
-            "description": "Unauthenticated — session cookie or API key missing/invalid",
+            "description": "Unauthenticated - session cookie or API key missing/invalid",
             "content": {
               "application/json": {
                 "schema": {
@@ -18753,7 +19053,7 @@
             }
           },
           "403": {
-            "description": "Forbidden — caller is not an admin",
+            "description": "Forbidden - caller is not an admin",
             "content": {
               "application/json": {
                 "schema": {
@@ -18846,7 +19146,7 @@
             }
           },
           "401": {
-            "description": "Unauthenticated — session cookie or API key missing/invalid",
+            "description": "Unauthenticated - session cookie or API key missing/invalid",
             "content": {
               "application/json": {
                 "schema": {
@@ -18878,7 +19178,7 @@
             }
           },
           "403": {
-            "description": "Forbidden — caller is not an admin",
+            "description": "Forbidden - caller is not an admin",
             "content": {
               "application/json": {
                 "schema": {
@@ -18971,7 +19271,7 @@
             }
           },
           "401": {
-            "description": "Unauthenticated — session cookie or API key missing/invalid",
+            "description": "Unauthenticated - session cookie or API key missing/invalid",
             "content": {
               "application/json": {
                 "schema": {
@@ -19003,7 +19303,7 @@
             }
           },
           "403": {
-            "description": "Forbidden — caller is not an admin",
+            "description": "Forbidden - caller is not an admin",
             "content": {
               "application/json": {
                 "schema": {
@@ -19096,7 +19396,7 @@
             }
           },
           "401": {
-            "description": "Unauthenticated — session cookie or API key missing/invalid",
+            "description": "Unauthenticated - session cookie or API key missing/invalid",
             "content": {
               "application/json": {
                 "schema": {
@@ -19128,7 +19428,7 @@
             }
           },
           "403": {
-            "description": "Forbidden — caller is not an admin",
+            "description": "Forbidden - caller is not an admin",
             "content": {
               "application/json": {
                 "schema": {
@@ -19261,7 +19561,7 @@
             }
           },
           "401": {
-            "description": "Unauthenticated — session cookie or API key missing/invalid",
+            "description": "Unauthenticated - session cookie or API key missing/invalid",
             "content": {
               "application/json": {
                 "schema": {
@@ -19293,7 +19593,7 @@
             }
           },
           "403": {
-            "description": "Forbidden — caller is not an admin",
+            "description": "Forbidden - caller is not an admin",
             "content": {
               "application/json": {
                 "schema": {
@@ -19398,7 +19698,7 @@
             }
           },
           "401": {
-            "description": "Unauthenticated — session cookie or API key missing/invalid",
+            "description": "Unauthenticated - session cookie or API key missing/invalid",
             "content": {
               "application/json": {
                 "schema": {
@@ -19430,7 +19730,7 @@
             }
           },
           "403": {
-            "description": "Forbidden — caller is not an admin",
+            "description": "Forbidden - caller is not an admin",
             "content": {
               "application/json": {
                 "schema": {
@@ -19565,7 +19865,7 @@
             }
           },
           "401": {
-            "description": "Unauthenticated — session cookie or API key missing/invalid",
+            "description": "Unauthenticated - session cookie or API key missing/invalid",
             "content": {
               "application/json": {
                 "schema": {
@@ -19597,7 +19897,7 @@
             }
           },
           "403": {
-            "description": "Forbidden — caller is not an admin",
+            "description": "Forbidden - caller is not an admin",
             "content": {
               "application/json": {
                 "schema": {
@@ -19734,7 +20034,7 @@
             }
           },
           "401": {
-            "description": "Unauthenticated — session cookie or API key missing/invalid",
+            "description": "Unauthenticated - session cookie or API key missing/invalid",
             "content": {
               "application/json": {
                 "schema": {
@@ -19766,7 +20066,7 @@
             }
           },
           "403": {
-            "description": "Forbidden — caller is not an admin",
+            "description": "Forbidden - caller is not an admin",
             "content": {
               "application/json": {
                 "schema": {
@@ -19913,7 +20213,7 @@
             }
           },
           "401": {
-            "description": "Unauthenticated — session cookie or API key missing/invalid",
+            "description": "Unauthenticated - session cookie or API key missing/invalid",
             "content": {
               "application/json": {
                 "schema": {
@@ -19945,7 +20245,7 @@
             }
           },
           "403": {
-            "description": "Forbidden — caller is not an admin",
+            "description": "Forbidden - caller is not an admin",
             "content": {
               "application/json": {
                 "schema": {
@@ -20082,7 +20382,7 @@
             }
           },
           "401": {
-            "description": "Unauthenticated — session cookie or API key missing/invalid",
+            "description": "Unauthenticated - session cookie or API key missing/invalid",
             "content": {
               "application/json": {
                 "schema": {
@@ -20114,7 +20414,7 @@
             }
           },
           "403": {
-            "description": "Forbidden — caller is not an admin",
+            "description": "Forbidden - caller is not an admin",
             "content": {
               "application/json": {
                 "schema": {
@@ -20251,7 +20551,7 @@
             }
           },
           "401": {
-            "description": "Unauthenticated — session cookie or API key missing/invalid",
+            "description": "Unauthenticated - session cookie or API key missing/invalid",
             "content": {
               "application/json": {
                 "schema": {
@@ -20283,7 +20583,7 @@
             }
           },
           "403": {
-            "description": "Forbidden — caller is not an admin",
+            "description": "Forbidden - caller is not an admin",
             "content": {
               "application/json": {
                 "schema": {
@@ -20452,7 +20752,7 @@
             }
           },
           "401": {
-            "description": "Unauthenticated — session cookie or API key missing/invalid",
+            "description": "Unauthenticated - session cookie or API key missing/invalid",
             "content": {
               "application/json": {
                 "schema": {
@@ -20484,7 +20784,7 @@
             }
           },
           "403": {
-            "description": "Forbidden — caller is not an admin",
+            "description": "Forbidden - caller is not an admin",
             "content": {
               "application/json": {
                 "schema": {
@@ -20621,7 +20921,7 @@
             }
           },
           "401": {
-            "description": "Unauthenticated — session cookie or API key missing/invalid",
+            "description": "Unauthenticated - session cookie or API key missing/invalid",
             "content": {
               "application/json": {
                 "schema": {
@@ -20653,7 +20953,7 @@
             }
           },
           "403": {
-            "description": "Forbidden — caller is not an admin",
+            "description": "Forbidden - caller is not an admin",
             "content": {
               "application/json": {
                 "schema": {
@@ -20842,7 +21142,7 @@
             }
           },
           "401": {
-            "description": "Unauthenticated — session cookie or API key missing/invalid",
+            "description": "Unauthenticated - session cookie or API key missing/invalid",
             "content": {
               "application/json": {
                 "schema": {
@@ -20874,7 +21174,7 @@
             }
           },
           "403": {
-            "description": "Forbidden — caller is not an admin",
+            "description": "Forbidden - caller is not an admin",
             "content": {
               "application/json": {
                 "schema": {
@@ -21009,7 +21309,7 @@
             }
           },
           "401": {
-            "description": "Unauthenticated — session cookie or API key missing/invalid",
+            "description": "Unauthenticated - session cookie or API key missing/invalid",
             "content": {
               "application/json": {
                 "schema": {
@@ -21041,7 +21341,7 @@
             }
           },
           "403": {
-            "description": "Forbidden — caller is not an admin",
+            "description": "Forbidden - caller is not an admin",
             "content": {
               "application/json": {
                 "schema": {
@@ -21147,7 +21447,7 @@
             }
           },
           "401": {
-            "description": "Unauthenticated — session cookie or API key missing/invalid",
+            "description": "Unauthenticated - session cookie or API key missing/invalid",
             "content": {
               "application/json": {
                 "schema": {
@@ -21179,7 +21479,7 @@
             }
           },
           "403": {
-            "description": "Forbidden — caller is not an admin",
+            "description": "Forbidden - caller is not an admin",
             "content": {
               "application/json": {
                 "schema": {
@@ -21315,7 +21615,7 @@
             }
           },
           "401": {
-            "description": "Unauthenticated — session cookie or API key missing/invalid",
+            "description": "Unauthenticated - session cookie or API key missing/invalid",
             "content": {
               "application/json": {
                 "schema": {
@@ -21347,7 +21647,7 @@
             }
           },
           "403": {
-            "description": "Forbidden — caller is not an admin",
+            "description": "Forbidden - caller is not an admin",
             "content": {
               "application/json": {
                 "schema": {
@@ -21440,7 +21740,7 @@
             }
           },
           "401": {
-            "description": "Unauthenticated — session cookie or API key missing/invalid",
+            "description": "Unauthenticated - session cookie or API key missing/invalid",
             "content": {
               "application/json": {
                 "schema": {
@@ -21472,7 +21772,7 @@
             }
           },
           "403": {
-            "description": "Forbidden — caller is not an admin",
+            "description": "Forbidden - caller is not an admin",
             "content": {
               "application/json": {
                 "schema": {
@@ -21565,7 +21865,7 @@
             }
           },
           "401": {
-            "description": "Unauthenticated — session cookie or API key missing/invalid",
+            "description": "Unauthenticated - session cookie or API key missing/invalid",
             "content": {
               "application/json": {
                 "schema": {
@@ -21597,7 +21897,7 @@
             }
           },
           "403": {
-            "description": "Forbidden — caller is not an admin",
+            "description": "Forbidden - caller is not an admin",
             "content": {
               "application/json": {
                 "schema": {
@@ -21690,7 +21990,7 @@
             }
           },
           "401": {
-            "description": "Unauthenticated — session cookie or API key missing/invalid",
+            "description": "Unauthenticated - session cookie or API key missing/invalid",
             "content": {
               "application/json": {
                 "schema": {
@@ -21722,7 +22022,7 @@
             }
           },
           "403": {
-            "description": "Forbidden — caller is not an admin",
+            "description": "Forbidden - caller is not an admin",
             "content": {
               "application/json": {
                 "schema": {
@@ -21827,12 +22127,11 @@
       },
       "AddInboundWgPeerResponse": {
         "type": "object",
-        "description": "Response for `POST /api/inbound-wg/peers`.\n\nCarries the freshly generated **private key** exactly once — it is never\npersisted server-side, so the admin must copy it now to configure the peer.",
+        "description": "Response for `POST /api/inbound-wg/peers`.\n\nCarries the complete, ready-to-import `WireGuard` client configuration —\nassembled server-side and containing the freshly generated **private key**\nexactly once. The daemon never persists the private key (it lives only in\nthis response); the admin must copy/scan it now. This is the ONLY endpoint\nthat ever exposes private key material, and it is admin-gated.",
         "required": [
           "id",
           "name",
           "public_key",
-          "private_key",
           "allowed_ip"
         ],
         "properties": {
@@ -21840,16 +22139,19 @@
             "type": "string",
             "description": "The peer's allocated `/32` inside the inbound tunnel subnet."
           },
+          "client_config": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "The full `WireGuard` client config (`.conf`) — `[Interface]`/`[Peer]`\nstanzas including the private key and endpoint — ready to render as a QR\ncode or download. `None` when no reachable endpoint is known yet (remote\naccess / DDNS not configured); the credential is created but not usable\nuntil an endpoint exists."
+          },
           "id": {
             "type": "string",
             "format": "uuid"
           },
           "name": {
             "type": "string"
-          },
-          "private_key": {
-            "type": "string",
-            "description": "Base64 `WireGuard` private key — returned once, never stored."
           },
           "public_key": {
             "type": "string",
@@ -24472,6 +24774,14 @@
             "type": "string",
             "format": "date-time"
           },
+          "device_id": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "uuid",
+            "description": "The `Device` this credential grants remote access to. `None` only for\npre-#810 rows written before the device link existed; every row\nwritten since always carries it."
+          },
           "enabled": {
             "type": "boolean"
           },
@@ -26033,6 +26343,18 @@
         "properties": {
           "policy": {
             "type": "string"
+          }
+        }
+      },
+      "SetInboundWgPeerEnabledRequest": {
+        "type": "object",
+        "description": "Request body for `PATCH /api/inbound-wg/peers/{id}`.\n\nPauses or resumes a peer without deleting its credential — distinct from\n`DELETE`, which revokes it permanently and requires a fresh keypair (and\nQR scan) to re-grant.",
+        "required": [
+          "enabled"
+        ],
+        "properties": {
+          "enabled": {
+            "type": "boolean"
           }
         }
       },

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -12373,6 +12373,625 @@
         ]
       }
     },
+    "/api/inbound-wg/config": {
+      "put": {
+        "tags": [
+          "inbound-wg"
+        ],
+        "description": "Enable or disable the inbound (multi-peer) WireGuard server and set its UDP listen port. On enable the daemon generates the server keypair (once), stands up the `wg_wardin0` interface, installs the NAT masquerade and listen-port accept firewall rules, and re-admits every enabled peer. On disable it removes those rules and tears the interface down; peer definitions are preserved. Admin only.",
+        "operationId": "set_config",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/InboundWgConfigRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Inbound WireGuard config applied",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InboundWgConfigResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthenticated — session cookie or API key missing/invalid",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "description": "Standard API error response.",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "detail": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "error": {
+                      "type": "string"
+                    },
+                    "request_id": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "description": "Request ID for correlation with server logs."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden — caller is not an admin",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "description": "Standard API error response.",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "detail": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "error": {
+                      "type": "string"
+                    },
+                    "request_id": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "description": "Request ID for correlation with server logs."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "description": "Standard API error response.",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "detail": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "error": {
+                      "type": "string"
+                    },
+                    "request_id": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "description": "Request ID for correlation with server logs."
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "session_cookie": []
+          },
+          {
+            "bearer_auth": []
+          }
+        ]
+      }
+    },
+    "/api/inbound-wg/peers": {
+      "get": {
+        "tags": [
+          "inbound-wg"
+        ],
+        "description": "List every admitted inbound WireGuard peer with its name, public key, allocated address, and enabled state. Private keys are never returned. Admin only.",
+        "operationId": "list_peers",
+        "responses": {
+          "200": {
+            "description": "Configured inbound peers",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListInboundWgPeersResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthenticated — session cookie or API key missing/invalid",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "description": "Standard API error response.",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "detail": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "error": {
+                      "type": "string"
+                    },
+                    "request_id": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "description": "Request ID for correlation with server logs."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden — caller is not an admin",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "description": "Standard API error response.",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "detail": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "error": {
+                      "type": "string"
+                    },
+                    "request_id": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "description": "Request ID for correlation with server logs."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "description": "Standard API error response.",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "detail": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "error": {
+                      "type": "string"
+                    },
+                    "request_id": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "description": "Request ID for correlation with server logs."
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "session_cookie": []
+          },
+          {
+            "bearer_auth": []
+          }
+        ]
+      },
+      "post": {
+        "tags": [
+          "inbound-wg"
+        ],
+        "description": "Grant remote access to an already-managed device via inbound WireGuard. The daemon generates a fresh keypair, allocates the next free address on the inbound subnet, stores the peer (public key + device link), and admits it onto the server interface. The peer's name is taken from the device. The response carries the peer's **private key exactly once** — it is never persisted, so it must be copied now. Returns 409 if the server is disabled or the device already has a credential, 404 if the device does not exist. Admin only.",
+        "operationId": "add_peer",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AddInboundWgPeerRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Peer admitted",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AddInboundWgPeerResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthenticated — session cookie or API key missing/invalid",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "description": "Standard API error response.",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "detail": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "error": {
+                      "type": "string"
+                    },
+                    "request_id": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "description": "Request ID for correlation with server logs."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden — caller is not an admin",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "description": "Standard API error response.",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "detail": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "error": {
+                      "type": "string"
+                    },
+                    "request_id": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "description": "Request ID for correlation with server logs."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Resource not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "description": "Standard API error response.",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "detail": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "error": {
+                      "type": "string"
+                    },
+                    "request_id": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "description": "Request ID for correlation with server logs."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflicting concurrent operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "description": "Standard API error response.",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "detail": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "error": {
+                      "type": "string"
+                    },
+                    "request_id": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "description": "Request ID for correlation with server logs."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "description": "Standard API error response.",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "detail": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "error": {
+                      "type": "string"
+                    },
+                    "request_id": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "description": "Request ID for correlation with server logs."
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "session_cookie": []
+          },
+          {
+            "bearer_auth": []
+          }
+        ]
+      }
+    },
+    "/api/inbound-wg/peers/{id}": {
+      "delete": {
+        "tags": [
+          "inbound-wg"
+        ],
+        "description": "Remove an inbound WireGuard peer by id: drop it from the live server interface and delete its stored definition. Admin only.",
+        "operationId": "remove_peer",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Peer ID",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Peer removed"
+          },
+          "401": {
+            "description": "Unauthenticated — session cookie or API key missing/invalid",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "description": "Standard API error response.",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "detail": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "error": {
+                      "type": "string"
+                    },
+                    "request_id": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "description": "Request ID for correlation with server logs."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden — caller is not an admin",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "description": "Standard API error response.",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "detail": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "error": {
+                      "type": "string"
+                    },
+                    "request_id": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "description": "Request ID for correlation with server logs."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Resource not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "description": "Standard API error response.",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "detail": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "error": {
+                      "type": "string"
+                    },
+                    "request_id": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "description": "Request ID for correlation with server logs."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "description": "Standard API error response.",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "detail": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "error": {
+                      "type": "string"
+                    },
+                    "request_id": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "description": "Request ID for correlation with server logs."
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "session_cookie": []
+          },
+          {
+            "bearer_auth": []
+          }
+        ]
+      }
+    },
     "/api/info": {
       "get": {
         "tags": [
@@ -21192,6 +21811,52 @@
   },
   "components": {
     "schemas": {
+      "AddInboundWgPeerRequest": {
+        "type": "object",
+        "description": "Request body for `POST /api/inbound-wg/peers`.\n\nA remote-access grant targets an already-managed device (issue #810): the\npeer's user-facing name is taken from that device, not supplied here.",
+        "required": [
+          "device_id"
+        ],
+        "properties": {
+          "device_id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "The device to grant remote access to. Must already exist (discovered on\nthe LAN at least once) and must not already have a credential."
+          }
+        }
+      },
+      "AddInboundWgPeerResponse": {
+        "type": "object",
+        "description": "Response for `POST /api/inbound-wg/peers`.\n\nCarries the freshly generated **private key** exactly once — it is never\npersisted server-side, so the admin must copy it now to configure the peer.",
+        "required": [
+          "id",
+          "name",
+          "public_key",
+          "private_key",
+          "allowed_ip"
+        ],
+        "properties": {
+          "allowed_ip": {
+            "type": "string",
+            "description": "The peer's allocated `/32` inside the inbound tunnel subnet."
+          },
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "name": {
+            "type": "string"
+          },
+          "private_key": {
+            "type": "string",
+            "description": "Base64 `WireGuard` private key — returned once, never stored."
+          },
+          "public_key": {
+            "type": "string",
+            "description": "Base64 `WireGuard` public key (stored server-side)."
+          }
+        }
+      },
       "AdvanceWizardRequest": {
         "type": "object",
         "description": "Request body for POST /api/setup/advance.",
@@ -22549,11 +23214,16 @@
           "zone_id",
           "dns_capture_enabled",
           "dns_capture_cap_count",
-          "dns_capture_cap_days"
+          "dns_capture_cap_days",
+          "connection_mode"
         ],
         "properties": {
           "admin_locked": {
             "type": "boolean"
+          },
+          "connection_mode": {
+            "$ref": "#/components/schemas/DeviceConnectionMode",
+            "description": "How the device is currently reachable (LAN vs. inbound `WireGuard`).\nLive status, last-observation-wins — see [`DeviceConnectionMode`]."
           },
           "device_type": {
             "$ref": "#/components/schemas/DeviceType"
@@ -22623,6 +23293,14 @@
             "type": "boolean"
           }
         }
+      },
+      "DeviceConnectionMode": {
+        "type": "string",
+        "description": "How a device is currently reachable on the network (issue #810).\n\nA **live status**, not a lineage tag: a device flips between the two as it\nconnects from different paths over time (last-observation-wins), exactly\nlike `last_ip` already does across DHCP renewals. Set by whichever path\nmost recently observed the device — LAN ARP/DHCP discovery sets [`Lan`], an\ninbound `WireGuard` handshake sets [`Remote`].\n\n[`Lan`]: DeviceConnectionMode::Lan\n[`Remote`]: DeviceConnectionMode::Remote",
+        "enum": [
+          "lan",
+          "remote"
+        ]
       },
       "DeviceDetailResponse": {
         "type": "object",
@@ -23728,6 +24406,87 @@
           "DOWN"
         ]
       },
+      "InboundWgConfigRequest": {
+        "type": "object",
+        "description": "Request body for `PUT /api/inbound-wg/config`.",
+        "required": [
+          "enabled",
+          "listen_port"
+        ],
+        "properties": {
+          "enabled": {
+            "type": "boolean",
+            "description": "Whether the inbound `WireGuard` server should be running."
+          },
+          "listen_port": {
+            "type": "integer",
+            "format": "int32",
+            "description": "UDP port the server listens on for inbound peer handshakes.",
+            "minimum": 0
+          }
+        }
+      },
+      "InboundWgConfigResponse": {
+        "type": "object",
+        "description": "Response for `PUT /api/inbound-wg/config`.",
+        "required": [
+          "enabled",
+          "listen_port"
+        ],
+        "properties": {
+          "enabled": {
+            "type": "boolean",
+            "description": "The applied enabled state."
+          },
+          "listen_port": {
+            "type": "integer",
+            "format": "int32",
+            "description": "The applied listen port.",
+            "minimum": 0
+          },
+          "server_public_key": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "The server's public key once a keypair exists (generated on first\nenable). `None` until the server has been enabled at least once."
+          }
+        }
+      },
+      "InboundWgPeerSummary": {
+        "type": "object",
+        "description": "A single inbound-`WireGuard` peer, without any private key material.",
+        "required": [
+          "id",
+          "name",
+          "public_key",
+          "allowed_ip",
+          "enabled",
+          "created_at"
+        ],
+        "properties": {
+          "allowed_ip": {
+            "type": "string"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "enabled": {
+            "type": "boolean"
+          },
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "name": {
+            "type": "string"
+          },
+          "public_key": {
+            "type": "string"
+          }
+        }
+      },
       "InfoResponse": {
         "type": "object",
         "description": "Response from the public info endpoint.\n\nReturns basic server information without requiring authentication.\nUsed by the web UI's connection status widget.",
@@ -24203,6 +24962,21 @@
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/ConditionalForwardingRule"
+            }
+          }
+        }
+      },
+      "ListInboundWgPeersResponse": {
+        "type": "object",
+        "description": "Response for `GET /api/inbound-wg/peers`.",
+        "required": [
+          "peers"
+        ],
+        "properties": {
+          "peers": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/InboundWgPeerSummary"
             }
           }
         }

--- a/source/admin-app/src/components/ConnectionBanner.tsx
+++ b/source/admin-app/src/components/ConnectionBanner.tsx
@@ -15,7 +15,7 @@ export function ConnectionBanner({ connState }: Props) {
         role="alert"
         icon={<WifiOffIcon size={15} strokeWidth={1.9} />}
       >
-        No connection to wardnet daemon — showing last known state
+        No connection to wardnet daemon - showing last known state
       </Banner>
     );
   }

--- a/source/admin-app/src/components/DeviceRoutingSheet.tsx
+++ b/source/admin-app/src/components/DeviceRoutingSheet.tsx
@@ -1,13 +1,21 @@
-import { useRef } from "react";
-import { Drawer, DrawerContent, DrawerTitle, Text } from "@wardnet/web";
+import { useRef, useState } from "react";
+import { Drawer, DrawerContent, DrawerTitle, Text, Button } from "@wardnet/web";
 import {
   useUpdateDevice,
   useNetworkZones,
   useAssignDeviceZone,
+  useInboundWgPeers,
+  useAddInboundWgPeer,
   countryFlag,
 } from "@wardnet/web";
-import type { Device, Tunnel, RoutingTarget } from "@wardnet/js";
+import type {
+  AddInboundWgPeerResponse,
+  Device,
+  Tunnel,
+  RoutingTarget,
+} from "@wardnet/js";
 import { CheckIcon } from "lucide-react";
+import { InboundWgGrantedView } from "./InboundWgGrantedView";
 
 interface Props {
   device: Device | null;
@@ -101,7 +109,13 @@ export function DeviceRoutingSheet({
   const updateDevice = useUpdateDevice({ successMessage: "Routing updated" });
   const { data: zoneData } = useNetworkZones();
   const assignZone = useAssignDeviceZone({ successMessage: "Zone updated" });
+  const { data: peersData } = useInboundWgPeers();
+  const addPeer = useAddInboundWgPeer();
   const zones = zoneData?.zones ?? [];
+
+  // The one-time grant response. When set, the sheet swaps to the QR view so
+  // the private key (embedded in `client_config`) can be scanned once.
+  const [granted, setGranted] = useState<AddInboundWgPeerResponse | null>(null);
 
   // Keep the last non-null device in a ref so the exit animation can complete
   // even if the parent clears selectedDevice while the sheet is animating closed.
@@ -113,6 +127,20 @@ export function DeviceRoutingSheet({
   const deviceLabel =
     activeDevice?.name ?? activeDevice?.hostname ?? activeDevice?.mac ?? "";
   const busy = updateDevice.isPending || assignZone.isPending;
+
+  // Grantable = managed (admin-named; the backend rejects unmanaged devices)
+  // AND has no peer row yet. `connection_mode` is monitor-driven liveness, not
+  // credential existence, so a peer-row lookup is the authoritative signal.
+  const peers = peersData?.peers ?? [];
+  const alreadyGranted =
+    activeDevice != null && peers.some((p) => p.device_id === activeDevice.id);
+  const grantable =
+    activeDevice != null && activeDevice.name != null && !alreadyGranted;
+
+  function handleOpenChange(next: boolean) {
+    if (!next) setGranted(null);
+    onOpenChange(next);
+  }
 
   function handleSelect(target: RoutingTarget) {
     if (!activeDevice) return;
@@ -131,77 +159,137 @@ export function DeviceRoutingSheet({
     );
   }
 
+  async function handleGrant() {
+    if (!activeDevice) return;
+    try {
+      const response = await addPeer.mutateAsync({
+        device_id: activeDevice.id,
+      });
+      setGranted(response);
+    } catch {
+      // The mutation's onError already surfaced a toast; keep the sheet open so
+      // the admin can retry, and swallow the rejection so it isn't an unhandled
+      // promise rejection.
+    }
+  }
+
   return (
-    <Drawer open={open} onOpenChange={onOpenChange}>
+    <Drawer open={open} onOpenChange={handleOpenChange}>
       <DrawerContent side="bottom" aria-describedby={undefined}>
         <div className="mx-auto mt-3 mb-4 h-1 w-10 rounded-full bg-line" />
         <DrawerTitle className="px-4 pb-1 text-[11px] font-semibold uppercase tracking-wider text-ink-3">
-          Route: {deviceLabel}
+          {granted
+            ? `Remote access granted - ${granted.name}`
+            : `Route: ${deviceLabel}`}
         </DrawerTitle>
-        <div
-          data-testid="device-routing-sheet"
-          className="flex flex-col"
-          style={{ paddingBottom: "max(24px, env(safe-area-inset-bottom))" }}
-        >
-          <OptionRow
-            label="Default"
-            sublabel="Follow gateway policy"
-            active={current === "default"}
-            disabled={busy}
-            onSelect={() => handleSelect({ type: "default" })}
-            testId="device-routing-default"
-          />
-          <OptionRow
-            label="Direct"
-            sublabel="No VPN"
-            active={current === "direct"}
-            disabled={busy}
-            onSelect={() => handleSelect({ type: "direct" })}
-            testId="device-routing-direct"
-          />
-          {tunnels.length > 0 && <div className="mx-4 my-2 h-px bg-line" />}
-          {tunnels.map((tunnel) => {
-            const { label: statusLabel, tone } = tunnelSublabel(tunnel.status);
-            return (
-              <OptionRow
-                key={tunnel.id}
-                label={`${countryFlag(tunnel.country_code)} ${tunnel.label}`}
-                sublabel={statusLabel || undefined}
-                sublabelTone={tone === "ok" ? undefined : tone}
-                active={current === tunnel.id}
-                disabled={busy}
-                onSelect={() =>
-                  handleSelect({ type: "tunnel", tunnel_id: tunnel.id })
-                }
-              />
-            );
-          })}
-
-          {zones.length > 0 && (
-            <>
-              <div className="mx-4 my-2 h-px bg-line" />
-              <Text
-                as="p"
-                size="xs"
-                weight="medium"
-                className="px-4 pt-1 pb-0.5 uppercase tracking-wider text-ink-3"
-              >
-                Zone
-              </Text>
-              {zones.map((zone) => (
+        {granted ? (
+          <div
+            data-testid="device-routing-sheet"
+            className="flex flex-col"
+            style={{ paddingBottom: "max(24px, env(safe-area-inset-bottom))" }}
+          >
+            <InboundWgGrantedView
+              peer={granted}
+              onDone={() => handleOpenChange(false)}
+            />
+          </div>
+        ) : (
+          <div
+            data-testid="device-routing-sheet"
+            className="flex flex-col"
+            style={{ paddingBottom: "max(24px, env(safe-area-inset-bottom))" }}
+          >
+            <OptionRow
+              label="Default"
+              sublabel="Follow gateway policy"
+              active={current === "default"}
+              disabled={busy}
+              onSelect={() => handleSelect({ type: "default" })}
+              testId="device-routing-default"
+            />
+            <OptionRow
+              label="Direct"
+              sublabel="No VPN"
+              active={current === "direct"}
+              disabled={busy}
+              onSelect={() => handleSelect({ type: "direct" })}
+              testId="device-routing-direct"
+            />
+            {tunnels.length > 0 && <div className="mx-4 my-2 h-px bg-line" />}
+            {tunnels.map((tunnel) => {
+              const { label: statusLabel, tone } = tunnelSublabel(
+                tunnel.status,
+              );
+              return (
                 <OptionRow
-                  key={zone.id}
-                  label={zone.name}
-                  sublabel={zone.is_default ? "Home" : undefined}
-                  active={activeDevice?.zone_id === zone.id}
+                  key={tunnel.id}
+                  label={`${countryFlag(tunnel.country_code)} ${tunnel.label}`}
+                  sublabel={statusLabel || undefined}
+                  sublabelTone={tone === "ok" ? undefined : tone}
+                  active={current === tunnel.id}
                   disabled={busy}
-                  onSelect={() => handleZoneSelect(zone.id)}
-                  testId="device-zone-option"
+                  onSelect={() =>
+                    handleSelect({ type: "tunnel", tunnel_id: tunnel.id })
+                  }
                 />
-              ))}
-            </>
-          )}
-        </div>
+              );
+            })}
+
+            {zones.length > 0 && (
+              <>
+                <div className="mx-4 my-2 h-px bg-line" />
+                <Text
+                  as="p"
+                  size="xs"
+                  weight="medium"
+                  className="px-4 pt-1 pb-0.5 uppercase tracking-wider text-ink-3"
+                >
+                  Zone
+                </Text>
+                {zones.map((zone) => (
+                  <OptionRow
+                    key={zone.id}
+                    label={zone.name}
+                    sublabel={zone.is_default ? "Home" : undefined}
+                    active={activeDevice?.zone_id === zone.id}
+                    disabled={busy}
+                    onSelect={() => handleZoneSelect(zone.id)}
+                    testId="device-zone-option"
+                  />
+                ))}
+              </>
+            )}
+
+            {grantable && (
+              <>
+                <div className="mx-4 my-2 h-px bg-line" />
+                <Text
+                  as="p"
+                  size="xs"
+                  weight="medium"
+                  className="px-4 pt-1 pb-1 uppercase tracking-wider text-ink-3"
+                >
+                  Remote access
+                </Text>
+                <div className="px-4 pt-1">
+                  <Button
+                    className="w-full"
+                    data-testid="device-grant-remote-access"
+                    onClick={handleGrant}
+                    disabled={addPeer.isPending}
+                  >
+                    {addPeer.isPending ? "Granting…" : "Grant remote access"}
+                  </Button>
+                  <Text as="p" size="xs" className="pt-2 text-ink-3">
+                    Issues a WireGuard credential so this device can connect
+                    back in from off the LAN. You&apos;ll get a QR code to scan
+                    once.
+                  </Text>
+                </div>
+              </>
+            )}
+          </div>
+        )}
       </DrawerContent>
     </Drawer>
   );

--- a/source/admin-app/src/components/InboundWgGrantedView.tsx
+++ b/source/admin-app/src/components/InboundWgGrantedView.tsx
@@ -1,0 +1,58 @@
+import { Text, Button, InboundWgQrCode } from "@wardnet/web";
+import { peerConfigFilename, triggerBrowserDownload } from "@wardnet/web";
+import type { AddInboundWgPeerResponse } from "@wardnet/js";
+
+interface Props {
+  /** The one-time grant response. Its `client_config` embeds the private key
+   *  and is never re-fetchable, so this view is the only chance to scan it. */
+  peer: AddInboundWgPeerResponse;
+  onDone: () => void;
+}
+
+/** The post-grant QR / `.conf` view, shared by every mobile grant entry point.
+ *  The daemon assembles the full client config; this just renders it. */
+export function InboundWgGrantedView({ peer, onDone }: Props) {
+  const config = peer.client_config;
+
+  function download() {
+    if (!config) return;
+    const blob = new Blob([config], { type: "text/plain" });
+    triggerBrowserDownload(blob, `${peerConfigFilename(peer.name)}.conf`);
+  }
+
+  return (
+    <div className="flex flex-col items-center gap-4 px-4 pb-2">
+      {config ? (
+        <>
+          <InboundWgQrCode value={config} size={220} />
+          <Text as="p" size="xs" className="text-center text-ink-3">
+            In the WireGuard app, tap Add, then Scan from QR code. The phone
+            camera just shows text, since a WireGuard config isn&apos;t a link.
+          </Text>
+          <Text as="p" size="xs" className="text-center text-ink-3">
+            This is the only time the private key is shown; it is never stored
+            on the daemon.
+          </Text>
+          <div className="flex w-full flex-col gap-2">
+            <Button variant="outline" className="w-full" onClick={download}>
+              Download .conf
+            </Button>
+            <Button className="w-full" onClick={onDone}>
+              I&apos;ve saved this
+            </Button>
+          </div>
+        </>
+      ) : (
+        <>
+          <Text as="p" size="sm" className="text-center text-danger">
+            No public hostname or IP is known yet. Set up remote access first to
+            get a usable config.
+          </Text>
+          <Button className="w-full" onClick={onDone}>
+            Close
+          </Button>
+        </>
+      )}
+    </div>
+  );
+}

--- a/source/admin-app/src/components/InboundWgPeerSheet.tsx
+++ b/source/admin-app/src/components/InboundWgPeerSheet.tsx
@@ -1,0 +1,95 @@
+import { useRef, useState } from "react";
+import {
+  Drawer,
+  DrawerContent,
+  DrawerTitle,
+  Text,
+  Button,
+  Toggle,
+} from "@wardnet/web";
+import {
+  useSetInboundWgPeerEnabled,
+  useRemoveInboundWgPeer,
+} from "@wardnet/web";
+import { ConfirmDialog } from "@/components/ConfirmDialog";
+import type { InboundWgPeerSummary } from "@wardnet/js";
+
+interface Props {
+  peer: InboundWgPeerSummary | null;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+/** Operational peer management (issue #813): pause/resume (keeps the
+ *  credential) and revoke (deletes it). No QR/config here — the private
+ *  key only ever exists at grant time. */
+export function InboundWgPeerSheet({ peer, open, onOpenChange }: Props) {
+  const setEnabled = useSetInboundWgPeerEnabled();
+  const removePeer = useRemoveInboundWgPeer();
+  const [revokeOpen, setRevokeOpen] = useState(false);
+
+  // Keep the last non-null peer so the exit animation can complete even if
+  // the parent clears the selection while the sheet is closing.
+  const latchedRef = useRef<InboundWgPeerSummary | null>(null);
+  if (peer !== null) latchedRef.current = peer;
+  const activePeer = latchedRef.current;
+
+  if (!activePeer) return null;
+
+  return (
+    <>
+      <Drawer open={open} onOpenChange={onOpenChange}>
+        <DrawerContent side="bottom" aria-describedby={undefined}>
+          <div className="mx-auto mt-3 mb-4 h-1 w-10 rounded-full bg-line" />
+          <DrawerTitle className="px-4 pb-1 text-[11px] font-semibold uppercase tracking-wider text-ink-3">
+            Remote access - {activePeer.name}
+          </DrawerTitle>
+          <div
+            className="flex flex-col gap-4 px-4"
+            style={{ paddingBottom: "max(24px, env(safe-area-inset-bottom))" }}
+          >
+            <div className="flex items-center justify-between gap-3 rounded-xl border border-line bg-card p-4">
+              <div>
+                <Text as="p" size="base" weight="medium" className="text-ink">
+                  {activePeer.enabled ? "Active" : "Paused"}
+                </Text>
+                <Text as="p" size="xs" className="mt-0.5 text-ink-3">
+                  Pausing keeps the credential - resuming needs no new QR scan.
+                </Text>
+              </div>
+              <Toggle
+                aria-label="Enable this peer"
+                checked={activePeer.enabled}
+                disabled={setEnabled.isPending}
+                onCheckedChange={(next) =>
+                  setEnabled.mutate({ id: activePeer.id, enabled: next })
+                }
+              />
+            </div>
+            <Button
+              variant="destructive"
+              onClick={() => setRevokeOpen(true)}
+              disabled={removePeer.isPending}
+            >
+              Revoke access
+            </Button>
+          </div>
+        </DrawerContent>
+      </Drawer>
+
+      <ConfirmDialog
+        open={revokeOpen}
+        onOpenChange={setRevokeOpen}
+        title="Revoke remote access"
+        description={`This permanently deletes ${activePeer.name}'s credential. Re-granting later needs a fresh QR scan.`}
+        confirmLabel="Revoke"
+        onConfirm={() => {
+          removePeer.mutate(activePeer.id, {
+            onSuccess: () => onOpenChange(false),
+          });
+          setRevokeOpen(false);
+        }}
+      />
+    </>
+  );
+}

--- a/source/admin-app/src/features/dashboard/DevicesCard.tsx
+++ b/source/admin-app/src/features/dashboard/DevicesCard.tsx
@@ -51,7 +51,7 @@ export function DevicesCard({ deviceCount, devices, defaultPolicy }: Props) {
             </Text>
             <div className="mt-0.5 flex items-baseline gap-1.5">
               <Text as="span" size="2xl" weight="bold" className="text-ink">
-                {onlineCount !== null ? onlineCount : "—"}
+                {onlineCount !== null ? onlineCount : "-"}
               </Text>
               <Text as="span" size="sm" className="text-ink-3">
                 / {deviceCount}

--- a/source/admin-app/src/features/dashboard/StatusCard.tsx
+++ b/source/admin-app/src/features/dashboard/StatusCard.tsx
@@ -51,7 +51,7 @@ export function StatusCard({ reachable, uptimeSeconds }: Props) {
             weight="medium"
             className="mt-0.5 text-side-ink"
           >
-            {uptimeSeconds != null ? formatUptime(uptimeSeconds) : "—"}
+            {uptimeSeconds != null ? formatUptime(uptimeSeconds) : "-"}
           </Text>
         </div>
       </div>

--- a/source/admin-app/src/pages/Devices.tsx
+++ b/source/admin-app/src/pages/Devices.tsx
@@ -5,17 +5,20 @@ import {
   useDefaultPolicy,
   usePendingDevices,
   useAssignDeviceZone,
+  useInboundWgPeers,
   countryFlag,
   deviceDisplayName,
   isDeviceOnline,
   timeAgo,
   Text,
   Heading,
+  Pill,
 } from "@wardnet/web";
 import { useOnlineStatusContext } from "@/context/OnlineStatusContext";
 import { DeviceRoutingSheet } from "@/components/DeviceRoutingSheet";
+import { InboundWgPeerSheet } from "@/components/InboundWgPeerSheet";
 import { ChevronRightIcon } from "lucide-react";
-import type { Device, Tunnel } from "@wardnet/js";
+import type { Device, InboundWgPeerSummary, Tunnel } from "@wardnet/js";
 
 type Filter = "all" | "online" | "vpn";
 
@@ -69,40 +72,62 @@ const DeviceRow = memo(function DeviceRow({
   device,
   online,
   tunnels,
+  remotePeer,
   onSelect,
+  onSelectPeer,
 }: {
   device: Device;
   online: boolean;
   tunnels: Tunnel[];
+  remotePeer?: InboundWgPeerSummary;
   onSelect: (id: string) => void;
+  onSelectPeer: (peer: InboundWgPeerSummary) => void;
 }) {
+  const displayName = device.name ?? device.hostname ?? device.mac;
   return (
-    <button
-      data-testid="device-row"
-      onClick={() => onSelect(device.id)}
-      className="flex w-full items-center gap-3 px-4 py-3 text-left transition-colors duration-snap active:bg-sunken first:rounded-t-xl last:rounded-b-xl"
-    >
-      <span
-        className={[
-          "mt-0.5 size-2 shrink-0 self-start rounded-full",
-          online ? "bg-accent" : "bg-line-strong",
-        ].join(" ")}
-      />
-      <div className="flex min-w-0 flex-1 flex-col">
-        <Text
-          as="span"
-          size="base"
-          weight="medium"
-          className="truncate text-ink"
+    // A row container (not itself a button): the device area and the Remote
+    // badge are separate sibling buttons. Nesting the badge inside the row
+    // button was invalid (interactive-in-interactive) and left the badge
+    // keyboard-inaccessible.
+    <div className="flex w-full items-center gap-3 px-4 py-3 transition-colors duration-snap active:bg-sunken first:rounded-t-xl last:rounded-b-xl">
+      <button
+        data-testid="device-row"
+        onClick={() => onSelect(device.id)}
+        className="flex min-w-0 flex-1 items-center gap-3 text-left"
+      >
+        <span
+          className={[
+            "mt-0.5 size-2 shrink-0 self-start rounded-full",
+            online ? "bg-accent" : "bg-line-strong",
+          ].join(" ")}
+        />
+        <div className="flex min-w-0 flex-1 flex-col">
+          <Text
+            as="span"
+            size="base"
+            weight="medium"
+            className="truncate text-ink"
+          >
+            {displayName}
+          </Text>
+          <Text as="span" size="xs" className="truncate text-ink-3">
+            {device.last_ip} · {routeLabel(device, tunnels)}
+          </Text>
+        </div>
+      </button>
+      {remotePeer && (
+        <button
+          type="button"
+          data-testid="device-remote-badge"
+          aria-label={`Manage remote access for ${displayName}`}
+          onClick={() => onSelectPeer(remotePeer)}
+          className="shrink-0"
         >
-          {device.name ?? device.hostname ?? device.mac}
-        </Text>
-        <Text as="span" size="xs" className="truncate text-ink-3">
-          {device.last_ip} · {routeLabel(device, tunnels)}
-        </Text>
-      </div>
+          <Pill variant={remotePeer.enabled ? "info" : "ghost"}>Remote</Pill>
+        </button>
+      )}
       <ChevronRightIcon size={16} className="shrink-0 text-ink-4" />
-    </button>
+    </div>
   );
 });
 
@@ -171,6 +196,7 @@ export default function Devices() {
   const { data: devicesData, isLoading: devicesLoading } = useDevices();
   const { data: tunnelsData } = useTunnels();
   const { data: policyData, isLoading: policyLoading } = useDefaultPolicy();
+  const { data: peersData } = useInboundWgPeers();
   const isLoading = devicesLoading || policyLoading;
 
   const { showingLastKnownState } = useOnlineStatusContext();
@@ -178,10 +204,26 @@ export default function Devices() {
   const [filter, setFilter] = useState<Filter>("all");
   const [selectedDeviceId, setSelectedDeviceId] = useState<string | null>(null);
   const [sheetOpen, setSheetOpen] = useState(false);
+  const [selectedPeer, setSelectedPeer] = useState<InboundWgPeerSummary | null>(
+    null,
+  );
+  const [peerSheetOpen, setPeerSheetOpen] = useState(false);
 
   const allDevices = devicesData?.devices ?? [];
   const tunnels = tunnelsData?.tunnels ?? [];
   const defaultPolicy = policyData?.policy;
+  const peers = peersData?.peers ?? [];
+
+  const peersByDevice = useMemo(() => {
+    const map = new Map<string, InboundWgPeerSummary>();
+    for (const p of peers) if (p.device_id) map.set(p.device_id, p);
+    return map;
+  }, [peers]);
+
+  const handleSelectPeer = useCallback((peer: InboundWgPeerSummary) => {
+    setSelectedPeer(peer);
+    setPeerSheetOpen(true);
+  }, []);
 
   // Derived from live query data — always reflects the latest refetch.
   const selectedDevice = useMemo(
@@ -313,7 +355,9 @@ export default function Devices() {
                 device={device}
                 online={online}
                 tunnels={tunnels}
+                remotePeer={peersByDevice.get(device.id)}
                 onSelect={handleDeviceClick}
+                onSelectPeer={handleSelectPeer}
               />
             ))}
           </div>
@@ -325,6 +369,12 @@ export default function Devices() {
         tunnels={tunnels}
         open={sheetOpen}
         onOpenChange={setSheetOpen}
+      />
+
+      <InboundWgPeerSheet
+        peer={selectedPeer}
+        open={peerSheetOpen}
+        onOpenChange={setPeerSheetOpen}
       />
     </div>
   );

--- a/source/admin-app/src/pages/Dns.tsx
+++ b/source/admin-app/src/pages/Dns.tsx
@@ -123,7 +123,7 @@ export default function Dns() {
                     size="base"
                     className="mt-1 text-ink tabular-nums"
                   >
-                    {dnsStats?.total.toLocaleString() ?? "—"}
+                    {dnsStats?.total.toLocaleString() ?? "-"}
                   </Text>
                   {dnsStats && dnsStats.totalSeries.length > 0 && (
                     <div className="mt-1.5 h-6">
@@ -149,7 +149,7 @@ export default function Dns() {
                     size="base"
                     className="mt-1 text-ink tabular-nums"
                   >
-                    {dnsStats ? `${dnsStats.blockedPercent.toFixed(1)}%` : "—"}
+                    {dnsStats ? `${dnsStats.blockedPercent.toFixed(1)}%` : "-"}
                   </Text>
                   {dnsStats && dnsStats.blockedSeries.length > 0 && (
                     <div className="mt-1.5 h-6">

--- a/source/admin-app/src/pages/System.tsx
+++ b/source/admin-app/src/pages/System.tsx
@@ -19,6 +19,8 @@ import {
   useDdnsStatus,
   useTlsStatus,
   useResolutionCheck,
+  useInboundWgConfig,
+  useSetInboundWgConfig,
   usePushNotifications,
   useRecentNotifications,
   useClearNotifications,
@@ -190,6 +192,8 @@ export default function System() {
   const secureEnabled = !!ddns?.provider;
   const { data: tls } = useTlsStatus({ enabled: secureEnabled });
   const { data: resolution } = useResolutionCheck(secureEnabled);
+  const { data: inboundWg } = useInboundWgConfig();
+  const setInboundWgConfig = useSetInboundWgConfig();
   const pill = resolution ? verdictPill(resolution.verdict) : null;
   const { showingLastKnownState } = useOnlineStatusContext();
   const { logout } = useAuth();
@@ -310,7 +314,7 @@ export default function System() {
                     Version
                   </Text>
                   <Text as="p" size="base" className="mt-1 font-mono text-ink">
-                    {daemonStatus?.version ? `v${daemonStatus.version}` : "—"}
+                    {daemonStatus?.version ? `v${daemonStatus.version}` : "-"}
                   </Text>
                 </div>
                 <div>
@@ -323,7 +327,7 @@ export default function System() {
                     Uptime
                   </Text>
                   <Text as="p" size="base" className="mt-1 text-ink">
-                    {status ? formatUptime(status.uptime_seconds) : "—"}
+                    {status ? formatUptime(status.uptime_seconds) : "-"}
                   </Text>
                 </div>
                 <div>
@@ -336,7 +340,7 @@ export default function System() {
                     CPU
                   </Text>
                   <Text as="p" size="base" className="mt-1 text-ink">
-                    {status ? `${status.cpu_usage_percent.toFixed(1)}%` : "—"}
+                    {status ? `${status.cpu_usage_percent.toFixed(1)}%` : "-"}
                   </Text>
                   {status && <Bar percent={status.cpu_usage_percent} />}
                 </div>
@@ -352,7 +356,7 @@ export default function System() {
                   <Text as="p" size="base" className="mt-1 text-ink">
                     {status
                       ? `${formatBytes(status.memory_used_bytes)} / ${formatBytes(status.memory_total_bytes)}`
-                      : "—"}
+                      : "-"}
                   </Text>
                   {status && status.memory_total_bytes > 0 && (
                     <Bar percent={memoryPercent} />
@@ -401,7 +405,7 @@ export default function System() {
                     size="sm"
                     className="mt-1 break-all font-mono text-ink"
                   >
-                    {ddns?.fqdn ?? "—"}
+                    {ddns?.fqdn ?? "-"}
                   </Text>
                 </div>
 
@@ -420,7 +424,7 @@ export default function System() {
                         <Pill variant={pill.variant}>{pill.label}</Pill>
                       ) : (
                         <Text as="span" size="base" className="text-ink">
-                          —
+                          -
                         </Text>
                       )}
                     </div>
@@ -439,13 +443,43 @@ export default function System() {
                         ? `Until ${formatDate(tls.not_after)}`
                         : tls?.phase === "issuing"
                           ? "Issuing…"
-                          : "—"}
+                          : "-"}
                     </Text>
                   </div>
                 </div>
               </div>
             </div>
           )}
+
+          {/* ── VPN section (issue #813) ── */}
+          <div>
+            <SectionLabel>VPN</SectionLabel>
+            <div className="rounded-xl border border-line bg-card p-4">
+              <div className="flex items-center justify-between gap-3">
+                <div className="min-w-0">
+                  <Text as="p" size="base" weight="medium" className="text-ink">
+                    Inbound WireGuard server
+                  </Text>
+                  <Text as="p" size="xs" className="mt-0.5 text-ink-3">
+                    {inboundWg?.enabled
+                      ? `Listening on port ${inboundWg.listen_port}`
+                      : "Lets granted devices connect back in from off the LAN"}
+                  </Text>
+                </div>
+                <Toggle
+                  aria-label="Enable inbound WireGuard server"
+                  checked={inboundWg?.enabled ?? false}
+                  disabled={setInboundWgConfig.isPending}
+                  onCheckedChange={(next) =>
+                    setInboundWgConfig.mutate({
+                      enabled: next,
+                      listen_port: inboundWg?.listen_port ?? 51821,
+                    })
+                  }
+                />
+              </div>
+            </div>
+          </div>
 
           {/* ── Notifications section (issue #482) ── */}
           <NotificationsSection />

--- a/source/admin-app/src/pages/Tunnels.tsx
+++ b/source/admin-app/src/pages/Tunnels.tsx
@@ -250,7 +250,7 @@ const TunnelCard = memo(function TunnelCard({
               Last Handshake
             </Text>
             <Text as="p" size="sm" className="mt-0.5 text-ink">
-              {tunnel.last_handshake ? timeAgo(tunnel.last_handshake) : "—"}
+              {tunnel.last_handshake ? timeAgo(tunnel.last_handshake) : "-"}
             </Text>
           </div>
           <div>

--- a/source/admin-app/tests/components/DeviceRoutingSheet.test.tsx
+++ b/source/admin-app/tests/components/DeviceRoutingSheet.test.tsx
@@ -8,13 +8,26 @@ const {
   assignZone,
   useNetworkZones,
   useAssignDeviceZone,
+  useInboundWgPeers,
+  addPeerMutateAsync,
+  useAddInboundWgPeer,
 } = vi.hoisted(() => {
   const mutate = vi.fn();
   const assignZone = vi.fn();
+  const addPeerMutateAsync = vi.fn();
   return {
     mutate,
     useUpdateDevice: vi.fn(() => ({ mutate, isPending: false })),
     assignZone,
+    // The sheet reads the peer list (to decide if a device is already granted)
+    // and an add-peer mutation for the grant action. Default to no peers so
+    // every managed device is grantable; specs override as needed.
+    useInboundWgPeers: vi.fn(() => ({ data: { peers: [] } })),
+    addPeerMutateAsync,
+    useAddInboundWgPeer: vi.fn(() => ({
+      mutateAsync: addPeerMutateAsync,
+      isPending: false,
+    })),
     // The sheet reads zones + an assign mutation for its zone-reassignment
     // section; keep the list empty so these specs stay focused on routing.
     // `zones` is typed loosely — the hook is mocked, so the component's real
@@ -37,7 +50,14 @@ const {
 });
 vi.mock("@wardnet/web", async (importOriginal) => {
   const actual = await importOriginal<Record<string, unknown>>();
-  return { ...actual, useUpdateDevice, useNetworkZones, useAssignDeviceZone };
+  return {
+    ...actual,
+    useUpdateDevice,
+    useNetworkZones,
+    useAssignDeviceZone,
+    useInboundWgPeers,
+    useAddInboundWgPeer,
+  };
 });
 
 import { DeviceRoutingSheet } from "@/components/DeviceRoutingSheet";
@@ -51,6 +71,12 @@ describe("DeviceRoutingSheet", () => {
     useNetworkZones.mockReturnValue({ data: { zones: [] } });
     useAssignDeviceZone.mockReturnValue({
       mutate: assignZone,
+      isPending: false,
+    });
+    addPeerMutateAsync.mockReset();
+    useInboundWgPeers.mockReturnValue({ data: { peers: [] } });
+    useAddInboundWgPeer.mockReturnValue({
+      mutateAsync: addPeerMutateAsync,
       isPending: false,
     });
   });
@@ -173,5 +199,72 @@ describe("DeviceRoutingSheet", () => {
     );
     await userEvent.click(screen.getByText("Trusted"));
     expect(assignZone).not.toHaveBeenCalled();
+  });
+
+  it("grants remote access for the tapped device and shows the config", async () => {
+    addPeerMutateAsync.mockResolvedValue({
+      id: "peer-1",
+      name: "Laptop",
+      public_key: "pub",
+      allowed_ip: "10.100.64.2/32",
+      client_config: "[Interface]\nPrivateKey = k\n",
+    });
+    render(
+      <DeviceRoutingSheet
+        device={makeDevice({ id: "dev-7", name: "Laptop" })}
+        tunnels={[]}
+        open
+        onOpenChange={vi.fn()}
+      />,
+    );
+    await userEvent.click(screen.getByTestId("device-grant-remote-access"));
+    expect(addPeerMutateAsync).toHaveBeenCalledWith({ device_id: "dev-7" });
+    // On success the sheet swaps to the one-time QR / config view.
+    expect(
+      await screen.findByText(/Remote access granted - Laptop/),
+    ).toBeInTheDocument();
+  });
+
+  it("hides the grant action for a device that already has a peer", () => {
+    useInboundWgPeers.mockReturnValue({
+      data: {
+        peers: [
+          {
+            id: "peer-9",
+            name: "Laptop",
+            public_key: "pub",
+            allowed_ip: "10.100.64.2/32",
+            enabled: true,
+            created_at: "2026-01-01T00:00:00Z",
+            device_id: "dev-8",
+          },
+        ],
+      },
+    });
+    render(
+      <DeviceRoutingSheet
+        device={makeDevice({ id: "dev-8", name: "Laptop" })}
+        tunnels={[]}
+        open
+        onOpenChange={vi.fn()}
+      />,
+    );
+    expect(
+      screen.queryByTestId("device-grant-remote-access"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("hides the grant action for an unmanaged (unnamed) device", () => {
+    render(
+      <DeviceRoutingSheet
+        device={makeDevice({ id: "dev-9", name: null })}
+        tunnels={[]}
+        open
+        onOpenChange={vi.fn()}
+      />,
+    );
+    expect(
+      screen.queryByTestId("device-grant-remote-access"),
+    ).not.toBeInTheDocument();
   });
 });

--- a/source/admin-app/tests/features/dashboard/cards.test.tsx
+++ b/source/admin-app/tests/features/dashboard/cards.test.tsx
@@ -39,7 +39,7 @@ describe("StatusCard", () => {
   it("renders the unreachable badge and an em dash for null uptime", () => {
     renderWithProviders(<StatusCard reachable={false} uptimeSeconds={null} />);
     expect(screen.getByText("Daemon Unreachable")).toBeInTheDocument();
-    expect(screen.getByText("—")).toBeInTheDocument();
+    expect(screen.getByText("-")).toBeInTheDocument();
   });
 });
 
@@ -85,7 +85,7 @@ describe("DevicesCard", () => {
         defaultPolicy={undefined}
       />,
     );
-    expect(screen.getByText("—")).toBeInTheDocument();
+    expect(screen.getByText("-")).toBeInTheDocument();
     expect(
       screen.queryByText(/routed through a tunnel/),
     ).not.toBeInTheDocument();

--- a/source/admin-app/tests/test-utils.tsx
+++ b/source/admin-app/tests/test-utils.tsx
@@ -66,6 +66,7 @@ export function makeDevice(overrides: Partial<Device> = {}): Device {
     dns_capture_cap_days: 0,
     dhcp_status: "lease",
     current_rule: null,
+    connection_mode: "lan",
     ...overrides,
   };
 }

--- a/source/admin-app/vite.config.ts
+++ b/source/admin-app/vite.config.ts
@@ -50,7 +50,7 @@ export default defineConfig({
   },
   optimizeDeps: {
     // CJS deps of the excluded workspace packages (see admin-site/web config).
-    include: ["use-sync-external-store/shim", "cronstrue", "consola"],
+    include: ["use-sync-external-store/shim", "cronstrue", "consola", "qrcode"],
     // See admin-site/web/vite.config.ts: don't pre-bundle our own source
     // workspace packages, so source edits aren't masked by a stale .vite cache.
     exclude: ["@wardnet/web", "@wardnet/js"],

--- a/source/admin-site/src/App.tsx
+++ b/source/admin-site/src/App.tsx
@@ -14,6 +14,7 @@ import TunnelDetail from "@/pages/TunnelDetail";
 import Zones from "@/pages/Zones";
 import Settings from "@/pages/Settings";
 import RemoteAccess from "@/pages/RemoteAccess";
+import Vpn from "@/pages/Vpn";
 import Power from "@/pages/Power";
 import Backups from "@/pages/Backups";
 import Dhcp from "@/pages/Dhcp";
@@ -238,6 +239,14 @@ export default function App() {
           element={
             <AdminRoute>
               <RemoteAccess />
+            </AdminRoute>
+          }
+        />
+        <Route
+          path="vpn"
+          element={
+            <AdminRoute>
+              <Vpn />
             </AdminRoute>
           }
         />

--- a/source/admin-site/src/components/compound/AllowlistTable.tsx
+++ b/source/admin-site/src/components/compound/AllowlistTable.tsx
@@ -24,7 +24,7 @@ function createColumns(): ColumnDef<AllowlistEntry>[] {
           className="block truncate text-ink-3"
           title={row.original.reason ?? ""}
         >
-          {row.original.reason ?? "—"}
+          {row.original.reason ?? "-"}
         </span>
       ),
     },

--- a/source/admin-site/src/components/compound/ConfirmDialog.tsx
+++ b/source/admin-site/src/components/compound/ConfirmDialog.tsx
@@ -4,10 +4,8 @@ import {
   AlertModalAction,
   AlertModalCancel,
   AlertModalContent,
-  AlertModalDescription,
   AlertModalFooter,
-  AlertModalHeader,
-  AlertModalTitle,
+  AlertModalTitleBlock,
 } from "@wardnet/web";
 
 interface ConfirmDialogProps {
@@ -33,10 +31,7 @@ export function ConfirmDialog({
   return (
     <AlertModal open={open} onOpenChange={onOpenChange}>
       <AlertModalContent>
-        <AlertModalHeader>
-          <AlertModalTitle>{title}</AlertModalTitle>
-          <AlertModalDescription>{description}</AlertModalDescription>
-        </AlertModalHeader>
+        <AlertModalTitleBlock title={title} description={description} />
         <AlertModalFooter>
           <AlertModalCancel asChild>
             <Button variant="outline" data-testid="confirm-dialog-cancel">

--- a/source/admin-site/src/components/compound/DeviceSelect.tsx
+++ b/source/admin-site/src/components/compound/DeviceSelect.tsx
@@ -12,12 +12,27 @@ import type { Device } from "@wardnet/js";
 interface DeviceSelectProps {
   /** Devices to choose from. Order is preserved. */
   devices: Device[];
-  /** Currently selected device IP. Empty string = "any". */
+  /** Currently selected value. Empty string = nothing selected (shows the
+   *  sentinel/placeholder). */
   value: string;
-  /** Called with the chosen IP (or "" for the any-device sentinel). */
-  onChange: (ip: string) => void;
-  /** Override the placeholder / "any" option label. */
+  /** Called with the chosen value (or "" for the any-device sentinel). */
+  onChange: (value: string) => void;
+  /**
+   * Which device field the option value is keyed by. `"ip"` (default) uses
+   * `last_ip` — what the DNS query log indexes by, for filter pickers;
+   * `"id"` uses the device id, for grant/assignment pickers that target a
+   * specific device.
+   */
+  valueKey?: "ip" | "id";
+  /** Label for the trigger when nothing is selected, and for the sentinel
+   *  option when `includeAny` is true. */
   anyLabel?: string;
+  /** When true (default), renders a sentinel "any" option (value `""`) so the
+   *  select can represent "no filter". Set false for a required single pick. */
+  includeAny?: boolean;
+  /** Message rendered inside the dropdown when `devices` is empty and there is
+   *  no sentinel option to fall back on. */
+  emptyLabel?: string;
   /** Override the input id (for `<label htmlFor>`). */
   id?: string;
   /** Extra classes to apply to the underlying SelectTrigger — useful
@@ -32,18 +47,23 @@ interface DeviceSelectProps {
  * label exists. Keeps filter pickers visually consistent with the
  * tables they narrow.
  *
- * The select's value is the device's `last_ip` because that's what the
- * DNS query log indexes by; "" is the sentinel for "any device".
+ * Two modes via `valueKey`/`includeAny`: an IP-keyed filter with an "any"
+ * sentinel (the default), or an id-keyed required picker (e.g. selecting a
+ * device to grant remote access to).
  */
 export function DeviceSelect({
   devices,
   value,
   onChange,
+  valueKey = "ip",
   anyLabel = "Any device",
+  includeAny = true,
+  emptyLabel,
   id,
   triggerClassName,
 }: DeviceSelectProps) {
-  const selected = devices.find((d) => d.last_ip === value);
+  const keyOf = (d: Device) => (valueKey === "id" ? d.id : d.last_ip);
+  const selected = devices.find((d) => keyOf(d) === value);
   // Trigger label collapses to a single line (icon + name) so it fits
   // the narrow filter column. Dropdown items remain two-line so users
   // can disambiguate by IP.
@@ -58,11 +78,15 @@ export function DeviceSelect({
     <span className="text-ink-3">{anyLabel}</span>
   );
 
+  // Radix Select forbids an empty-string item value, so the "any" sentinel
+  // maps to the reserved "any" token; without a sentinel, the empty value
+  // simply shows the placeholder.
+  const selectValue = includeAny ? value || "any" : value;
+  const handleChange = (v: string) =>
+    onChange(includeAny && v === "any" ? "" : v);
+
   return (
-    <Select
-      value={value || "any"}
-      onValueChange={(v) => onChange(v === "any" ? "" : v)}
-    >
+    <Select value={selectValue} onValueChange={handleChange}>
       {/* `w-full` overrides the SelectTrigger default of `w-fit` so the
           trigger fills its parent column instead of shrinking to the
           width of the longest device label. */}
@@ -75,14 +99,23 @@ export function DeviceSelect({
         </SelectValue>
       </SelectTrigger>
       <SelectContent>
-        <SelectItem value="any">
-          <span className="text-ink-3">{anyLabel}</span>
-        </SelectItem>
+        {includeAny && (
+          <SelectItem value="any">
+            <span className="text-ink-3">{anyLabel}</span>
+          </SelectItem>
+        )}
+        {!includeAny && devices.length === 0 && emptyLabel && (
+          <div className="px-2 py-1.5">
+            <Text as="span" size="sm" className="text-ink-3">
+              {emptyLabel}
+            </Text>
+          </div>
+        )}
         {devices.map((d) => {
           const primary = d.name || d.hostname || d.last_ip;
           const secondary = d.name || d.hostname ? d.last_ip : null;
           return (
-            <SelectItem key={d.id} value={d.last_ip}>
+            <SelectItem key={d.id} value={keyOf(d)}>
               <div className="flex items-center gap-2">
                 <DeviceIcon type={d.device_type} size={16} />
                 <div className="flex flex-col">

--- a/source/admin-site/src/components/compound/DeviceTable.tsx
+++ b/source/admin-site/src/components/compound/DeviceTable.tsx
@@ -63,7 +63,7 @@ function buildColumns(
       header: "Manufacturer",
       meta: { className: "hidden lg:table-cell" },
       cell: ({ row }) => (
-        <span className="text-ink-3">{row.original.manufacturer ?? "—"}</span>
+        <span className="text-ink-3">{row.original.manufacturer ?? "-"}</span>
       ),
     },
     {
@@ -104,7 +104,7 @@ function buildColumns(
           .map((id) => profilesById.get(id)?.name)
           .filter((n): n is string => !!n);
         return (
-          <StatusBadge tone="success">{names.join(", ") || "—"}</StatusBadge>
+          <StatusBadge tone="success">{names.join(", ") || "-"}</StatusBadge>
         );
       },
     },

--- a/source/admin-site/src/components/compound/DhcpConfigCard.tsx
+++ b/source/admin-site/src/components/compound/DhcpConfigCard.tsx
@@ -102,7 +102,7 @@ export function DhcpConfigCard({ config }: DhcpConfigCardProps) {
       return "Pool end must be at or after pool start.";
     // LAN addressing must be private (RFC 1918) — a public range would
     // blackhole real internet hosts.
-    const privateHint = "a private range (10.x, 172.16–31.x, or 192.168.x)";
+    const privateHint = "a private range (10.x, 172.16-31.x, or 192.168.x)";
     if (!isPrivateIpv4(poolStart)) return `Pool start must be ${privateHint}.`;
     if (!isPrivateIpv4(poolEnd)) return `Pool end must be ${privateHint}.`;
     if (routerIp !== "" && !isPrivateIpv4(routerIp))
@@ -350,7 +350,7 @@ export function DhcpConfigCard({ config }: DhcpConfigCardProps) {
             <div>
               <dt className="text-ink-3">Fallback router</dt>
               <Text as="dd" size="xs" className="font-mono">
-                {config.router_ip ?? "—"}
+                {config.router_ip ?? "-"}
               </Text>
             </div>
             <div>
@@ -358,7 +358,7 @@ export function DhcpConfigCard({ config }: DhcpConfigCardProps) {
               <dd className={dnsEnabled ? "font-medium" : "font-mono text-xs"}>
                 {dnsEnabled
                   ? "Wardnet DNS"
-                  : config.upstream_dns.join(", ") || "—"}
+                  : config.upstream_dns.join(", ") || "-"}
               </dd>
             </div>
           </dl>

--- a/source/admin-site/src/components/compound/InboundWgPeersTable.tsx
+++ b/source/admin-site/src/components/compound/InboundWgPeersTable.tsx
@@ -1,0 +1,88 @@
+import { useMemo } from "react";
+import type { ColumnDef } from "@tanstack/react-table";
+import { Text } from "@wardnet/web";
+import { DataTable, RowAction } from "@/components/core/ui/data-table";
+import { StatusBadge } from "@/components/compound/StatusBadge";
+import type { InboundWgPeerSummary } from "@wardnet/js";
+
+function buildColumns(): ColumnDef<InboundWgPeerSummary>[] {
+  return [
+    {
+      id: "name",
+      header: "Device",
+      cell: ({ row }) => (
+        <Text as="span" weight="medium">
+          {row.original.name}
+        </Text>
+      ),
+    },
+    {
+      id: "allowed_ip",
+      header: "Tunnel IP",
+      meta: { className: "hidden md:table-cell" },
+      cell: ({ row }) => (
+        <Text as="span" size="xs" className="font-mono">
+          {row.original.allowed_ip}
+        </Text>
+      ),
+    },
+    {
+      id: "status",
+      header: "Status",
+      cell: ({ row }) => (
+        <StatusBadge tone={row.original.enabled ? "success" : "neutral"}>
+          {row.original.enabled ? "Active" : "Paused"}
+        </StatusBadge>
+      ),
+    },
+  ];
+}
+
+interface InboundWgPeersTableProps {
+  peers: InboundWgPeerSummary[];
+  onToggleEnabled: (peer: InboundWgPeerSummary) => void;
+  onRevoke: (peer: InboundWgPeerSummary) => void;
+}
+
+/** Peers list for the VPN page's server card — toggle (pause/resume,
+ *  keeps the credential) and revoke (delete it) live per row. */
+export function InboundWgPeersTable({
+  peers,
+  onToggleEnabled,
+  onRevoke,
+}: InboundWgPeersTableProps) {
+  const columns = useMemo(() => buildColumns(), []);
+
+  if (peers.length === 0) {
+    return (
+      <Text as="p" size="sm" className="py-8 text-center text-ink-3">
+        No remote-access peers yet.
+      </Text>
+    );
+  }
+
+  return (
+    <DataTable
+      columns={columns}
+      data={peers}
+      rowActionsTestId="inbound-wg-peer-menu"
+      rowActions={(peer) => (
+        <>
+          <RowAction
+            onSelect={() => onToggleEnabled(peer)}
+            testId="inbound-wg-peer-toggle"
+          >
+            {peer.enabled ? "Pause" : "Resume"}
+          </RowAction>
+          <RowAction
+            onSelect={() => onRevoke(peer)}
+            destructive
+            testId="inbound-wg-peer-revoke"
+          >
+            Revoke
+          </RowAction>
+        </>
+      )}
+    />
+  );
+}

--- a/source/admin-site/src/components/compound/LogViewer.tsx
+++ b/source/admin-site/src/components/compound/LogViewer.tsx
@@ -97,7 +97,7 @@ export function LogViewer({
     <div className="logs" style={{ maxHeight }}>
       {skipped > 0 && (
         <div className="logrow is-warn">
-          <div className="t">—</div>
+          <div className="t">-</div>
           <div className="l">SKIP</div>
           <div className="m">{skipped} entries skipped (buffer lag)</div>
         </div>

--- a/source/admin-site/src/components/compound/ProgressDialog.tsx
+++ b/source/admin-site/src/components/compound/ProgressDialog.tsx
@@ -93,28 +93,40 @@ export function ProgressDialog({
     >
       <AlertModalContent data-testid="progress-dialog">
         <AlertModalHeader>
-          <AlertModalTitle
-            className="flex items-center gap-2"
-            data-testid="progress-title"
-          >
-            {phase === "in-progress" && (
-              <Loader2Icon className="h-5 w-5 animate-spin text-ink-3" />
+          {/* Column-wrapped so the description stacks under the (icon-bearing)
+              title - the DS AlertModalHeader is a flex row. Same layout the
+              AlertModalTitleBlock helper applies; kept inline here only because
+              this title has a bespoke icon/phase row. */}
+          <div className="flex w-full min-w-0 flex-col gap-1">
+            <AlertModalTitle
+              className="flex items-center gap-2"
+              data-testid="progress-title"
+            >
+              {phase === "in-progress" && (
+                <Loader2Icon className="h-5 w-5 animate-spin text-ink-3" />
+              )}
+              {phase === "success" && successIcon}
+              {phase === "failed" && (
+                <AlertTriangleIcon className="h-5 w-5 text-danger" />
+              )}
+              {phase === "success" ? successTitle : title}
+            </AlertModalTitle>
+            {phase === "success" && successDescription && (
+              <AlertModalDescription className="text-sm leading-relaxed text-ink-3">
+                {successDescription}
+              </AlertModalDescription>
             )}
-            {phase === "success" && successIcon}
-            {phase === "failed" && (
-              <AlertTriangleIcon className="h-5 w-5 text-danger" />
+            {phase === "in-progress" && description && (
+              <AlertModalDescription className="text-sm leading-relaxed text-ink-3">
+                {description}
+              </AlertModalDescription>
             )}
-            {phase === "success" ? successTitle : title}
-          </AlertModalTitle>
-          {phase === "success" && successDescription && (
-            <AlertModalDescription>{successDescription}</AlertModalDescription>
-          )}
-          {phase === "in-progress" && description && (
-            <AlertModalDescription>{description}</AlertModalDescription>
-          )}
-          {phase === "failed" && description && (
-            <AlertModalDescription>{description}</AlertModalDescription>
-          )}
+            {phase === "failed" && description && (
+              <AlertModalDescription className="text-sm leading-relaxed text-ink-3">
+                {description}
+              </AlertModalDescription>
+            )}
+          </div>
         </AlertModalHeader>
 
         {phase === "in-progress" && (

--- a/source/admin-site/src/components/compound/Sidebar.tsx
+++ b/source/admin-site/src/components/compound/Sidebar.tsx
@@ -3,7 +3,6 @@ import { NavLink, useNavigate } from "react-router";
 import {
   Archive,
   Boxes,
-  Cable,
   Globe,
   GlobeLock,
   Inbox,
@@ -11,10 +10,11 @@ import {
   Monitor,
   Network,
   Power,
+  Route,
   Router,
   Settings as SettingsIcon,
-  ShieldCheck,
 } from "lucide-react";
+import { ShieldWifi, GlobeFilter } from "@wardnet/web";
 import { useAuth } from "@wardnet/web";
 import { useDaemonStatus } from "@wardnet/web";
 import { useUpdateStatus } from "@wardnet/web";
@@ -65,7 +65,8 @@ const adminSections: NavSection[] = [
         icon: Monitor,
         testId: "nav-devices",
       },
-      { to: "/tunnels", label: "Tunnels", icon: Cable, testId: "nav-tunnels" },
+      { to: "/tunnels", label: "Tunnels", icon: Route, testId: "nav-tunnels" },
+      { to: "/vpn", label: "VPN", icon: ShieldWifi, testId: "nav-vpn" },
       { to: "/zones", label: "Zones", icon: Boxes, testId: "nav-zones" },
       { to: "/dhcp", label: "DHCP", icon: Router, testId: "nav-dhcp" },
     ],
@@ -83,7 +84,7 @@ const adminSections: NavSection[] = [
       {
         to: "/dns/filter",
         label: "DNS Filtering",
-        icon: ShieldCheck,
+        icon: GlobeFilter,
         testId: "nav-dns-filter",
       },
       {

--- a/source/admin-site/src/components/compound/TunnelCard.tsx
+++ b/source/admin-site/src/components/compound/TunnelCard.tsx
@@ -143,8 +143,8 @@ function statusTooltip(tunnel: Tunnel): string | undefined {
       return "Waiting for first handshake from peer.";
     case "reconnecting":
       return tunnel.last_handshake
-        ? `Last handshake ${timeAgo(tunnel.last_handshake)} — peer not responding.`
-        : "Lost handshake — peer not responding.";
+        ? `Last handshake ${timeAgo(tunnel.last_handshake)} - peer not responding.`
+        : "Lost handshake - peer not responding.";
     case "up":
     case "down":
       return undefined;
@@ -274,7 +274,7 @@ export function TunnelCard({ tunnel, providers, onDelete }: TunnelCardProps) {
           <div>
             <dt>Last handshake</dt>
             <dd>
-              {tunnel.last_handshake ? timeAgo(tunnel.last_handshake) : "—"}
+              {tunnel.last_handshake ? timeAgo(tunnel.last_handshake) : "-"}
             </dd>
           </div>
         </dl>

--- a/source/admin-site/src/components/compound/UncleanShutdownBanner.tsx
+++ b/source/admin-site/src/components/compound/UncleanShutdownBanner.tsx
@@ -58,7 +58,7 @@ export function UncleanShutdownBanner() {
         Wardnet did not shut down cleanly
       </Text>
       <span className="ml-2 opacity-80">
-        Last seen {timeAgo(shutdown.at)} — likely a crash or power loss.
+        Last seen {timeAgo(shutdown.at)} - likely a crash or power loss.
       </span>
     </Banner>
   );

--- a/source/admin-site/src/components/features/BackupCard.tsx
+++ b/source/admin-site/src/components/features/BackupCard.tsx
@@ -206,7 +206,7 @@ export function BackupCard({
             <CardContent className="flex flex-col gap-4">
               <Text as="p" size="sm" className="text-ink-3">
                 Choose a passphrase of at least {MIN_PASSPHRASE_LEN} characters.
-                The passphrase is required to restore this bundle — we
+                The passphrase is required to restore this bundle - we
                 can&apos;t recover it if you lose it.
               </Text>
 

--- a/source/admin-site/src/components/features/DeviceDnsFilterCard.tsx
+++ b/source/admin-site/src/components/features/DeviceDnsFilterCard.tsx
@@ -193,7 +193,7 @@ export function DeviceDnsFilterCard({ device }: DeviceDnsFilterCardProps) {
               </Text>
               <dd>
                 {!settings.enabled
-                  ? "—"
+                  ? "-"
                   : assignedProfiles.length === 0
                     ? defaultProfiles.length > 0
                       ? `${defaultProfiles.map((p) => p.name).join(", ")} (default)`
@@ -230,14 +230,14 @@ function DefaultProfileHint({
   if (!enabled) {
     return (
       <Text as="p" size="xs" className="text-ink-3">
-        Filtering off — DNS queries from this device skip every profile.
+        Filtering off - DNS queries from this device skip every profile.
       </Text>
     );
   }
   if (hasExplicit) {
     return (
       <Text as="p" size="xs" className="text-ink-3">
-        Selected profiles are stacked — a domain blocked in any one of them is
+        Selected profiles are stacked - a domain blocked in any one of them is
         blocked.
       </Text>
     );
@@ -246,7 +246,7 @@ function DefaultProfileHint({
     const noun = defaultProfiles.length === 1 ? "profile" : "profiles";
     return (
       <Text as="p" size="xs" className="text-ink-3">
-        No profile selected — this device follows the global default {noun}{" "}
+        No profile selected - this device follows the global default {noun}{" "}
         <Text weight="medium" className="text-ink">
           {defaultProfiles.map((p) => p.name).join(", ")}
         </Text>
@@ -256,7 +256,7 @@ function DefaultProfileHint({
   }
   return (
     <Text as="p" size="xs" className="text-ink-3">
-      No profile selected and no global default is set — this device's traffic
+      No profile selected and no global default is set - this device's traffic
       isn't filtered.
     </Text>
   );

--- a/source/admin-site/src/components/features/DeviceIdentityCard.tsx
+++ b/source/admin-site/src/components/features/DeviceIdentityCard.tsx
@@ -38,7 +38,7 @@ export function DeviceIdentityCard({ device }: DeviceIdentityCardProps) {
             >
               Hostname
             </Text>
-            <dd>{device.hostname ?? "—"}</dd>
+            <dd>{device.hostname ?? "-"}</dd>
           </div>
           <div>
             <Text
@@ -48,7 +48,7 @@ export function DeviceIdentityCard({ device }: DeviceIdentityCardProps) {
             >
               Manufacturer
             </Text>
-            <dd>{device.manufacturer ?? "—"}</dd>
+            <dd>{device.manufacturer ?? "-"}</dd>
           </div>
           <div>
             <Text

--- a/source/admin-site/src/components/features/DeviceSettingsCard.tsx
+++ b/source/admin-site/src/components/features/DeviceSettingsCard.tsx
@@ -205,7 +205,7 @@ export function DeviceSettingsCard({
             <Text size="xs" className="uppercase tracking-wide text-ink-3">
               Friendly name
             </Text>
-            <Text size="sm">{device.name ?? "—"}</Text>
+            <Text size="sm">{device.name ?? "-"}</Text>
           </div>
           <div className="flex flex-col gap-0.5">
             <Text size="xs" className="uppercase tracking-wide text-ink-3">

--- a/source/admin-site/src/components/features/DeviceZoneCard.tsx
+++ b/source/admin-site/src/components/features/DeviceZoneCard.tsx
@@ -121,7 +121,7 @@ export function DeviceZoneCard({ device }: DeviceZoneCardProps) {
                     )}
                   </span>
                 ) : (
-                  "—"
+                  "-"
                 )}
               </Text>
             </div>

--- a/source/admin-site/src/components/features/DhcpLanInfoCard.tsx
+++ b/source/admin-site/src/components/features/DhcpLanInfoCard.tsx
@@ -46,7 +46,7 @@ export function DhcpLanInfoCard() {
             lan
           </Text>{" "}
           zone. These records are managed for you and aren&apos;t listed under
-          Records — revoke a lease or remove the device on the DHCP page to
+          Records - revoke a lease or remove the device on the DHCP page to
           clear one.
         </Text>
       </CardContent>

--- a/source/admin-site/src/components/features/DnsStatsSection.tsx
+++ b/source/admin-site/src/components/features/DnsStatsSection.tsx
@@ -118,8 +118,8 @@ export function DnsStatsSection({ range }: Props) {
 
   const topBlockedDomain = data?.topDomains.entries[0];
   const topBlockedLabel = topBlockedDomain
-    ? (parseLabels(topBlockedDomain.labels).domain ?? "—")
-    : "—";
+    ? (parseLabels(topBlockedDomain.labels).domain ?? "-")
+    : "-";
 
   if (isError) {
     return (
@@ -136,11 +136,11 @@ export function DnsStatsSection({ range }: Props) {
       <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
         <DashboardStatCard
           title={`Queries (${zoomLabel ?? range})`}
-          value={cardTotal != null ? cardTotal.toLocaleString() : "—"}
+          value={cardTotal != null ? cardTotal.toLocaleString() : "-"}
         />
         <DashboardStatCard
           title={`Blocked (${zoomLabel ?? range})`}
-          value={cardBlockedPct != null ? `${cardBlockedPct.toFixed(1)}%` : "—"}
+          value={cardBlockedPct != null ? `${cardBlockedPct.toFixed(1)}%` : "-"}
           subtitle={
             cardTotal != null && cardBlocked != null
               ? `${cardBlocked.toLocaleString()} of ${cardTotal.toLocaleString()}`
@@ -159,7 +159,7 @@ export function DnsStatsSection({ range }: Props) {
         />
         <DashboardStatCard
           title={`Active clients (${zoomLabel ?? range})`}
-          value={data ? data.topClients.entries.length.toString() : "—"}
+          value={data ? data.topClients.entries.length.toString() : "-"}
         />
       </div>
 

--- a/source/admin-site/src/components/features/DnsZonesCard.tsx
+++ b/source/admin-site/src/components/features/DnsZonesCard.tsx
@@ -170,7 +170,7 @@ export function DnsZonesCard() {
           if (!open) setDeleteId(null);
         }}
         title="Delete zone"
-        description={`Delete zone "${zoneToDelete?.name ?? ""}"? Its ${deleteCount} record(s) are kept (they become unzoned), but the gateway stops being authoritative for *.${zoneToDelete?.name ?? ""} — unknown names under it will be forwarded upstream again.`}
+        description={`Delete zone "${zoneToDelete?.name ?? ""}"? Its ${deleteCount} record(s) are kept (they become unzoned), but the gateway stops being authoritative for *.${zoneToDelete?.name ?? ""} - unknown names under it will be forwarded upstream again.`}
         confirmLabel="Delete"
         onConfirm={() => {
           if (deleteId) deleteZone.mutate(deleteId);

--- a/source/admin-site/src/components/features/InboundWgPeerGrantedModal.tsx
+++ b/source/admin-site/src/components/features/InboundWgPeerGrantedModal.tsx
@@ -1,0 +1,67 @@
+import { Modal, ModalContent, ModalBody, ModalFooter } from "@wardnet/web";
+import { Button } from "@wardnet/web";
+import { Text } from "@wardnet/web";
+import { InboundWgQrCode, ModalTitleBlock } from "@wardnet/web";
+import { peerConfigFilename, triggerBrowserDownload } from "@wardnet/web";
+import type { AddInboundWgPeerResponse } from "@wardnet/js";
+
+interface InboundWgPeerGrantedModalProps {
+  /** `null` closes the modal. The private key inside `client_config` is the
+   *  only copy that will ever exist client- or server-side. Once dismissed
+   *  it's gone. */
+  peer: AddInboundWgPeerResponse | null;
+  onDismiss: () => void;
+}
+
+/** Shown exactly once, immediately after a successful grant. The daemon
+ *  assembles the full client config (private key included) and returns it in
+ *  this one response. It is never persisted server-side and can't be shown
+ *  again, so this is the admin's only chance to scan the QR or download the
+ *  `.conf`. */
+export function InboundWgPeerGrantedModal({
+  peer,
+  onDismiss,
+}: InboundWgPeerGrantedModalProps) {
+  if (!peer) return null;
+
+  const config = peer.client_config;
+
+  function downloadConfig() {
+    if (!config) return;
+    const blob = new Blob([config], { type: "text/plain" });
+    triggerBrowserDownload(blob, `${peerConfigFilename(peer!.name)}.conf`);
+  }
+
+  return (
+    <Modal open onOpenChange={(next) => !next && onDismiss()}>
+      <ModalContent>
+        <ModalTitleBlock
+          title={`Remote access granted - ${peer.name}`}
+          description="In the WireGuard app, choose Add, then Scan from QR code, or import the downloaded config file. This is the only time the private key is shown; it is never stored on the daemon."
+        />
+        <ModalBody className="flex flex-col items-center gap-4">
+          {config ? (
+            <>
+              <InboundWgQrCode value={config} />
+              <Text as="p" size="xs" className="text-center text-ink-3">
+                Scan from inside the WireGuard app. The phone camera just shows
+                text, since a WireGuard config isn&apos;t a link.
+              </Text>
+            </>
+          ) : (
+            <Text as="p" size="sm" className="text-danger">
+              No public hostname or IP is known yet. Set up remote access (DDNS)
+              first, then the config can include a reachable endpoint.
+            </Text>
+          )}
+        </ModalBody>
+        <ModalFooter className="flex-col gap-2 sm:flex-row sm:justify-end">
+          <Button variant="outline" onClick={downloadConfig} disabled={!config}>
+            Download .conf
+          </Button>
+          <Button onClick={onDismiss}>I&apos;ve saved this</Button>
+        </ModalFooter>
+      </ModalContent>
+    </Modal>
+  );
+}

--- a/source/admin-site/src/components/features/LocalRecordsCard.tsx
+++ b/source/admin-site/src/components/features/LocalRecordsCard.tsx
@@ -56,7 +56,7 @@ export function LocalRecordsCard() {
   const zones = useMemo(() => zoneData?.zones ?? [], [zoneData]);
   const zoneName = useMemo(() => {
     const map = new Map(zones.map((z) => [z.id, z.name]));
-    return (id?: string | null) => (id ? (map.get(id) ?? "—") : "—");
+    return (id?: string | null) => (id ? (map.get(id) ?? "-") : "-");
   }, [zones]);
 
   const records = useMemo(

--- a/source/admin-site/src/components/features/PowerCard.tsx
+++ b/source/admin-site/src/components/features/PowerCard.tsx
@@ -14,10 +14,8 @@ import {
   AlertModalAction,
   AlertModalCancel,
   AlertModalContent,
-  AlertModalDescription,
   AlertModalFooter,
-  AlertModalHeader,
-  AlertModalTitle,
+  AlertModalTitleBlock,
 } from "@wardnet/web";
 
 interface Props {
@@ -74,7 +72,7 @@ export function PowerCard({
         </CardHeader>
         <CardContent>
           <Text as="p" size="sm" className="text-ink-3">
-            Reboot the system. Wardnet will be unavailable for ~30–60 seconds
+            Reboot the system. Wardnet will be unavailable for ~30-60 seconds
             while it comes back up; managed devices fall back to the upstream
             router during that gap.
           </Text>
@@ -136,13 +134,10 @@ export function PowerCard({
 
       <AlertModal open={rebootOpen} onOpenChange={setRebootOpen}>
         <AlertModalContent>
-          <AlertModalHeader>
-            <AlertModalTitle>Reboot Wardnet?</AlertModalTitle>
-            <AlertModalDescription>
-              Wardnet will restart. Your network will be unavailable for ~30–60
-              seconds while it comes back up.
-            </AlertModalDescription>
-          </AlertModalHeader>
+          <AlertModalTitleBlock
+            title="Reboot Wardnet?"
+            description="Wardnet will restart. Your network will be unavailable for ~30-60 seconds while it comes back up."
+          />
           <AlertModalFooter>
             <AlertModalCancel asChild>
               <Button variant="outline">Cancel</Button>
@@ -163,13 +158,10 @@ export function PowerCard({
 
       <AlertModal open={shutdownOpen} onOpenChange={setShutdownOpen}>
         <AlertModalContent>
-          <AlertModalHeader>
-            <AlertModalTitle>Shut Wardnet down?</AlertModalTitle>
-            <AlertModalDescription>
-              Wardnet will power off. Internet will be unavailable until you
-              turn the system back on manually.
-            </AlertModalDescription>
-          </AlertModalHeader>
+          <AlertModalTitleBlock
+            title="Shut Wardnet down?"
+            description="Wardnet will power off. Internet will be unavailable until you turn the system back on manually."
+          />
           <AlertModalFooter>
             <AlertModalCancel asChild>
               <Button variant="outline">Cancel</Button>
@@ -191,14 +183,10 @@ export function PowerCard({
 
       <AlertModal open={restartOpen} onOpenChange={setRestartOpen}>
         <AlertModalContent>
-          <AlertModalHeader>
-            <AlertModalTitle>Restart daemon?</AlertModalTitle>
-            <AlertModalDescription>
-              The wardnetd process will exit and the supervisor will bring it
-              back up. The host keeps running; the network stays online except
-              for a few seconds while the daemon comes back.
-            </AlertModalDescription>
-          </AlertModalHeader>
+          <AlertModalTitleBlock
+            title="Restart daemon?"
+            description="The wardnetd process will exit and the supervisor will bring it back up. The host keeps running; the network stays online except for a few seconds while the daemon comes back."
+          />
           <AlertModalFooter>
             <AlertModalCancel asChild>
               <Button variant="outline">Cancel</Button>

--- a/source/admin-site/src/components/features/RemoteAccessProgress.tsx
+++ b/source/admin-site/src/components/features/RemoteAccessProgress.tsx
@@ -28,7 +28,7 @@ export function RemoteAccessProgress({
           {domain ? (
             <>
               Provisioning HTTPS for <span className="font-mono">{domain}</span>
-              . This can take a minute — publishing the DNS challenge and
+              . This can take a minute - publishing the DNS challenge and
               waiting for Let's Encrypt.
             </>
           ) : (
@@ -73,16 +73,16 @@ export function RemoteAccessProgress({
           Certificate issuance failed
         </Text>
         {/* line-clamp-2 + min-h-10: `error` is an upstream ACME/HTTP error
-            string of unbounded length — clamped so a long one can't push the
+            string of unbounded length - clamped so a long one can't push the
             rest of the page (e.g. the dashboard's stat grid below this
             banner) around; the full text remains in the DOM for assistive
             tech. The min-height pins this to exactly 2 lines' worth of space
-            even when the (possibly short) text only wraps to 1 — a
+            even when the (possibly short) text only wraps to 1 - a
             content-dependent 1-vs-2-line height wouldn't be a stable target
             for the e2e dashboard visual test to mask. */}
         <Text as="p" className="mt-1 line-clamp-2 min-h-10 text-ink-2">
           {error ?? "The daemon could not issue a certificate."} You can retry
-          later from Settings — the daemon also retries automatically.
+          later from Settings - the daemon also retries automatically.
         </Text>
       </Text>
     );

--- a/source/admin-site/src/components/features/RemoteAccessStatus.tsx
+++ b/source/admin-site/src/components/features/RemoteAccessStatus.tsx
@@ -52,7 +52,7 @@ function verdictView(verdict: DdnsResolutionVerdict): {
 function providerLabel(provider: string | null | undefined): string {
   if (provider === "wardnet") return "Wardnet";
   if (provider === "cloudflare") return "Your domain (Cloudflare)";
-  return "—";
+  return "-";
 }
 
 export function RemoteAccessStatus({
@@ -80,7 +80,7 @@ export function RemoteAccessStatus({
         <div>
           <dt className="text-ink-3">Public hostname</dt>
           <Text as="dd" size="xs" className="font-mono">
-            {ddns?.fqdn ?? "—"}
+            {ddns?.fqdn ?? "-"}
           </Text>
         </div>
         <div>
@@ -100,7 +100,7 @@ export function RemoteAccessStatus({
         <div>
           <dt className="text-ink-3">Public DNS</dt>
           <dd className={verdict?.tone ?? "font-medium"}>
-            {verdict ? verdict.label : "—"}
+            {verdict ? verdict.label : "-"}
             {resolution && resolution.resolved_ips.length > 0 && (
               <Text as="span" size="xs" className="block font-mono text-ink-3">
                 {resolution.resolved_ips.join(", ")}

--- a/source/admin-site/src/components/features/RestartProgressDialog.tsx
+++ b/source/admin-site/src/components/features/RestartProgressDialog.tsx
@@ -157,7 +157,7 @@ function descriptionFor(phase: RestartPhase): string {
     case "timeout":
       return "The daemon didn't come back within 45 seconds. This usually means the supervisor (systemd) needs attention.";
     case "did_not_fire":
-      return "Wardnet didn't restart. The privileged migration may not have run — try Settings → Updates, or re-run install.sh.";
+      return "Wardnet didn't restart. The privileged migration may not have run - try Settings → Updates, or re-run install.sh.";
     default:
       return "";
   }

--- a/source/admin-site/src/components/features/ShutdownProgressDialog.tsx
+++ b/source/admin-site/src/components/features/ShutdownProgressDialog.tsx
@@ -99,7 +99,7 @@ function descriptionFor(phase: ShutdownPhase): string {
     case "down":
       return "Daemon went offline. Confirming the host is fully off.";
     case "did_not_fire":
-      return "Wardnet didn't shut down. The privileged migration may not have run — try Settings → Updates, or re-run install.sh.";
+      return "Wardnet didn't shut down. The privileged migration may not have run - try Settings → Updates, or re-run install.sh.";
     case "timeout":
       return "The daemon went offline but came back before we could confirm the host had powered off. Try again.";
     default:

--- a/source/admin-site/src/components/features/TunnelLatencyChart.tsx
+++ b/source/admin-site/src/components/features/TunnelLatencyChart.tsx
@@ -95,7 +95,7 @@ export function TunnelLatencyChart({
             size="sm"
             className="flex h-64 items-center justify-center text-ink-3"
           >
-            No latency samples yet — bring this tunnel up to start collecting
+            No latency samples yet - bring this tunnel up to start collecting
             probes.
           </Text>
         ) : (
@@ -130,7 +130,7 @@ export function TunnelLatencyChart({
                 labelFormatter={(ts) => new Date(ts as number).toLocaleString()}
                 formatter={(value) => [
                   value == null
-                    ? "—"
+                    ? "-"
                     : `${typeof value === "number" ? value.toFixed(1) : value} ms`,
                   "RTT",
                 ]}

--- a/source/admin-site/src/components/features/TunnelThroughputChart.tsx
+++ b/source/admin-site/src/components/features/TunnelThroughputChart.tsx
@@ -172,7 +172,7 @@ export function TunnelThroughputChart({
             size="sm"
             className="flex h-64 items-center justify-center text-ink-3"
           >
-            No throughput history yet — bring this tunnel up to start collecting
+            No throughput history yet - bring this tunnel up to start collecting
             samples.
           </Text>
         ) : (

--- a/source/admin-site/src/components/features/UpdateCard.tsx
+++ b/source/admin-site/src/components/features/UpdateCard.tsx
@@ -116,7 +116,7 @@ export function UpdateCard({
               next to title+pill (`ml-auto`); the Channel + Check
               group wraps to its own full-width row 2 below (via
               `w-full`) with channel-left / check-right.
-            - At ≥890px: classes get reset — Toggle drops `ml-auto`,
+            - At ≥890px: classes get reset - Toggle drops `ml-auto`,
               the group reclaims content width and uses `order-2`
               to sit between the pill and the toggle. CardAction's
               `margin-left: auto` (from `.right`) then pushes the

--- a/source/admin-site/src/components/features/UpstreamServersCard.tsx
+++ b/source/admin-site/src/components/features/UpstreamServersCard.tsx
@@ -52,14 +52,14 @@ const MODE_META: Record<
   single: {
     label: "Single server",
     description:
-      "Every query goes to one server only — choose it with the radio in the table below. The others are never used.",
+      "Every query goes to one server only - choose it with the radio in the table below. The others are never used.",
   },
 };
 
 /** Format a probed latency for the table: rounded ms, or an em-dash when
  *  the prober hasn't produced a sample yet. */
 function formatLatency(entry: UpstreamLatency | undefined): string {
-  if (!entry || entry.avg_latency_ms == null) return "—";
+  if (!entry || entry.avg_latency_ms == null) return "-";
   return `${Math.round(entry.avg_latency_ms)} ms`;
 }
 
@@ -284,7 +284,7 @@ export function UpstreamServersCard({
       <CardContent className="flex flex-col gap-4">
         {fallbackOnly && (
           <Text as="p" size="sm" className="text-ink-3">
-            Recursive resolution is active — these upstreams are used only as a
+            Recursive resolution is active - these upstreams are used only as a
             fallback if recursion fails. Leave empty to resolve purely from the
             root servers (failures return SERVFAIL instead of forwarding).
           </Text>
@@ -349,7 +349,7 @@ export function UpstreamServersCard({
             rowActions={(row) => (
               <>
                 {/* Reordering only matters in failover mode, so only offer it
-                    there — keeps the menu honest about what does anything. */}
+                    there - keeps the menu honest about what does anything. */}
                 {effMode === "failover" && (
                   <>
                     <RowAction
@@ -371,7 +371,7 @@ export function UpstreamServersCard({
                   // first. The daemon rejects removing it (400); this makes
                   // that clear without a failed request.
                   <RowAction icon={<Lock aria-hidden />}>
-                    Selected — pick another to remove
+                    Selected - pick another to remove
                   </RowAction>
                 ) : (
                   <RowAction

--- a/source/admin-site/src/components/features/ZoneExceptionsCard.tsx
+++ b/source/admin-site/src/components/features/ZoneExceptionsCard.tsx
@@ -138,7 +138,7 @@ export function ZoneExceptionsCard() {
       <CardContent className="flex flex-col gap-4">
         <Text size="sm" className="text-ink-3">
           Allow one device or zone to reach another across an isolated boundary
-          — for example, casting from your phone to a TV in the IoT zone.
+          - for example, casting from your phone to a TV in the IoT zone.
         </Text>
 
         {formOpen && (
@@ -309,7 +309,7 @@ function ExceptionForm({
             className="text-danger"
             data-testid="exception-port-error"
           >
-            Add at least one valid port (0–65535, with end ≥ start).
+            Add at least one valid port (0-65535, with end ≥ start).
           </Text>
         )}
 
@@ -402,7 +402,7 @@ function CustomPortsEditor({ rows, onChange }: CustomPortsEditorProps) {
               update(i, { from: e.target.value.replace(/\D/g, "").slice(0, 5) })
             }
           />
-          <span className="text-ink-3">–</span>
+          <span className="text-ink-3">-</span>
           <Input
             aria-label={`To port row ${i + 1}`}
             data-testid={`exception-port-to-${i}`}

--- a/source/admin-site/src/components/features/ZonesCard.tsx
+++ b/source/admin-site/src/components/features/ZonesCard.tsx
@@ -80,7 +80,7 @@ export function ZonesCard() {
               {row.original.name}
             </Text>
             {row.original.is_default && (
-              <span title="The home zone — your main trusted network. Full trust, exactly one, can't be deleted.">
+              <span title="The home zone - your main trusted network. Full trust, exactly one, can't be deleted.">
                 <Pill variant="ghost">Home</Pill>
               </span>
             )}
@@ -90,7 +90,7 @@ export function ZonesCard() {
               </span>
             )}
             {row.original.provenance === "system" && (
-              <span title="Built-in zone seeded by Wardnet — can't be deleted (unlike zones you create).">
+              <span title="Built-in zone seeded by Wardnet - can't be deleted (unlike zones you create).">
                 <Pill variant="ghost">System</Pill>
               </span>
             )}
@@ -116,7 +116,7 @@ export function ZonesCard() {
         meta: { className: "hidden md:table-cell" },
         cell: ({ row }) => (
           <Text as="span" size="sm" className="capitalize">
-            {row.original.allowed_targets.join(", ") || "—"}
+            {row.original.allowed_targets.join(", ") || "-"}
           </Text>
         ),
       },

--- a/source/admin-site/src/components/features/wardnet-enrollment.tsx
+++ b/source/admin-site/src/components/features/wardnet-enrollment.tsx
@@ -188,7 +188,7 @@ export function AvailabilityHint({
           {slug.length < 3
             ? "At least 3 characters."
             : isReservedName(slug)
-              ? "This name is reserved — try another."
+              ? "This name is reserved - try another."
               : "Use lowercase letters, digits, and hyphens only."}
         </span>
       );
@@ -197,11 +197,11 @@ export function AvailabilityHint({
     case "available":
       return <span className="text-ink-2">✓ {slug} is available</span>;
     case "taken":
-      return <span className="text-danger">{slug} is taken — try another</span>;
+      return <span className="text-danger">{slug} is taken - try another</span>;
     case "error":
       return (
         <span className="text-ink-3">
-          Couldn't check availability — you can still continue or try again.
+          Couldn't check availability - you can still continue or try again.
         </span>
       );
     default:

--- a/source/admin-site/src/lib/router-instructions.ts
+++ b/source/admin-site/src/lib/router-instructions.ts
@@ -151,7 +151,7 @@ export const ROUTER_INSTRUCTIONS: RouterInstruction[] = [
       'Sign in with the admin credentials and find the "DHCP" or "LAN" settings.',
       "Disable the DHCP server / DHCP service and save.",
       "Reboot the router so the change takes effect.",
-      "If you can't find the setting, switch to the locked-router branch on the previous screen — Wardnet works without owning DHCP, you just configure each device manually.",
+      "If you can't find the setting, switch to the locked-router branch on the previous screen - Wardnet works without owning DHCP, you just configure each device manually.",
     ],
   },
 ];

--- a/source/admin-site/src/pages/Dashboard.tsx
+++ b/source/admin-site/src/pages/Dashboard.tsx
@@ -106,14 +106,14 @@ export default function Dashboard() {
           <DashboardStatCard
             testId="stat-dns-queries"
             title="DNS queries (24h)"
-            value={dnsStats?.total.toLocaleString() ?? "—"}
+            value={dnsStats?.total.toLocaleString() ?? "-"}
             to="/dns/logs"
             error={dnsStatsErrorMsg}
           />
           <DashboardStatCard
             testId="stat-blocked"
             title="Blocked traffic (24h)"
-            value={dnsStats ? `${dnsStats.blockedPercent.toFixed(1)}%` : "—"}
+            value={dnsStats ? `${dnsStats.blockedPercent.toFixed(1)}%` : "-"}
             subtitle={
               dnsStats
                 ? `${dnsStats.blocked.toLocaleString()} of ${dnsStats.total.toLocaleString()}`

--- a/source/admin-site/src/pages/Dns.tsx
+++ b/source/admin-site/src/pages/Dns.tsx
@@ -301,7 +301,7 @@ export default function Dns() {
                   <Text as="div" size="lg" weight="semibold">
                     {config.query_log_enabled
                       ? `${config.query_log_retention_days} days`
-                      : "—"}
+                      : "-"}
                   </Text>
                 </div>
               </CardContent>

--- a/source/admin-site/src/pages/DnsFilterProfile.tsx
+++ b/source/admin-site/src/pages/DnsFilterProfile.tsx
@@ -192,7 +192,7 @@ function ProfileIdentityCard({
                 data-testid="profile-edit-desc"
                 value={draftDesc}
                 onChange={(e) => setDraftDesc(e.target.value)}
-                placeholder="e.g. Strict — for kids' devices"
+                placeholder="e.g. Strict - for kids' devices"
               />
             </Field>
             {update.isError && (
@@ -243,7 +243,7 @@ function ProfileIdentityCard({
                 Description
               </Text>
               <Text size="sm" className="text-ink-2">
-                {description ?? "—"}
+                {description ?? "-"}
               </Text>
             </div>
           )}

--- a/source/admin-site/src/pages/DnsFilterProfileNew.tsx
+++ b/source/admin-site/src/pages/DnsFilterProfileNew.tsx
@@ -60,7 +60,7 @@ export default function DnsFilterProfileNew() {
               id="profile-desc"
               value={description}
               onChange={(e) => setDescription(e.target.value)}
-              placeholder="e.g. Strict — for kids' devices"
+              placeholder="e.g. Strict - for kids' devices"
             />
           </Field>
 

--- a/source/admin-site/src/pages/RemoteAccess.tsx
+++ b/source/admin-site/src/pages/RemoteAccess.tsx
@@ -14,10 +14,8 @@ import {
   AlertModalAction,
   AlertModalCancel,
   AlertModalContent,
-  AlertModalDescription,
   AlertModalFooter,
-  AlertModalHeader,
-  AlertModalTitle,
+  AlertModalTitleBlock,
 } from "@wardnet/web";
 import { toast } from "@wardnet/ui";
 import { WardnetApiError } from "@wardnet/js";
@@ -131,7 +129,7 @@ export default function RemoteAccess() {
         toast.error("Public DNS points to the wrong IP");
         break;
       case "pending":
-        toast.warning("Public DNS isn't visible yet — still propagating");
+        toast.warning("Public DNS isn't visible yet - still propagating");
         break;
       default:
         toast("Rechecked public DNS");
@@ -155,7 +153,7 @@ export default function RemoteAccess() {
       <div className="flex flex-col gap-2">
         <ProviderOption
           label="Wardnet"
-          description="Zero-config. We assign a hostname under wardnet.services and handle DNS — enroll with your wardnet account."
+          description="Zero-config. We assign a hostname under wardnet.services and handle DNS - enroll with your wardnet account."
           selected={provider === "wardnet"}
           onSelect={() => selectProvider("wardnet")}
         />
@@ -326,14 +324,10 @@ export default function RemoteAccess() {
 
       <AlertModal open={removeOpen} onOpenChange={setRemoveOpen}>
         <AlertModalContent>
-          <AlertModalHeader>
-            <AlertModalTitle>Remove remote access?</AlertModalTitle>
-            <AlertModalDescription>
-              The public hostname will be released and the certificate deleted;
-              Wardnet reverts to plain HTTP. You can set it up again at any
-              time.
-            </AlertModalDescription>
-          </AlertModalHeader>
+          <AlertModalTitleBlock
+            title="Remove remote access?"
+            description="The public hostname will be released and the certificate deleted; Wardnet reverts to plain HTTP. You can set it up again at any time."
+          />
           <AlertModalFooter>
             <AlertModalCancel asChild>
               <Button variant="outline" disabled={teardown.isPending}>

--- a/source/admin-site/src/pages/RuleRequests.tsx
+++ b/source/admin-site/src/pages/RuleRequests.tsx
@@ -122,7 +122,7 @@ export default function RuleRequests() {
     <>
       <PageHeader
         title="Rule requests"
-        description="Block / allow requests from household devices. Approving records the decision — apply the rule in DNS Filtering."
+        description="Block / allow requests from household devices. Approving records the decision - apply the rule in DNS Filtering."
       />
 
       <div className="flex flex-col gap-4">

--- a/source/admin-site/src/pages/TunnelDetail.tsx
+++ b/source/admin-site/src/pages/TunnelDetail.tsx
@@ -166,12 +166,12 @@ export default function TunnelDetail() {
             <Field
               label="Provider"
               editing={false}
-              value={tunnel.provider ?? "—"}
+              value={tunnel.provider ?? "-"}
             />
             <Field
               label="Country"
               editing={false}
-              value={`${flag ? `${flag} ` : ""}${tunnel.country_code?.toUpperCase() ?? "—"}`}
+              value={`${flag ? `${flag} ` : ""}${tunnel.country_code?.toUpperCase() ?? "-"}`}
             />
             <Field
               label="Endpoint"

--- a/source/admin-site/src/pages/Vpn.tsx
+++ b/source/admin-site/src/pages/Vpn.tsx
@@ -1,0 +1,264 @@
+import { useState } from "react";
+import { Link } from "react-router";
+import {
+  Card,
+  CardAction,
+  CardContent,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@wardnet/web";
+import { Button } from "@wardnet/web";
+import { Text } from "@wardnet/web";
+import { Input } from "@wardnet/web";
+import { Toggle } from "@wardnet/web";
+import {
+  useInboundWgConfig,
+  useSetInboundWgConfig,
+  useInboundWgPeers,
+  useAddInboundWgPeer,
+  useRemoveInboundWgPeer,
+  useSetInboundWgPeerEnabled,
+  useDevices,
+} from "@wardnet/web";
+import { PageHeader } from "@/components/compound/PageHeader";
+import { ConfirmDialog } from "@/components/compound/ConfirmDialog";
+import { DeviceSelect } from "@/components/compound/DeviceSelect";
+import { InboundWgPeersTable } from "@/components/compound/InboundWgPeersTable";
+import { InboundWgPeerGrantedModal } from "@/components/features/InboundWgPeerGrantedModal";
+import type {
+  AddInboundWgPeerResponse,
+  InboundWgPeerSummary,
+} from "@wardnet/js";
+
+const DEFAULT_LISTEN_PORT = 51821;
+
+/** VPN page (admin only) — enable the inbound WireGuard server and
+ *  grant/revoke/pause per-device remote-access peers (issue #812). */
+export default function Vpn() {
+  const { data: config, isLoading: configLoading } = useInboundWgConfig();
+  const setConfig = useSetInboundWgConfig();
+  const { data: peersData, isLoading: peersLoading } = useInboundWgPeers();
+  const { data: devicesData } = useDevices();
+  const addPeer = useAddInboundWgPeer();
+  const removePeer = useRemoveInboundWgPeer();
+  const setPeerEnabled = useSetInboundWgPeerEnabled();
+
+  const peers = peersData?.peers ?? [];
+  const devices = devicesData?.devices ?? [];
+  // Only *managed* (admin-named) devices can be granted remote access — the
+  // backend rejects unmanaged ones. A device with no name is still just
+  // "discovered".
+  const managedDevices = devices.filter((d) => d.name != null);
+  // Grantable = managed AND has no peer row yet. `connection_mode` is NOT a
+  // reliable signal: the daemon only flips it to `remote` once the peer
+  // actually handshakes (and clears it again on pause), so an offline /
+  // freshly granted / paused device would still read `!== "remote"` and get
+  // offered for a re-grant that the one-credential-per-device guard 409s.
+  const grantedDeviceIds = new Set(
+    peers.map((p) => p.device_id).filter((id): id is string => id !== null),
+  );
+  const grantable = managedDevices.filter((d) => !grantedDeviceIds.has(d.id));
+
+  // Local override for the listen-port input — `null` until the admin
+  // edits it, so the field otherwise tracks the fetched config directly
+  // instead of syncing it into state via an effect.
+  const [listenPortDraft, setListenPortDraft] = useState<number | null>(null);
+  const listenPort =
+    listenPortDraft ?? config?.listen_port ?? DEFAULT_LISTEN_PORT;
+  // `Number("")` is 0, so a cleared field yields 0 (a value `??` does not
+  // coalesce and `min={1}` does not block). Gate every mutation on a valid
+  // port so the server is never (re)configured onto port 0.
+  const portValid =
+    Number.isInteger(listenPort) && listenPort >= 1 && listenPort <= 65535;
+
+  const [creating, setCreating] = useState(false);
+  const [selectedDeviceId, setSelectedDeviceId] = useState("");
+  const [revokeTarget, setRevokeTarget] = useState<InboundWgPeerSummary | null>(
+    null,
+  );
+  const [granted, setGranted] = useState<AddInboundWgPeerResponse | null>(null);
+
+  const enabled = config?.enabled ?? false;
+
+  async function handleGrant() {
+    if (!selectedDeviceId) return;
+    try {
+      const response = await addPeer.mutateAsync({
+        device_id: selectedDeviceId,
+      });
+      setGranted(response);
+      setCreating(false);
+      setSelectedDeviceId("");
+    } catch {
+      // The mutation's onError already surfaced a toast; keep the panel open
+      // (with the selection) so the admin can retry or pick another device,
+      // and swallow the rejection so it isn't an unhandled promise rejection.
+    }
+  }
+
+  return (
+    <div className="col gap-20">
+      <PageHeader
+        title="VPN"
+        description="Let devices connect back in from off the LAN through an inbound WireGuard server."
+      />
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Server</CardTitle>
+          <CardAction>
+            <Toggle
+              aria-label="Enable inbound WireGuard server"
+              checked={enabled}
+              // Block enabling with an invalid port; disabling is always
+              // allowed (the port is irrelevant when turning the server off).
+              disabled={
+                configLoading || setConfig.isPending || (!enabled && !portValid)
+              }
+              onCheckedChange={(next) =>
+                setConfig.mutate({ enabled: next, listen_port: listenPort })
+              }
+            />
+          </CardAction>
+        </CardHeader>
+        <CardContent>
+          <div className="flex flex-col gap-2 sm:max-w-xs">
+            <Text as="p" size="xs" weight="medium" className="text-ink-3">
+              Listen port
+            </Text>
+            <Input
+              type="number"
+              min={1}
+              max={65535}
+              value={listenPort}
+              onChange={(e) => setListenPortDraft(Number(e.target.value))}
+              disabled={setConfig.isPending}
+            />
+          </div>
+        </CardContent>
+        {enabled && listenPort !== config?.listen_port && (
+          <CardFooter className="justify-end">
+            <Button
+              size="sm"
+              disabled={setConfig.isPending || !portValid}
+              onClick={() =>
+                setConfig.mutate({ enabled: true, listen_port: listenPort })
+              }
+            >
+              {setConfig.isPending ? "Saving…" : "Save port"}
+            </Button>
+          </CardFooter>
+        )}
+      </Card>
+
+      {enabled && (
+        <Card>
+          <CardHeader>
+            <CardTitle>Peers</CardTitle>
+            <CardAction>
+              {!creating && grantable.length > 0 && (
+                <Button size="sm" onClick={() => setCreating(true)}>
+                  Grant access
+                </Button>
+              )}
+            </CardAction>
+          </CardHeader>
+          <CardContent className="flex flex-col gap-4">
+            {managedDevices.length === 0 && (
+              <Text as="p" size="sm" className="text-ink-3">
+                Only managed devices can be granted remote access. Give a device
+                a name on the{" "}
+                <Link to="/devices" className="text-accent hover:underline">
+                  Devices
+                </Link>{" "}
+                page to manage it, then grant it access here.
+              </Text>
+            )}
+            {managedDevices.length > 0 &&
+              grantable.length === 0 &&
+              !creating && (
+                <Text as="p" size="sm" className="text-ink-3">
+                  Every managed device already has remote access. Name another
+                  device on the{" "}
+                  <Link to="/devices" className="text-accent hover:underline">
+                    Devices
+                  </Link>{" "}
+                  page to grant more.
+                </Text>
+              )}
+            {creating && (
+              <div className="flex flex-col gap-3 rounded-lg border border-line p-4 sm:flex-row sm:items-end">
+                <div className="flex-1">
+                  <Text
+                    as="p"
+                    size="xs"
+                    weight="medium"
+                    className="mb-2 text-ink-3"
+                  >
+                    Device
+                  </Text>
+                  <DeviceSelect
+                    devices={grantable}
+                    value={selectedDeviceId}
+                    onChange={setSelectedDeviceId}
+                    valueKey="id"
+                    includeAny={false}
+                    anyLabel="Choose a device"
+                    emptyLabel="Every managed device already has remote access."
+                  />
+                </div>
+                <div className="flex gap-2">
+                  <Button
+                    variant="ghost"
+                    onClick={() => {
+                      setCreating(false);
+                      setSelectedDeviceId("");
+                    }}
+                    disabled={addPeer.isPending}
+                  >
+                    Cancel
+                  </Button>
+                  <Button
+                    onClick={handleGrant}
+                    disabled={!selectedDeviceId || addPeer.isPending}
+                  >
+                    {addPeer.isPending ? "Granting…" : "Grant"}
+                  </Button>
+                </div>
+              </div>
+            )}
+            {!peersLoading && (
+              <InboundWgPeersTable
+                peers={peers}
+                onToggleEnabled={(peer) =>
+                  setPeerEnabled.mutate({ id: peer.id, enabled: !peer.enabled })
+                }
+                onRevoke={setRevokeTarget}
+              />
+            )}
+          </CardContent>
+        </Card>
+      )}
+
+      <ConfirmDialog
+        open={!!revokeTarget}
+        onOpenChange={(open) => {
+          if (!open) setRevokeTarget(null);
+        }}
+        title="Revoke remote access"
+        description={`This permanently deletes ${revokeTarget?.name ?? "this peer"}'s credential. Re-granting later needs a fresh QR scan.`}
+        confirmLabel="Revoke"
+        onConfirm={() => {
+          if (revokeTarget) removePeer.mutate(revokeTarget.id);
+          setRevokeTarget(null);
+        }}
+      />
+
+      <InboundWgPeerGrantedModal
+        peer={granted}
+        onDismiss={() => setGranted(null)}
+      />
+    </div>
+  );
+}

--- a/source/admin-site/src/pages/setup/StepDhcp.tsx
+++ b/source/admin-site/src/pages/setup/StepDhcp.tsx
@@ -162,7 +162,7 @@ export default function StepDhcp({
           <div className="flex items-center justify-end gap-3">
             {probe.isError && (
               <Text as="p" size="sm" className="flex-1 text-danger">
-                Probe failed — try again.
+                Probe failed - try again.
               </Text>
             )}
             {probeBlocked && (
@@ -176,7 +176,7 @@ export default function StepDhcp({
             )}
             {probeClean && (
               <Text as="p" size="sm" className="flex-1 text-ink">
-                Only Wardnet responded — good.
+                Only Wardnet responded - good.
               </Text>
             )}
             <Button

--- a/source/admin-site/src/pages/setup/StepNetwork.tsx
+++ b/source/admin-site/src/pages/setup/StepNetwork.tsx
@@ -32,22 +32,22 @@ export default function StepNetwork() {
       <dl className="grid grid-cols-[auto_1fr] gap-x-4 gap-y-2 rounded-lg border border-line bg-sunken p-4 text-sm">
         <dt className="text-ink-3">Interface</dt>
         <dd className="mono">
-          {isLoading ? "…" : isError ? "—" : (data?.interface ?? "—")}
+          {isLoading ? "…" : isError ? "-" : (data?.interface ?? "-")}
         </dd>
         <dt className="text-ink-3">IP address</dt>
         <dd className="mono">
-          {isLoading ? "…" : isError ? "—" : (data?.ip ?? "—")}
+          {isLoading ? "…" : isError ? "-" : (data?.ip ?? "-")}
         </dd>
         <dt className="text-ink-3">Gateway</dt>
         <dd className="mono">
-          {isLoading ? "…" : isError ? "—" : (data?.gateway ?? "not detected")}
+          {isLoading ? "…" : isError ? "-" : (data?.gateway ?? "not detected")}
         </dd>
         <dt className="text-ink-3">Source</dt>
         <dd>
           {isLoading
             ? "…"
             : isError
-              ? "—"
+              ? "-"
               : data?.dhcp_source === "static"
                 ? "Static (install.sh)"
                 : data?.dhcp_source === "dhcp"
@@ -67,7 +67,7 @@ export default function StepNetwork() {
               Your IP isn't pinned
             </Text>
             <Text as="p">
-              The router is currently leasing this address — it may change on
+              The router is currently leasing this address - it may change on
               the next reboot. Re-run <code>install.sh</code> with{" "}
               <code>--static-ip {data?.ip ?? "&lt;cidr&gt;"}/24</code> (or
               another IP from your subnet) to write{" "}

--- a/source/admin-site/src/pages/setup/StepPolicy.tsx
+++ b/source/admin-site/src/pages/setup/StepPolicy.tsx
@@ -68,7 +68,7 @@ export default function StepPolicy() {
         />
         {tunnelList.length === 0 && (
           <Text as="p" size="xs" className="text-ink-3">
-            No tunnels configured — defaulting to direct routing. You can change
+            No tunnels configured - defaulting to direct routing. You can change
             this from Settings whenever you add a tunnel.
           </Text>
         )}

--- a/source/admin-site/src/pages/setup/StepRemoteAccess.tsx
+++ b/source/admin-site/src/pages/setup/StepRemoteAccess.tsx
@@ -109,7 +109,7 @@ export default function StepRemoteAccess() {
           </Heading>
           <Text as="p" size="sm" className="mt-1 text-ink-3">
             Your hostname is registered. The certificate is being issued in the
-            background — you can wait here or finish setup; it'll keep going.
+            background - you can wait here or finish setup; it'll keep going.
           </Text>
         </div>
 
@@ -127,7 +127,7 @@ export default function StepRemoteAccess() {
 
         {nav.isError && (
           <Text as="p" size="sm" className="text-danger">
-            Couldn't save progress — try again.
+            Couldn't save progress - try again.
           </Text>
         )}
 
@@ -165,7 +165,7 @@ export default function StepRemoteAccess() {
           className="rounded-md border border-line bg-sunken p-4 text-ink-3"
         >
           This is usually temporary. You can finish setup now and enable remote
-          access later from Settings — the rest of your configuration is
+          access later from Settings - the rest of your configuration is
           unaffected.
         </Text>
 
@@ -180,7 +180,7 @@ export default function StepRemoteAccess() {
 
         {nav.isError && (
           <Text as="p" size="sm" className="text-danger">
-            Couldn't save progress — try again.
+            Couldn't save progress - try again.
           </Text>
         )}
 
@@ -210,7 +210,7 @@ export default function StepRemoteAccess() {
       <div className="flex flex-col gap-2">
         <ProviderOption
           label="Wardnet"
-          description="Zero-config. We assign a hostname under wardnet.services and handle DNS — enroll with your wardnet account."
+          description="Zero-config. We assign a hostname under wardnet.services and handle DNS - enroll with your wardnet account."
           selected={provider === "wardnet"}
           onSelect={() => setProvider("wardnet")}
         />
@@ -246,7 +246,7 @@ export default function StepRemoteAccess() {
 
       {(formError || nav.isError) && (
         <Text as="p" size="sm" className="text-danger">
-          {formError ?? "Couldn't save progress — try again."}
+          {formError ?? "Couldn't save progress - try again."}
         </Text>
       )}
 

--- a/source/admin-site/src/pages/setup/StepReview.tsx
+++ b/source/admin-site/src/pages/setup/StepReview.tsx
@@ -42,7 +42,7 @@ export default function StepReview() {
       ? "Locked router"
       : setupStatus?.wizard_mode === "primary"
         ? "Primary"
-        : "—";
+        : "-";
 
   const defaultProfileNames = (dnsConfig?.config.default_profile_ids ?? [])
     .map((id) => (dnsProfiles?.profiles ?? []).find((p) => p.id === id)?.name)
@@ -73,11 +73,11 @@ export default function StepReview() {
     value: ReactNode;
     editStep?: WizardStep;
   }> = [
-    { key: "admin", label: "Admin user", value: me?.username ?? "—" },
+    { key: "admin", label: "Admin user", value: me?.username ?? "-" },
     {
       key: "lan-ip",
       label: "LAN IP",
-      value: <span className="mono">{network?.ip ?? "—"}</span>,
+      value: <span className="mono">{network?.ip ?? "-"}</span>,
       editStep: "network",
     },
     { key: "dhcp", label: "DHCP mode", value: dhcpMode, editStep: "dhcp" },
@@ -119,7 +119,7 @@ export default function StepReview() {
           Review &amp; finish
         </Heading>
         <Text as="p" size="sm" className="mt-1 text-ink-3">
-          Everything below is already saved — confirm it looks right, or jump
+          Everything below is already saved - confirm it looks right, or jump
           back to a step to change it.
         </Text>
       </div>
@@ -166,7 +166,7 @@ export default function StepReview() {
 
       {nav.isError && (
         <Text as="p" size="sm" className="text-danger">
-          Couldn't save progress — try again.
+          Couldn't save progress - try again.
         </Text>
       )}
 

--- a/source/admin-site/src/pages/setup/StepRouterMac.tsx
+++ b/source/admin-site/src/pages/setup/StepRouterMac.tsx
@@ -86,7 +86,7 @@ export default function StepRouterMac() {
           className="flex flex-col gap-3"
         >
           <Field
-            label="ARP probe failed — enter the router MAC manually"
+            label="ARP probe failed - enter the router MAC manually"
             htmlFor="router-mac"
             name="mac"
           >

--- a/source/admin-site/src/pages/setup/StepTunnel.tsx
+++ b/source/admin-site/src/pages/setup/StepTunnel.tsx
@@ -51,7 +51,7 @@ export default function StepTunnel() {
           First VPN tunnel
         </Heading>
         <Text as="p" size="sm" className="mt-1 text-ink-3">
-          Optional — connect a VPN provider so opted-in devices can route
+          Optional - connect a VPN provider so opted-in devices can route
           through it. You can add more from the Tunnels page once setup is
           complete.
         </Text>
@@ -72,7 +72,7 @@ export default function StepTunnel() {
           size="sm"
           className="rounded-md border border-line bg-sunken p-4 text-ink-3"
         >
-          No tunnels yet. Add one now or skip — you can change the default
+          No tunnels yet. Add one now or skip - you can change the default
           routing policy from Settings later.
         </Text>
       )}

--- a/source/admin-site/tests/components/compound/AllowlistTable.test.tsx
+++ b/source/admin-site/tests/components/compound/AllowlistTable.test.tsx
@@ -42,7 +42,7 @@ describe("AllowlistTable", () => {
     expect(screen.getByText("a.com")).toBeInTheDocument();
     expect(screen.getByText("why")).toBeInTheDocument();
     expect(screen.getByText("b.com")).toBeInTheDocument();
-    expect(screen.getByText("—")).toBeInTheDocument();
+    expect(screen.getByText("-")).toBeInTheDocument();
   });
 
   it("removes an entry via the row overflow menu", async () => {

--- a/source/admin-site/tests/components/compound/DeviceTable.test.tsx
+++ b/source/admin-site/tests/components/compound/DeviceTable.test.tsx
@@ -54,7 +54,7 @@ describe("DeviceTable", () => {
     expect(screen.getByText("Dell")).toBeInTheDocument();
     expect(screen.getByText("Lease")).toBeInTheDocument();
     expect(screen.getByText("Reserved")).toBeInTheDocument();
-    expect(screen.getByText("—")).toBeInTheDocument();
+    expect(screen.getByText("-")).toBeInTheDocument();
   });
 
   it("shows the External DHCP badge", () => {
@@ -105,7 +105,7 @@ describe("DeviceTable", () => {
     expect(screen.getAllByText("(default)").length).toBeGreaterThanOrEqual(2);
     // Unknown profile id resolves to no name, rendering the em dash
     // (manufacturer columns also render em dashes here).
-    expect(screen.getAllByText("—").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("-").length).toBeGreaterThan(0);
   });
 
   it("fires onDeviceClick when a row is clicked", async () => {

--- a/source/admin-site/tests/components/features/DeviceIdentityCard.test.tsx
+++ b/source/admin-site/tests/components/features/DeviceIdentityCard.test.tsx
@@ -29,6 +29,6 @@ describe("DeviceIdentityCard", () => {
     );
 
     // Both hostname and manufacturer render the em dash placeholder.
-    expect(screen.getAllByText("—").length).toBeGreaterThanOrEqual(2);
+    expect(screen.getAllByText("-").length).toBeGreaterThanOrEqual(2);
   });
 });

--- a/source/admin-site/tests/components/features/DeviceZoneCard.test.tsx
+++ b/source/admin-site/tests/components/features/DeviceZoneCard.test.tsx
@@ -72,7 +72,7 @@ describe("DeviceZoneCard", () => {
     renderWithProviders(
       <DeviceZoneCard device={makeDevice({ zone_id: "gone" })} />,
     );
-    expect(screen.getByTestId("device-zone-value")).toHaveTextContent("—");
+    expect(screen.getByTestId("device-zone-value")).toHaveTextContent("-");
     expect(screen.queryByText("Home")).not.toBeInTheDocument();
   });
 

--- a/source/admin-site/tests/components/features/DnsStatsSection.test.tsx
+++ b/source/admin-site/tests/components/features/DnsStatsSection.test.tsx
@@ -122,7 +122,7 @@ describe("DnsStatsSection", () => {
     renderWithProviders(<DnsStatsSection range="1h" />);
     expect(screen.getByText("Loading…")).toBeInTheDocument();
     // Stat cards fall back to em dashes with no data.
-    expect(screen.getAllByText("—").length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText("-").length).toBeGreaterThanOrEqual(1);
   });
 
   it("shows an empty chart message when the series is empty", () => {

--- a/source/admin-site/tests/components/features/RemoteAccessStatus.test.tsx
+++ b/source/admin-site/tests/components/features/RemoteAccessStatus.test.tsx
@@ -34,7 +34,7 @@ describe("RemoteAccessStatus", () => {
     expect(screen.getByText("Public hostname")).toBeInTheDocument();
     expect(screen.getByText("Not issued yet")).toBeInTheDocument();
     // Provider label fallback and resolution fallback both render em dashes.
-    expect(screen.getAllByText("—").length).toBeGreaterThanOrEqual(2);
+    expect(screen.getAllByText("-").length).toBeGreaterThanOrEqual(2);
   });
 
   it("renders wardnet provider label and cert expiry", () => {

--- a/source/admin-site/tests/components/features/wardnet-enrollment.test.tsx
+++ b/source/admin-site/tests/components/features/wardnet-enrollment.test.tsx
@@ -120,7 +120,7 @@ describe("AvailabilityHint", () => {
       <AvailabilityHint availability="invalid" slug="admin" />,
     );
     expect(
-      screen.getByText("This name is reserved — try another."),
+      screen.getByText("This name is reserved - try another."),
     ).toBeInTheDocument();
   });
 
@@ -150,7 +150,7 @@ describe("AvailabilityHint", () => {
       <AvailabilityHint availability="taken" slug="cool-name" />,
     );
     expect(
-      screen.getByText("cool-name is taken — try another"),
+      screen.getByText("cool-name is taken - try another"),
     ).toBeInTheDocument();
   });
 

--- a/source/admin-site/tests/pages/Dashboard.test.tsx
+++ b/source/admin-site/tests/pages/Dashboard.test.tsx
@@ -112,8 +112,8 @@ describe("Dashboard", () => {
     // No system status → status cards hidden.
     expect(screen.queryByTestId("stat-uptime")).not.toBeInTheDocument();
     // dnsStats undefined → em dash.
-    expect(screen.getByTestId("stat-dns-queries-value")).toHaveTextContent("—");
-    expect(screen.getByTestId("stat-blocked-value")).toHaveTextContent("—");
+    expect(screen.getByTestId("stat-dns-queries-value")).toHaveTextContent("-");
+    expect(screen.getByTestId("stat-blocked-value")).toHaveTextContent("-");
     expect(screen.getByTestId("recent-errors")).toHaveTextContent("0");
     expect(screen.getByTestId("log-widget")).toBeInTheDocument();
   });

--- a/source/admin-site/tests/pages/Dns.test.tsx
+++ b/source/admin-site/tests/pages/Dns.test.tsx
@@ -178,7 +178,7 @@ describe("Dns", () => {
   it("renders the disabled query-log branch", () => {
     setConfig({ query_log_enabled: false });
     renderWithProviders(<Dns />);
-    expect(screen.getByText("—")).toBeInTheDocument();
+    expect(screen.getByText("-")).toBeInTheDocument();
     expect(
       screen.queryByRole("button", { name: "Edit" }),
     ).not.toBeInTheDocument();

--- a/source/admin-site/tests/pages/RemoteAccess.test.tsx
+++ b/source/admin-site/tests/pages/RemoteAccess.test.tsx
@@ -130,7 +130,7 @@ beforeEach(() => {
   });
 });
 
-describe("RemoteAccess — unconfigured", () => {
+describe("RemoteAccess - unconfigured", () => {
   it("renders the enable form with provider options and wardnet fields", () => {
     renderWithProviders(<RemoteAccess />);
     expect(screen.getByText("Remote access")).toBeInTheDocument();
@@ -208,7 +208,7 @@ describe("RemoteAccess — unconfigured", () => {
   });
 });
 
-describe("RemoteAccess — configured", () => {
+describe("RemoteAccess - configured", () => {
   beforeEach(() => {
     useDdnsStatus.mockReturnValue({ data: { provider: "wardnet" } });
     useTlsStatus.mockReturnValue({ data: { phase: "ready" } });

--- a/source/admin-site/tests/pages/setup/StepDhcp.test.tsx
+++ b/source/admin-site/tests/pages/setup/StepDhcp.test.tsx
@@ -112,7 +112,7 @@ describe("StepDhcp", () => {
     const user = userEvent.setup();
     renderWithProviders(<StepDhcp initialMode="primary" />);
     expect(
-      screen.getByText("Only Wardnet responded — good."),
+      screen.getByText("Only Wardnet responded - good."),
     ).toBeInTheDocument();
     const cont = screen.getByTestId("setup-dhcp-continue");
     expect(cont).not.toBeDisabled();
@@ -140,7 +140,7 @@ describe("StepDhcp", () => {
   it("shows a probe-failed message on error", () => {
     setProbe({ isError: true });
     renderWithProviders(<StepDhcp initialMode="primary" />);
-    expect(screen.getByText("Probe failed — try again.")).toBeInTheDocument();
+    expect(screen.getByText("Probe failed - try again.")).toBeInTheDocument();
   });
 
   it("shows 'Probing…' and disables the probe button while pending", () => {

--- a/source/admin-site/tests/pages/setup/StepNetwork.test.tsx
+++ b/source/admin-site/tests/pages/setup/StepNetwork.test.tsx
@@ -45,7 +45,7 @@ describe("StepNetwork", () => {
       isError: true,
     });
     renderWithProviders(<StepNetwork />);
-    expect(screen.getAllByText("—").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("-").length).toBeGreaterThan(0);
   });
 
   it("renders static source with no warning panel", () => {

--- a/source/admin-site/tests/pages/setup/StepPolicy.test.tsx
+++ b/source/admin-site/tests/pages/setup/StepPolicy.test.tsx
@@ -68,7 +68,7 @@ describe("StepPolicy", () => {
   it("shows the no-tunnels hint and defaults to direct", () => {
     renderWithProviders(<StepPolicy />);
     expect(
-      screen.getByText(/No tunnels configured — defaulting to direct/),
+      screen.getByText(/No tunnels configured - defaulting to direct/),
     ).toBeInTheDocument();
     expect(screen.getByTestId("rs-value")).toHaveTextContent(
       '{"type":"direct"}',

--- a/source/admin-site/tests/pages/setup/StepRemoteAccess.test.tsx
+++ b/source/admin-site/tests/pages/setup/StepRemoteAccess.test.tsx
@@ -209,7 +209,7 @@ describe("StepRemoteAccess", () => {
     });
     renderWithProviders(<StepRemoteAccess />);
     expect(
-      screen.getByText("Couldn't save progress — try again."),
+      screen.getByText("Couldn't save progress - try again."),
     ).toBeInTheDocument();
   });
 

--- a/source/admin-site/tests/pages/setup/StepReview.test.tsx
+++ b/source/admin-site/tests/pages/setup/StepReview.test.tsx
@@ -131,7 +131,7 @@ describe("StepReview", () => {
     renderWithProviders(<StepReview />);
     // Admin user and LAN IP fall back to em dashes; DNS shows the
     // empty-set label and routing defaults to direct.
-    expect(screen.getAllByText("—").length).toBeGreaterThanOrEqual(2);
+    expect(screen.getAllByText("-").length).toBeGreaterThanOrEqual(2);
     expect(screen.getByText("No profiles")).toBeInTheDocument();
     expect(screen.getByText("Direct (no VPN)")).toBeInTheDocument();
   });

--- a/source/admin-site/tests/test-utils.tsx
+++ b/source/admin-site/tests/test-utils.tsx
@@ -45,6 +45,7 @@ export function makeDevice(overrides: Partial<Device> = {}): Device {
     dns_capture_cap_days: 0,
     dhcp_status: "lease",
     current_rule: null,
+    connection_mode: "lan",
     ...overrides,
   };
 }

--- a/source/admin-site/vite.config.ts
+++ b/source/admin-site/vite.config.ts
@@ -24,10 +24,13 @@ export default defineConfig({
   },
   optimizeDeps: {
     // Pre-bundle the CommonJS deps that the excluded workspace packages import
-    // (cronstrue via @wardnet/web, consola via @wardnet/js): excluding a
-    // linked package stops Vite bundling its deps, so its CJS deps must be
-    // pre-bundled explicitly or their `default` export won't be interop'd.
-    include: ["use-sync-external-store/shim", "cronstrue", "consola"],
+    // (cronstrue + qrcode via @wardnet/web, consola via @wardnet/js): excluding
+    // a linked package stops Vite bundling its deps, so its CJS deps must be
+    // pre-bundled explicitly or their `default`/named exports won't be
+    // interop'd — qrcode's "browser" field swaps in a plain-CJS file with
+    // internal `require()` calls that throw `ReferenceError: require is not
+    // defined` when Vite serves it unbundled.
+    include: ["use-sync-external-store/shim", "cronstrue", "consola", "qrcode"],
     // Our own source workspace packages (linked via Yarn `portal:`) must NOT be
     // pre-bundled: Vite caches a pre-bundle in node_modules/.vite/deps and does
     // not invalidate it when a portal dep's *source* changes, so edits to these

--- a/source/daemon/crates/wardnet-common/src/api.rs
+++ b/source/daemon/crates/wardnet-common/src/api.rs
@@ -306,18 +306,25 @@ pub struct AddInboundWgPeerRequest {
 
 /// Response for `POST /api/inbound-wg/peers`.
 ///
-/// Carries the freshly generated **private key** exactly once — it is never
-/// persisted server-side, so the admin must copy it now to configure the peer.
+/// Carries the complete, ready-to-import `WireGuard` client configuration —
+/// assembled server-side and containing the freshly generated **private key**
+/// exactly once. The daemon never persists the private key (it lives only in
+/// this response); the admin must copy/scan it now. This is the ONLY endpoint
+/// that ever exposes private key material, and it is admin-gated.
 #[derive(Debug, Clone, Serialize, Deserialize, utoipa::ToSchema)]
 pub struct AddInboundWgPeerResponse {
     pub id: Uuid,
     pub name: String,
     /// Base64 `WireGuard` public key (stored server-side).
     pub public_key: String,
-    /// Base64 `WireGuard` private key — returned once, never stored.
-    pub private_key: String,
     /// The peer's allocated `/32` inside the inbound tunnel subnet.
     pub allowed_ip: String,
+    /// The full `WireGuard` client config (`.conf`) — `[Interface]`/`[Peer]`
+    /// stanzas including the private key and endpoint — ready to render as a QR
+    /// code or download. `None` when no reachable endpoint is known yet (remote
+    /// access / DDNS not configured); the credential is created but not usable
+    /// until an endpoint exists.
+    pub client_config: Option<String>,
 }
 
 /// A single inbound-`WireGuard` peer, without any private key material.
@@ -329,12 +336,26 @@ pub struct InboundWgPeerSummary {
     pub allowed_ip: String,
     pub enabled: bool,
     pub created_at: DateTime<Utc>,
+    /// The `Device` this credential grants remote access to. `None` only for
+    /// pre-#810 rows written before the device link existed; every row
+    /// written since always carries it.
+    pub device_id: Option<Uuid>,
 }
 
 /// Response for `GET /api/inbound-wg/peers`.
 #[derive(Debug, Clone, Serialize, Deserialize, utoipa::ToSchema)]
 pub struct ListInboundWgPeersResponse {
     pub peers: Vec<InboundWgPeerSummary>,
+}
+
+/// Request body for `PATCH /api/inbound-wg/peers/{id}`.
+///
+/// Pauses or resumes a peer without deleting its credential — distinct from
+/// `DELETE`, which revokes it permanently and requires a fresh keypair (and
+/// QR scan) to re-grant.
+#[derive(Debug, Clone, Serialize, Deserialize, utoipa::ToSchema)]
+pub struct SetInboundWgPeerEnabledRequest {
+    pub enabled: bool,
 }
 
 /// Response for `GET /api/tunnels/{id}/devices`.

--- a/source/daemon/crates/wardnetd-api/src/api/inbound_wg.rs
+++ b/source/daemon/crates/wardnetd-api/src/api/inbound_wg.rs
@@ -6,7 +6,8 @@ use utoipa_axum::routes;
 use uuid::Uuid;
 use wardnet_common::api::{
     AddInboundWgPeerRequest, AddInboundWgPeerResponse, InboundWgConfigRequest,
-    InboundWgConfigResponse, ListInboundWgPeersResponse,
+    InboundWgConfigResponse, InboundWgPeerSummary, ListInboundWgPeersResponse,
+    SetInboundWgPeerEnabledRequest,
 };
 
 use crate::api::middleware::AdminAuth;
@@ -17,9 +18,32 @@ use wardnetd_services::error::AppError;
 /// Register inbound-`WireGuard` routes onto the given [`OpenApiRouter`].
 pub fn register(router: OpenApiRouter<AppState>) -> OpenApiRouter<AppState> {
     router
-        .routes(routes!(set_config))
+        .routes(routes!(get_config, set_config))
         .routes(routes!(list_peers, add_peer))
-        .routes(routes!(remove_peer))
+        .routes(routes!(remove_peer, set_peer_enabled))
+}
+
+#[utoipa::path(
+    get,
+    path = "/api/inbound-wg/config",
+    tag = "inbound-wg",
+    description = "Read the current inbound WireGuard server config (enabled, listen port, \
+                   public key) without mutating anything. Admin only.",
+    responses(
+        (status = 200, description = "Current inbound WireGuard config", body = InboundWgConfigResponse),
+        AuthErrors,
+    ),
+    security(
+        ("session_cookie" = []),
+        ("bearer_auth" = []),
+    ),
+)]
+pub async fn get_config(
+    State(state): State<AppState>,
+    _auth: AdminAuth,
+) -> Result<Json<InboundWgConfigResponse>, AppError> {
+    let response = state.inbound_wg_service().get_config().await?;
+    Ok(Json(response))
 }
 
 #[utoipa::path(
@@ -107,8 +131,30 @@ pub async fn add_peer(
     _auth: AdminAuth,
     Json(body): Json<AddInboundWgPeerRequest>,
 ) -> Result<(StatusCode, Json<AddInboundWgPeerResponse>), AppError> {
-    let response = state.inbound_wg_service().add_peer(body.device_id).await?;
+    // Compose the reachable endpoint here (the API layer has both services):
+    // the client dials `<host>:<listen_port>`. `host` is the public hostname
+    // (or last-known public IP) from DDNS — a placeholder for the real cloud
+    // relay until #824 lands. When neither is known, the peer is still granted
+    // but the response carries no client config.
+    let endpoint = build_endpoint(&state).await?;
+    let response = state
+        .inbound_wg_service()
+        .add_peer(body.device_id, endpoint)
+        .await?;
     Ok((StatusCode::CREATED, Json(response)))
+}
+
+/// `<host>:<listen_port>` for a peer's `Endpoint`, or `None` when no public
+/// hostname / IP is configured yet. Prefers the DDNS FQDN, falling back to the
+/// last-known public IP.
+async fn build_endpoint(state: &AppState) -> Result<Option<String>, AppError> {
+    let ddns = state.ddns_service().status().await?;
+    let host = ddns.fqdn.or(ddns.last_public_ip);
+    let Some(host) = host else {
+        return Ok(None);
+    };
+    let listen_port = state.inbound_wg_service().get_config().await?.listen_port;
+    Ok(Some(format!("{host}:{listen_port}")))
 }
 
 #[utoipa::path(
@@ -135,4 +181,38 @@ pub async fn remove_peer(
 ) -> Result<StatusCode, AppError> {
     state.inbound_wg_service().remove_peer(id).await?;
     Ok(StatusCode::NO_CONTENT)
+}
+
+#[utoipa::path(
+    patch,
+    path = "/api/inbound-wg/peers/{id}",
+    tag = "inbound-wg",
+    description = "Pause or resume an inbound WireGuard peer without deleting its \
+                   credential: re-admits it onto the live interface (enable) or \
+                   best-effort removes it (disable), then persists the flag. Distinct \
+                   from DELETE, which revokes the credential permanently — a paused \
+                   peer can be resumed without a fresh keypair or QR scan. Admin only.",
+    params(("id" = Uuid, Path, description = "Peer ID")),
+    request_body = SetInboundWgPeerEnabledRequest,
+    responses(
+        (status = 200, description = "Peer state applied", body = InboundWgPeerSummary),
+        AuthErrors,
+        NotFound,
+    ),
+    security(
+        ("session_cookie" = []),
+        ("bearer_auth" = []),
+    ),
+)]
+pub async fn set_peer_enabled(
+    State(state): State<AppState>,
+    _auth: AdminAuth,
+    Path(id): Path<Uuid>,
+    Json(body): Json<SetInboundWgPeerEnabledRequest>,
+) -> Result<Json<InboundWgPeerSummary>, AppError> {
+    let response = state
+        .inbound_wg_service()
+        .set_peer_enabled(id, body.enabled)
+        .await?;
+    Ok(Json(response))
 }

--- a/source/daemon/crates/wardnetd-api/src/api/responses.rs
+++ b/source/daemon/crates/wardnetd-api/src/api/responses.rs
@@ -16,11 +16,11 @@ pub enum AuthErrors {
     /// Missing or invalid session cookie / API key.
     #[response(
         status = 401,
-        description = "Unauthenticated — session cookie or API key missing/invalid"
+        description = "Unauthenticated - session cookie or API key missing/invalid"
     )]
     Unauthorized(#[to_schema] ApiError),
     /// Caller authenticated but lacks admin role.
-    #[response(status = 403, description = "Forbidden — caller is not an admin")]
+    #[response(status = 403, description = "Forbidden - caller is not an admin")]
     Forbidden(#[to_schema] ApiError),
     /// Unhandled server-side failure.
     #[response(status = 500, description = "Internal server error")]

--- a/source/daemon/crates/wardnetd-api/src/api/tests/inbound_wg.rs
+++ b/source/daemon/crates/wardnetd-api/src/api/tests/inbound_wg.rs
@@ -1,0 +1,326 @@
+//! Tests for the inbound (multi-peer) `WireGuard` admin API
+//! (`/api/inbound-wg/*`) — issue #811. Drives the real handlers through an
+//! axum router with a canned `InboundWgService`, asserting status codes,
+//! response envelopes, and the auth guard.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use axum::Router;
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use axum::routing::{delete, get, put};
+use tower::ServiceExt;
+use uuid::Uuid;
+use wardnet_common::api::{
+    AddInboundWgPeerResponse, InboundWgConfigResponse, InboundWgPeerSummary,
+};
+
+use crate::state::AppState;
+use crate::tests::stubs::{
+    AlwaysAdminAuth, StubBackupService, StubDdnsService, StubDeviceService, StubDhcpServer,
+    StubDhcpService, StubDiscoveryService, StubDnsFilterService, StubDnsLocalService,
+    StubDnsServer, StubDnsService, StubEventPublisher, StubLogService, StubNetworkZoneService,
+    StubProviderService, StubRoutingService, StubRuleRequestService, StubStatsService,
+    StubSystemService, StubTlsService, StubTunnelService, StubUpdateService,
+    StubZoneExceptionService,
+};
+use wardnetd_services::LogService;
+use wardnetd_services::error::AppError;
+use wardnetd_services::inbound_wg::service::{InboundWgMonitorPeer, InboundWgService};
+
+// ── Mock ────────────────────────────────────────────────────────────────────
+
+/// Which outcome `add_peer` should return, so a single mock can drive every
+/// documented response path (201 / 404 / 409) without a per-test struct.
+enum AddPeerOutcome {
+    Success,
+    DeviceNotFound,
+    AlreadyGranted,
+}
+
+struct MockInboundWg {
+    add_peer_outcome: AddPeerOutcome,
+}
+
+#[async_trait]
+impl InboundWgService for MockInboundWg {
+    async fn set_config(
+        &self,
+        enabled: bool,
+        listen_port: u16,
+    ) -> Result<InboundWgConfigResponse, AppError> {
+        Ok(InboundWgConfigResponse {
+            enabled,
+            listen_port,
+            server_public_key: Some("c2VydmVyLXB1YmtleQ==".to_owned()),
+        })
+    }
+
+    async fn add_peer(&self, device_id: Uuid) -> Result<AddInboundWgPeerResponse, AppError> {
+        match self.add_peer_outcome {
+            AddPeerOutcome::Success => Ok(AddInboundWgPeerResponse {
+                id: Uuid::nil(),
+                name: "kitchen-tv".to_owned(),
+                public_key: "cHVia2V5".to_owned(),
+                private_key: "cHJpdmtleQ==".to_owned(),
+                allowed_ip: "10.100.64.2/32".to_owned(),
+            }),
+            AddPeerOutcome::DeviceNotFound => {
+                Err(AppError::NotFound(format!("device {device_id} not found")))
+            }
+            AddPeerOutcome::AlreadyGranted => Err(AppError::Conflict(
+                "device already has an inbound WireGuard credential".to_owned(),
+            )),
+        }
+    }
+
+    async fn remove_peer(&self, _id: Uuid) -> Result<(), AppError> {
+        Ok(())
+    }
+
+    async fn list_peers(&self) -> Result<Vec<InboundWgPeerSummary>, AppError> {
+        Ok(vec![InboundWgPeerSummary {
+            id: Uuid::nil(),
+            name: "kitchen-tv".to_owned(),
+            public_key: "cHVia2V5".to_owned(),
+            allowed_ip: "10.100.64.2/32".to_owned(),
+            enabled: true,
+            created_at: chrono::Utc::now(),
+        }])
+    }
+
+    async fn list_peers_for_monitor(&self) -> Result<Vec<InboundWgMonitorPeer>, AppError> {
+        unimplemented!()
+    }
+
+    async fn reconcile(&self) -> Result<(), AppError> {
+        unimplemented!()
+    }
+}
+
+// ── Harness ─────────────────────────────────────────────────────────────────
+
+fn make_state(inbound_wg: Arc<dyn InboundWgService>) -> AppState {
+    AppState::new(
+        Arc::new(AlwaysAdminAuth),
+        Arc::new(StubBackupService),
+        Arc::new(StubDeviceService),
+        Arc::new(StubDhcpService),
+        Arc::new(StubDnsService),
+        Arc::new(StubDnsFilterService),
+        Arc::new(StubDnsLocalService),
+        Arc::new(StubDdnsService),
+        Arc::new(StubTlsService),
+        Arc::new(StubDiscoveryService),
+        Arc::new(StubLogService) as Arc<dyn LogService>,
+        Arc::new(StubProviderService),
+        Arc::new(StubRoutingService),
+        Arc::new(StubNetworkZoneService),
+        Arc::new(StubSystemService),
+        Arc::new(StubTunnelService),
+        Arc::new(StubUpdateService),
+        Arc::new(StubDhcpServer),
+        Arc::new(StubDnsServer),
+        Arc::new(StubEventPublisher),
+        crate::tests::stubs::StubJobService::new_arc(),
+        Arc::new(StubStatsService),
+        Arc::new(StubRuleRequestService),
+        Arc::new(StubZoneExceptionService),
+    )
+    .with_inbound_wg_service(inbound_wg)
+}
+
+fn app(state: AppState) -> Router {
+    Router::new()
+        .route(
+            "/api/inbound-wg/config",
+            put(crate::api::inbound_wg::set_config),
+        )
+        .route(
+            "/api/inbound-wg/peers",
+            get(crate::api::inbound_wg::list_peers).post(crate::api::inbound_wg::add_peer),
+        )
+        .route(
+            "/api/inbound-wg/peers/{id}",
+            delete(crate::api::inbound_wg::remove_peer),
+        )
+        .with_state(state)
+}
+
+fn admin_request(method: &str, uri: &str, body: Option<serde_json::Value>) -> Request<Body> {
+    request(method, uri, body, true)
+}
+
+fn request(
+    method: &str,
+    uri: &str,
+    body: Option<serde_json::Value>,
+    authenticated: bool,
+) -> Request<Body> {
+    let mut builder = Request::builder().method(method).uri(uri);
+    if authenticated {
+        builder = builder.header("Cookie", "wardnet_session=test");
+    }
+    let body = match body {
+        Some(value) => {
+            builder = builder.header("Content-Type", "application/json");
+            Body::from(serde_json::to_vec(&value).unwrap())
+        }
+        None => Body::empty(),
+    };
+    builder.body(body).unwrap()
+}
+
+// ── Tests ───────────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn set_config_enables_and_returns_server_pubkey() {
+    let state = make_state(Arc::new(MockInboundWg {
+        add_peer_outcome: AddPeerOutcome::Success,
+    }));
+    let req = admin_request(
+        "PUT",
+        "/api/inbound-wg/config",
+        Some(serde_json::json!({ "enabled": true, "listen_port": 51900 })),
+    );
+    let resp = app(state).oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = axum::body::to_bytes(resp.into_body(), 4096).await.unwrap();
+    let json: InboundWgConfigResponse = serde_json::from_slice(&body).unwrap();
+    assert!(json.enabled);
+    assert_eq!(json.listen_port, 51900);
+    assert!(json.server_public_key.is_some());
+}
+
+#[tokio::test]
+async fn list_peers_returns_configured_peers() {
+    let state = make_state(Arc::new(MockInboundWg {
+        add_peer_outcome: AddPeerOutcome::Success,
+    }));
+    let req = admin_request("GET", "/api/inbound-wg/peers", None);
+    let resp = app(state).oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = axum::body::to_bytes(resp.into_body(), 4096).await.unwrap();
+    let value: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    let peers = value["peers"].as_array().unwrap();
+    assert_eq!(peers.len(), 1);
+    assert_eq!(peers[0]["name"], "kitchen-tv");
+    // Pin the exact field set so a future handler change that swaps in a
+    // type carrying `private_key` (e.g. `AddInboundWgPeerResponse`) fails
+    // this test instead of silently leaking it — `InboundWgPeerSummary`
+    // itself has no such field, so this can't be caught by the type system
+    // alone once erased through `serde_json::Value`.
+    let mut keys: Vec<&str> = peers[0]
+        .as_object()
+        .unwrap()
+        .keys()
+        .map(String::as_str)
+        .collect();
+    keys.sort_unstable();
+    assert_eq!(
+        keys,
+        vec![
+            "allowed_ip",
+            "created_at",
+            "enabled",
+            "id",
+            "name",
+            "public_key"
+        ]
+    );
+}
+
+#[tokio::test]
+async fn add_peer_success_returns_private_key_once() {
+    let state = make_state(Arc::new(MockInboundWg {
+        add_peer_outcome: AddPeerOutcome::Success,
+    }));
+    let req = admin_request(
+        "POST",
+        "/api/inbound-wg/peers",
+        Some(serde_json::json!({ "device_id": Uuid::new_v4() })),
+    );
+    let resp = app(state).oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::CREATED);
+    let body = axum::body::to_bytes(resp.into_body(), 4096).await.unwrap();
+    let json: AddInboundWgPeerResponse = serde_json::from_slice(&body).unwrap();
+    assert!(!json.private_key.is_empty());
+}
+
+#[tokio::test]
+async fn add_peer_device_not_found_returns_404() {
+    let state = make_state(Arc::new(MockInboundWg {
+        add_peer_outcome: AddPeerOutcome::DeviceNotFound,
+    }));
+    let req = admin_request(
+        "POST",
+        "/api/inbound-wg/peers",
+        Some(serde_json::json!({ "device_id": Uuid::new_v4() })),
+    );
+    let resp = app(state).oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn add_peer_already_granted_returns_409() {
+    let state = make_state(Arc::new(MockInboundWg {
+        add_peer_outcome: AddPeerOutcome::AlreadyGranted,
+    }));
+    let req = admin_request(
+        "POST",
+        "/api/inbound-wg/peers",
+        Some(serde_json::json!({ "device_id": Uuid::new_v4() })),
+    );
+    let resp = app(state).oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::CONFLICT);
+}
+
+#[tokio::test]
+async fn remove_peer_returns_no_content() {
+    let state = make_state(Arc::new(MockInboundWg {
+        add_peer_outcome: AddPeerOutcome::Success,
+    }));
+    let req = admin_request(
+        "DELETE",
+        &format!("/api/inbound-wg/peers/{}", Uuid::new_v4()),
+        None,
+    );
+    let resp = app(state).oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::NO_CONTENT);
+}
+
+#[tokio::test]
+async fn inbound_wg_endpoints_reject_unauthenticated() {
+    let routes: [(&str, &str, Option<serde_json::Value>); 4] = [
+        (
+            "PUT",
+            "/api/inbound-wg/config",
+            Some(serde_json::json!({ "enabled": true, "listen_port": 51900 })),
+        ),
+        ("GET", "/api/inbound-wg/peers", None),
+        (
+            "POST",
+            "/api/inbound-wg/peers",
+            Some(serde_json::json!({ "device_id": Uuid::new_v4() })),
+        ),
+        (
+            "DELETE",
+            &format!("/api/inbound-wg/peers/{}", Uuid::new_v4()),
+            None,
+        ),
+    ];
+
+    for (method, uri, body) in routes {
+        let state = make_state(Arc::new(MockInboundWg {
+            add_peer_outcome: AddPeerOutcome::Success,
+        }));
+        let req = request(method, uri, body, false);
+        let resp = app(state).oneshot(req).await.unwrap();
+        assert_eq!(
+            resp.status(),
+            StatusCode::UNAUTHORIZED,
+            "{method} {uri} should reject an unauthenticated caller"
+        );
+    }
+}

--- a/source/daemon/crates/wardnetd-api/src/api/tests/inbound_wg.rs
+++ b/source/daemon/crates/wardnetd-api/src/api/tests/inbound_wg.rs
@@ -9,7 +9,7 @@ use async_trait::async_trait;
 use axum::Router;
 use axum::body::Body;
 use axum::http::{Request, StatusCode};
-use axum::routing::{delete, get, put};
+use axum::routing::{delete, get};
 use tower::ServiceExt;
 use uuid::Uuid;
 use wardnet_common::api::{
@@ -39,12 +39,28 @@ enum AddPeerOutcome {
     AlreadyGranted,
 }
 
+/// Which outcome `set_peer_enabled` should return, mirroring
+/// [`AddPeerOutcome`] for the same reason.
+enum SetPeerEnabledOutcome {
+    Success,
+    NotFound,
+}
+
 struct MockInboundWg {
     add_peer_outcome: AddPeerOutcome,
+    set_peer_enabled_outcome: SetPeerEnabledOutcome,
 }
 
 #[async_trait]
 impl InboundWgService for MockInboundWg {
+    async fn get_config(&self) -> Result<InboundWgConfigResponse, AppError> {
+        Ok(InboundWgConfigResponse {
+            enabled: true,
+            listen_port: 51821,
+            server_public_key: Some("c2VydmVyLXB1YmtleQ==".to_owned()),
+        })
+    }
+
     async fn set_config(
         &self,
         enabled: bool,
@@ -57,14 +73,22 @@ impl InboundWgService for MockInboundWg {
         })
     }
 
-    async fn add_peer(&self, device_id: Uuid) -> Result<AddInboundWgPeerResponse, AppError> {
+    async fn add_peer(
+        &self,
+        device_id: Uuid,
+        endpoint: Option<String>,
+    ) -> Result<AddInboundWgPeerResponse, AppError> {
         match self.add_peer_outcome {
             AddPeerOutcome::Success => Ok(AddInboundWgPeerResponse {
                 id: Uuid::nil(),
                 name: "kitchen-tv".to_owned(),
                 public_key: "cHVia2V5".to_owned(),
-                private_key: "cHJpdmtleQ==".to_owned(),
                 allowed_ip: "10.100.64.2/32".to_owned(),
+                // Echo the endpoint the handler derived so the test can assert
+                // the DDNS-status → endpoint wiring ran.
+                client_config: endpoint.map(|e| {
+                    format!("[Interface]\nPrivateKey = cHJpdmtleQ==\n\n[Peer]\nEndpoint = {e}\n")
+                }),
             }),
             AddPeerOutcome::DeviceNotFound => {
                 Err(AppError::NotFound(format!("device {device_id} not found")))
@@ -79,6 +103,27 @@ impl InboundWgService for MockInboundWg {
         Ok(())
     }
 
+    async fn set_peer_enabled(
+        &self,
+        id: Uuid,
+        enabled: bool,
+    ) -> Result<InboundWgPeerSummary, AppError> {
+        match self.set_peer_enabled_outcome {
+            SetPeerEnabledOutcome::Success => Ok(InboundWgPeerSummary {
+                id,
+                name: "kitchen-tv".to_owned(),
+                public_key: "cHVia2V5".to_owned(),
+                allowed_ip: "10.100.64.2/32".to_owned(),
+                enabled,
+                created_at: chrono::Utc::now(),
+                device_id: Some(Uuid::new_v4()),
+            }),
+            SetPeerEnabledOutcome::NotFound => Err(AppError::NotFound(format!(
+                "inbound-wg peer {id} not found"
+            ))),
+        }
+    }
+
     async fn list_peers(&self) -> Result<Vec<InboundWgPeerSummary>, AppError> {
         Ok(vec![InboundWgPeerSummary {
             id: Uuid::nil(),
@@ -87,6 +132,7 @@ impl InboundWgService for MockInboundWg {
             allowed_ip: "10.100.64.2/32".to_owned(),
             enabled: true,
             created_at: chrono::Utc::now(),
+            device_id: Some(Uuid::new_v4()),
         }])
     }
 
@@ -135,7 +181,7 @@ fn app(state: AppState) -> Router {
     Router::new()
         .route(
             "/api/inbound-wg/config",
-            put(crate::api::inbound_wg::set_config),
+            get(crate::api::inbound_wg::get_config).put(crate::api::inbound_wg::set_config),
         )
         .route(
             "/api/inbound-wg/peers",
@@ -143,7 +189,8 @@ fn app(state: AppState) -> Router {
         )
         .route(
             "/api/inbound-wg/peers/{id}",
-            delete(crate::api::inbound_wg::remove_peer),
+            delete(crate::api::inbound_wg::remove_peer)
+                .patch(crate::api::inbound_wg::set_peer_enabled),
         )
         .with_state(state)
 }
@@ -178,6 +225,7 @@ fn request(
 async fn set_config_enables_and_returns_server_pubkey() {
     let state = make_state(Arc::new(MockInboundWg {
         add_peer_outcome: AddPeerOutcome::Success,
+        set_peer_enabled_outcome: SetPeerEnabledOutcome::Success,
     }));
     let req = admin_request(
         "PUT",
@@ -194,9 +242,25 @@ async fn set_config_enables_and_returns_server_pubkey() {
 }
 
 #[tokio::test]
+async fn get_config_returns_current_state_without_mutating() {
+    let state = make_state(Arc::new(MockInboundWg {
+        add_peer_outcome: AddPeerOutcome::Success,
+        set_peer_enabled_outcome: SetPeerEnabledOutcome::Success,
+    }));
+    let req = admin_request("GET", "/api/inbound-wg/config", None);
+    let resp = app(state).oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = axum::body::to_bytes(resp.into_body(), 4096).await.unwrap();
+    let json: InboundWgConfigResponse = serde_json::from_slice(&body).unwrap();
+    assert!(json.enabled);
+    assert_eq!(json.listen_port, 51821);
+}
+
+#[tokio::test]
 async fn list_peers_returns_configured_peers() {
     let state = make_state(Arc::new(MockInboundWg {
         add_peer_outcome: AddPeerOutcome::Success,
+        set_peer_enabled_outcome: SetPeerEnabledOutcome::Success,
     }));
     let req = admin_request("GET", "/api/inbound-wg/peers", None);
     let resp = app(state).oneshot(req).await.unwrap();
@@ -223,6 +287,7 @@ async fn list_peers_returns_configured_peers() {
         vec![
             "allowed_ip",
             "created_at",
+            "device_id",
             "enabled",
             "id",
             "name",
@@ -232,9 +297,10 @@ async fn list_peers_returns_configured_peers() {
 }
 
 #[tokio::test]
-async fn add_peer_success_returns_private_key_once() {
+async fn add_peer_success_returns_client_config_with_endpoint() {
     let state = make_state(Arc::new(MockInboundWg {
         add_peer_outcome: AddPeerOutcome::Success,
+        set_peer_enabled_outcome: SetPeerEnabledOutcome::Success,
     }));
     let req = admin_request(
         "POST",
@@ -245,13 +311,18 @@ async fn add_peer_success_returns_private_key_once() {
     assert_eq!(resp.status(), StatusCode::CREATED);
     let body = axum::body::to_bytes(resp.into_body(), 4096).await.unwrap();
     let json: AddInboundWgPeerResponse = serde_json::from_slice(&body).unwrap();
-    assert!(!json.private_key.is_empty());
+    // The handler derived an endpoint from DDNS status and the service built a
+    // config carrying the private key — the only place it is ever exposed.
+    let cfg = json.client_config.expect("client_config present");
+    assert!(cfg.contains("PrivateKey ="));
+    assert!(cfg.contains("Endpoint ="));
 }
 
 #[tokio::test]
 async fn add_peer_device_not_found_returns_404() {
     let state = make_state(Arc::new(MockInboundWg {
         add_peer_outcome: AddPeerOutcome::DeviceNotFound,
+        set_peer_enabled_outcome: SetPeerEnabledOutcome::Success,
     }));
     let req = admin_request(
         "POST",
@@ -266,6 +337,7 @@ async fn add_peer_device_not_found_returns_404() {
 async fn add_peer_already_granted_returns_409() {
     let state = make_state(Arc::new(MockInboundWg {
         add_peer_outcome: AddPeerOutcome::AlreadyGranted,
+        set_peer_enabled_outcome: SetPeerEnabledOutcome::Success,
     }));
     let req = admin_request(
         "POST",
@@ -280,6 +352,7 @@ async fn add_peer_already_granted_returns_409() {
 async fn remove_peer_returns_no_content() {
     let state = make_state(Arc::new(MockInboundWg {
         add_peer_outcome: AddPeerOutcome::Success,
+        set_peer_enabled_outcome: SetPeerEnabledOutcome::Success,
     }));
     let req = admin_request(
         "DELETE",
@@ -291,8 +364,42 @@ async fn remove_peer_returns_no_content() {
 }
 
 #[tokio::test]
+async fn set_peer_enabled_returns_updated_summary() {
+    let state = make_state(Arc::new(MockInboundWg {
+        add_peer_outcome: AddPeerOutcome::Success,
+        set_peer_enabled_outcome: SetPeerEnabledOutcome::Success,
+    }));
+    let req = admin_request(
+        "PATCH",
+        &format!("/api/inbound-wg/peers/{}", Uuid::new_v4()),
+        Some(serde_json::json!({ "enabled": false })),
+    );
+    let resp = app(state).oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = axum::body::to_bytes(resp.into_body(), 4096).await.unwrap();
+    let json: InboundWgPeerSummary = serde_json::from_slice(&body).unwrap();
+    assert!(!json.enabled);
+}
+
+#[tokio::test]
+async fn set_peer_enabled_not_found_returns_404() {
+    let state = make_state(Arc::new(MockInboundWg {
+        add_peer_outcome: AddPeerOutcome::Success,
+        set_peer_enabled_outcome: SetPeerEnabledOutcome::NotFound,
+    }));
+    let req = admin_request(
+        "PATCH",
+        &format!("/api/inbound-wg/peers/{}", Uuid::new_v4()),
+        Some(serde_json::json!({ "enabled": true })),
+    );
+    let resp = app(state).oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
 async fn inbound_wg_endpoints_reject_unauthenticated() {
-    let routes: [(&str, &str, Option<serde_json::Value>); 4] = [
+    let routes: [(&str, &str, Option<serde_json::Value>); 6] = [
+        ("GET", "/api/inbound-wg/config", None),
         (
             "PUT",
             "/api/inbound-wg/config",
@@ -309,11 +416,17 @@ async fn inbound_wg_endpoints_reject_unauthenticated() {
             &format!("/api/inbound-wg/peers/{}", Uuid::new_v4()),
             None,
         ),
+        (
+            "PATCH",
+            &format!("/api/inbound-wg/peers/{}", Uuid::new_v4()),
+            Some(serde_json::json!({ "enabled": true })),
+        ),
     ];
 
     for (method, uri, body) in routes {
         let state = make_state(Arc::new(MockInboundWg {
             add_peer_outcome: AddPeerOutcome::Success,
+            set_peer_enabled_outcome: SetPeerEnabledOutcome::Success,
         }));
         let req = request(method, uri, body, false);
         let resp = app(state).oneshot(req).await.unwrap();

--- a/source/daemon/crates/wardnetd-api/src/api/tests/mod.rs
+++ b/source/daemon/crates/wardnetd-api/src/api/tests/mod.rs
@@ -9,6 +9,7 @@ mod dns_filter;
 mod dns_local;
 mod entitlement_gate;
 mod health;
+mod inbound_wg;
 mod info;
 mod jobs;
 mod logs_ws;

--- a/source/daemon/crates/wardnetd-api/src/state.rs
+++ b/source/daemon/crates/wardnetd-api/src/state.rs
@@ -404,6 +404,14 @@ struct NoopInboundWgService;
 
 #[async_trait::async_trait]
 impl InboundWgService for NoopInboundWgService {
+    async fn get_config(
+        &self,
+    ) -> Result<wardnet_common::api::InboundWgConfigResponse, wardnetd_services::error::AppError>
+    {
+        Err(wardnetd_services::error::AppError::Internal(
+            anyhow::anyhow!("inbound-wg service not configured"),
+        ))
+    }
     async fn set_config(
         &self,
         _enabled: bool,
@@ -417,6 +425,7 @@ impl InboundWgService for NoopInboundWgService {
     async fn add_peer(
         &self,
         _device_id: uuid::Uuid,
+        _endpoint: Option<String>,
     ) -> Result<wardnet_common::api::AddInboundWgPeerResponse, wardnetd_services::error::AppError>
     {
         Err(wardnetd_services::error::AppError::Internal(
@@ -425,6 +434,15 @@ impl InboundWgService for NoopInboundWgService {
     }
     async fn remove_peer(&self, _id: uuid::Uuid) -> Result<(), wardnetd_services::error::AppError> {
         Ok(())
+    }
+    async fn set_peer_enabled(
+        &self,
+        _id: uuid::Uuid,
+        _enabled: bool,
+    ) -> Result<wardnet_common::api::InboundWgPeerSummary, wardnetd_services::error::AppError> {
+        Err(wardnetd_services::error::AppError::Internal(
+            anyhow::anyhow!("inbound-wg service not configured"),
+        ))
     }
     async fn list_peers(
         &self,

--- a/source/daemon/crates/wardnetd-api/src/tests/stubs.rs
+++ b/source/daemon/crates/wardnetd-api/src/tests/stubs.rs
@@ -1273,7 +1273,14 @@ impl wardnetd_services::DdnsService for StubDdnsService {
         unimplemented!()
     }
     async fn status(&self) -> Result<wardnetd_services::ddns::DdnsStatus, AppError> {
-        unimplemented!()
+        // A configured wardnet DDNS box, so handlers that derive a reachable
+        // endpoint from DDNS (inbound-wg add_peer) have a hostname to use.
+        Ok(wardnetd_services::ddns::DdnsStatus {
+            provider: Some("wardnet".to_owned()),
+            fqdn: Some("test.my.wardnet.services".to_owned()),
+            last_public_ip: Some("203.0.113.10".to_owned()),
+            suspended: false,
+        })
     }
     async fn teardown(&self) -> Result<(), AppError> {
         unimplemented!()

--- a/source/daemon/crates/wardnetd-data/src/repository/inbound_wg.rs
+++ b/source/daemon/crates/wardnetd-data/src/repository/inbound_wg.rs
@@ -89,4 +89,9 @@ pub trait InboundWgPeerRepository: Send + Sync {
 
     /// Delete a peer by id. No-op when the id is absent.
     async fn delete(&self, id: &str) -> anyhow::Result<()>;
+
+    /// Set a peer's `enabled` flag. No-op when the id is absent — callers
+    /// that need to distinguish "not found" resolve that via `find_by_id`
+    /// first, the same pattern `remove_peer`/`add_peer` already use.
+    async fn set_enabled(&self, id: &str, enabled: bool) -> anyhow::Result<()>;
 }

--- a/source/daemon/crates/wardnetd-data/src/repository/sqlite/inbound_wg.rs
+++ b/source/daemon/crates/wardnetd-data/src/repository/sqlite/inbound_wg.rs
@@ -150,4 +150,13 @@ impl InboundWgPeerRepository for SqliteInboundWgPeerRepository {
             .await?;
         Ok(())
     }
+
+    async fn set_enabled(&self, id: &str, enabled: bool) -> anyhow::Result<()> {
+        sqlx::query("UPDATE inbound_wg_peers SET enabled = ? WHERE id = ?")
+            .bind(enabled)
+            .bind(id)
+            .execute(&self.pools.write)
+            .await?;
+        Ok(())
+    }
 }

--- a/source/daemon/crates/wardnetd-data/src/secret_store.rs
+++ b/source/daemon/crates/wardnetd-data/src/secret_store.rs
@@ -288,7 +288,7 @@ impl SecretStore for FileSecretStore {
 #[derive(Debug, Default)]
 pub struct NullSecretStore;
 
-const NULL_MSG: &str = "no secret store configured — add a [secret_store] section to wardnet.toml to enable tunnels and backup";
+const NULL_MSG: &str = "no secret store configured - add a [secret_store] section to wardnet.toml to enable tunnels and backup";
 
 #[async_trait]
 impl SecretStore for NullSecretStore {
@@ -324,7 +324,7 @@ impl SecretStore for NullSecretStore {
         // them, fail loud — the operator must configure a secret store
         // before importing.
         anyhow::bail!(
-            "bundle contains {} secret entries but no secret store is configured — add a [secret_store] section to wardnet.toml before importing",
+            "bundle contains {} secret entries but no secret store is configured - add a [secret_store] section to wardnet.toml before importing",
             entries.len()
         );
     }
@@ -350,7 +350,7 @@ pub fn build_secret_store(config: Option<&SecretStoreConfig>) -> Arc<dyn SecretS
         }
         None => {
             tracing::warn!(
-                "secret store: no [secret_store] section in config — tunnels and backup will be unavailable"
+                "secret store: no [secret_store] section in config - tunnels and backup will be unavailable"
             );
             Arc::new(NullSecretStore)
         }

--- a/source/daemon/crates/wardnetd-mock/src/backends/noop_remote_access.rs
+++ b/source/daemon/crates/wardnetd-mock/src/backends/noop_remote_access.rs
@@ -129,6 +129,24 @@ impl MockRemoteAccessState {
     fn clear(&self) {
         *self.sim.lock().unwrap() = None;
     }
+
+    /// Seed an already-issued demo DDNS/TLS configuration so remote-access
+    /// features that need a public endpoint (inbound-WireGuard QR codes /
+    /// `.conf` downloads) render a plausible `Endpoint` without the operator
+    /// running the enrollment flow. Called only when demo seeding is enabled.
+    pub fn configure_demo(&self) {
+        *self.sim.lock().unwrap() = Some(Sim {
+            provider: "wardnet",
+            fqdn: "home1.demo.wardnet.services".to_owned(),
+            public_ip: FAKE_PUBLIC_IP.to_owned(),
+            // Backdate so the cert reads as already `Issued`; DDNS status is
+            // configured regardless of this.
+            started: Instant::now()
+                .checked_sub(ISSUE_DELAY)
+                .unwrap_or_else(Instant::now),
+            force_failure: false,
+        });
+    }
 }
 
 /// Mock [`DdnsService`] — see [module docs](self).

--- a/source/daemon/crates/wardnetd-mock/src/main.rs
+++ b/source/daemon/crates/wardnetd-mock/src/main.rs
@@ -44,6 +44,7 @@ use wardnetd_services::db_maintenance_runner::DbMaintenanceRunner;
 use wardnetd_services::dns::DnsCaptureRunner;
 use wardnetd_services::dns::query_log_runner::DnsQueryLogRunner;
 use wardnetd_services::dns_filter::blocklist_downloader::HttpBlocklistFetcher;
+use wardnetd_services::entitlement::Entitlement;
 use wardnetd_services::health::checks::{DbHealthCheck, LivenessHealthCheck};
 use wardnetd_services::logging::{
     ErrorNotifierService, LogService, LogServiceImpl, LogStreamService,
@@ -309,6 +310,15 @@ async fn run(
     )
     .await?;
 
+    // Startup reconcile of the inbound-WireGuard server, mirroring the real
+    // daemon (`wardnetd` main): stands the interface back up if enabled and,
+    // crucially for the mock's persistent secret store, re-caches the server
+    // public key into `system_config` so an enabled-across-restart server never
+    // reads back with a null public key.
+    if let Err(e) = services.inbound_wg.reconcile().await {
+        tracing::warn!(error = %e, "inbound wireguard reconcile failed on startup: {e}");
+    }
+
     // No-op DHCP and DNS servers — services and handlers treat them
     // opaquely so the UI gets consistent start/stop semantics.
     let dhcp_server: Arc<dyn wardnetd_services::dhcp::server::DhcpServer> =
@@ -323,6 +333,21 @@ async fn run(
     // reach out to live upstreams; we discard them here. See
     // `backends::noop_remote_access`.
     let remote_access_state = MockRemoteAccessState::new();
+    // Both of these are process-local in-memory state (NOT persisted in the
+    // DB), so they must be re-established on every boot — including a
+    // `--no-seed` resume of an on-disk DB, where the demo data already exists
+    // but this state was lost with the previous process. Gating them on seeding
+    // meant a kept-DB restart silently dropped premium + the demo DDNS host.
+    //
+    // Demo DDNS: an already-issued host so remote-access QR codes / `.conf`
+    // downloads have a reachable-looking Endpoint out of the box.
+    remote_access_state.configure_demo();
+    // Entitlement (issue #795): the premium app surfaces (user PWA + admin
+    // mobile app) self-gate on `/api/info`'s `entitled` flag. The mock always
+    // stands in for a wardnet-subscribed box so those apps are testable
+    // locally.
+    let entitlement = Entitlement::shared();
+    entitlement.set_premium(true);
     let mock_ddns: Arc<dyn wardnetd_services::ddns::DdnsService> =
         Arc::new(MockDdnsService::new(remote_access_state.clone()));
     let mock_tls: Arc<dyn wardnetd_services::tls::TlsService> =
@@ -369,6 +394,7 @@ async fn run(
     )
     .with_push_service(services.push.clone())
     .with_inbound_wg_service(services.inbound_wg.clone())
+    .with_entitlement(entitlement)
     .with_health_monitor(health_monitor);
 
     // Drain the DNS query log persistence channel into SQLite so the
@@ -445,7 +471,7 @@ async fn run(
     let addr: SocketAddr = format!("{}:{}", config.server.host, config.server.port).parse()?;
 
     println!(
-        "\n  wardnetd-mock\n  Listening on http://{}\n  Database: {}\n  (Setup wizard runs on every launch — no admin is seeded.)\n",
+        "\n  wardnetd-mock\n  Listening on http://{}\n  Database: {}\n  (Setup wizard runs on every launch - no admin is seeded.)\n",
         addr, config.database.connection_string,
     );
 

--- a/source/daemon/crates/wardnetd-mock/src/seed.rs
+++ b/source/daemon/crates/wardnetd-mock/src/seed.rs
@@ -171,7 +171,7 @@ pub async fn populate(factory: &dyn RepositoryFactory) -> anyhow::Result<SeededI
             mac_address: mac.clone(),
             ip_address: ip.clone(),
             hostname: hostname.clone(),
-            description: Some("Smart plug — kitchen".to_owned()),
+            description: Some("Smart plug - kitchen".to_owned()),
         };
         dhcp_repo.insert_reservation(&reservation).await?;
     }

--- a/source/daemon/crates/wardnetd-services/src/auth/service.rs
+++ b/source/daemon/crates/wardnetd-services/src/auth/service.rs
@@ -252,7 +252,7 @@ impl AuthService for AuthServiceImpl {
 
         if !is_refreshable {
             return Err(AppError::Forbidden(
-                "session was not created with remember_me — refresh not permitted".to_owned(),
+                "session was not created with remember_me - refresh not permitted".to_owned(),
             ));
         }
 
@@ -263,7 +263,7 @@ impl AuthService for AuthServiceImpl {
         let absolute_expiry = created_at + chrono::Duration::days(MAX_SESSION_DAYS);
         if now >= absolute_expiry {
             return Err(AppError::Unauthorized(
-                "session has exceeded maximum lifetime — please log in again".to_owned(),
+                "session has exceeded maximum lifetime - please log in again".to_owned(),
             ));
         }
 

--- a/source/daemon/crates/wardnetd-services/src/backup/archiver.rs
+++ b/source/daemon/crates/wardnetd-services/src/backup/archiver.rs
@@ -297,14 +297,14 @@ fn unpack_sync(passphrase: &str, bytes: &[u8]) -> anyhow::Result<BundleContents>
             other => {
                 tracing::warn!(
                     entry = %other,
-                    "backup bundle contained unexpected entry — ignored: entry={other}",
+                    "backup bundle contained unexpected entry - ignored: entry={other}",
                 );
             }
         }
     }
 
     let manifest = manifest
-        .ok_or_else(|| anyhow::anyhow!("bundle is missing manifest.json — not a wardnet backup"))?;
+        .ok_or_else(|| anyhow::anyhow!("bundle is missing manifest.json - not a wardnet backup"))?;
     let database_bytes =
         database_bytes.ok_or_else(|| anyhow::anyhow!("bundle is missing wardnet.db"))?;
     let config_bytes =

--- a/source/daemon/crates/wardnetd-services/src/backup/service.rs
+++ b/source/daemon/crates/wardnetd-services/src/backup/service.rs
@@ -190,7 +190,7 @@ impl BackupServiceImpl {
             return Ok((
                 false,
                 Some(format!(
-                    "bundle format version {} is newer than supported ({}) — upgrade the daemon first",
+                    "bundle format version {} is newer than supported ({}) - upgrade the daemon first",
                     manifest.bundle_format_version, CURRENT_BUNDLE_FORMAT_VERSION
                 )),
             ));
@@ -204,7 +204,7 @@ impl BackupServiceImpl {
             return Ok((
                 false,
                 Some(format!(
-                    "bundle schema version {} is newer than the running daemon's ({}) — upgrade the daemon first, then retry",
+                    "bundle schema version {} is newer than the running daemon's ({}) - upgrade the daemon first, then retry",
                     manifest.schema_version, running_schema
                 )),
             ));
@@ -677,7 +677,7 @@ impl BackupService for BackupServiceImpl {
             let mut pending = self.pending.lock().await;
             pending.remove(&req.preview_token).ok_or_else(|| {
                 AppError::BadRequest(
-                    "preview token is unknown or expired — call preview_import again".into(),
+                    "preview token is unknown or expired - call preview_import again".into(),
                 )
             })?
         };
@@ -709,7 +709,7 @@ impl BackupService for BackupServiceImpl {
                 tracing::info!(
                     schema_version = manifest.schema_version,
                     host_id = %manifest.host_id,
-                    "backup applied — daemon restart required: schema_version={sv}, host_id={host}",
+                    "backup applied - daemon restart required: schema_version={sv}, host_id={host}",
                     sv = manifest.schema_version,
                     host = manifest.host_id,
                 );

--- a/source/daemon/crates/wardnetd-services/src/cloud/tests/tunneller.rs
+++ b/source/daemon/crates/wardnetd-services/src/cloud/tests/tunneller.rs
@@ -348,7 +348,7 @@ async fn ninth_concurrent_conn_is_rejected_at_cap() {
         &fake_open_ok,
     )
     .await;
-    assert_eq!(conns.len(), 8, "9th conn_id rejected — cap holds");
+    assert_eq!(conns.len(), 8, "9th conn_id rejected - cap holds");
     let msg = out_rx
         .try_recv()
         .expect("cap rejection must send FRAME_CLOSE");

--- a/source/daemon/crates/wardnetd-services/src/ddns/mod.rs
+++ b/source/daemon/crates/wardnetd-services/src/ddns/mod.rs
@@ -424,7 +424,7 @@ impl DdnsServiceImpl {
             .await
             .map_err(AppError::Internal)?
             .ok_or_else(|| {
-                AppError::Conflict("not enrolled — request a code and enroll first".to_owned())
+                AppError::Conflict("not enrolled - request a code and enroll first".to_owned())
             })?;
         let seed: [u8; 32] = bytes.try_into().map_err(|_| {
             AppError::Internal(anyhow::anyhow!("daemon signing key is not 32 bytes"))
@@ -976,7 +976,7 @@ impl DdnsService for DdnsServiceImpl {
     async fn set_acme_challenge(&self, values: &[String]) -> Result<(), AppError> {
         auth_context::require_admin()?;
         let provider = self.build_provider().await?.ok_or_else(|| {
-            AppError::Conflict("DDNS is not configured — cannot publish ACME challenge".to_owned())
+            AppError::Conflict("DDNS is not configured - cannot publish ACME challenge".to_owned())
         })?;
         provider
             .set_txt(values)
@@ -987,7 +987,7 @@ impl DdnsService for DdnsServiceImpl {
     async fn clear_acme_challenge(&self) -> Result<(), AppError> {
         auth_context::require_admin()?;
         let provider = self.build_provider().await?.ok_or_else(|| {
-            AppError::Conflict("DDNS is not configured — cannot clear ACME challenge".to_owned())
+            AppError::Conflict("DDNS is not configured - cannot clear ACME challenge".to_owned())
         })?;
         provider
             .delete_txt()

--- a/source/daemon/crates/wardnetd-services/src/ddns/tests/runner.rs
+++ b/source/daemon/crates/wardnetd-services/src/ddns/tests/runner.rs
@@ -86,7 +86,7 @@ async fn runner_refreshes_then_shuts_down() {
     assert_eq!(
         mock.probes.load(Ordering::SeqCst),
         0,
-        "an entitled runner never probes — it refreshes"
+        "an entitled runner never probes - it refreshes"
     );
 }
 

--- a/source/daemon/crates/wardnetd-services/src/ddns/tests/service.rs
+++ b/source/daemon/crates/wardnetd-services/src/ddns/tests/service.rs
@@ -786,7 +786,7 @@ async fn configure_cloudflare_resolves_zone_and_persists_identity() {
     );
     assert!(
         !svc.entitlement().is_entitled(),
-        "BYOD-Cloudflare is a free provider — it must not flip premium entitlement"
+        "BYOD-Cloudflare is a free provider - it must not flip premium entitlement"
     );
 }
 

--- a/source/daemon/crates/wardnetd-services/src/dhcp/service.rs
+++ b/source/daemon/crates/wardnetd-services/src/dhcp/service.rs
@@ -395,7 +395,7 @@ impl DhcpServiceImpl {
         }
 
         Err(AppError::Conflict(
-            "DHCP pool exhausted — no available IP addresses".to_owned(),
+            "DHCP pool exhausted - no available IP addresses".to_owned(),
         ))
     }
 

--- a/source/daemon/crates/wardnetd-services/src/dns_filter/blocklist_downloader.rs
+++ b/source/daemon/crates/wardnetd-services/src/dns_filter/blocklist_downloader.rs
@@ -88,7 +88,7 @@ pub async fn refresh_blocklist(
 
     if count == 0 {
         let msg =
-            "parsed 0 domains from response (check the URL — it may redirect to an HTML page)"
+            "parsed 0 domains from response (check the URL - it may redirect to an HTML page)"
                 .to_owned();
         tracing::error!(blocklist_id = %blocklist.id, "{msg}");
         let _ = repo.set_blocklist_error(blocklist.id, Some(&msg)).await;

--- a/source/daemon/crates/wardnetd-services/src/inbound_wg/service.rs
+++ b/source/daemon/crates/wardnetd-services/src/inbound_wg/service.rs
@@ -79,6 +79,11 @@ const SERVER_HOST: u8 = 1;
 /// `Remote` via the discovery service, driven by the inbound-WireGuard monitor.
 #[async_trait]
 pub trait InboundWgService: Send + Sync {
+    /// Read the current server config (enabled, listen port, public key)
+    /// without mutating anything — for UI surfaces that need to show live
+    /// state on load rather than only after a `set_config` call.
+    async fn get_config(&self) -> Result<InboundWgConfigResponse, AppError>;
+
     /// Enable or disable the inbound server and set its listen port.
     ///
     /// On enable: generates + persists the server keypair if none exists,
@@ -94,14 +99,33 @@ pub trait InboundWgService: Send + Sync {
 
     /// Grant remote access to an already-managed device: generate a keypair,
     /// allocate an IP, persist the row (public key + `device_id`), add it to
-    /// the interface, and return the private key **once**. The peer's
-    /// user-facing name is taken from the device itself. Rejected when the
-    /// server is disabled, when the device does not exist, or when the device
-    /// already has a credential (one per device).
-    async fn add_peer(&self, device_id: Uuid) -> Result<AddInboundWgPeerResponse, AppError>;
+    /// the interface, and return the **full client config** (with the private
+    /// key) exactly once. The peer's user-facing name is taken from the device
+    /// itself. `endpoint` is the reachable `host:port` the client dials, which
+    /// the caller derives (DDNS today, cloud relay per #824) — `None` yields a
+    /// response with no `client_config`. Rejected when the server is disabled,
+    /// the device does not exist or is unmanaged, or it already has a
+    /// credential (one per device).
+    async fn add_peer(
+        &self,
+        device_id: Uuid,
+        endpoint: Option<String>,
+    ) -> Result<AddInboundWgPeerResponse, AppError>;
 
     /// Remove a peer by id from both the interface and the database.
     async fn remove_peer(&self, id: Uuid) -> Result<(), AppError>;
+
+    /// Pause or resume a peer without deleting its credential: re-admit it
+    /// onto the live interface (enable) or best-effort remove it (disable),
+    /// then persist the flag. Distinct from `remove_peer` — the keypair and
+    /// allocated IP survive, so re-enabling never needs a fresh QR scan.
+    /// No-op (returns the current summary) if the peer is already in the
+    /// requested state. 404 if the peer does not exist.
+    async fn set_peer_enabled(
+        &self,
+        id: Uuid,
+        enabled: bool,
+    ) -> Result<InboundWgPeerSummary, AppError>;
 
     /// List every peer (no private keys).
     async fn list_peers(&self) -> Result<Vec<InboundWgPeerSummary>, AppError>;
@@ -199,22 +223,61 @@ impl InboundWgServiceImpl {
         IpNetwork::new(ip.into(), SUBNET_MASK).expect("valid /24 server address")
     }
 
+    /// Assemble the full `WireGuard` client `.conf` for a freshly-granted peer.
+    /// It embeds the peer's private key, so it is only ever produced here (for
+    /// the one-time `add_peer` response) and never persisted. The client's
+    /// `DNS` is the inbound server's own address (`10.100.64.1`) so filtering
+    /// still applies, and the tunnel is full (`AllowedIPs = 0.0.0.0/0, ::/0`)
+    /// so a remote device routes everything through the home gateway.
+    /// `allowed_ip` already carries its `/32`.
+    fn build_client_config(
+        private_key_b64: &str,
+        allowed_ip: &str,
+        server_pubkey_b64: &str,
+        endpoint: &str,
+    ) -> String {
+        let dns = format!(
+            "{}.{}.{}.{SERVER_HOST}",
+            SUBNET_PREFIX[0], SUBNET_PREFIX[1], SUBNET_PREFIX[2]
+        );
+        format!(
+            "[Interface]\n\
+             PrivateKey = {private_key_b64}\n\
+             Address = {allowed_ip}\n\
+             DNS = {dns}\n\
+             \n\
+             [Peer]\n\
+             PublicKey = {server_pubkey_b64}\n\
+             Endpoint = {endpoint}\n\
+             AllowedIPs = 0.0.0.0/0, ::/0\n\
+             PersistentKeepalive = 25\n"
+        )
+    }
+
     /// Load the persisted server private key, or generate + persist a fresh
     /// keypair if none exists. Returns the raw private key and the base64
-    /// public key. The public key is persisted to `system_config`.
+    /// public key, and (idempotently) caches the public key in `system_config`.
     async fn ensure_server_keypair(&self) -> Result<([u8; 32], String), AppError> {
-        if let Some(priv_b64) = self.keys.load_key().await.map_err(AppError::Internal)? {
-            let private = Self::decode_key(&priv_b64)?;
-            let public = x25519_dalek::x25519(private, x25519_dalek::X25519_BASEPOINT_BYTES);
-            return Ok((private, Self::encode_key(&public)));
-        }
-        let (private, public) = generate_keypair();
-        let priv_b64 = Self::encode_key(&private);
-        let pub_b64 = Self::encode_key(&public);
-        self.keys
-            .save_key(&priv_b64)
-            .await
-            .map_err(AppError::Internal)?;
+        let (private, pub_b64) =
+            if let Some(priv_b64) = self.keys.load_key().await.map_err(AppError::Internal)? {
+                let private = Self::decode_key(&priv_b64)?;
+                let public = x25519_dalek::x25519(private, x25519_dalek::X25519_BASEPOINT_BYTES);
+                (private, Self::encode_key(&public))
+            } else {
+                let (private, public) = generate_keypair();
+                let priv_b64 = Self::encode_key(&private);
+                self.keys
+                    .save_key(&priv_b64)
+                    .await
+                    .map_err(AppError::Internal)?;
+                (private, Self::encode_key(&public))
+            };
+        // Persist the public key on EVERY call, not just first keygen: the
+        // `system_config` copy is a cache of what the key store holds, and the
+        // two can desync (e.g. the DB is reset while the key-store file
+        // survives). Without this, an enabled server whose key predates the
+        // cache reads back with a `null` public key, and every generated client
+        // config gets an empty `PublicKey =` line (WireGuard "syntax error").
         self.system_config
             .set_inbound_wg_server_pubkey(&pub_b64)
             .await
@@ -255,7 +318,7 @@ impl InboundWgServiceImpl {
             }
         }
         Err(AppError::Conflict(
-            "inbound WireGuard subnet is full — no free address".to_owned(),
+            "inbound WireGuard subnet is full - no free address".to_owned(),
         ))
     }
 
@@ -295,10 +358,79 @@ impl InboundWgServiceImpl {
         }
         Ok(())
     }
+
+    /// Best-effort removal of a peer from the live `wg_wardin0` interface. The
+    /// DB row is the source of truth, so a kernel-side removal failure is
+    /// logged and swallowed. A malformed stored public key IS fatal (it
+    /// signals corruption the caller should surface). Shared by revoke
+    /// ([`Self::remove_peer`]) and pause ([`Self::set_peer_enabled`]) so the
+    /// eviction path stays identical.
+    async fn remove_peer_from_interface(&self, row: &InboundWgPeerRow) -> Result<(), AppError> {
+        let public_key = Self::decode_key(&row.public_key)?;
+        if let Err(e) = self
+            .interface
+            .remove_peer(INBOUND_WG_INTERFACE, public_key)
+            .await
+        {
+            tracing::warn!(
+                peer_id = %row.id,
+                error = %e,
+                "inbound-wg: failed to remove peer {} from interface, continuing: {e}",
+                row.id,
+            );
+        }
+        Ok(())
+    }
+
+    /// Reset the peer's device back off `Remote` `connection_mode`. A peer
+    /// with no live path (revoked or paused) must not leave its device stuck
+    /// `Remote` with nothing to correct it. Best-effort — the primary state
+    /// change is already persisted, so a failure here is logged, not fatal.
+    /// Shared by revoke ([`Self::remove_peer`]) and pause
+    /// ([`Self::set_peer_enabled`]).
+    async fn reset_peer_connection_mode(&self, row: &InboundWgPeerRow) {
+        if let Some(device_id) = &row.device_id
+            && let Err(e) = self.devices.clear_remote_connection_mode(device_id).await
+        {
+            tracing::warn!(
+                peer_id = %row.id,
+                device_id = %device_id,
+                error = %e,
+                "inbound-wg: failed to reset device connection_mode for peer {}: {e}",
+                row.id,
+            );
+        }
+    }
 }
 
 #[async_trait]
 impl InboundWgService for InboundWgServiceImpl {
+    async fn get_config(&self) -> Result<InboundWgConfigResponse, AppError> {
+        auth_context::require_admin()?;
+
+        let enabled = self
+            .system_config
+            .inbound_wg_enabled()
+            .await
+            .map_err(AppError::Internal)?;
+        let listen_port = self
+            .system_config
+            .inbound_wg_listen_port()
+            .await
+            .map_err(AppError::Internal)?;
+        let server_public_key = self
+            .system_config
+            .inbound_wg_server_pubkey()
+            .await
+            .map_err(AppError::Internal)?;
+
+        Ok(InboundWgConfigResponse {
+            enabled,
+            listen_port,
+            server_public_key,
+        })
+    }
+
     async fn set_config(
         &self,
         enabled: bool,
@@ -367,7 +499,11 @@ impl InboundWgService for InboundWgServiceImpl {
         }
     }
 
-    async fn add_peer(&self, device_id: Uuid) -> Result<AddInboundWgPeerResponse, AppError> {
+    async fn add_peer(
+        &self,
+        device_id: Uuid,
+        endpoint: Option<String>,
+    ) -> Result<AddInboundWgPeerResponse, AppError> {
         auth_context::require_admin()?;
 
         // Precondition first: no keygen / DB work if the server is off.
@@ -378,7 +514,7 @@ impl InboundWgService for InboundWgServiceImpl {
             .map_err(AppError::Internal)?
         {
             return Err(AppError::Conflict(
-                "inbound WireGuard server is disabled — enable it before adding peers".to_owned(),
+                "inbound WireGuard server is disabled - enable it before adding peers".to_owned(),
             ));
         }
 
@@ -405,13 +541,16 @@ impl InboundWgService for InboundWgServiceImpl {
             )));
         }
 
-        // User-facing label comes from the device, not a free-text param:
-        // admin-set name, else hostname, else MAC as a last resort.
-        let name = device
-            .name
-            .clone()
-            .or_else(|| device.hostname.clone())
-            .unwrap_or_else(|| device.mac.clone());
+        // Only a *managed* device — one an admin has named — can be granted
+        // remote access; a bare discovered device must be adopted (named)
+        // first. The admin UI filters unmanaged devices out of the picker, so
+        // this is defense-in-depth. The peer's user-facing label is that
+        // admin-set name (never a free-text param).
+        let Some(name) = device.name.clone() else {
+            return Err(AppError::Conflict(format!(
+                "device {device_id} is unmanaged - name (adopt) it before granting remote access"
+            )));
+        };
 
         let (private, public) = generate_keypair();
         let private_b64 = Self::encode_key(&private);
@@ -463,12 +602,31 @@ impl InboundWgService for InboundWgServiceImpl {
             return Err(AppError::Internal(error));
         }
 
+        // Assemble the full client config server-side (the private key never
+        // leaves this method's memory otherwise). The server public key is the
+        // one persisted on enable; if it is somehow absent, or no endpoint is
+        // known, there is no usable config to return.
+        let server_pubkey = self
+            .system_config
+            .inbound_wg_server_pubkey()
+            .await
+            .map_err(AppError::Internal)?;
+        let client_config = match (server_pubkey, endpoint) {
+            (Some(pubkey), Some(endpoint)) => Some(Self::build_client_config(
+                &private_b64,
+                &allowed_ip,
+                &pubkey,
+                &endpoint,
+            )),
+            _ => None,
+        };
+
         Ok(AddInboundWgPeerResponse {
             id,
             name,
             public_key: public_b64,
-            private_key: private_b64,
             allowed_ip,
+            client_config,
         })
     }
 
@@ -482,16 +640,7 @@ impl InboundWgService for InboundWgServiceImpl {
             .map_err(AppError::Internal)?
             .ok_or_else(|| AppError::NotFound(format!("inbound-wg peer {id} not found")))?;
 
-        let public_key = Self::decode_key(&row.public_key)?;
-        // Best-effort removal from the live interface; the DB row is the source
-        // of truth, so a failed kernel removal is logged, not fatal.
-        if let Err(e) = self
-            .interface
-            .remove_peer(INBOUND_WG_INTERFACE, public_key)
-            .await
-        {
-            tracing::warn!(peer_id = %id, error = %e, "inbound-wg: failed to remove peer from interface, deleting row anyway");
-        }
+        self.remove_peer_from_interface(&row).await?;
 
         self.peers
             .delete(&id.to_string())
@@ -499,21 +648,66 @@ impl InboundWgService for InboundWgServiceImpl {
             .map_err(AppError::Internal)?;
 
         // The revoked credential was this device's only remote-access path, so
-        // its `connection_mode` (set to `Remote` by the inbound-WG monitor)
-        // would otherwise stay stuck with no live path left to correct it.
-        // Best-effort: the primary revoke already succeeded, so a failure here
-        // is logged, not fatal.
-        if let Some(device_id) = &row.device_id
-            && let Err(e) = self.devices.clear_remote_connection_mode(device_id).await
-        {
-            tracing::warn!(
-                peer_id = %id,
-                device_id = %device_id,
-                error = %e,
-                "inbound-wg: failed to reset device connection_mode after revoke: {e}",
-            );
-        }
+        // clear its (monitor-set) `Remote` connection_mode now that nothing is
+        // left to correct it.
+        self.reset_peer_connection_mode(&row).await;
         Ok(())
+    }
+
+    async fn set_peer_enabled(
+        &self,
+        id: Uuid,
+        enabled: bool,
+    ) -> Result<InboundWgPeerSummary, AppError> {
+        auth_context::require_admin()?;
+
+        let row = self
+            .peers
+            .find_by_id(&id.to_string())
+            .await
+            .map_err(AppError::Internal)?
+            .ok_or_else(|| AppError::NotFound(format!("inbound-wg peer {id} not found")))?;
+
+        if row.enabled == enabled {
+            return row_to_summary(row);
+        }
+
+        // Only touch the live interface when the server itself is up —
+        // otherwise nothing is admitted to add/remove, and `bring_up_server`'s
+        // `find_enabled()` re-admit sweep picks up the persisted flag on the
+        // next enable.
+        let server_up = self
+            .system_config
+            .inbound_wg_enabled()
+            .await
+            .map_err(AppError::Internal)?;
+
+        if server_up {
+            if enabled {
+                let config = Self::peer_row_to_config(&row)?;
+                self.interface
+                    .add_peer(INBOUND_WG_INTERFACE, config)
+                    .await
+                    .map_err(AppError::Internal)?;
+            } else {
+                self.remove_peer_from_interface(&row).await?;
+            }
+        }
+
+        self.peers
+            .set_enabled(&id.to_string(), enabled)
+            .await
+            .map_err(AppError::Internal)?;
+
+        // A disabled peer has no live path, so clear its device's (monitor-set)
+        // `Remote` connection_mode — same teardown revoke applies.
+        if !enabled {
+            self.reset_peer_connection_mode(&row).await;
+        }
+
+        let mut updated = row;
+        updated.enabled = enabled;
+        row_to_summary(updated)
     }
 
     async fn list_peers(&self) -> Result<Vec<InboundWgPeerSummary>, AppError> {
@@ -614,6 +808,15 @@ fn row_to_summary(row: InboundWgPeerRow) -> Result<InboundWgPeerSummary, AppErro
     let created_at = chrono::DateTime::parse_from_rfc3339(&row.created_at)
         .map_err(|e| AppError::Internal(anyhow::anyhow!("invalid stored created_at: {e}")))?
         .with_timezone(&chrono::Utc);
+    // Unparseable is treated the same as absent (logged, not fatal) — a
+    // single bad row must not break the whole listing.
+    let device_id = row.device_id.as_deref().and_then(|s| match s.parse() {
+        Ok(id) => Some(id),
+        Err(e) => {
+            tracing::warn!(peer_id = %row.id, error = %e, "inbound-wg: unparseable device_id for peer {}", row.id);
+            None
+        }
+    });
     Ok(InboundWgPeerSummary {
         id,
         name: row.name,
@@ -621,5 +824,6 @@ fn row_to_summary(row: InboundWgPeerRow) -> Result<InboundWgPeerSummary, AppErro
         allowed_ip: row.allowed_ip,
         enabled: row.enabled,
         created_at,
+        device_id,
     })
 }

--- a/source/daemon/crates/wardnetd-services/src/inbound_wg/tests/service.rs
+++ b/source/daemon/crates/wardnetd-services/src/inbound_wg/tests/service.rs
@@ -28,13 +28,22 @@ struct MockDeviceService {
 }
 
 impl MockDeviceService {
-    /// Register a device with the given display name and return its id.
+    /// Register a managed device with the given display name and return its id.
     fn add_device(&self, name: &str) -> Uuid {
+        self.insert_device(Some(name.to_owned()))
+    }
+
+    /// Register an unmanaged (never-named) device and return its id.
+    fn add_unmanaged_device(&self) -> Uuid {
+        self.insert_device(None)
+    }
+
+    fn insert_device(&self, name: Option<String>) -> Uuid {
         let id = Uuid::new_v4();
         let device = Device {
             id,
             mac: format!("aa:bb:cc:00:00:{:02x}", self.devices.lock().unwrap().len()),
-            name: Some(name.to_owned()),
+            name,
             hostname: None,
             manufacturer: None,
             device_type: DeviceType::Unknown,
@@ -199,6 +208,12 @@ impl InboundWgPeerRepository for MockPeerRepo {
     }
     async fn delete(&self, id: &str) -> anyhow::Result<()> {
         self.rows.lock().unwrap().retain(|r| r.id != id);
+        Ok(())
+    }
+    async fn set_enabled(&self, id: &str, enabled: bool) -> anyhow::Result<()> {
+        if let Some(row) = self.rows.lock().unwrap().iter_mut().find(|r| r.id == id) {
+            row.enabled = enabled;
+        }
         Ok(())
     }
 }
@@ -469,10 +484,65 @@ async fn enable_persists_config_and_calls_backends() {
 }
 
 #[tokio::test]
+async fn get_config_reads_without_mutating() {
+    let h = harness();
+    let before = auth_context::with_context(admin_ctx(), h.service.get_config())
+        .await
+        .unwrap();
+    assert!(!before.enabled);
+    assert!(before.server_public_key.is_none());
+    // A read must not stand up the interface or touch the firewall.
+    assert!(h.interface.ensure_calls.lock().unwrap().is_empty());
+
+    auth_context::with_context(admin_ctx(), h.service.set_config(true, 51821))
+        .await
+        .unwrap();
+    let after = auth_context::with_context(admin_ctx(), h.service.get_config())
+        .await
+        .unwrap();
+    assert!(after.enabled);
+    assert_eq!(after.listen_port, 51821);
+    assert!(after.server_public_key.is_some());
+}
+
+#[tokio::test]
+async fn enable_caches_public_key_when_keypair_predates_cache() {
+    let h = harness();
+    // Simulate a key store that already holds a key while system_config has no
+    // cached public key — e.g. the DB was reset but the key-store file
+    // survived. Before the fix this made the server read back enabled with a
+    // null public key, so generated client configs got an empty `PublicKey =`.
+    h.keys
+        .save_key("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=")
+        .await
+        .unwrap();
+    assert!(
+        h.system_config
+            .inbound_wg_server_pubkey()
+            .await
+            .unwrap()
+            .is_none(),
+        "precondition: no cached public key"
+    );
+
+    auth_context::with_context(admin_ctx(), h.service.set_config(true, 51821))
+        .await
+        .unwrap();
+
+    let cfg = auth_context::with_context(admin_ctx(), h.service.get_config())
+        .await
+        .unwrap();
+    assert!(
+        cfg.server_public_key.is_some(),
+        "get_config must derive/cache a public key from the existing keypair"
+    );
+}
+
+#[tokio::test]
 async fn add_peer_rejected_when_disabled() {
     let h = harness();
     let device_id = h.add_device("laptop");
-    let result = auth_context::with_context(admin_ctx(), h.service.add_peer(device_id)).await;
+    let result = auth_context::with_context(admin_ctx(), h.service.add_peer(device_id, None)).await;
     assert!(result.is_err(), "add_peer must fail when server disabled");
     // Nothing was persisted or pushed to the interface.
     assert!(h.peers.find_all().await.unwrap().is_empty());
@@ -480,30 +550,63 @@ async fn add_peer_rejected_when_disabled() {
 }
 
 #[tokio::test]
-async fn add_peer_generates_private_key_never_persisted() {
+async fn add_peer_rejected_for_unmanaged_device() {
+    let h = harness();
+    auth_context::with_context(admin_ctx(), h.service.set_config(true, 51821))
+        .await
+        .unwrap();
+    let device_id = h.devices.add_unmanaged_device();
+
+    let result = auth_context::with_context(admin_ctx(), h.service.add_peer(device_id, None)).await;
+    assert!(
+        matches!(result, Err(AppError::Conflict(_))),
+        "an unmanaged (unnamed) device must be rejected, got {result:?}"
+    );
+    // Nothing was persisted or pushed to the interface.
+    assert!(h.peers.find_all().await.unwrap().is_empty());
+    assert!(h.interface.added_peers.lock().unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn add_peer_config_carries_private_key_never_persisted() {
     let h = harness();
     auth_context::with_context(admin_ctx(), h.service.set_config(true, 51821))
         .await
         .unwrap();
 
     let device_id = h.add_device("phone");
-    let resp = auth_context::with_context(admin_ctx(), h.service.add_peer(device_id))
-        .await
-        .expect("add_peer succeeds when enabled");
+    let resp = auth_context::with_context(
+        admin_ctx(),
+        h.service
+            .add_peer(device_id, Some("vpn.example.com:51821".to_owned())),
+    )
+    .await
+    .expect("add_peer succeeds when enabled");
 
     assert_eq!(resp.name, "phone");
-    assert!(!resp.private_key.is_empty());
-    assert_ne!(resp.private_key, resp.public_key);
     assert_eq!(resp.allowed_ip, "10.100.64.2/32", "first peer gets .2");
 
-    // The row stores only the public key + allocated IP — never the private key.
+    // The full client config is returned, carrying the private key and the
+    // derived endpoint/address; that is the only place the private key exists.
+    let cfg = resp
+        .client_config
+        .expect("client_config present when enabled + endpoint");
+    assert!(cfg.contains("PrivateKey = "));
+    assert!(cfg.contains("Endpoint = vpn.example.com:51821"));
+    assert!(cfg.contains("Address = 10.100.64.2/32"));
+
+    // The row stores only the public key + allocated IP, never the private key.
     let rows = h.peers.find_all().await.unwrap();
     assert_eq!(rows.len(), 1);
     assert_eq!(rows[0].public_key, resp.public_key);
     assert_eq!(rows[0].allowed_ip, resp.allowed_ip);
+    let private_key = cfg
+        .lines()
+        .find_map(|l| l.strip_prefix("PrivateKey = "))
+        .expect("config has a PrivateKey line");
     let serialized = format!("{:?}", rows[0]);
     assert!(
-        !serialized.contains(&resp.private_key),
+        !serialized.contains(private_key),
         "private key must not be persisted anywhere on the row"
     );
 
@@ -522,7 +625,7 @@ async fn add_peer_rolls_back_row_when_interface_fails() {
     h.interface.fail_add_peer.store(true, Ordering::SeqCst);
 
     let device_id = h.add_device("laptop");
-    let result = auth_context::with_context(admin_ctx(), h.service.add_peer(device_id)).await;
+    let result = auth_context::with_context(admin_ctx(), h.service.add_peer(device_id, None)).await;
     assert!(
         result.is_err(),
         "add_peer must fail when the interface rejects the peer"
@@ -546,10 +649,10 @@ async fn second_peer_gets_next_free_ip() {
         .unwrap();
     let id_a = h.add_device("a");
     let id_b = h.add_device("b");
-    let a = auth_context::with_context(admin_ctx(), h.service.add_peer(id_a))
+    let a = auth_context::with_context(admin_ctx(), h.service.add_peer(id_a, None))
         .await
         .unwrap();
-    let b = auth_context::with_context(admin_ctx(), h.service.add_peer(id_b))
+    let b = auth_context::with_context(admin_ctx(), h.service.add_peer(id_b, None))
         .await
         .unwrap();
     assert_eq!(a.allowed_ip, "10.100.64.2/32");
@@ -563,7 +666,7 @@ async fn remove_peer_deletes_row() {
         .await
         .unwrap();
     let device_id = h.add_device("x");
-    let peer = auth_context::with_context(admin_ctx(), h.service.add_peer(device_id))
+    let peer = auth_context::with_context(admin_ctx(), h.service.add_peer(device_id, None))
         .await
         .unwrap();
     assert_eq!(h.peers.find_all().await.unwrap().len(), 1);
@@ -582,7 +685,7 @@ async fn disable_does_not_delete_peer_rows() {
         .await
         .unwrap();
     let device_id = h.add_device("keep");
-    auth_context::with_context(admin_ctx(), h.service.add_peer(device_id))
+    auth_context::with_context(admin_ctx(), h.service.add_peer(device_id, None))
         .await
         .unwrap();
 
@@ -606,6 +709,97 @@ async fn disable_does_not_delete_peer_rows() {
 }
 
 #[tokio::test]
+async fn set_peer_enabled_disable_removes_from_interface_but_keeps_row() {
+    let h = harness();
+    auth_context::with_context(admin_ctx(), h.service.set_config(true, 51821))
+        .await
+        .unwrap();
+    let device_id = h.add_device("laptop");
+    let peer = auth_context::with_context(admin_ctx(), h.service.add_peer(device_id, None))
+        .await
+        .unwrap();
+    assert_eq!(h.interface.added_peers.lock().unwrap().len(), 1);
+
+    let summary =
+        auth_context::with_context(admin_ctx(), h.service.set_peer_enabled(peer.id, false))
+            .await
+            .expect("disable succeeds");
+
+    assert!(!summary.enabled);
+    // Row survives — distinct from `remove_peer`.
+    assert_eq!(h.peers.find_all().await.unwrap().len(), 1);
+    assert!(
+        !h.peers
+            .find_by_id(&peer.id.to_string())
+            .await
+            .unwrap()
+            .unwrap()
+            .enabled
+    );
+    // Best-effort removed from the live interface.
+    assert_eq!(h.interface.removed_peers.lock().unwrap().len(), 1);
+}
+
+#[tokio::test]
+async fn set_peer_enabled_reenable_readmits_same_credential() {
+    let h = harness();
+    auth_context::with_context(admin_ctx(), h.service.set_config(true, 51821))
+        .await
+        .unwrap();
+    let device_id = h.add_device("laptop");
+    let peer = auth_context::with_context(admin_ctx(), h.service.add_peer(device_id, None))
+        .await
+        .unwrap();
+    auth_context::with_context(admin_ctx(), h.service.set_peer_enabled(peer.id, false))
+        .await
+        .unwrap();
+
+    let summary =
+        auth_context::with_context(admin_ctx(), h.service.set_peer_enabled(peer.id, true))
+            .await
+            .expect("re-enable succeeds");
+
+    assert!(summary.enabled);
+    assert_eq!(
+        summary.public_key, peer.public_key,
+        "same credential, no new keypair"
+    );
+    // add_peer once (initial grant) + re-admit once on re-enable.
+    assert_eq!(h.interface.added_peers.lock().unwrap().len(), 2);
+}
+
+#[tokio::test]
+async fn set_peer_enabled_not_found_returns_404() {
+    let h = harness();
+    let result = auth_context::with_context(
+        admin_ctx(),
+        h.service.set_peer_enabled(Uuid::new_v4(), false),
+    )
+    .await;
+    assert!(result.is_err(), "unknown peer id must 404");
+}
+
+#[tokio::test]
+async fn set_peer_enabled_noop_when_already_in_requested_state() {
+    let h = harness();
+    auth_context::with_context(admin_ctx(), h.service.set_config(true, 51821))
+        .await
+        .unwrap();
+    let device_id = h.add_device("laptop");
+    let peer = auth_context::with_context(admin_ctx(), h.service.add_peer(device_id, None))
+        .await
+        .unwrap();
+
+    auth_context::with_context(admin_ctx(), h.service.set_peer_enabled(peer.id, true))
+        .await
+        .expect("no-op enable succeeds");
+
+    // No extra interface calls beyond the initial grant.
+    assert_eq!(h.interface.added_peers.lock().unwrap().len(), 1);
+    assert!(h.interface.removed_peers.lock().unwrap().is_empty());
+}
+
+#[tokio::test]
 async fn requires_admin() {
     let h = harness();
     // No auth context — must be rejected.
@@ -620,7 +814,7 @@ async fn reconcile_reenables_peers_when_enabled() {
         .await
         .unwrap();
     let device_id = h.add_device("p");
-    auth_context::with_context(admin_ctx(), h.service.add_peer(device_id))
+    auth_context::with_context(admin_ctx(), h.service.add_peer(device_id, None))
         .await
         .unwrap();
 

--- a/source/daemon/crates/wardnetd-services/src/lib.rs
+++ b/source/daemon/crates/wardnetd-services/src/lib.rs
@@ -419,7 +419,7 @@ async fn classify_previous_shutdown(repo_factory: &dyn RepositoryFactory) {
         Err(e) => {
             tracing::warn!(
                 error = %e,
-                "failed to classify previous shutdown — skipping detection: {e}",
+                "failed to classify previous shutdown - skipping detection: {e}",
             );
         }
     }

--- a/source/daemon/crates/wardnetd-services/src/routing/service.rs
+++ b/source/daemon/crates/wardnetd-services/src/routing/service.rs
@@ -964,7 +964,7 @@ impl RoutingService for RoutingServiceImpl {
                 tunnel_id = %tunnel_id,
                 affected_count = affected.len(),
                 table = ?tunnel_table,
-                "tunnel down — removing routing for affected devices"
+                "tunnel down - removing routing for affected devices"
             );
         }
 
@@ -975,7 +975,7 @@ impl RoutingService for RoutingServiceImpl {
             tracing::warn!(
                 device_id = %device_id,
                 tunnel_id = %tunnel_id,
-                "tunnel down — removing routing for device"
+                "tunnel down - removing routing for device"
             );
             if let Some(rule) = state.applied.get(device_id) {
                 affected_ips.push(rule.device_ip.clone());
@@ -1032,7 +1032,7 @@ impl RoutingService for RoutingServiceImpl {
         tracing::info!(
             tunnel_id = %tunnel_id,
             device_count = devices.len(),
-            "tunnel up — re-applying routing rules for devices"
+            "tunnel up - re-applying routing rules for devices"
         );
 
         let mut success_count = 0u32;

--- a/source/daemon/crates/wardnetd-services/src/system/service.rs
+++ b/source/daemon/crates/wardnetd-services/src/system/service.rs
@@ -424,7 +424,7 @@ impl SystemService for SystemServiceImpl {
         auth_context::require_admin()?;
         tracing::warn!(
             grace_ms = RESTART_GRACE.as_millis(),
-            "daemon restart requested via API — triggering graceful shutdown in {grace_ms}ms",
+            "daemon restart requested via API - triggering graceful shutdown in {grace_ms}ms",
             grace_ms = RESTART_GRACE.as_millis(),
         );
         let token = self.shutdown_token.clone();
@@ -447,7 +447,7 @@ impl SystemService for SystemServiceImpl {
         tracing::warn!(
             action = "reboot",
             grace_ms = POWER_GRACE.as_millis(),
-            "host reboot requested via API — invoking systemctl reboot in {grace_ms}ms",
+            "host reboot requested via API - invoking systemctl reboot in {grace_ms}ms",
             grace_ms = POWER_GRACE.as_millis(),
         );
         let ops = self.power_ops.clone();
@@ -471,7 +471,7 @@ impl SystemService for SystemServiceImpl {
         tracing::warn!(
             action = "shutdown",
             grace_ms = POWER_GRACE.as_millis(),
-            "host shutdown requested via API — invoking systemctl poweroff in {grace_ms}ms",
+            "host shutdown requested via API - invoking systemctl poweroff in {grace_ms}ms",
             grace_ms = POWER_GRACE.as_millis(),
         );
         let ops = self.power_ops.clone();

--- a/source/daemon/crates/wardnetd-services/src/tunnel/service.rs
+++ b/source/daemon/crates/wardnetd-services/src/tunnel/service.rs
@@ -1124,7 +1124,7 @@ impl TunnelService for TunnelServiceImpl {
         let _guard = self.acquire_in_flight(id)?;
         self.tear_down_core(id, "admin rebuild").await?;
         if let Err(e) = self.bring_up_core(id).await {
-            tracing::error!(tunnel_id = %id, error = %e, "rebuild: tear-down succeeded but bring-up failed — tunnel is down");
+            tracing::error!(tunnel_id = %id, error = %e, "rebuild: tear-down succeeded but bring-up failed - tunnel is down");
             return Err(e);
         }
         Ok(())

--- a/source/daemon/crates/wardnetd-services/src/update/service.rs
+++ b/source/daemon/crates/wardnetd-services/src/update/service.rs
@@ -261,7 +261,7 @@ impl UpdateServiceImpl {
                     .map_err(AppError::Internal)?;
                 tracing::info!(
                     target = %target,
-                    "update installed — cancelling shutdown token to trigger systemd restart: target={target}",
+                    "update installed - cancelling shutdown token to trigger systemd restart: target={target}",
                     target = target,
                 );
                 self.shutdown_token.cancel();
@@ -666,10 +666,10 @@ impl UpdateService for UpdateServiceImpl {
             .await
             .map_err(AppError::Internal)?;
 
-        tracing::info!("rollback staged — cancelling shutdown token to trigger systemd restart");
+        tracing::info!("rollback staged - cancelling shutdown token to trigger systemd restart");
         self.shutdown_token.cancel();
         Ok(RollbackResponse {
-            message: "rollback staged — daemon will restart".to_owned(),
+            message: "rollback staged - daemon will restart".to_owned(),
         })
     }
 

--- a/source/daemon/crates/wardnetd/src/dns/server.rs
+++ b/source/daemon/crates/wardnetd/src/dns/server.rs
@@ -732,7 +732,7 @@ async fn handle_query(
                         upstream = %r.upstream,
                         domain = %domain_lower,
                         error = %e,
-                        "malformed conditional forwarding upstream — falling through to default"
+                        "malformed conditional forwarding upstream - falling through to default"
                     );
                 })
                 .ok()

--- a/source/daemon/crates/wardnetd/src/dns/tests/server.rs
+++ b/source/daemon/crates/wardnetd/src/dns/tests/server.rs
@@ -1972,7 +1972,7 @@ async fn conditional_forwarding_overrides_zone_authority() {
 
     assert!(
         !resp.metadata.authoritative,
-        "a forwarded query must NOT be answered authoritatively — the forwarding rule overrides zone authority"
+        "a forwarded query must NOT be answered authoritatively - the forwarding rule overrides zone authority"
     );
 
     server.stop().await.unwrap();

--- a/source/sdk/wardnet-js/src/index.ts
+++ b/source/sdk/wardnet-js/src/index.ts
@@ -20,6 +20,7 @@ export { InfoService } from "./services/info.js";
 export { DhcpService } from "./services/dhcp.js";
 export { JobsService } from "./services/jobs.js";
 export { RuleRequestService } from "./services/rule-requests.js";
+export { InboundWgService } from "./services/inbound-wg.js";
 export { PushService } from "./services/push.js";
 export { LogService } from "./services/logs.js";
 export type { LogEntry, LogFilter, LogStreamCallbacks } from "./services/logs.js";
@@ -43,6 +44,7 @@ export type {
   Device,
   DeviceType,
   DhcpStatus,
+  DeviceConnectionMode,
   RoutingTarget,
   RuleCreator,
   RoutingRule,
@@ -230,6 +232,16 @@ export type {
   TlsProvisioningPhase,
   TlsStatusResponse,
 } from "./types/remote-access.js";
+
+// Types — inbound WireGuard remote-access grants
+export type {
+  InboundWgConfigRequest,
+  InboundWgConfigResponse,
+  AddInboundWgPeerRequest,
+  AddInboundWgPeerResponse,
+  InboundWgPeerSummary,
+  ListInboundWgPeersResponse,
+} from "./types/inbound-wg.js";
 
 // Types — backup
 export type {

--- a/source/sdk/wardnet-js/src/index.ts
+++ b/source/sdk/wardnet-js/src/index.ts
@@ -241,6 +241,7 @@ export type {
   AddInboundWgPeerResponse,
   InboundWgPeerSummary,
   ListInboundWgPeersResponse,
+  SetInboundWgPeerEnabledRequest,
 } from "./types/inbound-wg.js";
 
 // Types — backup

--- a/source/sdk/wardnet-js/src/services/inbound-wg.ts
+++ b/source/sdk/wardnet-js/src/services/inbound-wg.ts
@@ -4,7 +4,9 @@ import type {
   AddInboundWgPeerResponse,
   InboundWgConfigRequest,
   InboundWgConfigResponse,
+  InboundWgPeerSummary,
   ListInboundWgPeersResponse,
+  SetInboundWgPeerEnabledRequest,
 } from "../types/inbound-wg.js";
 
 /**
@@ -13,6 +15,11 @@ import type {
  */
 export class InboundWgService {
   constructor(private readonly client: WardnetClient) {}
+
+  /** Read the current server config without mutating anything. */
+  async getConfig(): Promise<InboundWgConfigResponse> {
+    return this.client.request<InboundWgConfigResponse>("/inbound-wg/config");
+  }
 
   /** Enable/disable the inbound WireGuard server and set its listen port. */
   async setConfig(body: InboundWgConfigRequest): Promise<InboundWgConfigResponse> {
@@ -42,6 +49,21 @@ export class InboundWgService {
   async removePeer(id: string): Promise<void> {
     await this.client.request<void>(`/inbound-wg/peers/${id}`, {
       method: "DELETE",
+    });
+  }
+
+  /**
+   * Pause or resume a peer without deleting its credential. Distinct from
+   * {@link removePeer}, which revokes permanently and requires a fresh
+   * keypair (and QR scan) to re-grant.
+   */
+  async setPeerEnabled(
+    id: string,
+    body: SetInboundWgPeerEnabledRequest,
+  ): Promise<InboundWgPeerSummary> {
+    return this.client.request<InboundWgPeerSummary>(`/inbound-wg/peers/${id}`, {
+      method: "PATCH",
+      body: JSON.stringify(body),
     });
   }
 }

--- a/source/sdk/wardnet-js/src/services/inbound-wg.ts
+++ b/source/sdk/wardnet-js/src/services/inbound-wg.ts
@@ -1,0 +1,47 @@
+import type { WardnetClient } from "../client.js";
+import type {
+  AddInboundWgPeerRequest,
+  AddInboundWgPeerResponse,
+  InboundWgConfigRequest,
+  InboundWgConfigResponse,
+  ListInboundWgPeersResponse,
+} from "../types/inbound-wg.js";
+
+/**
+ * Inbound (multi-peer) WireGuard remote-access grant management
+ * (issues #809-#811). All operations are admin-only.
+ */
+export class InboundWgService {
+  constructor(private readonly client: WardnetClient) {}
+
+  /** Enable/disable the inbound WireGuard server and set its listen port. */
+  async setConfig(body: InboundWgConfigRequest): Promise<InboundWgConfigResponse> {
+    return this.client.request<InboundWgConfigResponse>("/inbound-wg/config", {
+      method: "PUT",
+      body: JSON.stringify(body),
+    });
+  }
+
+  /** List every configured inbound peer (no private keys). */
+  async listPeers(): Promise<ListInboundWgPeersResponse> {
+    return this.client.request<ListInboundWgPeersResponse>("/inbound-wg/peers");
+  }
+
+  /**
+   * Grant remote access to an already-managed device. The response carries
+   * the peer's private key exactly once — it is never persisted server-side.
+   */
+  async addPeer(body: AddInboundWgPeerRequest): Promise<AddInboundWgPeerResponse> {
+    return this.client.request<AddInboundWgPeerResponse>("/inbound-wg/peers", {
+      method: "POST",
+      body: JSON.stringify(body),
+    });
+  }
+
+  /** Revoke a peer's remote-access credential. */
+  async removePeer(id: string): Promise<void> {
+    await this.client.request<void>(`/inbound-wg/peers/${id}`, {
+      method: "DELETE",
+    });
+  }
+}

--- a/source/sdk/wardnet-js/src/types/device.ts
+++ b/source/sdk/wardnet-js/src/types/device.ts
@@ -1,6 +1,13 @@
 /** DHCP status for a device. */
 export type DhcpStatus = "lease" | "reservation" | "external";
 
+/**
+ * How a device is currently reachable on the network: over the LAN, or via
+ * the inbound WireGuard server. A live status (last-observation-wins), not a
+ * record of how the device was first discovered. See issue #810.
+ */
+export type DeviceConnectionMode = "lan" | "remote";
+
 /** The type/category of a network device. */
 export type DeviceType =
   | "tv"
@@ -39,6 +46,8 @@ export interface Device {
    * explicit persisted default choice.
    */
   current_rule: RoutingTarget | null;
+  /** How the device is currently reachable (LAN vs. inbound WireGuard). */
+  connection_mode: DeviceConnectionMode;
 }
 
 /** Where a device's traffic is routed. */

--- a/source/sdk/wardnet-js/src/types/inbound-wg.ts
+++ b/source/sdk/wardnet-js/src/types/inbound-wg.ts
@@ -44,18 +44,27 @@ export interface AddInboundWgPeerRequest {
 /**
  * Response for `POST /api/inbound-wg/peers`.
  *
- * Carries the freshly generated **private key** exactly once — it is never
- * persisted server-side, so it must be copied now to configure the peer.
+ * Carries the full WireGuard client config (`.conf`) exactly once, assembled
+ * daemon-side. It embeds the freshly generated private key, which is never
+ * persisted server-side, so it must be scanned/saved now to configure the
+ * peer. This is the only endpoint that ever exposes private key material, and
+ * it is admin-gated.
  */
 export interface AddInboundWgPeerResponse {
   id: string;
   name: string;
   /** Base64 WireGuard public key (stored server-side). */
   public_key: string;
-  /** Base64 WireGuard private key — returned once, never stored. */
-  private_key: string;
   /** The peer's allocated /32 inside the inbound tunnel subnet. */
   allowed_ip: string;
+  /**
+   * The complete WireGuard client config (`[Interface]` + `[Peer]`), ready to
+   * render as a QR code or download as a `.conf`. Embeds the private key and
+   * is returned exactly once. `null` when no reachable endpoint is known yet
+   * (no DDNS hostname or public IP), in which case a usable config cannot be
+   * assembled.
+   */
+  client_config: string | null;
 }
 
 /** A single inbound-WireGuard peer, without any private key material. */
@@ -66,9 +75,23 @@ export interface InboundWgPeerSummary {
   allowed_ip: string;
   enabled: boolean;
   created_at: string;
+  /** The device this credential grants remote access to. `null` only for
+   *  pre-#810 rows written before the device link existed. */
+  device_id: string | null;
 }
 
 /** Response for `GET /api/inbound-wg/peers`. */
 export interface ListInboundWgPeersResponse {
   peers: InboundWgPeerSummary[];
+}
+
+/**
+ * Request body for `PATCH /api/inbound-wg/peers/{id}`.
+ *
+ * Pauses or resumes a peer without deleting its credential — distinct from
+ * `removePeer`, which revokes it permanently and requires a fresh keypair
+ * (and QR scan) to re-grant.
+ */
+export interface SetInboundWgPeerEnabledRequest {
+  enabled: boolean;
 }

--- a/source/sdk/wardnet-js/src/types/inbound-wg.ts
+++ b/source/sdk/wardnet-js/src/types/inbound-wg.ts
@@ -1,0 +1,74 @@
+/**
+ * Inbound (multi-peer) WireGuard remote-access grants (issues #809-#811).
+ *
+ * A grant lets an already-managed device connect back in from off the LAN.
+ * Distinct from `RemoteAccessService` (types/remote-access.ts), which covers
+ * wardnet-cloud DDNS/TLS enrollment for reaching the box itself, not
+ * per-device inbound tunnels.
+ */
+
+/** Request body for `PUT /api/inbound-wg/config`. */
+export interface InboundWgConfigRequest {
+  /** Whether the inbound WireGuard server should be running. */
+  enabled: boolean;
+  /** UDP port the server listens on for inbound peer handshakes. */
+  listen_port: number;
+}
+
+/** Response for `PUT /api/inbound-wg/config`. */
+export interface InboundWgConfigResponse {
+  /** The applied enabled state. */
+  enabled: boolean;
+  /** The applied listen port. */
+  listen_port: number;
+  /**
+   * The server's public key once a keypair exists (generated on first
+   * enable). `null` until the server has been enabled at least once.
+   */
+  server_public_key: string | null;
+}
+
+/**
+ * Request body for `POST /api/inbound-wg/peers`.
+ *
+ * A remote-access grant targets an already-managed device (issue #810).
+ */
+export interface AddInboundWgPeerRequest {
+  /**
+   * The device to grant remote access to. Must already exist (discovered on
+   * the LAN at least once) and must not already have a credential.
+   */
+  device_id: string;
+}
+
+/**
+ * Response for `POST /api/inbound-wg/peers`.
+ *
+ * Carries the freshly generated **private key** exactly once — it is never
+ * persisted server-side, so it must be copied now to configure the peer.
+ */
+export interface AddInboundWgPeerResponse {
+  id: string;
+  name: string;
+  /** Base64 WireGuard public key (stored server-side). */
+  public_key: string;
+  /** Base64 WireGuard private key — returned once, never stored. */
+  private_key: string;
+  /** The peer's allocated /32 inside the inbound tunnel subnet. */
+  allowed_ip: string;
+}
+
+/** A single inbound-WireGuard peer, without any private key material. */
+export interface InboundWgPeerSummary {
+  id: string;
+  name: string;
+  public_key: string;
+  allowed_ip: string;
+  enabled: boolean;
+  created_at: string;
+}
+
+/** Response for `GET /api/inbound-wg/peers`. */
+export interface ListInboundWgPeersResponse {
+  peers: InboundWgPeerSummary[];
+}

--- a/source/user-app/src/components/ConnectionBanner.tsx
+++ b/source/user-app/src/components/ConnectionBanner.tsx
@@ -15,7 +15,7 @@ export function ConnectionBanner({ connState }: Props) {
         role="alert"
         icon={<WifiOffIcon size={15} strokeWidth={1.9} />}
       >
-        No connection to wardnet daemon — showing last known state
+        No connection to wardnet daemon - showing last known state
       </Banner>
     );
   }

--- a/source/user-app/src/lib/dnsDb.ts
+++ b/source/user-app/src/lib/dnsDb.ts
@@ -110,7 +110,7 @@ export function applyEvent(db: IDBDatabase, item: DnsEventItem): Promise<void> {
     cursorReq.onsuccess = () => {
       const cursor = (cursorReq.result?.value as number | undefined) ?? 0;
       if (item.id <= cursor) {
-        return; // already aggregated — skip, tx commits as a no-op
+        return; // already aggregated - skip, tx commits as a no-op
       }
       events.put(item);
 

--- a/source/user-app/src/pages/Home.tsx
+++ b/source/user-app/src/pages/Home.tsx
@@ -393,8 +393,8 @@ export default function Home() {
             <div className="flex flex-col gap-3" data-testid="zone-readonly">
               <Text as="p" size="sm" className="text-ink">
                 {zone.is_default
-                  ? `You're on: ${zone.name} — the home network.`
-                  : `You're on: ${zone.name} — isolated from the home network.`}
+                  ? `You're on: ${zone.name} - the home network.`
+                  : `You're on: ${zone.name} - isolated from the home network.`}
               </Text>
               <div className="flex items-start gap-2 text-ink-3">
                 <LockIcon className="mt-0.5 size-4 shrink-0" />

--- a/source/user-app/src/pages/Settings.tsx
+++ b/source/user-app/src/pages/Settings.tsx
@@ -160,7 +160,7 @@ export default function Settings() {
         <CardContent className="flex flex-col gap-3">
           <Text as="p" size="sm" className="text-ink-3">
             Wardnet will capture your device's DNS activity and sync it to this
-            device so you can see your own stats. Data stays on this device — it
+            device so you can see your own stats. Data stays on this device - it
             is not sent anywhere else.
           </Text>
 

--- a/source/user-app/tests/pages/Home.test.tsx
+++ b/source/user-app/tests/pages/Home.test.tsx
@@ -220,7 +220,7 @@ describe("Home page", () => {
     renderWithProviders(<Home />);
     const card = screen.getByTestId("zone-readonly");
     expect(card).toHaveTextContent(
-      "You're on: Guest — isolated from the home network.",
+      "You're on: Guest - isolated from the home network.",
     );
     expect(card).toHaveTextContent(/network administrator can change/i);
   });
@@ -229,7 +229,7 @@ describe("Home page", () => {
     setMyDevice({ zone: { name: "Trusted", is_default: true } });
     renderWithProviders(<Home />);
     expect(screen.getByTestId("zone-readonly")).toHaveTextContent(
-      "You're on: Trusted — the home network.",
+      "You're on: Trusted - the home network.",
     );
   });
 

--- a/source/user-app/tests/test-utils.tsx
+++ b/source/user-app/tests/test-utils.tsx
@@ -55,6 +55,7 @@ export function makeDevice(overrides: Partial<Device> = {}): Device {
     dns_capture_cap_days: 7,
     dhcp_status: "lease",
     current_rule: null,
+    connection_mode: "lan",
     ...overrides,
   };
 }

--- a/source/user-app/vite.config.ts
+++ b/source/user-app/vite.config.ts
@@ -46,7 +46,7 @@ export default defineConfig({
   },
   optimizeDeps: {
     // CJS deps of the excluded workspace packages (see admin-site/web config).
-    include: ["cronstrue", "consola"],
+    include: ["cronstrue", "consola", "qrcode"],
     // See admin-site/web/vite.config.ts: don't pre-bundle our own source
     // workspace packages, so source edits aren't masked by a stale .vite cache.
     exclude: ["@wardnet/web", "@wardnet/js"],

--- a/source/web/package.json
+++ b/source/web/package.json
@@ -30,6 +30,7 @@
     "@wardnet/ui": "^0.3.0",
     "clsx": "2.1.1",
     "cronstrue": "3.24.0",
+    "qrcode": "1.5.4",
     "tailwind-merge": "3.6.0"
   },
   "peerDependencies": {
@@ -46,6 +47,7 @@
     "@testing-library/jest-dom": "6.9.1",
     "@testing-library/react": "16.3.2",
     "@testing-library/user-event": "14.6.1",
+    "@types/qrcode": "1.5.5",
     "@vitejs/plugin-react": "6.0.3",
     "@vitest/coverage-v8": "4.1.9",
     "@wardnet/js": "workspace:*",

--- a/source/web/src/components/AlertModalTitleBlock.tsx
+++ b/source/web/src/components/AlertModalTitleBlock.tsx
@@ -1,0 +1,41 @@
+import type { ReactNode } from "react";
+import {
+  AlertModalHeader,
+  AlertModalTitle,
+  AlertModalDescription,
+} from "@wardnet/ui";
+
+interface AlertModalTitleBlockProps {
+  title: ReactNode;
+  /** Optional supporting copy, rendered muted under the title. */
+  description?: ReactNode;
+}
+
+/**
+ * Stacked title + description for an `AlertModal`'s header — the confirm/alert
+ * counterpart of {@link ModalTitleBlock}.
+ *
+ * The design-system `AlertModalHeader` is a flex **row**, so dropping an
+ * `AlertModalTitle` and `AlertModalDescription` into it directly lays them out
+ * side by side (a squeezed title on the left, description on the right). This
+ * wraps them in a full-width column so the description sits under the title,
+ * and mutes it. Use it for every confirm/alert dialog so the header never
+ * regresses.
+ */
+export function AlertModalTitleBlock({
+  title,
+  description,
+}: AlertModalTitleBlockProps) {
+  return (
+    <AlertModalHeader>
+      <div className="flex w-full min-w-0 flex-col gap-1">
+        <AlertModalTitle>{title}</AlertModalTitle>
+        {description && (
+          <AlertModalDescription className="text-sm leading-relaxed text-ink-3">
+            {description}
+          </AlertModalDescription>
+        )}
+      </div>
+    </AlertModalHeader>
+  );
+}

--- a/source/web/src/components/ConnectionGate.tsx
+++ b/source/web/src/components/ConnectionGate.tsx
@@ -157,7 +157,7 @@ function PremiumRequired() {
   return (
     <FullScreenNotice
       heading="This app requires wardnet Premium"
-      body="The mobile apps are a Premium capability. Subscribe or check your subscription status from the admin website. Everything on your network keeps running locally — only these apps are paused."
+      body="The mobile apps are a Premium capability. Subscribe or check your subscription status from the admin website. Everything on your network keeps running locally - only these apps are paused."
     />
   );
 }

--- a/source/web/src/components/InboundWgQrCode.tsx
+++ b/source/web/src/components/InboundWgQrCode.tsx
@@ -1,0 +1,53 @@
+import { useEffect, useState } from "react";
+import { toDataURL } from "qrcode";
+
+interface InboundWgQrCodeProps {
+  /** The full WireGuard client `.conf` text to encode. */
+  value: string;
+  size?: number;
+  className?: string;
+}
+
+/** QR rendering for an inbound-WireGuard peer's client config (issues
+ *  #812-#813), shared so admin-site and admin-app render identically. */
+export function InboundWgQrCode({
+  value,
+  size = 240,
+  className,
+}: InboundWgQrCodeProps) {
+  const [dataUrl, setDataUrl] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    toDataURL(value, { width: size, margin: 1 })
+      .then((url) => {
+        if (!cancelled) setDataUrl(url);
+      })
+      .catch(() => {
+        if (!cancelled) setDataUrl(null);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [value, size]);
+
+  if (!dataUrl) {
+    return (
+      <div
+        className={className}
+        style={{ width: size, height: size }}
+        aria-hidden
+      />
+    );
+  }
+
+  return (
+    <img
+      src={dataUrl}
+      alt="WireGuard client config QR code"
+      width={size}
+      height={size}
+      className={className}
+    />
+  );
+}

--- a/source/web/src/components/ModalTitleBlock.tsx
+++ b/source/web/src/components/ModalTitleBlock.tsx
@@ -1,0 +1,33 @@
+import type { ReactNode } from "react";
+import { ModalHeader, ModalTitle, ModalDescription } from "@wardnet/ui";
+
+interface ModalTitleBlockProps {
+  title: ReactNode;
+  /** Optional supporting copy, rendered muted under the title. */
+  description?: ReactNode;
+}
+
+/**
+ * Stacked title + description for a `Modal`'s header.
+ *
+ * The design-system `ModalHeader` is a flex **row** (a title beside an
+ * optional trailing action), so dropping a `ModalTitle` and `ModalDescription`
+ * into it directly lays them out side by side — a squeezed title on the left,
+ * the description on the right. This wraps them in a full-width column so the
+ * description sits under the title, and mutes the description text. Reuse it
+ * for any informational modal that needs a title + description.
+ */
+export function ModalTitleBlock({ title, description }: ModalTitleBlockProps) {
+  return (
+    <ModalHeader>
+      <div className="flex w-full min-w-0 flex-col gap-1">
+        <ModalTitle>{title}</ModalTitle>
+        {description && (
+          <ModalDescription className="text-sm leading-relaxed text-ink-3">
+            {description}
+          </ModalDescription>
+        )}
+      </div>
+    </ModalHeader>
+  );
+}

--- a/source/web/src/components/SubnetInput.tsx
+++ b/source/web/src/components/SubnetInput.tsx
@@ -139,12 +139,12 @@ export function SubnetInput({ value, onChange, id, testId }: SubnetInputProps) {
 
       {resolved && !isPrivate ? (
         <Text size="xs" className="text-danger" data-testid={`${t}-cidr`}>
-          Must be a private range (10.x, 172.16–31.x, or 192.168.x).
+          Must be a private range (10.x, 172.16-31.x, or 192.168.x).
         </Text>
       ) : (
         <Text size="xs" className="text-ink-3" data-testid={`${t}-cidr`}>
           {resolved
-            ? `Resolves to ${resolved} — ${usableHosts(prefix)} usable hosts`
+            ? `Resolves to ${resolved} - ${usableHosts(prefix)} usable hosts`
             : "Enter a base address to build the subnet."}
         </Text>
       )}

--- a/source/web/src/hooks/useBackup.ts
+++ b/source/web/src/hooks/useBackup.ts
@@ -10,6 +10,7 @@ import {
   type RestorePreviewResponse,
 } from "@wardnet/js";
 import { backupService } from "../lib/sdk";
+import { triggerBrowserDownload } from "../lib/download";
 
 /** Extract the most user-friendly message we can from an API error. */
 function errorMessage(err: unknown, fallback: string): string {
@@ -91,27 +92,10 @@ export function useApplyImport() {
   return useMutation<ApplyImportResponse, unknown, ApplyImportRequest>({
     mutationFn: (body) => backupService.applyImport(body),
     onSuccess: () => {
-      toast.success("Backup restored — restart the daemon to complete");
+      toast.success("Backup restored - restart the daemon to complete");
       qc.invalidateQueries({ queryKey: STATUS_KEY });
       qc.invalidateQueries({ queryKey: SNAPSHOTS_KEY });
     },
     onError: (err) => toast.error(errorMessage(err, "Restore failed")),
   });
-}
-
-/**
- * Build an `<a download>` link, click it, then release the object
- * URL. The Blob never touches disk outside the browser's download
- * flow — in particular, plaintext secrets inside the archive are
- * encrypted before they ever leave the daemon.
- */
-function triggerBrowserDownload(blob: Blob, filename: string): void {
-  const url = URL.createObjectURL(blob);
-  const a = document.createElement("a");
-  a.href = url;
-  a.download = filename;
-  document.body.appendChild(a);
-  a.click();
-  a.remove();
-  URL.revokeObjectURL(url);
 }

--- a/source/web/src/hooks/useInboundWg.ts
+++ b/source/web/src/hooks/useInboundWg.ts
@@ -1,0 +1,88 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { toast } from "@wardnet/ui";
+import type {
+  AddInboundWgPeerRequest,
+  InboundWgConfigRequest,
+} from "@wardnet/js";
+import { inboundWgService } from "../lib/sdk";
+
+/** Server config + public key, for the enable/settings card. */
+export function useInboundWgConfig() {
+  return useQuery({
+    queryKey: ["inbound-wg", "config"],
+    queryFn: () => inboundWgService.getConfig(),
+  });
+}
+
+export function useSetInboundWgConfig() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (body: InboundWgConfigRequest) =>
+      inboundWgService.setConfig(body),
+    onSuccess: (data, vars) => {
+      qc.setQueryData(["inbound-wg", "config"], data);
+      toast.success(
+        vars.enabled ? "Remote access enabled" : "Remote access disabled",
+      );
+      qc.invalidateQueries({ queryKey: ["inbound-wg", "peers"] });
+    },
+    onError: () => toast.error("Failed to update remote access settings"),
+  });
+}
+
+export function useInboundWgPeers() {
+  return useQuery({
+    queryKey: ["inbound-wg", "peers"],
+    queryFn: () => inboundWgService.listPeers(),
+    // No refetchInterval: the peer list only changes via admin mutations
+    // (grant/revoke/pause), each of which already invalidates this key. A
+    // timer here would idle-poll on every surface that mounts the hook —
+    // including the Devices list, which polls devices separately — and each
+    // refetch would hand memoized rows fresh objects, defeating their memo.
+  });
+}
+
+export function useAddInboundWgPeer() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (body: AddInboundWgPeerRequest) =>
+      inboundWgService.addPeer(body),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["inbound-wg", "peers"] });
+    },
+    onError: (error) => {
+      const message =
+        error instanceof Error
+          ? error.message
+          : "Failed to grant remote access";
+      toast.error(message);
+    },
+  });
+}
+
+export function useRemoveInboundWgPeer() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (id: string) => inboundWgService.removePeer(id),
+    onSuccess: () => {
+      toast.success("Remote access revoked");
+      qc.invalidateQueries({ queryKey: ["inbound-wg", "peers"] });
+    },
+    onError: () => toast.error("Failed to revoke remote access"),
+  });
+}
+
+export function useSetInboundWgPeerEnabled() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({ id, enabled }: { id: string; enabled: boolean }) =>
+      inboundWgService.setPeerEnabled(id, { enabled }),
+    onSuccess: (_data, vars) => {
+      toast.success(
+        vars.enabled ? "Remote access resumed" : "Remote access paused",
+      );
+      qc.invalidateQueries({ queryKey: ["inbound-wg", "peers"] });
+    },
+    onError: () => toast.error("Failed to update peer"),
+  });
+}

--- a/source/web/src/hooks/usePushNotifications.ts
+++ b/source/web/src/hooks/usePushNotifications.ts
@@ -86,7 +86,7 @@ export function usePushNotifications(): {
           return;
         }
         const registration = await swReady();
-        if (!registration) return; // No SW on this surface — leave the initial state.
+        if (!registration) return; // No SW on this surface - leave the initial state.
         const sub = await registration.pushManager.getSubscription();
         if (cancelled) return;
         if (sub) {
@@ -120,7 +120,7 @@ export function usePushNotifications(): {
       }
       const registration = await swReady();
       if (!registration) {
-        toast.error("No service worker is active — use the installed app");
+        toast.error("No service worker is active - use the installed app");
         return;
       }
       const existing = await registration.pushManager.getSubscription();
@@ -150,7 +150,7 @@ export function usePushNotifications(): {
     try {
       const registration = await swReady();
       if (!registration) {
-        toast.error("No service worker is active — use the installed app");
+        toast.error("No service worker is active - use the installed app");
         return;
       }
       const sub = await registration.pushManager.getSubscription();

--- a/source/web/src/hooks/useUpdate.ts
+++ b/source/web/src/hooks/useUpdate.ts
@@ -98,7 +98,7 @@ export function useRollbackUpdate() {
   return useMutation({
     mutationFn: () => updateService.rollback(),
     onSuccess: () => {
-      toast.success("Rollback staged — daemon will restart", {
+      toast.success("Rollback staged - daemon will restart", {
         id: TOAST_ROLLBACK,
       });
       qc.invalidateQueries({ queryKey: STATUS_KEY });

--- a/source/web/src/icons/GlobeFilter.tsx
+++ b/source/web/src/icons/GlobeFilter.tsx
@@ -1,0 +1,40 @@
+import type { SVGProps } from "react";
+
+/**
+ * Globe with a filter badge in the top-right — the "DNS filtering" mark.
+ * Built like lucide's `globe-lock` (an open globe trimmed on the right to
+ * seat a badge), swapping the lock for lucide's `list-filter` bars rotated
+ * 180° (widest bar at the bottom) so it reads as a filter.
+ *
+ * lucide-compatible: renders a 24×24 `currentColor` stroked SVG and spreads
+ * any props (the sidebar passes `className="ico"`, which sizes it via CSS).
+ */
+export function GlobeFilter(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width={24}
+      height={24}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      {...props}
+    >
+      {/* Open globe (from lucide `globe-lock`): a near-full globe whose
+          right side is trimmed to seat the badge, plus a left-half equator. */}
+      <path d="M15.686 15A14.5 14.5 0 0 1 12 22a14.5 14.5 0 0 1 0-20 10 10 0 1 0 9.542 13" />
+      <path d="M2 12h8.5" />
+      {/* Filter badge, seated in the globe's top-right cutout (like the lock
+          in `globe-lock`): lucide `list-filter`'s three decreasing bars,
+          rotated 180° so the widest bar is at the bottom. */}
+      <g transform="translate(12.32 1.8) scale(0.44)" strokeWidth={3.9}>
+        <path d="M9 5h6" />
+        <path d="M6 12h12" />
+        <path d="M2 19h20" />
+      </g>
+    </svg>
+  );
+}

--- a/source/web/src/icons/ShieldWifi.tsx
+++ b/source/web/src/icons/ShieldWifi.tsx
@@ -1,0 +1,35 @@
+import type { SVGProps } from "react";
+
+/**
+ * Shield with a WiFi fan inside — the "VPN / remote access into the home
+ * network" mark. Composed rather than from lucide because no single lucide
+ * glyph reads as "secure inbound VPN" without colliding with the Tunnels
+ * (outbound) icon.
+ *
+ * lucide-compatible: renders a 24×24 `currentColor` stroked SVG and spreads
+ * any props (the sidebar passes `className="ico"`, which sizes it via CSS).
+ */
+export function ShieldWifi(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width={24}
+      height={24}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      {...props}
+    >
+      <path d="M20 13c0 5-3.5 7.5-7.66 8.95a1 1 0 0 1-.67-.01C7.5 20.5 4 18 4 13V6a1 1 0 0 1 1-1c2 0 4.5-1.2 6.24-2.72a1.17 1.17 0 0 1 1.52 0C14.51 3.81 17 5 19 5a1 1 0 0 1 1 1z" />
+      <g transform="translate(6.48 5.06) scale(0.46)" strokeWidth={3.3}>
+        <path d="M12 20h.01" />
+        <path d="M2 8.82a15 15 0 0 1 20 0" />
+        <path d="M5 12.859a10 10 0 0 1 14 0" />
+        <path d="M8.5 16.429a5 5 0 0 1 7 0" />
+      </g>
+    </svg>
+  );
+}

--- a/source/web/src/index.ts
+++ b/source/web/src/index.ts
@@ -320,6 +320,26 @@ export {
   useDeleteDdns,
 } from "./hooks/useRemoteAccess";
 
+// Hooks — inbound WireGuard remote-access grants (issues #809-#813)
+export {
+  useInboundWgConfig,
+  useSetInboundWgConfig,
+  useInboundWgPeers,
+  useAddInboundWgPeer,
+  useRemoveInboundWgPeer,
+  useSetInboundWgPeerEnabled,
+} from "./hooks/useInboundWg";
+export { peerConfigFilename } from "./lib/inboundWgConfig";
+export { InboundWgQrCode } from "./components/InboundWgQrCode";
+export { triggerBrowserDownload } from "./lib/download";
+export { ModalTitleBlock } from "./components/ModalTitleBlock";
+export { AlertModalTitleBlock } from "./components/AlertModalTitleBlock";
+
+// Custom icons (composed marks not in lucide). Exported individually so
+// consumers only bundle the ones they import.
+export { ShieldWifi } from "./icons/ShieldWifi";
+export { GlobeFilter } from "./icons/GlobeFilter";
+
 // PWA helpers
 export { registerSW } from "./lib/registerSW";
 export type { RegisterSWOptions } from "./lib/registerSW";

--- a/source/web/src/lib/download.ts
+++ b/source/web/src/lib/download.ts
@@ -1,0 +1,19 @@
+/**
+ * Build an `<a download>` link, click it, then release the object URL. The
+ * anchor is appended to the DOM before `.click()` because some browsers
+ * ignore a click on a detached anchor. The Blob never touches disk outside
+ * the browser's own download flow.
+ *
+ * Shared by backup export and inbound-WireGuard `.conf` download so both
+ * behave identically.
+ */
+export function triggerBrowserDownload(blob: Blob, filename: string): void {
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  a.remove();
+  URL.revokeObjectURL(url);
+}

--- a/source/web/src/lib/inboundWgConfig.ts
+++ b/source/web/src/lib/inboundWgConfig.ts
@@ -1,0 +1,24 @@
+/**
+ * Client-side helpers for inbound-WireGuard peer grants (issues #809-#813).
+ *
+ * The WireGuard client `.conf` itself is assembled daemon-side and returned by
+ * `addPeer` as `client_config` (the only place the peer's private key is ever
+ * exposed, admin-gated). The frontend just renders that string as a QR code or
+ * downloads it, so the only helper needed here is a safe download filename.
+ */
+
+/**
+ * Filesystem-safe base filename (no extension) for a peer's `.conf`, derived
+ * from the device name. Collapses whitespace to `-`, drops characters that
+ * are hostile in a filename (slashes, dots that could form path segments,
+ * etc.), and falls back to `peer` when nothing usable remains, so a blank
+ * or all-symbol device name never produces a hidden/`.conf`-only download.
+ */
+export function peerConfigFilename(name: string): string {
+  const safe = name
+    .trim()
+    .toLowerCase()
+    .replace(/\s+/g, "-")
+    .replace(/[^a-z0-9_-]/g, "");
+  return safe || "peer";
+}

--- a/source/web/src/lib/sdk.ts
+++ b/source/web/src/lib/sdk.ts
@@ -23,6 +23,7 @@ import {
   NetworkZonesService,
   ZoneExceptionsService,
   PushService,
+  InboundWgService,
 } from "@wardnet/js";
 
 /** Shared SDK client instance. All services use this single client. */
@@ -54,3 +55,4 @@ export const ruleRequestService = new RuleRequestService(client);
 export const networkZonesService = new NetworkZonesService(client);
 export const zoneExceptionsService = new ZoneExceptionsService(client);
 export const pushService = new PushService(client);
+export const inboundWgService = new InboundWgService(client);

--- a/source/web/src/lib/swPush.ts
+++ b/source/web/src/lib/swPush.ts
@@ -65,7 +65,7 @@ export function registerPushHandlers(
     try {
       payload = event.data?.json() as PushPayload | undefined;
     } catch {
-      return; // Not JSON — not one of ours.
+      return; // Not JSON - not one of ours.
     }
     if (!payload?.title) return;
     const data = payload.data;

--- a/source/web/src/lib/utils.ts
+++ b/source/web/src/lib/utils.ts
@@ -134,7 +134,7 @@ export function formatDate(
   value: Date | string | number | null | undefined,
 ): string {
   const d = parseDate(value);
-  if (!d) return "—";
+  if (!d) return "-";
   return `${d.getFullYear()}.${pad(d.getMonth() + 1)}.${pad(d.getDate())}`;
 }
 
@@ -143,7 +143,7 @@ export function formatTime(
   value: Date | string | number | null | undefined,
 ): string {
   const d = parseDate(value);
-  if (!d) return "—";
+  if (!d) return "-";
   return `${pad(d.getHours())}:${pad(d.getMinutes())}:${pad(d.getSeconds())}`;
 }
 
@@ -153,7 +153,7 @@ export function formatTimeShort(
   value: Date | string | number | null | undefined,
 ): string {
   const d = parseDate(value);
-  if (!d) return "—";
+  if (!d) return "-";
   return `${pad(d.getHours())}:${pad(d.getMinutes())}`;
 }
 
@@ -165,7 +165,7 @@ export function formatDateTime(
   value: Date | string | number | null | undefined,
 ): string {
   const d = parseDate(value);
-  if (!d) return "—";
+  if (!d) return "-";
   return `${formatDate(d)} ${formatTime(d)}`;
 }
 

--- a/source/web/tests/hooks/useBackup.test.tsx
+++ b/source/web/tests/hooks/useBackup.test.tsx
@@ -91,7 +91,7 @@ describe("useBackup", () => {
       await result.current.mutateAsync({ token: "t" } as never);
     });
     expect(toast.success).toHaveBeenCalledWith(
-      "Backup restored — restart the daemon to complete",
+      "Backup restored - restart the daemon to complete",
     );
   });
 });

--- a/source/web/tests/hooks/usePushNotifications.test.tsx
+++ b/source/web/tests/hooks/usePushNotifications.test.tsx
@@ -270,7 +270,7 @@ describe("usePushNotifications", () => {
       await pending;
 
       expect(toast.error).toHaveBeenCalledWith(
-        "No service worker is active — use the installed app",
+        "No service worker is active - use the installed app",
       );
       expect(pushManager.subscribe).not.toHaveBeenCalled();
       expect(result.current.isBusy).toBe(false);

--- a/source/web/tests/hooks/useUpdate.test.tsx
+++ b/source/web/tests/hooks/useUpdate.test.tsx
@@ -104,7 +104,7 @@ describe("useUpdate", () => {
       await result.current.mutateAsync();
     });
     expect(toast.success).toHaveBeenCalledWith(
-      "Rollback staged — daemon will restart",
+      "Rollback staged - daemon will restart",
       { id: "update-rollback" },
     );
   });

--- a/source/web/tests/lib/cidr.test.ts
+++ b/source/web/tests/lib/cidr.test.ts
@@ -85,7 +85,7 @@ describe("cidr helpers", () => {
     expect(isPrivateCidr("8.8.0.0/16")).toBe(false);
     // Straddlers: private base but the range extends into public space.
     expect(isPrivateCidr("192.168.0.0/15")).toBe(false); // → 192.169.x
-    expect(isPrivateCidr("172.16.0.0/11")).toBe(false); // → 172.0–172.15 / 172.32+
+    expect(isPrivateCidr("172.16.0.0/11")).toBe(false); // → 172.0-172.15 / 172.32+
     expect(isPrivateCidr("10.0.0.0/7")).toBe(false); // → 11.x
     expect(isPrivateCidr("not a cidr")).toBe(false);
   });

--- a/source/web/tests/lib/utils.test.ts
+++ b/source/web/tests/lib/utils.test.ts
@@ -140,11 +140,11 @@ describe("date/time formatters", () => {
     expect(formatDateTime(d)).toBe("2026.07.02 09:05:07");
   });
   it("returns em dash for null/invalid/pre-2000 values", () => {
-    expect(formatDate(null)).toBe("—");
-    expect(formatDate("not a date")).toBe("—");
-    expect(formatTime(undefined)).toBe("—");
-    expect(formatTimeShort(new Date("1999-01-01"))).toBe("—");
-    expect(formatDateTime("garbage")).toBe("—");
+    expect(formatDate(null)).toBe("-");
+    expect(formatDate("not a date")).toBe("-");
+    expect(formatTime(undefined)).toBe("-");
+    expect(formatTimeShort(new Date("1999-01-01"))).toBe("-");
+    expect(formatDateTime("garbage")).toBe("-");
   });
   it("accepts string and numeric inputs", () => {
     expect(formatDate("2026-07-02T00:00:00")).toBe("2026.07.02");

--- a/source/web/tests/test-utils.tsx
+++ b/source/web/tests/test-utils.tsx
@@ -64,8 +64,9 @@ export function makeDevice(overrides: Partial<Device> = {}): Device {
     dns_capture_cap_days: 0,
     dhcp_status: "lease",
     current_rule: null,
+    connection_mode: "lan",
     ...overrides,
-  } as Device;
+  };
 }
 
 /** Build a TunnelSummary with sensible defaults. */

--- a/source/yarn.lock
+++ b/source/yarn.lock
@@ -5086,6 +5086,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/node@npm:*":
+  version: 26.1.1
+  resolution: "@types/node@npm:26.1.1"
+  dependencies:
+    undici-types: "npm:~8.3.0"
+  checksum: 10c0/25ac5093195736dd074d5027adbba85617bc951d5a41506ebd3b9073048acb7233613f3822d5f9b9447f9c0841c91f6387c46283916767e3ef79f23917452c46
+  languageName: node
+  linkType: hard
+
 "@types/node@npm:26.1.0":
   version: 26.1.0
   resolution: "@types/node@npm:26.1.0"
@@ -5099,6 +5108,15 @@ __metadata:
   version: 12.20.55
   resolution: "@types/node@npm:12.20.55"
   checksum: 10c0/3b190bb0410047d489c49bbaab592d2e6630de6a50f00ba3d7d513d59401d279972a8f5a598b5bb8ddc1702f8a2f4ec57a65d93852f9c329639738e7053637d1
+  languageName: node
+  linkType: hard
+
+"@types/qrcode@npm:1.5.5":
+  version: 1.5.5
+  resolution: "@types/qrcode@npm:1.5.5"
+  dependencies:
+    "@types/node": "npm:*"
+  checksum: 10c0/b8e6709905d1edb32dda414408acab18ac4aefcbe7bf96d9e32ba94218f45b99c8938ba7a09863ce82a67b226195099fd0f48881d16ee844899087b7f249955f
   languageName: node
   linkType: hard
 
@@ -5678,6 +5696,7 @@ __metadata:
     "@testing-library/jest-dom": "npm:6.9.1"
     "@testing-library/react": "npm:16.3.2"
     "@testing-library/user-event": "npm:14.6.1"
+    "@types/qrcode": "npm:1.5.5"
     "@vitejs/plugin-react": "npm:6.0.3"
     "@vitest/coverage-v8": "npm:4.1.9"
     "@wardnet/js": "workspace:*"
@@ -5692,6 +5711,7 @@ __metadata:
     globals: "npm:17.7.0"
     jsdom: "npm:29.1.1"
     prettier: "npm:3.9.4"
+    qrcode: "npm:1.5.4"
     tailwind-merge: "npm:3.6.0"
     typescript: "npm:6.0.3"
     typescript-eslint: "npm:8.62.1"
@@ -5767,6 +5787,15 @@ __metadata:
   version: 5.0.1
   resolution: "ansi-regex@npm:5.0.1"
   checksum: 10c0/9a64bb8627b434ba9327b60c027742e5d17ac69277960d041898596271d992d4d52ba7267a63ca10232e29f6107fc8a835f6ce8d719b88c5f8493f8254813737
+  languageName: node
+  linkType: hard
+
+"ansi-styles@npm:^4.0.0":
+  version: 4.3.0
+  resolution: "ansi-styles@npm:4.3.0"
+  dependencies:
+    color-convert: "npm:^2.0.1"
+  checksum: 10c0/895a23929da416f2bd3de7e9cb4eabd340949328ab85ddd6e484a637d8f6820d485f53933446f5291c3b760cbc488beb8e88573dd0f9c7daf83dccc8fe81b041
   languageName: node
   linkType: hard
 
@@ -6093,6 +6122,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"camelcase@npm:^5.0.0":
+  version: 5.3.1
+  resolution: "camelcase@npm:5.3.1"
+  checksum: 10c0/92ff9b443bfe8abb15f2b1513ca182d16126359ad4f955ebc83dc4ddcc4ef3fdd2c078bc223f2673dc223488e75c99b16cc4d056624374b799e6a1555cf61b23
+  languageName: node
+  linkType: hard
+
 "caniuse-lite@npm:^1.0.30001782":
   version: 1.0.30001799
   resolution: "caniuse-lite@npm:1.0.30001799"
@@ -6174,6 +6210,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"cliui@npm:^6.0.0":
+  version: 6.0.0
+  resolution: "cliui@npm:6.0.0"
+  dependencies:
+    string-width: "npm:^4.2.0"
+    strip-ansi: "npm:^6.0.0"
+    wrap-ansi: "npm:^6.2.0"
+  checksum: 10c0/35229b1bb48647e882104cac374c9a18e34bbf0bace0e2cf03000326b6ca3050d6b59545d91e17bfe3705f4a0e2988787aa5cde6331bf5cbbf0164732cef6492
+  languageName: node
+  linkType: hard
+
 "clsx@npm:2.1.1, clsx@npm:^2.1.1":
   version: 2.1.1
   resolution: "clsx@npm:2.1.1"
@@ -6193,6 +6240,22 @@ __metadata:
     react: ^18 || ^19 || ^19.0.0-rc
     react-dom: ^18 || ^19 || ^19.0.0-rc
   checksum: 10c0/5605ac4396ec9bc65c82f954da19dd89a0636a54026df72780e2470da1381f9d57434a80a53f2d57eaa4e759660a3ebba9232b74258dc09970576591eae03116
+  languageName: node
+  linkType: hard
+
+"color-convert@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "color-convert@npm:2.0.1"
+  dependencies:
+    color-name: "npm:~1.1.4"
+  checksum: 10c0/37e1150172f2e311fe1b2df62c6293a342ee7380da7b9cfdba67ea539909afbd74da27033208d01d6d5cfc65ee7868a22e18d7e7648e004425441c0f8a15a7d7
+  languageName: node
+  linkType: hard
+
+"color-name@npm:~1.1.4":
+  version: 1.1.4
+  resolution: "color-name@npm:1.1.4"
+  checksum: 10c0/a1a3f914156960902f46f7f56bc62effc6c94e84b2cae157a526b1c1f74b677a47ec602bf68a61abfa2b42d15b7c5651c6dbe72a43af720bc588dff885b10f95
   languageName: node
   linkType: hard
 
@@ -6467,6 +6530,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"decamelize@npm:^1.2.0":
+  version: 1.2.0
+  resolution: "decamelize@npm:1.2.0"
+  checksum: 10c0/85c39fe8fbf0482d4a1e224ef0119db5c1897f8503bcef8b826adff7a1b11414972f6fef2d7dec2ee0b4be3863cf64ac1439137ae9e6af23a3d8dcbe26a5b4b2
+  languageName: node
+  linkType: hard
+
 "decimal.js-light@npm:^2.5.1":
   version: 2.5.1
   resolution: "decimal.js-light@npm:2.5.1"
@@ -6563,6 +6633,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"dijkstrajs@npm:^1.0.1":
+  version: 1.0.3
+  resolution: "dijkstrajs@npm:1.0.3"
+  checksum: 10c0/2183d61ac1f25062f3c3773f3ea8d9f45ba164a00e77e07faf8cc5750da966222d1e2ce6299c875a80f969190c71a0973042192c5624d5223e4ed196ff584c99
+  languageName: node
+  linkType: hard
+
 "dir-glob@npm:^3.0.1":
   version: 3.0.1
   resolution: "dir-glob@npm:3.0.1"
@@ -6612,6 +6689,13 @@ __metadata:
   version: 1.5.376
   resolution: "electron-to-chromium@npm:1.5.376"
   checksum: 10c0/c57e306ef12ad258e427218f90e14d155dfba68b23699674d7b66e528ce41ff69b46a78f38545ee7690d080d25d3ebb98338282e95d65510e8fa5fd4f7455a86
+  languageName: node
+  linkType: hard
+
+"emoji-regex@npm:^8.0.0":
+  version: 8.0.0
+  resolution: "emoji-regex@npm:8.0.0"
+  checksum: 10c0/b6053ad39951c4cf338f9092d7bfba448cdfd46fe6a2a034700b149ac9ffbc137e361cbd3c442297f86bed2e5f7576c1b54cc0a6bf8ef5106cc62f496af35010
   languageName: node
   linkType: hard
 
@@ -7420,6 +7504,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"get-caller-file@npm:^2.0.1":
+  version: 2.0.5
+  resolution: "get-caller-file@npm:2.0.5"
+  checksum: 10c0/c6c7b60271931fa752aeb92f2b47e355eac1af3a2673f47c9589e8f8a41adc74d45551c1bc57b5e66a80609f10ffb72b6f575e4370d61cc3f7f3aaff01757cde
+  languageName: node
+  linkType: hard
+
 "get-intrinsic@npm:^1.2.4, get-intrinsic@npm:^1.2.5, get-intrinsic@npm:^1.2.6, get-intrinsic@npm:^1.2.7, get-intrinsic@npm:^1.3.0":
   version: 1.3.1
   resolution: "get-intrinsic@npm:1.3.1"
@@ -7901,6 +7992,13 @@ __metadata:
   dependencies:
     call-bound: "npm:^1.0.3"
   checksum: 10c0/818dff679b64f19e228a8205a1e2d09989a98e98def3a817f889208cfcbf918d321b251aadf2c05918194803ebd2eb01b14fc9d0b2bea53d984f4137bfca5e97
+  languageName: node
+  linkType: hard
+
+"is-fullwidth-code-point@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "is-fullwidth-code-point@npm:3.0.0"
+  checksum: 10c0/bb11d825e049f38e04c06373a8d72782eee0205bda9d908cc550ccb3c59b99d750ff9537982e01733c1c94a58e35400661f57042158ff5e8f3e90cf936daf0fc
   languageName: node
   linkType: hard
 
@@ -9642,6 +9740,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"pngjs@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "pngjs@npm:5.0.0"
+  checksum: 10c0/c074d8a94fb75e2defa8021e85356bf7849688af7d8ce9995b7394d57cd1a777b272cfb7c4bce08b8d10e71e708e7717c81fd553a413f21840c548ec9d4893c6
+  languageName: node
+  linkType: hard
+
 "possible-typed-array-names@npm:^1.0.0, possible-typed-array-names@npm:^1.1.0":
   version: 1.1.0
   resolution: "possible-typed-array-names@npm:1.1.0"
@@ -9778,6 +9883,19 @@ __metadata:
   version: 2.3.1
   resolution: "punycode@npm:2.3.1"
   checksum: 10c0/14f76a8206bc3464f794fb2e3d3cc665ae416c01893ad7a02b23766eb07159144ee612ad67af5e84fa4479ccfe67678c4feb126b0485651b302babf66f04f9e9
+  languageName: node
+  linkType: hard
+
+"qrcode@npm:1.5.4":
+  version: 1.5.4
+  resolution: "qrcode@npm:1.5.4"
+  dependencies:
+    dijkstrajs: "npm:^1.0.1"
+    pngjs: "npm:^5.0.0"
+    yargs: "npm:^15.3.1"
+  bin:
+    qrcode: bin/qrcode
+  checksum: 10c0/ae1d57c9cff6099639a590b432c71b15e3bd3905ce4353e6d00c95dee6bb769a8f773f6a7575ecc1b8ed476bf79c5138a4a65cb380c682de3b926d7205d34d10
   languageName: node
   linkType: hard
 
@@ -10225,10 +10343,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"require-directory@npm:^2.1.1":
+  version: 2.1.1
+  resolution: "require-directory@npm:2.1.1"
+  checksum: 10c0/83aa76a7bc1531f68d92c75a2ca2f54f1b01463cb566cf3fbc787d0de8be30c9dbc211d1d46be3497dac5785fe296f2dd11d531945ac29730643357978966e99
+  languageName: node
+  linkType: hard
+
 "require-from-string@npm:^2.0.2":
   version: 2.0.2
   resolution: "require-from-string@npm:2.0.2"
   checksum: 10c0/aaa267e0c5b022fc5fd4eef49d8285086b15f2a1c54b28240fdf03599cbd9c26049fee3eab894f2e1f6ca65e513b030a7c264201e3f005601e80c49fb2937ce2
+  languageName: node
+  linkType: hard
+
+"require-main-filename@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "require-main-filename@npm:2.0.0"
+  checksum: 10c0/db91467d9ead311b4111cbd73a4e67fa7820daed2989a32f7023785a2659008c6d119752d9c4ac011ae07e537eb86523adff99804c5fdb39cd3a017f9b401bb6
   languageName: node
   linkType: hard
 
@@ -10686,6 +10818,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"set-blocking@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "set-blocking@npm:2.0.0"
+  checksum: 10c0/9f8c1b2d800800d0b589de1477c753492de5c1548d4ade52f57f1d1f5e04af5481554d75ce5e5c43d4004b80a3eb714398d6907027dc0534177b7539119f4454
+  languageName: node
+  linkType: hard
+
 "set-function-length@npm:^1.2.2":
   version: 1.2.2
   resolution: "set-function-length@npm:1.2.2"
@@ -10906,6 +11045,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"string-width@npm:^4.1.0, string-width@npm:^4.2.0":
+  version: 4.2.3
+  resolution: "string-width@npm:4.2.3"
+  dependencies:
+    emoji-regex: "npm:^8.0.0"
+    is-fullwidth-code-point: "npm:^3.0.0"
+    strip-ansi: "npm:^6.0.1"
+  checksum: 10c0/1e525e92e5eae0afd7454086eed9c818ee84374bb80328fc41217ae72ff5f065ef1c9d7f72da41de40c75fa8bb3dee63d92373fd492c84260a552c636392a47b
+  languageName: node
+  linkType: hard
+
 "string.prototype.matchall@npm:^4.0.12":
   version: 4.0.12
   resolution: "string.prototype.matchall@npm:4.0.12"
@@ -10987,7 +11137,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"strip-ansi@npm:^6.0.1":
+"strip-ansi@npm:^6.0.0, strip-ansi@npm:^6.0.1":
   version: 6.0.1
   resolution: "strip-ansi@npm:6.0.1"
   dependencies:
@@ -12122,6 +12272,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"which-module@npm:^2.0.0":
+  version: 2.0.1
+  resolution: "which-module@npm:2.0.1"
+  checksum: 10c0/087038e7992649eaffa6c7a4f3158d5b53b14cf5b6c1f0e043dccfacb1ba179d12f17545d5b85ebd94a42ce280a6fe65d0cbcab70f4fc6daad1dfae85e0e6a3e
+  languageName: node
+  linkType: hard
+
 "which-typed-array@npm:^1.1.16, which-typed-array@npm:^1.1.19":
   version: 1.1.22
   resolution: "which-typed-array@npm:1.1.22"
@@ -12368,6 +12525,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"wrap-ansi@npm:^6.2.0":
+  version: 6.2.0
+  resolution: "wrap-ansi@npm:6.2.0"
+  dependencies:
+    ansi-styles: "npm:^4.0.0"
+    string-width: "npm:^4.1.0"
+    strip-ansi: "npm:^6.0.0"
+  checksum: 10c0/baad244e6e33335ea24e86e51868fe6823626e3a3c88d9a6674642afff1d34d9a154c917e74af8d845fd25d170c4ea9cf69a47133c3f3656e1252b3d462d9f6c
+  languageName: node
+  linkType: hard
+
 "xml-name-validator@npm:^5.0.0":
   version: 5.0.0
   resolution: "xml-name-validator@npm:5.0.0"
@@ -12379,6 +12547,13 @@ __metadata:
   version: 2.2.0
   resolution: "xmlchars@npm:2.2.0"
   checksum: 10c0/b64b535861a6f310c5d9bfa10834cf49127c71922c297da9d4d1b45eeaae40bf9b4363275876088fbe2667e5db028d2cd4f8ee72eed9bede840a67d57dab7593
+  languageName: node
+  linkType: hard
+
+"y18n@npm:^4.0.0":
+  version: 4.0.3
+  resolution: "y18n@npm:4.0.3"
+  checksum: 10c0/308a2efd7cc296ab2c0f3b9284fd4827be01cfeb647b3ba18230e3a416eb1bc887ac050de9f8c4fd9e7856b2e8246e05d190b53c96c5ad8d8cb56dffb6f81024
   languageName: node
   linkType: hard
 
@@ -12402,6 +12577,35 @@ __metadata:
   bin:
     yaml: bin.mjs
   checksum: 10c0/f340718df45e97a9551b9bf9dac61c80050bc464513b710debfb5067c380c8472e3b67809cffacb4ab5ffb5e66ef9310816c88b05f371cec60abfedd8c88e0a2
+  languageName: node
+  linkType: hard
+
+"yargs-parser@npm:^18.1.2":
+  version: 18.1.3
+  resolution: "yargs-parser@npm:18.1.3"
+  dependencies:
+    camelcase: "npm:^5.0.0"
+    decamelize: "npm:^1.2.0"
+  checksum: 10c0/25df918833592a83f52e7e4f91ba7d7bfaa2b891ebf7fe901923c2ee797534f23a176913ff6ff7ebbc1cc1725a044cc6a6539fed8bfd4e13b5b16376875f9499
+  languageName: node
+  linkType: hard
+
+"yargs@npm:^15.3.1":
+  version: 15.4.1
+  resolution: "yargs@npm:15.4.1"
+  dependencies:
+    cliui: "npm:^6.0.0"
+    decamelize: "npm:^1.2.0"
+    find-up: "npm:^4.1.0"
+    get-caller-file: "npm:^2.0.1"
+    require-directory: "npm:^2.1.1"
+    require-main-filename: "npm:^2.0.0"
+    set-blocking: "npm:^2.0.0"
+    string-width: "npm:^4.2.0"
+    which-module: "npm:^2.0.0"
+    y18n: "npm:^4.0.0"
+    yargs-parser: "npm:^18.1.2"
+  checksum: 10c0/f1ca680c974333a5822732825cca7e95306c5a1e7750eb7b973ce6dc4f97a6b0a8837203c8b194f461969bfe1fb1176d1d423036635285f6010b392fa498ab2d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

Closes #811, the next slice of epic #266 (remote access). Stacked on #810's branch (`feature/issue-810`, PR #820) — **do not merge before #820 merges**.

#810 already fully implemented the admin HTTP API for the inbound-WireGuard remote-access grant flow (handlers, DTOs, OpenAPI annotations, auth guards). Investigation confirmed the only real gaps left for #811 were:

1. **Rust API integration tests** — `wardnetd-api/src/api/inbound_wg.rs` was the only api module without a sibling test file. Added `api/tests/inbound_wg.rs` covering config/list/add/remove, the 404/409 add-peer failure paths, and the auth guard (7 tests).
2. **TypeScript SDK** — the SDK had zero references to `/api/inbound-wg/*`. Added `InboundWgService` (`services/inbound-wg.ts`) and matching DTOs (`types/inbound-wg.ts`), wired into `index.ts`. Also added the missing `connection_mode`/`DeviceConnectionMode` field to the SDK's `Device` type (present on the Rust struct since #810 but never mirrored).
3. **`docs/openapi.json`** regenerated — it had drifted since #810 never ran `make openapi` after adding the inbound-wg endpoints and `Device.connection_mode`; the diff here is purely additive/mechanical.

Adding `connection_mode` as a required `Device` field broke type-checking in `admin-app`, `user-app`, and `admin-site`'s `makeDevice()` test fixtures (and silently masked it in `web`'s fixture, which used an `as Device` cast) — fixed by adding the field to all four fixtures and dropping the now-unnecessary cast in `web`.

## Test plan

- [x] `cargo fmt --check` (wardnetd-api)
- [x] `cargo clippy -p wardnetd-api --all-targets -- -D warnings`
- [x] `cargo test --workspace` — 1144 passed (full container run) + 7 new `inbound_wg` tests
- [x] `yarn type-check` + `yarn format:check` in `sdk/wardnet-js`
- [x] `yarn type-check` in `admin-app`, `user-app`, `admin-site`, `web` (all clean after the `Device` fixture fix)
- [x] `make openapi` — confirmed the diff is purely additive, reflecting already-merged #810 changes

## Merge Commit Message

test(daemon,sdk): add inbound-wg admin API tests and TypeScript SDK service, fix Device.connection_mode SDK fixture breakage (#811)
