### PR TITLE
fix(daemon): unbreak main CI — MAC-collision test flake + RUSTSEC advisory

### DIFF
--- a/source/daemon/Cargo.lock
+++ b/source/daemon/Cargo.lock
@@ -1018,9 +1018,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/source/daemon/crates/wardnetd-services/src/dns_filter/tests/service.rs
+++ b/source/daemon/crates/wardnetd-services/src/dns_filter/tests/service.rs
@@ -47,6 +47,8 @@ use crate::error::AppError;
 use crate::event::{BroadcastEventBus, EventPublisher};
 use crate::jobs::{BoxedJobTask, JobService};
 
+use crate::tests::mac_from;
+
 const AD_BLOCKING: &str = "00000000-0000-0000-0000-000000000100";
 
 // ---------------------------------------------------------------------------
@@ -89,7 +91,7 @@ impl MemoryDeviceRepository {
             id,
             Device {
                 id,
-                mac: format!("aa:bb:cc:dd:ee:{:02x}", (id.as_u128() & 0xff) as u8),
+                mac: mac_from(id),
                 name: None,
                 hostname: None,
                 manufacturer: None,

--- a/source/daemon/crates/wardnetd-services/src/network_zone/tests/service.rs
+++ b/source/daemon/crates/wardnetd-services/src/network_zone/tests/service.rs
@@ -27,6 +27,8 @@ use crate::error::AppError;
 use crate::event::{BroadcastEventBus, EventPublisher};
 use crate::network_zone::service::{NetworkZoneService, NetworkZoneServiceImpl};
 
+use crate::tests::mac_from;
+
 const TRUSTED: &str = "00000000-0000-0000-0000-000000000201";
 const IOT: &str = "00000000-0000-0000-0000-000000000202";
 const GUEST: &str = "00000000-0000-0000-0000-000000000203";
@@ -90,7 +92,7 @@ async fn insert_device(devices: &Arc<dyn DeviceRepository>, id: Uuid, zone_id: &
     devices
         .insert(&DeviceRow {
             id: id.to_string(),
-            mac: format!("aa:bb:cc:00:00:{:02x}", id.as_bytes()[15]),
+            mac: mac_from(id),
             hostname: None,
             manufacturer: None,
             device_type: "unknown".to_owned(),

--- a/source/daemon/crates/wardnetd-services/src/routing/tests/routing.rs
+++ b/source/daemon/crates/wardnetd-services/src/routing/tests/routing.rs
@@ -21,6 +21,8 @@ use wardnetd_data::repository::device::DeviceRow;
 use wardnetd_data::repository::tunnel::TunnelRow;
 use wardnetd_data::repository::{DeviceRepository, SystemConfigRepository, TunnelRepository};
 
+use crate::tests::mac_from;
+
 /// Run a future under admin auth context (required by all routing service methods).
 async fn as_admin<F: std::future::Future>(f: F) -> F::Output {
     auth_context::with_context(
@@ -714,7 +716,7 @@ fn tunnel_id_1() -> Uuid {
 fn sample_device(id: Uuid, ip: &str) -> Device {
     Device {
         id,
-        mac: format!("AA:BB:CC:DD:EE:{:02X}", id.as_bytes()[15]),
+        mac: mac_from(id).to_uppercase(),
         name: Some("Test Device".to_owned()),
         hostname: None,
         manufacturer: None,

--- a/source/daemon/crates/wardnetd-services/src/tests/mod.rs
+++ b/source/daemon/crates/wardnetd-services/src/tests/mod.rs
@@ -7,3 +7,19 @@ mod init;
 mod jobs;
 mod request_context;
 mod version;
+
+use uuid::Uuid;
+
+/// A MAC address derived from `id`, for test devices.
+///
+/// `devices.mac` is UNIQUE, so every device a test inserts needs a distinct
+/// MAC. Deriving one from a single byte of the UUID leaves only 256 possible
+/// addresses — two devices in one test then collide about 1 run in 256, which
+/// is exactly the flake this replaced. A MAC is six bytes, so use six.
+pub(crate) fn mac_from(id: Uuid) -> String {
+    let b = id.as_bytes();
+    format!(
+        "{:02x}:{:02x}:{:02x}:{:02x}:{:02x}:{:02x}",
+        b[10], b[11], b[12], b[13], b[14], b[15]
+    )
+}

--- a/source/daemon/crates/wardnetd-services/src/zone_exception/tests/service.rs
+++ b/source/daemon/crates/wardnetd-services/src/zone_exception/tests/service.rs
@@ -29,6 +29,8 @@ use crate::error::AppError;
 use crate::event::{BroadcastEventBus, EventPublisher};
 use crate::zone_exception::service::{ZoneExceptionService, ZoneExceptionServiceImpl};
 
+use crate::tests::mac_from;
+
 const IOT: &str = "00000000-0000-0000-0000-000000000202";
 const GUEST: &str = "00000000-0000-0000-0000-000000000203";
 
@@ -80,7 +82,7 @@ async fn insert_device(devices: &Arc<dyn DeviceRepository>, id: Uuid) {
     devices
         .insert(&DeviceRow {
             id: id.to_string(),
-            mac: format!("aa:bb:cc:00:00:{:02x}", id.as_bytes()[15]),
+            mac: mac_from(id),
             hostname: None,
             manufacturer: None,
             device_type: "unknown".to_owned(),


### PR DESCRIPTION
Two independent failures currently red on `main`. Neither was introduced by a feature branch — both surfaced while investigating #825's CI, and both will keep failing PRs at random until fixed.

## 1. A real flaky test (~1 run in 256)

Four test helpers derive a device MAC from **a single byte** of a random UUID:

```rust
mac: format!("aa:bb:cc:00:00:{:02x}", id.as_bytes()[15]),
```

`devices.mac` carries a UNIQUE constraint, so this leaves only **256 possible addresses**. Any test that inserts two devices collides on ~0.4% of runs. Simulated it at **0.41%**, which matches the failure actually observed on #825:

```
UNIQUE constraint failed: devices.mac
  zone_exception::tests::service::list_returns_created_exceptions
```

A MAC is six bytes — so use six, via a shared `mac_from` helper in the crate's `#[cfg(test)]` module. Affected: `network_zone`, `zone_exception`, `routing`, `dns_filter` test helpers.

## 2. cargo-audit: RUSTSEC-2026-0204

`crossbeam-epoch` 0.9.18 — invalid pointer dereference in the `fmt::Pointer` impl for `Atomic`/`Shared` when the underlying pointer is invalid. The advisory was **published 2026-07-06**, so `main` went red on its own without any code change. Pulled in transitively via `moka` → `hickory-resolver`. Lockfile-only bump to 0.9.20, no API change.

## Test plan

- [x] The previously-flaky test passes **40/40** consecutive runs (a single green run proves nothing at a 0.4% rate).
- [x] Full `wardnetd-services` suite green — **1119 passed, 0 failed**.
- [x] `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` both clean.
- [x] `cargo-audit` reports 0 vulnerabilities with the bump.

## Merge Commit Message

fix(daemon): unbreak main CI — fix MAC-collision test flake and bump crossbeam-epoch for RUSTSEC-2026-0204