### PR TITLE
docs(agents): correct drift found by the docs-accuracy audit

### DIFF
--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -43,12 +43,18 @@ Key conventions:
 
 A generic pre-aggregating stats subsystem. All layers (data, services, API) are complete as of PR 2.
 
-### Two-tier storage — mirrors the `tunnel_metrics` pattern
+### Three-tier storage — mirrors the `tunnel_metrics` pattern
 
 | Table | Granularity | Retention | Key |
 |---|---|---|---|
-| `stats_intraday` | 1-minute buckets (`bucket_ts` = Unix seconds truncated to minute) | 48 h | `(metric, labels, bucket_ts)` |
-| `stats_daily` | 1-day rollup (`day` = `YYYY-MM-DD` UTC) | 13 months | `(metric, labels, day)` |
+| `stats_intraday` | 1-minute buckets (`bucket_ts` = Unix seconds truncated to minute) | 25 h (`INTRADAY_RETENTION`) | `(metric, labels, bucket_ts)` |
+| `stats_hourly` | 1-hour rollup (`hour_ts`) | 8 days (`HOURLY_RETENTION`) | `(metric, labels, hour_ts)` |
+| `stats_daily` | 1-day rollup (`day` = `YYYY-MM-DD` UTC) | 13 months / 397 days (`DAILY_RETENTION_DAYS`) | `(metric, labels, day)` |
+
+The retention constants live in `wardnetd-services/src/stats/service.rs`; the
+hourly tier was added by the `20260611000000_stats_hourly.sql` migration. The
+`Hour` query granularity reads the `stats_hourly` table — it is **not** computed
+on the fly from intraday rows.
 
 ### Instrument kinds
 
@@ -105,7 +111,7 @@ StatsRepository::trim_intraday / trim_daily  (retention enforcement)
 | `service.rs` | `StatsService` trait + `StatsServiceImpl` (time-series and top-N queries; calls `require_admin`) |
 | `flush_runner.rs` | `StatsFlushRunner` — background task: 10 s flush + 1 h maintenance; follows runner contract |
 
-`StatsService::query` supports three granularities: `Minute` (raw intraday rows), `Hour` (server-side aggregation of intraday), and `Day` (daily rollup table).
+`StatsService::query` supports three granularities: `Minute` (raw intraday rows), `Hour` (the `stats_hourly` rollup table), and `Day` (the `stats_daily` rollup table).
 
 ### API endpoints (`wardnetd-api/src/api/stats.rs`)
 

--- a/.agents/auth.md
+++ b/.agents/auth.md
@@ -7,8 +7,14 @@
 
 ## Unauthenticated endpoints
 
+This list is **illustrative, not exhaustive** — it drifts. For the current set,
+grep `security(())` in `wardnetd-api/src/api` (at time of writing: `auth.rs`,
+`devices.rs`, `dns_capture.rs`, `dns_events.rs`, `health.rs`, `info.rs`,
+`push.rs`, `rule_requests.rs`, `setup.rs`).
+
 - `GET /api/info` — version + uptime
 - `GET /api/setup/status`, `POST /api/setup`
+- `GET /api/health` — unauthenticated by design; the watchdog depends on it
 - `GET /api/devices/me`, `PUT /api/devices/me/rule` — self-service, identifies the caller by source IP via `ConnectInfo<SocketAddr>`
 
 ## Admin endpoints
@@ -51,7 +57,12 @@ let result = auth_context::with_context(admin_ctx, svc.get_config()).await;
 ### Rules
 
 1. Every service trait method implementation must call `auth_context::require_admin()?;` or `auth_context::require_authenticated()?;` as its first line.
-2. The only exception is startup/restore methods that run before the system is ready (e.g. `restore_tunnels`) — these should be documented with a comment explaining why the guard is skipped.
+2. There are exactly three sanctioned exception categories. Each one **must** carry a comment explaining why the guard is skipped; an undocumented exception is a violation, not a precedent:
+   - **(a) Startup / restore** — methods that run before the system is ready (e.g. `restore_tunnels`, `sync_premium`).
+   - **(b) Auth bootstrap** — methods that establish identity in the first place, and therefore cannot require it (`login`, `setup_admin`, `validate_session`, `validate_api_key`, `wizard_state`).
+   - **(c) Self-service by IP/device** — methods backing the unauthenticated endpoints below, which implement their own `AuthContext`-variant checks (e.g. `DeviceService`'s Admin/Device/Anonymous model) instead of the blunt `require_admin` / `require_authenticated` pair. These are *not* unguarded — they are guarded differently, and the check must still be the first thing the method does.
+
+   Anything outside these three categories with no guard is a defect.
 3. Background tasks wrap service calls in `auth_context::with_context(AuthContext::Admin { admin_id: Uuid::nil() }, ...)`.
 4. Tests wrap service calls in `auth_context::with_context(admin_ctx, ...)` to simulate the caller identity.
 5. Anonymous callers get `Err(AppError::Forbidden)` — never silently succeed.

--- a/.agents/code-conventions.md
+++ b/.agents/code-conventions.md
@@ -66,7 +66,10 @@
   ```
 - **Parameterised queries only** (`.bind()`) — never string-interpolate user input into SQL.
 - `format!()` is acceptable for `PRAGMA` statements with **numeric constants** (e.g. `PRAGMA incremental_vacuum({N})`), not for WHERE clauses or column lists.
+- Interpolating a `const` column list into an otherwise-fixed query is **still a violation**, even though it is not an injection risk: if every component is constant, the whole statement is constant — hoist it to a `const` instead of paying a `format!()` allocation on every call.
 
 ## Dependencies
 
-- Always add a comment with the crates.io or npmjs URL before each dependency in `Cargo.toml` / `package.json`.
+- Always add a comment with the crates.io URL before each dependency in `Cargo.toml`.
+  (`package.json` is standard JSON and cannot carry inline comments — no equivalent
+  convention applies to the JS/TS packages.)

--- a/.agents/logging.md
+++ b/.agents/logging.md
@@ -25,7 +25,10 @@ tracing::info!("device detected: mac={mac}, ip={ip}", mac = obs.mac, ip = obs.ip
 1. Always use `tracing` macros (`tracing::info!`, `tracing::warn!`, etc.), never `log` or `println!`.
 2. Structured fields go first: `field = %value` or `field = value` (for Display vs Debug).
 3. The message string repeats key values using tracing's `{variable}` interpolation syntax (resolved at the macro level, zero-cost when level is disabled).
-4. `error` level — always include the error in the message: `"operation failed on {thing}: {e}"`.
+4. `error` level — always capture the error as a structured field (`error = %e`).
+   Interpolating it into the message text as well (`"operation failed on {thing}: {e}"`)
+   is optional, and worth doing for one-off or rare errors. The structured field is
+   what Loki queries key off, so it is the part that must never be omitted.
 5. `warn` level — include enough context to diagnose: what failed, which entity, the error.
 6. `info` level — include the primary identifiers: MAC, IP, device_id, interface, etc.
 7. `debug` level — include counts and operational details: `"flushed {count} timestamps"`.

--- a/.agents/observability.md
+++ b/.agents/observability.md
@@ -6,13 +6,20 @@ Every log entry includes the daemon version via a hierarchical span tree. This i
 
 ### Span hierarchy
 
+**Illustrative excerpt, not an exhaustive list.** The tree below shows the shape
+and the naming convention; the daemon runs more background spans than are listed
+here, and a hand-maintained full list would go stale immediately. The rule in
+"Rules for new components" below is what actually binds — every background
+component opens a child span of the root. To see the current set, grep for
+`#[instrument]` and `info_span!`.
+
 ```
 wardnetd{version=0.1.1-dev.5+gabc1234}       # root span in main.rs
   ├── tunnel_monitor{}                         # background task
   ├── idle_watcher{}                           # background task
   ├── device_detector{}                        # background task
   ├── routing_listener{}                       # background task (event→routing dispatcher)
-  ├── dhcp_server{}                            # background task (if DHCP enabled)
+  ├── dhcp_runner{}                            # background task (if DHCP enabled)
   ├── update_runner{}                          # background task (auto-update poll)
   ├── backup_cleanup_runner{}                  # background task (.bak-* sweep)
   ├── stats_flush_runner{}                     # background task (10s buffer flush + 1h rollup/trim)

--- a/.agents/project-structure.md
+++ b/.agents/project-structure.md
@@ -110,11 +110,9 @@ source/
 │                                    #   useCombinedTunnelStats and useRebuildTunnel from @wardnet/web.
 │                                    #   Devices page: showingLastKnownState offline overlay; loading skeleton
 │                                    #   gated on both devices + policy loaded.
-├── ui/                              # @wardnet/ui — design system: UI primitives + components (CSS Modules + @wardnet/styles tokens)
-│   ├── src/
-│   │   ├── primitives/              # Button, Card, Modal, Combobox, Drawer, Select, Toggle, Sparkline, Text, Heading, etc. (each with a *.stories.tsx)
-│   │   └── components/              # Higher-level compositions (SegmentedTabs, FormActions, StatTile, …)
-│   └── .storybook/                  # Storybook config; preview.css imports the compiled @wardnet/ui/styles.css (see technical-stack.md)
+│                                    # NOTE: @wardnet/ui and @wardnet/styles are NOT in this tree. They are external,
+│                                    #   versioned deps from GitHub Packages (repo: wardnet-design-system). Changing a
+│                                    #   component or token is a dependency bump here, not a first-party edit.
 ├── web/                             # @wardnet/web — shared React hooks, utilities, stores; re-exports @wardnet/ui primitives
 │   └── src/
 │       ├── hooks/                   # All shared TanStack Query hooks: useAuth, useDevices, useTunnels, useStats,

--- a/.agents/technical-stack.md
+++ b/.agents/technical-stack.md
@@ -25,21 +25,21 @@
 ## Shared React library (`@wardnet/web`)
 - Lives at `source/web/`; linked via `"@wardnet/web": "portal:../web"`
 - Contains all shared TanStack Query hooks (useTunnels, useRebuildTunnel, useCombinedTunnelStats, useDevices, useStats, …), shared components (LoginForm, JobProgressDescription), Zustand stores, and utility functions
-- **UI primitives/components now live in `@wardnet/ui`** (see below); `@wardnet/web` re-exports them (`export * from "@wardnet/ui"`) so existing consumers can keep importing primitives from `@wardnet/web`. New surfaces should import design-system components directly from `@wardnet/ui`.
+- **UI primitives/components live in `@wardnet/ui`** (see below); `@wardnet/web` re-exports them (`export * from "@wardnet/ui"`) so existing consumers can keep importing primitives from `@wardnet/web`. New surfaces should import design-system components directly from `@wardnet/ui`.
 - All app surfaces (admin-site, user-app, admin-app) import hooks, utilities, and primitives from here — **do not duplicate hook or component logic in app-local files**
 
-## Design system (`@wardnet/ui`)
-- Lives at `source/ui/`; the home of all UI primitives and components (Button, Card, Modal, Combobox, Drawer, Select, Toggle, Sparkline, SegmentedTabs, FormActions, StatTile, the `<Text>`/`<Heading>` typography primitives, …). Built with Vite to `dist/index.js`; exports `"."` (components) and `"./styles.css"` (compiled `dist/ui.css`).
-- Components are styled with **CSS Modules** (`*.module.css`) plus `@wardnet/styles` tokens — no Tailwind runtime in the component package.
-- **Storybook** is the development + visual-spec surface (`yarn workspace @wardnet/ui storybook`). Every primitive/component has a `*.stories.tsx`; `Foundations/Typography` is a scale/role *showcase* (not a component export). `.storybook/preview.css` `@import`s `@wardnet/ui/styles.css` (the package's own compiled CSS) so the built, hashed module classes are present in the preview — required for components that compose styles across files (SegmentedTabs, FormActions) to render styled. Do not drop that import.
-- **Design-sync**: `@wardnet/ui` is mirrored to Claude Design (claude.ai/design) via the `/design-sync` skill. Committed sync state + re-sync caveats live in `.design-sync/` at the worktree root (`config.json`, `NOTES.md`, `conventions.md`, font aliases) — read `NOTES.md` before re-syncing.
+## Design system (`@wardnet/ui`, `@wardnet/styles`)
 
-## Design tokens (`@wardnet/styles`)
-- Lives at `source/styles/`; linked via `"@wardnet/styles": "portal:../styles"`
-- CSS tokens + Tailwind base layer in `styles.css`; typed design token constants (brand, status, radius, density, font) in `src/tokens.ts`
-- `typography.css` — semantic text variant classes (`.t-label`, `.t-body`, `.t-metric`, `.t-h1`…) plus `t-size-*` / `t-weight-*` helpers, all in `@layer components`; variant selectors are wrapped in `:where()` (zero specificity) so helper and colour utilities override structurally. Imported from `styles.css`, so consumers reach it via the single `@wardnet/styles` CSS entry. Backs the `<Text>` primitive in `@wardnet/ui` (see `docs/adr/0012-typography-scale-and-roles.md`).
-- Import CSS: `@import "@wardnet/styles"` (the `"."` export resolves to `styles.css`)
-- Import tokens: `import { brand, status } from "@wardnet/styles/tokens"`
+**These are external, versioned dependencies — not first-party code in this repo.**
+They are published to GitHub Packages from the sibling `wardnet-design-system`
+repository and consumed here as ordinary npm deps (`@wardnet/ui`, `@wardnet/styles`,
+`@wardnet/brand`). There is no `source/ui/` or `source/styles/` directory in this
+tree; changing a component or a token means a release in that repo followed by a
+**dependency bump here**, not an edit.
+
+- `@wardnet/ui` — all UI primitives and components (Button, Card, Modal, Combobox, Drawer, Select, Toggle, Sparkline, SegmentedTabs, FormActions, StatTile, the `<Text>`/`<Heading>` typography primitives, …), styled with CSS Modules plus `@wardnet/styles` tokens.
+- `@wardnet/styles` — CSS tokens + Tailwind base layer, and `typography.css`, which backs the `<Text>` primitive (see `docs/adr/0012-typography-scale-and-roles.md`).
+- Import CSS: `@import "@wardnet/styles"`. Import tokens: `import { brand, status } from "@wardnet/styles/tokens"`.
 
 ## Admin site (`source/admin-site/` — `@wardnet/admin-site`)
 - Full desktop admin UI; served at `/admin/`

--- a/.agents/testing.md
+++ b/.agents/testing.md
@@ -67,7 +67,10 @@ Tests **must** live in separate files. Never put `#[test]` or `#[tokio::test]` b
 
 **Repository tests** follow the same layout under `src/repository/tests/`. The shared `test_pool()` helper lives in `src/repository/tests/mod.rs`.
 
-This rule is enforced by clippy and code review — no exceptions.
+This rule is enforced by code review — no exceptions. (It is *not* currently
+enforced by a clippy lint, so review is the only gate. Source files that still
+carry an inline `#[cfg(test)] mod tests` block are pre-existing debt, not
+precedent.)
 
 ## Test patterns
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,8 +39,9 @@ you're about to make, rather than the whole set.
 - **[Local-DNS subsystem](.agents/architecture.md#local-dns-subsystem-issue-217)** —
   `AuthoritativeView` (ArcSwap-backed, lock-free), resolution pipeline order
   (authoritative → cache → filter → conditional/tunnel upstream),
-  event-driven rebuild on `DnsLocalChanged`, and why `DnsRunner` reads
-  `dns_local_repo` directly instead of going through `DnsLocalService`.
+  event-driven rebuild on `DnsLocalChanged`, and why background runners
+  (including `DnsRunner`) call `DnsLocalService` rather than holding
+  `dns_local_repo` directly.
 - **[DDNS subsystem](.agents/architecture.md#ddns-subsystem-issue-527--521-umbrella)** —
   `DnsProvider` trait (bridge + Cloudflare impls), `DdnsService` (auth-gated, stores config in
   `system_config` and secrets in `SecretStore`), `DdnsUpdateRunner` (idle-until-configured 5-min


### PR DESCRIPTION
## Why

An automated audit checked every **checkable claim** in `AGENTS.md`, `CONTEXT.md` and the eleven `.agents/*.md` docs against the actual tree — does this path exist, does this crate exist, does this rule still hold in the code. It found **35 drifts across 13 docs**.

This matters more than usual because these docs are the house rules injected into coding agents. A false rule in here doesn't just mislead a human skimming the docs — it becomes a false premise that an agent applies literally to every file it touches.

## What changed

**Four rules with repo-wide blast radius** (these would have generated bogus findings on nearly every file):

| Doc | Problem | Fix |
|---|---|---|
| `code-conventions.md` | Required a URL comment before each `package.json` dependency. **JSON cannot carry comments.** | Scoped the rule to `Cargo.toml` |
| `testing.md` | Claimed the no-inline-tests rule is "enforced by clippy". **No such lint is configured**, and ~14 files violate it. | Rule stands (deliberate call); removed the false enforcement claim; the 14 files are now explicitly debt |
| `logging.md` | Required interpolating the error into every `error!` message. **36 of 56 sampled sites don't** — they capture `error = %e` as a structured field, which is what Loki keys off. | The structured field is what's mandatory; interpolation is optional |
| `auth.md` | Called `restore_tunnels` "the only exception" to the auth-guard rule. A literal reading flags **`AuthService::login` itself**. | Enumerated the three real exception categories: startup/restore, auth bootstrap, self-service-by-IP |

**Factual corrections, each verified against the code:**

- **`architecture.md`** — the stats subsystem has **three** storage tiers, not two: intraday (25h), hourly (8d, via a real `stats_hourly` table added in `20260611000000_stats_hourly.sql`), daily (397d). `Hour` reads the rollup table; it is not computed on the fly from intraday rows.
- **`AGENTS.md`** — the Local-DNS bullet **inverted its own linked doc**. Runners call `DnsLocalService`; they do not hold `dns_local_repo`. (`DnsRunner::start` takes `Arc<dyn DnsLocalService>`; `architecture.md` has a section titled "Background runners call auth-gated services, never repositories".)
- **`observability.md`** — span tree marked illustrative (it omitted ~13 real spans); `dhcp_server` renamed to its actual span name, `dhcp_runner`.
- **`project-structure.md`, `technical-stack.md`** — `@wardnet/ui` and `@wardnet/styles` are **external GitHub Packages deps** from the `wardnet-design-system` repo. They are not in-repo packages at `source/ui` / `source/styles`, and changes to them are dependency bumps here, not first-party edits.

## What is deliberately NOT in this PR

The audit also found code that drifted from rules the docs still mean. **These are code bugs and are not papered over by editing the doc.** They are queued as seed findings for the upcoming full-repo code review, where they'll be verified and filed as issues:

- `LogServiceImpl::list_log_files` / `::download_log_file` — **no auth guard on any method**, where every other service file has one. Reachable from `api/system.rs:79` (currently behind `AdminAuth` middleware, so this is a defense-in-depth gap rather than an open door).
- `StatsFlushRunner` (`flush_runner.rs:153,169`) — calls `StatsService::run_flush`/`run_maintenance` with **no `with_context` wrapper**, and the callees have no guard either, so that path has no auth check at all. `tunnel_idle.rs` does the same job correctly.
- 11 SQLite repo sites that `format!()` a const column list into an otherwise-fixed query.
- Dead `generate_oui_data()` in `wardnetd/build.rs`, still shipping a duplicate ~39k-row `oui.csv`.

## Merge Commit Message

docs(agents): correct drift found by the docs-accuracy audit

Fixes 35 documentation drifts across 13 agent-facing docs. Four rules had repo-wide blast radius and would have caused reviewers to file bogus findings: the package.json dependency-comment rule (impossible — JSON has no comments), testing.md's false "enforced by clippy" claim, logging.md's error-interpolation mandate (64% of sites don't follow it), and auth.md's incomplete exception list (a literal reading flags AuthService::login). Also corrects the stats subsystem to three storage tiers, fixes an inverted layering claim in AGENTS.md, and records that @wardnet/ui and @wardnet/styles are external deps rather than in-repo packages. Code that drifted from still-valid rules is queued for the code review, not papered over here.

https://claude.ai/code/session_01LRWPhnm3tqDjQnmmaQXrzh