### PR TITLE
feat(daemon): premium-gate the inbound WireGuard (Personal VPN) feature

### DIFF
--- a/source/daemon/crates/wardnet-common/src/event.rs
+++ b/source/daemon/crates/wardnet-common/src/event.rs
@@ -248,6 +248,16 @@ pub enum WardnetEvent {
         policy: String,
         timestamp: DateTime<Utc>,
     },
+    /// The box's entitlement (Premium) state changed, i.e. `is_entitled()`
+    /// flipped: premium was gained or lost, or the subscription was suspended /
+    /// restored (issue #266). Emitted once on the edge by the shared
+    /// `Entitlement` handle. Listeners tear down Premium-only runtime state on
+    /// loss: notably, the inbound-WireGuard ("Personal VPN") server is disabled
+    /// so a lapsed box does not keep serving a Premium feature.
+    EntitlementChanged {
+        entitled: bool,
+        timestamp: DateTime<Utc>,
+    },
     /// A previously-unseen device was discovered while new-device quarantine is
     /// enabled (issue #738). Fires exactly once per device — only from the
     /// truly-new insert path, never on reconnect — so it is a valid "first-ever"

--- a/source/daemon/crates/wardnetd-mock/src/main.rs
+++ b/source/daemon/crates/wardnetd-mock/src/main.rs
@@ -44,7 +44,6 @@ use wardnetd_services::db_maintenance_runner::DbMaintenanceRunner;
 use wardnetd_services::dns::DnsCaptureRunner;
 use wardnetd_services::dns::query_log_runner::DnsQueryLogRunner;
 use wardnetd_services::dns_filter::blocklist_downloader::HttpBlocklistFetcher;
-use wardnetd_services::entitlement::Entitlement;
 use wardnetd_services::health::checks::{DbHealthCheck, LivenessHealthCheck};
 use wardnetd_services::logging::{
     ErrorNotifierService, LogService, LogServiceImpl, LogStreamService,
@@ -310,6 +309,14 @@ async fn run(
     )
     .await?;
 
+    // Personal VPN (inbound WireGuard) and the premium app surfaces (user PWA +
+    // admin mobile app) are Premium capabilities gated on `services.entitlement`
+    // (the one shared handle the DDNS service owns and inbound-WG reads). The
+    // mock always stands in for a wardnet-subscribed box, so mark it entitled
+    // up front — in particular before the inbound-WG reconcile below, whose
+    // Premium gate would otherwise disable an enabled-across-restart server.
+    services.entitlement.set_premium(true);
+
     // Startup reconcile of the inbound-WireGuard server, mirroring the real
     // daemon (`wardnetd` main): stands the interface back up if enabled and,
     // crucially for the mock's persistent secret store, re-caches the server
@@ -342,12 +349,6 @@ async fn run(
     // Demo DDNS: an already-issued host so remote-access QR codes / `.conf`
     // downloads have a reachable-looking Endpoint out of the box.
     remote_access_state.configure_demo();
-    // Entitlement (issue #795): the premium app surfaces (user PWA + admin
-    // mobile app) self-gate on `/api/info`'s `entitled` flag. The mock always
-    // stands in for a wardnet-subscribed box so those apps are testable
-    // locally.
-    let entitlement = Entitlement::shared();
-    entitlement.set_premium(true);
     let mock_ddns: Arc<dyn wardnetd_services::ddns::DdnsService> =
         Arc::new(MockDdnsService::new(remote_access_state.clone()));
     let mock_tls: Arc<dyn wardnetd_services::tls::TlsService> =
@@ -394,7 +395,7 @@ async fn run(
     )
     .with_push_service(services.push.clone())
     .with_inbound_wg_service(services.inbound_wg.clone())
-    .with_entitlement(entitlement)
+    .with_entitlement(services.entitlement.clone())
     .with_health_monitor(health_monitor);
 
     // Drain the DNS query log persistence channel into SQLite so the

--- a/source/daemon/crates/wardnetd-services/src/entitlement.rs
+++ b/source/daemon/crates/wardnetd-services/src/entitlement.rs
@@ -37,12 +37,17 @@
 //! logged once (on the edge) so the journal shows when a box's state changed,
 //! not every poll.
 
-use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, OnceLock};
+
+use chrono::Utc;
+use wardnet_common::event::WardnetEvent;
+
+use crate::event::EventPublisher;
 
 /// Shared entitlement state. Construct one per process via [`Entitlement::shared`]
 /// and clone the `Arc` to every reader/writer.
-#[derive(Debug, Default)]
+#[derive(Default)]
 pub struct Entitlement {
     /// `true` once a token mint was refused for entitlement; cleared on the next
     /// successful mint. Starts `false` (assume active until told otherwise, so
@@ -54,6 +59,22 @@ pub struct Entitlement {
     /// entitled to the premium app surfaces by default. Flipped by the DDNS
     /// service when the configured provider changes.
     premium: AtomicBool,
+    /// Optional event sink, wired once after construction (the DDNS service
+    /// creates this handle before the event bus exists). When present, every
+    /// `is_entitled()` edge publishes [`WardnetEvent::EntitlementChanged`], so
+    /// listeners can tear down Premium-only runtime state the moment the box
+    /// loses entitlement (e.g. disable the inbound-WireGuard server).
+    publisher: OnceLock<Arc<dyn EventPublisher>>,
+}
+
+impl std::fmt::Debug for Entitlement {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // `dyn EventPublisher` is not `Debug`; report the observable state only.
+        f.debug_struct("Entitlement")
+            .field("premium", &self.premium.load(Ordering::Relaxed))
+            .field("suspended", &self.suspended.load(Ordering::Relaxed))
+            .finish_non_exhaustive()
+    }
 }
 
 impl Entitlement {
@@ -61,6 +82,32 @@ impl Entitlement {
     #[must_use]
     pub fn shared() -> Arc<Self> {
         Arc::new(Self::default())
+    }
+
+    /// Wire the event bus so `is_entitled()` edges publish
+    /// [`WardnetEvent::EntitlementChanged`]. Idempotent: the first call wins,
+    /// later calls are ignored. Called once during service init, after the
+    /// bus is built. Until set, edges are silent (fine for tests / the mock).
+    pub fn set_publisher(&self, publisher: Arc<dyn EventPublisher>) {
+        let _ = self.publisher.set(publisher);
+    }
+
+    /// Publish an [`WardnetEvent::EntitlementChanged`] iff `is_entitled()`
+    /// actually flipped relative to `was_entitled`. No-op when no publisher is
+    /// wired. Best-effort: the event is an optimization over the reconcile /
+    /// request-time gates, and listeners re-check state, so a missed or
+    /// spurious edge is not load-bearing.
+    fn emit_if_entitlement_changed(&self, was_entitled: bool) {
+        let now_entitled = self.is_entitled();
+        if now_entitled == was_entitled {
+            return;
+        }
+        if let Some(publisher) = self.publisher.get() {
+            publisher.publish(WardnetEvent::EntitlementChanged {
+                entitled: now_entitled,
+                timestamp: Utc::now(),
+            });
+        }
     }
 
     /// Whether the daemon currently believes its subscription has lapsed.
@@ -80,6 +127,7 @@ impl Entitlement {
     /// Record that a token mint was refused for entitlement. Logs once on the
     /// active → suspended edge.
     pub fn suspend(&self) {
+        let was_entitled = self.is_entitled();
         if self
             .suspended
             .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
@@ -90,10 +138,12 @@ impl Entitlement {
                  premium app surfaces are disabled until it is restored"
             );
         }
+        self.emit_if_entitlement_changed(was_entitled);
     }
 
     /// Record a successful token mint. Logs once on the suspended → active edge.
     pub fn restore(&self) {
+        let was_entitled = self.is_entitled();
         if self
             .suspended
             .compare_exchange(true, false, Ordering::AcqRel, Ordering::Acquire)
@@ -101,6 +151,7 @@ impl Entitlement {
         {
             tracing::info!("entitlement restored: the wardnet subscription is active again");
         }
+        self.emit_if_entitlement_changed(was_entitled);
     }
 
     /// Record whether the box is currently on the wardnet-operated DDNS
@@ -109,6 +160,7 @@ impl Entitlement {
     /// once at startup to prime the flag from persisted config. Logs once on
     /// each edge.
     pub fn set_premium(&self, premium: bool) {
+        let was_entitled = self.is_entitled();
         let prev = self.premium.swap(premium, Ordering::AcqRel);
         if prev != premium {
             if premium {
@@ -123,6 +175,7 @@ impl Entitlement {
                 );
             }
         }
+        self.emit_if_entitlement_changed(was_entitled);
     }
 }
 
@@ -180,6 +233,76 @@ mod tests {
         e.set_premium(true);
         e.set_premium(true); // no-op edge
         assert!(e.is_entitled());
+        e.set_premium(false);
+        assert!(!e.is_entitled());
+    }
+
+    /// Records published events so edge emission can be asserted.
+    #[derive(Default)]
+    struct RecordingPublisher {
+        events: std::sync::Mutex<Vec<wardnet_common::event::WardnetEvent>>,
+    }
+
+    impl crate::event::EventPublisher for RecordingPublisher {
+        fn publish(&self, event: wardnet_common::event::WardnetEvent) {
+            self.events.lock().unwrap().push(event);
+        }
+        fn subscribe(
+            &self,
+        ) -> tokio::sync::broadcast::Receiver<wardnet_common::event::WardnetEvent> {
+            tokio::sync::broadcast::channel(16).1
+        }
+    }
+
+    fn entitled_edges(pubr: &RecordingPublisher) -> Vec<bool> {
+        pubr.events
+            .lock()
+            .unwrap()
+            .iter()
+            .filter_map(|ev| match ev {
+                wardnet_common::event::WardnetEvent::EntitlementChanged { entitled, .. } => {
+                    Some(*entitled)
+                }
+                _ => None,
+            })
+            .collect()
+    }
+
+    #[test]
+    fn premium_edges_emit_entitlement_changed() {
+        let e = Entitlement::shared();
+        let pubr = std::sync::Arc::new(RecordingPublisher::default());
+        e.set_publisher(pubr.clone());
+        e.set_premium(true); // not-entitled -> entitled
+        e.set_premium(true); // no-op edge, no event
+        e.set_premium(false); // entitled -> not-entitled
+        assert_eq!(entitled_edges(&pubr), vec![true, false]);
+    }
+
+    #[test]
+    fn suspend_restore_edges_emit_only_while_premium() {
+        let e = Entitlement::shared();
+        let pubr = std::sync::Arc::new(RecordingPublisher::default());
+        e.set_publisher(pubr.clone());
+        // A free box (never premium): suspend/restore never cross the entitled
+        // edge, so nothing is published.
+        e.suspend();
+        e.restore();
+        assert!(entitled_edges(&pubr).is_empty());
+        // Once premium, suspension crosses the edge and restoration crosses back.
+        e.set_premium(true); // -> entitled
+        e.suspend(); // -> not entitled
+        e.restore(); // -> entitled
+        assert_eq!(entitled_edges(&pubr), vec![true, false, true]);
+    }
+
+    #[test]
+    fn no_publisher_wired_is_silent() {
+        // The mock and unit tests may never wire a publisher; edges must not panic.
+        let e = Entitlement::shared();
+        e.set_premium(true);
+        e.suspend();
+        e.restore();
         e.set_premium(false);
         assert!(!e.is_entitled());
     }

--- a/source/daemon/crates/wardnetd-services/src/inbound_wg/service.rs
+++ b/source/daemon/crates/wardnetd-services/src/inbound_wg/service.rs
@@ -12,6 +12,7 @@ use wardnet_common::api::{
 
 use crate::auth_context;
 use crate::device::service::DeviceService;
+use crate::entitlement::Entitlement;
 use crate::error::AppError;
 use crate::inbound_wg::interface::{
     InboundWgInterface, InboundWgPeerConfig, InboundWgServerConfig,
@@ -153,6 +154,10 @@ pub struct InboundWgServiceImpl {
     /// [`DeviceService`] (never `DeviceRepository` directly) so the
     /// single-service-per-repository rule holds.
     devices: Arc<dyn DeviceService>,
+    /// Shared entitlement handle. Personal VPN is a Premium capability, so
+    /// enabling the server and granting peers require an active entitlement,
+    /// and a box that has lost entitlement disables the server on reconcile.
+    entitlement: Arc<Entitlement>,
 }
 
 impl InboundWgServiceImpl {
@@ -165,6 +170,7 @@ impl InboundWgServiceImpl {
         interface: Arc<dyn InboundWgInterface>,
         firewall: Arc<dyn FirewallManager>,
         devices: Arc<dyn DeviceService>,
+        entitlement: Arc<Entitlement>,
     ) -> Self {
         let keys: Arc<dyn ServerKeyStore> = Arc::new(ServerKeyStoreAdapter::new(secret_store));
         Self {
@@ -174,6 +180,7 @@ impl InboundWgServiceImpl {
             interface,
             firewall,
             devices,
+            entitlement,
         }
     }
 
@@ -186,6 +193,7 @@ impl InboundWgServiceImpl {
         interface: Arc<dyn InboundWgInterface>,
         firewall: Arc<dyn FirewallManager>,
         devices: Arc<dyn DeviceService>,
+        entitlement: Arc<Entitlement>,
     ) -> Self {
         Self {
             peers,
@@ -194,6 +202,21 @@ impl InboundWgServiceImpl {
             interface,
             firewall,
             devices,
+            entitlement,
+        }
+    }
+
+    /// Premium gate for the Personal VPN feature. Enabling the inbound server
+    /// and granting peers require an active entitlement, mirroring the 403 the
+    /// serving layer returns for the premium PWA surfaces.
+    fn require_entitled(&self) -> Result<(), AppError> {
+        if self.entitlement.is_entitled() {
+            Ok(())
+        } else {
+            Err(AppError::Forbidden(
+                "inbound WireGuard (Personal VPN) requires an active Premium subscription"
+                    .to_owned(),
+            ))
         }
     }
 
@@ -439,6 +462,10 @@ impl InboundWgService for InboundWgServiceImpl {
         auth_context::require_admin()?;
 
         if enabled {
+            // Disabling is always allowed (an unentitled box must be able to
+            // turn the server off); only enabling is Premium-gated.
+            self.require_entitled()?;
+
             let (private_key, server_pubkey) = self.ensure_server_keypair().await?;
 
             self.bring_up_server(private_key, listen_port).await?;
@@ -505,6 +532,7 @@ impl InboundWgService for InboundWgServiceImpl {
         endpoint: Option<String>,
     ) -> Result<AddInboundWgPeerResponse, AppError> {
         auth_context::require_admin()?;
+        self.require_entitled()?;
 
         // Precondition first: no keygen / DB work if the server is off.
         if !self
@@ -771,6 +799,27 @@ impl InboundWgService for InboundWgServiceImpl {
             .await
             .map_err(AppError::Internal)?
         {
+            return Ok(());
+        }
+
+        // Personal VPN is Premium. If the server was enabled while entitled but
+        // the box has since lost entitlement (subscription lapsed, or moved off
+        // the wardnet provider), do not stand it back up: disable it and persist
+        // that, so the daemon never serves a Premium feature the box no longer
+        // has. Interface/firewall teardown is best-effort (nothing is up yet on
+        // a fresh boot; this only matters if a prior process left state behind).
+        if !self.entitlement.is_entitled() {
+            tracing::warn!(
+                "inbound wireguard server was enabled but the box is no longer entitled to \
+                 Premium; disabling it on reconcile"
+            );
+            self.system_config
+                .set_inbound_wg_enabled(false)
+                .await
+                .map_err(AppError::Internal)?;
+            let _ = self.interface.tear_down_server(INBOUND_WG_INTERFACE).await;
+            let _ = self.firewall.remove_masquerade(INBOUND_WG_INTERFACE).await;
+            let _ = self.firewall.remove_inbound_wg_accept().await;
             return Ok(());
         }
 

--- a/source/daemon/crates/wardnetd-services/src/inbound_wg/tests/service.rs
+++ b/source/daemon/crates/wardnetd-services/src/inbound_wg/tests/service.rs
@@ -10,6 +10,7 @@ use wardnet_common::device::{Device, DeviceConnectionMode, DeviceType};
 
 use crate::auth_context;
 use crate::device::service::DeviceService;
+use crate::entitlement::Entitlement;
 use crate::error::AppError;
 use crate::inbound_wg::interface::{
     InboundWgInterface, InboundWgPeerConfig, InboundWgPeerStats, InboundWgServerConfig,
@@ -403,6 +404,7 @@ struct Harness {
     interface: Arc<MockInterface>,
     firewall: Arc<MockFirewall>,
     devices: Arc<MockDeviceService>,
+    entitlement: Arc<Entitlement>,
     service: InboundWgServiceImpl,
 }
 
@@ -420,6 +422,10 @@ fn harness() -> Harness {
     let interface = Arc::new(MockInterface::default());
     let firewall = Arc::new(MockFirewall::default());
     let devices = Arc::new(MockDeviceService::default());
+    // Personal VPN is Premium; default the harness to an entitled box so the
+    // existing specs exercise the happy path. The gate spec flips this off.
+    let entitlement = Entitlement::shared();
+    entitlement.set_premium(true);
     let service = InboundWgServiceImpl::with_key_store(
         peers.clone(),
         system_config.clone(),
@@ -427,6 +433,7 @@ fn harness() -> Harness {
         interface.clone(),
         firewall.clone(),
         devices.clone(),
+        entitlement.clone(),
     );
     Harness {
         peers,
@@ -435,6 +442,7 @@ fn harness() -> Harness {
         interface,
         firewall,
         devices,
+        entitlement,
         service,
     }
 }
@@ -481,6 +489,64 @@ async fn enable_persists_config_and_calls_backends() {
         vec![INBOUND_WG_INTERFACE.to_owned()]
     );
     assert_eq!(*h.firewall.accept_added.lock().unwrap(), vec![51821]);
+}
+
+#[tokio::test]
+async fn enable_without_entitlement_is_forbidden() {
+    let h = harness();
+    h.entitlement.set_premium(false); // not Premium
+    let err = auth_context::with_context(admin_ctx(), h.service.set_config(true, 51821))
+        .await
+        .expect_err("enabling Personal VPN without Premium is rejected");
+    assert!(matches!(err, AppError::Forbidden(_)));
+    // Nothing was stood up or persisted.
+    assert!(!h.system_config.inbound_wg_enabled().await.unwrap());
+    assert!(h.interface.ensure_calls.lock().unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn add_peer_without_entitlement_is_forbidden() {
+    let h = harness();
+    let device_id = h.add_device("Laptop");
+    h.entitlement.set_premium(false);
+    let err = auth_context::with_context(admin_ctx(), h.service.add_peer(device_id, None))
+        .await
+        .expect_err("granting a peer without Premium is rejected");
+    assert!(matches!(err, AppError::Forbidden(_)));
+}
+
+#[tokio::test]
+async fn disable_is_allowed_without_entitlement() {
+    let h = harness();
+    // Enable while entitled, then lose Premium and confirm disabling still works
+    // (an unentitled box must be able to turn the server off).
+    auth_context::with_context(admin_ctx(), h.service.set_config(true, 51821))
+        .await
+        .expect("enable while entitled");
+    h.entitlement.set_premium(false);
+    let resp = auth_context::with_context(admin_ctx(), h.service.set_config(false, 51821))
+        .await
+        .expect("disable is allowed without Premium");
+    assert!(!resp.enabled);
+    assert!(!h.system_config.inbound_wg_enabled().await.unwrap());
+}
+
+#[tokio::test]
+async fn reconcile_disables_server_when_entitlement_lost() {
+    let h = harness();
+    auth_context::with_context(admin_ctx(), h.service.set_config(true, 51821))
+        .await
+        .expect("enable while entitled");
+    assert!(h.system_config.inbound_wg_enabled().await.unwrap());
+
+    // Premium lapses, then the daemon restarts (reconcile). The server must not
+    // come back up; it is disabled and persisted so.
+    h.entitlement.set_premium(false);
+    h.service.reconcile().await.expect("reconcile succeeds");
+    assert!(
+        !h.system_config.inbound_wg_enabled().await.unwrap(),
+        "reconcile disables an enabled server once Premium is lost"
+    );
 }
 
 #[tokio::test]

--- a/source/daemon/crates/wardnetd-services/src/lib.rs
+++ b/source/daemon/crates/wardnetd-services/src/lib.rs
@@ -660,6 +660,7 @@ fn create_services(
         backends.inbound_wg_interface.clone(),
         backends.firewall.clone(),
         device_service.clone(),
+        entitlement.clone(),
     ));
 
     let discovery_service = build_discovery_service(

--- a/source/daemon/crates/wardnetd-services/src/lib.rs
+++ b/source/daemon/crates/wardnetd-services/src/lib.rs
@@ -580,6 +580,11 @@ fn create_services(
         ddns_settings,
     );
     let entitlement = ddns_impl.entitlement();
+    // Wire the event bus so entitlement edges (Premium gained/lost, subscription
+    // suspended/restored) publish `EntitlementChanged`. The `entitlement_listener`
+    // in `wardnetd` consumes it to disable the inbound-WireGuard server the moment
+    // the box loses entitlement, rather than waiting for the next reconcile.
+    entitlement.set_publisher(event_publisher.clone());
     let ddns: Arc<dyn DdnsService> = Arc::new(ddns_impl);
 
     // Reverse-tunnel connector (issue #809): the runner in `wardnetd`'s `main`

--- a/source/daemon/crates/wardnetd/src/entitlement_listener.rs
+++ b/source/daemon/crates/wardnetd/src/entitlement_listener.rs
@@ -1,0 +1,113 @@
+//! Background task that disables Premium-only runtime state the moment the box
+//! loses entitlement (issue #266).
+//!
+//! Personal VPN (the inbound-WireGuard server) is Premium. The request-time gate
+//! blocks enabling/granting without entitlement, and `reconcile()` disables an
+//! enabled server on the next restart after a loss — but neither tears down a
+//! *running* server the instant a subscription lapses. This listener does: it
+//! subscribes to the domain event bus and reacts to
+//! [`WardnetEvent::EntitlementChanged`] with `entitled: false` by disabling the
+//! inbound server immediately.
+//!
+//! Mirrors [`ZoneEnforcementListener`](crate::zone_enforcement_listener): a
+//! dedicated subscriber, cancellation-aware, supplying a nil-admin context for
+//! the admin-guarded service call.
+
+use std::sync::Arc;
+
+use tokio_util::sync::CancellationToken;
+use tracing::Instrument;
+use wardnet_common::auth::AuthContext;
+use wardnet_common::event::WardnetEvent;
+
+use wardnetd_services::InboundWgService;
+use wardnetd_services::event::EventPublisher;
+
+/// Owns the spawned entitlement-listener event loop and its cancellation handle.
+pub struct EntitlementListener {
+    cancel: CancellationToken,
+    handle: tokio::task::JoinHandle<()>,
+}
+
+impl EntitlementListener {
+    /// Start the entitlement listener. The `parent` span roots the
+    /// `entitlement_listener` child span so its log output carries the version
+    /// field like every other background component.
+    pub fn start(
+        events: &Arc<dyn EventPublisher>,
+        inbound_wg: Arc<dyn InboundWgService>,
+        parent: &tracing::Span,
+    ) -> Self {
+        let cancel = CancellationToken::new();
+        let span = tracing::info_span!(parent: parent, "entitlement_listener");
+        let rx = events.subscribe();
+        let handle = tokio::spawn(event_loop(rx, inbound_wg, cancel.clone()).instrument(span));
+        Self { cancel, handle }
+    }
+
+    /// Cancel the background task and wait for it to finish.
+    pub async fn shutdown(self) {
+        self.cancel.cancel();
+        let _ = self.handle.await;
+        tracing::info!("entitlement listener shut down");
+    }
+}
+
+async fn event_loop(
+    mut rx: tokio::sync::broadcast::Receiver<WardnetEvent>,
+    inbound_wg: Arc<dyn InboundWgService>,
+    cancel: CancellationToken,
+) {
+    loop {
+        tokio::select! {
+            () = cancel.cancelled() => break,
+            result = rx.recv() => {
+                match result {
+                    // The only event this listener cares about: entitlement lost.
+                    Ok(WardnetEvent::EntitlementChanged { entitled: false, .. }) => {
+                        disable_inbound_wg(&*inbound_wg).await;
+                    }
+                    Ok(_) => {}
+                    Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {
+                        tracing::warn!(skipped = n, "entitlement listener: lagged behind event bus: skipped={n}");
+                    }
+                    Err(tokio::sync::broadcast::error::RecvError::Closed) => {
+                        tracing::info!("entitlement listener: event bus closed");
+                        break;
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// Disable the inbound-WireGuard server on entitlement loss, in a nil-admin
+/// context because the service methods are admin-guarded (the same pattern the
+/// zone-enforcement listener uses for background enforcement).
+async fn disable_inbound_wg(inbound_wg: &dyn InboundWgService) {
+    if let Err(e) = wardnetd_services::auth_context::with_context(
+        AuthContext::Admin {
+            admin_id: uuid::Uuid::nil(),
+        },
+        disable_if_enabled(inbound_wg),
+    )
+    .await
+    {
+        tracing::warn!(error = %e, "entitlement listener: disabling inbound WireGuard failed: {e}");
+    }
+}
+
+/// The admin-guarded operation: turn the server off if it is currently on
+/// (an already-off server is a silent no-op). The explicit `Result` return
+/// type is what lets the caller's `with_context` future infer — an inline
+/// `async {}` block there cannot.
+async fn disable_if_enabled(
+    inbound_wg: &dyn InboundWgService,
+) -> Result<(), wardnetd_services::error::AppError> {
+    let config = inbound_wg.get_config().await?;
+    if config.enabled {
+        tracing::warn!("entitlement lost: disabling the inbound WireGuard (Personal VPN) server");
+        inbound_wg.set_config(false, config.listen_port).await?;
+    }
+    Ok(())
+}

--- a/source/daemon/crates/wardnetd/src/lib.rs
+++ b/source/daemon/crates/wardnetd/src/lib.rs
@@ -27,6 +27,7 @@ pub mod tls_server;
 
 // Background tasks.
 pub mod device_detector;
+pub mod entitlement_listener;
 pub mod garp_learning;
 pub mod health_runner;
 pub mod heartbeat;

--- a/source/daemon/crates/wardnetd/src/main.rs
+++ b/source/daemon/crates/wardnetd/src/main.rs
@@ -22,6 +22,7 @@ use tracing_subscriber::util::SubscriberInitExt;
 use wardnet_common::auth::AuthContext;
 use wardnet_common::config::{ApplicationConfiguration, LogFormat, LogRotation, OtelConfig};
 use wardnetd::device_detector::DeviceDetector;
+use wardnetd::entitlement_listener::EntitlementListener;
 use wardnetd::firewall_netlink::NetlinkFirewallManager;
 use wardnetd::garp_pnet::PnetGarpOps;
 use wardnetd::health_runner::HealthMonitorRunner;
@@ -513,6 +514,14 @@ async fn run(
         services.zone_enforcement.clone(),
         &root_span,
     );
+    // Disables the inbound-WireGuard (Personal VPN) server the instant the box
+    // loses entitlement, complementing the request-time gate and the
+    // reconcile-on-restart teardown (issue #266).
+    let entitlement_listener = EntitlementListener::start(
+        &services.event_publisher,
+        services.inbound_wg.clone(),
+        &root_span,
+    );
     let push_listener = PushNotificationListener::start(
         &services.event_publisher,
         services.push.clone(),
@@ -985,6 +994,7 @@ async fn run(
     health_runner.shutdown().await;
     routing_listener.shutdown().await;
     zone_enforcement_listener.shutdown().await;
+    entitlement_listener.shutdown().await;
     push_listener.shutdown().await;
     route_monitor.shutdown().await;
     idle_watcher.shutdown().await;

--- a/source/daemon/crates/wardnetd/src/routing_listener.rs
+++ b/source/daemon/crates/wardnetd/src/routing_listener.rs
@@ -234,6 +234,8 @@ async fn handle_event(event: WardnetEvent, routing: &dyn RoutingService) {
         // push-notification concerns only.
         | WardnetEvent::NewDeviceQuarantined { .. }
         | WardnetEvent::RuleRequestCreated { .. }
+        // Entitlement changes are handled by the dedicated `entitlement_listener`.
+        | WardnetEvent::EntitlementChanged { .. }
         | WardnetEvent::DefaultPolicyChanged { .. } => {}
     }
 }

--- a/source/daemon/crates/wardnetd/src/zone_enforcement_listener.rs
+++ b/source/daemon/crates/wardnetd/src/zone_enforcement_listener.rs
@@ -181,6 +181,8 @@ async fn handle_event(event: WardnetEvent, enforcer: &dyn ZoneEnforcementService
         // Rule requests (#482) likewise only drive an admin push.
         | WardnetEvent::NewDeviceQuarantined { .. }
         | WardnetEvent::RuleRequestCreated { .. }
+        // Entitlement changes are handled by the dedicated `entitlement_listener`.
+        | WardnetEvent::EntitlementChanged { .. }
         | WardnetEvent::DnsEventInserted { .. } => {}
 
         // A cross-zone exception changed — rebuild the L3 isolation state so its


### PR DESCRIPTION
## Summary

Follow-up to #819 (Epic #266): the daemon-side Premium gate for the inbound WireGuard "Personal VPN" feature, which landed ~a minute after #819 squash-merged and so missed that merge.

Personal VPN is Premium. Gated on the shared `Entitlement` handle the DDNS service owns (the same one that gates the premium PWAs), in three layers:

1. **Request-time gate** — `set_config(enable)` and `add_peer` return **403 Forbidden** when the box is not entitled. Disabling is always allowed, so an unentitled box can still turn it off.
2. **Reconcile-on-restart** — `reconcile()` disables an enabled server on startup when entitlement has been lost, so a lapsed box never stands the feature back up across a restart.
3. **Immediate, event-driven teardown** — a new `WardnetEvent::EntitlementChanged` is published by the `Entitlement` handle on every `is_entitled()` edge (premium set/cleared, suspend/restore), and a new `EntitlementListener` (wardnetd) disables a *running* server the instant entitlement is lost, via an admin-context `set_config(false)`. Mirrors the zone-enforcement listener; both exhaustive event matches (routing + zone listeners) updated for the new variant.

The mock now marks its shared `services.entitlement` premium (before the inbound-WG reconcile) rather than a separate handle, so the one instance inbound-WG reads is entitled in local dev.

## Tests

- Service specs: enable-forbidden, add_peer-forbidden, disable-allowed-without-Premium, reconcile-disables-on-loss.
- Entitlement specs: premium/suspend/restore edges publish `EntitlementChanged` correctly; no-publisher is silent.
- `wardnetd-services` (1158) green; clippy + fmt clean on `wardnet-common` / `wardnetd-services` / `wardnetd-api` / `wardnetd-mock`. The `wardnetd` crate is Linux-only (netlink) so its compile is CI-verified; the `EntitlementListener` has no dedicated integration test yet (the event emission it depends on is unit-tested).

## Merge Commit Message

feat(daemon): premium-gate the inbound WireGuard (Personal VPN) feature, with request-time, reconcile, and event-driven teardown

https://claude.ai/code/session_01KHfXeDW28XnY8ovaqqvUG8