### PR TITLE
test(marketing): expect 3 Premium feature cards, not 2

### DIFF
--- a/source/marketing-site/tests/layouts/Features.test.tsx
+++ b/source/marketing-site/tests/layouts/Features.test.tsx
@@ -53,7 +53,7 @@ describe("Features", () => {
 
   it("tags the Premium cards", () => {
     renderFeatures();
-    // Remote access and mobile apps are the two Premium features.
-    expect(screen.getAllByText("Premium")).toHaveLength(2);
+    // Remote access, Personal VPN, and mobile apps are the Premium features.
+    expect(screen.getAllByText("Premium")).toHaveLength(3);
   });
 });


### PR DESCRIPTION
The Personal VPN feature card added to the home-page Features grid (Epic #266, merged in #819) is a third Premium-tagged card, but `tests/layouts/Features.test.tsx` still asserted exactly 2 — so it fails on `main`.

Fix: bump the assertion to 3 and update the comment. Full marketing-site suite is green locally (29 files / 134 tests).

## Merge Commit Message

test(marketing): expect 3 Premium feature cards, not 2

https://claude.ai/code/session_01KHfXeDW28XnY8ovaqqvUG8