### PR TITLE
fix(ddns): point the region catalog at the deployed euc region

### DIFF
--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -567,6 +567,9 @@ else
         echo "=== Upgrade complete ==="
     else
         echo "=== Install complete ==="
-        echo "Web UI: http://${IP:-<host>}:7411"
+        # The admin site (and with it the first-run setup wizard) is mounted at
+        # /admin/ — `/` serves the user PWA, which is not where the operator
+        # needs to land on a fresh install.
+        echo "Setup wizard: http://${IP:-<host>}:7411/admin/"
     fi
 fi

--- a/source/daemon/crates/wardnetd-services/src/cloud/ddns.rs
+++ b/source/daemon/crates/wardnetd-services/src/cloud/ddns.rs
@@ -36,7 +36,7 @@ pub struct DdnsClient {
 
 impl DdnsClient {
     /// Build a client sharing the pooled `http` and pointed at the region's
-    /// gateway `base_url` (e.g. `https://api.use1.wardnet.network`).
+    /// gateway `base_url` (e.g. `https://api.euc.wardnet.network`).
     #[must_use]
     pub fn new(http: reqwest::Client, base_url: String) -> Self {
         Self { http, base_url }

--- a/source/daemon/crates/wardnetd-services/src/cloud/tunneller.rs
+++ b/source/daemon/crates/wardnetd-services/src/cloud/tunneller.rs
@@ -146,7 +146,7 @@ pub struct TunnelerClient {
 
 impl TunnelerClient {
     /// Build a client pointed at the region's gateway `base_url` (e.g.
-    /// `https://api.use1.wardnet.network`). The scheme is rewritten to `ws(s)://`
+    /// `https://api.euc.wardnet.network`). The scheme is rewritten to `ws(s)://`
     /// and [`TUNNEL_PATH`] appended at dial time.
     #[must_use]
     pub fn new(base_url: String) -> Self {

--- a/source/daemon/crates/wardnetd-services/src/ddns/region.rs
+++ b/source/daemon/crates/wardnetd-services/src/ddns/region.rs
@@ -21,8 +21,8 @@
 //! The global gateway (`tenants`) is scope-wide, so it is a single constant
 //! rather than a per-region catalog entry.
 //!
-//! Today only `use1` exists, but the probe-and-pick mechanism is built in from
-//! the start so adding a region is a one-line catalog change.
+//! Today only `euc` (eu-central) is deployed, but the probe-and-pick mechanism
+//! is built in from the start so adding a region is a one-line catalog change.
 
 use std::time::{Duration, Instant};
 
@@ -30,15 +30,15 @@ use std::time::{Duration, Instant};
 /// `tenants` service (enroll / token / availability / networks under prefix-free
 /// `/v1/…`, cloud ADR-0015). One deployment, region-independent.
 ///
-/// FIXME(infra): confirm the daemon-facing gateway FQDN once the gateway
-/// manifest lands in wardnet-infrastructure; ADR-0032's shape is
-/// `api.<slug>.<base>` with the global scope dropping the slug.
+/// Confirmed against wardnet-infrastructure `resources/prd/`: the global scope
+/// drops the region label (ADR-0032's `api.<slug>.<base>` shape), so billing /
+/// identity / tenants all answer here.
 pub const GLOBAL_GATEWAY_URL: &str = "https://api.wardnet.network";
 
 /// One entry in the built-in region catalog.
 #[derive(Debug, Clone)]
 pub struct RegionEndpoint {
-    /// Short region slug, e.g. `use1`. Selects the region and is passed to
+    /// Short region slug, e.g. `euc`. Selects the region and is passed to
     /// `POST /v1/networks` as `region`.
     pub slug: String,
     /// The region's **gateway** base URL (`https://api.<region-slug>…`) — fronts
@@ -62,15 +62,19 @@ impl RegionEndpoint {
 
 /// The built-in catalog. Extend this to add regions.
 ///
-/// FIXME(infra): confirm the regional gateway FQDN against the gateway manifest
-/// once it lands in wardnet-infrastructure (ADR-0032 shape `api.<slug>.<base>`,
-/// region slug `use1`). Kept as data here so confirming it is a one-line change.
+/// The slug is the **wire value**: it is sent verbatim as `region` on
+/// `POST /v1/networks`, where the global `tenants` service checks it against its
+/// `KNOWN_REGIONS` set and 400s on a miss. It is also the gateway's hostname
+/// label (ADR-0032's `api.<slug>.<base>`). Both come from
+/// wardnet-infrastructure `resources/prd/regions.yaml`, which is the single
+/// authority: region `eu-central` carries `slug: euc`, and the deployed
+/// `KNOWN_REGIONS` is `euc`. `eu-central` is the human name — never the slug.
 #[must_use]
 pub fn default_catalog() -> Vec<RegionEndpoint> {
     vec![RegionEndpoint::new(
-        "use1",
-        "https://api.use1.wardnet.network",
-        "http://api.use1.wardnet.network:81/readyz",
+        "euc",
+        "https://api.euc.wardnet.network",
+        "http://api.euc.wardnet.network:81/readyz",
     )]
 }
 


### PR DESCRIPTION
Two first-run fixes found while bringing up a fresh beta box.

## 1. DDNS registration 502s — the region catalog pointed at a region that doesn't exist

`POST /api/ddns/register` failed with **502 Bad Gateway** during the setup wizard.

Not a bug in the DDNS code — it dials regionally, correctly. The catalog just still held the ADR placeholder, and its own comment admitted it:

> `FIXME(infra): confirm the regional gateway FQDN against the gateway manifest once it lands in wardnet-infrastructure (ADR-0032 shape api.<slug>.<base>, region slug use1).`

It never got confirmed. **`api.use1.wardnet.network` has no DNS record at all** — the connection never establishes, the upstream call fails, and `AppError::UpstreamUnavailable` surfaces as a 502.

### Resolved against the authority, not guessed

`wardnet-infrastructure` `resources/prd/regions.yaml` (on `main`) is the single authority:

```yaml
regions:
  eu-central:
    slug: euc
```

and the deployed global tenants service runs with `KNOWN_REGIONS: euc`.

So **`euc` is the wire value** — sent verbatim as `region` on `POST /v1/networks`, where tenants does a set-membership check and 400s on a miss (`tenants/src/service.rs:596-603`) — and it doubles as the gateway's hostname label (`api.<slug>.<base>`). **`eu-central` is the human name and must never be used as the slug.** That distinction is now written into the doc comment so nobody has to re-derive it.

Catalog is now:

| | before | after |
|---|---|---|
| slug (wire value) | `use1` | `euc` |
| gateway | `https://api.use1.wardnet.network` (no DNS) | `https://api.euc.wardnet.network` |
| health | `:81/readyz` | `:81/readyz` |

Verified live — the exact URL `select_best()` probes:

```
http://api.euc.wardnet.network:81/readyz  ->  200  {"cloudflare":"up"}  (~355ms, 3/3)
```

Kept as a list so regions can be added as we grow. Also fixes two stale `api.use1` doc examples in `cloud/{ddns,tunneller}.rs`.

Test fixtures still say `use1` **deliberately** — they're hermetic wiremock tests that construct their own catalog and assert nothing about the real one. `ddns/tests/settings.rs` compares against `default_catalog()` structurally, so it stays green.

## 2. Installer sends the operator to the wrong app

`install.sh` closed with:

```
=== Install complete ===
Web UI: http://192.168.100.2:7411
```

But `/` serves the **user PWA**. The admin site — and with it the **first-run setup wizard** — is mounted at `/admin/` (`wardnetd-api/src/web.rs:19-21`). A fresh installer is dropped on the wrong app with no hint where to go. Now prints:

```
Setup wizard: http://192.168.100.2:7411/admin/
```

## Test plan

- `make check-daemon` — green (fmt + clippy `-D warnings` + workspace tests)
- Regional health endpoint verified live (200, 3/3 probes)
- Cloud contract verified by reading `wardnet-cloud` (`KNOWN_REGIONS` set-membership) and `wardnet-infrastructure` (`regions.yaml`, prd tenants env)

## Merge Commit Message

fix(ddns): point the region catalog at the deployed euc region

The DDNS region catalog held the ADR placeholder `use1`, whose hostname has no DNS record, so first-run DDNS registration surfaced a 502. Point it at the deployed `euc` (eu-central) region, confirmed against wardnet-infrastructure's `regions.yaml` and the tenants service's `KNOWN_REGIONS`, and document that the slug is the wire value sent to the cloud. Also fixes the installer's closing line, which pointed at the user PWA rather than the admin site where the setup wizard lives.

https://claude.ai/code/session_016wT23SWMLwBihgkDxW1soY