### PR TITLE
fix(daemon): stop the Pi blackholing its own IP when a device claims it (#886)

### DIFF
--- a/source/daemon/crates/wardnetd-services/src/device/discovery.rs
+++ b/source/daemon/crates/wardnetd-services/src/device/discovery.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, VecDeque};
 use std::sync::Arc;
 use std::time::Instant;
 
@@ -29,6 +29,30 @@ struct DeviceMemoryState {
     last_ip: String,
     last_seen: Instant,
     gone: bool,
+}
+
+/// How far back the IP-flap detector looks.
+const FLAP_WINDOW: std::time::Duration = std::time::Duration::from_mins(1);
+
+/// How many distinct IPs a single MAC may claim within [`FLAP_WINDOW`] before
+/// its observations stop being trusted.
+///
+/// A real device changes address rarely, and one at a time — a DHCP move is a
+/// single transition. The MAC behind issue #886 claimed four addresses inside
+/// one second: a powerline bridge answering ARP for hosts across its segment.
+/// Three is comfortably above honest churn and well below that.
+const FLAP_MAX_DISTINCT_IPS: usize = 3;
+
+/// Recent distinct IPs claimed by one MAC, for the flap detector (issue #886).
+#[derive(Default)]
+struct IpFlapHistory {
+    /// Distinct IPs seen inside the window, each with the time it was last
+    /// observed. Entries age out, so a MAC that settles becomes trusted again
+    /// on its own.
+    ips: VecDeque<(String, Instant)>,
+    /// Whether the current flapping episode has already been warned about, so a
+    /// storm of observations doesn't become a storm of log lines.
+    warned: bool,
 }
 
 /// Result of processing a device observation.
@@ -169,6 +193,11 @@ pub struct DeviceDiscoveryServiceImpl {
     /// Filters out return traffic from the internet (remote IPs arriving with
     /// the router's MAC on the Ethernet frame).
     lan_subnet: ipnetwork::Ipv4Network,
+    /// Wardnet's own LAN IP. Never a device, whatever ARP says (issue #886).
+    lan_ip: std::net::Ipv4Addr,
+    /// Per-MAC recent distinct-IP history, keyed by MAC. Feeds the flap detector
+    /// that stops trusting a MAC claiming many addresses at once (issue #886).
+    ip_history: Arc<RwLock<HashMap<String, IpFlapHistory>>>,
     state: Arc<RwLock<HashMap<String, DeviceMemoryState>>>,
     /// Per-mac locks serializing the full observe-then-persist sequence for a
     /// single device across the LAN and `WireGuard` observation paths, so their DB
@@ -180,6 +209,7 @@ pub struct DeviceDiscoveryServiceImpl {
 
 impl DeviceDiscoveryServiceImpl {
     /// Create a new discovery service with the given dependencies.
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         devices: Arc<dyn DeviceRepository>,
         zones: Arc<dyn NetworkZoneRepository>,
@@ -188,6 +218,7 @@ impl DeviceDiscoveryServiceImpl {
         events: Arc<dyn EventPublisher>,
         resolver: Arc<dyn HostnameResolver>,
         lan_subnet: ipnetwork::Ipv4Network,
+        lan_ip: std::net::Ipv4Addr,
     ) -> Self {
         Self {
             devices,
@@ -197,9 +228,54 @@ impl DeviceDiscoveryServiceImpl {
             events,
             resolver,
             lan_subnet,
+            lan_ip,
             state: Arc::new(RwLock::new(HashMap::new())),
+            ip_history: Arc::new(RwLock::new(HashMap::new())),
             device_locks: tokio::sync::Mutex::new(HashMap::new()),
         }
+    }
+
+    /// Record `ip` against `mac` and report whether that MAC is currently
+    /// flapping — claiming more than [`FLAP_MAX_DISTINCT_IPS`] distinct
+    /// addresses inside [`FLAP_WINDOW`].
+    ///
+    /// A device changes address rarely and one at a time. A MAC cycling through
+    /// several addresses in seconds is not a device moving — it is something
+    /// answering ARP on behalf of other hosts (the powerline bridge in issue
+    /// #886, which claimed four addresses in one second, one of them the Pi's
+    /// own) or spoofing outright. Either way it is not telling the truth about
+    /// any of those addresses, so we stop believing it until it settles.
+    ///
+    /// Entries age out of the window, so a MAC recovers on its own without any
+    /// operator action.
+    async fn is_flapping(&self, mac: &str, ip: &str) -> bool {
+        let mut history = self.ip_history.write().await;
+        let entry = history.entry(mac.to_owned()).or_default();
+
+        let now = Instant::now();
+        entry.ips.retain(|(_, seen)| now - *seen < FLAP_WINDOW);
+        if let Some((_, seen)) = entry.ips.iter_mut().find(|(known, _)| known == ip) {
+            *seen = now;
+        } else {
+            entry.ips.push_back((ip.to_owned(), now));
+        }
+
+        let flapping = entry.ips.len() > FLAP_MAX_DISTINCT_IPS;
+        if flapping && !entry.warned {
+            entry.warned = true;
+            let claimed: Vec<&str> = entry.ips.iter().map(|(ip, _)| ip.as_str()).collect();
+            tracing::warn!(
+                mac,
+                claimed = ?claimed,
+                window_secs = FLAP_WINDOW.as_secs(),
+                "device discovery: MAC is claiming several IPs at once — ignoring its \
+                 observations until it settles. Something is answering ARP for addresses \
+                 it does not own (issue #886)"
+            );
+        } else if !flapping {
+            entry.warned = false;
+        }
+        flapping
     }
 
     /// Fetch (or lazily create) the per-mac serialization lock. The returned
@@ -502,12 +578,36 @@ impl DeviceDiscoveryService for DeviceDiscoveryServiceImpl {
             return Ok(ObservationResult::Ignored);
         }
 
+        // Our own address is never a device, whatever answers ARP for it. A row
+        // claiming it makes zone enforcement act on the Pi itself — installing a
+        // /32 host route for our own IP that collides with the kernel's local
+        // route and blackholes the box to its entire network (issue #886).
+        if obs
+            .ip
+            .parse::<std::net::Ipv4Addr>()
+            .is_ok_and(|ip| ip == self.lan_ip)
+        {
+            tracing::warn!(
+                mac = %obs.mac,
+                ip = %obs.ip,
+                "device discovery: a device is claiming Wardnet's own LAN IP — refusing to \
+                 record it. This is an address conflict on the LAN (issue #886)"
+            );
+            return Ok(ObservationResult::Ignored);
+        }
+
         // Serialize the full observe-then-persist sequence for this mac against
         // the WireGuard-peer path, so their DB writes can't land out of order
         // relative to their in-memory state transitions (per-mac only — unrelated
         // devices proceed concurrently).
         let mac_lock = self.lock_for_mac(&obs.mac).await;
         let _guard = mac_lock.lock_owned().await;
+
+        // A MAC claiming many addresses at once is not a device moving; believe
+        // none of them until it settles (issue #886).
+        if self.is_flapping(&obs.mac, &obs.ip).await {
+            return Ok(ObservationResult::Ignored);
+        }
 
         // Phase 1: classify the observation via the shared state machine. The
         // LAN path passes `None` for an untracked mac (defer to the DB — it may

--- a/source/daemon/crates/wardnetd-services/src/device/discovery.rs
+++ b/source/daemon/crates/wardnetd-services/src/device/discovery.rs
@@ -268,14 +268,34 @@ impl DeviceDiscoveryServiceImpl {
                 mac,
                 claimed = ?claimed,
                 window_secs = FLAP_WINDOW.as_secs(),
-                "device discovery: MAC is claiming several IPs at once — ignoring its \
-                 observations until it settles. Something is answering ARP for addresses \
-                 it does not own (issue #886)"
+                "device discovery: {mac} claimed {claimed:?} within {window_secs}s — ignoring \
+                 its observations until it settles; something is answering ARP for addresses \
+                 it does not own (issue #886)",
+                claimed = claimed,
+                window_secs = FLAP_WINDOW.as_secs(),
             );
         } else if !flapping {
             entry.warned = false;
         }
         flapping
+    }
+
+    /// Refresh a tracked, present MAC's in-memory `last_seen` without touching
+    /// its IP or the database.
+    ///
+    /// Called for observations we deliberately ignore (own-IP claims, flapping
+    /// MACs): the observation is a lie about the *address*, but it still proves
+    /// the MAC is on the wire. Without this, a persistently-lying MAC stops
+    /// refreshing `last_seen`, the departure sweep marks it gone after the
+    /// timeout, and `DeviceGone` tears down its zone enforcement fail-open
+    /// while the device is still present (issue #886).
+    async fn touch_presence(&self, mac: &str) {
+        let mut state = self.state.write().await;
+        if let Some(entry) = state.get_mut(mac)
+            && !entry.gone
+        {
+            entry.last_seen = Instant::now();
+        }
     }
 
     /// Fetch (or lazily create) the per-mac serialization lock. The returned
@@ -547,7 +567,31 @@ impl DeviceDiscoveryService for DeviceDiscoveryServiceImpl {
         let count = devices.len();
 
         let mut state = self.state.write().await;
-        for device in devices {
+        let mut poisoned: Vec<(Uuid, String, DeviceConnectionMode)> = Vec::new();
+        for mut device in devices {
+            // Repair a row claiming our own LAN IP (written by a pre-fix daemon
+            // — ingest refuses to create one now). Left alone it would be
+            // silently un-enforceable forever while the UI shows it as a normal
+            // device holding the Pi's address (issue #886). Clearing the IP is
+            // truthful: we do not know where this device really is.
+            if device
+                .last_ip
+                .parse::<std::net::Ipv4Addr>()
+                .is_ok_and(|ip| !ip.is_unspecified() && ip == self.lan_ip)
+            {
+                tracing::error!(
+                    device_id = %device.id,
+                    mac = %device.mac,
+                    ip = %device.last_ip,
+                    "device discovery: stored device {mac} claims Wardnet's own LAN IP {ip} — \
+                     clearing its address; it will be re-registered at its real IP on the \
+                     next observation (issue #886)",
+                    mac = device.mac,
+                    ip = device.last_ip,
+                );
+                poisoned.push((device.id, device.mac.clone(), device.connection_mode));
+                device.last_ip = String::new();
+            }
             state.insert(
                 device.mac.clone(),
                 DeviceMemoryState {
@@ -561,6 +605,22 @@ impl DeviceDiscoveryService for DeviceDiscoveryServiceImpl {
         }
         drop(state);
 
+        for (device_id, mac, mode) in poisoned {
+            let now = chrono::Utc::now().to_rfc3339();
+            if let Err(e) = self
+                .devices
+                .update_last_seen_and_ip(&device_id.to_string(), "", &now, mode)
+                .await
+            {
+                tracing::warn!(
+                    error = %e,
+                    device_id = %device_id,
+                    mac = %mac,
+                    "device discovery: failed to clear own-IP device row (issue #886)"
+                );
+            }
+        }
+
         tracing::info!(count, "restored device state from database: count={count}");
         Ok(())
     }
@@ -572,27 +632,10 @@ impl DeviceDiscoveryService for DeviceDiscoveryServiceImpl {
         // Filter out observations from IPs outside the LAN subnet.
         // When the Pi is the gateway, return traffic from the internet arrives
         // with the router's MAC but remote server IPs — ignore those.
-        if let Ok(ip) = obs.ip.parse::<std::net::Ipv4Addr>()
+        let parsed_ip = obs.ip.parse::<std::net::Ipv4Addr>().ok();
+        if let Some(ip) = parsed_ip
             && !self.lan_subnet.contains(ip)
         {
-            return Ok(ObservationResult::Ignored);
-        }
-
-        // Our own address is never a device, whatever answers ARP for it. A row
-        // claiming it makes zone enforcement act on the Pi itself — installing a
-        // /32 host route for our own IP that collides with the kernel's local
-        // route and blackholes the box to its entire network (issue #886).
-        if obs
-            .ip
-            .parse::<std::net::Ipv4Addr>()
-            .is_ok_and(|ip| ip == self.lan_ip)
-        {
-            tracing::warn!(
-                mac = %obs.mac,
-                ip = %obs.ip,
-                "device discovery: a device is claiming Wardnet's own LAN IP — refusing to \
-                 record it. This is an address conflict on the LAN (issue #886)"
-            );
             return Ok(ObservationResult::Ignored);
         }
 
@@ -603,9 +646,34 @@ impl DeviceDiscoveryService for DeviceDiscoveryServiceImpl {
         let mac_lock = self.lock_for_mac(&obs.mac).await;
         let _guard = mac_lock.lock_owned().await;
 
+        // Record the claim in the flap history BEFORE any ignore-branch below:
+        // a claim of our own IP must still count toward the flap threshold —
+        // the #886 incident MAC claimed three real addresses plus the Pi's own,
+        // and dropping the own-IP claim first would leave it forever one short
+        // of the threshold, keeping its lies about the other three trusted.
+        let flapping = self.is_flapping(&obs.mac, &obs.ip).await;
+
+        // Our own address is never a device, whatever answers ARP for it. A row
+        // claiming it makes zone enforcement act on the Pi itself — installing a
+        // /32 host route for our own IP that collides with the kernel's local
+        // route and blackholes the box to its entire network (issue #886).
+        if parsed_ip.is_some_and(|ip| ip == self.lan_ip) {
+            tracing::warn!(
+                mac = %obs.mac,
+                ip = %obs.ip,
+                "device discovery: {mac} is claiming Wardnet's own LAN IP {ip} — refusing to \
+                 record it; this is an address conflict on the LAN (issue #886)",
+                mac = obs.mac,
+                ip = obs.ip,
+            );
+            self.touch_presence(&obs.mac).await;
+            return Ok(ObservationResult::Ignored);
+        }
+
         // A MAC claiming many addresses at once is not a device moving; believe
         // none of them until it settles (issue #886).
-        if self.is_flapping(&obs.mac, &obs.ip).await {
+        if flapping {
+            self.touch_presence(&obs.mac).await;
             return Ok(ObservationResult::Ignored);
         }
 

--- a/source/daemon/crates/wardnetd-services/src/device/tests/discovery.rs
+++ b/source/daemon/crates/wardnetd-services/src/device/tests/discovery.rs
@@ -570,6 +570,7 @@ fn build_harness_with_devices(devices: Vec<Device>) -> TestHarness {
         events.clone(),
         resolver,
         "192.168.1.0/24".parse().unwrap(),
+        std::net::Ipv4Addr::new(192, 168, 1, 1),
     );
 
     TestHarness {
@@ -604,6 +605,7 @@ fn build_harness_with_resolver_and_dhcp(
         events.clone(),
         resolver,
         "192.168.1.0/24".parse().unwrap(),
+        std::net::Ipv4Addr::new(192, 168, 1, 1),
     );
 
     TestHarness {
@@ -1536,5 +1538,128 @@ async fn mark_peer_gone_untracked_is_noop() {
     assert!(
         h.events.published_events().is_empty(),
         "no event when the device was not tracked as present"
+    );
+}
+
+// -- Untrustworthy observations (issue #886) ---------------------------------
+
+/// The daemon's own LAN IP, as configured in the test harness.
+const OWN_LAN_IP: &str = "192.168.1.1";
+
+/// Regression test for #886.
+///
+/// A powerline bridge proxy-ARP'd for the Pi's own address, so discovery
+/// recorded `last_ip = <the Pi's IP>` against that MAC. Zone enforcement then
+/// keyed on that address and blackholed the box to its own network. Discovery
+/// is the first of the two guards: our own address is never a device.
+#[tokio::test]
+async fn observation_claiming_our_own_lan_ip_is_ignored() {
+    let h = build_harness();
+    let obs = sample_observation("aa:bb:cc:dd:ee:02", OWN_LAN_IP);
+
+    let result = h.svc.process_observation(&obs).await.unwrap();
+
+    assert!(
+        matches!(result, ObservationResult::Ignored),
+        "an observation claiming the daemon's own LAN IP must be ignored (#886), \
+         got {result:?}"
+    );
+    assert!(
+        h.repo.inserted.lock().unwrap().is_empty(),
+        "no device row may be created for the daemon's own IP (#886)"
+    );
+    assert!(
+        h.events.published_events().is_empty(),
+        "no discovery event may be published for the daemon's own IP (#886)"
+    );
+}
+
+/// A device that already exists must not be *moved* onto our own address either
+/// — the incident's device flapped onto the Pi's IP from a legitimate one.
+#[tokio::test]
+async fn known_device_flapping_onto_our_own_lan_ip_is_ignored() {
+    let h = build_harness();
+    let mac = "aa:bb:cc:dd:ee:03";
+    h.svc
+        .process_observation(&sample_observation(mac, "192.168.1.40"))
+        .await
+        .unwrap();
+
+    let result = h
+        .svc
+        .process_observation(&sample_observation(mac, OWN_LAN_IP))
+        .await
+        .unwrap();
+
+    assert!(
+        matches!(result, ObservationResult::Ignored),
+        "a known device claiming the daemon's own IP must be ignored (#886), got {result:?}"
+    );
+    let updates = h.repo.last_seen_updates.lock().unwrap();
+    assert!(
+        updates.iter().all(|(_, ip, _, _)| ip != OWN_LAN_IP),
+        "last_ip must never be written as the daemon's own IP (#886): {updates:?}"
+    );
+}
+
+/// Regression test for #886.
+///
+/// The MAC behind the incident claimed four different addresses within a single
+/// second (`.4`, `.22`, `.2`, `.59`) — a powerline bridge answering ARP for
+/// hosts across its segment, not a device changing address. A MAC cycling
+/// through addresses that fast is not telling the truth about any of them, so
+/// its observations stop being trusted until it settles.
+#[tokio::test]
+async fn mac_flapping_across_many_ips_stops_being_trusted() {
+    let h = build_harness();
+    let mac = "aa:bb:cc:dd:ee:04";
+
+    // Establish the device, then flap it across distinct addresses.
+    for ip in ["192.168.1.4", "192.168.1.22", "192.168.1.59"] {
+        h.svc
+            .process_observation(&sample_observation(mac, ip))
+            .await
+            .unwrap();
+    }
+
+    // One address too many, inside the window: the MAC is now untrustworthy.
+    let result = h
+        .svc
+        .process_observation(&sample_observation(mac, "192.168.1.77"))
+        .await
+        .unwrap();
+
+    assert!(
+        matches!(result, ObservationResult::Ignored),
+        "a MAC claiming more distinct IPs than the flap threshold inside the \
+         window must stop being trusted (#886), got {result:?}"
+    );
+    let updates = h.repo.last_seen_updates.lock().unwrap();
+    assert!(
+        updates.iter().all(|(_, ip, _, _)| ip != "192.168.1.77"),
+        "an untrusted flapping MAC must not rewrite last_ip (#886): {updates:?}"
+    );
+}
+
+/// The guard must not punish a device that simply changed address once (a
+/// normal DHCP move) — only one cycling through many.
+#[tokio::test]
+async fn a_device_changing_ip_normally_is_still_trusted() {
+    let h = build_harness();
+    let mac = "aa:bb:cc:dd:ee:05";
+    h.svc
+        .process_observation(&sample_observation(mac, "192.168.1.50"))
+        .await
+        .unwrap();
+
+    let result = h
+        .svc
+        .process_observation(&sample_observation(mac, "192.168.1.51"))
+        .await
+        .unwrap();
+
+    assert!(
+        matches!(result, ObservationResult::IpChanged { .. }),
+        "a single, ordinary IP change must still be honoured, got {result:?}"
     );
 }

--- a/source/daemon/crates/wardnetd-services/src/device/tests/discovery.rs
+++ b/source/daemon/crates/wardnetd-services/src/device/tests/discovery.rs
@@ -1663,3 +1663,102 @@ async fn a_device_changing_ip_normally_is_still_trusted() {
         "a single, ordinary IP change must still be honoured, got {result:?}"
     );
 }
+
+/// Code-review follow-up on #886: a claim of the Pi's own IP must still COUNT
+/// toward the flap threshold. The incident MAC claimed three real addresses
+/// plus the Pi's own inside one second; if the own-IP claim is dropped before
+/// the flap history records it, the MAC stays forever one short of the
+/// threshold and its lies about the three victim IPs keep being trusted.
+#[tokio::test]
+async fn own_ip_claims_count_toward_the_flap_threshold() {
+    let h = build_harness();
+    let mac = "aa:bb:cc:dd:ee:06";
+
+    // The recorded #886 trace: .4, .22, <own IP>, .59 from one MAC.
+    for ip in ["192.168.1.4", "192.168.1.22", OWN_LAN_IP] {
+        h.svc
+            .process_observation(&sample_observation(mac, ip))
+            .await
+            .unwrap();
+    }
+    let result = h
+        .svc
+        .process_observation(&sample_observation(mac, "192.168.1.59"))
+        .await
+        .unwrap();
+
+    assert!(
+        matches!(result, ObservationResult::Ignored),
+        "the fourth distinct claim (own IP counted) must trip the flap \
+         detector (#886), got {result:?}"
+    );
+    let updates = h.repo.last_seen_updates.lock().unwrap();
+    assert!(
+        updates.iter().all(|(_, ip, _, _)| ip != "192.168.1.59"),
+        "the flapping MAC's claim on .59 must not be recorded (#886): {updates:?}"
+    );
+}
+
+/// Code-review follow-up on #886: ignoring a flapping MAC's observations must
+/// not let the departure sweep mark it gone — the claims lie about the address,
+/// but they still prove the MAC is on the wire, and a gone-marking tears down
+/// its zone enforcement fail-open via `DeviceGone` → `remove_device`.
+#[tokio::test]
+async fn flap_ignored_observations_still_count_as_presence() {
+    let h = build_harness();
+    let mac = "aa:bb:cc:dd:ee:07";
+
+    // Register, then trip the flap threshold (4 distinct IPs).
+    for ip in [
+        "192.168.1.61",
+        "192.168.1.62",
+        "192.168.1.63",
+        "192.168.1.64",
+    ] {
+        h.svc
+            .process_observation(&sample_observation(mac, ip))
+            .await
+            .unwrap();
+    }
+
+    // Let more than the departure timeout pass, then observe the (still
+    // flapping) MAC again: the observation is Ignored but must refresh
+    // presence.
+    tokio::time::sleep(std::time::Duration::from_millis(1200)).await;
+    let result = h
+        .svc
+        .process_observation(&sample_observation(mac, "192.168.1.64"))
+        .await
+        .unwrap();
+    assert!(matches!(result, ObservationResult::Ignored));
+
+    let departed = h.svc.scan_departures(1).await.unwrap();
+    assert!(
+        departed.is_empty(),
+        "a flapping-but-present MAC must not be marked gone (#886): {departed:?}"
+    );
+}
+
+/// Code-review follow-up on #886: a device row claiming the Pi's own IP that
+/// survived in an older database is repaired at startup — its address is
+/// cleared (loudly) rather than left to make every zone action on it a silent
+/// no-op forever.
+#[tokio::test]
+async fn restore_devices_repairs_a_row_claiming_our_own_ip() {
+    let poisoned = sample_device(
+        "0a0a0a0a-0000-0000-0000-000000000001",
+        "aa:bb:cc:dd:ee:08",
+        OWN_LAN_IP,
+    );
+    let h = build_harness_with_devices(vec![poisoned]);
+
+    h.svc.restore_devices().await.unwrap();
+
+    let updates = h.repo.last_seen_updates.lock().unwrap();
+    assert!(
+        updates
+            .iter()
+            .any(|(id, ip, _, _)| id == "0a0a0a0a-0000-0000-0000-000000000001" && ip.is_empty()),
+        "the poisoned row's last_ip must be cleared at startup (#886): {updates:?}"
+    );
+}

--- a/source/daemon/crates/wardnetd-services/src/lib.rs
+++ b/source/daemon/crates/wardnetd-services/src/lib.rs
@@ -788,6 +788,7 @@ fn build_discovery_service(
         event_publisher,
         hostname_resolver,
         lan_subnet,
+        lan_ip,
     ))
 }
 

--- a/source/daemon/crates/wardnetd-services/src/zone_enforcement/service.rs
+++ b/source/daemon/crates/wardnetd-services/src/zone_enforcement/service.rs
@@ -181,6 +181,37 @@ impl ZoneEnforcementServiceImpl {
         }
     }
 
+    /// True if `ip` is the daemon's own LAN address — in which case the caller
+    /// must do nothing at all with it.
+    ///
+    /// Enforcement is keyed by device IP, so a device row claiming the Pi's own
+    /// address turns every enforcement action against the Pi itself. That is not
+    /// hypothetical: a powerline bridge proxy-ARP'd for the Pi's IP, discovery
+    /// recorded it as that device's `last_ip`, and moving it into a zone drove a
+    /// `/32` host route for our own address — which collides with the kernel's
+    /// `local` route for ourselves and makes the box blackhole its own IP to
+    /// every client, on every path (issue #886).
+    ///
+    /// Discovery now refuses to record our own IP, but a row can survive in an
+    /// older database and reach us via startup reconcile, so the enforcement
+    /// side refuses it independently. Loud, because it always means the device
+    /// inventory is lying about a real IP conflict on the LAN.
+    fn is_own_lan_ip(&self, ip: &str, op: &str) -> bool {
+        let is_ours = ip
+            .parse::<Ipv4Addr>()
+            .is_ok_and(|parsed| parsed == self.lan_ip);
+        if is_ours {
+            tracing::warn!(
+                ip,
+                op,
+                lan_ip = %self.lan_ip,
+                "zone enforcer: refusing to enforce on the daemon's own LAN IP — \
+                 a device record claims it (issue #886)"
+            );
+        }
+        is_ours
+    }
+
     /// Install a device IP's zone rules. On a live change (`flush = true`) the
     /// device's conntrack is flushed so already-open flows re-evaluate at once;
     /// on bulk reconcile (`flush = false`) it is skipped — the table was just
@@ -191,6 +222,9 @@ impl ZoneEnforcementServiceImpl {
         zone: &NetworkZone,
         flush: bool,
     ) -> Result<(), AppError> {
+        if self.is_own_lan_ip(device_ip, "apply_zone_rules") {
+            return Ok(());
+        }
         let rules = Self::zone_rules(zone);
         self.firewall
             .apply_zone_rules(device_ip, rules, &self.lan_interface)
@@ -432,6 +466,12 @@ impl ZoneEnforcementServiceImpl {
     /// proxy-ARP'd peer traffic can be forwarded/filtered; otherwise the route
     /// is removed. Errors are warn-logged, never fatal.
     async fn manage_host_route(&self, device: &Device, zone: &NetworkZone, dhcp_enabled: bool) {
+        // Never install *or* remove a host route for our own address: the
+        // removal path is what deleted the kernel's local route and locked the
+        // box out of itself (#886).
+        if self.is_own_lan_ip(&device.last_ip, "manage_host_route") {
+            return;
+        }
         let want = dhcp_enabled && zone.member_isolation && zone.subnet.is_some();
         let res = if want {
             self.policy_router
@@ -826,19 +866,25 @@ impl ZoneEnforcementService for ZoneEnforcementServiceImpl {
     ) -> Result<(), AppError> {
         auth_context::require_admin()?;
         tracing::debug!(device_id = %device_id, old_ip, new_ip, "zone enforcer: handle_ip_change");
-        // Drop the stale-IP rules first so they never outlive the device's move.
-        self.firewall
-            .remove_zone_rules(old_ip)
-            .await
-            .map_err(AppError::Internal)?;
-        // The old IP's `/32` host route is no longer valid — drop it before the
-        // new one is (conditionally) installed below.
-        if let Err(e) = self
-            .policy_router
-            .remove_host_route(old_ip, &self.lan_interface)
-            .await
-        {
-            tracing::warn!(error = %e, old_ip, "zone enforcer: failed to remove old-IP host route");
+        // A device flapping off our own address must not drag our own state down
+        // with it: we never enforced on that IP, so there is nothing to tear
+        // down, and tearing down anyway deletes the kernel's local route (#886).
+        // The `new_ip` side is guarded inside apply_one/manage_host_route.
+        if !self.is_own_lan_ip(old_ip, "handle_ip_change/old_ip") {
+            // Drop the stale-IP rules first so they never outlive the device's move.
+            self.firewall
+                .remove_zone_rules(old_ip)
+                .await
+                .map_err(AppError::Internal)?;
+            // The old IP's `/32` host route is no longer valid — drop it before
+            // the new one is (conditionally) installed below.
+            if let Err(e) = self
+                .policy_router
+                .remove_host_route(old_ip, &self.lan_interface)
+                .await
+            {
+                tracing::warn!(error = %e, old_ip, "zone enforcer: failed to remove old-IP host route");
+            }
         }
         if let Some((device, zone)) = self.load_device_and_zone(device_id).await? {
             // Key on the event's new IP rather than the row's `last_ip`, which
@@ -860,16 +906,21 @@ impl ZoneEnforcementService for ZoneEnforcementServiceImpl {
     async fn remove_device(&self, device_id: Uuid, last_ip: &str) -> Result<(), AppError> {
         auth_context::require_admin()?;
         tracing::debug!(device_id = %device_id, last_ip, "zone enforcer: remove_device");
-        self.firewall
-            .remove_zone_rules(last_ip)
-            .await
-            .map_err(AppError::Internal)?;
-        if let Err(e) = self
-            .policy_router
-            .remove_host_route(last_ip, &self.lan_interface)
-            .await
-        {
-            tracing::warn!(error = %e, last_ip, "zone enforcer: failed to remove host route");
+        // Nothing was ever enforced on our own address, so there is nothing to
+        // remove — and removing anyway takes the kernel's local route with it
+        // (#886). Still recompute isolation: the device is gone either way.
+        if !self.is_own_lan_ip(last_ip, "remove_device") {
+            self.firewall
+                .remove_zone_rules(last_ip)
+                .await
+                .map_err(AppError::Internal)?;
+            if let Err(e) = self
+                .policy_router
+                .remove_host_route(last_ip, &self.lan_interface)
+                .await
+            {
+                tracing::warn!(error = %e, last_ip, "zone enforcer: failed to remove host route");
+            }
         }
         self.reconcile_isolation().await?;
         Ok(())
@@ -887,7 +938,13 @@ impl ZoneEnforcementService for ZoneEnforcementServiceImpl {
     async fn handle_zone_change(&self, device_id: Uuid) -> Result<(), AppError> {
         auth_context::require_admin()?;
         tracing::debug!(device_id = %device_id, "zone enforcer: handle_zone_change");
-        if let Some((device, zone)) = self.load_device_and_zone(device_id).await? {
+        if let Some((device, zone)) = self.load_device_and_zone(device_id).await?
+            // A device row claiming our own IP is a lie about the LAN, not a
+            // device to enforce on. Skip the whole per-device sequence — the
+            // conntrack flush would tear down our own live admin sessions and
+            // the host-route path would blackhole us outright (#886).
+            && !self.is_own_lan_ip(&device.last_ip, "handle_zone_change")
+        {
             // Force the device to re-IP into its new zone's subnet: release its
             // DHCP lease and flush its conntrack. There is a brief connectivity
             // blip until the device renews (typically seconds for a cooperating

--- a/source/daemon/crates/wardnetd-services/src/zone_enforcement/service.rs
+++ b/source/daemon/crates/wardnetd-services/src/zone_enforcement/service.rs
@@ -181,35 +181,57 @@ impl ZoneEnforcementServiceImpl {
         }
     }
 
-    /// True if `ip` is the daemon's own LAN address — in which case the caller
-    /// must do nothing at all with it.
+    /// True if `ip` is an address the Pi itself owns — the primary LAN IP or
+    /// any per-zone gateway alias — in which case the caller must do nothing
+    /// at all with it.
     ///
-    /// Enforcement is keyed by device IP, so a device row claiming the Pi's own
-    /// address turns every enforcement action against the Pi itself. That is not
-    /// hypothetical: a powerline bridge proxy-ARP'd for the Pi's IP, discovery
-    /// recorded it as that device's `last_ip`, and moving it into a zone drove a
-    /// `/32` host route for our own address — which collides with the kernel's
-    /// `local` route for ourselves and makes the box blackhole its own IP to
-    /// every client, on every path (issue #886).
+    /// Enforcement is keyed by device IP, so a device row claiming one of the
+    /// Pi's own addresses turns every enforcement action against the Pi itself
+    /// (see the module notes on issue #886: a proxy-ARP'd claim of the LAN IP
+    /// drove a host-route removal that blackholed the box). The gateway aliases
+    /// `reconcile_isolation` installs are just as much ours as the primary
+    /// address — flushing conntrack for one kills every live flow through that
+    /// zone.
     ///
-    /// Discovery now refuses to record our own IP, but a row can survive in an
-    /// older database and reach us via startup reconcile, so the enforcement
-    /// side refuses it independently. Loud, because it always means the device
-    /// inventory is lying about a real IP conflict on the LAN.
-    fn is_own_lan_ip(&self, ip: &str, op: &str) -> bool {
-        let is_ours = ip
-            .parse::<Ipv4Addr>()
-            .is_ok_and(|parsed| parsed == self.lan_ip);
+    /// Discovery refuses to record our own IP, but a row can survive in an
+    /// older database, so enforcement refuses independently. Loud, because it
+    /// always means the device inventory is lying about a real IP conflict.
+    async fn is_own_address(&self, ip: &str, op: &str) -> bool {
+        let Ok(parsed) = ip.parse::<Ipv4Addr>() else {
+            return false;
+        };
+        let is_ours = (!self.lan_ip.is_unspecified() && parsed == self.lan_ip)
+            || self.is_zone_gateway(parsed).await;
         if is_ours {
             tracing::warn!(
                 ip,
                 op,
                 lan_ip = %self.lan_ip,
-                "zone enforcer: refusing to enforce on the daemon's own LAN IP — \
-                 a device record claims it (issue #886)"
+                "zone enforcer: refusing to enforce on {ip} during {op} — it is one of the \
+                 daemon's own addresses and a device record claims it (issue #886)",
+                ip = ip,
+                op = op,
             );
         }
         is_ours
+    }
+
+    /// True if `addr` is the gateway alias of any zone subnet — an address
+    /// `reconcile_isolation` puts on the Pi's own interface. A zones-repository
+    /// failure degrades to `false` (the primary-LAN-IP check above still holds).
+    async fn is_zone_gateway(&self, addr: Ipv4Addr) -> bool {
+        let zones = match self.zones.find_all().await {
+            Ok(zones) => zones,
+            Err(e) => {
+                tracing::warn!(error = %e, "zone enforcer: failed to load zones for own-address check");
+                return false;
+            }
+        };
+        zones
+            .iter()
+            .filter_map(|z| z.subnet.as_ref())
+            .filter_map(|s| s.cidr.parse::<Ipv4Network>().ok())
+            .any(|net| crate::subnet::gateway_for(net) == addr)
     }
 
     /// Install a device IP's zone rules. On a live change (`flush = true`) the
@@ -222,7 +244,7 @@ impl ZoneEnforcementServiceImpl {
         zone: &NetworkZone,
         flush: bool,
     ) -> Result<(), AppError> {
-        if self.is_own_lan_ip(device_ip, "apply_zone_rules") {
+        if self.is_own_address(device_ip, "apply_zone_rules").await {
             return Ok(());
         }
         let rules = Self::zone_rules(zone);
@@ -268,6 +290,26 @@ impl ZoneEnforcementServiceImpl {
             );
             return Ok(None);
         };
+        // Chokepoint for every device-keyed entry point, present and future: a
+        // row without a usable address, or one claiming an address the Pi
+        // itself owns, is not a device to enforce on (issue #886). The
+        // IP-keyed teardown paths (`remove_device`, `handle_ip_change`) carry
+        // their own guards, as do `apply_one`/`manage_host_route` for the
+        // IP-keyed reconcile loop.
+        if device.last_ip.parse::<Ipv4Addr>().is_err() {
+            tracing::debug!(
+                device_id = %device_id,
+                last_ip = %device.last_ip,
+                "zone enforcer: device has no usable IP, skipping"
+            );
+            return Ok(None);
+        }
+        if self
+            .is_own_address(&device.last_ip, "load_device_and_zone")
+            .await
+        {
+            return Ok(None);
+        }
         Ok(Some((device, zone)))
     }
 
@@ -469,7 +511,10 @@ impl ZoneEnforcementServiceImpl {
         // Never install *or* remove a host route for our own address: the
         // removal path is what deleted the kernel's local route and locked the
         // box out of itself (#886).
-        if self.is_own_lan_ip(&device.last_ip, "manage_host_route") {
+        if self
+            .is_own_address(&device.last_ip, "manage_host_route")
+            .await
+        {
             return;
         }
         let want = dhcp_enabled && zone.member_isolation && zone.subnet.is_some();
@@ -746,6 +791,16 @@ impl ZoneEnforcementService for ZoneEnforcementServiceImpl {
         let mut applied = 0u32;
         let mut live_ips: HashSet<String> = HashSet::with_capacity(devices.len());
         for device in &devices {
+            // A repaired own-IP row (issue #886) has an empty `last_ip` until
+            // its next observation — nothing to enforce and nothing to key
+            // rules on.
+            if device.last_ip.parse::<Ipv4Addr>().is_err() {
+                tracing::debug!(
+                    device_id = %device.id,
+                    "zone enforcer: device has no usable IP during reconcile, skipping"
+                );
+                continue;
+            }
             live_ips.insert(device.last_ip.clone());
             let Some(zone) = zone_by_id.get(&device.zone_id) else {
                 tracing::warn!(
@@ -870,7 +925,7 @@ impl ZoneEnforcementService for ZoneEnforcementServiceImpl {
         // with it: we never enforced on that IP, so there is nothing to tear
         // down, and tearing down anyway deletes the kernel's local route (#886).
         // The `new_ip` side is guarded inside apply_one/manage_host_route.
-        if !self.is_own_lan_ip(old_ip, "handle_ip_change/old_ip") {
+        if !self.is_own_address(old_ip, "handle_ip_change/old_ip").await {
             // Drop the stale-IP rules first so they never outlive the device's move.
             self.firewall
                 .remove_zone_rules(old_ip)
@@ -909,7 +964,7 @@ impl ZoneEnforcementService for ZoneEnforcementServiceImpl {
         // Nothing was ever enforced on our own address, so there is nothing to
         // remove — and removing anyway takes the kernel's local route with it
         // (#886). Still recompute isolation: the device is gone either way.
-        if !self.is_own_lan_ip(last_ip, "remove_device") {
+        if !self.is_own_address(last_ip, "remove_device").await {
             self.firewall
                 .remove_zone_rules(last_ip)
                 .await
@@ -938,13 +993,10 @@ impl ZoneEnforcementService for ZoneEnforcementServiceImpl {
     async fn handle_zone_change(&self, device_id: Uuid) -> Result<(), AppError> {
         auth_context::require_admin()?;
         tracing::debug!(device_id = %device_id, "zone enforcer: handle_zone_change");
-        if let Some((device, zone)) = self.load_device_and_zone(device_id).await?
-            // A device row claiming our own IP is a lie about the LAN, not a
-            // device to enforce on. Skip the whole per-device sequence — the
-            // conntrack flush would tear down our own live admin sessions and
-            // the host-route path would blackhole us outright (#886).
-            && !self.is_own_lan_ip(&device.last_ip, "handle_zone_change")
-        {
+        // A row claiming one of the Pi's own addresses is filtered inside
+        // `load_device_and_zone` (#886) — the conntrack flush below would
+        // otherwise tear down our own live admin sessions.
+        if let Some((device, zone)) = self.load_device_and_zone(device_id).await? {
             // Force the device to re-IP into its new zone's subnet: release its
             // DHCP lease and flush its conntrack. There is a brief connectivity
             // blip until the device renews (typically seconds for a cooperating

--- a/source/daemon/crates/wardnetd-services/src/zone_enforcement/tests/service.rs
+++ b/source/daemon/crates/wardnetd-services/src/zone_enforcement/tests/service.rs
@@ -1122,3 +1122,56 @@ async fn handle_ip_change_never_touches_the_daemons_own_ip() {
          or the new address (#886), but it did: {touched:?}"
     );
 }
+
+/// Code-review follow-up on #886: the per-zone gateway aliases are the Pi's own
+/// addresses too. A device row claiming one must be refused exactly like a row
+/// claiming the primary LAN IP — flushing conntrack for a zone gateway kills
+/// every live flow through that zone.
+#[tokio::test]
+async fn handle_zone_change_never_touches_a_zone_gateway_alias() {
+    let h = build().await;
+    enable_dhcp(&h).await;
+    insert_subnet_zone(&h.zones, ZONE_A, "ZoneA", "10.44.1.0/24", false).await;
+    // 10.44.1.1 is ZoneA's gateway alias — an address the Pi itself holds.
+    let dev = insert_device(&h.devices, "10.44.1.1", ZONE_A).await;
+
+    as_admin(h.svc.handle_zone_change(dev)).await.unwrap();
+
+    let touched = calls_mentioning(&h, "10.44.1.1").await;
+    // The isolation rebuild legitimately names the gateway as an alias to
+    // install; only per-device enforcement calls are forbidden.
+    let forbidden: Vec<&String> = touched
+        .iter()
+        .filter(|c| {
+            c.starts_with("apply:")
+                || c.starts_with("remove:")
+                || c.starts_with("flush_conntrack:")
+                || c.contains("host_route")
+        })
+        .collect();
+    assert!(
+        forbidden.is_empty(),
+        "per-device enforcement must never touch a zone gateway alias (#886): {forbidden:?}"
+    );
+}
+
+/// Code-review follow-up on #886: a repaired own-IP row has an empty `last_ip`
+/// until re-observed. Reconcile must skip it cleanly — no rules keyed on an
+/// empty string, no error.
+#[tokio::test]
+async fn reconcile_skips_devices_without_a_usable_ip() {
+    let h = build().await;
+    let _dev = insert_device(&h.devices, "", GUEST).await;
+
+    as_admin(h.svc.reconcile()).await.unwrap();
+
+    let bogus: Vec<String> = calls(&h)
+        .await
+        .into_iter()
+        .filter(|c| c.starts_with("apply::"))
+        .collect();
+    assert!(
+        bogus.is_empty(),
+        "reconcile must not apply rules keyed on an empty IP (#886): {bogus:?}"
+    );
+}

--- a/source/daemon/crates/wardnetd-services/src/zone_enforcement/tests/service.rs
+++ b/source/daemon/crates/wardnetd-services/src/zone_enforcement/tests/service.rs
@@ -1022,3 +1022,103 @@ async fn handle_zone_change_releases_lease_and_flushes_conntrack() {
         "isolation recomputed on zone change"
     );
 }
+
+// -- The daemon's own LAN IP is untouchable (issue #886) ----------------------
+
+/// The Pi's own LAN address, as a device would (wrongly) claim it.
+const OWN_IP: &str = "192.168.1.1";
+
+/// Every kernel-touching call the enforcer made that names `ip`.
+async fn calls_mentioning(h: &Harness, ip: &str) -> Vec<String> {
+    calls(h)
+        .await
+        .into_iter()
+        .chain(policy_calls(h).await)
+        .filter(|c| c.contains(ip))
+        .collect()
+}
+
+/// Regression test for #886.
+///
+/// A discovery bug let a device row claim the Pi's own LAN IP. Moving it into a
+/// zone drove the enforcer to act on that address — culminating in a
+/// `remove_host_route` that deleted the kernel's local route for the Pi's own
+/// address and blackholed the box to every client on every path. The enforcer
+/// must refuse to touch its own address, whatever the database says.
+#[tokio::test]
+async fn handle_zone_change_never_touches_the_daemons_own_ip() {
+    let h = build().await;
+    enable_dhcp(&h).await;
+    insert_subnet_zone(&h.zones, ZONE_A, "Network Devices", "10.100.1.0/24", true).await;
+    let dev = insert_device(&h.devices, OWN_IP, ZONE_A).await;
+
+    as_admin(h.svc.handle_zone_change(dev)).await.unwrap();
+
+    let touched = calls_mentioning(&h, OWN_IP).await;
+    assert!(
+        touched.is_empty(),
+        "the enforcer must never apply rules, host routes or conntrack flushes \
+         to the daemon's own LAN IP (#886), but it did: {touched:?}"
+    );
+}
+
+/// The startup path must not faithfully re-apply the bad state either: a
+/// surviving device row holding our own IP is inert, not re-enforced.
+#[tokio::test]
+async fn reconcile_never_applies_rules_to_the_daemons_own_ip() {
+    let h = build().await;
+    enable_dhcp(&h).await;
+    insert_subnet_zone(&h.zones, ZONE_A, "Network Devices", "10.100.1.0/24", true).await;
+    let _dev = insert_device(&h.devices, OWN_IP, ZONE_A).await;
+
+    as_admin(h.svc.reconcile()).await.unwrap();
+
+    let touched = calls_mentioning(&h, OWN_IP).await;
+    assert!(
+        touched.is_empty(),
+        "startup reconcile must not re-apply enforcement to the daemon's own IP \
+         (#886), but it did: {touched:?}"
+    );
+}
+
+/// Teardown is as dangerous as setup: `remove_device` would delete the host
+/// route for the given IP, which for our own address means the local route.
+#[tokio::test]
+async fn remove_device_never_touches_the_daemons_own_ip() {
+    let h = build().await;
+    let dev = insert_device(&h.devices, OWN_IP, GUEST).await;
+
+    as_admin(h.svc.remove_device(dev, OWN_IP)).await.unwrap();
+
+    let touched = calls_mentioning(&h, OWN_IP).await;
+    assert!(
+        touched.is_empty(),
+        "remove_device must not tear down state for the daemon's own IP (#886), \
+         but it did: {touched:?}"
+    );
+}
+
+/// An IP change *into* or *out of* our own address must be inert on both sides:
+/// the old IP is torn down, the new IP is set up, and neither may be ours.
+#[tokio::test]
+async fn handle_ip_change_never_touches_the_daemons_own_ip() {
+    let h = build().await;
+    enable_dhcp(&h).await;
+    let dev = insert_device(&h.devices, OWN_IP, GUEST).await;
+
+    // A device flapping onto our address...
+    as_admin(h.svc.handle_ip_change(dev, "192.168.1.77", OWN_IP))
+        .await
+        .unwrap();
+    // ...and back off it.
+    as_admin(h.svc.handle_ip_change(dev, OWN_IP, "192.168.1.77"))
+        .await
+        .unwrap();
+
+    let touched = calls_mentioning(&h, OWN_IP).await;
+    assert!(
+        touched.is_empty(),
+        "handle_ip_change must not act on the daemon's own IP as either the old \
+         or the new address (#886), but it did: {touched:?}"
+    );
+}

--- a/source/daemon/crates/wardnetd/src/main.rs
+++ b/source/daemon/crates/wardnetd/src/main.rs
@@ -192,13 +192,27 @@ async fn run(
     )
     .await
     .unwrap_or(std::net::Ipv4Addr::UNSPECIFIED);
-    tracing::info!(
-        lan_ip = %lan_ip,
-        interface = %config.network.lan_interface,
-        "detected LAN IP for DHCP gateway: lan_ip={lan_ip}, interface={iface}",
-        lan_ip = lan_ip,
-        iface = config.network.lan_interface,
-    );
+    if lan_ip.is_unspecified() {
+        // Not fatal (the box may still be acquiring an address and a restart
+        // heals it), but every subsystem keyed on our own address — DHCP
+        // gateway advertisement and the #886 own-IP guards in discovery and
+        // zone enforcement — is degraded until then, so say it loudly.
+        tracing::error!(
+            interface = %config.network.lan_interface,
+            "LAN IP detection timed out on {iface}: running with 0.0.0.0 — DHCP gateway \
+             advertisement is poisoned and the own-address protections (issue #886) are \
+             inactive until the daemon restarts with an address present",
+            iface = config.network.lan_interface,
+        );
+    } else {
+        tracing::info!(
+            lan_ip = %lan_ip,
+            interface = %config.network.lan_interface,
+            "detected LAN IP for DHCP gateway: lan_ip={lan_ip}, interface={iface}",
+            lan_ip = lan_ip,
+            iface = config.network.lan_interface,
+        );
+    }
 
     // Build real network backends (Linux kernel interfaces).
     let executor = Arc::new(wardnetd::command::ShellCommandExecutor);

--- a/source/daemon/crates/wardnetd/src/policy_router_netlink.rs
+++ b/source/daemon/crates/wardnetd/src/policy_router_netlink.rs
@@ -9,19 +9,25 @@ use rtnetlink::packet_route::route::{RouteAddress, RouteAttribute, RouteScope};
 use rtnetlink::packet_route::rule::{RuleAction, RuleAttribute, RuleMessage};
 use rtnetlink::{Handle, RouteMessageBuilder};
 
-use rtnetlink::packet_route::route::RouteMessage;
+use rtnetlink::packet_route::route::{RouteHeader, RouteMessage};
 
 use wardnetd_services::command::{CommandExecutor, CommandOutput};
 use wardnetd_services::routing::policy_router::PolicyRouter;
 
-/// The `main` routing table (`RT_TABLE_MAIN`). `add_host_route` sets no table,
-/// so the kernel files the routes it adds here — and it is therefore the only
-/// table `remove_host_route` may delete from.
-///
-/// The table the kernel owns, and which Wardnet must never touch, is `local`
-/// (255): for every address configured on the box it holds a `scope host` `/32`
-/// route that makes packets to that address deliver locally (issue #886).
-pub(crate) const RT_TABLE_MAIN: u8 = 254;
+/// The routing table a route belongs to. For tables > 255 the number lives in
+/// an attribute; otherwise in the header. The attribute wins so a wide table
+/// can't alias onto a small one. Shared with `route_monitor`, which watches
+/// these same tables for external deletions.
+pub(crate) fn route_table(route: &RouteMessage) -> u32 {
+    route
+        .attributes
+        .iter()
+        .find_map(|a| match a {
+            RouteAttribute::Table(t) => Some(*t),
+            _ => None,
+        })
+        .unwrap_or_else(|| u32::from(route.header.table))
+}
 
 /// Production [`PolicyRouter`] backed by Linux netlink sockets.
 ///
@@ -567,17 +573,10 @@ pub(crate) fn is_removable_host_route(route: &RouteMessage, addr: Ipv4Addr, oif:
     if route.header.scope != RouteScope::Link {
         return false;
     }
-    // For tables > 255 the number lives in an attribute; otherwise in the
-    // header. Read the attribute first so a wide table can't alias onto `main`.
-    let table = route
-        .attributes
-        .iter()
-        .find_map(|a| match a {
-            RouteAttribute::Table(t) => Some(*t),
-            _ => None,
-        })
-        .unwrap_or_else(|| u32::from(route.header.table));
-    if table != u32::from(RT_TABLE_MAIN) {
+    // `add_host_route` sets no table, so the kernel files our routes in `main`.
+    // The kernel's own `local` table (255) — holding the `scope host` `/32`
+    // that delivers each of the box's addresses to itself — must never match.
+    if route_table(route) != u32::from(RouteHeader::RT_TABLE_MAIN) {
         return false;
     }
     let dest_matches = route

--- a/source/daemon/crates/wardnetd/src/policy_router_netlink.rs
+++ b/source/daemon/crates/wardnetd/src/policy_router_netlink.rs
@@ -9,8 +9,19 @@ use rtnetlink::packet_route::route::{RouteAddress, RouteAttribute, RouteScope};
 use rtnetlink::packet_route::rule::{RuleAction, RuleAttribute, RuleMessage};
 use rtnetlink::{Handle, RouteMessageBuilder};
 
+use rtnetlink::packet_route::route::RouteMessage;
+
 use wardnetd_services::command::{CommandExecutor, CommandOutput};
 use wardnetd_services::routing::policy_router::PolicyRouter;
+
+/// The `main` routing table (`RT_TABLE_MAIN`). `add_host_route` sets no table,
+/// so the kernel files the routes it adds here — and it is therefore the only
+/// table `remove_host_route` may delete from.
+///
+/// The table the kernel owns, and which Wardnet must never touch, is `local`
+/// (255): for every address configured on the box it holds a `scope host` `/32`
+/// route that makes packets to that address deliver locally (issue #886).
+pub(crate) const RT_TABLE_MAIN: u8 = 254;
 
 /// Production [`PolicyRouter`] backed by Linux netlink sockets.
 ///
@@ -523,17 +534,7 @@ impl PolicyRouter for NetlinkPolicyRouter {
 
         let mut routes = self.handle.route().get(Self::ipv4_route_filter()).execute();
         while let Some(route) = routes.try_next().await? {
-            if route.header.destination_prefix_length != 32 {
-                continue;
-            }
-            let dest_matches = route.attributes.iter().any(
-                |a| matches!(a, RouteAttribute::Destination(RouteAddress::Inet(d)) if *d == addr),
-            );
-            let oif_matches = route
-                .attributes
-                .iter()
-                .any(|a| matches!(a, RouteAttribute::Oif(o) if *o == index));
-            if dest_matches && oif_matches {
+            if is_removable_host_route(&route, addr, index) {
                 if let Err(e) = self.handle.route().del(route).execute().await {
                     anyhow::bail!("failed to remove host route {ip}/32 dev {interface}: {e}");
                 }
@@ -543,4 +544,49 @@ impl PolicyRouter for NetlinkPolicyRouter {
         tracing::debug!(ip, interface, "host route not present, nothing to remove");
         Ok(())
     }
+}
+
+/// True if `route` is a host route that [`PolicyRouter::add_host_route`] itself
+/// could have installed for `addr` out of link index `oif` — i.e. one
+/// [`PolicyRouter::remove_host_route`] is allowed to delete.
+///
+/// The table and scope checks are load-bearing, not cosmetic. For every address
+/// configured on this box the kernel keeps a route in the `local` table that is
+/// ALSO a `/32` with the same destination and output interface — it is what
+/// makes packets addressed to us deliver to us. Matching on destination + oif
+/// alone therefore matches the kernel's local route, and deleting it makes the
+/// box blackhole its own address: it keeps answering ARP, but every packet to
+/// it is forwarded rather than delivered, and it replies `ICMP destination host
+/// unreachable` from its own IP. Restricting removal to what we add (table
+/// `main`, `scope link`) is what keeps a device row that claims our own IP from
+/// locking the admin out of the box entirely (issue #886).
+pub(crate) fn is_removable_host_route(route: &RouteMessage, addr: Ipv4Addr, oif: u32) -> bool {
+    if route.header.destination_prefix_length != 32 {
+        return false;
+    }
+    if route.header.scope != RouteScope::Link {
+        return false;
+    }
+    // For tables > 255 the number lives in an attribute; otherwise in the
+    // header. Read the attribute first so a wide table can't alias onto `main`.
+    let table = route
+        .attributes
+        .iter()
+        .find_map(|a| match a {
+            RouteAttribute::Table(t) => Some(*t),
+            _ => None,
+        })
+        .unwrap_or_else(|| u32::from(route.header.table));
+    if table != u32::from(RT_TABLE_MAIN) {
+        return false;
+    }
+    let dest_matches = route
+        .attributes
+        .iter()
+        .any(|a| matches!(a, RouteAttribute::Destination(RouteAddress::Inet(d)) if *d == addr));
+    let oif_matches = route
+        .attributes
+        .iter()
+        .any(|a| matches!(a, RouteAttribute::Oif(o) if *o == oif));
+    dest_matches && oif_matches
 }

--- a/source/daemon/crates/wardnetd/src/route_monitor.rs
+++ b/source/daemon/crates/wardnetd/src/route_monitor.rs
@@ -4,7 +4,6 @@ use futures::StreamExt;
 use rtnetlink::MulticastGroup;
 use rtnetlink::packet_core::NetlinkPayload;
 use rtnetlink::packet_route::RouteNetlinkMessage;
-use rtnetlink::packet_route::route::RouteAttribute;
 use tokio_util::sync::CancellationToken;
 use tracing::Instrument;
 use wardnet_common::event::WardnetEvent;
@@ -85,19 +84,7 @@ fn handle_message(payload: RouteNetlinkMessage, events: &dyn EventPublisher) {
         return;
     };
 
-    // Extract the table number. For tables > 255 the value is in an attribute;
-    // for smaller tables it's in the header.
-    let table = route
-        .attributes
-        .iter()
-        .find_map(|a| {
-            if let RouteAttribute::Table(t) = a {
-                Some(*t)
-            } else {
-                None
-            }
-        })
-        .unwrap_or(u32::from(route.header.table));
+    let table = crate::policy_router_netlink::route_table(&route);
 
     if table < WARDNET_MIN_TABLE {
         return;

--- a/source/daemon/crates/wardnetd/src/tests/mod.rs
+++ b/source/daemon/crates/wardnetd/src/tests/mod.rs
@@ -9,6 +9,7 @@ mod mdns_advertiser;
 mod metrics_collector;
 mod packet_capture;
 mod pidfile;
+mod policy_router_netlink;
 mod profiling;
 mod routing_listener;
 pub mod stubs;

--- a/source/daemon/crates/wardnetd/src/tests/policy_router_netlink.rs
+++ b/source/daemon/crates/wardnetd/src/tests/policy_router_netlink.rs
@@ -1,0 +1,116 @@
+//! Host-independent tests for the netlink policy router's pure helpers.
+//!
+//! The rtnetlink socket calls have no mockable boundary (they need a real
+//! kernel) and are exercised by the e2e harness. What we CAN test here is the
+//! predicate deciding which kernel routes `remove_host_route` is allowed to
+//! delete — the one that locked a live Pi out of its own network (#886).
+
+use std::net::Ipv4Addr;
+
+use rtnetlink::packet_route::AddressFamily;
+use rtnetlink::packet_route::route::{
+    RouteAddress, RouteAttribute, RouteHeader, RouteMessage, RouteScope, RouteType,
+};
+
+use crate::policy_router_netlink::{RT_TABLE_MAIN, is_removable_host_route};
+
+/// The kernel-owned `local` table (`RT_TABLE_LOCAL`), which holds the `scope
+/// host` route delivering each of the box's own addresses to itself. Production
+/// code never names it — it may only ever write to `main` — so it lives here,
+/// where we assert we keep our hands off it (issue #886).
+const RT_TABLE_LOCAL: u8 = 255;
+
+const OIF: u32 = 2;
+const LAN_IP: Ipv4Addr = Ipv4Addr::new(192, 168, 100, 2);
+const DEVICE_IP: Ipv4Addr = Ipv4Addr::new(192, 168, 100, 50);
+
+/// A `/32` route for `addr` out of [`OIF`], in `table` with `scope`/`kind` —
+/// the fields that distinguish the kernel's own `local` route from ours.
+fn host_route(addr: Ipv4Addr, table: u8, scope: RouteScope, kind: RouteType) -> RouteMessage {
+    let mut msg = RouteMessage::default();
+    msg.header = RouteHeader {
+        address_family: AddressFamily::Inet,
+        destination_prefix_length: 32,
+        table,
+        scope,
+        kind,
+        ..RouteHeader::default()
+    };
+    msg.attributes = vec![
+        RouteAttribute::Destination(RouteAddress::Inet(addr)),
+        RouteAttribute::Oif(OIF),
+        RouteAttribute::Table(u32::from(table)),
+    ];
+    msg
+}
+
+/// What `add_host_route` installs: table `main`, scope `link`, unicast.
+fn our_host_route(addr: Ipv4Addr) -> RouteMessage {
+    host_route(addr, RT_TABLE_MAIN, RouteScope::Link, RouteType::Unicast)
+}
+
+/// The kernel's own route making an address on this box deliver locally:
+/// table `local` (255), scope `host`, type `local`.
+fn kernel_local_route(addr: Ipv4Addr) -> RouteMessage {
+    host_route(addr, RT_TABLE_LOCAL, RouteScope::Host, RouteType::Local)
+}
+
+/// Regression test for #886.
+///
+/// `remove_host_route` used to match on `/32` + destination + oif alone, and
+/// the kernel's `local` route for an address on this box matches all three. A
+/// device row holding the daemon's own LAN IP therefore made it delete the
+/// route that delivers its own address to itself: the Pi kept answering ARP but
+/// blackholed every packet to it, replying `ICMP destination host unreachable`
+/// sourced from its own address. Total admin lockout over every path, only
+/// cleared by a reboot (which re-creates local routes on address assignment).
+#[test]
+fn kernel_local_route_for_our_own_ip_is_never_removable() {
+    assert!(
+        !is_removable_host_route(&kernel_local_route(LAN_IP), LAN_IP, OIF),
+        "the kernel's local-table route for the daemon's own IP must never be \
+         treated as a removable host route (#886)"
+    );
+}
+
+/// The same protection for any address on the box, not just the LAN IP.
+#[test]
+fn kernel_local_route_is_never_removable_for_any_address() {
+    assert!(!is_removable_host_route(
+        &kernel_local_route(DEVICE_IP),
+        DEVICE_IP,
+        OIF
+    ));
+}
+
+#[test]
+fn our_own_host_route_is_removable() {
+    assert!(is_removable_host_route(
+        &our_host_route(DEVICE_IP),
+        DEVICE_IP,
+        OIF
+    ));
+}
+
+#[test]
+fn host_route_for_a_different_ip_or_interface_is_not_removable() {
+    assert!(
+        !is_removable_host_route(
+            &our_host_route(DEVICE_IP),
+            Ipv4Addr::new(192, 168, 100, 51),
+            OIF
+        ),
+        "must not match a different destination"
+    );
+    assert!(
+        !is_removable_host_route(&our_host_route(DEVICE_IP), DEVICE_IP, OIF + 1),
+        "must not match a different output interface"
+    );
+}
+
+#[test]
+fn non_host_prefix_is_not_removable() {
+    let mut route = our_host_route(DEVICE_IP);
+    route.header.destination_prefix_length = 24;
+    assert!(!is_removable_host_route(&route, DEVICE_IP, OIF));
+}

--- a/source/daemon/crates/wardnetd/src/tests/policy_router_netlink.rs
+++ b/source/daemon/crates/wardnetd/src/tests/policy_router_netlink.rs
@@ -12,13 +12,15 @@ use rtnetlink::packet_route::route::{
     RouteAddress, RouteAttribute, RouteHeader, RouteMessage, RouteScope, RouteType,
 };
 
-use crate::policy_router_netlink::{RT_TABLE_MAIN, is_removable_host_route};
+use crate::policy_router_netlink::is_removable_host_route;
 
-/// The kernel-owned `local` table (`RT_TABLE_LOCAL`), which holds the `scope
-/// host` route delivering each of the box's own addresses to itself. Production
-/// code never names it — it may only ever write to `main` — so it lives here,
-/// where we assert we keep our hands off it (issue #886).
-const RT_TABLE_LOCAL: u8 = 255;
+/// `main` (254) is where `add_host_route` files our routes; `local` (255) is
+/// the kernel-owned table holding the `scope host` route that delivers each of
+/// the box's own addresses to itself — production code must never touch it
+/// (issue #886). netlink-packet-route exports no `RT_TABLE_LOCAL`, so libc is
+/// the canonical source for that one.
+const RT_TABLE_MAIN: u8 = RouteHeader::RT_TABLE_MAIN;
+const RT_TABLE_LOCAL: u8 = libc::RT_TABLE_LOCAL;
 
 const OIF: u32 = 2;
 const LAN_IP: Ipv4Addr = Ipv4Addr::new(192, 168, 100, 2);


### PR DESCRIPTION
Closes #886.

## The mechanism, demonstrated

The earlier root cause on the issue (the `/32` host route hijacking the Pi's IP) was wrong, and the "firewall rules did it" theory is ruled out by the reboot: the box came back reachable with the bad zone and bad device row still in the database, and startup reconcile re-applies nftables rules for every device — including the one holding the Pi's IP. So the rules cannot be the cause.

**`remove_host_route()` deleted the kernel's `local`-table route for the daemon's own address.**

That route — `local 192.168.100.2 dev eth0 table local proto kernel scope host` — is what makes Linux deliver packets addressed to the Pi *to the Pi*. `remove_host_route()` dumped **every** IPv4 route in **every** table (`RouteMessageBuilder::new().build()` — an unfiltered dump) and deleted the first `/32` matching destination + oif. The kernel's local route matches all three.

The chain, each link evidenced from the box:

1. **Trigger** (daemon log, 05:20:41.140): the device detector flapped MAC `8c:86:dd:3d:0f:96` through `.4 → .22 → .2 → .59 → .2` several times in one second, repeatedly setting `last_ip = 192.168.100.2`.
2. **Remove branch**: the zone had `member_isolation = 0` (confirmed in the preserved DB), so `manage_host_route()`'s `want` was **false** → it called `remove_host_route()` on `192.168.100.2` — despite no host route ever having been added.
3. **The bug**: unfiltered route dump → the kernel's local route for our own IP matched → deleted.
4. **The kernel's receipt** (log, 05:20:41.171): the daemon's own route monitor logged it — `WARN detected route deletion in wardnet-managed table, table=255`. Table 255 *is* the `local` table; the monitor's `>= 100` threshold caught it incidentally. It is the only route deletion at the moment of lockout.
5. **Symptom, reproduced** in network namespaces on the Pi itself: delete only that route → address still assigned, ARP still answered, but 100% loss and `Destination Host Unreachable` **sourced from the box's own IP** — the packet now takes the *forwarding* path, next hop is itself, neighbour resolution fails, and the box emits the unreachable. This matches every field observation, including the "ARP resolves but nothing connects" paradox.
6. **Why a reboot fixed it with the bad DB intact**: boot re-creates local routes when addresses are assigned. Startup reconcile re-applies nftables rules and isolation chains but **never calls `manage_host_route()`** — host routes are only touched on event paths. The harmless rules came back; the fatal deletion did not.

## How the device came to hold the Pi's IP

Not an ingest bug and not a fabricated record: the TL-WPA7517 powerline bridge genuinely answers ARP for addresses it doesn't own — the log shows its MAC claiming `.4`, `.22`, `.59` and `.2` within one second. Discovery recorded real (but untrustworthy) ARP replies.

## The fix — three independent guards

Any **one** of these would have prevented the lockout; all three are here because they fail differently.

1. **`remove_host_route()` only deletes what `add_host_route()` installs** — table `main` (254), `scope link`. The kernel's `local` table is off-limits. This is the actual lockout fix.
2. **Zone enforcement refuses to act on the daemon's own LAN IP** — no zone rules, no host routes, no conntrack flush — at every entry point (`apply_one`, `manage_host_route`, `handle_zone_change`, `handle_ip_change` on both the old and new address, `remove_device`, and startup `reconcile`). A bad row surviving in an older database is now **inert rather than faithfully re-applied**.
3. **Device discovery never records our own LAN IP as a device**, and **stops trusting a MAC that claims more than 3 distinct IPs within a minute** — that is something answering ARP for addresses it does not own, not a device moving. History entries age out, so a MAC recovers on its own with no operator action.

## Tests

Written test-first; each failed against the unfixed code for the right reason before the fix went in.

- `crates/wardnetd/src/tests/policy_router_netlink.rs` (new) — the route-matching predicate, extracted for testability. `kernel_local_route_for_our_own_ip_is_never_removable` is the direct regression guard; controls confirm we still remove our own host routes.
- `zone_enforcement/tests/service.rs` — 4 tests asserting no kernel-touching call ever names the daemon's own IP, across zone change / reconcile / remove / IP change. Before the fix these failed with a verbatim record of the incident: `add_host_route:192.168.1.1`, `remove_host_route:192.168.1.1`, `flush_conntrack:192.168.1.1`.
- `device/tests/discovery.rs` — own-IP observations ignored (new and known devices); flapping MAC untrusted; **plus a control test that an ordinary single DHCP IP change is still honoured**, so the guard isn't over-broad.

`make check-daemon` (fmt + clippy `-D warnings` + full workspace suite) green: ~2,290 tests, 0 failures.

## Still open, deliberately not in this PR

The issue's remaining asks are policy/UX rather than this defect, and are better sized separately: surfacing a LAN IP conflict as a **red-alert** (this PR only warns in the log); the **dead-man's switch** (provisional enforcement with auto-revert unless re-confirmed); refusing a zone assignment that would isolate the gateway or the admin's own device; and documenting the recovery path alongside #864's uninstall.

## Merge Commit Message

fix(daemon): stop the Pi blackholing its own IP when a device claims it (#886)

https://claude.ai/code/session_016wT23SWMLwBihgkDxW1soY