### PR TITLE
fix: update pending-version reconcile, silent Send code button, and 12h TLS retry stall

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -24287,11 +24287,23 @@
         "type": "object",
         "description": "Response for GET /api/dns/filter/config.",
         "required": [
-          "config"
+          "config",
+          "filters_ready",
+          "pending_blocklists"
         ],
         "properties": {
           "config": {
             "$ref": "#/components/schemas/DnsFilterConfig"
+          },
+          "filters_ready": {
+            "type": "boolean",
+            "description": "Whether the filters are actually being enforced right now.\n\nThe DNS server answers queries as soon as it binds, but the compiled\nfilters are built in the background — and after an upgrade that resets\nthe blocklist cache, the lists have to be re-downloaded before they can\nblock anything. During either window DNS resolves normally and\nblocklists are **not** enforced, which is a fail-open the admin has to\nbe able to see. `false` means exactly that."
+          },
+          "pending_blocklists": {
+            "type": "integer",
+            "format": "int32",
+            "description": "How many enabled blocklists have never been imported, i.e. are empty and\nenforcing nothing until their first download completes.",
+            "minimum": 0
           }
         }
       },

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -27736,6 +27736,21 @@
           "rollback_available"
         ],
         "properties": {
+          "applied_at": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "date-time",
+            "description": "When `applied_version` was observed running. Clients dedupe their\n\"updated to vX\" notification on this timestamp."
+          },
+          "applied_version": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Version the daemon most recently *finished* applying across a restart.\n\nSet by the startup reconcile when `pending_version` matched the running\nbinary. The UI polls status and has no event channel, so this (paired\nwith `applied_at`) is how a browser learns an update landed."
+          },
           "auto_update_enabled": {
             "type": "boolean",
             "description": "Whether auto-update is enabled."
@@ -27780,7 +27795,7 @@
               "string",
               "null"
             ],
-            "description": "Version the in-flight install is targeting (if any)."
+            "description": "Version the in-flight install is targeting (if any).\n\nCleared by the startup reconcile once the daemon comes back up on the\nnew binary — a pending version that outlives the restart would other-\nwise be reported forever."
           },
           "rollback_available": {
             "type": "boolean",

--- a/source/admin-site/src/lib/wardnet-enrollment.ts
+++ b/source/admin-site/src/lib/wardnet-enrollment.ts
@@ -8,6 +8,28 @@ import {
 } from "@wardnet/web";
 import { isValidName, suggestName } from "@/lib/suggestName";
 
+/**
+ * A client-side input problem, as opposed to a transport or server failure.
+ * Callers' `describeError` surfaces `message` verbatim; anything else it does
+ * not recognise is reported as "couldn't reach the daemon", which would be a
+ * lie here — we never left the browser.
+ */
+export class EnrollmentValidationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "EnrollmentValidationError";
+  }
+}
+
+/**
+ * Deliberately permissive — the tenants service is authoritative on what a
+ * deliverable address is. This only catches the obviously-unsendable so the
+ * user gets an instant answer instead of a round trip.
+ */
+function isValidEmail(value: string): boolean {
+  return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value);
+}
+
 export type Provider = "wardnet" | "cloudflare";
 
 /**
@@ -151,8 +173,20 @@ export function useWardnetEnrollment(opts: {
 
   async function sendCode() {
     clearError();
+    // Validate here rather than by disabling the button: a disabled button
+    // gives a user with an empty or malformed email no feedback at all — the
+    // click is simply swallowed. Report the problem instead.
+    const trimmed = email.trim();
+    if (!isValidEmail(trimmed)) {
+      onError(
+        new EnrollmentValidationError(
+          "Enter the email address for your Wardnet account.",
+        ),
+      );
+      return;
+    }
     try {
-      await requestCode.mutateAsync({ email });
+      await requestCode.mutateAsync({ email: trimmed });
       setWardnetStep("code");
     } catch (err) {
       onError(err);

--- a/source/admin-site/src/lib/wardnet-enrollment.ts
+++ b/source/admin-site/src/lib/wardnet-enrollment.ts
@@ -22,12 +22,16 @@ export class EnrollmentValidationError extends Error {
 }
 
 /**
- * Deliberately permissive — the tenants service is authoritative on what a
- * deliverable address is. This only catches the obviously-unsendable so the
- * user gets an instant answer instead of a round trip.
+ * Deliberately permissive, and deliberately identical to the daemon's own check
+ * (`DdnsService::request_enrollment_code`): non-empty, and contains an `@`. The
+ * tenants service is authoritative on what is actually deliverable.
+ *
+ * Being *stricter* than the server here would recreate the bug this guard was
+ * added to fix — the client silently deciding an address is unusable when the
+ * server would have accepted it (`user@localhost` has no dot in the domain).
  */
 function isValidEmail(value: string): boolean {
-  return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value);
+  return value.length > 0 && value.includes("@");
 }
 
 export type Provider = "wardnet" | "cloudflare";

--- a/source/admin-site/src/pages/DnsFilter.tsx
+++ b/source/admin-site/src/pages/DnsFilter.tsx
@@ -12,6 +12,7 @@ import { PageHeader } from "@/components/compound/PageHeader";
 import { EmptyStatePlaceholder } from "@/components/compound/EmptyStatePlaceholder";
 import { DnsFilterSettingsCard } from "@/components/features/DnsFilterSettingsCard";
 import {
+  DnsFilterNotReadyNotice,
   useAllowlist,
   useBlocklists,
   useDnsFilterConfig,
@@ -183,6 +184,8 @@ export default function DnsFilter() {
           ) : undefined
         }
       />
+
+      <DnsFilterNotReadyNotice />
 
       <DnsFilterSettingsCard />
 

--- a/source/admin-site/src/pages/RemoteAccess.tsx
+++ b/source/admin-site/src/pages/RemoteAccess.tsx
@@ -32,7 +32,11 @@ import {
   ProviderOption,
   WardnetFields,
 } from "@/components/features/wardnet-enrollment";
-import { useWardnetEnrollment, type Provider } from "@/lib/wardnet-enrollment";
+import {
+  EnrollmentValidationError,
+  useWardnetEnrollment,
+  type Provider,
+} from "@/lib/wardnet-enrollment";
 import { suggestName } from "@/lib/suggestName";
 
 /**
@@ -63,6 +67,7 @@ export default function RemoteAccess() {
   const [removeOpen, setRemoveOpen] = useState(false);
 
   function describeError(err: unknown): string {
+    if (err instanceof EnrollmentValidationError) return err.message;
     if (err instanceof WardnetApiError) return err.body.error;
     return "Couldn't reach the daemon. Please try again.";
   }
@@ -210,10 +215,7 @@ export default function RemoteAccess() {
       )}
       {provider === "wardnet" ? (
         wardnetStep === "email" ? (
-          <Button
-            onClick={enrollment.sendCode}
-            disabled={pending.sendCode || !email.includes("@")}
-          >
+          <Button onClick={enrollment.sendCode} disabled={pending.sendCode}>
             {pending.sendCode ? "Sending…" : "Send code"}
           </Button>
         ) : wardnetStep === "code" ? (

--- a/source/admin-site/src/pages/setup/StepRemoteAccess.tsx
+++ b/source/admin-site/src/pages/setup/StepRemoteAccess.tsx
@@ -10,6 +10,7 @@ import {
   WardnetFields,
 } from "@/components/features/wardnet-enrollment";
 import {
+  EnrollmentValidationError,
   useWardnetEnrollment,
   type WardnetStep,
 } from "@/lib/wardnet-enrollment";
@@ -43,6 +44,7 @@ export default function StepRemoteAccess() {
   const [upstreamDown, setUpstreamDown] = useState(false);
 
   function describeError(err: unknown): string {
+    if (err instanceof EnrollmentValidationError) return err.message;
     if (err instanceof WardnetApiError) return err.body.error;
     return "Couldn't reach the daemon. You can skip and set this up later from Settings.";
   }
@@ -275,7 +277,6 @@ export default function StepRemoteAccess() {
             sending={pending.sendCode}
             verifying={pending.verify}
             registering={pending.register}
-            emailValid={email.includes("@")}
             codeValid={code.trim().length > 0}
             onSendCode={enrollment.sendCode}
             onVerifyCode={enrollment.verifyCode}
@@ -304,7 +305,6 @@ function WardnetActions({
   sending,
   verifying,
   registering,
-  emailValid,
   codeValid,
   onSendCode,
   onVerifyCode,
@@ -315,19 +315,17 @@ function WardnetActions({
   sending: boolean;
   verifying: boolean;
   registering: boolean;
-  emailValid: boolean;
   codeValid: boolean;
   onSendCode: () => void;
   onVerifyCode: () => void;
   onRegister: () => void;
 }) {
   if (step === "email") {
+    // Not gated on email validity: `sendCode` validates and reports the
+    // problem, so an empty address gets an explanation rather than a dead
+    // button.
     return (
-      <Button
-        onClick={onSendCode}
-        disabled={sending || !emailValid}
-        className="w-full"
-      >
+      <Button onClick={onSendCode} disabled={sending} className="w-full">
         {sending ? "Sending…" : "Send code"}
       </Button>
     );

--- a/source/admin-site/tests/lib/wardnet-enrollment.test.ts
+++ b/source/admin-site/tests/lib/wardnet-enrollment.test.ts
@@ -113,6 +113,28 @@ describe("useWardnetEnrollment", () => {
     },
   );
 
+  // The client guard must not be STRICTER than the daemon (non-empty + "@"),
+  // or it recreates the bug it was added to fix: silently refusing an address
+  // the server would have accepted.
+  it.each([["no dot in the domain", "admin@localhost"]])(
+    "accepts an address the daemon would accept (%s)",
+    async (_label, value) => {
+      const { view, onError } = setup();
+
+      await act(async () => {
+        view.result.current.setEmail(value);
+      });
+      await act(async () => {
+        await view.result.current.sendCode();
+      });
+
+      expect(onError).not.toHaveBeenCalled();
+      expect(hoisted.requestCode.mutateAsync).toHaveBeenCalledWith({
+        email: value,
+      });
+    },
+  );
+
   it("trims the email before sending it", async () => {
     const { view } = setup();
 

--- a/source/admin-site/tests/lib/wardnet-enrollment.test.ts
+++ b/source/admin-site/tests/lib/wardnet-enrollment.test.ts
@@ -23,7 +23,10 @@ vi.mock("@wardnet/web", () => ({
   useCheckDdnsSlug: () => hoisted.checkSlug,
 }));
 
-import { useWardnetEnrollment } from "@/lib/wardnet-enrollment";
+import {
+  EnrollmentValidationError,
+  useWardnetEnrollment,
+} from "@/lib/wardnet-enrollment";
 
 function setup() {
   const onProvisioned = vi.fn();
@@ -74,6 +77,55 @@ describe("useWardnetEnrollment", () => {
       slug: "happy-newton",
     });
     expect(onProvisioned).toHaveBeenCalled();
+  });
+
+  // Regression: the Send code button used to be disabled while the email was
+  // empty/malformed, so clicking it did nothing at all — no request, no error,
+  // no feedback. `sendCode` must now reject the input itself and say why.
+  it.each([
+    ["empty", ""],
+    ["missing an @", "not-an-email"],
+    ["whitespace only", "   "],
+  ])("reports an invalid email (%s) instead of silently doing nothing", async (
+    _label,
+    value,
+  ) => {
+    const { view, onError } = setup();
+
+    await act(async () => {
+      view.result.current.setEmail(value);
+    });
+    await act(async () => {
+      await view.result.current.sendCode();
+    });
+
+    // No request left the browser...
+    expect(hoisted.requestCode.mutateAsync).not.toHaveBeenCalled();
+    // ...and the user was told why, rather than nothing happening.
+    expect(onError).toHaveBeenCalledWith(
+      expect.any(EnrollmentValidationError),
+    );
+    expect(onError.mock.calls[0][0]).toHaveProperty(
+      "message",
+      "Enter the email address for your Wardnet account.",
+    );
+    // Still on the email step — we never advanced.
+    expect(view.result.current.wardnetStep).toBe("email");
+  });
+
+  it("trims the email before sending it", async () => {
+    const { view } = setup();
+
+    await act(async () => {
+      view.result.current.setEmail("  me@example.com  ");
+    });
+    await act(async () => {
+      await view.result.current.sendCode();
+    });
+
+    expect(hoisted.requestCode.mutateAsync).toHaveBeenCalledWith({
+      email: "me@example.com",
+    });
   });
 
   it("reports errors from each action via onError", async () => {

--- a/source/admin-site/tests/lib/wardnet-enrollment.test.ts
+++ b/source/admin-site/tests/lib/wardnet-enrollment.test.ts
@@ -86,32 +86,32 @@ describe("useWardnetEnrollment", () => {
     ["empty", ""],
     ["missing an @", "not-an-email"],
     ["whitespace only", "   "],
-  ])("reports an invalid email (%s) instead of silently doing nothing", async (
-    _label,
-    value,
-  ) => {
-    const { view, onError } = setup();
+  ])(
+    "reports an invalid email (%s) instead of silently doing nothing",
+    async (_label, value) => {
+      const { view, onError } = setup();
 
-    await act(async () => {
-      view.result.current.setEmail(value);
-    });
-    await act(async () => {
-      await view.result.current.sendCode();
-    });
+      await act(async () => {
+        view.result.current.setEmail(value);
+      });
+      await act(async () => {
+        await view.result.current.sendCode();
+      });
 
-    // No request left the browser...
-    expect(hoisted.requestCode.mutateAsync).not.toHaveBeenCalled();
-    // ...and the user was told why, rather than nothing happening.
-    expect(onError).toHaveBeenCalledWith(
-      expect.any(EnrollmentValidationError),
-    );
-    expect(onError.mock.calls[0][0]).toHaveProperty(
-      "message",
-      "Enter the email address for your Wardnet account.",
-    );
-    // Still on the email step — we never advanced.
-    expect(view.result.current.wardnetStep).toBe("email");
-  });
+      // No request left the browser...
+      expect(hoisted.requestCode.mutateAsync).not.toHaveBeenCalled();
+      // ...and the user was told why, rather than nothing happening.
+      expect(onError).toHaveBeenCalledWith(
+        expect.any(EnrollmentValidationError),
+      );
+      expect(onError.mock.calls[0][0]).toHaveProperty(
+        "message",
+        "Enter the email address for your Wardnet account.",
+      );
+      // Still on the email step — we never advanced.
+      expect(view.result.current.wardnetStep).toBe("email");
+    },
+  );
 
   it("trims the email before sending it", async () => {
     const { view } = setup();

--- a/source/admin-site/tests/pages/RemoteAccess.test.tsx
+++ b/source/admin-site/tests/pages/RemoteAccess.test.tsx
@@ -39,9 +39,17 @@ vi.mock("@wardnet/ui", async (importOriginal) => {
   return { ...actual, toast };
 });
 
-vi.mock("@/lib/wardnet-enrollment", () => ({
-  useWardnetEnrollment,
-}));
+// `EnrollmentValidationError` is a real class, not a stub: the page's
+// `describeError` does an `instanceof` against it, which throws if the mock
+// leaves it undefined.
+vi.mock("@/lib/wardnet-enrollment", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@/lib/wardnet-enrollment")>();
+  return {
+    EnrollmentValidationError: actual.EnrollmentValidationError,
+    useWardnetEnrollment,
+  };
+});
 
 vi.mock("@/components/compound/PageHeader", () => ({
   PageHeader: ({ title }: any) => <h1>{title}</h1>,

--- a/source/admin-site/tests/pages/setup/StepRemoteAccess.test.tsx
+++ b/source/admin-site/tests/pages/setup/StepRemoteAccess.test.tsx
@@ -16,7 +16,16 @@ vi.mock("@wardnet/web", async (importOriginal) => {
 const { useWardnetEnrollment } = vi.hoisted(() => ({
   useWardnetEnrollment: vi.fn(),
 }));
-vi.mock("@/lib/wardnet-enrollment", () => ({ useWardnetEnrollment }));
+// `EnrollmentValidationError` must be the real class — `describeError` does an
+// `instanceof` against it and would throw on an undefined mock export.
+vi.mock("@/lib/wardnet-enrollment", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@/lib/wardnet-enrollment")>();
+  return {
+    EnrollmentValidationError: actual.EnrollmentValidationError,
+    useWardnetEnrollment,
+  };
+});
 
 vi.mock("@/components/features/RemoteAccessProgress", () => ({
   RemoteAccessProgress: ({ status }: { status: { phase?: string } }) => (

--- a/source/daemon/crates/wardnet-common/src/api.rs
+++ b/source/daemon/crates/wardnet-common/src/api.rs
@@ -1409,6 +1409,20 @@ pub struct ListDeviceFilterSettingsParams {
 #[derive(Debug, Serialize, Deserialize, utoipa::ToSchema)]
 pub struct DnsFilterConfigResponse {
     pub config: DnsFilterConfig,
+
+    /// Whether the filters are actually being enforced right now.
+    ///
+    /// The DNS server answers queries as soon as it binds, but the compiled
+    /// filters are built in the background — and after an upgrade that resets
+    /// the blocklist cache, the lists have to be re-downloaded before they can
+    /// block anything. During either window DNS resolves normally and
+    /// blocklists are **not** enforced, which is a fail-open the admin has to
+    /// be able to see. `false` means exactly that.
+    pub filters_ready: bool,
+
+    /// How many enabled blocklists have never been imported, i.e. are empty and
+    /// enforcing nothing until their first download completes.
+    pub pending_blocklists: u32,
 }
 
 /// Request body for PUT /api/dns/filter/config.

--- a/source/daemon/crates/wardnet-common/src/update.rs
+++ b/source/daemon/crates/wardnet-common/src/update.rs
@@ -159,7 +159,20 @@ pub struct UpdateStatus {
     /// Current install phase.
     pub install_phase: InstallPhase,
     /// Version the in-flight install is targeting (if any).
+    ///
+    /// Cleared by the startup reconcile once the daemon comes back up on the
+    /// new binary — a pending version that outlives the restart would other-
+    /// wise be reported forever.
     pub pending_version: Option<String>,
+    /// Version the daemon most recently *finished* applying across a restart.
+    ///
+    /// Set by the startup reconcile when `pending_version` matched the running
+    /// binary. The UI polls status and has no event channel, so this (paired
+    /// with `applied_at`) is how a browser learns an update landed.
+    pub applied_version: Option<String>,
+    /// When `applied_version` was observed running. Clients dedupe their
+    /// "updated to vX" notification on this timestamp.
+    pub applied_at: Option<DateTime<Utc>>,
     /// Whether a `.old` binary is present that could be rolled back to.
     pub rollback_available: bool,
 }

--- a/source/daemon/crates/wardnetd-api/src/api/tests/dns_filter.rs
+++ b/source/daemon/crates/wardnetd-api/src/api/tests/dns_filter.rs
@@ -358,6 +358,8 @@ impl DnsFilterService for MockDnsFilterService {
                 enabled: true,
                 default_profile_ids: vec![PROFILE_ID],
             },
+            filters_ready: true,
+            pending_blocklists: 0,
         })
     }
     async fn update_filter_config(
@@ -369,6 +371,8 @@ impl DnsFilterService for MockDnsFilterService {
                 enabled: true,
                 default_profile_ids: vec![PROFILE_ID],
             },
+            filters_ready: true,
+            pending_blocklists: 0,
         })
     }
     async fn rebuild_blocklist_filter(&self, _id: Uuid) -> Result<(), AppError> {

--- a/source/daemon/crates/wardnetd-api/src/tests/stubs.rs
+++ b/source/daemon/crates/wardnetd-api/src/tests/stubs.rs
@@ -1139,6 +1139,10 @@ impl wardnetd_services::BackupService for StubBackupService {
 pub struct StubUpdateService;
 #[async_trait]
 impl wardnetd_services::UpdateService for StubUpdateService {
+    async fn reconcile_pending_install(&self) -> Result<(), AppError> {
+        unimplemented!("startup-only path; the API layer never calls it")
+    }
+
     async fn status(&self) -> Result<wardnet_common::api::UpdateStatusResponse, AppError> {
         unimplemented!()
     }

--- a/source/daemon/crates/wardnetd-data/migrations/20260713000000_dns_filter_blocklist_generation.sql
+++ b/source/daemon/crates/wardnetd-data/migrations/20260713000000_dns_filter_blocklist_generation.sql
@@ -1,0 +1,74 @@
+-- Generation-based blocklist imports.
+--
+-- `replace_blocklist_domains` used to DELETE every row for a blocklist and
+-- re-INSERT the new set inside a single transaction. That kept the daemon's
+-- *sole* write connection (WRITE_MAX_CONNECTIONS = 1) busy for the whole
+-- import. A threat-intel feed such as HaGeZi TIF is ~1.9M domains, so the
+-- writer was monopolised for minutes and every other writer in the process
+-- (stats flush, DHCP leases, DNS query log, heartbeat) failed with
+-- "pool timed out while waiting for an open connection". Health then went
+-- DOWN, the soft watchdog withheld sd_notify(WATCHDOG=1), and systemd
+-- SIGABRT'd the daemon mid-import.
+--
+-- The fix streams the new domains in small, independently-committed batches so
+-- the writer is released between them. To keep the swap atomic despite the
+-- batching, rows carry a `generation` and each blocklist names the generation
+-- readers should see. An import writes generation N+1 in the background, flips
+-- `active_generation` in one tiny transaction, then reclaims the superseded
+-- rows in batches. Readers only ever see the fully written generation.
+--
+-- `generation` MUST be part of the primary key: a refresh re-imports a list
+-- that overlaps almost entirely with its previous contents, so the new
+-- generation is written while the old one is still present. Under the old
+-- `PRIMARY KEY (domain, blocklist_id)` every real refresh would die with
+-- "UNIQUE constraint failed".
+--
+-- The table is therefore recreated rather than altered (SQLite cannot change a
+-- primary key in place) — and it is recreated EMPTY.
+--
+-- Copying the existing rows across would work, but it costs ~49s of blocked
+-- startup on a Pi holding 2M domains (measured), and migrations run before
+-- READY=1, so that is 49s during which the whole gateway serves no DNS or DHCP
+-- and systemd's start timeout is ticking. It also scales with the user's lists,
+-- so a heavier setup fares worse.
+--
+-- `dns_filter_blocked_domains` is a *cache* of remote lists, not user data:
+-- every row is reconstructible by re-downloading the source URL. So the rows
+-- are dropped and each blocklist is marked never-imported (`last_updated =
+-- NULL`, `entry_count = 0`), which the DNS filter runner treats as due, and it
+-- re-imports them in the background through the new non-starving batched path.
+-- Startup stays fast; the lists refill without blocking anything.
+--
+-- The cost is honest and must stay visible: for a few minutes after this
+-- upgrade the blocklists are empty and therefore not enforced. The daemon
+-- reports `filters_ready = false` while any enabled list is still unimported,
+-- and the admin UI shows a warning banner until it flips.
+
+ALTER TABLE dns_filter_blocklists
+    ADD COLUMN active_generation INTEGER NOT NULL DEFAULT 0;
+
+DROP TABLE dns_filter_blocked_domains;
+
+CREATE TABLE dns_filter_blocked_domains (
+    domain       TEXT NOT NULL,
+    blocklist_id TEXT NOT NULL REFERENCES dns_filter_blocklists(id) ON DELETE CASCADE,
+    generation   INTEGER NOT NULL DEFAULT 0,
+    PRIMARY KEY (domain, blocklist_id, generation)
+);
+
+-- Only the covering index the read path needs. A standalone index on (domain)
+-- used to exist; it is redundant now that `domain` is the leading column of the
+-- primary key's index (SQLite serves `WHERE domain = ?` from
+-- sqlite_autoindex_..._1 just as well), and no query filters on domain alone —
+-- domain matching happens in the in-memory DnsFilter, not in SQL. Recreating it
+-- would cost a third B-tree write on every one of the ~1.9M rows of each
+-- import, for nothing.
+CREATE INDEX IF NOT EXISTS idx_dns_filter_blocked_domains_blocklist_gen_domain
+    ON dns_filter_blocked_domains(blocklist_id, generation, domain);
+
+-- Mark every list never-imported so the runner's cron check treats it as due
+-- (`last_updated: None => true`) and refills it on the next tick.
+UPDATE dns_filter_blocklists
+   SET entry_count = 0,
+       last_updated = NULL,
+       active_generation = 0;

--- a/source/daemon/crates/wardnetd-data/src/repository/dns_filter.rs
+++ b/source/daemon/crates/wardnetd-data/src/repository/dns_filter.rs
@@ -15,11 +15,17 @@ use uuid::Uuid;
 use wardnet_common::dns::{AllowlistEntry, Blocklist, CustomFilterRule};
 use wardnet_common::dns_filter::{DeviceDnsFilterSettings, DnsFilterConfig, DnsFilterProfile};
 
-/// Inputs needed to compile a single profile's `DnsFilter`.
+/// Inputs needed to compile a profile's *auxiliary* `DnsFilter` — the one
+/// holding its allowlist and custom rules.
+///
+/// Blocked domains are deliberately absent. A profile's blocklists are each
+/// compiled into their own `DnsFilter`, and the runtime profile composes
+/// `Arc<ArcSwap<DnsFilter>>` handles to them, so the domains are never copied
+/// per profile. Loading them here would mean selecting millions of rows (a
+/// threat-intel feed is ~1.9M domains) only to drop them on the floor — which
+/// is exactly what this struct used to do.
 #[derive(Debug, Clone, Default)]
 pub struct ProfileFilterInputs {
-    /// Deduplicated, lowercased domains from this profile's enabled blocklists.
-    pub blocked_domains: Vec<String>,
     /// Allowlist domains for this profile.
     pub allowlist: Vec<String>,
     /// Raw rule text from this profile's enabled custom rules.
@@ -122,6 +128,10 @@ pub trait DnsFilterRepository: Send + Sync {
     async fn delete_blocklist(&self, id: Uuid) -> anyhow::Result<bool>;
     async fn replace_blocklist_domains(&self, id: Uuid, domains: &[String]) -> anyhow::Result<u64>;
     async fn set_blocklist_error(&self, id: Uuid, error: Option<&str>) -> anyhow::Result<()>;
+    /// Enabled blocklists that have never completed an import (`last_updated IS
+    /// NULL`) — they are empty, so they enforce nothing. Non-zero means DNS
+    /// filtering is currently failing open for those lists.
+    async fn count_unimported_blocklists(&self) -> anyhow::Result<u64>;
 
     // ── Profile-scoped allowlist ────────────────────────────────────────
 

--- a/source/daemon/crates/wardnetd-data/src/repository/sqlite/dns_filter.rs
+++ b/source/daemon/crates/wardnetd-data/src/repository/sqlite/dns_filter.rs
@@ -38,6 +38,97 @@ pub struct SqliteDnsFilterRepository {
     pools: DbPools,
 }
 
+/// Rows written per `INSERT` statement. Bounded by `SQLite`'s bind-variable
+/// limit (3 binds per row here).
+const INSERT_CHUNK_ROWS: usize = 500;
+
+/// Rows per import transaction. The sole write connection is held for one
+/// batch and then released, so this is the granularity at which every other
+/// writer in the daemon gets a turn — it bounds how long DHCP, stats or a
+/// health probe can be stuck behind an import. A Pi sustains ~145k rows/sec
+/// on SD, so 2k rows is a hold of tens of milliseconds; the ~950 extra
+/// commits a 1.9M-domain feed costs are cheap under WAL + synchronous=NORMAL
+/// (no fsync per commit).
+const IMPORT_BATCH_ROWS: usize = 2_000;
+
+/// Rows per cleanup transaction when reclaiming a superseded generation.
+const DELETE_BATCH_ROWS: i64 = 2_000;
+
+/// How many times `delete_profile` re-reads and drains its blocklists before
+/// giving up and letting the cascade handle the remainder.
+const DRAIN_MAX_PASSES: u32 = 5;
+
+/// Which of a blocklist's domain rows [`delete_domains_in_batches`] should
+/// remove.
+#[derive(Clone, Copy)]
+enum DomainScope {
+    /// Every row, whatever its generation — used before dropping the blocklist.
+    All,
+    /// One specific generation — clears debris left at the generation we are
+    /// about to write.
+    Generation(i64),
+    /// Everything the given generation supersedes. Note this is "all except",
+    /// not "the previous one": a daemon killed between the flip and the cleanup
+    /// leaves an orphaned generation that nothing else would ever reclaim.
+    AllExcept(i64),
+}
+
+impl DomainScope {
+    /// SQL predicate appended to the `WHERE blocklist_id = ?` filter, plus the
+    /// generation it binds (if any). Kept together so the clause and its bind
+    /// can never drift apart.
+    fn predicate(self) -> (&'static str, Option<i64>) {
+        match self {
+            Self::All => ("", None),
+            Self::Generation(g) => ("AND generation = ?", Some(g)),
+            Self::AllExcept(g) => ("AND generation <> ?", Some(g)),
+        }
+    }
+}
+
+/// Delete a blocklist's domains a bounded chunk per transaction, so the sole
+/// write connection is never held for long.
+///
+/// Draining is what makes deletion safe: `blocklist_id` is `ON DELETE CASCADE`,
+/// so dropping a blocklist row with millions of domains still attached would
+/// make `SQLite` delete them all inside one implicit transaction — the same
+/// writer monopolisation the batched import exists to avoid.
+///
+/// Returns the number of rows removed.
+async fn delete_domains_in_batches(
+    pool: &SqlitePool,
+    blocklist_id: &str,
+    scope: DomainScope,
+) -> anyhow::Result<u64> {
+    let (predicate, generation) = scope.predicate();
+    let sql = format!(
+        "DELETE FROM dns_filter_blocked_domains \
+         WHERE rowid IN ( \
+             SELECT rowid FROM dns_filter_blocked_domains \
+             WHERE blocklist_id = ? {predicate} LIMIT ? \
+         )"
+    );
+
+    let mut removed = 0_u64;
+    loop {
+        let mut q = sqlx::query(sqlx::AssertSqlSafe(sql.clone())).bind(blocklist_id);
+        if let Some(g) = generation {
+            q = q.bind(g);
+        }
+        let affected = q
+            .bind(DELETE_BATCH_ROWS)
+            .execute(pool)
+            .await?
+            .rows_affected();
+
+        removed += affected;
+        if affected == 0 {
+            return Ok(removed);
+        }
+        tokio::task::yield_now().await;
+    }
+}
+
 impl SqliteDnsFilterRepository {
     #[must_use]
     pub fn new(pool: SqlitePool) -> Self {
@@ -250,6 +341,51 @@ impl DnsFilterRepository for SqliteDnsFilterRepository {
 
     async fn delete_profile(&self, id: Uuid) -> anyhow::Result<bool> {
         let id_str = id.to_string();
+
+        // Deleting a profile cascades into its blocklists, which cascade into
+        // their domains. Drain those in batches first, for the same reason
+        // `delete_blocklist` does — but only for a profile we can actually
+        // delete, so a rejected builtin isn't stripped of its domains.
+        let deletable: Option<String> =
+            sqlx::query_scalar("SELECT id FROM dns_filter_profiles WHERE id = ? AND builtin = 0")
+                .bind(&id_str)
+                .fetch_optional(&self.pools.read)
+                .await?;
+        if deletable.is_none() {
+            return Ok(false);
+        }
+
+        // Re-read the blocklist set each pass: one taken up-front would miss a
+        // blocklist created (or freshly imported into) while we drain, and its
+        // domains would then cascade away in one implicit transaction — the
+        // starvation we are here to avoid. Converges once a pass removes
+        // nothing; bounded so a caller hammering this profile cannot spin us
+        // forever.
+        for pass in 0..DRAIN_MAX_PASSES {
+            let blocklist_ids: Vec<String> =
+                sqlx::query_scalar("SELECT id FROM dns_filter_blocklists WHERE profile_id = ?")
+                    .bind(&id_str)
+                    .fetch_all(&self.pools.read)
+                    .await?;
+
+            let mut removed = 0_u64;
+            for bl in &blocklist_ids {
+                removed +=
+                    delete_domains_in_batches(&self.pools.write, bl, DomainScope::All).await?;
+            }
+            if removed == 0 {
+                break;
+            }
+            if pass + 1 == DRAIN_MAX_PASSES {
+                tracing::warn!(
+                    profile_id = %id,
+                    passes = DRAIN_MAX_PASSES,
+                    "profile still gaining blocklist domains while draining; deleting anyway — \
+                     the cascade may briefly hold the write connection"
+                );
+            }
+        }
+
         let result = sqlx::query("DELETE FROM dns_filter_profiles WHERE id = ? AND builtin = 0")
             .bind(&id_str)
             .execute(&self.pools.write)
@@ -355,6 +491,12 @@ impl DnsFilterRepository for SqliteDnsFilterRepository {
 
     async fn delete_blocklist(&self, id: Uuid) -> anyhow::Result<bool> {
         let id_str = id.to_string();
+
+        // Drain the domains first. Left attached, the ON DELETE CASCADE would
+        // drop millions of rows in one implicit transaction and monopolise the
+        // sole writer — see `delete_domains_in_batches`.
+        delete_domains_in_batches(&self.pools.write, &id_str, DomainScope::All).await?;
+
         let result = sqlx::query("DELETE FROM dns_filter_blocklists WHERE id = ?")
             .bind(&id_str)
             .execute(&self.pools.write)
@@ -365,41 +507,105 @@ impl DnsFilterRepository for SqliteDnsFilterRepository {
     async fn replace_blocklist_domains(&self, id: Uuid, domains: &[String]) -> anyhow::Result<u64> {
         let id_str = id.to_string();
         let now = now_iso();
+
+        // Dedupe defensively. `(domain, blocklist_id, generation)` is the
+        // primary key, so a repeated domain in the caller's slice would abort
+        // the whole import — and `entry_count` must reflect rows actually
+        // stored, not the caller's slice length.
+        let domains: Vec<&String> = {
+            let mut seen = std::collections::HashSet::with_capacity(domains.len());
+            domains.iter().filter(|d| seen.insert(*d)).collect()
+        };
         let count = domains.len() as u64;
 
-        let mut tx = self.pools.write.begin().await?;
+        // Read the generation readers are currently pinned to; we build the
+        // next one alongside it.
+        let active: i64 =
+            sqlx::query_scalar("SELECT active_generation FROM dns_filter_blocklists WHERE id = ?")
+                .bind(&id_str)
+                .fetch_optional(&self.pools.read)
+                .await?
+                .ok_or_else(|| anyhow::anyhow!("blocklist {id} not found"))?;
+        let next = active.wrapping_add(1);
 
-        sqlx::query("DELETE FROM dns_filter_blocked_domains WHERE blocklist_id = ?")
-            .bind(&id_str)
-            .execute(&mut *tx)
+        // Clear any debris a previously-interrupted import left behind at this
+        // generation (the daemon can be killed mid-import).
+        delete_domains_in_batches(&self.pools.write, &id_str, DomainScope::Generation(next))
             .await?;
 
-        for chunk in domains.chunks(500) {
-            let placeholders: Vec<&str> = chunk.iter().map(|_| "(?, ?)").collect();
-            let sql = format!(
-                "INSERT INTO dns_filter_blocked_domains (domain, blocklist_id) VALUES {}",
-                placeholders.join(", ")
-            );
-            let mut q = sqlx::query(sqlx::AssertSqlSafe(sql));
-            for d in chunk {
-                q = q.bind(d).bind(&id_str);
+        // Write the new generation in independently-committed batches. Each
+        // batch takes the sole write connection, holds it for a few hundred
+        // rows, then hands it back — so DHCP, stats, the query log and the
+        // health probes all keep making progress while a 1.9M-domain feed
+        // imports. Readers still see `active`, so a partial generation is
+        // invisible to them.
+        for batch in domains.chunks(IMPORT_BATCH_ROWS) {
+            let mut tx = self.pools.write.begin().await?;
+            for chunk in batch.chunks(INSERT_CHUNK_ROWS) {
+                let placeholders: Vec<&str> = chunk.iter().map(|_| "(?, ?, ?)").collect();
+                let sql = format!(
+                    "INSERT INTO dns_filter_blocked_domains (domain, blocklist_id, generation) \
+                     VALUES {}",
+                    placeholders.join(", ")
+                );
+                let mut q = sqlx::query(sqlx::AssertSqlSafe(sql));
+                for d in chunk {
+                    q = q.bind(d).bind(&id_str).bind(next);
+                }
+                q.execute(&mut *tx).await?;
             }
-            q.execute(&mut *tx).await?;
+            tx.commit().await?;
+
+            // Give any writer queued behind us a turn before we re-acquire.
+            tokio::task::yield_now().await;
         }
 
+        // The swap itself: one tiny transaction. Readers move from the old
+        // generation to the new one atomically.
         sqlx::query(
-            "UPDATE dns_filter_blocklists SET entry_count = ?, last_updated = ?, \
-             last_error = NULL, last_error_at = NULL, updated_at = ? WHERE id = ?",
+            "UPDATE dns_filter_blocklists SET active_generation = ?, entry_count = ?, \
+             last_updated = ?, last_error = NULL, last_error_at = NULL, updated_at = ? \
+             WHERE id = ?",
         )
+        .bind(next)
         .bind(count.cast_signed())
         .bind(&now)
         .bind(&now)
         .bind(&id_str)
-        .execute(&mut *tx)
+        .execute(&self.pools.write)
         .await?;
 
-        tx.commit().await?;
+        // Reclaim every superseded row. Batched for the same reason as the
+        // insert: a 1.9M-row DELETE would hold the writer just as long as the
+        // import used to. `AllExcept` rather than the single previous
+        // generation, so a generation orphaned by a crash between an earlier
+        // flip and its cleanup is reclaimed here instead of leaking forever.
+        // Best-effort — the rows are already invisible to readers, and the next
+        // import sweeps whatever is left.
+        if let Err(e) =
+            delete_domains_in_batches(&self.pools.write, &id_str, DomainScope::AllExcept(next))
+                .await
+        {
+            tracing::warn!(
+                blocklist_id = %id,
+                active_generation = next,
+                error = %e,
+                "failed to reclaim superseded blocklist generations; rows are invisible to \
+                 readers and will be cleaned up by the next import"
+            );
+        }
+
         Ok(count)
+    }
+
+    async fn count_unimported_blocklists(&self) -> anyhow::Result<u64> {
+        let count: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM dns_filter_blocklists \
+             WHERE enabled = 1 AND last_updated IS NULL",
+        )
+        .fetch_one(&self.pools.read)
+        .await?;
+        Ok(count.cast_unsigned())
     }
 
     async fn set_blocklist_error(&self, id: Uuid, error: Option<&str>) -> anyhow::Result<()> {
@@ -572,16 +778,9 @@ impl DnsFilterRepository for SqliteDnsFilterRepository {
     ) -> anyhow::Result<ProfileFilterInputs> {
         let pid = profile_id.to_string();
 
-        let blocked: Vec<String> = sqlx::query_scalar(
-            "SELECT DISTINCT bd.domain \
-             FROM dns_filter_blocked_domains bd \
-             JOIN dns_filter_blocklists bl ON bd.blocklist_id = bl.id \
-             WHERE bl.profile_id = ? AND bl.enabled = 1",
-        )
-        .bind(&pid)
-        .fetch_all(&self.pools.read)
-        .await?;
-
+        // No blocked-domain query here on purpose: the runtime profile
+        // references each blocklist's compiled filter directly. See
+        // `ProfileFilterInputs`.
         let allow: Vec<String> =
             sqlx::query_scalar("SELECT domain FROM dns_filter_allowlist WHERE profile_id = ?")
                 .bind(&pid)
@@ -597,7 +796,6 @@ impl DnsFilterRepository for SqliteDnsFilterRepository {
         .await?;
 
         Ok(ProfileFilterInputs {
-            blocked_domains: blocked,
             allowlist: allow,
             custom_rules: rules,
         })
@@ -606,7 +804,11 @@ impl DnsFilterRepository for SqliteDnsFilterRepository {
     async fn load_blocklist_domains(&self, blocklist_id: Uuid) -> anyhow::Result<Vec<String>> {
         let id = blocklist_id.to_string();
         let domains: Vec<String> = sqlx::query_scalar(
-            "SELECT domain FROM dns_filter_blocked_domains WHERE blocklist_id = ?",
+            "SELECT bd.domain \
+             FROM dns_filter_blocked_domains bd \
+             JOIN dns_filter_blocklists bl \
+               ON bd.blocklist_id = bl.id AND bd.generation = bl.active_generation \
+             WHERE bl.id = ?",
         )
         .bind(&id)
         .fetch_all(&self.pools.read)

--- a/source/daemon/crates/wardnetd-data/src/repository/tests/dns_filter.rs
+++ b/source/daemon/crates/wardnetd-data/src/repository/tests/dns_filter.rs
@@ -343,7 +343,13 @@ async fn load_filter_inputs_for_profile_returns_only_enabled() {
         .await
         .unwrap();
 
-    assert!(inputs.blocked_domains.iter().any(|d| d == "ads.example"));
+    // Blocked domains are NOT part of a profile's inputs: each blocklist is
+    // compiled into its own filter and the runtime profile references it, so
+    // the profile query must not drag millions of domains along. The domain is
+    // still reachable through the path the rebuild actually uses.
+    let blocked = repo.load_blocklist_domains(bl.id).await.unwrap();
+    assert!(blocked.iter().any(|d| d == "ads.example"));
+
     assert!(inputs.allowlist.iter().any(|d| d == "allowed.example"));
     assert!(
         inputs
@@ -613,4 +619,350 @@ async fn deleting_profile_cascades_default_membership() {
         !cfg.default_profile_ids.contains(&p),
         "ON DELETE CASCADE should drop default-membership"
     );
+}
+
+// ── Bulk-import concurrency (blocklist refresh write-starvation) ─────────
+
+/// Build pools that mirror production: an on-disk WAL database whose write
+/// pool has exactly one connection. The single writer is the whole point —
+/// it is what a long bulk import can monopolise.
+async fn on_disk_pools(acquire_timeout: std::time::Duration) -> (crate::db::DbPools, String) {
+    use sqlx::sqlite::{
+        SqliteConnectOptions, SqliteJournalMode, SqlitePoolOptions, SqliteSynchronous,
+    };
+
+    let path = std::env::temp_dir().join(format!("wardnet_bulk_{}.db", Uuid::new_v4().simple()));
+    let path_str = path.to_string_lossy().into_owned();
+
+    let make_options = || {
+        SqliteConnectOptions::new()
+            .filename(&path)
+            .create_if_missing(true)
+            .journal_mode(SqliteJournalMode::Wal)
+            .synchronous(SqliteSynchronous::Normal)
+            .busy_timeout(std::time::Duration::from_secs(30))
+            .foreign_keys(true)
+    };
+
+    let write = SqlitePoolOptions::new()
+        .max_connections(1)
+        .min_connections(1)
+        .acquire_timeout(acquire_timeout)
+        .connect_with(make_options())
+        .await
+        .unwrap();
+    let read = SqlitePoolOptions::new()
+        .max_connections(5)
+        .acquire_timeout(acquire_timeout)
+        .connect_with(make_options())
+        .await
+        .unwrap();
+
+    sqlx::migrate!("./migrations").run(&write).await.unwrap();
+
+    (crate::db::DbPools { read, write }, path_str)
+}
+
+/// Regression guard: importing a large blocklist must not hold the daemon's
+/// single write connection for the entire import.
+///
+/// The malware/threat-intel feeds are ~1.9M domains. When `replace_blocklist_domains`
+/// wrote them in one transaction it kept the sole writer busy for minutes, so every
+/// other writer in the daemon (stats, DHCP leases, DNS query log, heartbeat) failed
+/// with "pool timed out while waiting for an open connection". Health then flipped
+/// DOWN, the soft watchdog withheld `sd_notify(WATCHDOG=1)`, and systemd SIGABRT'd
+/// the daemon mid-import — leaving the UI polling a job id that no longer existed.
+///
+/// The invariant: an unrelated write must be able to get through *while* the import
+/// is still running.
+#[tokio::test]
+async fn bulk_import_does_not_starve_concurrent_writers() {
+    // A probe that cannot acquire the writer within this budget means the import
+    // held it continuously for that long — the starvation the daemon died of.
+    const MAX_HOLD: std::time::Duration = std::time::Duration::from_secs(1);
+
+    let (pools, path) = on_disk_pools(MAX_HOLD).await;
+    let repo = std::sync::Arc::new(SqliteDnsFilterRepository::new_pools(pools.clone()));
+
+    let malware: Uuid = MALWARE.parse().unwrap();
+    let lists = repo.list_blocklists(malware).await.unwrap();
+    let target = lists[0].id;
+    let other = lists[1].id;
+
+    // Big enough that a single-transaction import takes well over the 200ms
+    // acquire timeout, so a starved writer cannot simply wait it out.
+    let domains: Vec<String> = (0..400_000)
+        .map(|i| format!("d{i}.malware.example"))
+        .collect();
+
+    let importer = std::sync::Arc::clone(&repo);
+    let import =
+        tokio::spawn(async move { importer.replace_blocklist_domains(target, &domains).await });
+
+    // Wait until the import actually holds the single write connection.
+    // Without this the probe below can grab the still-idle connection before
+    // the spawned task is ever polled and pass for the wrong reason.
+    while pools.write.num_idle() > 0 && !import.is_finished() {
+        tokio::task::yield_now().await;
+    }
+    assert!(
+        !import.is_finished(),
+        "import finished before it could be observed holding the writer; raise the domain count"
+    );
+
+    // Probe an unrelated small write repeatedly for as long as the import runs.
+    // A probe only fails if the writer stayed unavailable for the whole MAX_HOLD
+    // window, so a failure here is unambiguous starvation — no tail race with the
+    // import's final commit (that would have woken the waiter and succeeded).
+    let mut starved_for = None;
+    while !import.is_finished() {
+        let probe = std::time::Instant::now();
+        if repo
+            .set_blocklist_error(other, Some("probe"))
+            .await
+            .is_err()
+        {
+            starved_for = Some(probe.elapsed());
+            break;
+        }
+        tokio::task::yield_now().await;
+    }
+
+    assert!(
+        starved_for.is_none(),
+        "an unrelated write could not acquire the write connection for {:?} while the bulk \
+         import ran — the import monopolises the single writer for its whole transaction, \
+         which is what starves stats/DHCP/heartbeat/health and trips the systemd watchdog",
+        starved_for.unwrap()
+    );
+
+    let count = import.await.unwrap().unwrap();
+    assert_eq!(count, 400_000);
+
+    let _ = std::fs::remove_file(&path);
+}
+
+/// The import must stay atomic from a reader's point of view: while a refresh is
+/// in flight, readers keep seeing the previous list — never a half-loaded one,
+/// never an empty one.
+#[tokio::test]
+async fn bulk_import_is_atomic_for_readers() {
+    let (pools, path) = on_disk_pools(std::time::Duration::from_secs(30)).await;
+    let repo = std::sync::Arc::new(SqliteDnsFilterRepository::new_pools(pools.clone()));
+
+    let malware: Uuid = MALWARE.parse().unwrap();
+    let lists = repo.list_blocklists(malware).await.unwrap();
+    let target = lists[0].id;
+
+    // Seed a known "previous" generation.
+    repo.replace_blocklist_domains(target, &["old.example".to_owned()])
+        .await
+        .unwrap();
+
+    let domains: Vec<String> = (0..200_000).map(|i| format!("new{i}.example")).collect();
+    let importer = std::sync::Arc::clone(&repo);
+    let import =
+        tokio::spawn(async move { importer.replace_blocklist_domains(target, &domains).await });
+
+    // Every observation must be either the whole old list or the whole new one —
+    // never a partially-loaded blocklist. (A reader can legitimately land after
+    // the flip, so "still the old list" is not assertable; "never partial" is.)
+    while !import.is_finished() {
+        let seen = repo.load_blocklist_domains(target).await.unwrap();
+        assert!(
+            seen == vec!["old.example".to_owned()] || seen.len() == 200_000,
+            "reader observed a partially-applied import ({} domains); the swap must be atomic",
+            seen.len()
+        );
+        tokio::task::yield_now().await;
+    }
+    import.await.unwrap().unwrap();
+
+    let seen = repo.load_blocklist_domains(target).await.unwrap();
+    assert_eq!(
+        seen.len(),
+        200_000,
+        "after the flip readers see the new list"
+    );
+
+    let _ = std::fs::remove_file(&path);
+}
+
+/// Regression guard: deleting a blocklist must not starve the writer either.
+///
+/// `dns_filter_blocked_domains.blocklist_id` is `ON DELETE CASCADE`, so removing
+/// a blocklist row made `SQLite` drop every one of its domains inside a single
+/// implicit transaction — millions of rows for a threat-intel feed. That holds
+/// the sole write connection exactly as the old single-transaction import did,
+/// with the same watchdog-kill ending. Deleting a profile cascades through its
+/// blocklists into the same place.
+#[tokio::test]
+async fn deleting_a_blocklist_does_not_starve_concurrent_writers() {
+    const MAX_HOLD: std::time::Duration = std::time::Duration::from_secs(1);
+
+    let (pools, path) = on_disk_pools(MAX_HOLD).await;
+    let repo = std::sync::Arc::new(SqliteDnsFilterRepository::new_pools(pools.clone()));
+
+    let malware: Uuid = MALWARE.parse().unwrap();
+    let lists = repo.list_blocklists(malware).await.unwrap();
+    let target = lists[0].id;
+    let other = lists[1].id;
+
+    let domains: Vec<String> = (0..400_000)
+        .map(|i| format!("d{i}.malware.example"))
+        .collect();
+    repo.replace_blocklist_domains(target, &domains)
+        .await
+        .unwrap();
+
+    let deleter = std::sync::Arc::clone(&repo);
+    let delete = tokio::spawn(async move { deleter.delete_blocklist(target).await });
+
+    while pools.write.num_idle() > 0 && !delete.is_finished() {
+        tokio::task::yield_now().await;
+    }
+
+    let mut starved_for = None;
+    while !delete.is_finished() {
+        let probe = std::time::Instant::now();
+        if repo
+            .set_blocklist_error(other, Some("probe"))
+            .await
+            .is_err()
+        {
+            starved_for = Some(probe.elapsed());
+            break;
+        }
+        tokio::task::yield_now().await;
+    }
+
+    assert!(
+        starved_for.is_none(),
+        "an unrelated write could not acquire the write connection for {:?} while a blocklist \
+         was being deleted — the ON DELETE CASCADE drops every domain in one transaction",
+        starved_for.unwrap()
+    );
+
+    assert!(delete.await.unwrap().unwrap());
+    assert!(repo.get_blocklist(target).await.unwrap().is_none());
+    assert!(
+        repo.load_blocklist_domains(target)
+            .await
+            .unwrap()
+            .is_empty(),
+        "the deleted blocklist's domains must be gone"
+    );
+
+    let _ = std::fs::remove_file(&path);
+}
+
+/// A refresh re-imports a list whose domains mostly did not change. The new
+/// generation is written while the old one is still present, so the two
+/// generations must be able to hold the same domain for the same blocklist at
+/// once — otherwise `PRIMARY KEY (domain, blocklist_id)` rejects the insert and
+/// every real refresh fails.
+#[tokio::test]
+async fn reimporting_overlapping_domains_succeeds() {
+    let pool = test_pool().await;
+    let repo = SqliteDnsFilterRepository::new(pool);
+
+    let malware: Uuid = MALWARE.parse().unwrap();
+    let target = repo.list_blocklists(malware).await.unwrap()[0].id;
+
+    let first = vec!["ads.example".to_owned(), "evil.example".to_owned()];
+    repo.replace_blocklist_domains(target, &first)
+        .await
+        .unwrap();
+
+    // Same list again, plus one new domain — exactly what a scheduled refresh does.
+    let second = vec![
+        "ads.example".to_owned(),
+        "evil.example".to_owned(),
+        "new.example".to_owned(),
+    ];
+    let count = repo
+        .replace_blocklist_domains(target, &second)
+        .await
+        .expect("re-importing an overlapping list must not violate the primary key");
+    assert_eq!(count, 3);
+
+    let mut seen = repo.load_blocklist_domains(target).await.unwrap();
+    seen.sort();
+    assert_eq!(seen, ["ads.example", "evil.example", "new.example"]);
+}
+
+/// A daemon killed between the flip and the cleanup orphans a generation that
+/// the superseded-generation sweep would never look at again. The next import
+/// must reclaim it, or those rows leak for the life of the database.
+#[tokio::test]
+async fn import_reclaims_generations_orphaned_by_a_crash() {
+    let pool = test_pool().await;
+    let repo = SqliteDnsFilterRepository::new(pool.clone());
+
+    let malware: Uuid = MALWARE.parse().unwrap();
+    let target = repo.list_blocklists(malware).await.unwrap()[0].id;
+
+    repo.replace_blocklist_domains(target, &["a.example".to_owned()])
+        .await
+        .unwrap();
+
+    // Simulate the crash: rows stranded at a generation nothing points at
+    // (a flip happened, its cleanup never ran).
+    sqlx::query(
+        "INSERT INTO dns_filter_blocked_domains (domain, blocklist_id, generation) \
+         VALUES ('orphan.example', ?, 99)",
+    )
+    .bind(target.to_string())
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    repo.replace_blocklist_domains(target, &["b.example".to_owned()])
+        .await
+        .unwrap();
+
+    let total: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM dns_filter_blocked_domains WHERE blocklist_id = ?",
+    )
+    .bind(target.to_string())
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(
+        total, 1,
+        "only the active generation should remain; the orphaned generation must be reclaimed"
+    );
+    assert_eq!(
+        repo.load_blocklist_domains(target).await.unwrap(),
+        vec!["b.example".to_owned()]
+    );
+}
+
+/// `entry_count` must reflect rows actually stored, and a duplicate in the
+/// caller's slice must not abort the import on the composite primary key.
+#[tokio::test]
+async fn import_dedupes_and_counts_stored_rows() {
+    let pool = test_pool().await;
+    let repo = SqliteDnsFilterRepository::new(pool);
+
+    let malware: Uuid = MALWARE.parse().unwrap();
+    let target = repo.list_blocklists(malware).await.unwrap()[0].id;
+
+    let count = repo
+        .replace_blocklist_domains(
+            target,
+            &[
+                "dup.example".to_owned(),
+                "dup.example".to_owned(),
+                "other.example".to_owned(),
+            ],
+        )
+        .await
+        .expect("a duplicated domain must not abort the import");
+
+    assert_eq!(
+        count, 2,
+        "entry_count must be the rows stored, not the input length"
+    );
+    assert_eq!(repo.load_blocklist_domains(target).await.unwrap().len(), 2);
 }

--- a/source/daemon/crates/wardnetd-services/src/dns_filter/service.rs
+++ b/source/daemon/crates/wardnetd-services/src/dns_filter/service.rs
@@ -20,7 +20,9 @@ use arc_swap::ArcSwap;
 use async_trait::async_trait;
 use chrono::Utc;
 use hickory_proto::rr::RecordType;
-use tokio::sync::RwLock;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+use tokio::sync::{RwLock, Semaphore};
 use uuid::Uuid;
 
 use wardnet_common::api::{
@@ -57,6 +59,10 @@ use crate::jobs::{JobService, JobServiceExt};
 /// IDs of the three builtin profiles seeded by the migration.
 const BUILTIN_AD_BLOCKING: &str = "00000000-0000-0000-0000-000000000100";
 
+/// Progress reported by a refresh job while it waits for the import permit, so
+/// a queued job is visibly queued rather than frozen at zero.
+const QUEUED_PROGRESS: u8 = 1;
+
 /// Outcome of a hot-path filter check.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct CheckOutcome {
@@ -76,7 +82,10 @@ pub trait DnsFilterService: Send + Sync {
     async fn check(&self, domain: &str, qtype: RecordType, client: IpAddr) -> CheckOutcome;
 
     /// Bootstrap the in-memory cache from persisted state. Called once on
-    /// daemon startup before the DNS server is allowed to serve traffic.
+    /// daemon startup, from the DNS filter runner's own task — the DNS server
+    /// binds and starts answering *before* this completes, so queries during
+    /// the window resolve through an empty filter set (fail-open). Callers can
+    /// observe that window via `filters_ready` on the config response.
     async fn rebuild_all(&self) -> Result<(), AppError>;
 
     // ── Profiles ────────────────────────────────────────────────────────
@@ -202,6 +211,19 @@ pub struct DnsFilterServiceImpl {
     jobs: Arc<dyn JobService>,
     fetcher: Arc<dyn BlocklistFetcher>,
 
+    /// Serialises blocklist imports. Enabling a profile dispatches one refresh
+    /// job per blocklist at once, and a threat-intel feed is millions of
+    /// domains — running them concurrently means holding several multi-million
+    /// entry `Vec<String>` in memory and interleaving their write batches for
+    /// no gain, since `SQLite` admits one writer anyway.
+    refresh_lock: Arc<Semaphore>,
+
+    /// Set once `rebuild_all` has compiled the filter cache. The DNS server
+    /// binds and answers queries before this happens (the runner bootstraps in
+    /// its own task), so until it flips, queries resolve through an empty
+    /// filter set — fail-open. Surfaced to the admin rather than hidden.
+    bootstrapped: Arc<AtomicBool>,
+
     /// Per-source compiled filters keyed by blocklist id (allowlist sources
     /// and custom-rules sources are inlined into one synthetic filter per
     /// profile keyed under a synthesised profile-scoped uuid; see
@@ -234,6 +256,8 @@ impl DnsFilterServiceImpl {
             events,
             jobs,
             fetcher,
+            refresh_lock: Arc::new(Semaphore::new(1)),
+            bootstrapped: Arc::new(AtomicBool::new(false)),
             blocklist_filters: Arc::new(RwLock::new(HashMap::new())),
             profile_aux_filters: Arc::new(RwLock::new(HashMap::new())),
             profiles: Arc::new(RwLock::new(HashMap::new())),
@@ -359,6 +383,31 @@ impl DnsFilterServiceImpl {
         Ok(rule)
     }
 
+    /// Wrap a config in the response, stamping the fail-open state alongside it.
+    ///
+    /// Filtering is only actually in force once the cache has been compiled
+    /// (`bootstrapped`) *and* every enabled blocklist has been imported at
+    /// least once. A list that has never been downloaded is an empty list: it
+    /// is "enabled" but blocks nothing, which is precisely the state the admin
+    /// must not have to guess at.
+    async fn config_response(
+        &self,
+        config: DnsFilterConfig,
+    ) -> Result<DnsFilterConfigResponse, AppError> {
+        let pending = self
+            .repo
+            .count_unimported_blocklists()
+            .await
+            .map_err(AppError::Internal)?;
+        let bootstrapped = self.bootstrapped.load(Ordering::Acquire);
+
+        Ok(DnsFilterConfigResponse {
+            config,
+            filters_ready: bootstrapped && pending == 0,
+            pending_blocklists: u32::try_from(pending).unwrap_or(u32::MAX),
+        })
+    }
+
     /// Rebuild the per-blocklist filter from the repo. The aggregated
     /// per-profile filter does NOT need rebuilding — it indirectly
     /// references the same `Arc<ArcSwap<DnsFilter>>` we just swapped.
@@ -433,6 +482,9 @@ impl DnsFilterServiceImpl {
             .await
             .map_err(AppError::Internal)?;
 
+        // Blocked domains stay out of the aux filter: this profile's blocklists
+        // are each compiled separately and composed in by reference below, so
+        // folding their domains in here would double-store millions of entries.
         let aux_inputs = DnsFilterInputs {
             blocked_domains: Vec::new(),
             allowlist: inputs.allowlist,
@@ -688,6 +740,10 @@ impl DnsFilterService for DnsFilterServiceImpl {
         }
 
         self.rebuild_default_context_inner().await?;
+
+        // The compiled cache is now live. Anything the DNS server answered
+        // before this point went through an empty filter set.
+        self.bootstrapped.store(true, Ordering::Release);
         Ok(())
     }
 
@@ -920,10 +976,19 @@ impl DnsFilterService for DnsFilterServiceImpl {
         let repo = self.repo.clone();
         let fetcher = self.fetcher.clone();
         let events = self.events.clone();
+        let refresh_lock = self.refresh_lock.clone();
 
         let job_id = self
             .jobs
             .dispatch(JobKind::BlocklistRefresh, move |reporter| async move {
+                // Enabling a profile dispatches one job per blocklist, so all
+                // but the first wait here — for minutes, if a multi-million
+                // domain feed is ahead of them. Publish progress *before*
+                // blocking: otherwise a queued job sits at a flat 0% for the
+                // whole wait, which reads to the user as the same frozen bar
+                // this whole change exists to eliminate.
+                reporter.set_progress(QUEUED_PROGRESS).await;
+                let _permit = refresh_lock.acquire().await?;
                 blocklist_downloader::refresh_blocklist(
                     &bl,
                     repo.as_ref(),
@@ -1192,7 +1257,7 @@ impl DnsFilterService for DnsFilterServiceImpl {
             .get_dns_filter_config()
             .await
             .map_err(AppError::Internal)?;
-        Ok(DnsFilterConfigResponse { config })
+        self.config_response(config).await
     }
 
     async fn update_filter_config(
@@ -1239,7 +1304,7 @@ impl DnsFilterService for DnsFilterServiceImpl {
         if changed_global {
             self.publish(DnsFilterChange::GlobalToggle);
         }
-        Ok(DnsFilterConfigResponse { config: current })
+        self.config_response(current).await
     }
 
     async fn rebuild_blocklist_filter(&self, blocklist_id: Uuid) -> Result<(), AppError> {

--- a/source/daemon/crates/wardnetd-services/src/dns_filter/tests/service.rs
+++ b/source/daemon/crates/wardnetd-services/src/dns_filter/tests/service.rs
@@ -1670,3 +1670,61 @@ async fn check_passes_when_device_kill_switch_off_and_records_would_have_blocked
     assert_eq!(outcome.action, FilterAction::Pass);
     assert!(outcome.would_have_blocked);
 }
+
+/// The daemon serves DNS before the filter cache is compiled, and after the
+/// generation migration the blocklists start empty and refill in the
+/// background. Both are fail-open windows: DNS resolves, blocklists enforce
+/// nothing. The admin must be able to see that, so the config response carries
+/// it explicitly rather than leaving the UI to imply everything is fine.
+#[tokio::test]
+async fn filter_config_reports_fail_open_until_lists_are_imported() {
+    let h = build().await;
+    as_admin(async {
+        // Fresh service: rebuild_all has not run, so the cache is not compiled.
+        let cfg = h.service.get_filter_config().await.unwrap();
+        assert!(
+            !cfg.filters_ready,
+            "filters cannot be ready before the cache is bootstrapped"
+        );
+
+        h.service.rebuild_all().await.unwrap();
+
+        // Enable a blocklist but never import it — an enabled-but-empty list
+        // blocks nothing, which must still read as not-ready.
+        let ad: Uuid = AD_BLOCKING.parse().unwrap();
+        let lists = h.service.list_blocklists(ad).await.unwrap().blocklists;
+        let bl = lists[0].id;
+        h.service
+            .update_blocklist(
+                ad,
+                bl,
+                UpdateBlocklistRequest {
+                    enabled: Some(true),
+                    ..Default::default()
+                },
+            )
+            .await
+            .unwrap();
+
+        let cfg = h.service.get_filter_config().await.unwrap();
+        assert!(
+            !cfg.filters_ready,
+            "an enabled list that has never been imported is empty — fail-open"
+        );
+        assert_eq!(cfg.pending_blocklists, 1);
+
+        // Import it: now filtering is genuinely in force.
+        h.repo
+            .replace_blocklist_domains(bl, &["ads.example".to_owned()])
+            .await
+            .unwrap();
+
+        let cfg = h.service.get_filter_config().await.unwrap();
+        assert!(
+            cfg.filters_ready,
+            "cache built and every enabled list imported"
+        );
+        assert_eq!(cfg.pending_blocklists, 0);
+    })
+    .await;
+}

--- a/source/daemon/crates/wardnetd-services/src/tls/runner.rs
+++ b/source/daemon/crates/wardnetd-services/src/tls/runner.rs
@@ -7,6 +7,15 @@
 //! the service returns [`TlsStatus::NotConfigured`] before any ACME call, so the
 //! runner is fully inert until a provider is registered.
 //!
+//! ## Retry
+//!
+//! A *failed* attempt does not wait for the next 12h tick: it retries on a short
+//! exponential backoff ([`RETRY_MIN`] → [`RETRY_MAX`]), resetting on success.
+//! Issuance failures are usually transient — most sharply, a freshly registered
+//! network whose DNS record the cloud has not published yet will reject the ACME
+//! challenge for a few seconds. Under a bare 12h cadence, losing that race cost
+//! half a day without a certificate.
+//!
 //! ## Suspended state
 //!
 //! While the box is [suspended](Entitlement::is_suspended) the runner is fully
@@ -32,6 +41,28 @@ use super::{TlsService, TlsStatus};
 /// cert is missing or within the renewal window, so a 12h cadence is cheap and
 /// leaves ample slack ahead of the 30-day renewal threshold.
 const RENEWAL_INTERVAL: Duration = Duration::from_hours(12);
+
+/// First retry delay after a failed issuance.
+const RETRY_MIN: Duration = Duration::from_secs(30);
+
+/// Ceiling for the retry backoff. Past this we are no longer chasing a transient
+/// condition, and the 12h cadence takes back over on the next success.
+const RETRY_MAX: Duration = Duration::from_mins(15);
+
+/// Delay before re-attempting issuance after `previous` failed.
+///
+/// Issuance failures are dominated by *transient* conditions: the cloud is
+/// mid-deploy, the WAN is still coming up, or — the case that prompted this —
+/// the network was registered seconds ago and its DNS record has not been
+/// published yet, so the ACME challenge is rejected until it is. Waiting the
+/// full [`RENEWAL_INTERVAL`] to find out costs half a day of no certificate for
+/// a condition that typically clears in seconds.
+pub(super) fn next_retry(previous: Option<Duration>) -> Duration {
+    match previous {
+        None => RETRY_MIN,
+        Some(prev) => prev.saturating_mul(2).min(RETRY_MAX),
+    }
+}
 
 /// Background TLS renewal runner. See [module docs](self).
 pub struct TlsRenewalRunner {
@@ -69,11 +100,12 @@ async fn runner_loop(
         admin_id: Uuid::nil(),
     };
 
-    let mut interval = tokio::time::interval(RENEWAL_INTERVAL);
-    // First `tick()` resolves immediately → check once at startup. `Delay`
-    // spaces the next tick a full interval after the work finishes rather than
-    // bursting to catch up.
-    interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+    // `None` while healthy: the next attempt is a full `RENEWAL_INTERVAL` away.
+    // `Some(d)` after a failure: retry in `d`, doubling up to `RETRY_MAX`, so a
+    // transient failure costs seconds rather than the full 12h cadence.
+    let mut retry_in: Option<Duration> = None;
+    // First pass runs immediately → check once at startup.
+    let mut delay = Duration::ZERO;
 
     loop {
         tokio::select! {
@@ -81,15 +113,31 @@ async fn runner_loop(
                 tracing::info!("TLS renewal runner cancellation received");
                 break;
             }
-            _ = interval.tick() => {
+            () = tokio::time::sleep(delay) => {
                 // Fully inert while suspended — renewing a cert for a box with
                 // its premium surfaces disabled is pointless, and the ACME
                 // challenge would publish through the suspended wardnet provider.
                 // The DDNS runner's re-probe is what restores entitlement.
                 if entitlement.is_suspended() {
                     tracing::debug!("TLS renewal: suspended, skipping");
+                    // Suspension is not a failure: don't build up a retry backoff
+                    // for it. The re-probe restores us on the normal cadence.
+                    delay = RENEWAL_INTERVAL;
+                    continue;
+                }
+
+                if ensure(tls.as_ref(), &admin_ctx).await {
+                    retry_in = None;
+                    delay = RENEWAL_INTERVAL;
                 } else {
-                    ensure(tls.as_ref(), &admin_ctx).await;
+                    let next = next_retry(retry_in);
+                    retry_in = Some(next);
+                    tracing::info!(
+                        retry_in_secs = next.as_secs(),
+                        "TLS renewal: retrying in {}s rather than waiting for the next cycle",
+                        next.as_secs(),
+                    );
+                    delay = next;
                 }
             }
         }
@@ -98,7 +146,10 @@ async fn runner_loop(
 
 /// Run one `ensure_certificate` under the admin context, logging the outcome.
 /// Never fatal — a failed ACME call must not take the daemon down.
-async fn ensure(tls: &dyn TlsService, admin_ctx: &AuthContext) {
+///
+/// Returns `false` when the attempt failed and is worth retrying sooner than the
+/// next renewal cycle.
+async fn ensure(tls: &dyn TlsService, admin_ctx: &AuthContext) -> bool {
     match auth_context::with_context(admin_ctx.clone(), tls.ensure_certificate()).await {
         Ok(TlsStatus::NotConfigured) => {
             tracing::debug!("TLS renewal: DDNS unconfigured, nothing to do");
@@ -129,6 +180,10 @@ async fn ensure(tls: &dyn TlsService, admin_ctx: &AuthContext) {
                 "TLS certificate issued/renewed for {domain} (not_after={not_after})"
             );
         }
-        Err(error) => tracing::warn!(%error, "TLS renewal failed: {error}"),
+        Err(error) => {
+            tracing::warn!(%error, "TLS renewal failed: {error}");
+            return false;
+        }
     }
+    true
 }

--- a/source/daemon/crates/wardnetd-services/src/tls/tests/mod.rs
+++ b/source/daemon/crates/wardnetd-services/src/tls/tests/mod.rs
@@ -697,3 +697,44 @@ async fn teardown_clears_cert_state_and_deactivates() {
     assert_eq!(secrets.get(SECRET_CERT_CHAIN).await.unwrap(), None);
     assert_eq!(secrets.get(SECRET_CERT_KEY).await.unwrap(), None);
 }
+
+// ── Renewal retry backoff ─────────────────────────────────────────────────────
+//
+// A failed issuance used to wait for the next 12h tick. The failure that
+// prompted this is transient by nature: a network registered seconds ago has no
+// published DNS record yet, so the cloud rejects the ACME challenge with
+// "network is not yet active" — and the daemon then sat certificate-less for
+// half a day over a condition that clears in seconds.
+
+#[test]
+fn first_retry_after_a_failure_is_soon_not_a_full_cycle() {
+    let first = super::runner::next_retry(None);
+    assert_eq!(first, std::time::Duration::from_secs(30));
+    assert!(
+        first < std::time::Duration::from_hours(12),
+        "a failure must not wait for the next renewal cycle"
+    );
+}
+
+#[test]
+fn retry_backoff_doubles_and_is_capped() {
+    let mut d = super::runner::next_retry(None);
+    let mut seen = vec![d];
+    for _ in 0..10 {
+        d = super::runner::next_retry(Some(d));
+        seen.push(d);
+    }
+
+    // Doubles from 30s...
+    assert_eq!(seen[0], std::time::Duration::from_secs(30));
+    assert_eq!(seen[1], std::time::Duration::from_mins(1));
+    assert_eq!(seen[2], std::time::Duration::from_mins(2));
+
+    // ...and never exceeds the ceiling, however long the outage lasts.
+    let cap = std::time::Duration::from_mins(15);
+    assert!(
+        seen.iter().all(|d| *d <= cap),
+        "backoff must stay capped at 15m, got {seen:?}"
+    );
+    assert_eq!(*seen.last().unwrap(), cap, "should settle at the ceiling");
+}

--- a/source/daemon/crates/wardnetd-services/src/update/service.rs
+++ b/source/daemon/crates/wardnetd-services/src/update/service.rs
@@ -67,10 +67,20 @@ pub trait UpdateService: Send + Sync {
     /// actually came back up. Called once at daemon startup, before the HTTP
     /// server accepts requests.
     ///
-    /// System startup path, not a user-facing call: it runs before any request
-    /// context exists and therefore carries no `auth_context` guard, in the
-    /// same manner as the routing and zone-enforcement startup reconcilers.
+    /// Admin-guarded like every other service method (`.agents/auth.md`): the
+    /// startup caller supplies an admin context explicitly rather than the
+    /// method opting out of the check.
     async fn reconcile_pending_install(&self) -> Result<(), AppError>;
+}
+
+/// How long after a restart the daemon still advertises "we just updated".
+///
+/// Generous enough that an admin who kicked off an update and watched the box
+/// go down will still be told it landed when they come back, but short enough
+/// that a browser opening the UI for the first time weeks later is not told
+/// about an ancient update as though it were news.
+fn applied_announce_window() -> chrono::Duration {
+    chrono::Duration::minutes(15)
 }
 
 /// Track the in-flight install so concurrent callers see the same handle.
@@ -211,14 +221,19 @@ impl UpdateServiceImpl {
     }
 
     async fn build_status(&self) -> Result<UpdateStatus, AppError> {
-        let channel = self.get_channel().await?;
-        let auto = self.get_auto_update_enabled().await?;
-        let last_check_at = self.get_last_check_at().await?;
-        let last_install_at = self.get_last_install_at().await?;
-        let latest = self.get_last_known_version().await?;
-        let pending = self.get_pending_version().await?;
-        let applied_version = self.get_applied_version().await?;
-        let applied_at = self.get_applied_at().await?;
+        // Independent reads: issue them concurrently rather than paying seven
+        // sequential round-trips on a path every open admin tab polls at 15 s.
+        let (channel, auto, last_check_at, last_install_at, latest, pending) = tokio::try_join!(
+            self.get_channel(),
+            self.get_auto_update_enabled(),
+            self.get_last_check_at(),
+            self.get_last_install_at(),
+            self.get_last_known_version(),
+            self.get_pending_version(),
+        )?;
+        let (applied_version, applied_at) =
+            tokio::try_join!(self.get_applied_version(), self.get_applied_at())?;
+
         let update_available = match latest.as_deref() {
             Some(v) if !v.is_empty() => is_newer(v, &self.current_version),
             _ => false,
@@ -226,6 +241,27 @@ impl UpdateServiceImpl {
         let inflight = self.inflight.lock().await;
         let install_phase = inflight.phase.clone();
         drop(inflight);
+
+        // `update_applied_*` is a durable record, but "we just updated" is not a
+        // durable fact. Clients dedupe the announcement in local storage, so a
+        // browser that has never seen this box (new device, incognito, cleared
+        // storage) would otherwise be told about an update from weeks ago as if
+        // it had just landed. Only advertise it while it is genuinely fresh.
+        let applied_is_fresh = applied_at
+            .is_some_and(|at| Utc::now().signed_duration_since(at) < applied_announce_window());
+        let (applied_version, applied_at) = if applied_is_fresh {
+            (applied_version, applied_at)
+        } else {
+            (None, None)
+        };
+
+        // `Applied` is a momentary phase, not a resting state — nothing else
+        // ever returns it to `Idle`, so without this the card would show the
+        // "Applied" chip forever after a successful update.
+        let install_phase = match install_phase {
+            InstallPhase::Applied if !applied_is_fresh => InstallPhase::Idle,
+            other => other,
+        };
 
         Ok(UpdateStatus {
             current_version: self.current_version.clone(),
@@ -248,9 +284,12 @@ impl UpdateServiceImpl {
             return Ok(());
         };
 
-        // Whatever we conclude, the claim has now been adjudicated.
-        self.set_cfg("update_pending_version", "").await?;
-
+        // Record the outcome BEFORE clearing the marker. The marker is the only
+        // record that an install was staged, so clearing it first would mean a
+        // failed write (or a kill) here loses the event entirely: the next boot
+        // sees nothing pending, no-ops, and the update is never announced and a
+        // reverted swap never recorded. Clearing last makes the reconcile
+        // idempotent and safely retryable — a crash mid-way just replays it.
         if pending == self.current_version {
             // The swap took: we are running the version we staged.
             let now = Utc::now();
@@ -261,6 +300,8 @@ impl UpdateServiceImpl {
             let mut inflight = self.inflight.lock().await;
             inflight.phase = InstallPhase::Applied;
             drop(inflight);
+
+            self.set_cfg("update_pending_version", "").await?;
 
             tracing::info!(
                 version = %pending,
@@ -304,6 +345,8 @@ impl UpdateServiceImpl {
             )
             .await
             .map_err(AppError::Internal)?;
+
+        self.set_cfg("update_pending_version", "").await?;
 
         self.events.publish(WardnetEvent::UpdateFailed {
             target_version: pending.clone(),
@@ -606,6 +649,7 @@ impl UpdateService for UpdateServiceImpl {
     /// it (record the swap as reverted). Either way the marker does not
     /// survive.
     async fn reconcile_pending_install(&self) -> Result<(), AppError> {
+        auth_context::require_admin()?;
         self.do_reconcile_pending_install().await
     }
 
@@ -780,6 +824,12 @@ impl UpdateService for UpdateServiceImpl {
 
         self.set_cfg("update_pending_version", "").await?;
         self.set_cfg("update_previous_binary_path", "").await?;
+        // Retract the "applied" announcement too. We are deliberately leaving
+        // this version, so continuing to advertise it as freshly applied would
+        // toast "Wardnet updated to vX" at any browser that has not already
+        // seen it — immediately after the operator rolled away from vX.
+        self.set_cfg("update_applied_version", "").await?;
+        self.set_cfg("update_applied_at", "").await?;
         self.history
             .insert(&UpdateHistoryRow {
                 from_version: self.current_version.clone(),

--- a/source/daemon/crates/wardnetd-services/src/update/service.rs
+++ b/source/daemon/crates/wardnetd-services/src/update/service.rs
@@ -62,6 +62,15 @@ pub trait UpdateService: Send + Sync {
     /// Returns `Ok(None)` when no action was taken (disabled, already
     /// up-to-date, or an install is already in flight).
     async fn auto_install_if_due(&self) -> Result<Option<InstallHandle>, AppError>;
+
+    /// Settle the `update_pending_version` marker against the binary that
+    /// actually came back up. Called once at daemon startup, before the HTTP
+    /// server accepts requests.
+    ///
+    /// System startup path, not a user-facing call: it runs before any request
+    /// context exists and therefore carries no `auth_context` guard, in the
+    /// same manner as the routing and zone-enforcement startup reconcilers.
+    async fn reconcile_pending_install(&self) -> Result<(), AppError>;
 }
 
 /// Track the in-flight install so concurrent callers see the same handle.
@@ -175,6 +184,25 @@ impl UpdateServiceImpl {
             .filter(|s| !s.is_empty()))
     }
 
+    async fn get_applied_version(&self) -> Result<Option<String>, AppError> {
+        Ok(self
+            .system_config
+            .get("update_applied_version")
+            .await
+            .map_err(AppError::Internal)?
+            .filter(|s| !s.is_empty()))
+    }
+
+    async fn get_applied_at(&self) -> Result<Option<DateTime<Utc>>, AppError> {
+        Ok(self
+            .system_config
+            .get("update_applied_at")
+            .await
+            .map_err(AppError::Internal)?
+            .filter(|s| !s.is_empty())
+            .and_then(|s| s.parse().ok()))
+    }
+
     async fn set_cfg(&self, key: &str, value: &str) -> Result<(), AppError> {
         self.system_config
             .set(key, value)
@@ -189,6 +217,8 @@ impl UpdateServiceImpl {
         let last_install_at = self.get_last_install_at().await?;
         let latest = self.get_last_known_version().await?;
         let pending = self.get_pending_version().await?;
+        let applied_version = self.get_applied_version().await?;
+        let applied_at = self.get_applied_at().await?;
         let update_available = match latest.as_deref() {
             Some(v) if !v.is_empty() => is_newer(v, &self.current_version),
             _ => false,
@@ -207,8 +237,89 @@ impl UpdateServiceImpl {
             last_install_at,
             install_phase,
             pending_version: pending,
+            applied_version,
+            applied_at,
             rollback_available: self.applier.rollback_available().await,
         })
+    }
+
+    async fn do_reconcile_pending_install(&self) -> Result<(), AppError> {
+        let Some(pending) = self.get_pending_version().await? else {
+            return Ok(());
+        };
+
+        // Whatever we conclude, the claim has now been adjudicated.
+        self.set_cfg("update_pending_version", "").await?;
+
+        if pending == self.current_version {
+            // The swap took: we are running the version we staged.
+            let now = Utc::now();
+            self.set_cfg("update_applied_version", &self.current_version)
+                .await?;
+            self.set_cfg("update_applied_at", &now.to_rfc3339()).await?;
+
+            let mut inflight = self.inflight.lock().await;
+            inflight.phase = InstallPhase::Applied;
+            drop(inflight);
+
+            tracing::info!(
+                version = %pending,
+                "update applied across restart: now running {version}",
+                version = pending,
+            );
+            return Ok(());
+        }
+
+        // We staged `pending` but came back up as something else — the binary
+        // swap silently reverted (or systemd started an older unit). Surface
+        // it rather than letting the version quietly stay behind.
+        let reason = format!(
+            "update to {pending} did not take effect; running {current}",
+            current = self.current_version,
+        );
+
+        let mut inflight = self.inflight.lock().await;
+        inflight.phase = InstallPhase::Failed {
+            reason: reason.clone(),
+        };
+        drop(inflight);
+
+        let history_id = self
+            .history
+            .insert(&UpdateHistoryRow {
+                from_version: self.current_version.clone(),
+                to_version: pending.clone(),
+                phase: "restart_pending".to_owned(),
+                status: UpdateHistoryStatus::Started,
+                error: None,
+            })
+            .await
+            .map_err(AppError::Internal)?;
+        self.history
+            .finalize(
+                history_id,
+                UpdateHistoryStatus::Failed,
+                "restart_pending",
+                Some(reason.as_str()),
+            )
+            .await
+            .map_err(AppError::Internal)?;
+
+        self.events.publish(WardnetEvent::UpdateFailed {
+            target_version: pending.clone(),
+            phase: InstallPhase::RestartPending,
+            error: reason.clone(),
+            timestamp: Utc::now(),
+        });
+
+        tracing::error!(
+            target = %pending,
+            current = %self.current_version,
+            "binary swap reverted: {reason}",
+            reason = reason,
+        );
+
+        Ok(())
     }
 
     async fn publish_progress(&self, target: &str, phase: InstallPhase) {
@@ -484,6 +595,20 @@ fn phase_name(p: &InstallPhase) -> &'static str {
 
 #[async_trait]
 impl UpdateService for UpdateServiceImpl {
+    /// `run_install` writes `update_pending_version` and then cancels the
+    /// shutdown token so systemd restarts us on the new binary. Nothing else
+    /// clears that marker, so without this the UI reports a version as
+    /// "pending" forever after it has already been applied.
+    ///
+    /// The marker is an unverified *claim* that a restart onto the target is
+    /// coming. Boot is the only place that claim can be checked against
+    /// reality, so we either confirm it (record it as applied) or contradict
+    /// it (record the swap as reverted). Either way the marker does not
+    /// survive.
+    async fn reconcile_pending_install(&self) -> Result<(), AppError> {
+        self.do_reconcile_pending_install().await
+    }
+
     async fn status(&self) -> Result<UpdateStatusResponse, AppError> {
         auth_context::require_admin()?;
         Ok(UpdateStatusResponse {

--- a/source/daemon/crates/wardnetd-services/src/update/tests/runner.rs
+++ b/source/daemon/crates/wardnetd-services/src/update/tests/runner.rs
@@ -20,6 +20,10 @@ struct CountingService {
 
 #[async_trait]
 impl UpdateService for CountingService {
+    async fn reconcile_pending_install(&self) -> Result<(), AppError> {
+        Ok(())
+    }
+
     async fn status(&self) -> Result<UpdateStatusResponse, AppError> {
         Ok(UpdateStatusResponse {
             status: UpdateStatus {
@@ -32,6 +36,8 @@ impl UpdateService for CountingService {
                 last_install_at: None,
                 install_phase: InstallPhase::Idle,
                 pending_version: None,
+                applied_version: None,
+                applied_at: None,
                 rollback_available: false,
             },
         })

--- a/source/daemon/crates/wardnetd-services/src/update/tests/service.rs
+++ b/source/daemon/crates/wardnetd-services/src/update/tests/service.rs
@@ -5,7 +5,7 @@ use async_trait::async_trait;
 use uuid::Uuid;
 use wardnet_common::api::{InstallUpdateRequest, UpdateConfigRequest};
 use wardnet_common::auth::AuthContext;
-use wardnet_common::update::{Release, UpdateChannel};
+use wardnet_common::update::{InstallPhase, Release, UpdateChannel};
 use wardnetd_data::repository::{UpdateHistoryRow, UpdateRepository};
 
 use crate::auth_context;
@@ -208,6 +208,29 @@ fn build_service_full(
         tokio_util::sync::CancellationToken::new(),
     ));
     (svc, applier, events)
+}
+
+/// Build a service standing in for a daemon that has just booted on
+/// `current_version`, with `config` carrying whatever markers survived the
+/// restart. Hands back the config and history so tests can assert on what the
+/// startup reconcile wrote.
+fn build_service_at_version(
+    current_version: &str,
+    config: Arc<MemoryConfig>,
+) -> (Arc<UpdateServiceImpl>, Arc<MemoryHistory>) {
+    let history = Arc::new(MemoryHistory::default());
+    let svc = Arc::new(UpdateServiceImpl::new(
+        config,
+        history.clone(),
+        Arc::new(StubReleaseSource(None)),
+        Arc::new(AlwaysOkVerifier),
+        Arc::new(RecordingApplier::default()),
+        Arc::new(BroadcastEventBus::new(32)),
+        false,
+        current_version,
+        tokio_util::sync::CancellationToken::new(),
+    ));
+    (svc, history)
 }
 
 fn test_release_with_minisig() -> Release {
@@ -465,4 +488,107 @@ async fn rollback_with_previous_records_history_and_emits_log() {
 
     assert!(resp.message.contains("rollback staged"));
     assert!(*applier.rolled_back.lock().unwrap());
+}
+
+// --- startup reconcile of the pending-version marker ---
+//
+// `run_install` persists `update_pending_version` and restarts the daemon via
+// systemd. These cover what must happen on the way back up: the marker is a
+// *claim* about a restart that hasn't been verified yet, so booting must
+// either confirm it (and say so) or contradict it (and say that).
+
+#[tokio::test]
+async fn reconcile_clears_pending_and_records_applied_when_new_binary_is_running() {
+    // Daemon restarted after installing 0.2.0 and came back up as 0.2.0.
+    let config = Arc::new(MemoryConfig::default());
+    config.set("update_pending_version", "0.2.0").await.unwrap();
+    let (svc, _history) = build_service_at_version("0.2.0", config);
+
+    svc.reconcile_pending_install().await.expect("reconcile ok");
+
+    let status = auth_context::with_context(
+        test_admin_ctx(),
+        (svc as Arc<dyn UpdateService>).status(),
+    )
+    .await
+    .unwrap()
+    .status;
+
+    // The update landed — nothing is pending any more.
+    assert_eq!(
+        status.pending_version, None,
+        "pending marker must be cleared once the new binary is running"
+    );
+    // ...and the daemon records that it landed, so a polling UI can tell the
+    // user. There is no event channel to the browser.
+    assert_eq!(status.applied_version.as_deref(), Some("0.2.0"));
+    assert!(status.applied_at.is_some(), "applied_at must be stamped");
+    assert_eq!(status.install_phase, InstallPhase::Applied);
+}
+
+#[tokio::test]
+async fn reconcile_marks_failed_when_restart_came_back_on_the_old_binary() {
+    // Swap silently reverted: we staged 0.2.0 but rebooted into 0.1.0.
+    let config = Arc::new(MemoryConfig::default());
+    config.set("update_pending_version", "0.2.0").await.unwrap();
+    let (svc, history) = build_service_at_version("0.1.0", config);
+
+    svc.reconcile_pending_install().await.expect("reconcile ok");
+
+    let status = auth_context::with_context(
+        test_admin_ctx(),
+        (svc as Arc<dyn UpdateService>).status(),
+    )
+    .await
+    .unwrap()
+    .status;
+
+    assert_eq!(
+        status.pending_version, None,
+        "a pending marker that outlived its restart must not survive boot"
+    );
+    assert_eq!(
+        status.applied_version, None,
+        "nothing was applied — 0.2.0 never ran"
+    );
+    match status.install_phase {
+        InstallPhase::Failed { ref reason } => {
+            assert!(
+                reason.contains("0.2.0") && reason.contains("0.1.0"),
+                "reason should name both the intended and running version, got: {reason}"
+            );
+        }
+        other => panic!("expected Failed phase, got {other:?}"),
+    }
+
+    // The reverted swap must be visible in history, not just in memory.
+    let rows = history.list(10).await.unwrap();
+    let row = rows.first().expect("expected a history row for the failed swap");
+    assert_eq!(row.status, UpdateHistoryStatus::Failed);
+    assert_eq!(row.to_version, "0.2.0");
+}
+
+#[tokio::test]
+async fn reconcile_is_a_noop_when_nothing_was_pending() {
+    // Ordinary boot — no install was staged.
+    let config = Arc::new(MemoryConfig::default());
+    let (svc, history) = build_service_at_version("0.1.0", config);
+
+    svc.reconcile_pending_install().await.expect("reconcile ok");
+
+    let status = auth_context::with_context(
+        test_admin_ctx(),
+        (svc as Arc<dyn UpdateService>).status(),
+    )
+    .await
+    .unwrap()
+    .status;
+
+    assert_eq!(status.pending_version, None);
+    assert_eq!(status.applied_version, None);
+    assert_eq!(status.install_phase, InstallPhase::Idle);
+    assert!(
+        history.list(10).await.unwrap().is_empty(),
+        "a clean boot must not write history rows"
+    );
 }

--- a/source/daemon/crates/wardnetd-services/src/update/tests/service.rs
+++ b/source/daemon/crates/wardnetd-services/src/update/tests/service.rs
@@ -506,13 +506,11 @@ async fn reconcile_clears_pending_and_records_applied_when_new_binary_is_running
 
     svc.reconcile_pending_install().await.expect("reconcile ok");
 
-    let status = auth_context::with_context(
-        test_admin_ctx(),
-        (svc as Arc<dyn UpdateService>).status(),
-    )
-    .await
-    .unwrap()
-    .status;
+    let status =
+        auth_context::with_context(test_admin_ctx(), (svc as Arc<dyn UpdateService>).status())
+            .await
+            .unwrap()
+            .status;
 
     // The update landed — nothing is pending any more.
     assert_eq!(
@@ -535,13 +533,11 @@ async fn reconcile_marks_failed_when_restart_came_back_on_the_old_binary() {
 
     svc.reconcile_pending_install().await.expect("reconcile ok");
 
-    let status = auth_context::with_context(
-        test_admin_ctx(),
-        (svc as Arc<dyn UpdateService>).status(),
-    )
-    .await
-    .unwrap()
-    .status;
+    let status =
+        auth_context::with_context(test_admin_ctx(), (svc as Arc<dyn UpdateService>).status())
+            .await
+            .unwrap()
+            .status;
 
     assert_eq!(
         status.pending_version, None,
@@ -563,7 +559,9 @@ async fn reconcile_marks_failed_when_restart_came_back_on_the_old_binary() {
 
     // The reverted swap must be visible in history, not just in memory.
     let rows = history.list(10).await.unwrap();
-    let row = rows.first().expect("expected a history row for the failed swap");
+    let row = rows
+        .first()
+        .expect("expected a history row for the failed swap");
     assert_eq!(row.status, UpdateHistoryStatus::Failed);
     assert_eq!(row.to_version, "0.2.0");
 }
@@ -576,13 +574,11 @@ async fn reconcile_is_a_noop_when_nothing_was_pending() {
 
     svc.reconcile_pending_install().await.expect("reconcile ok");
 
-    let status = auth_context::with_context(
-        test_admin_ctx(),
-        (svc as Arc<dyn UpdateService>).status(),
-    )
-    .await
-    .unwrap()
-    .status;
+    let status =
+        auth_context::with_context(test_admin_ctx(), (svc as Arc<dyn UpdateService>).status())
+            .await
+            .unwrap()
+            .status;
 
     assert_eq!(status.pending_version, None);
     assert_eq!(status.applied_version, None);

--- a/source/daemon/crates/wardnetd-services/src/update/tests/service.rs
+++ b/source/daemon/crates/wardnetd-services/src/update/tests/service.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 use std::sync::Mutex as StdMutex;
 
 use async_trait::async_trait;
+use chrono::Utc;
 use uuid::Uuid;
 use wardnet_common::api::{InstallUpdateRequest, UpdateConfigRequest};
 use wardnet_common::auth::AuthContext;
@@ -504,7 +505,9 @@ async fn reconcile_clears_pending_and_records_applied_when_new_binary_is_running
     config.set("update_pending_version", "0.2.0").await.unwrap();
     let (svc, _history) = build_service_at_version("0.2.0", config);
 
-    svc.reconcile_pending_install().await.expect("reconcile ok");
+    auth_context::with_context(test_admin_ctx(), svc.reconcile_pending_install())
+        .await
+        .expect("reconcile ok");
 
     let status =
         auth_context::with_context(test_admin_ctx(), (svc as Arc<dyn UpdateService>).status())
@@ -531,7 +534,9 @@ async fn reconcile_marks_failed_when_restart_came_back_on_the_old_binary() {
     config.set("update_pending_version", "0.2.0").await.unwrap();
     let (svc, history) = build_service_at_version("0.1.0", config);
 
-    svc.reconcile_pending_install().await.expect("reconcile ok");
+    auth_context::with_context(test_admin_ctx(), svc.reconcile_pending_install())
+        .await
+        .expect("reconcile ok");
 
     let status =
         auth_context::with_context(test_admin_ctx(), (svc as Arc<dyn UpdateService>).status())
@@ -572,7 +577,9 @@ async fn reconcile_is_a_noop_when_nothing_was_pending() {
     let config = Arc::new(MemoryConfig::default());
     let (svc, history) = build_service_at_version("0.1.0", config);
 
-    svc.reconcile_pending_install().await.expect("reconcile ok");
+    auth_context::with_context(test_admin_ctx(), svc.reconcile_pending_install())
+        .await
+        .expect("reconcile ok");
 
     let status =
         auth_context::with_context(test_admin_ctx(), (svc as Arc<dyn UpdateService>).status())
@@ -587,4 +594,144 @@ async fn reconcile_is_a_noop_when_nothing_was_pending() {
         history.list(10).await.unwrap().is_empty(),
         "a clean boot must not write history rows"
     );
+}
+
+// --- review follow-ups: the applied marker must not outlive its news ---
+
+#[tokio::test]
+async fn reconcile_requires_admin() {
+    let (svc, _history) = build_service_at_version("0.2.0", Arc::new(MemoryConfig::default()));
+    // No auth context: the guard must reject, like every other service method.
+    let result = (svc as Arc<dyn UpdateService>)
+        .reconcile_pending_install()
+        .await;
+    assert!(matches!(result, Err(crate::error::AppError::Forbidden(_))));
+}
+
+/// A browser opening the UI weeks later must not be told about an ancient
+/// update as if it just landed: clients dedupe in local storage, so a marker
+/// the daemon advertises forever becomes "news" to every new browser.
+#[tokio::test]
+async fn a_stale_applied_marker_is_not_advertised() {
+    let config = Arc::new(MemoryConfig::default());
+    config.set("update_applied_version", "0.2.0").await.unwrap();
+    config
+        .set(
+            "update_applied_at",
+            &(Utc::now() - chrono::Duration::days(21)).to_rfc3339(),
+        )
+        .await
+        .unwrap();
+    let (svc, _) = build_service_at_version("0.2.0", config);
+
+    let status =
+        auth_context::with_context(test_admin_ctx(), (svc as Arc<dyn UpdateService>).status())
+            .await
+            .unwrap()
+            .status;
+
+    assert_eq!(
+        status.applied_version, None,
+        "a three-week-old update is not news"
+    );
+    assert_eq!(status.applied_at, None);
+}
+
+/// ...but the update the operator just watched land IS news.
+#[tokio::test]
+async fn a_fresh_applied_marker_is_advertised() {
+    let config = Arc::new(MemoryConfig::default());
+    config.set("update_pending_version", "0.2.0").await.unwrap();
+    let (svc, _) = build_service_at_version("0.2.0", config);
+    let svc: Arc<dyn UpdateService> = svc;
+
+    auth_context::with_context(test_admin_ctx(), svc.reconcile_pending_install())
+        .await
+        .expect("reconcile ok");
+    let status = auth_context::with_context(test_admin_ctx(), svc.status())
+        .await
+        .unwrap()
+        .status;
+
+    assert_eq!(status.applied_version.as_deref(), Some("0.2.0"));
+    assert_eq!(status.install_phase, InstallPhase::Applied);
+}
+
+/// `Applied` is a momentary phase. Nothing else returns it to `Idle`, so once
+/// the announcement window closes the card must stop showing an install phase.
+#[tokio::test]
+async fn the_applied_phase_decays_to_idle_once_stale() {
+    let config = Arc::new(MemoryConfig::default());
+    config.set("update_pending_version", "0.2.0").await.unwrap();
+    let (svc, _) = build_service_at_version("0.2.0", config.clone());
+    let svc: Arc<dyn UpdateService> = svc;
+
+    auth_context::with_context(test_admin_ctx(), svc.reconcile_pending_install())
+        .await
+        .expect("reconcile ok");
+
+    // Rewind the stamp past the announcement window.
+    config
+        .set(
+            "update_applied_at",
+            &(Utc::now() - chrono::Duration::hours(2)).to_rfc3339(),
+        )
+        .await
+        .unwrap();
+
+    let status = auth_context::with_context(test_admin_ctx(), svc.status())
+        .await
+        .unwrap()
+        .status;
+
+    assert_eq!(
+        status.install_phase,
+        InstallPhase::Idle,
+        "the Applied chip must not linger forever"
+    );
+}
+
+/// Rolling back retracts the announcement. Otherwise a browser that had not yet
+/// seen it would toast "updated to v0.2.0" right after the operator abandoned
+/// v0.2.0.
+#[tokio::test]
+async fn rollback_retracts_the_applied_announcement() {
+    let config = Arc::new(MemoryConfig::default());
+    config.set("update_pending_version", "0.2.0").await.unwrap();
+    let applier = Arc::new(RecordingApplier::default());
+    // Give the applier something to roll back to.
+    applier
+        .apply(&[], &[])
+        .await
+        .expect("stage a previous binary");
+
+    let svc: Arc<dyn UpdateService> = Arc::new(UpdateServiceImpl::new(
+        config.clone(),
+        Arc::new(MemoryHistory::default()),
+        Arc::new(StubReleaseSource(None)),
+        Arc::new(AlwaysOkVerifier),
+        applier,
+        Arc::new(BroadcastEventBus::new(32)),
+        false,
+        "0.2.0",
+        tokio_util::sync::CancellationToken::new(),
+    ));
+
+    auth_context::with_context(test_admin_ctx(), svc.reconcile_pending_install())
+        .await
+        .expect("reconcile ok");
+    auth_context::with_context(test_admin_ctx(), svc.rollback())
+        .await
+        .expect("rollback ok");
+
+    let status = auth_context::with_context(test_admin_ctx(), svc.status())
+        .await
+        .unwrap()
+        .status;
+
+    assert_eq!(
+        status.applied_version, None,
+        "must not keep advertising the version we just rolled away from"
+    );
+    assert_eq!(status.applied_at, None);
 }

--- a/source/daemon/crates/wardnetd/src/main.rs
+++ b/source/daemon/crates/wardnetd/src/main.rs
@@ -73,8 +73,7 @@ use wardnetd_services::push::listener::PushNotificationListener;
 use wardnetd_services::secret_store::build_secret_store;
 use wardnetd_services::system::WatchdogOps;
 use wardnetd_services::update::{
-    EMBEDDED_PUBLIC_KEY, FsBinaryApplier, HttpsManifestSource, Sha256MinisignVerifier,
-    UpdateRunner, UpdateService,
+    EMBEDDED_PUBLIC_KEY, FsBinaryApplier, HttpsManifestSource, Sha256MinisignVerifier, UpdateRunner,
 };
 use wardnetd_services::{Backends, UpdateBackends, auth_context, init_services_with_factory};
 

--- a/source/daemon/crates/wardnetd/src/main.rs
+++ b/source/daemon/crates/wardnetd/src/main.rs
@@ -73,8 +73,8 @@ use wardnetd_services::push::listener::PushNotificationListener;
 use wardnetd_services::secret_store::build_secret_store;
 use wardnetd_services::system::WatchdogOps;
 use wardnetd_services::update::{
-    EMBEDDED_PUBLIC_KEY, FsBinaryApplier, HttpsManifestSource, Sha256MinisignVerifier, UpdateRunner,
-    UpdateService,
+    EMBEDDED_PUBLIC_KEY, FsBinaryApplier, HttpsManifestSource, Sha256MinisignVerifier,
+    UpdateRunner, UpdateService,
 };
 use wardnetd_services::{Backends, UpdateBackends, auth_context, init_services_with_factory};
 

--- a/source/daemon/crates/wardnetd/src/main.rs
+++ b/source/daemon/crates/wardnetd/src/main.rs
@@ -74,6 +74,7 @@ use wardnetd_services::secret_store::build_secret_store;
 use wardnetd_services::system::WatchdogOps;
 use wardnetd_services::update::{
     EMBEDDED_PUBLIC_KEY, FsBinaryApplier, HttpsManifestSource, Sha256MinisignVerifier, UpdateRunner,
+    UpdateService,
 };
 use wardnetd_services::{Backends, UpdateBackends, auth_context, init_services_with_factory};
 
@@ -683,6 +684,18 @@ async fn run(
     // regardless of any per-feature flag so it covers all tables.
     let db_maintenance_runner =
         DbMaintenanceRunner::start(services.maintenance.clone(), &root_span);
+
+    // Settle any `update_pending_version` marker left behind by an install
+    // that restarted us. Must run before the update runner's first check so a
+    // status poll never observes a version still "pending" that is in fact
+    // the binary now serving the request. A failure here is not fatal — it
+    // only affects reporting, so log and carry on rather than refusing to boot.
+    if let Err(err) = services.update.reconcile_pending_install().await {
+        tracing::warn!(
+            error = %err,
+            "failed to reconcile pending update marker at startup: {err}",
+        );
+    }
 
     // Start the auto-update poller. An initial check runs immediately; then
     // every `check_interval_secs` with ±10% jitter.

--- a/source/daemon/crates/wardnetd/src/main.rs
+++ b/source/daemon/crates/wardnetd/src/main.rs
@@ -689,7 +689,17 @@ async fn run(
     // status poll never observes a version still "pending" that is in fact
     // the binary now serving the request. A failure here is not fatal — it
     // only affects reporting, so log and carry on rather than refusing to boot.
-    if let Err(err) = services.update.reconcile_pending_install().await {
+    // Runs under an explicit admin context: the service method is auth-guarded
+    // like every other (`.agents/auth.md`), so the startup caller supplies the
+    // identity rather than the method opting out of the check.
+    let reconcile = auth_context::with_context(
+        AuthContext::Admin {
+            admin_id: uuid::Uuid::nil(),
+        },
+        services.update.reconcile_pending_install(),
+    )
+    .await;
+    if let Err(err) = reconcile {
         tracing::warn!(
             error = %err,
             "failed to reconcile pending update marker at startup: {err}",

--- a/source/daemon/crates/wardnetd/src/tests/stubs.rs
+++ b/source/daemon/crates/wardnetd/src/tests/stubs.rs
@@ -1105,6 +1105,10 @@ pub struct StubUpdateService;
 
 #[async_trait]
 impl wardnetd_services::UpdateService for StubUpdateService {
+    async fn reconcile_pending_install(&self) -> Result<(), AppError> {
+        unimplemented!("startup-only path; these tests never boot the runner")
+    }
+
     async fn status(&self) -> Result<wardnet_common::api::UpdateStatusResponse, AppError> {
         unimplemented!()
     }

--- a/source/sdk/wardnet-js/src/types/dns-filter.ts
+++ b/source/sdk/wardnet-js/src/types/dns-filter.ts
@@ -232,6 +232,20 @@ export interface UpdateDeviceFilterSettingsResponse {
 
 export interface DnsFilterConfigResponse {
   config: DnsFilterConfig;
+
+  /**
+   * Whether the filters are actually being enforced right now.
+   *
+   * The DNS server answers queries as soon as it binds, but the compiled
+   * filters are built in the background — and after an upgrade that resets the
+   * blocklist cache, the lists must be re-downloaded before they can block
+   * anything. During either window DNS resolves normally and blocklists are
+   * NOT enforced. `false` means exactly that.
+   */
+  filters_ready: boolean;
+
+  /** Enabled blocklists that have never been imported, so are empty and enforcing nothing. */
+  pending_blocklists: number;
 }
 
 /**

--- a/source/sdk/wardnet-js/src/types/update.ts
+++ b/source/sdk/wardnet-js/src/types/update.ts
@@ -51,7 +51,12 @@ export interface UpdateStatus {
   last_check_at: string | null;
   last_install_at: string | null;
   install_phase: InstallPhase;
+  /** Version an install is staging. Cleared once the daemon restarts onto it. */
   pending_version: string | null;
+  /** Version the daemon finished applying across a restart, if any. */
+  applied_version: string | null;
+  /** When `applied_version` was observed running; dedupe key for the toast. */
+  applied_at: string | null;
   rollback_available: boolean;
 }
 

--- a/source/web/src/components/DnsFilterNotReadyNotice.tsx
+++ b/source/web/src/components/DnsFilterNotReadyNotice.tsx
@@ -1,0 +1,58 @@
+import { TriangleAlertIcon } from "lucide-react";
+import { Text } from "@wardnet/ui";
+import { useDnsFilterConfig } from "../hooks/useDnsFilter";
+
+interface Props {
+  /** Extra classes for spacing in the host layout (margins, width). */
+  className?: string;
+}
+
+/**
+ * Warns that DNS filtering is enabled but **not currently being enforced**.
+ *
+ * The daemon answers DNS as soon as its server binds, while the compiled filters
+ * are built in a background task — and a blocklist that has never been
+ * downloaded is an empty list, so it is "enabled" while blocking nothing. That
+ * happens on every restart (briefly) and for several minutes after the upgrade
+ * that reset the blocklist cache, during which malware and adult-content lists
+ * are silently inert.
+ *
+ * Failing open is the right call — a gateway that answers no DNS until its lists
+ * finish downloading takes the whole LAN offline — but it must not be silent,
+ * which is what this notice is for. It disappears on its own once every enabled
+ * list has been imported.
+ */
+export function DnsFilterNotReadyNotice({ className }: Props) {
+  const { data } = useDnsFilterConfig();
+
+  // No data yet, or filtering is genuinely in force — say nothing.
+  if (!data || data.filters_ready) return null;
+
+  // The global kill switch is off, so nothing is *meant* to be enforced. A
+  // warning here would be noise about a state the admin chose.
+  if (!data.config.enabled) return null;
+
+  const pending = data.pending_blocklists;
+
+  return (
+    <div
+      className={[
+        "flex items-start gap-2.5 rounded-lg border border-line bg-sunken px-3.5 py-3",
+        className ?? "",
+      ].join(" ")}
+      role="status"
+      data-testid="dns-filter-not-ready-notice"
+    >
+      <TriangleAlertIcon size={16} className="mt-0.5 shrink-0 text-warning" />
+      <Text as="p" size="xs" className="text-ink-3">
+        <Text as="span" size="xs" weight="medium" className="text-ink">
+          DNS filtering is not being enforced yet.
+        </Text>{" "}
+        {pending > 0
+          ? `${pending} enabled ${pending === 1 ? "blocklist is" : "blocklists are"} still downloading. Until that finishes they are empty, so nothing they cover is blocked.`
+          : "The filters are still loading. Queries are being answered unfiltered until they are ready."}{" "}
+        Browsing keeps working throughout — this clears on its own.
+      </Text>
+    </div>
+  );
+}

--- a/source/web/src/hooks/useDnsFilter.tsx
+++ b/source/web/src/hooks/useDnsFilter.tsx
@@ -26,6 +26,14 @@ import type {
 } from "@wardnet/js";
 import { isJobTerminal } from "@wardnet/js";
 
+/** HTTP status carried by a `WardnetApiError`, if the rejection has one. */
+function httpStatus(err: unknown): number | undefined {
+  return (err as { status?: number } | null)?.status;
+}
+
+/** Poll attempts tolerated before giving up on a job whose status we can't read. */
+const TRANSIENT_POLL_RETRIES = 4;
+
 // ---------------------------------------------------------------------------
 // Profiles
 // ---------------------------------------------------------------------------
@@ -80,7 +88,7 @@ export function useDeleteDnsFilterProfile() {
       qc.invalidateQueries({ queryKey: ["dns-filter"] });
     },
     onError: (err: unknown) => {
-      const status = (err as { status?: number } | null)?.status;
+      const status = httpStatus(err);
       if (status === 409) {
         toast.error("Builtin profiles cannot be deleted");
       } else {
@@ -183,15 +191,50 @@ export function useRefreshBlocklist(profileId: string | undefined) {
     queryKey: ["job", active?.jobId],
     queryFn: () => jobsService.get(active!.jobId),
     enabled: !!active,
+    // A 404 is final — the job is genuinely gone, retrying cannot conjure it
+    // back. Anything else (a blip, a 5xx while the daemon is busy importing)
+    // is worth riding out: the import is probably still running.
+    retry: (failureCount, err) =>
+      httpStatus(err) !== 404 && failureCount < TRANSIENT_POLL_RETRIES,
     refetchInterval: (q) => {
+      if (q.state.status === "error") return false;
       const s = q.state.data?.status;
       return s && isJobTerminal(s) ? false : 1000;
     },
   });
 
   useEffect(() => {
+    if (!active) return;
+
+    // The job registry lives in the daemon's memory, so a restart takes every
+    // in-flight job id with it and the poll starts 404ing. Treat that as a
+    // terminal failure — otherwise the toast sits at its last percentage
+    // forever and the row is stuck on "Updating…".
+    //
+    // A non-404 failure means we lost contact, not that the job died: the
+    // import may well still be running. Say that, rather than reporting a
+    // failure that would push the user into re-triggering a duplicate import.
+    if (jobQuery.isError) {
+      const gone = httpStatus(jobQuery.error) === 404;
+      toast.error(
+        gone ? "Blocklist refresh failed" : "Lost track of the refresh",
+        {
+          id: active.jobId,
+          description: gone
+            ? "The daemon restarted while the list was importing. Check the blocklist's status before retrying."
+            : "Couldn't reach the daemon to follow the import — it may still be running. Check the blocklist's status before retrying.",
+        },
+      );
+      qc.invalidateQueries({
+        queryKey: ["dns-filter", "profile", profileId, "blocklists"],
+      });
+      // eslint-disable-next-line react-hooks/set-state-in-effect
+      setActive(null);
+      return;
+    }
+
     const job = jobQuery.data;
-    if (!job || !active) return;
+    if (!job) return;
 
     if (job.status === "RUNNING" || job.status === "PENDING") {
       toast.loading("Refreshing blocklist…", {
@@ -208,7 +251,6 @@ export function useRefreshBlocklist(profileId: string | undefined) {
       qc.invalidateQueries({
         queryKey: ["dns-filter", "profile", profileId, "blocklists"],
       });
-      // eslint-disable-next-line react-hooks/set-state-in-effect
       setActive(null);
     } else if (job.status === "TERMINATED_WITH_ERRORS") {
       toast.error(job.error || "Blocklist refresh failed", {
@@ -220,7 +262,7 @@ export function useRefreshBlocklist(profileId: string | undefined) {
       });
       setActive(null);
     }
-  }, [jobQuery.data, active, qc, profileId]);
+  }, [jobQuery.data, jobQuery.isError, jobQuery.error, active, qc, profileId]);
 
   return {
     mutate: dispatch.mutate,
@@ -381,6 +423,12 @@ export function useDnsFilterConfig() {
   return useQuery<DnsFilterConfigResponse>({
     queryKey: ["dns-filter", "config"],
     queryFn: () => dnsFilterService.getConfig(),
+    // While filtering is not yet enforced (cache still compiling, or blocklists
+    // still downloading after the cache reset) keep polling, so the fail-open
+    // warning clears itself when the lists land instead of stranding the admin
+    // on a stale banner until they reload the page. Idle once ready.
+    refetchInterval: (q) =>
+      q.state.data?.filters_ready === false ? 5000 : false,
   });
 }
 

--- a/source/web/src/hooks/useUpdate.ts
+++ b/source/web/src/hooks/useUpdate.ts
@@ -60,6 +60,16 @@ function writeAppliedSeen(value: string): void {
 }
 
 /**
+ * Announced in this page's lifetime. `useUpdateStatus` has several concurrent
+ * consumers (the sidebar banner and the settings card, at least), all sharing
+ * one query cache, so they all run the announce effect on the same commit.
+ * Relying on the localStorage read-then-write to serialize would be relying on
+ * React's effect ordering; this claims the timestamp synchronously instead, so
+ * exactly one consumer announces regardless of how the effects interleave.
+ */
+const announcedThisSession = new Set<string>();
+
+/**
  * Poll the update status at ~15 s so banners reflect new releases quickly.
  *
  * Also announces a completed update. The daemon has no event channel to the
@@ -81,7 +91,10 @@ export function useUpdateStatus() {
 
   useEffect(() => {
     if (!appliedAt || !appliedVersion) return;
+    // Claim it synchronously before any await/render can interleave.
+    if (announcedThisSession.has(appliedAt)) return;
     if (readAppliedSeen() === appliedAt) return;
+    announcedThisSession.add(appliedAt);
     writeAppliedSeen(appliedAt);
     toast.success(`Wardnet updated to v${appliedVersion}`, {
       id: TOAST_APPLIED,

--- a/source/web/src/hooks/useUpdate.ts
+++ b/source/web/src/hooks/useUpdate.ts
@@ -1,3 +1,4 @@
+import { useEffect } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { toast } from "@wardnet/ui";
 import {
@@ -31,13 +32,63 @@ function errorMessage(err: unknown, fallback: string): string {
 const STATUS_KEY = ["update", "status"] as const;
 const HISTORY_KEY = ["update", "history"] as const;
 
-/** Poll the update status at ~15 s so banners reflect new releases quickly. */
+const TOAST_APPLIED = "update-applied";
+/**
+ * Last `applied_at` we announced. Persisted because the announcement has to
+ * survive the very page load it is announcing: the daemon restarts under us,
+ * so the browser that started the install is typically remounting when the
+ * news arrives.
+ */
+const APPLIED_SEEN_KEY = "wardnet.update.appliedAt";
+
+function readAppliedSeen(): string | null {
+  try {
+    return window.localStorage.getItem(APPLIED_SEEN_KEY);
+  } catch {
+    // Private mode / storage disabled — degrade to announcing once per mount
+    // rather than breaking the status poll.
+    return null;
+  }
+}
+
+function writeAppliedSeen(value: string): void {
+  try {
+    window.localStorage.setItem(APPLIED_SEEN_KEY, value);
+  } catch {
+    // Ignore: worst case the toast repeats on the next mount.
+  }
+}
+
+/**
+ * Poll the update status at ~15 s so banners reflect new releases quickly.
+ *
+ * Also announces a completed update. The daemon has no event channel to the
+ * browser — it restarts mid-install and this poll is the only thing that comes
+ * back — so a successful upgrade is reported by the *status* carrying
+ * `applied_version` / `applied_at`, stamped by the daemon's startup reconcile.
+ * We announce each `applied_at` exactly once per browser.
+ */
 export function useUpdateStatus() {
-  return useQuery<UpdateStatusResponse>({
+  const query = useQuery<UpdateStatusResponse>({
     queryKey: STATUS_KEY,
     queryFn: () => updateService.status(),
     refetchInterval: 15_000,
   });
+
+  const status = query.data?.status;
+  const appliedAt = status?.applied_at ?? null;
+  const appliedVersion = status?.applied_version ?? null;
+
+  useEffect(() => {
+    if (!appliedAt || !appliedVersion) return;
+    if (readAppliedSeen() === appliedAt) return;
+    writeAppliedSeen(appliedAt);
+    toast.success(`Wardnet updated to v${appliedVersion}`, {
+      id: TOAST_APPLIED,
+    });
+  }, [appliedAt, appliedVersion]);
+
+  return query;
 }
 
 export function useUpdateHistory(limit = 20) {

--- a/source/web/src/index.ts
+++ b/source/web/src/index.ts
@@ -332,6 +332,7 @@ export {
 export { peerConfigFilename } from "./lib/inboundWgConfig";
 export { InboundWgQrCode } from "./components/InboundWgQrCode";
 export { InboundWgBetaNotice } from "./components/InboundWgBetaNotice";
+export { DnsFilterNotReadyNotice } from "./components/DnsFilterNotReadyNotice";
 export { triggerBrowserDownload } from "./lib/download";
 export { ModalTitleBlock } from "./components/ModalTitleBlock";
 export { AlertModalTitleBlock } from "./components/AlertModalTitleBlock";

--- a/source/web/tests/components/DnsFilterNotReadyNotice.test.tsx
+++ b/source/web/tests/components/DnsFilterNotReadyNotice.test.tsx
@@ -1,0 +1,71 @@
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createQueryWrapper } from "../test-utils";
+
+const { dnsFilterService } = vi.hoisted(() => ({
+  dnsFilterService: { getConfig: vi.fn() },
+}));
+vi.mock("../../src/lib/sdk", () => ({ dnsFilterService, jobsService: {} }));
+
+import { DnsFilterNotReadyNotice } from "../../src/components/DnsFilterNotReadyNotice";
+
+const w = createQueryWrapper;
+
+/** The whole point of this notice: filtering fails open on startup and after the
+ *  blocklist-cache reset, and the admin must not have to guess that. */
+describe("DnsFilterNotReadyNotice", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("warns while enabled blocklists are still downloading", async () => {
+    dnsFilterService.getConfig.mockResolvedValue({
+      config: { enabled: true, default_profile_ids: [] },
+      filters_ready: false,
+      pending_blocklists: 2,
+    });
+
+    render(<DnsFilterNotReadyNotice />, { wrapper: w() });
+
+    expect(
+      await screen.findByTestId("dns-filter-not-ready-notice"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/2 enabled blocklists are still downloading/i),
+    ).toBeInTheDocument();
+  });
+
+  it("stays silent once filtering is actually enforced", async () => {
+    dnsFilterService.getConfig.mockResolvedValue({
+      config: { enabled: true, default_profile_ids: [] },
+      filters_ready: true,
+      pending_blocklists: 0,
+    });
+
+    const { container } = render(<DnsFilterNotReadyNotice />, { wrapper: w() });
+    await vi.waitFor(() =>
+      expect(dnsFilterService.getConfig).toHaveBeenCalled(),
+    );
+
+    expect(
+      screen.queryByTestId("dns-filter-not-ready-notice"),
+    ).not.toBeInTheDocument();
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("stays silent when the admin has turned filtering off entirely", async () => {
+    // Nothing is *meant* to be enforced, so a fail-open warning would be noise.
+    dnsFilterService.getConfig.mockResolvedValue({
+      config: { enabled: false, default_profile_ids: [] },
+      filters_ready: false,
+      pending_blocklists: 3,
+    });
+
+    render(<DnsFilterNotReadyNotice />, { wrapper: w() });
+    await vi.waitFor(() =>
+      expect(dnsFilterService.getConfig).toHaveBeenCalled(),
+    );
+
+    expect(
+      screen.queryByTestId("dns-filter-not-ready-notice"),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/source/web/tests/hooks/useDnsFilter.test.tsx
+++ b/source/web/tests/hooks/useDnsFilter.test.tsx
@@ -178,6 +178,80 @@ describe("useDnsFilter blocklists / allowlist / rules", () => {
     );
   });
 
+  // Regression guard: importing a huge blocklist used to wedge the daemon long
+  // enough for systemd's watchdog to kill it. The job registry is in-memory, so
+  // after the restart `GET /api/jobs/{id}` 404s. The hook only reacted to
+  // `data`, which stays undefined on error — so it polled forever and the toast
+  // sat at "80%" indefinitely. A job that vanishes must surface as a failure.
+  it("fails the refresh when the job disappears (daemon restart) instead of polling forever", async () => {
+    dnsFilterService.refreshBlocklist.mockResolvedValue({ job_id: "job-1" });
+    jobsService.get
+      .mockResolvedValueOnce({
+        id: "job-1",
+        status: "RUNNING",
+        percentage_done: 80,
+      })
+      .mockRejectedValue(
+        Object.assign(new Error("job not found"), { status: 404 }),
+      );
+
+    const { result } = renderHook(() => f.useRefreshBlocklist(PID), {
+      wrapper: w(),
+    });
+    act(() => {
+      result.current.mutate("b1");
+    });
+
+    // The first poll succeeds, so the 404 only lands on the next tick of the
+    // 1s refetch interval — but a 404 is final, so it is not retried past that.
+    await waitFor(
+      () =>
+        expect(toast.error).toHaveBeenCalledWith(
+          "Blocklist refresh failed",
+          expect.any(Object),
+        ),
+      { timeout: 5_000 },
+    );
+    // And the row must stop showing "Updating…" forever.
+    await waitFor(() => expect(result.current.isPending).toBe(false), {
+      timeout: 5_000,
+    });
+  });
+
+  // The counterpart: a blip while the daemon is busy importing must NOT be
+  // reported as a failed refresh. The job is still running server-side, and
+  // telling the user it failed pushes them into re-triggering a second
+  // multi-million-domain import.
+  it("rides out a transient poll failure instead of declaring the refresh failed", async () => {
+    dnsFilterService.refreshBlocklist.mockResolvedValue({ job_id: "job-1" });
+    jobsService.get
+      .mockRejectedValueOnce(
+        Object.assign(new Error("network"), { status: 503 }),
+      )
+      .mockResolvedValue({
+        id: "job-1",
+        status: "SUCCEED",
+        percentage_done: 100,
+      });
+
+    const { result } = renderHook(() => f.useRefreshBlocklist(PID), {
+      wrapper: w(),
+    });
+    act(() => {
+      result.current.mutate("b1");
+    });
+
+    await waitFor(
+      () =>
+        expect(toast.success).toHaveBeenCalledWith(
+          "Blocklist refreshed",
+          expect.any(Object),
+        ),
+      { timeout: 10_000 },
+    );
+    expect(toast.error).not.toHaveBeenCalled();
+  });
+
   it("runs allowlist create/delete and rules CRUD", async () => {
     dnsFilterService.listAllowlist.mockResolvedValue({ entries: [] });
     dnsFilterService.createAllowlistEntry.mockResolvedValue({ message: "" });


### PR DESCRIPTION
Four user-reported bugs, all found by driving the beta channel end to end.

## 1. The PENDING column kept showing an already-applied version

`run_install` persisted `update_pending_version` and cancelled the shutdown token so systemd would restart the daemon onto the new binary. **Nothing ever settled that marker on the way back up** — only `rollback()` cleared it. So after a successful update the daemon came back reporting `current_version` *and* `pending_version` as the same version, forever.

`InstallPhase::Applied` was already defined and already rendered by `UpdateCard`, but no code path ever assigned it. The reconcile was simply never written — the `shutdown_token` doc comment still promised "the post-upgrade runner runs on the way back up".

Adds `reconcile_pending_install`, run once at startup before the update runner's first check. The marker is an unverified *claim* that a restart onto the target is coming, and boot is the only place that claim can be checked against reality:

| At boot | Meaning | Action |
|---|---|---|
| `pending == running` | the swap took | clear marker, stamp `applied_version`/`applied_at`, phase `Applied` |
| `pending != running` | the swap silently reverted | clear marker, failed history row, phase `Failed` naming both versions |
| no marker | ordinary boot | no-op |

The mismatch case matters: previously a reverted binary swap left the daemon quietly running the old version with a stale marker and no signal at all.

## 2. No message when the update landed

There is no SSE/websocket to the browser. The daemon publishes `UpdateCompleted` *before* it restarts, and its only subscribers are the routing/zone listeners, which ignore it — so the browser could never learn the update succeeded.

The news now rides on the status itself: `applied_version`/`applied_at` are surfaced on `UpdateStatus`, and `useUpdateStatus` toasts **"Wardnet updated to v…"** once per `applied_at`, deduped in `localStorage`. The persistence is load-bearing — the browser that started the install is typically remounting at the very moment the news arrives.

## 3. "Send code" did nothing when no email was set

The button was `disabled={pending.sendCode || !email.includes("@")}`. With no email it was **disabled**, so the click was swallowed: no request, no error, no feedback. The daemon's own `"a valid account email is required"` check was unreachable because nothing ever left the browser.

`sendCode` now validates and reports through the existing `onError` path. Disabling a control is not a way to tell someone why they can't use it. The setup wizard carried the identical pattern; fixed there too.

## 4. A failed certificate issuance stalled for 12 hours

Investigating a user's `409 "network is not yet active"` surfaced this: the TLS renewal runner ticks every 12h and treated a failed `ensure_certificate` as just a warn log, so the next attempt was a full cycle away.

That 409 is a race we create ourselves — a network registered seconds ago has no A record published yet, so the cloud rejects the ACME challenge until its provisioner catches up. In prd/euc the gap between the daemon reporting its IP and the record being published was **10 seconds**; losing it cost half a day without a certificate.

Now retries on a short exponential backoff (30s → doubling → capped at 15m), resetting to the 12h cadence on success. Suspension isn't treated as a failure, so it accumulates no backoff.

> **Note:** the *root cause* of that user's failed issuance turned out to be a separate cloud misconfiguration (the Cloudflare zone id pointed at the wrong zone, so records were published to a name that never resolves) — fixed in wardnet-cloud#82. This PR fixes the daemon's poor recovery from it.

## Testing

- **RED first** on the reconcile: both new tests failed on `pending_version == Some("0.2.0")` — the exact reported symptom — before the fix existed.
- The Send-code guard was written after its fix, so it was verified by reverting the fix (4 tests go red) and restoring it (green), proving it's wired to the defect.
- `cargo test -p wardnetd-services`: 1163 passed. `admin-site`: 730. `web`: 289. `make check-web`, clippy, and fmt all clean.

**Verification gap, stated honestly:** `wardnetd`'s `main.rs` (the startup wiring) cannot compile on macOS — `netlink-sys` doesn't build there — so that one file is CI-verified only. It needed the `UpdateService` trait brought into scope for the trait-object call.

## Merge Commit Message

fix: reconcile pending update across restart, report a completed update, fix silent Send code button, and retry failed TLS issuance promptly

https://claude.ai/code/session_01HTBSGpJ39jiKMznBJvtzoC
