### PR TITLE
fix(ddns): persist the network's region from the register response, not the wizard's pick

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -23269,6 +23269,10 @@
           "fqdn"
         ],
         "properties": {
+          "adopted": {
+            "type": "boolean",
+            "description": "`true` when the daemon JOINED an already-existing network of this\naccount (same slug, re-enrollment) instead of creating a fresh one —\nthe network's region and name won over the request (display only)."
+          },
           "fqdn": {
             "type": "string",
             "description": "The public hostname now assigned to this network."

--- a/source/admin-site/src/lib/wardnet-enrollment.ts
+++ b/source/admin-site/src/lib/wardnet-enrollment.ts
@@ -6,6 +6,7 @@ import {
   useRegisterDdns,
   useRequestEnrollmentCode,
 } from "@wardnet/web";
+import type { DdnsRegisterResponse } from "@wardnet/js";
 import { isValidName, suggestName } from "@/lib/suggestName";
 
 /**
@@ -97,7 +98,10 @@ export interface WardnetEnrollment {
 }
 
 export function useWardnetEnrollment(opts: {
-  onProvisioned: () => void;
+  /** Called on success; `registration` is set for the wardnet-provider flow
+   *  (so callers can tell an adoption of an existing network from a fresh
+   *  create) and `null` for BYOD-Cloudflare. */
+  onProvisioned: (registration: DdnsRegisterResponse | null) => void;
   onError: (err: unknown) => void;
   clearError: () => void;
 }): WardnetEnrollment {
@@ -210,8 +214,8 @@ export function useWardnetEnrollment(opts: {
   async function registerWardnet() {
     clearError();
     try {
-      await register.mutateAsync({ slug });
-      onProvisioned();
+      const registration = await register.mutateAsync({ slug });
+      onProvisioned(registration);
     } catch (err) {
       onError(err);
     }
@@ -221,7 +225,7 @@ export function useWardnetEnrollment(opts: {
     clearError();
     try {
       await configureCf.mutateAsync({ token, domain });
-      onProvisioned();
+      onProvisioned(null);
     } catch (err) {
       onError(err);
     }

--- a/source/admin-site/src/pages/RemoteAccess.tsx
+++ b/source/admin-site/src/pages/RemoteAccess.tsx
@@ -73,7 +73,15 @@ export default function RemoteAccess() {
   }
 
   const enrollment = useWardnetEnrollment({
-    onProvisioned: () => setChanging(false),
+    onProvisioned: (registration) => {
+      setChanging(false);
+      if (registration?.adopted) {
+        toast.success(
+          `Joined your existing network ${registration.fqdn}` +
+            (registration.region ? ` (${registration.region})` : ""),
+        );
+      }
+    },
     onError: (err) => setFormError(describeError(err)),
     clearError: () => setFormError(null),
   });

--- a/source/admin-site/src/pages/setup/StepRemoteAccess.tsx
+++ b/source/admin-site/src/pages/setup/StepRemoteAccess.tsx
@@ -38,6 +38,8 @@ export default function StepRemoteAccess() {
   const [formError, setFormError] = useState<string | null>(null);
   // Once provisioning has been kicked off we swap the form for live progress.
   const [started, setStarted] = useState(false);
+  /** Set when registration JOINED an existing network instead of creating one. */
+  const [adoptedFqdn, setAdoptedFqdn] = useState<string | null>(null);
   // Set when an attempt failed because the upstream service was unreachable (vs
   // a fixable input error) — swaps the form for a clear "service unavailable,
   // continue anyway" view.
@@ -61,7 +63,10 @@ export default function StepRemoteAccess() {
   }
 
   const enrollment = useWardnetEnrollment({
-    onProvisioned: () => setStarted(true),
+    onProvisioned: (registration) => {
+      setStarted(true);
+      setAdoptedFqdn(registration?.adopted ? registration.fqdn : null);
+    },
     onError: (err) => {
       if (isUpstreamDown(err)) {
         setUpstreamDown(true);
@@ -110,8 +115,13 @@ export default function StepRemoteAccess() {
             Remote access
           </Heading>
           <Text as="p" size="sm" className="mt-1 text-ink-3">
-            Your hostname is registered. The certificate is being issued in the
-            background - you can wait here or finish setup; it'll keep going.
+            {adoptedFqdn
+              ? `Joined your existing network ${adoptedFqdn} - its region and ` +
+                "settings apply. The certificate is being issued in the " +
+                "background - you can wait here or finish setup; it'll keep going."
+              : "Your hostname is registered. The certificate is being issued " +
+                "in the background - you can wait here or finish setup; it'll " +
+                "keep going."}
           </Text>
         </div>
 

--- a/source/admin-site/tests/lib/wardnet-enrollment.test.ts
+++ b/source/admin-site/tests/lib/wardnet-enrollment.test.ts
@@ -150,6 +150,23 @@ describe("useWardnetEnrollment", () => {
     });
   });
 
+  it("passes the register response through to onProvisioned (adoption signal)", async () => {
+    hoisted.register.mutateAsync.mockResolvedValueOnce({
+      fqdn: "nairobi.my.wardnet.services",
+      region: "euc",
+      adopted: true,
+    });
+    const { view, onProvisioned } = setup();
+    await act(async () => {
+      await view.result.current.registerWardnet();
+    });
+    expect(onProvisioned).toHaveBeenCalledWith({
+      fqdn: "nairobi.my.wardnet.services",
+      region: "euc",
+      adopted: true,
+    });
+  });
+
   it("reports errors from each action via onError", async () => {
     hoisted.requestCode.mutateAsync.mockRejectedValueOnce(new Error("boom"));
     hoisted.enroll.mutateAsync.mockRejectedValueOnce(new Error("boom"));
@@ -179,6 +196,7 @@ describe("useWardnetEnrollment", () => {
     await act(async () => {
       await view.result.current.enableCloudflare();
     });
+    expect(onProvisioned).toHaveBeenCalledWith(null);
     expect(hoisted.configureCf.mutateAsync).toHaveBeenCalledWith({
       token: "tok",
       domain: "example.com",

--- a/source/admin-site/tests/pages/RemoteAccess.test.tsx
+++ b/source/admin-site/tests/pages/RemoteAccess.test.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { screen } from "@testing-library/react";
+import { act, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -248,6 +248,32 @@ describe("RemoteAccess - configured", () => {
     await user.click(screen.getByRole("button", { name: "Cancel" }));
     // Back to the status view.
     expect(screen.getByTestId("ra-status")).toBeInTheDocument();
+  });
+
+  it("toasts when registration adopted an existing network", async () => {
+    renderWithProviders(<RemoteAccess />);
+    await act(async () =>
+      capturedOpts.onProvisioned({
+        fqdn: "nairobi.my.wardnet.services",
+        region: "euc",
+        adopted: true,
+      }),
+    );
+    expect(toast.success).toHaveBeenCalledWith(
+      "Joined your existing network nairobi.my.wardnet.services (euc)",
+    );
+  });
+
+  it("stays quiet when registration created a fresh network", async () => {
+    renderWithProviders(<RemoteAccess />);
+    await act(async () =>
+      capturedOpts.onProvisioned({
+        fqdn: "nairobi.my.wardnet.services",
+        region: "euc",
+        adopted: false,
+      }),
+    );
+    expect(toast.success).not.toHaveBeenCalled();
   });
 
   it("recheck reports a matching verdict via toast", async () => {

--- a/source/admin-site/tests/pages/setup/StepRemoteAccess.test.tsx
+++ b/source/admin-site/tests/pages/setup/StepRemoteAccess.test.tsx
@@ -59,7 +59,13 @@ const registerWardnet = vi.fn();
 const enableCloudflare = vi.fn();
 
 type EnrollmentOpts = {
-  onProvisioned: () => void;
+  onProvisioned: (
+    registration?: {
+      fqdn: string;
+      region: string | null;
+      adopted: boolean;
+    } | null,
+  ) => void;
   onError: (err: unknown) => void;
   clearError: () => void;
 };
@@ -180,6 +186,22 @@ describe("StepRemoteAccess", () => {
     const skip = screen.getByTestId("setup-remote-access-skip");
     expect(skip).toBeDisabled();
     expect(skip).toHaveTextContent("Skipping…");
+  });
+
+  it("says it joined the existing network when registration adopted one", async () => {
+    renderWithProviders(<StepRemoteAccess />);
+    await act(async () =>
+      capturedOpts.onProvisioned({
+        fqdn: "nairobi.my.wardnet.services",
+        region: "euc",
+        adopted: true,
+      }),
+    );
+    expect(
+      screen.getByText(
+        /Joined your existing network nairobi\.my\.wardnet\.services/,
+      ),
+    ).toBeInTheDocument();
   });
 
   it("shows a pending label on the progress view while advancing", async () => {

--- a/source/daemon/crates/wardnet-common/src/api.rs
+++ b/source/daemon/crates/wardnet-common/src/api.rs
@@ -700,6 +700,11 @@ pub struct DdnsRegisterResponse {
     pub fqdn: String,
     /// The region slug (display only); `None` for BYOD-Cloudflare.
     pub region: Option<String>,
+    /// `true` when the daemon JOINED an already-existing network of this
+    /// account (same slug, re-enrollment) instead of creating a fresh one —
+    /// the network's region and name won over the request (display only).
+    #[serde(default)]
+    pub adopted: bool,
 }
 
 /// Response for `GET /api/ddns/status`.

--- a/source/daemon/crates/wardnetd-api/src/api/ddns.rs
+++ b/source/daemon/crates/wardnetd-api/src/api/ddns.rs
@@ -193,6 +193,7 @@ pub async fn ddns_register(
     Ok(Json(DdnsRegisterResponse {
         fqdn: registration.subdomain,
         region: Some(registration.region),
+        adopted: registration.adopted,
     }))
 }
 
@@ -227,6 +228,7 @@ pub async fn ddns_cloudflare(
         fqdn: registration.subdomain,
         // BYOD has no bridge region.
         region: None,
+        adopted: false,
     }))
 }
 

--- a/source/daemon/crates/wardnetd-api/src/api/tests/ddns.rs
+++ b/source/daemon/crates/wardnetd-api/src/api/tests/ddns.rs
@@ -55,6 +55,7 @@ impl DdnsService for MockDdns {
         Ok(DdnsRegistration {
             subdomain: format!("{slug}.my.wardnet.services"),
             region: "use1".to_owned(),
+            adopted: false,
         })
     }
     async fn configure_cloudflare(
@@ -66,6 +67,7 @@ impl DdnsService for MockDdns {
         Ok(DdnsRegistration {
             subdomain: domain,
             region: "us".to_owned(),
+            adopted: false,
         })
     }
     // Returns `Ok` (not `unimplemented!`) so the detached provisioning task the

--- a/source/daemon/crates/wardnetd-mock/src/backends/noop_remote_access.rs
+++ b/source/daemon/crates/wardnetd-mock/src/backends/noop_remote_access.rs
@@ -194,6 +194,7 @@ impl DdnsService for MockDdnsService {
         Ok(DdnsRegistration {
             subdomain: fqdn,
             region: "use1".to_owned(),
+            adopted: false,
         })
     }
 
@@ -212,6 +213,7 @@ impl DdnsService for MockDdnsService {
         Ok(DdnsRegistration {
             subdomain: domain,
             region: "cloudflare".to_owned(),
+            adopted: false,
         })
     }
 

--- a/source/daemon/crates/wardnetd-services/src/cloud/tenants.rs
+++ b/source/daemon/crates/wardnetd-services/src/cloud/tenants.rs
@@ -38,6 +38,10 @@ pub struct NetworkRegistration {
     pub region: String,
     /// `provisioning` | `active` | `deprovisioning` at registration time.
     pub provisioning_state: String,
+    /// `true` when the daemon JOINED an already-existing network of its tenant
+    /// (its region/state/name win over the request) rather than creating a
+    /// fresh one. Absent on older cloud versions → `false`.
+    pub adopted: bool,
 }
 
 /// A client for the tenants service at `base_url`.
@@ -204,6 +208,7 @@ impl TenantsClient {
             slug: view.slug,
             region: view.region,
             provisioning_state: view.provisioning_state,
+            adopted: view.adopted,
         })
     }
 
@@ -277,4 +282,7 @@ struct NetworkView {
     slug: String,
     region: String,
     provisioning_state: String,
+    /// Absent on older cloud versions -> `false`.
+    #[serde(default)]
+    adopted: bool,
 }

--- a/source/daemon/crates/wardnetd-services/src/cloud/tunneller_runner.rs
+++ b/source/daemon/crates/wardnetd-services/src/cloud/tunneller_runner.rs
@@ -176,11 +176,25 @@ impl TunnelerConnector {
         };
         auth_context::with_context(admin_ctx, async {
             let slug = self.system_config.get(KEY_REGION).await.ok().flatten()?;
-            let gateway = self
+            // Distinguish "misconfigured" from "not enrolled": a persisted region
+            // the catalog cannot resolve means the tunnel will never come up, and
+            // silence here previously made that state indistinguishable from a
+            // box without remote access.
+            let Some(gateway) = self
                 .region_catalog
                 .iter()
                 .find(|entry| entry.slug == slug)
-                .map(|entry| entry.gateway_base_url.clone())?;
+                .map(|entry| entry.gateway_base_url.clone())
+            else {
+                tracing::warn!(
+                    region = %slug,
+                    "tunnel runner: persisted DDNS region {slug} is not in this \
+                     build's region catalog — the reverse tunnel cannot connect \
+                     (update wardnet or re-register remote access)",
+                    slug = slug,
+                );
+                return None;
+            };
             let seed_bytes = self.secrets.get(SECRET_DAEMON_KEY).await.ok().flatten()?;
             let seed: [u8; 32] = seed_bytes.try_into().ok()?;
             let identity =

--- a/source/daemon/crates/wardnetd-services/src/ddns/mod.rs
+++ b/source/daemon/crates/wardnetd-services/src/ddns/mod.rs
@@ -86,6 +86,10 @@ pub struct DdnsRegistration {
     pub subdomain: String,
     /// The bridge's region label (display only).
     pub region: String,
+    /// `true` when the daemon joined an already-existing network of this
+    /// account instead of creating a fresh one — the network's region, state,
+    /// and name won over the request (display only).
+    pub adopted: bool,
 }
 
 /// Current DDNS state, surfaced to Settings / status views (C10).
@@ -702,6 +706,20 @@ impl DdnsService for DdnsServiceImpl {
         // The next token must be network-scoped (the daemon can now reach ddns).
         identity.forget_token();
 
+        // Defend at write time: the response's region is server-controlled
+        // (an ADOPTED network's region wins over our request) and every later
+        // gateway resolution — IP reports, ACME, the tunnel — keys off the
+        // persisted value strictly through the local catalog. Persisting a slug
+        // the catalog cannot resolve would 200 the wizard and then silently
+        // brick remote access on every background tick, so refuse it here,
+        // before any config is written.
+        self.gateway_base_for_region(&network.region).map_err(|_| {
+            AppError::UpstreamUnavailable(format!(
+                "your network '{}' lives in region '{}', which this wardnet build does not                  know — update wardnet and retry",
+                network.slug, network.region,
+            ))
+        })?;
+
         let subdomain = format!("{}.{SUBDOMAIN_PARENT}", network.slug);
         self.set_cfg(KEY_NETWORK_ID, &network.network_id).await?;
         self.set_cfg(KEY_SLUG, &network.slug).await?;
@@ -718,9 +736,11 @@ impl DdnsService for DdnsServiceImpl {
             %subdomain,
             region = %network.region,
             provisioning_state = %network.provisioning_state,
-            "registered DDNS network: subdomain={subdomain}, region={region}, state={state}",
+            adopted = network.adopted,
+            "registered DDNS network: subdomain={subdomain}, region={region}, state={state},              adopted={adopted}",
             region = network.region,
             state = network.provisioning_state,
+            adopted = network.adopted,
         );
 
         self.teardown_superseded(
@@ -735,6 +755,7 @@ impl DdnsService for DdnsServiceImpl {
         Ok(DdnsRegistration {
             subdomain,
             region: network.region,
+            adopted: network.adopted,
         })
     }
 
@@ -795,6 +816,7 @@ impl DdnsService for DdnsServiceImpl {
         Ok(DdnsRegistration {
             subdomain: domain,
             region: PROVIDER_CLOUDFLARE.to_owned(),
+            adopted: false,
         })
     }
 

--- a/source/daemon/crates/wardnetd-services/src/ddns/mod.rs
+++ b/source/daemon/crates/wardnetd-services/src/ddns/mod.rs
@@ -706,15 +706,21 @@ impl DdnsService for DdnsServiceImpl {
         self.set_cfg(KEY_NETWORK_ID, &network.network_id).await?;
         self.set_cfg(KEY_SLUG, &network.slug).await?;
         self.set_cfg(KEY_SUBDOMAIN, &subdomain).await?;
-        self.set_cfg(KEY_REGION, &region.slug).await?;
+        // The RESPONSE's region, not our latency-based pick: when the cloud
+        // adopts an existing network (same tenant re-registering its own slug),
+        // that network's region is authoritative — IP reports and ACME calls
+        // key their regional gateway off this value.
+        self.set_cfg(KEY_REGION, &network.region).await?;
         self.set_cfg(KEY_PROVIDER, PROVIDER_WARDNET).await?;
         self.entitlement.set_premium(true);
 
         tracing::info!(
             %subdomain,
-            region = %region.slug,
+            region = %network.region,
             provisioning_state = %network.provisioning_state,
-            "registered DDNS network"
+            "registered DDNS network: subdomain={subdomain}, region={region}, state={state}",
+            region = network.region,
+            state = network.provisioning_state,
         );
 
         self.teardown_superseded(

--- a/source/daemon/crates/wardnetd-services/src/ddns/tests/service.rs
+++ b/source/daemon/crates/wardnetd-services/src/ddns/tests/service.rs
@@ -1189,10 +1189,84 @@ async fn register_network_stores_the_networks_region_not_the_selected_one() {
             "display_name": "nairobi",
             "region": "euc",
             "provisioning_state": "active",
+            "adopted": true,
             "created_at": "2026-06-29T00:00:00Z",
             "updated_at": "2026-06-29T00:00:00Z"
         })))
         .expect(1)
+        .mount(&tenants)
+        .await;
+
+    let ddns = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/readyz"))
+        .respond_with(ResponseTemplate::new(200))
+        .mount(&ddns)
+        .await;
+
+    let config = Arc::new(MockSystemConfig::default());
+    let secrets = Arc::new(MockSecretStore::default());
+    seed_enrolled(&secrets).await;
+    // euc is in the catalog (so the response region resolves) but unhealthy —
+    // select_best still picks use1, which is what the request carries.
+    let mut catalog = region_catalog("use1", &ddns);
+    catalog.push(RegionEndpoint {
+        slug: "euc".to_owned(),
+        gateway_base_url: "http://127.0.0.1:9".to_owned(),
+        health_url: "http://127.0.0.1:9/readyz".to_owned(),
+    });
+    let svc = DdnsServiceImpl::with_settings(
+        config.clone(),
+        secrets.clone(),
+        settings(catalog, tenants.uri(), vec![]),
+    );
+
+    let registration = auth_context::with_context(
+        admin_ctx(),
+        svc.register_network("nairobi".to_owned(), None),
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(
+        registration.region, "euc",
+        "the adopted network's region is authoritative"
+    );
+    assert!(
+        registration.adopted,
+        "the response's adopted flag must ride through to the API"
+    );
+    assert_eq!(
+        config.get(KEY_REGION).await.unwrap().as_deref(),
+        Some("euc"),
+        "the daemon must persist the NETWORK's region, not its own selection — \
+         gateway routing for IP reports and ACME keys off this value"
+    );
+}
+
+/// Code-review follow-up: the response's region is server-controlled, and every
+/// later gateway resolution goes strictly through the local catalog. A region
+/// this build cannot resolve must fail the registration LOUDLY, before any
+/// config is persisted — not 200 the wizard and then brick every background
+/// tick ("unknown DDNS region slug") until someone reads the logs.
+#[tokio::test]
+async fn register_network_rejects_a_region_missing_from_the_catalog() {
+    let tenants = MockServer::start().await;
+    mount_token(&tenants).await;
+    Mock::given(method("POST"))
+        .and(path("/v1/networks"))
+        .and(header_exists("authorization"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "id": "n-10",
+            "tenant_id": "t-1",
+            "slug": "nairobi",
+            "display_name": "nairobi",
+            "region": "mars",
+            "provisioning_state": "active",
+            "adopted": true,
+            "created_at": "2026-06-29T00:00:00Z",
+            "updated_at": "2026-06-29T00:00:00Z"
+        })))
         .mount(&tenants)
         .await;
 
@@ -1212,21 +1286,21 @@ async fn register_network_stores_the_networks_region_not_the_selected_one() {
         settings(region_catalog("use1", &ddns), tenants.uri(), vec![]),
     );
 
-    let registration = auth_context::with_context(
+    let err = auth_context::with_context(
         admin_ctx(),
         svc.register_network("nairobi".to_owned(), None),
     )
     .await
-    .unwrap();
+    .unwrap_err();
 
-    assert_eq!(
-        registration.region, "euc",
-        "the adopted network's region is authoritative"
+    assert!(
+        matches!(err, AppError::UpstreamUnavailable(ref msg) if msg.contains("mars")),
+        "must fail loudly naming the unknown region, got {err:?}"
     );
     assert_eq!(
-        config.get(KEY_REGION).await.unwrap().as_deref(),
-        Some("euc"),
-        "the daemon must persist the NETWORK's region, not its own selection — \
-         gateway routing for IP reports and ACME keys off this value"
+        config.get(KEY_PROVIDER).await.unwrap(),
+        None,
+        "nothing may be persisted on a rejected region"
     );
+    assert_eq!(config.get(KEY_REGION).await.unwrap(), None);
 }

--- a/source/daemon/crates/wardnetd-services/src/ddns/tests/service.rs
+++ b/source/daemon/crates/wardnetd-services/src/ddns/tests/service.rs
@@ -1166,3 +1166,67 @@ async fn resolution_check_reports_pending_on_nxdomain() {
         .unwrap();
     assert_eq!(result.verdict, DdnsResolutionVerdict::Pending);
 }
+
+/// When the cloud ADOPTS an existing network (same tenant re-registering its
+/// own slug), the response's network is authoritative — including its region,
+/// which may differ from the wizard's latency-based pick. The daemon must
+/// persist the NETWORK's region, or every subsequent IP report and ACME call
+/// would go to the wrong regional gateway.
+#[tokio::test]
+async fn register_network_stores_the_networks_region_not_the_selected_one() {
+    let tenants = MockServer::start().await;
+    mount_token(&tenants).await;
+    // Wizard selects use1 (the only healthy catalog region), but the tenant's
+    // existing network lives in euc — the server adopts and echoes euc.
+    Mock::given(method("POST"))
+        .and(path("/v1/networks"))
+        .and(body_json(json!({ "slug": "nairobi", "region": "use1" })))
+        .and(header_exists("authorization"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "id": "n-9",
+            "tenant_id": "t-1",
+            "slug": "nairobi",
+            "display_name": "nairobi",
+            "region": "euc",
+            "provisioning_state": "active",
+            "created_at": "2026-06-29T00:00:00Z",
+            "updated_at": "2026-06-29T00:00:00Z"
+        })))
+        .expect(1)
+        .mount(&tenants)
+        .await;
+
+    let ddns = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/readyz"))
+        .respond_with(ResponseTemplate::new(200))
+        .mount(&ddns)
+        .await;
+
+    let config = Arc::new(MockSystemConfig::default());
+    let secrets = Arc::new(MockSecretStore::default());
+    seed_enrolled(&secrets).await;
+    let svc = DdnsServiceImpl::with_settings(
+        config.clone(),
+        secrets.clone(),
+        settings(region_catalog("use1", &ddns), tenants.uri(), vec![]),
+    );
+
+    let registration = auth_context::with_context(
+        admin_ctx(),
+        svc.register_network("nairobi".to_owned(), None),
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(
+        registration.region, "euc",
+        "the adopted network's region is authoritative"
+    );
+    assert_eq!(
+        config.get(KEY_REGION).await.unwrap().as_deref(),
+        Some("euc"),
+        "the daemon must persist the NETWORK's region, not its own selection — \
+         gateway routing for IP reports and ACME keys off this value"
+    );
+}

--- a/source/sdk/wardnet-js/src/types/remote-access.ts
+++ b/source/sdk/wardnet-js/src/types/remote-access.ts
@@ -44,6 +44,12 @@ export interface DdnsRegisterResponse {
   fqdn: string;
   /** The region slug (display only); `null` for BYOD-Cloudflare. */
   region: string | null;
+  /**
+   * `true` when the daemon JOINED an already-existing network of this account
+   * (re-enrollment with a slug it already owns) instead of creating a fresh
+   * one — the network's region and name won over the request.
+   */
+  adopted: boolean;
 }
 
 /** Response for `GET /api/ddns/status`. */


### PR DESCRIPTION
Daemon-side counterpart of wardnet/wardnet-cloud#89 (adopt-own-slug).

When the cloud adopts an existing network — a daemon re-registering a slug its own tenant already holds — the response's network is authoritative, including its **region**, which can differ from the wizard's latency-based selection. `register_network` used to persist the daemon's own pick (`region.slug`); an adopted daemon whose network lives elsewhere would then key every subsequent IP report and ACME call off the wrong regional gateway.

Now the daemon persists `network.region` from the response. Also correct standalone: the server's answer was always the truth about where the network lives.

Test written RED first: register where the mock cloud echoes a different region (`euc`) than requested (`use1`) — the daemon must store `euc`. Full `check-daemon` gate green (fmt, clippy `-D warnings`, workspace suite).

Note: the daemon flow already tolerates an `active` network in the register response (it never waited on `provisioning`), so adoption needs no further daemon changes — and issuance actually gets *more* reliable, since an adopted network has its FQDN already stored (no provisioner race, cf. #886 investigation).

## Merge Commit Message

fix(ddns): persist the network's region from the register response, not the wizard's pick

https://claude.ai/code/session_016wT23SWMLwBihgkDxW1soY