### PR TITLE
fix(ddns): resolution check treats resolving-at-all as healthy for the wardnet provider

### DIFF
--- a/source/daemon/crates/wardnetd-services/src/ddns/mod.rs
+++ b/source/daemon/crates/wardnetd-services/src/ddns/mod.rs
@@ -975,6 +975,28 @@ impl DdnsService for DdnsServiceImpl {
             ))
         })?;
 
+        // The wardnet provider's tenant record is a CNAME at the region's
+        // Tunneller ingress (cloud ADR-0016): public DNS is EXPECTED to
+        // resolve to the ingress, never this box's WAN address, so comparing
+        // against `last_public_ip` would report `Mismatch` forever on a
+        // healthy setup. Resolving AT ALL is the health signal — it proves
+        // the tenant CNAME and the region's ingress record both exist. BYOD
+        // keeps the WAN-IP comparison: the customer's own domain really is an
+        // A record of their address.
+        if status.provider.as_deref() == Some(PROVIDER_WARDNET) {
+            let verdict = if resolved_ips.is_empty() {
+                DdnsResolutionVerdict::Pending
+            } else {
+                DdnsResolutionVerdict::Match
+            };
+            return Ok(DdnsResolutionCheckResponse {
+                verdict,
+                fqdn: Some(fqdn),
+                expected_ip: None,
+                resolved_ips: resolved_ips.iter().map(ToString::to_string).collect(),
+            });
+        }
+
         let expected = status
             .last_public_ip
             .as_deref()

--- a/source/daemon/crates/wardnetd-services/src/ddns/tests/service.rs
+++ b/source/daemon/crates/wardnetd-services/src/ddns/tests/service.rs
@@ -1093,9 +1093,19 @@ fn resolution_settings(doh: &MockServer) -> DdnsSettings {
 /// Seed a configured wardnet identity with a known FQDN + last-published IP, for
 /// the resolution-check tests (which only read `status()` + query `DoH`).
 async fn seed_for_resolution(config: &MockSystemConfig, last_ip: &str) {
-    config.set(KEY_PROVIDER, PROVIDER_WARDNET).await.unwrap();
+    seed_for_resolution_with(config, last_ip, PROVIDER_WARDNET).await;
+}
+
+async fn seed_for_resolution_with(config: &MockSystemConfig, last_ip: &str, provider: &str) {
+    config.set(KEY_PROVIDER, provider).await.unwrap();
+    // Each provider reads its own fqdn key (see active_fqdn).
+    let fqdn_key = if provider == PROVIDER_CLOUDFLARE {
+        KEY_DOMAIN
+    } else {
+        KEY_SUBDOMAIN
+    };
     config
-        .set(KEY_SUBDOMAIN, "happy.my.wardnet.services")
+        .set(fqdn_key, "happy.my.wardnet.services")
         .await
         .unwrap();
     config.set(KEY_LAST_IP, last_ip).await.unwrap();
@@ -1134,10 +1144,37 @@ async fn resolution_check_reports_match() {
 }
 
 #[tokio::test]
-async fn resolution_check_reports_mismatch() {
-    let doh = doh_server(0, &["1.2.3.4"]).await;
+async fn wardnet_provider_resolving_to_the_ingress_is_a_match() {
+    // The tenant record is a CNAME at the region's Tunneller ingress
+    // (cloud ADR-0016): public DNS is EXPECTED to resolve to an address that
+    // is not this box's WAN IP. Comparing against last_public_ip reported
+    // Mismatch forever on a perfectly healthy setup.
+    let doh = doh_server(0, &["1.2.3.4"]).await; // ingress IP ≠ WAN 9.9.9.9
     let config = Arc::new(MockSystemConfig::default());
     seed_for_resolution(&config, "9.9.9.9").await;
+    let svc = DdnsServiceImpl::with_settings(
+        config,
+        Arc::new(MockSecretStore::default()),
+        resolution_settings(&doh),
+    );
+
+    let result = auth_context::with_context(admin_ctx(), svc.resolution_check())
+        .await
+        .unwrap();
+    assert_eq!(result.verdict, DdnsResolutionVerdict::Match);
+    assert_eq!(
+        result.expected_ip, None,
+        "there is no WAN-IP expectation to display for the wardnet provider"
+    );
+}
+
+#[tokio::test]
+async fn byod_cloudflare_still_compares_against_the_wan_ip() {
+    // BYOD keeps the old contract: the customer's own domain really is an A
+    // record of their WAN IP, so a divergent answer is a real mismatch.
+    let doh = doh_server(0, &["1.2.3.4"]).await;
+    let config = Arc::new(MockSystemConfig::default());
+    seed_for_resolution_with(&config, "9.9.9.9", PROVIDER_CLOUDFLARE).await;
     let svc = DdnsServiceImpl::with_settings(
         config,
         Arc::new(MockSecretStore::default()),


### PR DESCRIPTION
Companion to wardnet-cloud#92 (tenant records become CNAMEs at the region's Tunneller ingress, ADR-0016). With that change, public DNS for a wardnet-provider tenant is **expected** to resolve to the ingress — never this box's WAN address — so the resolution check's WAN-IP comparison reported `Mismatch` forever on a perfectly healthy setup.

## Changes

- For the **wardnet provider**, the verdict is now `Match` when the FQDN resolves at all (`Pending` when it doesn't), with `expected_ip` omitted from the response. Resolving at all proves both the tenant CNAME and the region's ingress record exist — that's the whole health signal.
- **BYOD is unchanged**: the customer's own domain really is an A record of their WAN address, so the IP comparison stays.

## Tests

Service tests cover the wardnet-provider Match (resolves, regardless of address), Pending (no answers), and the BYOD comparison staying intact. Full daemon gate (`make check-daemon`) green.

## Merge Commit Message

fix(ddns): resolution check treats resolving-at-all as healthy for the wardnet provider

https://claude.ai/code/session_016rUuXqBH8uWYXKJbTFkzSr