### PR TITLE
fix(dns): relay negative answers (NODATA/NXDOMAIN) instead of SERVFAIL; RFC 2308 negative caching

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -154,8 +154,13 @@ jobs:
     # PR doesn't spin up the 30-min daemon coverage (and vice versa).
     with:
       run-daemon: ${{ needs.preflight.outputs.daemon == 'true' || needs.preflight.outputs.ci == 'true' }}
-      run-site: ${{ needs.preflight.outputs.site == 'true' || needs.preflight.outputs.ci == 'true' }}
-      run-frontend: ${{ needs.preflight.outputs['admin-web'] == 'true' || needs.preflight.outputs['admin-app'] == 'true' || needs.preflight.outputs['user-app'] == 'true' || needs.preflight.outputs.ci == 'true' }}
+      # site + frontend LCOVs merge into ONE "typescript" pool in bulwark's
+      # coverage gate, and the baseline is recorded from full main runs. If
+      # only one of the two jobs runs on a PR, the partial pool is compared
+      # against the full-pool baseline and fails as a phantom regression —
+      # so any TypeScript-area change must run BOTH coverage jobs.
+      run-site: ${{ needs.preflight.outputs.site == 'true' || needs.preflight.outputs['admin-web'] == 'true' || needs.preflight.outputs['admin-app'] == 'true' || needs.preflight.outputs['user-app'] == 'true' || needs.preflight.outputs.ci == 'true' }}
+      run-frontend: ${{ needs.preflight.outputs.site == 'true' || needs.preflight.outputs['admin-web'] == 'true' || needs.preflight.outputs['admin-app'] == 'true' || needs.preflight.outputs['user-app'] == 'true' || needs.preflight.outputs.ci == 'true' }}
     secrets: inherit
 
   tests-e2e:

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -24422,6 +24422,7 @@
           "rewritten",
           "recursive",
           "upstream_error",
+          "negative",
           "authoritative",
           "error"
         ]

--- a/source/admin-site/src/pages/DnsLogs.tsx
+++ b/source/admin-site/src/pages/DnsLogs.tsx
@@ -42,6 +42,9 @@ const RESULT_BADGE: Record<string, "ok" | "warn" | "down" | "info" | "ghost"> =
     // signals "would-have-blocked" without the alarming red.
     blocked_skipped: "ghost",
     upstream_error: "down",
+    // Successful resolution whose answer is "no such name / record type"
+    // (NXDOMAIN / NODATA) — informational, not an error.
+    negative: "info",
     forwarded: "ghost",
     cache_hit: "ghost",
     rewritten: "info",
@@ -51,6 +54,7 @@ const RESULT_BADGE: Record<string, "ok" | "warn" | "down" | "info" | "ghost"> =
 
 const RESULT_LABEL: Record<string, string> = {
   blocked_skipped: "blocked (skipped)",
+  negative: "negative (no record)",
 };
 
 function fmtTime(ts: string): string {
@@ -240,6 +244,7 @@ export default function DnsLogs() {
           <SelectItem value="blocked_skipped">Blocked (skipped)</SelectItem>
           <SelectItem value="cache_hit">Cache hit</SelectItem>
           <SelectItem value="rewritten">Rewritten</SelectItem>
+          <SelectItem value="negative">Negative (no record)</SelectItem>
           <SelectItem value="upstream_error">Upstream error</SelectItem>
         </SelectContent>
       </Select>

--- a/source/daemon/crates/wardnet-common/src/dns.rs
+++ b/source/daemon/crates/wardnet-common/src/dns.rs
@@ -347,6 +347,10 @@ pub enum DnsQueryResult {
     Recursive,
     /// Upstream resolver returned an error — resolver string `"upstream_error"`.
     UpstreamError,
+    /// Resolved successfully with a negative answer: the name (NXDOMAIN) or
+    /// the requested record type (NODATA) does not exist — resolver string
+    /// `"negative"`.
+    Negative,
     /// Answered directly from a local authoritative record — resolver string `"authoritative"`.
     Authoritative,
     /// Resolution failed (parse fallback for unrecognised strings).
@@ -366,6 +370,7 @@ impl DnsQueryResult {
             Self::Rewritten => "rewritten",
             Self::Recursive => "recursive",
             Self::UpstreamError => "upstream_error",
+            Self::Negative => "negative",
             Self::Authoritative => "authoritative",
             Self::Error => "error",
         }
@@ -386,6 +391,7 @@ impl DnsQueryResult {
             "rewritten" => Self::Rewritten,
             "recursive" => Self::Recursive,
             "upstream_error" => Self::UpstreamError,
+            "negative" => Self::Negative,
             "authoritative" => Self::Authoritative,
             other => {
                 tracing::warn!(

--- a/source/daemon/crates/wardnet-common/src/tests/dns.rs
+++ b/source/daemon/crates/wardnet-common/src/tests/dns.rs
@@ -131,6 +131,7 @@ fn dns_query_result_round_trip() {
         DnsQueryResult::Rewritten,
         DnsQueryResult::Recursive,
         DnsQueryResult::UpstreamError,
+        DnsQueryResult::Negative,
         DnsQueryResult::Error,
     ] {
         let json = serde_json::to_string(&result).unwrap();

--- a/source/daemon/crates/wardnetd-mock/src/events.rs
+++ b/source/daemon/crates/wardnetd-mock/src/events.rs
@@ -209,6 +209,13 @@ fn emit_fake_dns_queries(
                 CDN[(seed >> 17) as usize % CDN.len()].to_owned(),
                 "forwarded",
             )
+        } else if bucket == 8 {
+            // Negative answers (NXDOMAIN / NODATA) — e.g. AAAA queries for
+            // IPv4-only names.
+            (
+                POPULAR[(seed >> 15) as usize % POPULAR.len()].to_owned(),
+                "negative",
+            )
         } else {
             (
                 POPULAR[(seed >> 19) as usize % POPULAR.len()].to_owned(),
@@ -221,7 +228,7 @@ fn emit_fake_dns_queries(
             "blocked" => 0.2 + ((seed >> 23) as f64 % 3.0) / 10.0,
             _ => 12.0 + ((seed >> 23) as f64 % 50.0),
         };
-        let upstream = if result == "forwarded" {
+        let upstream = if result == "forwarded" || result == "negative" {
             Some(UPSTREAMS[(seed >> 29) as usize % UPSTREAMS.len()].to_owned())
         } else {
             None

--- a/source/daemon/crates/wardnetd-mock/src/seed.rs
+++ b/source/daemon/crates/wardnetd-mock/src/seed.rs
@@ -659,6 +659,13 @@ fn generate_dns_query_log(client_ips: &[String], now: chrono::DateTime<Utc>) -> 
                     cdn[(seed >> 17) as usize % cdn.len()].to_owned(),
                     "forwarded",
                 )
+            } else if bucket_pick == 8 {
+                // 10 % negative answers (AAAA/HTTPS for names lacking the
+                // record type, or nonexistent hosts) — NXDOMAIN/NODATA.
+                (
+                    popular[(seed >> 15) as usize % popular.len()].to_owned(),
+                    "negative",
+                )
             } else {
                 // remainder — forwarded popular domains
                 (
@@ -674,7 +681,7 @@ fn generate_dns_query_log(client_ips: &[String], now: chrono::DateTime<Utc>) -> 
                 "blocked" => 0.2 + ((seed >> 23) as f64 % 3.0) / 10.0,
                 _ => 12.0 + ((seed >> 23) as f64 % 50.0),
             };
-            let upstream = if result == "forwarded" {
+            let upstream = if result == "forwarded" || result == "negative" {
                 Some(upstreams[(seed >> 29) as usize % upstreams.len()].to_owned())
             } else {
                 None

--- a/source/daemon/crates/wardnetd-services/src/dns/cache.rs
+++ b/source/daemon/crates/wardnetd-services/src/dns/cache.rs
@@ -54,7 +54,7 @@ impl DnsCache {
         domain: &str,
         rtype: RecordType,
     ) -> Option<&Message> {
-        let key = (upstream, domain.to_lowercase(), rtype);
+        let key = (upstream, canonical_domain(domain), rtype);
 
         // Check if entry exists and is not expired.
         let expired = self.entries.get(&key).is_none_or(CachedEntry::is_expired);
@@ -100,7 +100,7 @@ impl DnsCache {
             self.evict_oldest();
         }
 
-        let key = (upstream, domain.to_lowercase(), rtype);
+        let key = (upstream, canonical_domain(domain), rtype);
         self.entries.insert(
             key,
             CachedEntry {
@@ -114,7 +114,7 @@ impl DnsCache {
     /// Remove all cache entries for `domain` across all upstream pools and
     /// record types. Returns the number of entries removed.
     pub fn invalidate_domain(&mut self, domain: &str) -> u64 {
-        let d = domain.trim_end_matches('.').to_ascii_lowercase();
+        let d = canonical_domain(domain);
         let before = self.entries.len() as u64;
         self.entries
             .retain(|(_, cached_domain, _), _| cached_domain != &d);
@@ -180,4 +180,11 @@ impl DnsCache {
             self.entries.remove(&oldest_key);
         }
     }
+}
+
+/// Canonical cache-key form of a domain: lowercase, no trailing dot. The
+/// server inserts wire-format FQDNs ("foo.com.") while eviction callers pass
+/// bare names ("foo.com"); both must map to the same key.
+fn canonical_domain(domain: &str) -> String {
+    domain.trim_end_matches('.').to_ascii_lowercase()
 }

--- a/source/daemon/crates/wardnetd-services/src/dns/log_sink.rs
+++ b/source/daemon/crates/wardnetd-services/src/dns/log_sink.rs
@@ -235,6 +235,7 @@ fn normalize_outcome(result: &str) -> &'static str {
     match result {
         "blocked" | "blocked_skipped" => "blocked",
         "forwarded" => "forwarded",
+        "negative" => "negative",
         "cache_hit" | "cached" => "cached",
         "recursive" => "recursive",
         "rewritten" | "local" => "local",

--- a/source/daemon/crates/wardnetd-services/src/dns/tests/cache.rs
+++ b/source/daemon/crates/wardnetd-services/src/dns/tests/cache.rs
@@ -37,6 +37,33 @@ fn case_insensitive() {
 }
 
 #[test]
+fn trailing_dot_normalized_across_insert_get_and_invalidate() {
+    // The DNS server inserts under the wire-format FQDN ("foo.com.") while
+    // eviction callers pass the bare name ("foo.com"); both forms must hit
+    // the same entry or per-domain invalidation silently removes nothing.
+    let mut cache = DnsCache::new(100);
+    cache.insert(
+        DEFAULT,
+        "example.com.",
+        RecordType::A,
+        make_response(),
+        300,
+        0,
+        86400,
+    );
+    assert!(
+        cache.get(DEFAULT, "example.com", RecordType::A).is_some(),
+        "bare-name lookup must hit the FQDN-inserted entry"
+    );
+    assert_eq!(
+        cache.invalidate_domain("example.com"),
+        1,
+        "bare-name invalidation must evict the FQDN-inserted entry"
+    );
+    assert!(cache.is_empty());
+}
+
+#[test]
 fn zero_ttl_not_cached() {
     let mut cache = DnsCache::new(100);
     cache.insert(

--- a/source/daemon/crates/wardnetd/src/dns/server.rs
+++ b/source/daemon/crates/wardnetd/src/dns/server.rs
@@ -15,7 +15,9 @@ use hickory_resolver::config::{
 };
 use hickory_resolver::lookup::Lookup;
 use hickory_resolver::net::runtime::TokioRuntimeProvider;
-use hickory_resolver::recursor::{DnssecConfig, DnssecPolicy, Recursor, RecursorOptions};
+use hickory_resolver::recursor::{
+    DnssecConfig, DnssecPolicy, Recursor, RecursorError, RecursorOptions,
+};
 use tokio::net::UdpSocket;
 use tokio::sync::{Mutex, RwLock, broadcast};
 use tokio::task::JoinHandle;
@@ -24,8 +26,8 @@ use tokio_util::task::TaskTracker;
 use tracing::Instrument;
 use uuid::Uuid;
 use wardnet_common::dns::{
-    DnsConfig, DnsProtocol, DnsRecordType, DnsResolutionMode, FilterAction, ForwarderSelectionMode,
-    UpstreamDns, UpstreamId, UpstreamLatency,
+    DnsConfig, DnsProtocol, DnsQueryResult, DnsRecordType, DnsResolutionMode, FilterAction,
+    ForwarderSelectionMode, UpstreamDns, UpstreamId, UpstreamLatency,
 };
 use wardnet_common::event::WardnetEvent;
 use wardnetd_data::repository::QueryLogRow;
@@ -878,9 +880,9 @@ async fn handle_query(
 
     // 3. Forward to upstream — conditional forwarding overrides upstream_id.
     let pass_result = if outcome.would_have_blocked {
-        "blocked_skipped"
+        DnsQueryResult::BlockedSkipped.as_str()
     } else {
-        "forwarded"
+        DnsQueryResult::Forwarded.as_str()
     };
 
     if let Some(cond_upstream) = conditional_upstream {
@@ -1070,6 +1072,31 @@ async fn forward_via_default_resolver(
             )
             .await?;
         }
+        // The upstream answered "no such record / no such name" — a valid
+        // negative resolution, not an upstream failure. Relay it as
+        // NODATA/NXDOMAIN rather than SERVFAIL.
+        Err(e) if e.is_no_records_found() || e.is_nx_domain() => {
+            let nx_domain = e.is_nx_domain();
+            relay_negative(
+                socket,
+                cache,
+                log_sink,
+                &request,
+                id,
+                src,
+                domain,
+                rtype,
+                start,
+                pass_result,
+                upstream_id,
+                upstream,
+                nx_domain,
+                e.into_soa(),
+                cfg.cache_ttl_min_secs,
+                cfg.cache_ttl_max_secs,
+            )
+            .await?;
+        }
         Err(e) => {
             send_servfail(socket, src, id, &request).await?;
             let elapsed = start.elapsed();
@@ -1126,12 +1153,7 @@ async fn send_resolved(
     {
         // Empty NOERROR (NODATA), not NXDOMAIN: the name exists, we just
         // refuse the private answer.
-        let mut response = Message::response(id, OpCode::Query);
-        response.metadata.recursion_desired = true;
-        response.metadata.recursion_available = true;
-        response.add_queries(request.queries.clone());
-        let bytes = response.to_bytes()?;
-        socket.send_to(&bytes, src).await?;
+        send_negative(socket, src, id, request, false, None).await?;
         record_query(
             log_sink,
             domain,
@@ -1213,16 +1235,7 @@ pub(crate) async fn resolve_via_recursor(
         return Ok(());
     };
 
-    let (dnssec_ok, has_upstreams, rebinding, ttl_min, ttl_max) = {
-        let cfg = config.read().await;
-        (
-            cfg.dnssec_enabled,
-            !cfg.upstream_servers.is_empty(),
-            cfg.rebinding_protection,
-            cfg.cache_ttl_min_secs,
-            cfg.cache_ttl_max_secs,
-        )
-    };
+    let dnssec_ok = config.read().await.dnssec_enabled;
 
     let recursor_result = {
         let guard = recursor.read().await;
@@ -1233,6 +1246,56 @@ pub(crate) async fn resolve_via_recursor(
             ),
             None => None,
         }
+    };
+
+    handle_recursor_outcome(
+        recursor_result,
+        resolver,
+        socket,
+        config,
+        cache,
+        log_sink,
+        request,
+        id,
+        src,
+        domain,
+        rtype,
+        start,
+        pass_result,
+        upstream_id,
+    )
+    .await
+}
+
+/// React to the recursor's outcome: relay a resolved answer, fall back to
+/// forwarding on genuine failure, or SERVFAIL when neither is possible.
+/// Split from `resolve_via_recursor` so tests can inject outcomes (the
+/// recursor itself always walks from the real root servers).
+#[allow(clippy::too_many_arguments)]
+pub(crate) async fn handle_recursor_outcome(
+    recursor_result: Option<Result<Message, RecursorError>>,
+    resolver: &Arc<RwLock<TokioResolver>>,
+    socket: &Arc<dyn DnsSocket>,
+    config: &Arc<RwLock<DnsConfig>>,
+    cache: &Arc<RwLock<DnsCache>>,
+    log_sink: Option<&DnsLogSink>,
+    request: Message,
+    id: u16,
+    src: SocketAddr,
+    domain: &str,
+    rtype: hickory_proto::rr::RecordType,
+    start: std::time::Instant,
+    pass_result: &str,
+    upstream_id: UpstreamId,
+) -> anyhow::Result<()> {
+    let (has_upstreams, rebinding, ttl_min, ttl_max) = {
+        let cfg = config.read().await;
+        (
+            !cfg.upstream_servers.is_empty(),
+            cfg.rebinding_protection,
+            cfg.cache_ttl_min_secs,
+            cfg.cache_ttl_max_secs,
+        )
     };
 
     match recursor_result {
@@ -1254,6 +1317,32 @@ pub(crate) async fn resolve_via_recursor(
                 ttl_min,
                 ttl_max,
                 &msg.answers,
+            )
+            .await?;
+        }
+        // A negative answer (NODATA / NXDOMAIN) is a valid resolution, not a
+        // failure: relay it instead of falling back to the forwarder, which
+        // would re-ask a question the authority already answered — and, when
+        // the forwarder agreed the record doesn't exist, SERVFAIL the client.
+        Some(Err(e)) if e.is_no_records_found() || e.is_nx_domain() => {
+            let nx_domain = e.is_nx_domain();
+            relay_negative(
+                socket,
+                cache,
+                log_sink,
+                &request,
+                id,
+                src,
+                domain,
+                rtype,
+                start,
+                pass_result,
+                upstream_id,
+                Some("recursive".to_owned()),
+                nx_domain,
+                e.into_soa(),
+                ttl_min,
+                ttl_max,
             )
             .await?;
         }
@@ -1345,12 +1434,11 @@ async fn forward_via_tunnel(
     // raw bytes through and skip caching.
     socket.send_to(&buf, src).await?;
 
+    let mut result = pass_result;
     if let Ok(parsed) = Message::from_bytes(&buf) {
-        let mut min_ttl = u32::MAX;
-        for record in &parsed.answers {
-            min_ttl = min_ttl.min(record.ttl);
-        }
-        if min_ttl < u32::MAX && min_ttl > 0 {
+        let (is_negative, raw_ttl) = classify_response(&parsed);
+        result = relayed_result(is_negative, pass_result);
+        if raw_ttl > 0 {
             let cfg = config.read().await;
             let mut cache_guard = cache.write().await;
             cache_guard.insert(
@@ -1358,7 +1446,7 @@ async fn forward_via_tunnel(
                 domain,
                 rtype,
                 parsed,
-                min_ttl,
+                raw_ttl,
                 cfg.cache_ttl_min_secs,
                 cfg.cache_ttl_max_secs,
             );
@@ -1380,9 +1468,156 @@ async fn forward_via_tunnel(
         domain,
         rtype,
         src,
-        pass_result,
+        result,
         Some(forwarder.upstream.ip().to_string()),
         elapsed,
+    );
+    Ok(())
+}
+
+/// Classify a parsed upstream response for caching: positive answers use the
+/// answers' minimum TTL; negative answers (NXDOMAIN, or NOERROR with zero
+/// answers) use the RFC 2308 negative TTL — min(SOA record TTL, SOA MINIMUM)
+/// from the authority section, or 0 (uncacheable) when the zone forbids
+/// negative caching or carries no SOA. Returns `(is_negative, raw_ttl)`.
+fn classify_response(parsed: &Message) -> (bool, u32) {
+    use hickory_proto::rr::RData;
+
+    let negative = parsed.metadata.response_code == ResponseCode::NXDomain
+        || (parsed.metadata.response_code == ResponseCode::NoError && parsed.answers.is_empty());
+    if negative {
+        let ttl = parsed
+            .authorities
+            .iter()
+            .find_map(|r| match &r.data {
+                RData::SOA(soa) => Some(r.ttl.min(soa.minimum)),
+                _ => None,
+            })
+            .unwrap_or(0);
+        return (true, ttl);
+    }
+    let min_ttl = parsed.answers.iter().map(|r| r.ttl).min().unwrap_or(0);
+    (false, min_ttl)
+}
+
+/// The query-log result for a relayed upstream response: negative answers
+/// log as `"negative"`, except that the filter dry-run marker
+/// (`blocked_skipped`) outranks it for blocklist evaluation.
+fn relayed_result(is_negative: bool, pass_result: &str) -> &str {
+    if is_negative && pass_result != DnsQueryResult::BlockedSkipped.as_str() {
+        DnsQueryResult::Negative.as_str()
+    } else {
+        pass_result
+    }
+}
+
+/// Send a negative response — NODATA (empty NOERROR) or NXDOMAIN — with an
+/// optional pre-stamped authority record (the zone's SOA) so clients can
+/// negatively cache (RFC 2308). A negative answer is a *successful*
+/// resolution: "the name (or record type) does not exist" must never surface
+/// as SERVFAIL. Returns the response so callers can cache it.
+async fn send_negative(
+    socket: &Arc<dyn DnsSocket>,
+    src: SocketAddr,
+    id: u16,
+    request: &Message,
+    nx_domain: bool,
+    authority: Option<hickory_proto::rr::Record>,
+) -> anyhow::Result<Message> {
+    let mut response = Message::response(id, OpCode::Query);
+    response.metadata.recursion_desired = true;
+    response.metadata.recursion_available = true;
+    response.metadata.response_code = if nx_domain {
+        ResponseCode::NXDomain
+    } else {
+        ResponseCode::NoError
+    };
+    response.add_queries(request.queries.clone());
+    if let Some(authority) = authority {
+        response.add_authority(authority);
+    }
+    let bytes = response.to_bytes()?;
+    socket.send_to(&bytes, src).await?;
+    Ok(response)
+}
+
+/// Shared negative-answer responder for the recursive and forwarding paths:
+/// stamps the RFC 2308 negative TTL (min(SOA record TTL, SOA MINIMUM),
+/// clamped to the admin's cache bounds) on the relayed SOA, sends the
+/// response, caches it so repeated negative queries are served locally, and
+/// records the query as `"negative"` — unless the filter dry-run marker
+/// (`blocked_skipped`) applies, which outranks it for blocklist evaluation.
+#[allow(clippy::too_many_arguments)]
+async fn relay_negative(
+    socket: &Arc<dyn DnsSocket>,
+    cache: &Arc<RwLock<DnsCache>>,
+    log_sink: Option<&DnsLogSink>,
+    request: &Message,
+    id: u16,
+    src: SocketAddr,
+    domain: &str,
+    rtype: hickory_proto::rr::RecordType,
+    start: std::time::Instant,
+    pass_result: &str,
+    upstream_id: UpstreamId,
+    upstream_label: Option<String>,
+    nx_domain: bool,
+    soa: Option<Box<hickory_proto::rr::Record<hickory_proto::rr::rdata::SOA>>>,
+    cache_ttl_min_secs: u32,
+    cache_ttl_max_secs: u32,
+) -> anyhow::Result<()> {
+    tracing::debug!(
+        %domain,
+        ?rtype,
+        nx_domain,
+        "negative answer for {domain} ({rtype:?}): nx_domain={nx_domain}"
+    );
+
+    // RFC 2308 §5: the negative TTL is min(SOA record TTL, SOA MINIMUM). A
+    // raw value of 0 means the zone forbids negative caching — honour it
+    // (like the positive path's raw-TTL gate) rather than raising it to the
+    // admin's cache floor. Non-zero values get the same `.max(min).min(max)`
+    // clamp DnsCache::insert applies, so the TTL stamped on the wire and the
+    // daemon's own cache lifetime always agree.
+    let (authority, negative_ttl) = if let Some(soa) = soa {
+        let soa = *soa;
+        let raw_ttl = soa.ttl.min(soa.data.minimum);
+        let ttl = if raw_ttl == 0 {
+            0
+        } else {
+            raw_ttl.max(cache_ttl_min_secs).min(cache_ttl_max_secs)
+        };
+        let mut record = soa.into_record_of_rdata();
+        record.ttl = ttl;
+        (Some(record), ttl)
+    } else {
+        (None, 0)
+    };
+
+    let response = send_negative(socket, src, id, request, nx_domain, authority).await?;
+
+    if negative_ttl > 0 {
+        let mut cache_guard = cache.write().await;
+        cache_guard.insert(
+            upstream_id,
+            domain,
+            rtype,
+            response,
+            negative_ttl,
+            cache_ttl_min_secs,
+            cache_ttl_max_secs,
+        );
+    }
+
+    let result = relayed_result(true, pass_result);
+    record_query(
+        log_sink,
+        domain,
+        rtype,
+        src,
+        result,
+        upstream_label,
+        start.elapsed(),
     );
     Ok(())
 }
@@ -1720,6 +1955,7 @@ async fn forward_via_conditional(
     // Validate the response before forwarding: txid and question must match the
     // outbound query. A pooled socket could in theory receive a late response to a
     // prior query; txid validation ensures stale datagrams are never served or cached.
+    let mut result = pass_result;
     if let Ok(parsed) = Message::from_bytes(&buf) {
         if parsed.metadata.id != id {
             return_socket_to_pool(pool, bound).await;
@@ -1740,11 +1976,9 @@ async fn forward_via_conditional(
         socket.send_to(&buf, src).await?;
         return_socket_to_pool(pool, bound).await;
 
-        let mut min_ttl = u32::MAX;
-        for record in &parsed.answers {
-            min_ttl = min_ttl.min(record.ttl);
-        }
-        if min_ttl < u32::MAX && min_ttl > 0 {
+        let (is_negative, raw_ttl) = classify_response(&parsed);
+        result = relayed_result(is_negative, pass_result);
+        if raw_ttl > 0 {
             let cfg = config.read().await;
             let mut cache_guard = cache.write().await;
             cache_guard.insert(
@@ -1752,7 +1986,7 @@ async fn forward_via_conditional(
                 domain,
                 rtype,
                 parsed,
-                min_ttl,
+                raw_ttl,
                 cfg.cache_ttl_min_secs,
                 cfg.cache_ttl_max_secs,
             );
@@ -1770,7 +2004,7 @@ async fn forward_via_conditional(
         domain,
         rtype,
         src,
-        pass_result,
+        result,
         Some(upstream.ip().to_string()),
         elapsed,
     );

--- a/source/daemon/crates/wardnetd/src/dns/tests/server.rs
+++ b/source/daemon/crates/wardnetd/src/dns/tests/server.rs
@@ -34,8 +34,8 @@ use wardnetd_services::event::{BroadcastEventBus, EventPublisher};
 use crate::dns::server::{
     LATENCY_PROBE_INTERVAL, TunnelForwarderInfo, UdpDnsServer, build_recursor, build_resolver,
     duration_to_ms, effective_upstreams, fold_probe_outcomes, forwarder_ordering,
-    get_or_build_tunnel_forwarder, probe_upstreams, resolve_via_recursor, spawn_cache_invalidator,
-    spawn_upstream_latency_prober, upstream_label,
+    get_or_build_tunnel_forwarder, handle_recursor_outcome, probe_upstreams, resolve_via_recursor,
+    spawn_cache_invalidator, spawn_upstream_latency_prober, upstream_label,
 };
 use crate::tests::stubs::StubDnsFilterService;
 
@@ -2158,18 +2158,23 @@ impl DnsSocket for RecordingSocket {
     }
 }
 
-/// Parse the foo.com A request (id=0xCAFE) used by the recursor tests from the
-/// same wire bytes as `query_foo_com`, so the request carries exactly one
-/// question.
-fn foo_com_request() -> hickory_proto::op::Message {
+/// Build the foo.com request (id=0xCAFE, exactly one question) for the given
+/// record type, from the same wire template as `query_foo_com`.
+fn foo_com_request_of(rtype: RecordType) -> hickory_proto::op::Message {
     use hickory_proto::op::Message;
     use hickory_proto::serialize::binary::BinDecodable;
 
-    let query: &[u8] = &[
+    let mut query = [
         0xCA, 0xFE, 0x01, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x03, b'f', b'o',
         b'o', 0x03, b'c', b'o', b'm', 0x00, 0x00, 0x01, 0x00, 0x01,
     ];
-    Message::from_bytes(query).expect("parse foo.com request")
+    query[21..23].copy_from_slice(&u16::from(rtype).to_be_bytes());
+    Message::from_bytes(&query).expect("parse foo.com request")
+}
+
+/// The foo.com A request used by the recursor tests.
+fn foo_com_request() -> hickory_proto::op::Message {
+    foo_com_request_of(RecordType::A)
 }
 
 #[test]
@@ -2294,6 +2299,219 @@ async fn recursor_unavailable_servfails_when_no_upstreams() {
         "pure recursive with no upstreams must SERVFAIL, never forward to a default"
     );
     assert!(response.answers.is_empty(), "SERVFAIL carries no answers");
+}
+
+/// Build a `RecursorError::Negative` like the recursor returns for negative
+/// answers (NODATA / NXDOMAIN), carrying the zone's SOA. The SOA record TTL
+/// is fixed at 300 while MINIMUM is caller-chosen, so tests can assert the
+/// RFC 2308 negative TTL — min(TTL, MINIMUM) — is stamped on the relayed SOA.
+fn negative_recursor_error(
+    nx_domain: bool,
+    soa_minimum: u32,
+) -> hickory_resolver::recursor::RecursorError {
+    use hickory_proto::op::Query;
+    use hickory_proto::rr::rdata::SOA;
+    use hickory_proto::rr::{Name, Record};
+    use hickory_resolver::recursor::{AuthorityData, RecursorError};
+
+    let name = Name::from_str_relaxed("foo.com.").expect("query name");
+    let query = Box::new(Query::query(name, RecordType::A));
+    let soa = Record::from_rdata(
+        Name::from_str_relaxed("com.").expect("soa name"),
+        300,
+        SOA::new(
+            Name::from_str_relaxed("ns.com.").expect("mname"),
+            Name::from_str_relaxed("hostmaster.com.").expect("rname"),
+            1,
+            3600,
+            600,
+            86400,
+            soa_minimum,
+        ),
+    );
+    RecursorError::Negative(AuthorityData::new(
+        query,
+        Some(Box::new(soa)),
+        true,
+        nx_domain,
+        None,
+    ))
+}
+
+/// Shared driver for the negative-answer tests: run `handle_recursor_outcome`
+/// with the given recursor outcome and request against a stub upstream that
+/// WOULD answer the foo.com A query, so any wrongful fallback shows up as
+/// answers. Returns the parsed response plus the cache so tests can assert
+/// negative caching. An outcome of `None` exercises the recursor-unavailable
+/// fallback-to-forwarder branch.
+async fn run_recursor_outcome(
+    outcome: Option<Result<hickory_proto::op::Message, hickory_resolver::recursor::RecursorError>>,
+    request: hickory_proto::op::Message,
+    rtype: RecordType,
+    config_tweak: fn(&mut DnsConfig),
+) -> (hickory_proto::op::Message, Arc<RwLock<DnsCache>>) {
+    use hickory_proto::op::Message;
+    use hickory_proto::serialize::binary::BinDecodable;
+
+    let upstream_addr = spawn_stub_upstream().await;
+    let upstreams = vec![udp_upstream(upstream_addr)];
+    let resolver = Arc::new(RwLock::new(build_resolver(
+        &upstreams,
+        false,
+        ServerOrderingStrategy::QueryStatistics,
+    )));
+    let mut cfg = DnsConfig {
+        resolution_mode: DnsResolutionMode::Recursive,
+        upstream_servers: upstreams,
+        ..DnsConfig::default()
+    };
+    config_tweak(&mut cfg);
+    let config = Arc::new(RwLock::new(cfg));
+    let cache = Arc::new(RwLock::new(DnsCache::new(1000)));
+    let sent = Arc::new(StdMutex::new(Vec::new()));
+    let socket: Arc<dyn DnsSocket> = Arc::new(RecordingSocket { sent: sent.clone() });
+    let src: SocketAddr = SocketAddr::from(([127, 0, 0, 1], 5353));
+
+    handle_recursor_outcome(
+        outcome,
+        &resolver,
+        &socket,
+        &config,
+        &cache,
+        None,
+        request,
+        0xCAFE,
+        src,
+        "foo.com",
+        rtype,
+        std::time::Instant::now(),
+        "forwarded",
+        UpstreamId::Default,
+    )
+    .await
+    .expect("handle_recursor_outcome");
+
+    let frames = sent.lock().unwrap().clone();
+    assert_eq!(frames.len(), 1, "exactly one response sent");
+    let response = Message::from_bytes(&frames[0]).expect("parse response");
+    (response, cache)
+}
+
+/// Negative recursor outcome (SOA MINIMUM 60) against the foo.com A query.
+async fn run_negative_outcome(
+    nx_domain: bool,
+) -> (hickory_proto::op::Message, Arc<RwLock<DnsCache>>) {
+    run_recursor_outcome(
+        Some(Err(negative_recursor_error(nx_domain, 60))),
+        foo_com_request(),
+        RecordType::A,
+        |_| {},
+    )
+    .await
+}
+
+#[tokio::test]
+async fn recursor_nodata_relays_noerror_not_servfail() {
+    use hickory_proto::op::ResponseCode;
+
+    // A NODATA outcome from the recursor is a valid answer ("name exists,
+    // no records of this type") — e.g. AAAA for an IPv4-only domain or an
+    // HTTPS record most domains lack. The client must see NOERROR with zero
+    // answers, not SERVFAIL, and the server must NOT fall back to the
+    // forwarder (the stub upstream would answer the A query with a record).
+    let (response, cache) = run_negative_outcome(false).await;
+    assert_eq!(
+        response.metadata.response_code,
+        ResponseCode::NoError,
+        "NODATA must relay NOERROR, not SERVFAIL or a fallback answer"
+    );
+    assert!(response.answers.is_empty(), "NODATA carries no answers");
+    assert!(
+        !response.authorities.is_empty(),
+        "negative response must carry the SOA for negative caching"
+    );
+    assert_eq!(
+        response.authorities[0].ttl, 60,
+        "relayed SOA must carry the RFC 2308 negative TTL: min(SOA TTL 300, MINIMUM 60)"
+    );
+    assert!(
+        cache
+            .write()
+            .await
+            .get(UpstreamId::Default, "foo.com", RecordType::A)
+            .is_some(),
+        "negative response must be cached so repeats don't re-resolve"
+    );
+}
+
+#[tokio::test]
+async fn recursor_nxdomain_relays_nxdomain_not_servfail() {
+    use hickory_proto::op::ResponseCode;
+
+    let (response, _cache) = run_negative_outcome(true).await;
+    assert_eq!(
+        response.metadata.response_code,
+        ResponseCode::NXDomain,
+        "NXDOMAIN must relay NXDOMAIN, not SERVFAIL or a fallback answer"
+    );
+    assert!(response.answers.is_empty(), "NXDOMAIN carries no answers");
+    assert!(
+        !response.authorities.is_empty(),
+        "NXDOMAIN must carry the SOA for negative caching too"
+    );
+}
+
+#[tokio::test]
+async fn recursor_negative_with_zero_minimum_is_not_cached_or_raised() {
+    use hickory_proto::op::ResponseCode;
+
+    // SOA MINIMUM = 0 means the zone forbids negative caching (e.g. ACME
+    // DNS-01 zones that publish records seconds after the first query).
+    // Even with an admin cache floor configured, the negative must NOT be
+    // raised to the floor, cached, or relayed with a non-zero SOA TTL.
+    let (response, cache) = run_recursor_outcome(
+        Some(Err(negative_recursor_error(false, 0))),
+        foo_com_request(),
+        RecordType::A,
+        |cfg| cfg.cache_ttl_min_secs = 300,
+    )
+    .await;
+    assert_eq!(response.metadata.response_code, ResponseCode::NoError);
+    assert_eq!(
+        response.authorities[0].ttl, 0,
+        "a zone-forbidden negative TTL must not be raised to the cache floor"
+    );
+    assert!(
+        cache
+            .write()
+            .await
+            .get(UpstreamId::Default, "foo.com", RecordType::A)
+            .is_none(),
+        "a zone-forbidden negative must not be cached"
+    );
+}
+
+#[tokio::test]
+async fn fallback_forwarder_nodata_relays_noerror_not_servfail() {
+    use hickory_proto::op::ResponseCode;
+
+    // Recursor unavailable (outcome None) → fallback forwards to the stub
+    // upstream, which returns NOERROR with zero answers for AAAA queries.
+    // That negative answer must reach the client as NOERROR/NODATA, not
+    // SERVFAIL.
+    let (response, _cache) = run_recursor_outcome(
+        None,
+        foo_com_request_of(RecordType::AAAA),
+        RecordType::AAAA,
+        |_| {},
+    )
+    .await;
+    assert_eq!(
+        response.metadata.response_code,
+        ResponseCode::NoError,
+        "forwarder NODATA must relay NOERROR, not SERVFAIL"
+    );
+    assert!(response.answers.is_empty(), "NODATA carries no answers");
 }
 
 #[tokio::test]

--- a/source/sdk/wardnet-js/src/types/dns.ts
+++ b/source/sdk/wardnet-js/src/types/dns.ts
@@ -131,6 +131,7 @@ export type DnsQueryResult =
   | "rewritten"
   | "recursive"
   | "upstream_error"
+  | "negative"
   | "authoritative"
   | "error";
 


### PR DESCRIPTION
## Problem

In recursive mode, every legitimate negative DNS answer was converted into SERVFAIL. The hickory recursor returns `Err("negative response")` for NODATA/NXDOMAIN; `resolve_via_recursor` treated any `Err` as failure and fell back to the forwarder, whose lookup also errors ("no records found") → logged as `upstream_error` and SERVFAILed.

Measured on a live gateway over 24h: **19,702 upstream_errors** (11.2k HTTPS/type-65, 6.2k PTR, 2k AAAA — only 154 A), plus **20,022 rate-limited** drops from macOS retry-storming the SERVFAILs. Symptoms: resolution failures for slack.com, api.github.com, docs.google.com, etc.

## Fix

- **Relay negatives properly** on all four resolution paths (recursor, default forwarder, tunnel, conditional): NOERROR/NODATA or NXDOMAIN with the zone SOA in the authority section.
- **RFC 2308 negative TTL**: min(SOA TTL, SOA MINIMUM), clamped with the same `.max(min).min(max)` idiom `DnsCache::insert` uses so wire TTL and cache lifetime always agree; a raw 0 honours the zone's no-negative-caching intent (e.g. ACME DNS-01 zones) and skips the cache.
- **Negative caching**: negative responses are stored in `DnsCache`, so repeated AAAA/HTTPS/PTR negatives are served locally instead of re-resolving.
- **Observability**: new `"negative"` query-log result wired end-to-end — `DnsQueryResult::Negative`, stats sink outcome, JS SDK union, admin-site log filter + badge ("negative (no record)"), and the mock daemon's seeded/live catalogs. The filter dry-run marker (`blocked_skipped`) outranks it so blocklist evaluation is unaffected.
- **Cache-key bug (pre-existing, escalated by negative caching)**: `DnsCache` keys kept the wire-format trailing dot while `invalidate_domain` trimmed it — per-domain flush matched nothing. Keys are now canonicalized (lowercase, no trailing dot) across get/insert/invalidate.
- **Testable seam**: `handle_recursor_outcome` extracted from `resolve_via_recursor` so recursor outcomes can be injected in tests; shared `classify_response` / `relayed_result` / `send_negative` / `relay_negative` helpers.

## Tests

- RED→GREEN reproduction tests: recursor NODATA → NOERROR (not SERVFAIL, no wrongful fallback), NXDOMAIN → NXDOMAIN, fallback-forwarder NODATA → NOERROR.
- Negative TTL stamping (min(300, 60) = 60), zero-MINIMUM gate (not raised to the admin cache floor, not cached), cache insertion.
- Cache key normalization regression test (FQDN insert / bare-name lookup + invalidate).
- `DnsQueryResult` serde round-trip incl. the new variant.

Verified: `cargo fmt`, `clippy --all-targets -D warnings`, full daemon workspace green in the Linux container; SDK + admin-site typecheck and DnsLogs component tests green.

## Merge Commit Message

fix(dns): relay negative answers (NODATA/NXDOMAIN) instead of SERVFAIL, with RFC 2308 negative caching, a new "negative" query-log result, and canonical DnsCache domain keys so per-domain flush works.

https://claude.ai/code/session_01REFNyHXkbxzuBWN2uHgGWF