### PR TITLE
docs(release): cover the negative-DNS fix (#896) in the beta.4 notes

### DIFF
--- a/docs/releases/v2026.07.00-beta.4.md
+++ b/docs/releases/v2026.07.00-beta.4.md
@@ -1,11 +1,16 @@
 # Wardnet 2026.07.00-beta.4
 
-Patch beta following [`2026.07.00-beta.3`](v2026.07.00-beta.3.md), focused entirely on **remote access certificate issuance**: the failure that made the very first issuance attempt fail on every fresh enrollment is fixed, a failure caused by Let's Encrypt rate limiting now backs off instead of digging the hole deeper, and the dashboard's DNS resolution check no longer cries wolf on a perfectly healthy setup. Beta builds receive updates via the **beta channel** only — switch to it in **Settings → Updates** to opt in.
+Patch beta following [`2026.07.00-beta.3`](v2026.07.00-beta.3.md) with two focuses: **DNS correctness** — domains that legitimately have no record of the asked type (very common for HTTPS/AAAA/PTR lookups) are now answered properly instead of erroring, fixing intermittent resolution failures for major sites — and **remote access certificate issuance**: the failure that made the very first issuance attempt fail on every fresh enrollment is fixed, a failure caused by Let's Encrypt rate limiting now backs off instead of digging the hole deeper, and the dashboard's DNS resolution check no longer cries wolf on a perfectly healthy setup. Beta builds receive updates via the **beta channel** only — switch to it in **Settings → Updates** to opt in.
 
 > [!IMPORTANT]
 > A fresh, ground-up beta install is supported with `curl -fsSL https://wardnet.network/install.sh | sudo CHANNEL=beta bash`. The installer's `CHANNEL` only selects **which tarball is fetched** — the daemon's auto-update channel is stored separately and still defaults to `stable`. After a fresh beta install you **must** set the channel to `beta` in **Settings → Updates**, or the box will not receive further beta updates. It will not downgrade; it will simply sit on this build.
 
 ## Bug fixes
+
+### Negative DNS answers are answered honestly instead of erroring
+
+Asking for a record type a domain simply doesn't have — which devices do constantly (HTTPS/type-65, IPv6 AAAA, reverse PTR lookups) — made the gateway answer SERVFAIL instead of the correct "no such record" response. Clients treated that as a resolver failure and retry-stormed, causing intermittent resolution failures for perfectly healthy sites (Slack, GitHub, Google Docs) and tens of thousands of logged upstream errors per day on a live gateway. Negative answers are now relayed properly on every resolution path (NODATA and NXDOMAIN, with the zone's SOA attached), cached per RFC 2308 so repeat lookups are served locally, and surfaced in the query log with their own "negative (no record)" result badge instead of masquerading as errors. Closes [#896](https://github.com/wardnet/wardnet/pull/896).
+
 
 ### The first certificate issuance attempt no longer always fails
 


### PR DESCRIPTION
The beta.4 tag was retracted before publish so #896 could ride along — but the GitHub Release body is built from `docs/releases/v2026.07.00-beta.4.md` in the *tagged tree*, so the notes must mention it before the tag is re-pushed. Adds a Bug fixes section for the negative-DNS relay/caching fix and widens the lead paragraph. Doc-only.

## Merge Commit Message

docs(release): cover the negative-DNS fix (#896) in the beta.4 notes

https://claude.ai/code/session_016rUuXqBH8uWYXKJbTFkzSr