### PR TITLE
fix(dhcp): advertise the Wardnet DNS server to clients while it is enabled

### DIFF
--- a/source/admin-site/src/components/compound/DhcpConfigCard.tsx
+++ b/source/admin-site/src/components/compound/DhcpConfigCard.tsx
@@ -11,6 +11,7 @@ import { FormActions } from "@wardnet/web";
 import { Field } from "@wardnet/web";
 import { Input } from "@wardnet/web";
 import { Text } from "@wardnet/web";
+import { LEASE_RENEWAL_NOTE } from "@wardnet/web";
 import { Ipv4Input } from "@wardnet/web";
 import { isPrivateIpv4 } from "@wardnet/web";
 import { isCompleteIpv4, ipv4ToInt } from "@wardnet/js";
@@ -53,7 +54,11 @@ export function DhcpConfigCard({ config }: DhcpConfigCardProps) {
   const updateConfig = useUpdateDhcpConfig();
   const previewConfig = usePreviewDhcpConfig();
   const { data: dnsConfigData } = useDnsConfig();
-  const dnsEnabled = dnsConfigData?.config.enabled ?? false;
+  // Tri-state on purpose: `undefined` means the DNS query hasn't resolved
+  // (loading or errored). Falling back to `false` here would show the raw
+  // upstream list as the effective client DNS while the daemon is actually
+  // advertising the Pi — the exact misread this card exists to prevent.
+  const dnsEnabled: boolean | undefined = dnsConfigData?.config.enabled;
 
   const [editing, setEditing] = useState(false);
   const [confirmOpen, setConfirmOpen] = useState(false);
@@ -250,7 +255,7 @@ export function DhcpConfigCard({ config }: DhcpConfigCardProps) {
               </Field>
             </div>
 
-            {!dnsEnabled && (
+            {dnsEnabled === false && (
               <Field
                 label="Upstream DNS (comma-separated)"
                 htmlFor="dhcp-dns"
@@ -356,10 +361,26 @@ export function DhcpConfigCard({ config }: DhcpConfigCardProps) {
             <div>
               <dt className="text-ink-3">Upstream DNS</dt>
               <dd className={dnsEnabled ? "font-medium" : "font-mono text-xs"}>
-                {dnsEnabled
-                  ? "Wardnet DNS"
-                  : config.upstream_dns.join(", ") || "-"}
+                {dnsEnabled === undefined
+                  ? "…"
+                  : dnsEnabled
+                    ? "Wardnet DNS"
+                    : config.upstream_dns.join(", ") || "-"}
               </dd>
+              {/* "Wardnet DNS" is what NEW leases get. DHCP cannot push it to a
+                  device that already holds a lease, and a device resolving via
+                  its old server is silently unfiltered — so don't let this read
+                  as "every device is using Wardnet DNS right now". */}
+              {dnsEnabled && (
+                <Text
+                  as="p"
+                  size="xs"
+                  className="mt-1 text-ink-3"
+                  data-testid="dhcp-dns-lease-note"
+                >
+                  {LEASE_RENEWAL_NOTE}
+                </Text>
+              )}
             </div>
           </dl>
         </CardContent>

--- a/source/admin-site/tests/components/compound/DhcpConfigCard.test.tsx
+++ b/source/admin-site/tests/components/compound/DhcpConfigCard.test.tsx
@@ -88,6 +88,34 @@ describe("DhcpConfigCard", () => {
     expect(screen.getByText("Wardnet DNS")).toBeInTheDocument();
   });
 
+  // "Wardnet DNS" is what NEW leases get. DHCP cannot push it to a device
+  // already holding a lease, and such a device resolves unfiltered without any
+  // sign of it — so the read view must not imply the whole network is covered.
+  it("warns that already-leased devices keep their old DNS until they reconnect", () => {
+    mockDns.mockReturnValue({ data: { config: { enabled: true } } } as never);
+    renderWithProviders(<DhcpConfigCard config={makeConfig()} />);
+    expect(screen.getByTestId("dhcp-dns-lease-note")).toHaveTextContent(
+      /reconnect a device/i,
+    );
+  });
+
+  it("omits the lease note when the DNS server is off", () => {
+    mockDns.mockReturnValue({ data: { config: { enabled: false } } } as never);
+    renderWithProviders(<DhcpConfigCard config={makeConfig()} />);
+    expect(screen.queryByTestId("dhcp-dns-lease-note")).not.toBeInTheDocument();
+  });
+
+  it("shows a placeholder, not the upstream list, while the DNS query is unresolved", () => {
+    // While the ["dns"] query is loading (or errored) the effective client
+    // DNS is unknown — rendering the raw upstream list would claim clients
+    // bypass the Pi when the daemon may actually be advertising it.
+    mockDns.mockReturnValue({ data: undefined } as never);
+    renderWithProviders(<DhcpConfigCard config={makeConfig()} />);
+    expect(screen.getByText("…")).toBeInTheDocument();
+    expect(screen.queryByText(/1\.1\.1\.1/)).not.toBeInTheDocument();
+    expect(screen.queryByText("Wardnet DNS")).not.toBeInTheDocument();
+  });
+
   it("enters edit mode and hides the upstream DNS field when DNS is enabled", async () => {
     const user = userEvent.setup();
     mockDns.mockReturnValue({ data: { config: { enabled: true } } } as never);

--- a/source/daemon/crates/wardnetd-services/src/dhcp/service.rs
+++ b/source/daemon/crates/wardnetd-services/src/dhcp/service.rs
@@ -14,14 +14,23 @@ use wardnet_common::api::{
 use wardnet_common::dhcp::{DhcpConfig, DhcpLease, DhcpLeaseStatus, DhcpScope};
 
 use crate::auth_context;
+use crate::dns::service::DNS_ENABLED_KEY;
 use crate::error::AppError;
 use crate::event::EventPublisher;
 use wardnet_common::event::WardnetEvent;
+
 use wardnetd_data::repository::SystemConfigRepository;
 use wardnetd_data::repository::{
     DeviceRepository, DhcpLeaseLogRow, DhcpLeaseRow, DhcpRepository, DhcpReservationRow,
     NetworkZoneRepository,
 };
+
+/// Public resolvers used when the Wardnet DNS server is off and the admin has
+/// configured no upstream of their own. These are what the Pi's own resolver
+/// forwards to; they are only ever handed to *clients* when there is no Wardnet
+/// resolver for them to use. Never advertise the Pi in that state — nothing is
+/// listening on :53 and the LAN would lose name resolution entirely.
+const DEFAULT_UPSTREAM_DNS: [Ipv4Addr; 2] = [Ipv4Addr::new(1, 1, 1, 1), Ipv4Addr::new(8, 8, 8, 8)];
 
 /// DHCP lease and reservation management.
 ///
@@ -200,7 +209,13 @@ impl DhcpServiceImpl {
             .get("dhcp_upstream_dns")
             .await
             .map_err(AppError::Internal)?
-            .unwrap_or_else(|| r#"["1.1.1.1","8.8.8.8"]"#.to_owned());
+            .unwrap_or_else(|| {
+                // Key absent (pre-seed install): same default the migration
+                // seeds and `advertised_dns` falls back to — one source of
+                // truth for the default resolver set.
+                serde_json::to_string(&DEFAULT_UPSTREAM_DNS.map(|ip| ip.to_string()))
+                    .expect("serialize default upstream DNS")
+            });
         let upstream_dns: Vec<Ipv4Addr> = serde_json::from_str::<Vec<String>>(&upstream_dns_json)
             .map_err(|e| AppError::Internal(anyhow::anyhow!("invalid upstream_dns: {e}")))?
             .iter()
@@ -281,6 +296,66 @@ impl DhcpServiceImpl {
         }
     }
 
+    /// Is the Wardnet DNS server switched on? Read straight from `system_config`
+    /// rather than plumbed through `DnsService`, to avoid a service-to-service
+    /// dependency on the DHCP lease path. Uses the shared [`DNS_ENABLED_KEY`]
+    /// so this reader cannot drift from `DnsService::load_config`/`toggle`.
+    /// Defaults to off when the key is absent, matching `DnsService`.
+    async fn wardnet_dns_enabled(&self) -> Result<bool, AppError> {
+        Ok(self
+            .system_config
+            .get(DNS_ENABLED_KEY)
+            .await
+            .map_err(AppError::Internal)?
+            .unwrap_or_else(|| "false".to_owned())
+            == "true")
+    }
+
+    /// The DNS servers advertised to clients in DHCP option 6.
+    ///
+    /// While the Wardnet DNS server is running, that is **always** the Pi — its
+    /// address in whatever scope the client is leasing from. `dhcp_upstream_dns`
+    /// is what the Pi's *own* resolver forwards to (seeded `1.1.1.1`/`8.8.8.8`);
+    /// handing it to clients tells them to resolve via Cloudflare or Google
+    /// directly, so they never ask the Pi and every blocklist, allowlist and
+    /// parental control is silently bypassed. The DHCP config card already
+    /// documents this contract to the admin — "the daemon will advertise
+    /// Wardnet's own IP to clients regardless of what's saved here" — and shows
+    /// "Wardnet DNS" in the read view; the daemon simply never honoured it.
+    ///
+    /// The stored list is not dead config: with the DNS server switched off
+    /// there is nothing on the Pi to answer queries, so clients need a real
+    /// resolver or they lose DNS entirely.
+    ///
+    /// Never returns an empty list. An empty `scope.dns` makes the DHCP server
+    /// fall back to advertising the Pi — which, with the DNS server off, is a
+    /// host with nothing listening on :53, so the whole LAN would lose name
+    /// resolution. The stored list *can* be empty: the config card only exposes
+    /// the field for editing while Wardnet DNS is off, which is exactly the
+    /// state in which clearing it would be fatal.
+    fn advertised_dns(
+        wardnet_dns_enabled: bool,
+        scope_gateway: Ipv4Addr,
+        upstream: &[Ipv4Addr],
+    ) -> Vec<Ipv4Addr> {
+        if wardnet_dns_enabled {
+            return vec![scope_gateway];
+        }
+        if upstream.is_empty() {
+            // resolve_scope runs on every DHCP message; warn once, not once
+            // per packet, or a lease storm floods the log with duplicates.
+            static EMPTY_UPSTREAM_WARN: std::sync::Once = std::sync::Once::new();
+            EMPTY_UPSTREAM_WARN.call_once(|| {
+                tracing::warn!(
+                    "Wardnet DNS is disabled and no upstream DNS is configured; advertising \
+                     {DEFAULT_UPSTREAM_DNS:?} to DHCP clients so they keep working name resolution"
+                );
+            });
+            return DEFAULT_UPSTREAM_DNS.to_vec();
+        }
+        upstream.to_vec()
+    }
+
     /// Resolve the effective DHCP scope for a MAC (issue #737).
     ///
     /// The scope determines which subnet a device leases from and which options
@@ -292,13 +367,15 @@ impl DhcpServiceImpl {
     /// Zone lookup never fails a lease: any repository error, missing zone, or
     /// unparseable/too-small subnet degrades to the base scope with a log line.
     async fn resolve_scope(&self, mac: &str) -> Result<DhcpScope, AppError> {
-        let base = self.load_config().await?;
+        // Independent reads — overlap them rather than paying a second serial
+        // round-trip to `system_config` on every lease.
+        let (base, wardnet_dns) = tokio::try_join!(self.load_config(), self.wardnet_dns_enabled())?;
         let base_scope = DhcpScope {
             gateway_ip: base.gateway_ip,
             pool_start: base.pool_start,
             pool_end: base.pool_end,
             subnet_mask: base.subnet_mask,
-            dns: base.upstream_dns.clone(),
+            dns: Self::advertised_dns(wardnet_dns, base.gateway_ip, &base.upstream_dns),
             lease_duration_secs: base.lease_duration_secs,
             router_ip: base.router_ip,
             member_isolation: false,
@@ -343,8 +420,15 @@ impl DhcpServiceImpl {
             pool_end,
             subnet_mask,
             // The Pi's alias in this subnet, so per-zone DNS filtering still
-            // reaches the Pi.
-            dns: vec![gateway],
+            // reaches the Pi. With the DNS server off there is nothing there to
+            // answer, so fall back to the upstream list like the base scope.
+            //
+            // Known limit: a WAN-forbidden zone's egress gate drops direct
+            // client→public-resolver :53 traffic (only DNS *to the Pi* is
+            // exempted), so with Wardnet DNS off such zones still have no
+            // working resolver — same as before this change, when they were
+            // handed the dead Pi alias. Tracked in #898.
+            dns: Self::advertised_dns(wardnet_dns, gateway, &base.upstream_dns),
             lease_duration_secs: base.lease_duration_secs,
             // The gateway alias is the only router for a zone subnet.
             router_ip: None,

--- a/source/daemon/crates/wardnetd-services/src/dhcp/tests/dhcp.rs
+++ b/source/daemon/crates/wardnetd-services/src/dhcp/tests/dhcp.rs
@@ -278,6 +278,15 @@ struct MockSystemConfigRepository {
 }
 
 impl MockSystemConfigRepository {
+    /// Seed a key before the service is built (the `SystemConfigRepository::set`
+    /// impl is async; harnesses are not).
+    fn preset(&self, key: &str, value: &str) {
+        self.data
+            .lock()
+            .unwrap()
+            .insert(key.to_owned(), value.to_owned());
+    }
+
     fn new() -> Self {
         let mut data = HashMap::new();
         data.insert("dhcp_enabled".to_owned(), "false".to_owned());
@@ -290,6 +299,9 @@ impl MockSystemConfigRepository {
         );
         data.insert("dhcp_lease_duration_secs".to_owned(), "86400".to_owned());
         data.insert("dhcp_router_ip".to_owned(), String::new());
+        // `dns_enabled` is deliberately absent: it decides what DHCP advertises
+        // as option 6, so any test whose assertions depend on it sets it at the
+        // call site rather than inheriting it invisibly from here.
         Self {
             data: Mutex::new(data),
         }
@@ -1027,6 +1039,10 @@ fn build_service_with_zone_deps() -> (
 ) {
     let dhcp = Arc::new(MockDhcpRepository::new());
     let system_config = Arc::new(MockSystemConfigRepository::new());
+    // A real Wardnet box runs its own DNS server, which is what makes DHCP
+    // advertise the Pi (the zone tests below assert exactly that). Stated here
+    // rather than buried in the mock's defaults.
+    system_config.preset("dns_enabled", "true");
     let events = Arc::new(MockEventPublisher::new());
     let devices = Arc::new(MockDeviceRepository::new());
     let zones = Arc::new(MockNetworkZoneRepository::new());
@@ -2466,4 +2482,103 @@ async fn preview_config_rejects_inverted_range() {
     )
     .await;
     assert!(matches!(result, Err(AppError::BadRequest(_))));
+}
+
+// -- Advertised DNS (option 6) ---------------------------------------------
+
+/// Build a service whose `dns_enabled` flag is set, leaving `dhcp_upstream_dns`
+/// at its seeded `["1.1.1.1","8.8.8.8"]`.
+fn build_service_with_wardnet_dns(enabled: bool) -> DhcpServiceImpl {
+    let system_config = Arc::new(MockSystemConfigRepository::new());
+    system_config.preset("dns_enabled", if enabled { "true" } else { "false" });
+    DhcpServiceImpl::new(
+        Arc::new(MockDhcpRepository::new()),
+        system_config,
+        Arc::new(MockEventPublisher::new()),
+        Arc::new(MockDeviceRepository::new()),
+        Arc::new(MockNetworkZoneRepository::new()),
+        "10.0.0.1".parse().unwrap(),
+    )
+}
+
+/// Regression guard: with the Wardnet DNS server on, DHCP must hand clients the
+/// Pi as their resolver — never the stored upstream list.
+///
+/// `dhcp_upstream_dns` is seeded `["1.1.1.1","8.8.8.8"]` by the initial
+/// migration and is what the *Pi's own* resolver forwards to. It was being
+/// advertised verbatim as option 6, so every DHCP client resolved via Cloudflare
+/// or Google and never asked the Pi at all — silently bypassing DNS filtering
+/// (ads, malware, parental controls) on a box whose entire job is to filter DNS.
+/// The admin UI meanwhile displayed "Wardnet DNS", because it documents exactly
+/// the behaviour this test pins: the daemon advertises its own IP "regardless of
+/// what's saved here". Only the daemon never did.
+#[tokio::test]
+async fn base_scope_advertises_the_pi_when_wardnet_dns_is_enabled() {
+    let svc = build_service_with_wardnet_dns(true);
+
+    let scope = auth_context::with_context(admin_ctx(), svc.scope_for_mac("aa:bb:cc:dd:ee:ff"))
+        .await
+        .unwrap();
+
+    assert_eq!(
+        scope.dns,
+        vec![Ipv4Addr::new(10, 0, 0, 1)],
+        "DHCP must advertise the Pi as the client's DNS server while Wardnet DNS \
+         is enabled; advertising the upstream forwarders bypasses all filtering"
+    );
+}
+
+/// The stored upstream list is not dead config: with the Wardnet DNS server off,
+/// there is nothing on the Pi to resolve against, so clients must fall back to
+/// it or lose DNS entirely.
+#[tokio::test]
+async fn base_scope_falls_back_to_upstream_when_wardnet_dns_is_disabled() {
+    let svc = build_service_with_wardnet_dns(false);
+
+    let scope = auth_context::with_context(admin_ctx(), svc.scope_for_mac("aa:bb:cc:dd:ee:ff"))
+        .await
+        .unwrap();
+
+    assert_eq!(
+        scope.dns,
+        vec![Ipv4Addr::new(1, 1, 1, 1), Ipv4Addr::new(8, 8, 8, 8)],
+        "with Wardnet DNS off the client must still get a working resolver"
+    );
+}
+
+/// With Wardnet DNS off and the upstream list cleared, clients must still get a
+/// working resolver — never the Pi.
+///
+/// An empty `scope.dns` makes `build_response` fall back to advertising the Pi,
+/// but with the DNS server off nothing is listening on :53 there, so the whole
+/// LAN would lose name resolution. The config card only lets the admin edit
+/// (and clear) the upstream field while Wardnet DNS is off, which is precisely
+/// the state where clearing it would be fatal.
+#[tokio::test]
+async fn empty_upstream_with_wardnet_dns_off_never_advertises_the_pi() {
+    let system_config = Arc::new(MockSystemConfigRepository::new());
+    system_config.preset("dns_enabled", "false");
+    system_config.preset("dhcp_upstream_dns", "[]");
+    let svc = DhcpServiceImpl::new(
+        Arc::new(MockDhcpRepository::new()),
+        system_config,
+        Arc::new(MockEventPublisher::new()),
+        Arc::new(MockDeviceRepository::new()),
+        Arc::new(MockNetworkZoneRepository::new()),
+        "10.0.0.1".parse().unwrap(),
+    );
+
+    let scope = auth_context::with_context(admin_ctx(), svc.scope_for_mac("aa:bb:cc:dd:ee:ff"))
+        .await
+        .unwrap();
+
+    assert!(
+        !scope.dns.is_empty(),
+        "an empty DNS list makes the DHCP server advertise the Pi, which has no \
+         resolver running while Wardnet DNS is off — the LAN would lose DNS entirely"
+    );
+    assert!(
+        !scope.dns.contains(&Ipv4Addr::new(10, 0, 0, 1)),
+        "must not advertise the Pi as a resolver while its DNS server is off"
+    );
 }

--- a/source/daemon/crates/wardnetd-services/src/dns/service.rs
+++ b/source/daemon/crates/wardnetd-services/src/dns/service.rs
@@ -37,6 +37,12 @@ pub const QUERY_LOG_DEFAULT_LIMIT: u32 = 50;
 pub const QUERY_LOG_RETENTION_MIN_DAYS: u32 = 1;
 pub const QUERY_LOG_RETENTION_MAX_DAYS: u32 = 30;
 
+/// `system_config` key for the DNS server enable flag ("true"/"false",
+/// absent means off). Shared with the DHCP service, which advertises the Pi
+/// as the clients' resolver only while this is set — the two readers must
+/// never drift.
+pub(crate) const DNS_ENABLED_KEY: &str = "dns_enabled";
+
 #[async_trait]
 pub trait DnsService: Send + Sync {
     async fn get_config(&self) -> Result<DnsConfigResponse, AppError>;
@@ -96,7 +102,7 @@ impl DnsServiceImpl {
             async move { sc.get(&key).await.map_err(AppError::Internal) }
         };
 
-        let enabled = get("dns_enabled")
+        let enabled = get(DNS_ENABLED_KEY)
             .await?
             .unwrap_or_else(|| "false".to_owned())
             == "true";
@@ -411,7 +417,7 @@ impl DnsService for DnsServiceImpl {
     async fn toggle(&self, req: ToggleDnsRequest) -> Result<DnsConfigResponse, AppError> {
         auth_context::require_admin()?;
         self.system_config
-            .set("dns_enabled", if req.enabled { "true" } else { "false" })
+            .set(DNS_ENABLED_KEY, if req.enabled { "true" } else { "false" })
             .await
             .map_err(AppError::Internal)?;
         self.publish_config_changed();

--- a/source/daemon/crates/wardnetd/src/dhcp/tests/server.rs
+++ b/source/daemon/crates/wardnetd/src/dhcp/tests/server.rs
@@ -468,6 +468,58 @@ fn build_response_includes_router_and_dns() {
     assert!(has_server_id, "ServerIdentifier option missing");
 }
 
+/// Decode option 6 from an encoded response — helper for the wire-level
+/// DNS-advertisement guards below.
+fn decoded_dns_servers(response: &Message) -> Vec<Ipv4Addr> {
+    let mut buf = Vec::new();
+    let mut encoder = Encoder::new(&mut buf);
+    response.encode(&mut encoder).unwrap();
+    let decoded = Message::decode(&mut Decoder::new(&buf)).unwrap();
+    for (_code, opt) in decoded.opts().iter() {
+        if let DhcpOption::DomainNameServer(servers) = opt {
+            return servers.clone();
+        }
+    }
+    panic!("DomainNameServer option missing");
+}
+
+/// Wire-level guard for the scope→option-6 contract: whatever DNS list the
+/// resolved scope carries is exactly what clients receive. The
+/// advertise-wardnet-dns bug shipped because nothing asserted the rendered
+/// option, only the intermediate scope value.
+#[test]
+fn option6_carries_exactly_the_scope_dns_list() {
+    let request = build_discover([0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff]);
+    let lease = test_lease();
+    let mut scope = test_scope();
+    scope.dns = vec![Ipv4Addr::new(192, 168, 1, 1)];
+
+    let response = crate::dhcp::server::build_response(&request, MessageType::Ack, &lease, &scope);
+    assert_eq!(
+        decoded_dns_servers(&response),
+        vec![Ipv4Addr::new(192, 168, 1, 1)],
+        "clients must receive exactly the scope's DNS list in option 6"
+    );
+}
+
+/// The empty-scope fallback advertises the Pi itself (the scope gateway) —
+/// pinned at the wire level so a regression can't hide behind the
+/// service-layer tests.
+#[test]
+fn option6_empty_scope_dns_falls_back_to_the_pi() {
+    let request = build_discover([0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff]);
+    let lease = test_lease();
+    let mut scope = test_scope();
+    scope.dns = vec![];
+
+    let response = crate::dhcp::server::build_response(&request, MessageType::Ack, &lease, &scope);
+    assert_eq!(
+        decoded_dns_servers(&response),
+        vec![scope.gateway_ip],
+        "an empty scope DNS list must advertise the Pi, never nothing"
+    );
+}
+
 #[test]
 fn build_response_siaddr_is_wardnet_gateway_ip() {
     let request = build_discover([0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff]);

--- a/source/end2end-tests/web-ui/tests/admin-app/pages.spec.ts
+++ b/source/end2end-tests/web-ui/tests/admin-app/pages.spec.ts
@@ -207,6 +207,17 @@ test.describe("dns", () => {
     await confirmDialog();
     await expect(dnsToggle).toHaveAttribute("aria-checked", "true");
 
+    // The DNS toggle toast now carries the lease-renewal note (10s duration)
+    // and overlays the lower controls on the mobile viewport. Sonner pauses
+    // its auto-dismiss timer while hovered, and Playwright's click retries
+    // park the pointer on the intercepting toast — a deadlock until the test
+    // timeout. Move the pointer away and let the toasts expire first. (A real
+    // user's finger isn't resting on the toast, so this is harness-only.)
+    await page.mouse.move(0, 0);
+    await expect(page.locator("[data-sonner-toast]")).toHaveCount(0, {
+      timeout: 15_000,
+    });
+
     // Filtering toggle — flip and flip back to the original state.
     const filterToggle = page.getByTestId("dns-filter-toggle");
     const initial = await filterToggle.getAttribute("aria-checked");

--- a/source/marketing-site/tests/pages/ApiReference.test.tsx
+++ b/source/marketing-site/tests/pages/ApiReference.test.tsx
@@ -135,7 +135,13 @@ describe("ApiReference", () => {
     script.onerror?.(new Event("error"));
 
     expect(
-      await screen.findByText(/failed to load\. please refresh to try again/i),
+      // Default 1s findByText timeout flakes on loaded CI runners (the
+      // rejection → catch → setState → re-render chain lands just past it).
+      await screen.findByText(
+        /failed to load\. please refresh to try again/i,
+        undefined,
+        { timeout: 5_000 },
+      ),
     ).toBeInTheDocument();
   });
 

--- a/source/web/src/hooks/useDns.tsx
+++ b/source/web/src/hooks/useDns.tsx
@@ -28,14 +28,34 @@ export function useToggleDns() {
   return useMutation({
     mutationFn: (enabled: boolean) => dnsService.toggle({ enabled }),
     onSuccess: (data) => {
+      // Toggling this changes which DNS server DHCP advertises, but DHCP is
+      // pull-based: a device keeps the resolver it was handed until its lease
+      // renews (up to half the lease time — hours). Nothing can push the new
+      // value to it, so say so plainly rather than let the admin believe the
+      // switch took effect network-wide the moment they flipped it.
       toast.success(
         data.config.enabled ? "DNS server enabled" : "DNS server disabled",
+        {
+          description: LEASE_RENEWAL_NOTE,
+          duration: 10_000,
+        },
       );
       qc.invalidateQueries({ queryKey: ["dns"] });
+      // The advertised DHCP option changed with it. Only the config view
+      // derives from it — leases/reservations/status are unaffected, so
+      // don't refetch the whole ["dhcp"] prefix.
+      qc.invalidateQueries({ queryKey: ["dhcp", "config"] });
     },
     onError: () => toast.error("Failed to toggle DNS server"),
   });
 }
+
+/** Shared copy: DHCP cannot push a new DNS server to an already-leased device.
+ * Worded for both directions — after *disabling*, the server from a device's
+ * current lease is the now-dead Pi, so reconnecting is how an admin restores
+ * name resolution, not just how they speed up rollout. */
+export const LEASE_RENEWAL_NOTE =
+  "Devices keep using the DNS server from their current lease until it renews — until then a change may leave them resolving via the old server, or not at all. Reconnect a device (toggle its Wi-Fi) to apply the change immediately.";
 
 export function useUpdateDnsConfig() {
   const qc = useQueryClient();

--- a/source/web/src/index.ts
+++ b/source/web/src/index.ts
@@ -200,6 +200,7 @@ export {
   useToggleDns,
   useUpdateDnsConfig,
   useFlushDnsCache,
+  LEASE_RENEWAL_NOTE,
 } from "./hooks/useDns";
 
 export {

--- a/source/web/tests/hooks/useDns.test.tsx
+++ b/source/web/tests/hooks/useDns.test.tsx
@@ -52,13 +52,25 @@ describe("useDns hooks", () => {
       await result.current.mutateAsync(true);
     });
     expect(dnsService.toggle).toHaveBeenCalledWith({ enabled: true });
-    expect(toast.success).toHaveBeenCalledWith("DNS server enabled");
+    // The toast must carry the lease-renewal caveat: DHCP is pull-based, so
+    // flipping this does not reach already-leased devices until they renew.
+    // Without it the admin believes filtering went network-wide instantly, and
+    // silently-unfiltered devices look like a broken filter.
+    expect(toast.success).toHaveBeenCalledWith(
+      "DNS server enabled",
+      expect.objectContaining({
+        description: expect.stringContaining("Reconnect a device"),
+      }),
+    );
 
     dnsService.toggle.mockResolvedValueOnce({ config: { enabled: false } });
     await act(async () => {
       await result.current.mutateAsync(false);
     });
-    expect(toast.success).toHaveBeenCalledWith("DNS server disabled");
+    expect(toast.success).toHaveBeenCalledWith(
+      "DNS server disabled",
+      expect.objectContaining({ description: expect.any(String) }),
+    );
   });
 
   it("updates config", async () => {


### PR DESCRIPTION
## Problem

The admin UI has always documented that while the Wardnet DNS server is enabled, DHCP advertises the Pi's own IP to clients "regardless of what's saved here" — but the daemon never honoured it. Option 6 carried the stored `dhcp_upstream_dns` list (seeded `1.1.1.1`/`8.8.8.8`), so every DHCP client resolved via Cloudflare/Google directly and silently bypassed all Wardnet DNS filtering. Only devices with a hardcoded resolver ever used the Pi.

## Fix

**Daemon**
- `resolve_scope` reads the DNS enable flag and advertises the scope gateway (the Pi, or its per-zone alias) in option 6 while enabled — for both the base pool and zone scopes.
- The flag is read via a shared `DNS_ENABLED_KEY` constant used by `DnsService::load_config`/`toggle` and the DHCP reader alike, so the two cannot drift.
- With the DNS server off, the stored upstream list is advertised; an empty list falls back to `DEFAULT_UPSTREAM_DNS` (warned once, not per packet) — never the Pi, which would have nothing listening on :53.
- `load_config`'s key-absent default now derives from the same constant (single source of truth with the migration seed).

**Admin UI / web**
- `DhcpConfigCard` treats an unresolved DNS query as *unknown* (placeholder) instead of falsely claiming clients use the upstream list; the upstream field is only editable when DNS is known-off.
- Lease-renewal caveat (`LEASE_RENEWAL_NOTE`, shared copy, worded for both toggle directions) on the toggle toast and the read view — DHCP can't push a resolver change to an already-leased device.
- The DNS toggle invalidates only `["dhcp","config"]` instead of refetching leases/reservations/status.

**Tests**
- Service-level: enabled → Pi advertised; disabled → upstream list; disabled + empty list → default fallback, never the Pi.
- Wire-level guards on `build_response`: option 6 carries exactly the scope's DNS list; empty scope DNS advertises the Pi. (The original bug shipped because nothing asserted the rendered option.)
- Admin-site: placeholder while the DNS query is unresolved; note shown/hidden per state.

## Known limit

A WAN-forbidden zone's egress gate drops direct client→public-resolver :53 traffic, so with Wardnet DNS off such zones still have no working resolver — same as before this change (they were handed the dead Pi alias). Documented in-code and tracked in #898.

## Verification

`cargo fmt` clean, `clippy --all-targets -D warnings` clean, full daemon workspace tests green (Linux container); web + admin-site typecheck green; DhcpConfigCard 13/13, useDns 5/5.

## Merge Commit Message

fix(dhcp): advertise the Wardnet DNS server in option 6 while it is enabled, falling back to the configured upstream list (or defaults, never the dead Pi) when it is off — with shared config keys, direction-aware admin-UI messaging, and wire-level option-6 guards.

https://claude.ai/code/session_01REFNyHXkbxzuBWN2uHgGWF