### PR TITLE
docs(release): cover the DHCP DNS-advertisement fix (#899) in the beta.4 notes

### DIFF
--- a/docs/releases/v2026.07.00-beta.4.md
+++ b/docs/releases/v2026.07.00-beta.4.md
@@ -1,11 +1,15 @@
 # Wardnet 2026.07.00-beta.4
 
-Patch beta following [`2026.07.00-beta.3`](v2026.07.00-beta.3.md) with two focuses: **DNS correctness** — domains that legitimately have no record of the asked type (very common for HTTPS/AAAA/PTR lookups) are now answered properly instead of erroring, fixing intermittent resolution failures for major sites — and **remote access certificate issuance**: the failure that made the very first issuance attempt fail on every fresh enrollment is fixed, a failure caused by Let's Encrypt rate limiting now backs off instead of digging the hole deeper, and the dashboard's DNS resolution check no longer cries wolf on a perfectly healthy setup. Beta builds receive updates via the **beta channel** only — switch to it in **Settings → Updates** to opt in.
+Patch beta following [`2026.07.00-beta.3`](v2026.07.00-beta.3.md) with two focuses: **DNS correctness** — DHCP now actually hands the Wardnet DNS server to clients while it is enabled (devices were silently bypassing all filtering), and domains that legitimately have no record of the asked type (very common for HTTPS/AAAA/PTR lookups) are now answered properly instead of erroring, fixing intermittent resolution failures for major sites — and **remote access certificate issuance**: the failure that made the very first issuance attempt fail on every fresh enrollment is fixed, a failure caused by Let's Encrypt rate limiting now backs off instead of digging the hole deeper, and the dashboard's DNS resolution check no longer cries wolf on a perfectly healthy setup. Beta builds receive updates via the **beta channel** only — switch to it in **Settings → Updates** to opt in.
 
 > [!IMPORTANT]
 > A fresh, ground-up beta install is supported with `curl -fsSL https://wardnet.network/install.sh | sudo CHANNEL=beta bash`. The installer's `CHANNEL` only selects **which tarball is fetched** — the daemon's auto-update channel is stored separately and still defaults to `stable`. After a fresh beta install you **must** set the channel to `beta` in **Settings → Updates**, or the box will not receive further beta updates. It will not downgrade; it will simply sit on this build.
 
 ## Bug fixes
+
+### DHCP now hands out the Wardnet DNS server, so devices actually get filtered
+
+The admin UI has always said that while the Wardnet DNS server is enabled, DHCP advertises the gateway's own address to clients "regardless of what's saved here" — but the daemon never honoured it. DHCP kept advertising the stored upstream resolvers (seeded Cloudflare/Google), so every device that took a lease resolved directly against public DNS and **silently bypassed all Wardnet filtering**; only devices with a hardcoded resolver ever used the gateway. While the DNS server is enabled, DHCP now advertises the gateway (or its per-zone alias) to both the base pool and every zone; with it disabled, the stored upstream list is advertised as before. The DHCP settings page now also reflects this honestly, and notes that already-leased devices only pick up the change at lease renewal or reconnect. Closes [#899](https://github.com/wardnet/wardnet/pull/899).
 
 ### Negative DNS answers are answered honestly instead of erroring
 


### PR DESCRIPTION
Second notes addendum for the retracted-and-pending `v2026.07.00-beta.4` tag: the GitHub Release body is built from the notes file in the tagged tree, so #899 (DHCP advertising upstream resolvers instead of the Wardnet DNS server — devices silently bypassing filtering) must be in the notes before the tag is re-pushed. Doc-only.

## Merge Commit Message

docs(release): cover the DHCP DNS-advertisement fix (#899) in the beta.4 notes

https://claude.ai/code/session_016rUuXqBH8uWYXKJbTFkzSr