### PR TITLE
fix(ddns): region catalog probes the ddns service health vhost, not the gateway host

### DIFF
--- a/source/daemon/crates/wardnetd-services/src/ddns/region.rs
+++ b/source/daemon/crates/wardnetd-services/src/ddns/region.rs
@@ -15,8 +15,12 @@
 //! Two endpoints per region matter:
 //! * **control** (`https://api.<region-slug>…:443`) — the regional gateway; TLS
 //!   is a normal public cert, requests route to the service by `X-Mesh-Target`.
-//! * **health** (`http://api.<region-slug>…:81/readyz`) — the gateway host exposes
-//!   the readiness probe on plain-HTTP `:81` (cloud ADR-0027).
+//! * **health** (`http://ddns.svc.prd.<region-slug>…:81/readyz`) — the region's
+//!   `ddns` service readiness probe on the plain-HTTP `:81` health listener
+//!   (cloud ADR-0027). The `:81` listener serves **per-service** vhosts
+//!   (`<service>.svc.prd.<region>…`) only — the gateway host answers 404 there,
+//!   and `ddns` is the service registration is about to talk to, so its
+//!   readiness IS the "region reachable" signal.
 //!
 //! The global gateway (`tenants`) is scope-wide, so it is a single constant
 //! rather than a per-region catalog entry.
@@ -45,8 +49,10 @@ pub struct RegionEndpoint {
     /// the regional `ddns` and `tunneller` services (routing on `X-Mesh-Target`,
     /// cloud ADR-0015).
     pub gateway_base_url: String,
-    /// Health-probe URL for region selection — the cloud health tier's readiness
-    /// probe (`http://api.<region-slug>…:81/readyz`, plain HTTP; cloud ADR-0027).
+    /// Health-probe URL for region selection — the region's `ddns` service
+    /// readiness probe (`http://ddns.svc.prd.<region-slug>…:81/readyz`, plain
+    /// HTTP; cloud ADR-0027). The `:81` health listener routes by per-service
+    /// vhost, not by the gateway host.
     pub health_url: String,
 }
 
@@ -74,7 +80,7 @@ pub fn default_catalog() -> Vec<RegionEndpoint> {
     vec![RegionEndpoint::new(
         "euc",
         "https://api.euc.wardnet.network",
-        "http://api.euc.wardnet.network:81/readyz",
+        "http://ddns.svc.prd.euc.wardnet.network:81/readyz",
     )]
 }
 

--- a/source/daemon/crates/wardnetd-services/src/ddns/tests/settings.rs
+++ b/source/daemon/crates/wardnetd-services/src/ddns/tests/settings.rs
@@ -79,3 +79,21 @@ fn region_overrides_only_touch_the_first_catalog_entry() {
         "http://api.second-region.wardnet.network:81/readyz"
     );
 }
+
+/// The built-in catalog must probe the per-service health vhost
+/// (`http://<service>.svc.prd.<region>.wardnet.network:81/...`) — the plain-HTTP
+/// `:81` listener only serves per-service names; the gateway host (`api.<region>`)
+/// answers 404 there, which marked every region unreachable and 502'd
+/// registration on the beta fleet (2026-07-14 infra migration).
+#[test]
+fn default_catalog_probes_the_ddns_service_health_vhost() {
+    let catalog = region::default_catalog();
+    let euc = catalog
+        .iter()
+        .find(|entry| entry.slug == "euc")
+        .expect("euc in catalog");
+    assert_eq!(
+        euc.health_url,
+        "http://ddns.svc.prd.euc.wardnet.network:81/readyz"
+    );
+}


### PR DESCRIPTION
Fixes the remote-access registration failure on the beta fleet: `POST /api/ddns/register` → 502 **"upstream unavailable: no wardnet ddns region is reachable"**.

## Root cause

The daemon's built-in region catalog probes region health before registering. It probed `http://api.euc.wardnet.network:81/readyz` — but the plain-HTTP `:81` health listener routes by **per-service vhost** (`http://<service>.svc.prd.<region>.wardnet.network:81/…`); the gateway host answers 404 there. The 2026-07-14 infra deploy enforced this convention, so every region probe 404'd, the catalog marked all regions unreachable, and registration died before ever reaching the cloud. (Enrollment kept working — it goes to the global gateway over 443.)

## Fix

Catalog probes `http://ddns.svc.prd.euc.wardnet.network:81/readyz` — the regional `ddns` service is exactly what registration is about to talk to, so its readiness is the region-reachable signal. Verified 200 from a fielded Pi. Doc comments updated to the per-service vhost convention.

## Caveat

Fielded beta.3/beta.4 daemons have the old probe URL baked in — this needs the next release (and/or an infra-side `api.<region>:81` alias as a stopgap for the current fleet).

## Tests

TDD: new catalog test pins the svc-convention URL (RED on the old URL, GREEN after). Full `make check-daemon` exit 0.

## Merge Commit Message

fix(ddns): region catalog probes the ddns service health vhost, not the gateway host

https://claude.ai/code/session_016rUuXqBH8uWYXKJbTFkzSr