### PR TITLE
fix(ddns): DoH fallback resolver uses Google's JSON endpoint

### DIFF
--- a/source/daemon/crates/wardnetd-services/src/ddns/doh.rs
+++ b/source/daemon/crates/wardnetd-services/src/ddns/doh.rs
@@ -25,8 +25,7 @@ use serde::Deserialize;
 /// different paths — Cloudflare answers JSON on `/dns-query` (per its `accept`
 /// header), while Google serves JSON **only** on `/resolve` (`/dns-query` is
 /// RFC 8484 wire format and rejects a JSON request with HTTP 400).
-pub(crate) const DOH_RESOLVERS: &[&str] =
-    &["https://1.1.1.1/dns-query", "https://8.8.8.8/resolve"];
+pub(crate) const DOH_RESOLVERS: &[&str] = &["https://1.1.1.1/dns-query", "https://8.8.8.8/resolve"];
 
 /// DNS `A` record type number, used to pick A answers out of a CNAME chain.
 const DNS_TYPE_A: u16 = 1;

--- a/source/daemon/crates/wardnetd-services/src/ddns/doh.rs
+++ b/source/daemon/crates/wardnetd-services/src/ddns/doh.rs
@@ -21,9 +21,12 @@ use std::net::Ipv4Addr;
 use serde::Deserialize;
 
 /// Public DoH-JSON resolvers, queried **by IP** in order until one answers.
-/// Cloudflare + Google for redundancy; both serve `application/dns-json`.
+/// Cloudflare + Google for redundancy; both serve the same JSON schema but at
+/// different paths — Cloudflare answers JSON on `/dns-query` (per its `accept`
+/// header), while Google serves JSON **only** on `/resolve` (`/dns-query` is
+/// RFC 8484 wire format and rejects a JSON request with HTTP 400).
 pub(crate) const DOH_RESOLVERS: &[&str] =
-    &["https://1.1.1.1/dns-query", "https://8.8.8.8/dns-query"];
+    &["https://1.1.1.1/dns-query", "https://8.8.8.8/resolve"];
 
 /// DNS `A` record type number, used to pick A answers out of a CNAME chain.
 const DNS_TYPE_A: u16 = 1;

--- a/source/daemon/crates/wardnetd-services/src/ddns/tests/settings.rs
+++ b/source/daemon/crates/wardnetd-services/src/ddns/tests/settings.rs
@@ -97,3 +97,16 @@ fn default_catalog_probes_the_ddns_service_health_vhost() {
         "http://ddns.svc.prd.euc.wardnet.network:81/readyz"
     );
 }
+
+/// The pinned public resolvers must use each provider's **DoH-JSON** endpoint.
+/// Google serves JSON only at `/resolve` — `8.8.8.8/dns-query` speaks RFC 8484
+/// wire format and answers HTTP 400 to a JSON request, so pointing the fallback
+/// there made it permanently dead (single point of failure on 1.1.1.1).
+#[test]
+fn doh_fallback_uses_googles_json_endpoint() {
+    use crate::ddns::doh::DOH_RESOLVERS;
+    assert_eq!(
+        DOH_RESOLVERS,
+        &["https://1.1.1.1/dns-query", "https://8.8.8.8/resolve"]
+    );
+}


### PR DESCRIPTION
Found while investigating a "Not yet visible publicly" report on the Check DNS button: the check's fallback resolver never worked. The daemon queries pinned public resolvers over **DoH-JSON** — Cloudflare first, Google second — but Google serves the JSON convenience API only at `/resolve`; `8.8.8.8/dns-query` speaks RFC 8484 wire format and rejects a JSON request with **HTTP 400**. Every fallback attempt errored, making the check a single point of failure on 1.1.1.1 (an unreachable Cloudflare = check reports upstream-unavailable instead of falling back).

(The original user report itself was propagation timing — the record resolves publicly and the daemon's split-horizon serves the LAN answer; verified live on the Pi.)

## Fix

`DOH_RESOLVERS` fallback → `https://8.8.8.8/resolve` (same JSON schema, verified live). Doc comment explains the per-provider path difference.

## Tests

TDD: test pins both resolver URLs (RED on `/dns-query`, GREEN on `/resolve`). Full `make check-daemon` exit 0.

## Merge Commit Message

fix(ddns): DoH fallback resolver uses Google's JSON endpoint

https://claude.ai/code/session_016rUuXqBH8uWYXKJbTFkzSr