### PR TITLE
fix(pwa): distinct manifest ids so the admin app installs alongside the user app

### DIFF
--- a/source/admin-app/public/manifest.json
+++ b/source/admin-app/public/manifest.json
@@ -1,7 +1,8 @@
 {
+  "id": "/admin-app/",
   "name": "Wardnet Admin",
-  "short_name": "Wardnet",
-  "description": "Wardnet Admin — manage your network on the go",
+  "short_name": "Wardnet Admin",
+  "description": "Wardnet Admin \u2014 manage your network on the go",
   "start_url": "/admin-app/",
   "scope": "/admin-app/",
   "display": "standalone",

--- a/source/end2end-tests/web-ui/tests/admin-app/pwa-shell.spec.ts
+++ b/source/end2end-tests/web-ui/tests/admin-app/pwa-shell.spec.ts
@@ -52,6 +52,12 @@ test.describe("manifest + installability", () => {
     // Core installability fields: a name, an in-scope start URL, standalone
     // display, and the 192/512 icons Chrome requires to offer installation.
     expect(manifest.name).toBeTruthy();
+    // Explicit app identity, distinct from the user-app's root `id`: the
+    // admin-app lives INSIDE the user-app's `/` scope, so without its own
+    // `id` the browser considers it already installed once the user-app is,
+    // and refuses to install it. The launcher label must differ too.
+    expect(manifest.id).toBe("/admin-app/");
+    expect(manifest.short_name).toBe("Wardnet Admin");
     expect(manifest.start_url).toContain("/admin-app/");
     expect(manifest.scope).toContain("/admin-app/");
     expect(manifest.display).toBe("standalone");

--- a/source/end2end-tests/web-ui/tests/user-app/pwa-shell.spec.ts
+++ b/source/end2end-tests/web-ui/tests/user-app/pwa-shell.spec.ts
@@ -38,6 +38,10 @@ test.describe("manifest + installability", () => {
     // standalone display, and the 192/512 icons Chrome requires to offer
     // installation.
     expect(manifest.name).toBeTruthy();
+    // Explicit app identity: without `id`, identity falls back to start_url
+    // and the browser treats any same-origin PWA inside this root scope
+    // (the admin-app at /admin-app/) as THIS app, blocking its install.
+    expect(manifest.id).toBe("/");
     expect(manifest.start_url).toBe("/");
     expect(manifest.scope).toBe("/");
     expect(manifest.display).toBe("standalone");

--- a/source/user-app/public/manifest.json
+++ b/source/user-app/public/manifest.json
@@ -1,7 +1,8 @@
 {
+  "id": "/",
   "name": "Wardnet",
   "short_name": "Wardnet",
-  "description": "Wardnet — manage your network from anywhere",
+  "description": "Wardnet \u2014 manage your network from anywhere",
   "start_url": "/",
   "scope": "/",
   "display": "standalone",


### PR DESCRIPTION
With the user app installed, the admin app could not be installed — the browser offered "open in Wardnet" instead.

## Root cause

The user-app's manifest scope is the whole origin (`/`), which **contains** the admin-app at `/admin-app/`. Neither manifest declared an `id`, so PWA identity fell back to the resolved `start_url`, and any page inside an installed app's scope is treated as that app. Both apps also shared `short_name: "Wardnet"`, so even the launcher labels collided.

## Fix

- Explicit, distinct identities: `"id": "/"` (user-app), `"id": "/admin-app/"` (admin-app) — identity no longer hinges on scope containment.
- Admin launcher label becomes **"Wardnet Admin"**.
- Both PWA shell specs now pin `id` (and the admin `short_name`) so identity can't silently regress.

## Test plan

E2E PWA-shell specs extended and green in CI; manifests are static assets embedded at daemon build.

## Merge Commit Message

fix(pwa): distinct manifest ids so the admin app installs alongside the user app

https://claude.ai/code/session_016rUuXqBH8uWYXKJbTFkzSr