### PR TITLE
fix(e2e): pin the daemon's update manifest to the local cloud mock

### DIFF
--- a/source/end2end-tests/web-ui/compose.ui.yaml
+++ b/source/end2end-tests/web-ui/compose.ui.yaml
@@ -98,6 +98,18 @@ services:
           printf '\n[ddns_wardnet]\ngateway_url = "http://10.92.0.53:8080"\nregion_gateway_url = "http://10.92.0.53:8080"\nregion_health_url = "http://10.92.0.53:8080/readyz"\n' >> /etc/wardnet/wardnet.toml
           echo "wardnetd-ui e2e fixture: pinned ddns_wardnet gateways to http://10.92.0.53:8080" >&2
         fi
+        # Point the auto-update manifest at the local cloud mock so a
+        # "Check now" settles instantly (404 → terminal error) instead of
+        # egressing to the real releases.wardnet.network. Without this, a
+        # check fired by settings.spec.ts can leave the daemon's install
+        # phase stuck at `checking` while the request crawls toward the
+        # 60s timeout — and the stateful backups spec that runs next finds
+        # the channel selector disabled for minutes (the recurring
+        # backups.spec.ts flake). Idempotent on the [update] key.
+        if ! grep -q '^\[update\]' /etc/wardnet/wardnet.toml; then
+          printf '\n[update]\nmanifest_base_url = "http://10.92.0.53:8080/releases"\nhttp_timeout_secs = 5\n' >> /etc/wardnet/wardnet.toml
+          echo "wardnetd-ui e2e fixture: pinned update manifest to the cloud mock" >&2
+        fi
         exec /lib/systemd/systemd --log-target=console --log-level=debug --show-status=yes
     networks:
       wardnet_mgmt:
@@ -159,6 +171,12 @@ services:
           echo "wardnetd-ui-fresh e2e fixture: pinned lan_interface=$$LAN_IFACE" >&2
         else
           echo "wardnetd-ui-fresh e2e fixture: WARNING no NIC holds 10.93.0.1; leaving lan_interface as-is" >&2
+        fi
+        # Same local update-manifest pin as wardnetd-ui above: keep any
+        # update check instant and offline-deterministic.
+        if ! grep -q '^\[update\]' /etc/wardnet/wardnet.toml; then
+          printf '\n[update]\nmanifest_base_url = "http://10.92.0.53:8080/releases"\nhttp_timeout_secs = 5\n' >> /etc/wardnet/wardnet.toml
+          echo "wardnetd-ui-fresh e2e fixture: pinned update manifest to the cloud mock" >&2
         fi
         exec /lib/systemd/systemd --log-target=console --log-level=debug --show-status=yes
     networks:

--- a/source/end2end-tests/web-ui/fixtures/system.ts
+++ b/source/end2end-tests/web-ui/fixtures/system.ts
@@ -16,7 +16,15 @@ import { loginViaUi } from "./ui";
  * once the mutation settles — the caller asserts that.
  */
 export async function setChannel(page: Page, label: string): Promise<void> {
-  await page.getByTestId("update-channel-trigger").click();
+  const trigger = page.getByTestId("update-channel-trigger");
+  // The select is disabled while an update phase is active (e.g. a check
+  // kicked off by an earlier spec still settling server-side). Wait for it
+  // explicitly so a stuck phase fails loudly here rather than as an opaque
+  // full-test-timeout on the click below.
+  await expect(trigger, "update phase must settle first").toBeEnabled({
+    timeout: 30_000,
+  });
+  await trigger.click();
   await page.getByRole("option", { name: label }).click();
 }
 


### PR DESCRIPTION
Kills the recurring `backups.spec.ts` flake (three CI rounds on 2026-07-14, including the beta.4 release run).

## Root cause

The Playwright failure artifact shows the Settings page with **Current phase: Checking** and *Last checked: never* — the channel selector is `disabled` while any update phase is active, so the backups spec's first `setChannel` click retried for its entire 180s budget. The phase gets stuck because the e2e daemons keep the **default** `manifest_base_url` (`https://releases.wardnet.network`): `settings.spec.ts`'s "Check now" test egresses from the CI runner, and a slow/blackholed fetch holds `phase=checking` toward the 60s reqwest timeout — bleeding into the next spec.

## Fix

- Compose harness: pin `[update] manifest_base_url` to the local cloud mock (`http://10.92.0.53:8080/releases`, instant 404 → the check settles in milliseconds, offline-deterministic) with `http_timeout_secs = 5`, on both `wardnetd-ui` and `wardnetd-ui-fresh`. Same idempotent sed/printf pattern as the existing `[ddns_wardnet]` pin.
- Shared `setChannel` fixture: explicit `toBeEnabled` wait so a stuck phase fails loudly with "update phase must settle first" instead of an opaque click timeout.

## Merge Commit Message

fix(e2e): pin the daemon's update manifest to the local cloud mock

https://claude.ai/code/session_016rUuXqBH8uWYXKJbTFkzSr