### PR TITLE
fix(dns,logging): five unknown DNS result strings + admin-UI log noise

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -24424,6 +24424,11 @@
           "upstream_error",
           "negative",
           "authoritative",
+          "authoritative_nodata",
+          "authoritative_nxdomain",
+          "rate_limited",
+          "rebinding_blocked",
+          "recursor_failed",
           "error"
         ]
       },

--- a/source/admin-site/src/pages/DnsLogs.tsx
+++ b/source/admin-site/src/pages/DnsLogs.tsx
@@ -45,6 +45,14 @@ const RESULT_BADGE: Record<string, "ok" | "warn" | "down" | "info" | "ghost"> =
     // Successful resolution whose answer is "no such name / record type"
     // (NXDOMAIN / NODATA) — informational, not an error.
     negative: "info",
+    // Negative answers served from a local authoritative zone — successful
+    // resolutions whose answer is "no such name / record type".
+    authoritative_nodata: "info",
+    authoritative_nxdomain: "info",
+    // Refused: the answer pointed at a private IP for an external domain.
+    rebinding_blocked: "down",
+    rate_limited: "warn",
+    recursor_failed: "warn",
     forwarded: "ghost",
     cache_hit: "ghost",
     rewritten: "info",
@@ -52,9 +60,20 @@ const RESULT_BADGE: Record<string, "ok" | "warn" | "down" | "info" | "ghost"> =
     error: "warn",
   };
 
+// Keep these short. The Result column is fixed-width and the Pill is
+// `white-space: nowrap`, so a label wider than the column overflows into
+// Latency rather than wrapping or truncating.
 const RESULT_LABEL: Record<string, string> = {
   blocked_skipped: "blocked (skipped)",
-  negative: "negative (no record)",
+  negative: "no record",
+  // Distinct from `negative`: answered by a local authoritative zone, not
+  // upstream. Same meaning, different source — the labels must differ or the
+  // two are indistinguishable in the table.
+  authoritative_nodata: "no record (local)",
+  authoritative_nxdomain: "no such name (local)",
+  rebinding_blocked: "rebinding",
+  rate_limited: "rate limited",
+  recursor_failed: "recursor",
 };
 
 function fmtTime(ts: string): string {
@@ -245,7 +264,22 @@ export default function DnsLogs() {
           <SelectItem value="cache_hit">Cache hit</SelectItem>
           <SelectItem value="rewritten">Rewritten</SelectItem>
           <SelectItem value="negative">Negative (no record)</SelectItem>
+          <SelectItem value="authoritative">Authoritative</SelectItem>
+          {/* The filter is an exact `result = ?` match server-side, so every
+              result string needs its own option — otherwise rows the table
+              renders are unreachable through the filter. */}
+          <SelectItem value="authoritative_nodata">
+            Authoritative (no record)
+          </SelectItem>
+          <SelectItem value="authoritative_nxdomain">
+            Authoritative (no such name)
+          </SelectItem>
+          <SelectItem value="rate_limited">Rate limited</SelectItem>
+          <SelectItem value="rebinding_blocked">Rebinding blocked</SelectItem>
+          <SelectItem value="recursive">Recursive</SelectItem>
+          <SelectItem value="recursor_failed">Recursor failed</SelectItem>
           <SelectItem value="upstream_error">Upstream error</SelectItem>
+          <SelectItem value="error">Error</SelectItem>
         </SelectContent>
       </Select>
     </>

--- a/source/daemon/crates/wardnet-common/src/config.rs
+++ b/source/daemon/crates/wardnet-common/src/config.rs
@@ -231,6 +231,16 @@ pub struct LoggingConfig {
     pub max_recent_errors: usize,
     /// Channel capacity for the WebSocket log broadcast.
     pub broadcast_capacity: usize,
+    /// Tracing targets hidden from the admin-facing log surfaces (the
+    /// WebSocket log stream and the recent-errors buffer).
+    ///
+    /// Matched as a prefix against the event target, so
+    /// `hickory_resolver::recursor` also covers
+    /// `hickory_resolver::recursor::handle`. Entries here are **not** filtered
+    /// out of the log file or the `OTel` exporters — the full detail stays on
+    /// disk for debugging; this only keeps the admin UI free of events an
+    /// admin cannot act on.
+    pub ui_suppressed_targets: Vec<String>,
 }
 
 impl Default for LoggingConfig {
@@ -244,6 +254,14 @@ impl Default for LoggingConfig {
             max_log_files: 7,
             max_recent_errors: 15,
             broadcast_capacity: 256,
+            // Warns once per failed recursive lookup ("lookup error: no records
+            // found ..."). On a busy resolver that is one warning per client
+            // query for an ordinary negative DNS answer — it would drown the
+            // live log view and evict real errors from the recent-errors
+            // buffer. Unlike the netlink noise silenced in `to_filter_string`,
+            // this is worth keeping on disk: it names the query that failed, so
+            // it is genuinely useful when debugging resolution.
+            ui_suppressed_targets: vec!["hickory_resolver::recursor".to_owned()],
         }
     }
 }
@@ -254,11 +272,18 @@ impl LoggingConfig {
     pub fn to_filter_string(&self) -> String {
         use std::fmt::Write;
 
-        // `netlink_packet_route::link::buffer_tool` warns whenever the kernel
-        // returns more bytes for an attribute than the crate version knows
-        // about (e.g. `IFLA_INET6_STATS`: expecting 288, got 304). Newer
-        // kernels trip it constantly and it isn't actionable, so silence the
-        // module by default. A user-supplied `[logging.filters]` entry can
+        // Two mechanisms, deliberately: an `EnvFilter` directive here gates the
+        // *whole* subscriber (file and `OTel` included), while
+        // `ui_suppressed_targets` hides a target from the admin UI only.
+        //
+        // Use this one when the events are worthless to everybody, and
+        // `ui_suppressed_targets` when they are worth keeping on disk but would
+        // drown the admin. `netlink_packet_route::link::buffer_tool` is the
+        // former: it warns whenever the kernel returns more bytes for an
+        // attribute than the crate version knows about (e.g. `IFLA_INET6_STATS`:
+        // expecting 288, got 304), which newer kernels trip on every link poll.
+        // Nobody — admin or developer — can act on it, and letting it reach the
+        // file would churn the rotation window. A `[logging.filters]` entry can
         // still raise it again because it is appended after this directive.
         let mut directives = format!(
             "warn,wardnetd={level},wardnet_common={level},netlink_packet_route::link::buffer_tool=error",

--- a/source/daemon/crates/wardnet-common/src/dns.rs
+++ b/source/daemon/crates/wardnet-common/src/dns.rs
@@ -353,11 +353,76 @@ pub enum DnsQueryResult {
     Negative,
     /// Answered directly from a local authoritative record — resolver string `"authoritative"`.
     Authoritative,
+    /// Local authoritative zone answered NODATA: the name exists but has no
+    /// record of the requested type — resolver string `"authoritative_nodata"`.
+    AuthoritativeNodata,
+    /// Local authoritative zone answered NXDOMAIN: the name does not exist in
+    /// the zone — resolver string `"authoritative_nxdomain"`.
+    AuthoritativeNxdomain,
+    /// Dropped by the per-client query rate limiter — resolver string
+    /// `"rate_limited"`.
+    RateLimited,
+    /// DNS-rebinding protection refused an answer that pointed at a private IP
+    /// for an external domain — resolver string `"rebinding_blocked"`.
+    RebindingBlocked,
+    /// Recursive resolution failed — resolver string `"recursor_failed"`.
+    RecursorFailed,
     /// Resolution failed (parse fallback for unrecognised strings).
     Error,
 }
 
 impl DnsQueryResult {
+    /// Every variant, for exhaustive iteration.
+    ///
+    /// Kept honest by [`slot`](Self::slot): that match is exhaustive, so a new
+    /// variant fails to compile until it is given a slot here, and
+    /// `all_is_complete` asserts the slots and this array agree. Without that
+    /// pairing this array would be a comment, not a guarantee — and every test
+    /// that iterates it would quietly stop covering the new variant.
+    pub const ALL: [Self; 15] = [
+        Self::Forwarded,
+        Self::CacheHit,
+        Self::Blocked,
+        Self::BlockedSkipped,
+        Self::Rewritten,
+        Self::Recursive,
+        Self::UpstreamError,
+        Self::Negative,
+        Self::Authoritative,
+        Self::AuthoritativeNodata,
+        Self::AuthoritativeNxdomain,
+        Self::RateLimited,
+        Self::RebindingBlocked,
+        Self::RecursorFailed,
+        Self::Error,
+    ];
+
+    /// This variant's index in [`ALL`](Self::ALL).
+    ///
+    /// The only reason this exists: the match is exhaustive, so adding a
+    /// variant to the enum without adding it to `ALL` is a compile error here
+    /// rather than a silently under-covering test suite.
+    #[must_use]
+    pub const fn slot(self) -> usize {
+        match self {
+            Self::Forwarded => 0,
+            Self::CacheHit => 1,
+            Self::Blocked => 2,
+            Self::BlockedSkipped => 3,
+            Self::Rewritten => 4,
+            Self::Recursive => 5,
+            Self::UpstreamError => 6,
+            Self::Negative => 7,
+            Self::Authoritative => 8,
+            Self::AuthoritativeNodata => 9,
+            Self::AuthoritativeNxdomain => 10,
+            Self::RateLimited => 11,
+            Self::RebindingBlocked => 12,
+            Self::RecursorFailed => 13,
+            Self::Error => 14,
+        }
+    }
+
     /// Return the canonical `snake_case` string that the DNS resolver writes to
     /// the `dns_query_log.result` column. Inverse of [`DnsQueryResult::parse`].
     #[must_use]
@@ -372,35 +437,68 @@ impl DnsQueryResult {
             Self::UpstreamError => "upstream_error",
             Self::Negative => "negative",
             Self::Authoritative => "authoritative",
+            Self::AuthoritativeNodata => "authoritative_nodata",
+            Self::AuthoritativeNxdomain => "authoritative_nxdomain",
+            Self::RateLimited => "rate_limited",
+            Self::RebindingBlocked => "rebinding_blocked",
+            Self::RecursorFailed => "recursor_failed",
             Self::Error => "error",
+        }
+    }
+
+    /// Parse a raw DB / resolver string, returning `None` when it matches no
+    /// known variant. Exact inverse of [`as_str`](Self::as_str).
+    ///
+    /// This is the single source of truth for the accepted strings;
+    /// [`parse`](Self::parse) layers the lossy fallback on top. Keeping the
+    /// two apart is what lets the tests tell "parsed via a real arm" apart
+    /// from "fell through to `Error`" — the two are indistinguishable by
+    /// return value alone, which is how the missing `"error"` arm hid behind a
+    /// passing round-trip test.
+    #[must_use]
+    pub fn from_db_str(s: &str) -> Option<Self> {
+        match s {
+            "forwarded" => Some(Self::Forwarded),
+            "cache_hit" => Some(Self::CacheHit),
+            "blocked" => Some(Self::Blocked),
+            "blocked_skipped" => Some(Self::BlockedSkipped),
+            "rewritten" => Some(Self::Rewritten),
+            "recursive" => Some(Self::Recursive),
+            "upstream_error" => Some(Self::UpstreamError),
+            "negative" => Some(Self::Negative),
+            "authoritative" => Some(Self::Authoritative),
+            "authoritative_nodata" => Some(Self::AuthoritativeNodata),
+            "authoritative_nxdomain" => Some(Self::AuthoritativeNxdomain),
+            "rate_limited" => Some(Self::RateLimited),
+            "rebinding_blocked" => Some(Self::RebindingBlocked),
+            "recursor_failed" => Some(Self::RecursorFailed),
+            "error" => Some(Self::Error),
+            _ => None,
         }
     }
 
     /// Parse a raw DB / resolver string into the correct variant.
     ///
-    /// Every string the DNS resolver writes to the database is matched
-    /// exactly. Unknown strings emit a [`tracing::warn!`] and fall back to
+    /// Unknown strings emit a [`tracing::warn!`] and fall back to
     /// [`DnsQueryResult::Error`] so callers always get a typed value.
+    ///
+    /// This warning used to fire constantly, because the resolver wrote five
+    /// strings (`rate_limited`, `rebinding_blocked`, `recursor_failed`,
+    /// `authoritative_nodata`, `authoritative_nxdomain`) that had no variant —
+    /// so those queries were mislabelled `Error` in the UI and in the stats.
+    /// The strings are variants now, and the right response to the noise was to
+    /// fix the drift, not to lower the level: a fallback here means the
+    /// resolver is writing a string this enum does not know, which mislabels
+    /// rows and needs fixing. Keep it loud.
+    ///
+    /// Use [`from_db_str`](Self::from_db_str) when you need to distinguish an
+    /// unknown string from a genuine `Error` row.
     #[must_use]
     pub fn parse(s: &str) -> Self {
-        match s {
-            "forwarded" => Self::Forwarded,
-            "cache_hit" => Self::CacheHit,
-            "blocked" => Self::Blocked,
-            "blocked_skipped" => Self::BlockedSkipped,
-            "rewritten" => Self::Rewritten,
-            "recursive" => Self::Recursive,
-            "upstream_error" => Self::UpstreamError,
-            "negative" => Self::Negative,
-            "authoritative" => Self::Authoritative,
-            other => {
-                tracing::warn!(
-                    result = other,
-                    "unknown DNS result string; defaulting to Error"
-                );
-                Self::Error
-            }
-        }
+        Self::from_db_str(s).unwrap_or_else(|| {
+            tracing::warn!(result = s, "unknown DNS result string; defaulting to Error");
+            Self::Error
+        })
     }
 }
 
@@ -504,19 +602,47 @@ mod tests {
 
     #[test]
     fn as_str_round_trips_through_parse() {
-        let variants = [
-            DnsQueryResult::Forwarded,
-            DnsQueryResult::CacheHit,
-            DnsQueryResult::Blocked,
-            DnsQueryResult::BlockedSkipped,
-            DnsQueryResult::Rewritten,
-            DnsQueryResult::Recursive,
-            DnsQueryResult::UpstreamError,
-            DnsQueryResult::Authoritative,
-            DnsQueryResult::Error,
-        ];
-        for v in variants {
+        for v in DnsQueryResult::ALL {
             assert_eq!(DnsQueryResult::parse(v.as_str()), v);
+        }
+    }
+
+    /// `Error` round-trips through a real match arm, not the unknown-string
+    /// fallback.
+    ///
+    /// Without this, `as_str_round_trips_through_parse` passes vacuously for
+    /// `Error`: the fallback also returns `Error`, so a missing `"error"` arm
+    /// satisfies the assertion while silently routing every `"error"` row
+    /// through the "unknown DNS result string" path.
+    #[test]
+    fn every_variant_parses_without_hitting_the_fallback() {
+        for v in DnsQueryResult::ALL {
+            assert_eq!(
+                DnsQueryResult::from_db_str(v.as_str()),
+                Some(v),
+                "`{}` has no match arm — it would only survive the round-trip \
+                 via the unknown-string fallback",
+                v.as_str()
+            );
+        }
+    }
+
+    #[test]
+    fn from_db_str_rejects_unknown_strings() {
+        assert_eq!(DnsQueryResult::from_db_str("gibberish"), None);
+        assert_eq!(DnsQueryResult::from_db_str(""), None);
+    }
+
+    /// `ALL` really does hold every variant, exactly once.
+    ///
+    /// `slot()` is an exhaustive match, so a new variant cannot compile without
+    /// being given a slot; this asserts that slot lines up with a distinct
+    /// entry in `ALL`. Together they make `ALL` a guarantee rather than a
+    /// promise — every test that iterates it covers the new variant on day one.
+    #[test]
+    fn all_is_complete() {
+        for (i, v) in DnsQueryResult::ALL.into_iter().enumerate() {
+            assert_eq!(v.slot(), i, "ALL[{i}] = {v:?} is in the wrong slot");
         }
     }
 }

--- a/source/daemon/crates/wardnet-common/src/tests/config.rs
+++ b/source/daemon/crates/wardnet-common/src/tests/config.rs
@@ -24,6 +24,10 @@ fn defaults_when_file_missing() {
     assert_eq!(config.logging.max_log_files, 7);
     assert!(config.logging.filters.is_empty());
     assert_eq!(
+        config.logging.ui_suppressed_targets,
+        vec!["hickory_resolver::recursor".to_owned()]
+    );
+    assert_eq!(
         config.logging.to_filter_string(),
         "warn,wardnetd=info,wardnet_common=info,netlink_packet_route::link::buffer_tool=error"
     );

--- a/source/daemon/crates/wardnet-common/src/tests/dns.rs
+++ b/source/daemon/crates/wardnet-common/src/tests/dns.rs
@@ -123,20 +123,26 @@ fn dns_record_type_screaming_snake_rename() {
 
 #[test]
 fn dns_query_result_round_trip() {
-    for result in [
-        DnsQueryResult::Forwarded,
-        DnsQueryResult::CacheHit,
-        DnsQueryResult::Blocked,
-        DnsQueryResult::BlockedSkipped,
-        DnsQueryResult::Rewritten,
-        DnsQueryResult::Recursive,
-        DnsQueryResult::UpstreamError,
-        DnsQueryResult::Negative,
-        DnsQueryResult::Error,
-    ] {
+    // Iterate `ALL` rather than a hand-written list: a list that has to be
+    // updated by hand silently stops covering new variants (this one had
+    // already drifted — it was missing `Authoritative`).
+    for result in DnsQueryResult::ALL {
         let json = serde_json::to_string(&result).unwrap();
         let back: DnsQueryResult = serde_json::from_str(&json).unwrap();
         assert_eq!(result, back);
+    }
+}
+
+/// The `serde` rename and the DB string must agree: the API serialises the
+/// enum with `rename_all = "snake_case"`, while the resolver writes
+/// [`DnsQueryResult::as_str`] into `dns_query_log.result`. If the two ever
+/// diverge, a row written by the resolver would deserialise into a different
+/// variant over the wire than it parses to in the daemon.
+#[test]
+fn serde_repr_matches_db_string() {
+    for result in DnsQueryResult::ALL {
+        let json = serde_json::to_string(&result).unwrap();
+        assert_eq!(json, format!("\"{}\"", result.as_str()));
     }
 }
 

--- a/source/daemon/crates/wardnetd-mock/src/main.rs
+++ b/source/daemon/crates/wardnetd-mock/src/main.rs
@@ -123,8 +123,14 @@ async fn main() -> anyhow::Result<()> {
     // Build the log service BEFORE init_tracing so its tracing layers are
     // attached to the subscriber. This is what feeds the /system/logs/stream
     // websocket the web UI subscribes to.
-    let log_stream = Arc::new(LogStreamService::new(config.logging.broadcast_capacity));
-    let error_notifier = Arc::new(ErrorNotifierService::new(config.logging.max_recent_errors));
+    let log_stream = Arc::new(
+        LogStreamService::new(config.logging.broadcast_capacity)
+            .with_suppressed_targets(config.logging.ui_suppressed_targets.clone()),
+    );
+    let error_notifier = Arc::new(
+        ErrorNotifierService::new(config.logging.max_recent_errors)
+            .with_suppressed_targets(config.logging.ui_suppressed_targets.clone()),
+    );
     let log_service: Arc<dyn LogService> = Arc::new(LogServiceImpl::new(
         log_stream,
         error_notifier,

--- a/source/daemon/crates/wardnetd-services/src/dns/log_sink.rs
+++ b/source/daemon/crates/wardnetd-services/src/dns/log_sink.rs
@@ -231,15 +231,42 @@ fn record_dns_stats(inst: &DnsStatInstruments, row: &QueryLogRow) {
 }
 
 /// Normalise a raw DNS result string into the canonical outcome label value.
+///
+/// Matches on the parsed enum rather than the raw string so that the match is
+/// exhaustive: a new [`DnsQueryResult`] variant fails to compile here instead
+/// of silently landing in the `"error"` catch-all. That catch-all is exactly
+/// how `authoritative` — a *successful* local answer — came to be counted as
+/// an error in `dns.queries`, inflating the error rate on every dashboard
+/// reading these labels.
 fn normalize_outcome(result: &str) -> &'static str {
-    match result {
-        "blocked" | "blocked_skipped" => "blocked",
-        "forwarded" => "forwarded",
-        "negative" => "negative",
-        "cache_hit" | "cached" => "cached",
-        "recursive" => "recursive",
-        "rewritten" | "local" => "local",
-        _ => "error",
+    let Some(parsed) = DnsQueryResult::from_db_str(result) else {
+        return "error";
+    };
+
+    match parsed {
+        DnsQueryResult::Blocked | DnsQueryResult::BlockedSkipped => "blocked",
+        // NOT "blocked". `dns.queries.by_domain` is only recorded for the
+        // `blocked` outcome, and the web layer derives the blocked count, the
+        // block rate and "top blocked domains" from it. A rebinding refusal is
+        // a safety net firing on a domain that is on no blocklist, so counting
+        // it as a block would inflate the block rate and park legitimate
+        // domains in the top-blocked list.
+        DnsQueryResult::RebindingBlocked => "rebinding_blocked",
+        DnsQueryResult::Forwarded => "forwarded",
+        // Negative answers, whether they came from upstream or from a local
+        // authoritative zone. They are successful resolutions, not errors.
+        DnsQueryResult::Negative
+        | DnsQueryResult::AuthoritativeNodata
+        | DnsQueryResult::AuthoritativeNxdomain => "negative",
+        DnsQueryResult::CacheHit => "cached",
+        DnsQueryResult::Recursive => "recursive",
+        // Both are answered locally: `Rewritten` from a custom record,
+        // `Authoritative` from a local authoritative zone.
+        DnsQueryResult::Rewritten | DnsQueryResult::Authoritative => "local",
+        DnsQueryResult::RateLimited => "rate_limited",
+        DnsQueryResult::UpstreamError | DnsQueryResult::RecursorFailed | DnsQueryResult::Error => {
+            "error"
+        }
     }
 }
 

--- a/source/daemon/crates/wardnetd-services/src/logging/error_notifier.rs
+++ b/source/daemon/crates/wardnetd-services/src/logging/error_notifier.rs
@@ -7,6 +7,7 @@ use chrono::{DateTime, Utc};
 use serde::Serialize;
 
 use super::component::{BoxedLayer, LogComponent};
+use super::suppress::TargetSuppressor;
 
 /// A captured error or warning entry.
 #[derive(Debug, Clone, Serialize)]
@@ -33,6 +34,7 @@ pub struct ErrorNotifierService {
     entries: Arc<Mutex<VecDeque<ErrorEntry>>>,
     max_entries: usize,
     active: Arc<AtomicBool>,
+    suppressor: TargetSuppressor,
 }
 
 impl ErrorNotifierService {
@@ -46,7 +48,19 @@ impl ErrorNotifierService {
             entries: Arc::new(Mutex::new(VecDeque::with_capacity(max_entries))),
             max_entries,
             active: Arc::new(AtomicBool::new(false)),
+            suppressor: TargetSuppressor::default(),
         }
+    }
+
+    /// Keep the given tracing targets out of the recent-errors buffer.
+    ///
+    /// This matters more here than on the log stream: the buffer is a small
+    /// ring, so a dependency that warns once per DNS query would evict every
+    /// real error before an admin ever sees it. See [`TargetSuppressor`].
+    #[must_use]
+    pub fn with_suppressed_targets(mut self, targets: Vec<String>) -> Self {
+        self.suppressor = TargetSuppressor::new(targets);
+        self
     }
 }
 
@@ -63,6 +77,7 @@ impl LogComponent for ErrorNotifierService {
             entries: self.entries.clone(),
             max_entries: self.max_entries,
             active: self.active.clone(),
+            suppressor: self.suppressor.clone(),
         })
     }
 
@@ -88,6 +103,7 @@ struct ErrorNotifierLayer {
     entries: Arc<Mutex<VecDeque<ErrorEntry>>>,
     max_entries: usize,
     active: Arc<AtomicBool>,
+    suppressor: TargetSuppressor,
 }
 
 /// Visitor that extracts the message field from a tracing event.
@@ -125,6 +141,13 @@ where
 
         // Only capture WARN and ERROR.
         if level > tracing::Level::WARN {
+            return;
+        }
+
+        // Noise the admin cannot act on stays out of the buffer — otherwise it
+        // evicts the errors they can act on. Still written to the log file.
+        // ERROR is never suppressed, so this only drops WARN chatter.
+        if self.suppressor.is_suppressed(metadata.target(), &level) {
             return;
         }
 

--- a/source/daemon/crates/wardnetd-services/src/logging/mod.rs
+++ b/source/daemon/crates/wardnetd-services/src/logging/mod.rs
@@ -2,11 +2,13 @@ pub mod component;
 pub mod error_notifier;
 pub mod service;
 pub mod stream;
+pub mod suppress;
 
 pub use component::{BoxedLayer, LogComponent};
 pub use error_notifier::{ErrorEntry, ErrorNotifier, ErrorNotifierService};
 pub use service::{LogFileInfo, LogService, LogServiceImpl};
 pub use stream::{LogEntry, LogStream, LogStreamService};
+pub use suppress::TargetSuppressor;
 
 #[cfg(test)]
 mod tests;

--- a/source/daemon/crates/wardnetd-services/src/logging/stream.rs
+++ b/source/daemon/crates/wardnetd-services/src/logging/stream.rs
@@ -10,6 +10,7 @@ use tracing::field::{Field, Visit};
 use tracing_subscriber::registry::LookupSpan;
 
 use super::component::{BoxedLayer, LogComponent};
+use super::suppress::TargetSuppressor;
 
 /// A single structured log entry broadcast to WebSocket clients.
 #[derive(Debug, Clone, Serialize)]
@@ -40,6 +41,7 @@ pub trait LogStream: Send + Sync {
 pub struct LogStreamService {
     tx: broadcast::Sender<LogEntry>,
     active: Arc<AtomicBool>,
+    suppressor: TargetSuppressor,
 }
 
 impl LogStreamService {
@@ -53,7 +55,17 @@ impl LogStreamService {
         Self {
             tx,
             active: Arc::new(AtomicBool::new(false)),
+            suppressor: TargetSuppressor::default(),
         }
+    }
+
+    /// Hide the given tracing targets from the stream.
+    ///
+    /// See [`TargetSuppressor`] — suppressed events still reach the log file.
+    #[must_use]
+    pub fn with_suppressed_targets(mut self, targets: Vec<String>) -> Self {
+        self.suppressor = TargetSuppressor::new(targets);
+        self
     }
 }
 
@@ -69,6 +81,7 @@ impl LogComponent for LogStreamService {
         Box::new(LogStreamLayer {
             tx: self.tx.clone(),
             active: self.active.clone(),
+            suppressor: self.suppressor.clone(),
         })
     }
 
@@ -93,6 +106,7 @@ impl LogComponent for LogStreamService {
 struct LogStreamLayer {
     tx: broadcast::Sender<LogEntry>,
     active: Arc<AtomicBool>,
+    suppressor: TargetSuppressor,
 }
 
 /// Visitor that extracts all fields from a tracing event.
@@ -212,6 +226,15 @@ where
         }
 
         let metadata = event.metadata();
+
+        // Noise the admin cannot act on never reaches the UI, but it is still
+        // written to the log file by the fmt layer. ERROR is never suppressed.
+        if self
+            .suppressor
+            .is_suppressed(metadata.target(), metadata.level())
+        {
+            return;
+        }
 
         let level = metadata.level().as_str().to_uppercase();
         let target = metadata.target().to_string();

--- a/source/daemon/crates/wardnetd-services/src/logging/suppress.rs
+++ b/source/daemon/crates/wardnetd-services/src/logging/suppress.rs
@@ -1,0 +1,58 @@
+use std::sync::Arc;
+
+/// Prefix-matched deny-list of tracing targets that must not reach the
+/// admin-facing log surfaces.
+///
+/// This exists because the daemon has two classes of log consumer with very
+/// different needs:
+///
+/// * The **log file** and the `OTel` exporters want everything the subscriber's
+///   `EnvFilter` lets through — that is what you go read when something broke.
+/// * The **admin UI** (the WebSocket log stream and the recent-errors buffer)
+///   wants only events an admin can act on. A dependency that warns once per
+///   DNS query is not actionable; it drowns the live view and evicts real
+///   errors out of the fixed-size recent-errors ring buffer.
+///
+/// Filtering with a subscriber-level `EnvFilter` directive cannot express that
+/// split — it would drop the events for the file too. So the two UI-facing
+/// layers consult this deny-list themselves, leaving every other sink intact.
+///
+/// Prefix matching means `hickory_resolver::recursor` covers the whole module
+/// subtree, including `hickory_resolver::recursor::handle`. The list is
+/// configured by `logging.ui_suppressed_targets`.
+#[derive(Debug, Clone, Default)]
+pub struct TargetSuppressor {
+    prefixes: Arc<[String]>,
+}
+
+impl TargetSuppressor {
+    /// Build a suppressor from a list of target prefixes.
+    ///
+    /// Empty entries are discarded: an empty prefix matches every target and
+    /// would silence the admin UI entirely, which is never what a config
+    /// typo means to say.
+    #[must_use]
+    pub fn new(prefixes: Vec<String>) -> Self {
+        let prefixes: Vec<String> = prefixes.into_iter().filter(|p| !p.is_empty()).collect();
+        Self {
+            prefixes: prefixes.into(),
+        }
+    }
+
+    /// Whether an event from `target` at `level` should be hidden from the
+    /// admin UI.
+    ///
+    /// ERROR is **never** suppressed, whatever the target. The point of this
+    /// list is per-event chatter — a dependency that warns once per DNS query.
+    /// A dependency that logs an ERROR is saying something went genuinely
+    /// wrong, and silencing that by module name would turn a noise filter into
+    /// a blind spot: the admin would have no signal at all, in the live stream
+    /// or the recent-errors buffer.
+    #[must_use]
+    pub fn is_suppressed(&self, target: &str, level: &tracing::Level) -> bool {
+        if *level == tracing::Level::ERROR {
+            return false;
+        }
+        self.prefixes.iter().any(|p| target.starts_with(p.as_str()))
+    }
+}

--- a/source/daemon/crates/wardnetd-services/src/logging/tests/error_notifier.rs
+++ b/source/daemon/crates/wardnetd-services/src/logging/tests/error_notifier.rs
@@ -339,3 +339,85 @@ async fn stopped_service_after_start_drops_events() {
     assert_eq!(entries.len(), 1);
     assert!(entries[0].message.contains("before stop"));
 }
+
+// ---------------------------------------------------------------------------
+// Target suppression (admin-UI noise control)
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn layer_skips_suppressed_targets() {
+    let svc = Arc::new(
+        ErrorNotifierService::new(15)
+            .with_suppressed_targets(vec!["hickory_resolver::recursor".to_owned()]),
+    );
+    svc.start();
+    let subscriber = tracing_subscriber::registry().with(svc.tracing_layer());
+    let _guard = tracing::subscriber::set_default(subscriber);
+
+    tracing::warn!(target: "hickory_resolver::recursor::handle", "lookup error");
+
+    assert!(
+        svc.get_recent_errors().is_empty(),
+        "suppressed target must not enter the recent-errors buffer"
+    );
+}
+
+#[tokio::test]
+async fn layer_keeps_unsuppressed_targets() {
+    let svc = Arc::new(
+        ErrorNotifierService::new(15)
+            .with_suppressed_targets(vec!["hickory_resolver::recursor".to_owned()]),
+    );
+    svc.start();
+    let subscriber = tracing_subscriber::registry().with(svc.tracing_layer());
+    let _guard = tracing::subscriber::set_default(subscriber);
+
+    tracing::error!(target: "wardnetd::dns", "real failure");
+
+    let entries = svc.get_recent_errors();
+    assert_eq!(entries.len(), 1);
+    assert_eq!(entries[0].target, "wardnetd::dns");
+}
+
+#[tokio::test]
+async fn suppressed_noise_does_not_evict_real_errors() {
+    // The buffer is a small ring: a dependency warning once per DNS query
+    // would otherwise push every actionable error out of it.
+    let svc = Arc::new(
+        ErrorNotifierService::new(2)
+            .with_suppressed_targets(vec!["hickory_resolver::recursor".to_owned()]),
+    );
+    svc.start();
+    let subscriber = tracing_subscriber::registry().with(svc.tracing_layer());
+    let _guard = tracing::subscriber::set_default(subscriber);
+
+    tracing::error!(target: "wardnetd::dns", "real failure");
+    for _ in 0..10 {
+        tracing::warn!(target: "hickory_resolver::recursor::handle", "lookup error");
+    }
+
+    let entries = svc.get_recent_errors();
+    assert_eq!(entries.len(), 1);
+    assert_eq!(entries[0].target, "wardnetd::dns");
+}
+
+#[tokio::test]
+async fn suppressed_target_still_reports_errors() {
+    // Suppression is a noise filter, not a mute button: a genuine ERROR from a
+    // suppressed dependency must still reach the admin.
+    let svc = Arc::new(
+        ErrorNotifierService::new(15)
+            .with_suppressed_targets(vec!["hickory_resolver::recursor".to_owned()]),
+    );
+    svc.start();
+    let subscriber = tracing_subscriber::registry().with(svc.tracing_layer());
+    let _guard = tracing::subscriber::set_default(subscriber);
+
+    tracing::warn!(target: "hickory_resolver::recursor::handle", "lookup error");
+    tracing::error!(target: "hickory_resolver::recursor::handle", "recursor is broken");
+
+    let entries = svc.get_recent_errors();
+    assert_eq!(entries.len(), 1);
+    assert_eq!(entries[0].level, "ERROR");
+    assert!(entries[0].message.contains("recursor is broken"));
+}

--- a/source/daemon/crates/wardnetd-services/src/logging/tests/mod.rs
+++ b/source/daemon/crates/wardnetd-services/src/logging/tests/mod.rs
@@ -1,3 +1,4 @@
 mod error_notifier;
 mod service;
 mod stream;
+mod suppress;

--- a/source/daemon/crates/wardnetd-services/src/logging/tests/stream.rs
+++ b/source/daemon/crates/wardnetd-services/src/logging/tests/stream.rs
@@ -443,3 +443,62 @@ async fn layer_inactive_does_not_publish() {
     // Use try_recv to confirm no value was enqueued.
     assert!(rx.try_recv().is_err());
 }
+
+// ---------------------------------------------------------------------------
+// Target suppression (admin-UI noise control)
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn layer_does_not_broadcast_suppressed_targets() {
+    let svc = Arc::new(
+        LogStreamService::new(16)
+            .with_suppressed_targets(vec!["hickory_resolver::recursor".to_owned()]),
+    );
+    svc.start();
+    let mut rx = svc.subscribe();
+    let subscriber = tracing_subscriber::registry().with(svc.tracing_layer());
+    let _guard = tracing::subscriber::set_default(subscriber);
+
+    tracing::warn!(target: "hickory_resolver::recursor::handle", "lookup error");
+
+    assert!(
+        rx.try_recv().is_err(),
+        "suppressed target must not reach the log stream"
+    );
+}
+
+#[tokio::test]
+async fn layer_broadcasts_unsuppressed_targets() {
+    let svc = Arc::new(
+        LogStreamService::new(16)
+            .with_suppressed_targets(vec!["hickory_resolver::recursor".to_owned()]),
+    );
+    svc.start();
+    let mut rx = svc.subscribe();
+    let subscriber = tracing_subscriber::registry().with(svc.tracing_layer());
+    let _guard = tracing::subscriber::set_default(subscriber);
+
+    tracing::warn!(target: "wardnetd::dns", "real failure");
+
+    let entry = rx.try_recv().expect("unsuppressed event should broadcast");
+    assert_eq!(entry.target, "wardnetd::dns");
+}
+
+#[tokio::test]
+async fn suppressed_target_still_broadcasts_errors() {
+    let svc = Arc::new(
+        LogStreamService::new(16)
+            .with_suppressed_targets(vec!["hickory_resolver::recursor".to_owned()]),
+    );
+    svc.start();
+    let mut rx = svc.subscribe();
+    let subscriber = tracing_subscriber::registry().with(svc.tracing_layer());
+    let _guard = tracing::subscriber::set_default(subscriber);
+
+    tracing::warn!(target: "hickory_resolver::recursor::handle", "lookup error");
+    tracing::error!(target: "hickory_resolver::recursor::handle", "recursor is broken");
+
+    let entry = rx.try_recv().expect("ERROR must never be suppressed");
+    assert_eq!(entry.level, "ERROR");
+    assert!(rx.try_recv().is_err(), "the WARN must still be suppressed");
+}

--- a/source/daemon/crates/wardnetd-services/src/logging/tests/suppress.rs
+++ b/source/daemon/crates/wardnetd-services/src/logging/tests/suppress.rs
@@ -1,0 +1,50 @@
+//! Tests for [`TargetSuppressor`] prefix matching and the ERROR carve-out.
+
+use tracing::Level;
+
+use crate::logging::suppress::TargetSuppressor;
+
+#[test]
+fn default_suppresses_nothing() {
+    let s = TargetSuppressor::default();
+    assert!(!s.is_suppressed("hickory_resolver::recursor::handle", &Level::WARN));
+    assert!(!s.is_suppressed("wardnetd::dns", &Level::WARN));
+}
+
+#[test]
+fn matches_target_subtree_by_prefix() {
+    let s = TargetSuppressor::new(vec!["hickory_resolver::recursor".to_owned()]);
+    assert!(s.is_suppressed("hickory_resolver::recursor", &Level::WARN));
+    assert!(s.is_suppressed("hickory_resolver::recursor::handle", &Level::WARN));
+}
+
+#[test]
+fn leaves_other_targets_alone() {
+    let s = TargetSuppressor::new(vec!["hickory_resolver::recursor".to_owned()]);
+    assert!(!s.is_suppressed("hickory_resolver::pool", &Level::WARN));
+    assert!(!s.is_suppressed("wardnetd::dns", &Level::WARN));
+}
+
+#[test]
+fn suppresses_levels_below_warn() {
+    let s = TargetSuppressor::new(vec!["hickory_resolver::recursor".to_owned()]);
+    assert!(s.is_suppressed("hickory_resolver::recursor", &Level::INFO));
+    assert!(s.is_suppressed("hickory_resolver::recursor", &Level::DEBUG));
+}
+
+#[test]
+fn never_suppresses_error() {
+    // A noise filter must not become a blind spot: a dependency logging ERROR
+    // is saying something genuinely broke, and the admin needs to see it in
+    // both the live stream and the recent-errors buffer.
+    let s = TargetSuppressor::new(vec!["hickory_resolver::recursor".to_owned()]);
+    assert!(!s.is_suppressed("hickory_resolver::recursor::handle", &Level::ERROR));
+}
+
+#[test]
+fn empty_prefix_is_discarded() {
+    // An empty prefix matches every target — a config typo must not blank the
+    // admin UI.
+    let s = TargetSuppressor::new(vec![String::new()]);
+    assert!(!s.is_suppressed("wardnetd::dns", &Level::WARN));
+}

--- a/source/daemon/crates/wardnetd/src/dns/server.rs
+++ b/source/daemon/crates/wardnetd/src/dns/server.rs
@@ -614,7 +614,7 @@ async fn handle_query(
             &domain,
             rtype,
             src,
-            "rate_limited",
+            DnsQueryResult::RateLimited.as_str(),
             None,
             start.elapsed(),
         );
@@ -717,7 +717,7 @@ async fn handle_query(
             &domain,
             rtype,
             src,
-            "authoritative",
+            DnsQueryResult::Authoritative.as_str(),
             None,
             start.elapsed(),
         );
@@ -782,9 +782,9 @@ async fn handle_query(
         let bytes = response.to_bytes()?;
         socket.send_to(&bytes, src).await?;
         let result = if name_exists {
-            "authoritative_nodata"
+            DnsQueryResult::AuthoritativeNodata.as_str()
         } else {
-            "authoritative_nxdomain"
+            DnsQueryResult::AuthoritativeNxdomain.as_str()
         };
         tracing::trace!(%domain, ?rtype, result, "authoritative negative answer: {result}");
         record_query(log_sink, &domain, rtype, src, result, None, start.elapsed());
@@ -807,7 +807,7 @@ async fn handle_query(
                 &domain,
                 rtype,
                 src,
-                "cache_hit",
+                DnsQueryResult::CacheHit.as_str(),
                 None,
                 start.elapsed(),
             );
@@ -833,7 +833,7 @@ async fn handle_query(
                 &domain,
                 rtype,
                 src,
-                "blocked",
+                DnsQueryResult::Blocked.as_str(),
                 None,
                 start.elapsed(),
             );
@@ -869,7 +869,7 @@ async fn handle_query(
                 &domain,
                 rtype,
                 src,
-                "rewritten",
+                DnsQueryResult::Rewritten.as_str(),
                 None,
                 start.elapsed(),
             );
@@ -917,7 +917,7 @@ async fn handle_query(
                 &domain,
                 rtype,
                 src,
-                "upstream_error",
+                DnsQueryResult::UpstreamError.as_str(),
                 Some(cond_upstream.ip().to_string()),
                 start.elapsed(),
             );
@@ -998,7 +998,7 @@ async fn handle_query(
                             &domain,
                             rtype,
                             src,
-                            "upstream_error",
+                            DnsQueryResult::UpstreamError.as_str(),
                             Some(forwarder.upstream.ip().to_string()),
                             start.elapsed(),
                         );
@@ -1016,7 +1016,7 @@ async fn handle_query(
                         &domain,
                         rtype,
                         src,
-                        "upstream_error",
+                        DnsQueryResult::UpstreamError.as_str(),
                         None,
                         start.elapsed(),
                     );
@@ -1106,7 +1106,7 @@ async fn forward_via_default_resolver(
                 domain,
                 rtype,
                 src,
-                "upstream_error",
+                DnsQueryResult::UpstreamError.as_str(),
                 upstream,
                 elapsed,
             );
@@ -1159,7 +1159,7 @@ async fn send_resolved(
             domain,
             rtype,
             src,
-            "rebinding_blocked",
+            DnsQueryResult::RebindingBlocked.as_str(),
             upstream_label,
             start.elapsed(),
         );
@@ -1312,7 +1312,7 @@ pub(crate) async fn handle_recursor_outcome(
                 start,
                 pass_result,
                 upstream_id,
-                Some("recursive".to_owned()),
+                Some(DnsQueryResult::Recursive.as_str().to_owned()),
                 rebinding,
                 ttl_min,
                 ttl_max,
@@ -1338,7 +1338,7 @@ pub(crate) async fn handle_recursor_outcome(
                 start,
                 pass_result,
                 upstream_id,
-                Some("recursive".to_owned()),
+                Some(DnsQueryResult::Recursive.as_str().to_owned()),
                 nx_domain,
                 e.into_soa(),
                 ttl_min,
@@ -1376,7 +1376,7 @@ pub(crate) async fn handle_recursor_outcome(
                     domain,
                     rtype,
                     src,
-                    "recursor_failed",
+                    DnsQueryResult::RecursorFailed.as_str(),
                     None,
                     start.elapsed(),
                 );

--- a/source/daemon/crates/wardnetd/src/main.rs
+++ b/source/daemon/crates/wardnetd/src/main.rs
@@ -110,8 +110,14 @@ async fn main() -> anyhow::Result<()> {
 
     // Build the log service BEFORE init_tracing so its tracing layers can
     // be attached to the subscriber.
-    let log_stream = Arc::new(LogStreamService::new(config.logging.broadcast_capacity));
-    let error_notifier = Arc::new(ErrorNotifierService::new(config.logging.max_recent_errors));
+    let log_stream = Arc::new(
+        LogStreamService::new(config.logging.broadcast_capacity)
+            .with_suppressed_targets(config.logging.ui_suppressed_targets.clone()),
+    );
+    let error_notifier = Arc::new(
+        ErrorNotifierService::new(config.logging.max_recent_errors)
+            .with_suppressed_targets(config.logging.ui_suppressed_targets.clone()),
+    );
     let log_service: Arc<dyn LogService> = Arc::new(LogServiceImpl::new(
         log_stream,
         error_notifier,

--- a/source/marketing-site/content/docs/configuration.md
+++ b/source/marketing-site/content/docs/configuration.md
@@ -67,6 +67,7 @@ live over the `/api/system/logs/stream` WebSocket.
 | `max_log_files` | `7` | Retention count for rotated files. |
 | `max_recent_errors` | `15` | Ring buffer size for `/api/system/errors`. |
 | `broadcast_capacity` | `256` | Buffer size for the live log WebSocket. |
+| `ui_suppressed_targets` | `["hickory_resolver::recursor"]` | Tracing targets hidden from the admin UI (live log stream and `/api/system/errors`), matched as a target prefix. These events are still written to the log file — this only keeps per-query dependency noise from drowning the events an admin can act on. Set to `[]` to show everything. |
 
 ## `[network]`
 

--- a/source/sdk/wardnet-js/src/types/dns.ts
+++ b/source/sdk/wardnet-js/src/types/dns.ts
@@ -133,6 +133,11 @@ export type DnsQueryResult =
   | "upstream_error"
   | "negative"
   | "authoritative"
+  | "authoritative_nodata"
+  | "authoritative_nxdomain"
+  | "rate_limited"
+  | "rebinding_blocked"
+  | "recursor_failed"
   | "error";
 
 /** A single entry in the persisted DNS query log. */


### PR DESCRIPTION
## Why

The `unknown DNS result string; defaulting to Error` warning fires constantly. It turns out that is not a noisy log — it is a **mislabelling bug announcing itself**.

The resolver writes five result strings that `DnsQueryResult` has no variants for:

| written by the resolver | shown in the UI | counted in stats |
| --- | --- | --- |
| `rate_limited` | **Error** | `outcome=error` |
| `rebinding_blocked` | **Error** | `outcome=error` |
| `recursor_failed` | **Error** | `outcome=error` |
| `authoritative_nodata` | **Error** | `outcome=error` |
| `authoritative_nxdomain` | **Error** | `outcome=error` |

Every one fell through the `parse` fallback. The noise was the symptom; the wrong data was the bug. Lowering the log level (the first instinct) would have buried it.

## DNS result strings

- Add the five missing variants, plus the missing `"error"` arm — `as_str` emitted `"error"` but `parse` had no arm for it, so `Error` only ever round-tripped *through the fallback*.
- Split `from_db_str` (exact inverse of `as_str`) out of `parse`, so "parsed via a real arm" can be distinguished from "fell through". The existing round-trip test passed **vacuously** for `Error` precisely because it could not tell the two apart.
- The resolver now writes `DnsQueryResult::X.as_str()` instead of raw string literals — producer and enum can no longer drift.
- `ALL` is enforced by an exhaustive `slot()` match instead of being a promise in a comment.
- `normalize_outcome` matches on the enum exhaustively, so a new variant is a compile error rather than a silent `error` bucket. This also fixes **`authoritative` — a successful local answer — being counted as an error**, and gives `rebinding_blocked` its own outcome: folding it into `blocked` would inflate the block rate and push legitimate domains into "top blocked domains", because `dns.queries.by_domain` is only recorded for the `blocked` outcome.

## Admin-UI log noise

`hickory_resolver::recursor` warns once per failed recursive lookup — on a busy resolver, one warning per client query for an ordinary negative answer. It drowned the live log view and **evicted real errors from the 15-entry recent-errors ring buffer**.

It is now suppressed at the two admin-facing tracing layers (log stream + recent-errors buffer) via `logging.ui_suppressed_targets` — deliberately *not* in the `EnvFilter`, which gates the whole subscriber and would strip the detail from the log file and the OTel exporters as well. **Grafana and the on-disk log still see everything.** ERROR is never suppressed regardless of target: a noise filter must not become a blind spot.

The netlink directive stays in the `EnvFilter`, where it belongs — that noise is worthless to everyone, so there is no reason to write it to disk.

## DNS log UI

`negative` rendered as `negative (no record)`, which overflowed the fixed-width Result column into Latency. Shortened; the new results get labels, pill tones and filter options.

## Not in scope

No resolver or cache behavior changes, as requested. Separately worth knowing: the DNS cache is **not** broken — it is shared, TTL-aware, and caches negative answers per RFC 2308. Repeated identical queries in the same second both miss because there is no in-flight coalescing (single-flight); that is a real gap, but a hot-path change for another PR.

## Test plan

- `make check-daemon` — green (fmt, clippy `-D warnings`, full workspace tests)
- `make check-web` — green
- `make openapi` — `docs/openapi.json` regenerated with the five new enum values (the `check-openapi` CI gate would otherwise fail)
- New tests: every variant parses without hitting the fallback; `ALL` completeness; serde repr matches the DB string; suppressed targets are hidden from both admin surfaces while ERROR still gets through; suppressed noise no longer evicts real errors from the ring buffer

## Merge Commit Message

fix(dns,logging): five unknown DNS result strings + admin-UI log noise

https://claude.ai/code/session_01PwaGVLkybYapEUDYqf29g9