### PR TITLE
fix(admin-site): DNS cache hit rate displayed 100x too low

### DIFF
--- a/source/admin-site/src/pages/Dns.tsx
+++ b/source/admin-site/src/pages/Dns.tsx
@@ -198,7 +198,7 @@ export default function Dns() {
                     <div>
                       <div className="stat__label">Hit rate</div>
                       <Text as="div" size="2xl" weight="bold">
-                        {status.cache_hit_rate.toFixed(1)}%
+                        {(status.cache_hit_rate * 100).toFixed(1)}%
                       </Text>
                     </div>
                   </Text>

--- a/source/admin-site/tests/pages/Dns.test.tsx
+++ b/source/admin-site/tests/pages/Dns.test.tsx
@@ -110,7 +110,7 @@ beforeEach(() => {
       enabled: true,
       cache_size: 50,
       cache_capacity: 100,
-      cache_hit_rate: 88.25,
+      cache_hit_rate: 0.8825,
     },
     isLoading: false,
   });


### PR DESCRIPTION
## Summary
- admin-site's DNS page showed a cache hit rate of ~0.5% while admin-app (mobile) correctly showed ~51.8% for the same data
- The daemon's `cache_hit_rate` field is a fraction (0.0-1.0); admin-app multiplies by 100 before display, admin-site did not
- Fixes `source/admin-site/src/pages/Dns.tsx:201` to match admin-app's correct behavior

## Test plan
- [ ] Load the DNS page on admin-site and confirm hit rate matches admin-app's value for the same daemon instance

## Merge Commit Message
fix(admin-site): apply missing percentage conversion to DNS cache hit rate