### PR TITLE
fix(daemon): stop wardnetd from self-quarantining its own interfaces

### DIFF
--- a/.agentic-toolkit.lock.yaml
+++ b/.agentic-toolkit.lock.yaml
@@ -5,7 +5,7 @@ sources:
   sha: 3a19c994319dd8a0d16db16629d19df46cd7e920
 - url: github.com/pedromvgomes/agentic-toolkit.git
   ref: main
-  sha: 0fa843ca38a50e3d1d070cb8efe381d2239afceb
+  sha: 13fbcd81632de892d516a451b64fa07197a93893
 - url: github.com/anthropics/skills.git
   ref: main
   sha: 9d2f1ae187231d8199c64b5b762e1bdf2244733d

--- a/source/daemon/crates/wardnetd/src/dhcp/server.rs
+++ b/source/daemon/crates/wardnetd/src/dhcp/server.rs
@@ -1,3 +1,4 @@
+use std::collections::HashSet;
 use std::net::{Ipv4Addr, SocketAddr};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -160,6 +161,18 @@ impl DhcpServer for UdpDhcpServer {
         let service = Arc::clone(&self.service);
         let running = Arc::clone(&self.running);
 
+        // The daemon's own interfaces (including ones other than the LAN
+        // interface, e.g. an idle secondary NIC) must never be leased —
+        // otherwise a DISCOVER that loops back onto the LAN from the host's
+        // own hardware gets a real lease and shows up as a phantom device
+        // (mirrors the packet-capture self-filter in `packet_capture_pnet`).
+        let own_macs: Arc<HashSet<String>> = Arc::new(
+            crate::packet_capture_pnet::local_mac_addresses()
+                .into_iter()
+                .map(crate::packet_capture_pnet::format_mac)
+                .collect(),
+        );
+
         // Create a fresh cancellation token so stop()/start() cycles work.
         let new_cancel = CancellationToken::new();
         let cancel = new_cancel.clone();
@@ -168,7 +181,7 @@ impl DhcpServer for UdpDhcpServer {
         running.store(true, Ordering::SeqCst);
 
         let handle = tokio::spawn(async move {
-            server_loop(socket, service, running.clone(), cancel).await;
+            server_loop(socket, service, running.clone(), cancel, own_macs).await;
             running.store(false, Ordering::SeqCst);
             tracing::info!("DHCP server loop exited");
         });
@@ -207,6 +220,7 @@ pub(crate) async fn server_loop(
     service: Arc<dyn DhcpService>,
     running: Arc<AtomicBool>,
     cancel: CancellationToken,
+    own_macs: Arc<HashSet<String>>,
 ) {
     let mut buf = vec![0u8; 1500];
 
@@ -240,6 +254,15 @@ pub(crate) async fn server_loop(
 
         let mac = format_mac(msg.chaddr());
         tracing::debug!(%mac, ?msg_type, xid = msg.xid(), "received DHCP message: mac={mac}, type={msg_type:?}");
+
+        if own_macs.contains(&mac) {
+            tracing::debug!(
+                %mac,
+                ?msg_type,
+                "ignoring DHCP message from the daemon's own interface: mac={mac}, type={msg_type:?}"
+            );
+            continue;
+        }
 
         match msg_type {
             MessageType::Discover => match handle_discover(&service, &msg, &mac).await {

--- a/source/daemon/crates/wardnetd/src/dhcp/tests/server.rs
+++ b/source/daemon/crates/wardnetd/src/dhcp/tests/server.rs
@@ -1,4 +1,4 @@
-use std::collections::VecDeque;
+use std::collections::{HashSet, VecDeque};
 use std::net::{Ipv4Addr, SocketAddr};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -313,9 +313,10 @@ async fn run_server_loop_until_idle(
     let cancel_clone = cancel.clone();
     let socket_dyn: Arc<dyn DhcpSocket> = Arc::clone(&socket) as Arc<dyn DhcpSocket>;
     let running_clone = Arc::clone(&running);
+    let own_macs = Arc::new(HashSet::new());
 
     let handle = tokio::spawn(async move {
-        server::server_loop(socket_dyn, service, running_clone, cancel_clone).await;
+        server::server_loop(socket_dyn, service, running_clone, cancel_clone, own_macs).await;
     });
 
     // Give the loop time to process all queued packets.
@@ -902,6 +903,41 @@ async fn server_loop_responds_to_discover_with_offer() {
 }
 
 #[tokio::test]
+async fn server_loop_ignores_discover_from_own_mac() {
+    let lease = test_lease();
+    let service: Arc<dyn DhcpService> = Arc::new(MockDhcpService::new(lease));
+    let socket = Arc::new(MockDhcpSocket::new());
+
+    let own_chaddr = [0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff];
+    let discover = build_discover(own_chaddr);
+    socket.push_message(&discover, client_addr()).await;
+
+    let running = Arc::new(AtomicBool::new(true));
+    let cancel = tokio_util::sync::CancellationToken::new();
+    let cancel_clone = cancel.clone();
+    let socket_dyn: Arc<dyn DhcpSocket> = Arc::clone(&socket) as Arc<dyn DhcpSocket>;
+    let running_clone = Arc::clone(&running);
+    let own_macs = Arc::new(HashSet::from([server::format_mac(&own_chaddr)]));
+
+    let handle = tokio::spawn(async move {
+        server::server_loop(socket_dyn, service, running_clone, cancel_clone, own_macs).await;
+    });
+
+    for _ in 0..20 {
+        tokio::task::yield_now().await;
+        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+    }
+    cancel.cancel();
+    let _ = handle.await;
+
+    let messages = socket.sent_messages().await;
+    assert!(
+        messages.is_empty(),
+        "expected no DHCPOFFER for a DISCOVER from the daemon's own interface, got {messages:?}"
+    );
+}
+
+#[tokio::test]
 async fn server_loop_responds_to_request_with_ack() {
     let lease = test_lease();
     let service: Arc<dyn DhcpService> = Arc::new(MockDhcpService::new(lease.clone()));
@@ -1006,9 +1042,10 @@ async fn server_loop_stops_on_cancellation() {
     let cancel_clone = cancel.clone();
     let socket_dyn: Arc<dyn DhcpSocket> = Arc::clone(&socket) as Arc<dyn DhcpSocket>;
     let running_clone = Arc::clone(&running);
+    let own_macs = Arc::new(HashSet::new());
 
     let handle = tokio::spawn(async move {
-        server::server_loop(socket_dyn, service, running_clone, cancel_clone).await;
+        server::server_loop(socket_dyn, service, running_clone, cancel_clone, own_macs).await;
     });
 
     // Immediately cancel.
@@ -1176,9 +1213,10 @@ async fn server_loop_continues_after_recv_error() {
     let cancel_clone = cancel.clone();
     let socket_dyn: Arc<dyn DhcpSocket> = Arc::clone(&socket) as Arc<dyn DhcpSocket>;
     let running_clone = Arc::clone(&running);
+    let own_macs = Arc::new(HashSet::new());
 
     let handle = tokio::spawn(async move {
-        server::server_loop(socket_dyn, service, running_clone, cancel_clone).await;
+        server::server_loop(socket_dyn, service, running_clone, cancel_clone, own_macs).await;
     });
 
     // Give the loop time to hit the error and continue.

--- a/source/daemon/crates/wardnetd/src/packet_capture_pnet.rs
+++ b/source/daemon/crates/wardnetd/src/packet_capture_pnet.rs
@@ -144,9 +144,15 @@ pub(crate) fn format_mac(mac: MacAddr) -> String {
 }
 
 /// Check whether a MAC address should be filtered out.
-pub(crate) fn should_filter_mac(mac: MacAddr, own_mac: MacAddr) -> bool {
-    // Own MAC
-    if mac == own_mac {
+///
+/// `own_macs` covers every local interface on the host, not just the one
+/// being listened on — a secondary NIC (e.g. an unused onboard port) can
+/// still emit DHCP/ARP traffic that reaches the capture interface via the
+/// LAN switch, and without this the daemon would self-quarantine as a
+/// "new device".
+pub(crate) fn should_filter_mac(mac: MacAddr, own_macs: &[MacAddr]) -> bool {
+    // Any of the host's own interfaces
+    if own_macs.contains(&mac) {
         return true;
     }
     // Broadcast
@@ -160,8 +166,19 @@ pub(crate) fn should_filter_mac(mac: MacAddr, own_mac: MacAddr) -> bool {
     false
 }
 
+/// Collect the MAC addresses of every local network interface.
+///
+/// Used to build the self-filter set for packet capture — see
+/// `should_filter_mac`.
+pub(crate) fn local_mac_addresses() -> Vec<MacAddr> {
+    datalink::interfaces()
+        .into_iter()
+        .filter_map(|iface| iface.mac)
+        .collect()
+}
+
 /// Parse an Ethernet frame into an `ObservedDevice`, if applicable.
-pub(crate) fn parse_frame(data: &[u8], own_mac: MacAddr) -> Option<ObservedDevice> {
+pub(crate) fn parse_frame(data: &[u8], own_macs: &[MacAddr]) -> Option<ObservedDevice> {
     let eth = EthernetPacket::new(data)?;
 
     match eth.get_ethertype() {
@@ -170,7 +187,7 @@ pub(crate) fn parse_frame(data: &[u8], own_mac: MacAddr) -> Option<ObservedDevic
             let sender_mac = arp.get_sender_hw_addr();
             let sender_ip = arp.get_sender_proto_addr();
 
-            if should_filter_mac(sender_mac, own_mac) {
+            if should_filter_mac(sender_mac, own_macs) {
                 return None;
             }
             // Filter out 0.0.0.0 (incomplete ARP)
@@ -186,7 +203,7 @@ pub(crate) fn parse_frame(data: &[u8], own_mac: MacAddr) -> Option<ObservedDevic
         }
         EtherTypes::Ipv4 => {
             let src_mac = eth.get_source();
-            if should_filter_mac(src_mac, own_mac) {
+            if should_filter_mac(src_mac, own_macs) {
                 return None;
             }
 
@@ -276,6 +293,16 @@ impl PacketCapture for PnetCapture {
             .mac
             .ok_or_else(|| anyhow::anyhow!("interface '{interface}' has no MAC address"))?;
 
+        // Re-querying all interfaces (rather than reusing `iface` above) is
+        // what lets a *different* local interface's traffic get filtered
+        // too — but that second query is a separate syscall, so explicitly
+        // include the already-validated `own_mac` in case it raced with an
+        // interface state change between the two calls.
+        let mut own_macs = local_mac_addresses();
+        if !own_macs.contains(&own_mac) {
+            own_macs.push(own_mac);
+        }
+
         let config = Config {
             read_timeout: Some(std::time::Duration::from_millis(500)),
             ..Config::default()
@@ -293,7 +320,7 @@ impl PacketCapture for PnetCapture {
             while !cancel.is_cancelled() {
                 match rx.next() {
                     Ok(data) => {
-                        if let Some(obs) = parse_frame(data, own_mac) {
+                        if let Some(obs) = parse_frame(data, &own_macs) {
                             // Non-blocking send; drop if channel is full
                             let _ = sender.try_send(obs);
                         }

--- a/source/daemon/crates/wardnetd/src/tests/packet_capture.rs
+++ b/source/daemon/crates/wardnetd/src/tests/packet_capture.rs
@@ -49,13 +49,13 @@ fn format_mac_emits_lowercase_hex_digits() {
 #[test]
 fn filter_own_mac() {
     let own = MacAddr::new(0xDE, 0xAD, 0xBE, 0xEF, 0x00, 0x01);
-    assert!(should_filter_mac(own, own));
+    assert!(should_filter_mac(own, &[own]));
 }
 
 #[test]
 fn filter_broadcast_mac() {
     let own = MacAddr::new(0xDE, 0xAD, 0xBE, 0xEF, 0x00, 0x01);
-    assert!(should_filter_mac(MacAddr::broadcast(), own));
+    assert!(should_filter_mac(MacAddr::broadcast(), &[own]));
 }
 
 #[test]
@@ -63,14 +63,23 @@ fn filter_multicast_mac() {
     let own = MacAddr::new(0xDE, 0xAD, 0xBE, 0xEF, 0x00, 0x01);
     // Multicast: bit 0 of first octet is set (0x01, 0x33, etc.)
     let multicast = MacAddr::new(0x01, 0x00, 0x5E, 0x00, 0x00, 0x01);
-    assert!(should_filter_mac(multicast, own));
+    assert!(should_filter_mac(multicast, &[own]));
+}
+
+#[test]
+fn filter_secondary_own_mac() {
+    // A second local interface's MAC (e.g. an unused NIC) must also be
+    // filtered, even though it isn't the interface being listened on.
+    let primary = MacAddr::new(0xDE, 0xAD, 0xBE, 0xEF, 0x00, 0x01);
+    let secondary = MacAddr::new(0x76, 0x0B, 0xA7, 0x05, 0x0C, 0xC3);
+    assert!(should_filter_mac(secondary, &[primary, secondary]));
 }
 
 #[test]
 fn allow_normal_unicast_mac() {
     let own = MacAddr::new(0xDE, 0xAD, 0xBE, 0xEF, 0x00, 0x01);
     let other = MacAddr::new(0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0x00);
-    assert!(!should_filter_mac(other, own));
+    assert!(!should_filter_mac(other, &[own]));
 }
 
 #[test]
@@ -78,7 +87,7 @@ fn filter_ipv6_multicast_mac() {
     let own = MacAddr::new(0x02, 0x00, 0x00, 0x00, 0x00, 0x01);
     // IPv6 multicast prefix 33:33:xx:xx:xx:xx -- first octet 0x33 has bit 0 set
     let ipv6_mcast = MacAddr::new(0x33, 0x33, 0x00, 0x00, 0x00, 0x01);
-    assert!(should_filter_mac(ipv6_mcast, own));
+    assert!(should_filter_mac(ipv6_mcast, &[own]));
 }
 
 // ---------------------------------------------------------------------------
@@ -224,7 +233,7 @@ fn parse_frame_arp_valid() {
     let sender_ip = Ipv4Addr::new(192, 168, 1, 50);
 
     let frame = make_arp_frame(sender_mac, sender_ip);
-    let obs = parse_frame(&frame, own_mac).expect("should parse ARP frame");
+    let obs = parse_frame(&frame, &[own_mac]).expect("should parse ARP frame");
 
     assert_eq!(obs.mac, "aa:bb:cc:11:22:33");
     assert_eq!(obs.ip, "192.168.1.50");
@@ -235,7 +244,7 @@ fn parse_frame_arp_valid() {
 fn parse_frame_arp_filtered_own_mac() {
     let own_mac = MacAddr::new(0xAA, 0xBB, 0xCC, 0x11, 0x22, 0x33);
     let frame = make_arp_frame(own_mac, Ipv4Addr::new(192, 168, 1, 1));
-    assert!(parse_frame(&frame, own_mac).is_none());
+    assert!(parse_frame(&frame, &[own_mac]).is_none());
 }
 
 #[test]
@@ -243,7 +252,7 @@ fn parse_frame_arp_filtered_unspecified_ip() {
     let own_mac = MacAddr::new(0xDE, 0xAD, 0xBE, 0xEF, 0x00, 0x01);
     let sender_mac = MacAddr::new(0xAA, 0xBB, 0xCC, 0x11, 0x22, 0x33);
     let frame = make_arp_frame(sender_mac, Ipv4Addr::UNSPECIFIED);
-    assert!(parse_frame(&frame, own_mac).is_none());
+    assert!(parse_frame(&frame, &[own_mac]).is_none());
 }
 
 #[test]
@@ -251,7 +260,7 @@ fn parse_frame_arp_filtered_broadcast_sender() {
     let own_mac = MacAddr::new(0xDE, 0xAD, 0xBE, 0xEF, 0x00, 0x01);
     // ARP with broadcast as sender MAC should be filtered
     let frame = make_arp_frame(MacAddr::broadcast(), Ipv4Addr::new(10, 0, 0, 1));
-    assert!(parse_frame(&frame, own_mac).is_none());
+    assert!(parse_frame(&frame, &[own_mac]).is_none());
 }
 
 // ---------------------------------------------------------------------------
@@ -265,7 +274,7 @@ fn parse_frame_ipv4_valid() {
     let src_ip = Ipv4Addr::new(10, 0, 0, 42);
 
     let frame = make_ipv4_frame(src_mac, src_ip);
-    let obs = parse_frame(&frame, own_mac).expect("should parse IPv4 frame");
+    let obs = parse_frame(&frame, &[own_mac]).expect("should parse IPv4 frame");
 
     assert_eq!(obs.mac, "00:1a:2b:3c:4d:5e");
     assert_eq!(obs.ip, "10.0.0.42");
@@ -276,7 +285,7 @@ fn parse_frame_ipv4_valid() {
 fn parse_frame_ipv4_filtered_own_mac() {
     let own_mac = MacAddr::new(0x00, 0x1A, 0x2B, 0x3C, 0x4D, 0x5E);
     let frame = make_ipv4_frame(own_mac, Ipv4Addr::new(10, 0, 0, 1));
-    assert!(parse_frame(&frame, own_mac).is_none());
+    assert!(parse_frame(&frame, &[own_mac]).is_none());
 }
 
 #[test]
@@ -284,7 +293,7 @@ fn parse_frame_ipv4_filtered_unspecified_ip() {
     let own_mac = MacAddr::new(0xDE, 0xAD, 0xBE, 0xEF, 0x00, 0x01);
     let src_mac = MacAddr::new(0x00, 0x1A, 0x2B, 0x3C, 0x4D, 0x5E);
     let frame = make_ipv4_frame(src_mac, Ipv4Addr::UNSPECIFIED);
-    assert!(parse_frame(&frame, own_mac).is_none());
+    assert!(parse_frame(&frame, &[own_mac]).is_none());
 }
 
 // ---------------------------------------------------------------------------
@@ -294,14 +303,14 @@ fn parse_frame_ipv4_filtered_unspecified_ip() {
 #[test]
 fn parse_frame_empty_data() {
     let own_mac = MacAddr::new(0xDE, 0xAD, 0xBE, 0xEF, 0x00, 0x01);
-    assert!(parse_frame(&[], own_mac).is_none());
+    assert!(parse_frame(&[], &[own_mac]).is_none());
 }
 
 #[test]
 fn parse_frame_truncated_ethernet_header() {
     let own_mac = MacAddr::new(0xDE, 0xAD, 0xBE, 0xEF, 0x00, 0x01);
     // Ethernet header needs at least 14 bytes; provide only 10
-    assert!(parse_frame(&[0u8; 10], own_mac).is_none());
+    assert!(parse_frame(&[0u8; 10], &[own_mac]).is_none());
 }
 
 #[test]
@@ -315,7 +324,7 @@ fn parse_frame_unknown_ethertype() {
         eth.set_destination(own_mac);
         eth.set_ethertype(EtherTypes::Ipv6);
     }
-    assert!(parse_frame(&buf, own_mac).is_none());
+    assert!(parse_frame(&buf, &[own_mac]).is_none());
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Broaden wardnetd's packet-capture self-MAC filter from a single interface's MAC to every local interface's MAC — a second, idle NIC on the host (e.g. an unused onboard port) could still emit DHCP/ARP traffic that reached the capture interface via the LAN switch, and the daemon would mistake its own traffic for a new device and quarantine it under its own hostname.
- Apply the same self-exclusion to the DHCP server, which had no self-MAC check at all: it would happily issue a real lease to the host's own hardware and log it as a DHCP client.
- Close a narrow TOCTOU where the packet-capture filter set was built from a separate, non-atomic re-query of interfaces rather than including the already-validated listened interface's MAC directly.

## Test plan
- [x] `cargo fmt --check -p wardnetd`
- [x] `cargo clippy -p wardnetd --all-targets -- -D warnings`
- [x] `cargo test -p wardnetd packet_capture` — 29/29 passing (incl. new `filter_secondary_own_mac`)
- [x] `cargo test -p wardnetd dhcp::tests::server` — 42/42 passing (incl. new `server_loop_ignores_discover_from_own_mac`)
- [x] Reproduced live on a Pi: confirmed via daemon logs that a secondary NIC (`eth1`) got a self-issued DHCP lease and was quarantined as "wardnet" twice; manually cleaned up the two phantom device rows after identifying the root cause

## Merge Commit Message
fix(daemon): stop wardnetd from self-quarantining its own interfaces