### PR TITLE
feat(dns): attribute DNS logs and stats to devices at query time

### DIFF
--- a/.agentic-toolkit.lock.yaml
+++ b/.agentic-toolkit.lock.yaml
@@ -5,7 +5,7 @@ sources:
   sha: 3a19c994319dd8a0d16db16629d19df46cd7e920
 - url: github.com/pedromvgomes/agentic-toolkit.git
   ref: main
-  sha: 0fa843ca38a50e3d1d070cb8efe381d2239afceb
+  sha: 13fbcd81632de892d516a451b64fa07197a93893
 - url: github.com/anthropics/skills.git
   ref: main
   sha: 9d2f1ae187231d8199c64b5b762e1bdf2244733d

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -12083,6 +12083,19 @@
             }
           },
           {
+            "name": "device_id",
+            "in": "query",
+            "description": "Filter by the device attributed at query time. Stable across DHCP\nreassignment; rows recorded before device attribution existed (or\nfrom unknown sources) have no device and only match `client_ip`.",
+            "required": false,
+            "schema": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "format": "uuid"
+            }
+          },
+          {
             "name": "result",
             "in": "query",
             "required": false,
@@ -17979,6 +17992,18 @@
             "required": true,
             "schema": {
               "type": "string"
+            }
+          },
+          {
+            "name": "fallback_label_key",
+            "in": "query",
+            "description": "Optional label dimension to group by when `label_key` is absent\nfrom an entry's labels (e.g. rank by `\"device_id\"` falling back to\n`\"client\"` for queries from sources with no known device).",
+            "required": false,
+            "schema": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           {

--- a/source/admin-site/src/components/features/DnsStatsSection.tsx
+++ b/source/admin-site/src/components/features/DnsStatsSection.tsx
@@ -1,4 +1,5 @@
 import { useMemo, useState } from "react";
+import { Link } from "react-router";
 import {
   CartesianGrid,
   Legend,
@@ -14,14 +15,18 @@ import { ZoomableChartContainer } from "@/components/compound/ZoomableChartConta
 import { type ChartConfig } from "@/components/core/ui/chart";
 import { Card, CardContent, CardHeader, CardTitle } from "@wardnet/web";
 import { Text } from "@wardnet/web";
+import { DeviceIcon } from "@wardnet/web";
 import { DashboardStatCard } from "@/components/compound/DashboardStatCard";
+import { HostCell } from "@/components/compound/HostCell";
 import { useChartZoom, type ZoomRange } from "@/hooks/useChartZoom";
 import {
+  useDevices,
   useDnsStatsDashboard,
+  deviceDisplayName,
   RANGE_HOURS,
   type StatsRange,
 } from "@wardnet/web";
-import type { StatsTopEntry } from "@wardnet/js";
+import type { Device, StatsTopEntry } from "@wardnet/js";
 
 const chartConfig: ChartConfig = {
   total: { label: "Total", color: "var(--chart-1)" },
@@ -49,6 +54,10 @@ interface Props {
 
 /** Stats panel for the DNS page: top cards, time series, top tables. */
 export function DnsStatsSection({ range }: Props) {
+  // Device list for resolving top-client entries' `device_id` labels to
+  // names. Lookup is by immutable device id — never by IP, which DHCP may
+  // have reassigned since the stats were recorded.
+  const { data: devicesData } = useDevices();
   // Tag zoom with the range it was committed for so it auto-invalidates
   // when the parent changes range without needing a useEffect reset.
   const [storedZoom, setStoredZoom] = useState<{
@@ -264,11 +273,10 @@ export function DnsStatsSection({ range }: Props) {
           labelKey="domain"
           valueLabel="blocks"
         />
-        <TopList
+        <TopClientsList
           title={`Top clients (${zoomLabel ?? range})`}
           entries={data?.topClients.entries}
-          labelKey="client"
-          valueLabel="queries"
+          devices={devicesData?.devices}
         />
       </div>
     </div>
@@ -316,7 +324,7 @@ function TopList({
         {entries && entries.length > 0 ? (
           <Text as="ul" size="sm" className="flex flex-col gap-2">
             {entries.map((entry, i) => {
-              // eslint-disable-next-line security/detect-object-injection -- labelKey is a literal ("domain"/"client") from the two local TopList call sites; read-only
+              // eslint-disable-next-line security/detect-object-injection -- labelKey is a literal ("domain") from the local TopList call site; read-only
               const label = parseLabels(entry.labels)[labelKey] ?? entry.labels;
               return (
                 <li key={i} className="flex items-center justify-between gap-2">
@@ -326,6 +334,83 @@ function TopList({
                   <span className="tabular-nums text-ink-3">
                     {Math.round(entry.total).toLocaleString()} {valueLabel}
                   </span>
+                </li>
+              );
+            })}
+          </Text>
+        ) : (
+          <Text as="p" size="sm" className="text-ink-3">
+            No data yet.
+          </Text>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+/** Top-clients card: entries carry write-time device attribution.
+ *
+ * Each entry's labels hold `device_id` (when the daemon knew the device at
+ * query time) plus `client` (the IP seen). Known devices render name +
+ * icon linked to their detail page, with the IP as a secondary line;
+ * unattributed entries fall back to the bare IP. Resolution is by device
+ * id only — matching on IP would re-introduce the DHCP-churn
+ * misattribution this data model exists to prevent.
+ */
+function TopClientsList({
+  title,
+  entries,
+  devices,
+}: {
+  title: string;
+  entries: StatsTopEntry[] | undefined;
+  devices: Device[] | undefined;
+}) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-sm">{title}</CardTitle>
+      </CardHeader>
+      <CardContent>
+        {entries && entries.length > 0 ? (
+          <Text as="ul" size="sm" className="flex flex-col gap-2">
+            {entries.map((entry, i) => {
+              const labels = parseLabels(entry.labels);
+              const device = labels.device_id
+                ? devices?.find((d) => d.id === labels.device_id)
+                : undefined;
+              const total = (
+                <span className="tabular-nums text-ink-3">
+                  {Math.round(entry.total).toLocaleString()} queries
+                </span>
+              );
+              if (!device) {
+                return (
+                  <li
+                    key={i}
+                    className="flex items-center justify-between gap-2"
+                  >
+                    <Text size="xs" className="truncate font-mono">
+                      {labels.client ?? entry.labels}
+                    </Text>
+                    {total}
+                  </li>
+                );
+              }
+              return (
+                <li key={i} className="flex items-center justify-between gap-2">
+                  <Link to={`/devices/${device.id}`} className="min-w-0 flex-1">
+                    <HostCell
+                      primary={deviceDisplayName(device)}
+                      // The device's CURRENT IP — the entry's labels come
+                      // from an arbitrary member of the aggregated group,
+                      // so their client value may be any IP the device
+                      // held in the window.
+                      secondary={device.last_ip || labels.client || null}
+                      icon={<DeviceIcon type={device.device_type} size={16} />}
+                    />
+                  </Link>
+                  {total}
                 </li>
               );
             })}

--- a/source/admin-site/src/pages/DnsLogs.tsx
+++ b/source/admin-site/src/pages/DnsLogs.tsx
@@ -5,6 +5,7 @@ import { PageHeader } from "@/components/compound/PageHeader";
 import { DataTable } from "@/components/core/ui/data-table";
 import { Toggle } from "@wardnet/web";
 import { Button } from "@wardnet/web";
+import { Input } from "@wardnet/web";
 import { Pill } from "@wardnet/web";
 import { Text } from "@wardnet/web";
 import {
@@ -14,9 +15,11 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@wardnet/web";
+import { HelpCircle } from "lucide-react";
 import { DeviceIcon } from "@wardnet/web";
 import { DeviceSelect } from "@/components/compound/DeviceSelect";
-import { useDevices } from "@wardnet/web";
+import { HostCell } from "@/components/compound/HostCell";
+import { useDevices, deviceDisplayName } from "@wardnet/web";
 import { useDnsQueryLog } from "@wardnet/web";
 import { useDnsLogStore } from "@/stores/dnsLogStore";
 import { formatTime } from "@wardnet/web";
@@ -29,6 +32,9 @@ import type {
 interface RowShape {
   timestamp: string;
   client_ip: string;
+  /** Write-time device attribution; null for unknown sources and rows
+   *  recorded before attribution existed. */
+  device_id: string | null;
   domain: string;
   query_type: string;
   result: string;
@@ -89,23 +95,23 @@ const PAGE_SIZE = 50;
 /** DNS query log page: live tail + paginated history. Admin only. */
 export default function DnsLogs() {
   const [domain, setDomain] = useState("");
+  const [deviceId, setDeviceId] = useState("");
   const [clientIp, setClientIp] = useState("");
   const [result, setResult] = useState("any");
   const [page, setPage] = useState(0);
   const [liveTail, setLiveTail] = useState(true);
 
   const { data: devicesData } = useDevices();
-  // De-dupe by last_ip so the dropdown doesn't list two rows for the
-  // same IP — the DNS log is keyed on `client_ip` and that's what the
-  // filter narrows on.
-  const filterableDevices = useMemo(() => {
-    const seen = new Set<string>();
-    return (devicesData?.devices ?? []).filter((d) => {
-      if (!d.last_ip || seen.has(d.last_ip)) return false;
-      seen.add(d.last_ip);
-      return true;
-    });
-  }, [devicesData]);
+  // The dropdown is id-keyed so duplicates by IP are fine, but a device
+  // with no name, no hostname, and an empty last_ip would render a blank
+  // option (DeviceSelect's label falls back name → hostname → last_ip).
+  const filterableDevices = useMemo(
+    () =>
+      (devicesData?.devices ?? []).filter(
+        (d) => d.name || d.hostname || d.last_ip,
+      ),
+    [devicesData],
+  );
 
   const liveEntries = useDnsLogStore((s) => s.entries);
   const liveConnected = useDnsLogStore((s) => s.connected);
@@ -118,9 +124,10 @@ export default function DnsLogs() {
     setStoreFilter({
       domain,
       client_ip: clientIp,
+      device_id: deviceId,
       results: result === "any" ? [] : [result],
     });
-  }, [domain, clientIp, result, setStoreFilter]);
+  }, [domain, clientIp, deviceId, result, setStoreFilter]);
 
   // Auto-pause the store on filter change so a sudden flood of new
   // events doesn't interrupt scrolling.
@@ -135,15 +142,16 @@ export default function DnsLogs() {
       offset: page * PAGE_SIZE,
       domain: domain || undefined,
       client_ip: clientIp || undefined,
+      device_id: deviceId || undefined,
       result: result === "any" ? undefined : (result as DnsQueryResult),
     }),
-    [domain, clientIp, result, page],
+    [domain, clientIp, deviceId, result, page],
   );
   const { data, isLoading } = useDnsQueryLog(filterParams);
 
   const showLive = liveTail;
   const liveRows: RowShape[] = liveEntries
-    .filter(matchesFilter(domain, clientIp, result))
+    .filter(matchesFilter(domain, clientIp, deviceId, result))
     .map(eventToRow);
   const persistedRows: RowShape[] = data?.entries.map(persistedToRow) ?? [];
 
@@ -167,26 +175,23 @@ export default function DnsLogs() {
         header: "Device",
         meta: { className: "w-56" },
         cell: ({ row }) => {
-          const dev = devicesData?.devices.find(
-            (d) => d.last_ip === row.original.client_ip,
-          );
-          const primary = dev?.name || dev?.hostname || row.original.client_ip;
-          const secondary =
-            dev?.name || dev?.hostname ? row.original.client_ip : null;
+          // Resolve by the row's write-time device attribution — never by
+          // IP, which DHCP may have reassigned since the query happened.
+          const dev = row.original.device_id
+            ? devicesData?.devices.find((d) => d.id === row.original.device_id)
+            : undefined;
           return (
-            <div className="flex items-center gap-2">
-              {dev && <DeviceIcon type={dev.device_type} size={16} />}
-              <div className="flex min-w-0 flex-col">
-                <Text weight="medium" className="truncate">
-                  {primary}
-                </Text>
-                {secondary && (
-                  <Text size="xs" className="truncate text-ink-3">
-                    {secondary}
-                  </Text>
-                )}
-              </div>
-            </div>
+            <HostCell
+              primary={dev ? deviceDisplayName(dev) : row.original.client_ip}
+              secondary={dev ? row.original.client_ip : null}
+              icon={
+                dev ? (
+                  <DeviceIcon type={dev.device_type} size={16} />
+                ) : (
+                  <HelpCircle size={16} className="text-ink-3" />
+                )
+              }
+            />
           );
         },
       },
@@ -236,12 +241,26 @@ export default function DnsLogs() {
       <DeviceSelect
         id="device-filter"
         devices={filterableDevices}
-        value={clientIp}
-        onChange={(ip) => {
-          setClientIp(ip);
+        valueKey="id"
+        value={deviceId}
+        onChange={(id) => {
+          setDeviceId(id);
           setPage(0);
         }}
         triggerClassName="select-trigger--md w-48"
+      />
+      {/* Free-text IP filter: the only handle on rows with no device
+          attribution (unknown sources, pre-attribution history). */}
+      <Input
+        id="client-ip-filter"
+        data-testid="dns-log-ip-filter"
+        className="w-36"
+        placeholder="Client IP…"
+        value={clientIp}
+        onChange={(e) => {
+          setClientIp(e.target.value);
+          setPage(0);
+        }}
       />
       <Select
         value={result}
@@ -360,11 +379,14 @@ export default function DnsLogs() {
 function matchesFilter(
   domain: string,
   clientIp: string,
+  deviceId: string,
   result: string,
 ): (e: QueryLogEvent) => boolean {
   return (e) => {
     if (domain && !e.domain.includes(domain)) return false;
-    if (clientIp && e.client_ip !== clientIp) return false;
+    // Substring match, mirroring the domain filter and the server-side LIKE.
+    if (clientIp && !e.client_ip.includes(clientIp)) return false;
+    if (deviceId && e.device_id !== deviceId) return false;
     if (result !== "any" && e.result !== result) return false;
     return true;
   };
@@ -374,6 +396,7 @@ function eventToRow(e: QueryLogEvent): RowShape {
   return {
     timestamp: e.timestamp,
     client_ip: e.client_ip,
+    device_id: e.device_id ?? null,
     domain: e.domain,
     query_type: e.query_type,
     result: e.result,
@@ -385,6 +408,7 @@ function persistedToRow(e: DnsQueryLogEntry): RowShape {
   return {
     timestamp: e.timestamp,
     client_ip: e.client_ip,
+    device_id: e.device_id ?? null,
     domain: e.domain,
     query_type: e.query_type,
     result: e.result,

--- a/source/admin-site/src/stores/dnsLogStore.ts
+++ b/source/admin-site/src/stores/dnsLogStore.ts
@@ -6,6 +6,8 @@ const MAX_ENTRIES = 500;
 export interface DnsLogFilter {
   domain: string;
   client_ip: string;
+  /** Matches the event's write-time device attribution (empty = any). */
+  device_id: string;
   results: string[];
 }
 
@@ -31,7 +33,7 @@ export const useDnsLogStore = create<DnsLogState>((set) => ({
   connected: false,
   paused: false,
   skipped: 0,
-  filter: { domain: "", client_ip: "", results: [] },
+  filter: { domain: "", client_ip: "", device_id: "", results: [] },
 
   _addEvent: (event) =>
     set((state) => {

--- a/source/admin-site/tests/pages/DnsLogs.test.tsx
+++ b/source/admin-site/tests/pages/DnsLogs.test.tsx
@@ -49,9 +49,7 @@ vi.mock("@/components/compound/DeviceSelect", () => ({
     onChange: (value: string) => void;
     devices: unknown[];
   }) => (
-    <button onClick={() => onChange("10.232.1.10")}>
-      device-pick:{devices.length}
-    </button>
+    <button onClick={() => onChange("d1")}>device-pick:{devices.length}</button>
   ),
 }));
 
@@ -64,6 +62,9 @@ const liveEvent = (over: Record<string, unknown> = {}): QueryLogEvent =>
   ({
     timestamp: "2026-07-01T10:00:00Z",
     client_ip: "10.232.1.10",
+    // Write-time attribution to the "Laptop" device — the page resolves
+    // device names and the device filter by this id, never by IP.
+    device_id: "d1",
     domain: "ads.example.com",
     query_type: "A",
     result: "blocked",
@@ -78,7 +79,7 @@ beforeEach(() => {
     connected: false,
     paused: false,
     skipped: 0,
-    filter: { domain: "", client_ip: "", results: [] },
+    filter: { domain: "", client_ip: "", device_id: "", results: [] },
   });
   useDevices.mockReturnValue({
     data: {
@@ -90,7 +91,8 @@ beforeEach(() => {
           hostname: null,
           last_ip: undefined,
         }),
-        // Duplicate last_ip is de-duped out of the filter list.
+        // Shares d1's last_ip — still listed, since the dropdown is keyed
+        // by device id, not IP.
         makeDevice({ id: "d3", name: "Dup", last_ip: "10.232.1.10" }),
       ],
     },
@@ -108,8 +110,10 @@ describe("DnsLogs", () => {
       screen.getByRole("heading", { name: "DNS query log" }),
     ).toBeInTheDocument();
     expect(screen.getByText("Live tail (offline)")).toBeInTheDocument();
-    // Only one device row remains after de-duping on last_ip.
-    expect(screen.getByText("device-pick:1")).toBeInTheDocument();
+    // The dropdown is id-keyed (no de-duping on last_ip), but devices with
+    // no displayable label (d2: no name/hostname/last_ip) are excluded so
+    // no option renders blank.
+    expect(screen.getByText("device-pick:2")).toBeInTheDocument();
   });
 
   it("renders live rows with resolved device names and result badges", () => {
@@ -119,6 +123,7 @@ describe("DnsLogs", () => {
         liveEvent(),
         liveEvent({
           client_ip: "9.9.9.9",
+          device_id: null,
           domain: "unknown.test",
           result: "blocked_skipped",
         }),
@@ -148,8 +153,12 @@ describe("DnsLogs", () => {
   it("narrows the live tail when a device is picked", async () => {
     useDnsLogStore.setState({
       entries: [
-        liveEvent({ domain: "mine.example.com", client_ip: "10.232.1.10" }),
-        liveEvent({ domain: "theirs.example.com", client_ip: "9.9.9.9" }),
+        liveEvent({ domain: "mine.example.com" }),
+        liveEvent({
+          domain: "theirs.example.com",
+          client_ip: "9.9.9.9",
+          device_id: null,
+        }),
       ],
     });
     const user = userEvent.setup();
@@ -224,7 +233,9 @@ describe("DnsLogs", () => {
 
   it("renders the raw client IP when no device matches", () => {
     useDnsLogStore.setState({
-      entries: [liveEvent({ client_ip: "9.9.9.9", domain: "x.test" })],
+      entries: [
+        liveEvent({ client_ip: "9.9.9.9", device_id: null, domain: "x.test" }),
+      ],
     });
     renderWithProviders(<DnsLogs />);
     const row = screen.getByText("x.test").closest("tr")!;

--- a/source/admin-site/tests/stores/dnsLogStore.test.ts
+++ b/source/admin-site/tests/stores/dnsLogStore.test.ts
@@ -19,7 +19,7 @@ describe("dnsLogStore", () => {
       connected: false,
       paused: false,
       skipped: 0,
-      filter: { domain: "", client_ip: "", results: [] },
+      filter: { domain: "", client_ip: "", device_id: "", results: [] },
     });
   });
 
@@ -44,9 +44,12 @@ describe("dnsLogStore", () => {
 
   it("setFilter keeps existing entries", () => {
     useDnsLogStore.getState()._addEvent(event());
-    useDnsLogStore
-      .getState()
-      .setFilter({ domain: "x", client_ip: "", results: ["blocked"] });
+    useDnsLogStore.getState().setFilter({
+      domain: "x",
+      client_ip: "",
+      device_id: "",
+      results: ["blocked"],
+    });
     const s = useDnsLogStore.getState();
     expect(s.filter.domain).toBe("x");
     expect(s.entries).toHaveLength(1);

--- a/source/daemon/crates/wardnet-common/src/api.rs
+++ b/source/daemon/crates/wardnet-common/src/api.rs
@@ -1613,6 +1613,11 @@ pub struct ListQueryLogParams {
     pub domain: Option<String>,
     #[serde(default)]
     pub client_ip: Option<String>,
+    /// Filter by the device attributed at query time. Stable across DHCP
+    /// reassignment; rows recorded before device attribution existed (or
+    /// from unknown sources) have no device and only match `client_ip`.
+    #[serde(default)]
+    pub device_id: Option<Uuid>,
     #[serde(default)]
     pub result: Option<DnsQueryResult>,
 }

--- a/source/daemon/crates/wardnet-common/src/stats.rs
+++ b/source/daemon/crates/wardnet-common/src/stats.rs
@@ -68,6 +68,11 @@ pub struct StatsTopQuery {
     pub metric: String,
     /// Label dimension to rank by (e.g. `"domain"`, `"client"`).
     pub label_key: String,
+    /// Optional label dimension to group by when `label_key` is absent
+    /// from an entry's labels (e.g. rank by `"device_id"` falling back to
+    /// `"client"` for queries from sources with no known device).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub fallback_label_key: Option<String>,
     pub from: DateTime<Utc>,
     pub to: DateTime<Utc>,
     pub limit: u32,

--- a/source/daemon/crates/wardnetd-data/migrations/20260715000000_stats_intraday_device_id_index.sql
+++ b/source/daemon/crates/wardnetd-data/migrations/20260715000000_stats_intraday_device_id_index.sql
@@ -1,0 +1,7 @@
+-- Expression index for top-N queries grouped by the `device_id` label
+-- (issue: Top clients must rank by write-time device attribution, not by
+-- DHCP-recyclable client IP). Mirrors the existing `stats_intraday_client`
+-- index; the COALESCE(device_id, client) fallback form still scans, which
+-- is fine — stats_intraday is pre-aggregated and bounded by 25 h retention.
+CREATE INDEX IF NOT EXISTS stats_intraday_device_id
+    ON stats_intraday (metric, json_extract(labels, '$.device_id'), bucket_ts);

--- a/source/daemon/crates/wardnetd-data/src/repository/dns.rs
+++ b/source/daemon/crates/wardnetd-data/src/repository/dns.rs
@@ -52,6 +52,9 @@ pub struct QueryLogRow {
 #[derive(Debug, Clone, Default)]
 pub struct QueryLogFilter {
     pub client_ip: Option<String>,
+    /// Exact match on the write-time device attribution (stable across
+    /// DHCP reassignment, unlike `client_ip`).
+    pub device_id: Option<String>,
     pub domain: Option<String>,
     pub result: Option<DnsQueryResult>,
 }

--- a/source/daemon/crates/wardnetd-data/src/repository/sqlite/dns.rs
+++ b/source/daemon/crates/wardnetd-data/src/repository/sqlite/dns.rs
@@ -132,9 +132,16 @@ impl DnsRepository for SqliteDnsRepository {
 fn build_where(filter: &QueryLogFilter) -> (String, Vec<String>) {
     let mut conditions: Vec<&str> = Vec::new();
     let mut binds: Vec<String> = Vec::new();
+    // Substring match, mirroring the domain filter: the admin UI feeds this
+    // from a free-text input, so a partial IP ("192.168.1") must narrow
+    // rather than silently matching nothing.
     if let Some(ref ip) = filter.client_ip {
-        conditions.push("client_ip = ?");
-        binds.push(ip.clone());
+        conditions.push("client_ip LIKE ?");
+        binds.push(format!("%{ip}%"));
+    }
+    if let Some(ref device_id) = filter.device_id {
+        conditions.push("device_id = ?");
+        binds.push(device_id.clone());
     }
     if let Some(ref domain) = filter.domain {
         conditions.push("domain LIKE ?");

--- a/source/daemon/crates/wardnetd-data/src/repository/sqlite/stats.rs
+++ b/source/daemon/crates/wardnetd-data/src/repository/sqlite/stats.rs
@@ -380,31 +380,49 @@ impl StatsRepository for SqliteStatsRepository {
         &self,
         metric: &str,
         label_key: &str,
+        fallback_label_key: Option<&str>,
         from: i64,
         to: i64,
         limit: u32,
     ) -> anyhow::Result<Vec<StatsTopEntry>> {
         // json_extract is covered by the expression indexes for the known
-        // label keys (outcome, domain, client). Unknown keys fall back to a
-        // full scan but still return correct results.
+        // label keys (outcome, domain, client, device_id). Unknown keys —
+        // and the COALESCE form — fall back to a scan of the (small,
+        // 25 h-bounded, pre-aggregated) intraday table but still return
+        // correct results.
+        //
+        // With a fallback key one group can span rows with different label
+        // strings (a device seen under several IPs); MAX(labels) keeps the
+        // representative row deterministic instead of leaving SQLite to
+        // pick an arbitrary member.
         let key_path = format!("$.{label_key}");
-        let rows = sqlx::query_as::<_, DbTopEntry>(
-            "SELECT labels, SUM(value) AS total \
+        let fallback_path = fallback_label_key.map(|f| format!("$.{f}"));
+        let group_expr = match &fallback_path {
+            Some(_) => "COALESCE(json_extract(labels, ?), json_extract(labels, ?))",
+            None => "json_extract(labels, ?)",
+        };
+        let sql = format!(
+            "SELECT MAX(labels) AS labels, SUM(value) AS total \
              FROM stats_intraday \
              WHERE metric = ? AND bucket_ts BETWEEN ? AND ? \
-               AND json_extract(labels, ?) IS NOT NULL \
-             GROUP BY json_extract(labels, ?) \
+               AND {group_expr} IS NOT NULL \
+             GROUP BY {group_expr} \
              ORDER BY total DESC \
              LIMIT ?",
-        )
-        .bind(metric)
-        .bind(from)
-        .bind(to)
-        .bind(&key_path)
-        .bind(&key_path)
-        .bind(limit)
-        .fetch_all(&self.pools.read)
-        .await?;
+        );
+        let mut query = sqlx::query_as::<_, DbTopEntry>(sqlx::AssertSqlSafe(sql))
+            .bind(metric)
+            .bind(from)
+            .bind(to);
+        // The grouping expression appears twice (IS NOT NULL + GROUP BY);
+        // bind its path parameter(s) once per occurrence.
+        for _ in 0..2 {
+            query = query.bind(&key_path);
+            if let Some(ref fallback) = fallback_path {
+                query = query.bind(fallback);
+            }
+        }
+        let rows = query.bind(limit).fetch_all(&self.pools.read).await?;
         Ok(rows.into_iter().map(Into::into).collect())
     }
 }

--- a/source/daemon/crates/wardnetd-data/src/repository/stats.rs
+++ b/source/daemon/crates/wardnetd-data/src/repository/stats.rs
@@ -114,12 +114,18 @@ pub trait StatsRepository: Send + Sync {
 
     /// Sum values grouped by `label_key` via `json_extract`, ordered DESC.
     ///
+    /// When `fallback_label_key` is set, entries whose labels lack
+    /// `label_key` group by the fallback dimension instead (COALESCE), so
+    /// e.g. a `device_id` ranking still counts unattributed traffic under
+    /// its `client` IP rather than silently dropping it.
+    ///
     /// Queries `stats_intraday` only (bounded by 25 h intraday retention).
     /// Top-N over longer windows is a known limitation tracked separately.
     async fn top_n(
         &self,
         metric: &str,
         label_key: &str,
+        fallback_label_key: Option<&str>,
         from: i64,
         to: i64,
         limit: u32,

--- a/source/daemon/crates/wardnetd-data/src/repository/tests/dns.rs
+++ b/source/daemon/crates/wardnetd-data/src/repository/tests/dns.rs
@@ -65,6 +65,47 @@ async fn query_log_filter_by_client_ip() {
     for row in &rows {
         assert_eq!(row.client_ip, "192.168.1.10");
     }
+
+    // Substring semantics: a partial IP from the free-text filter narrows
+    // to every client that contains it.
+    let partial = QueryLogFilter {
+        client_ip: Some("192.168.1".to_owned()),
+        ..Default::default()
+    };
+    let rows = repo.query_log_paginated(10, 0, &partial).await.unwrap();
+    assert_eq!(rows.len(), 3, "partial IP must match all 192.168.1.* rows");
+}
+
+/// The device filter matches on write-time attribution: the same device
+/// stays findable after its IP changes, and an unattributed row (NULL
+/// `device_id`) never matches a device filter.
+#[tokio::test]
+async fn query_log_filter_by_device_id() {
+    let pool = test_pool().await;
+    let repo = SqliteDnsRepository::new(pool);
+
+    let device = "550e8400-e29b-41d4-a716-446655440000";
+    let mut before_dhcp_churn = sample_row("192.168.1.10", "a.com", "allowed");
+    before_dhcp_churn.device_id = Some(device.to_owned());
+    let mut after_dhcp_churn = sample_row("192.168.1.55", "b.com", "allowed");
+    after_dhcp_churn.device_id = Some(device.to_owned());
+    // Different device later holding the first IP — must not match.
+    let unattributed_on_same_ip = sample_row("192.168.1.10", "c.com", "blocked");
+
+    repo.insert_query_log_batch(&[before_dhcp_churn, after_dhcp_churn, unattributed_on_same_ip])
+        .await
+        .unwrap();
+
+    let filter = QueryLogFilter {
+        device_id: Some(device.to_owned()),
+        ..Default::default()
+    };
+    let rows = repo.query_log_paginated(10, 0, &filter).await.unwrap();
+    assert_eq!(rows.len(), 2, "both IPs' rows attribute to the device");
+    for row in &rows {
+        assert_eq!(row.device_id.as_deref(), Some(device));
+    }
+    assert_eq!(repo.query_log_count(&filter).await.unwrap(), 2);
 }
 
 #[tokio::test]

--- a/source/daemon/crates/wardnetd-data/src/repository/tests/stats.rs
+++ b/source/daemon/crates/wardnetd-data/src/repository/tests/stats.rs
@@ -214,12 +214,65 @@ async fn top_n_returns_results_sorted_by_total_desc() {
     .await
     .unwrap();
     let entries = repo
-        .top_n("dns.queries", "domain", 0, 9999, 2)
+        .top_n("dns.queries", "domain", None, 0, 9999, 2)
         .await
         .unwrap();
     assert_eq!(entries.len(), 2, "limit of 2 must be respected");
     assert_eq!(entries[0].total, 10.0, "highest total must be first");
     assert_eq!(entries[1].total, 7.0);
+}
+
+/// COALESCE fallback: ranking by `device_id` still counts traffic from
+/// sources with no attributed device — those entries group by their
+/// `client` IP instead of being dropped, and rows sharing a `device_id`
+/// aggregate across different client IPs (DHCP churn).
+#[tokio::test]
+async fn top_n_fallback_groups_unattributed_by_fallback_key() {
+    let pool = test_pool().await;
+    let repo = SqliteStatsRepository::new(pool);
+    repo.upsert_intraday(&[
+        // Same device seen under two IPs — must aggregate to one entry.
+        intraday(
+            "dns.queries.by_client",
+            r#"{"client":"10.0.0.5","device_id":"dev-a"}"#,
+            1000,
+            4.0,
+            "counter",
+        ),
+        intraday(
+            "dns.queries.by_client",
+            r#"{"client":"10.0.0.9","device_id":"dev-a"}"#,
+            1000,
+            3.0,
+            "counter",
+        ),
+        // Unknown source — no device_id label; groups by client IP.
+        intraday(
+            "dns.queries.by_client",
+            r#"{"client":"10.0.0.77"}"#,
+            1000,
+            5.0,
+            "counter",
+        ),
+    ])
+    .await
+    .unwrap();
+    let entries = repo
+        .top_n(
+            "dns.queries.by_client",
+            "device_id",
+            Some("client"),
+            0,
+            9999,
+            10,
+        )
+        .await
+        .unwrap();
+    assert_eq!(entries.len(), 2, "device group + unattributed IP group");
+    assert_eq!(entries[0].total, 7.0, "device totals aggregate across IPs");
+    assert!(entries[0].labels.contains("dev-a"));
+    assert_eq!(entries[1].total, 5.0);
+    assert!(entries[1].labels.contains("10.0.0.77"));
 }
 
 #[tokio::test]

--- a/source/daemon/crates/wardnetd-mock/src/seed.rs
+++ b/source/daemon/crates/wardnetd-mock/src/seed.rs
@@ -318,11 +318,22 @@ pub async fn populate(factory: &dyn RepositoryFactory) -> anyhow::Result<SeededI
     // deterministically from `now` so the dev experience is reproducible
     // across `make run-dev` restarts.
     // ------------------------------------------------------------------
-    let dns_client_ips: Vec<String> = device_lease_inputs
-        .iter()
-        .map(|(_, _, _, ip)| ip.clone())
-        .collect();
-    let log_rows = generate_dns_query_log(&dns_client_ips, now);
+    // (device_id, ip) pairs: seeded rows carry write-time device
+    // attribution just like the real DNS server records it. The last
+    // client is left unattributed so the dev UI exercises the
+    // unknown-source fallback rendering too.
+    let dns_clients: Vec<(Option<String>, String)> = {
+        let last = device_lease_inputs.len().saturating_sub(1);
+        device_lease_inputs
+            .iter()
+            .enumerate()
+            .map(|(i, (id, _, _, ip))| {
+                let device_id = (i != last).then(|| id.to_string());
+                (device_id, ip.clone())
+            })
+            .collect()
+    };
+    let log_rows = generate_dns_query_log(&dns_clients, now);
     let total_log_rows = log_rows.len();
     for chunk in log_rows.chunks(256) {
         dns_repo.insert_query_log_batch(chunk).await?;
@@ -333,19 +344,15 @@ pub async fn populate(factory: &dyn RepositoryFactory) -> anyhow::Result<SeededI
     // partial 7d tabs have data immediately, plus one rollup row per day
     // for the 12m daily chart.
     // ------------------------------------------------------------------
-    let dns_client_ips_for_stats: Vec<String> = device_lease_inputs
-        .iter()
-        .map(|(_, _, _, ip)| ip.clone())
-        .collect();
     let stats_repo = factory.stats();
 
-    let intraday_stat_rows = generate_dns_intraday_stats(&dns_client_ips_for_stats, now);
+    let intraday_stat_rows = generate_dns_intraday_stats(&dns_clients, now);
     let total_intraday = intraday_stat_rows.len();
     for chunk in intraday_stat_rows.chunks(256) {
         stats_repo.upsert_intraday(chunk).await?;
     }
 
-    let daily_rollup_days = seed_daily_stats(&*stats_repo, &dns_client_ips_for_stats, now).await?;
+    let daily_rollup_days = seed_daily_stats(&*stats_repo, &dns_clients, now).await?;
 
     // ------------------------------------------------------------------
     // Tunnel stats — throughput counters + latency gauge per tunnel.
@@ -590,6 +597,16 @@ async fn seed_tunnel_daily_stats(
 
 // ── DNS query log fixture ─────────────────────────────────────────────────
 
+/// Sorted-JSON labels for a `dns.queries.by_client` row, matching the
+/// format the real log sink writes: `device_id` present only when the
+/// client is attributed to a device (keys sorted: `client` < `device_id`).
+fn client_stat_labels(device_id: Option<&str>, client_ip: &str) -> String {
+    match device_id {
+        Some(id) => format!(r#"{{"client":"{client_ip}","device_id":"{id}"}}"#),
+        None => format!(r#"{{"client":"{client_ip}"}}"#),
+    }
+}
+
 /// Build a 24-hour synthetic query log spread across the seeded device IPs.
 /// Returns rows in chronological order (oldest first) so paginated UI views
 /// show recent queries first.
@@ -598,8 +615,11 @@ async fn seed_tunnel_daily_stats(
     clippy::cast_sign_loss,
     clippy::cast_precision_loss
 )]
-fn generate_dns_query_log(client_ips: &[String], now: chrono::DateTime<Utc>) -> Vec<QueryLogRow> {
-    if client_ips.is_empty() {
+fn generate_dns_query_log(
+    clients: &[(Option<String>, String)],
+    now: chrono::DateTime<Utc>,
+) -> Vec<QueryLogRow> {
+    if clients.is_empty() {
         return Vec::new();
     }
 
@@ -638,7 +658,7 @@ fn generate_dns_query_log(client_ips: &[String], now: chrono::DateTime<Utc>) -> 
         for q in 0..queries_per_minute {
             // Deterministic pseudo-random index — no rng dependency.
             let seed = (minute_offset as u64).wrapping_mul(2_654_435_761) ^ u64::from(q);
-            let client = &client_ips[(seed as usize) % client_ips.len()];
+            let (device_id, client) = &clients[(seed as usize) % clients.len()];
             let bucket_pick = (seed >> 7) % 10;
 
             let (domain, result) = if bucket_pick < 2 {
@@ -695,7 +715,7 @@ fn generate_dns_query_log(client_ips: &[String], now: chrono::DateTime<Utc>) -> 
                 result: result.to_owned(),
                 upstream,
                 latency_ms,
-                device_id: None,
+                device_id: device_id.clone(),
             });
         }
     }
@@ -729,7 +749,7 @@ const CLIENT_WEIGHTS: [f64; 5] = [0.30, 0.25, 0.20, 0.15, 0.10];
     clippy::cast_precision_loss
 )]
 fn generate_dns_intraday_stats(
-    client_ips: &[String],
+    clients: &[(Option<String>, String)],
     now: chrono::DateTime<Utc>,
 ) -> Vec<IntradayStatRow> {
     const HOURS: i64 = 48;
@@ -739,8 +759,8 @@ fn generate_dns_intraday_stats(
     let end_ts = (now.timestamp() / 60) * 60;
     let start_ts = end_ts - HOURS * 3_600;
 
-    let capacity = ((end_ts - start_ts) / 60) as usize
-        * (3 + AD_BLOCKED_DOMAINS.len() + client_ips.len().min(5));
+    let capacity =
+        ((end_ts - start_ts) / 60) as usize * (3 + AD_BLOCKED_DOMAINS.len() + clients.len().min(5));
     let mut rows = Vec::with_capacity(capacity);
 
     let mut minute_ts = start_ts;
@@ -790,10 +810,10 @@ fn generate_dns_intraday_stats(
             });
         }
 
-        for (i, client_ip) in client_ips.iter().enumerate().take(5) {
+        for (i, (device_id, client_ip)) in clients.iter().enumerate().take(5) {
             rows.push(IntradayStatRow {
                 metric: "dns.queries.by_client".to_owned(),
-                labels: format!(r#"{{"client":"{client_ip}"}}"#),
+                labels: client_stat_labels(device_id.as_deref(), client_ip),
                 bucket_ts: minute_ts,
                 value: (total_qpm * CLIENT_WEIGHTS[i]).max(0.01),
                 kind: "counter".to_owned(),
@@ -818,7 +838,7 @@ fn generate_dns_intraday_stats(
 )]
 async fn seed_daily_stats(
     stats_repo: &dyn wardnetd_data::repository::StatsRepository,
-    client_ips: &[String],
+    clients: &[(Option<String>, String)],
     now: chrono::DateTime<Utc>,
 ) -> anyhow::Result<usize> {
     const DAILY_RETENTION_DAYS: i64 = 397;
@@ -878,10 +898,10 @@ async fn seed_daily_stats(
             });
         }
 
-        for (i, client_ip) in client_ips.iter().enumerate().take(5) {
+        for (i, (device_id, client_ip)) in clients.iter().enumerate().take(5) {
             day_rows.push(IntradayStatRow {
                 metric: "dns.queries.by_client".to_owned(),
-                labels: format!(r#"{{"client":"{client_ip}"}}"#),
+                labels: client_stat_labels(device_id.as_deref(), client_ip),
                 bucket_ts: noon_ts,
                 value: (total * CLIENT_WEIGHTS[i]).max(0.1),
                 kind: "counter".to_owned(),

--- a/source/daemon/crates/wardnetd-services/src/device/ip_snapshot.rs
+++ b/source/daemon/crates/wardnetd-services/src/device/ip_snapshot.rs
@@ -1,0 +1,82 @@
+use std::collections::HashMap;
+use std::net::IpAddr;
+use std::sync::Arc;
+
+use arc_swap::ArcSwap;
+use uuid::Uuid;
+
+use wardnetd_data::repository::DeviceRepository;
+
+/// Lock-free IP → device-id map consulted from the DNS hot path.
+///
+/// The DNS server resolves each query's source IP to a device id **at query
+/// time** so log rows and stats carry a stable identity that survives DHCP
+/// reassigning the IP to a different device later. A per-query repository
+/// read is off the table on that path, so this mirrors the routing service's
+/// `dns_upstream_snapshot` pattern: consumers hold the inner
+/// [`ArcSwap`] and do a wait-free `load()` per query, while rebuilds swap in
+/// a fresh map built from the devices table.
+///
+/// Rebuilds are full (never incremental) so the map is always exactly what
+/// the devices table says: startup plus every event that can move an IP
+/// between devices (`DeviceDiscovered`, `DeviceIpChanged`, `DeviceGone`).
+pub struct DeviceIpSnapshot {
+    devices: Arc<dyn DeviceRepository>,
+    snapshot: Arc<ArcSwap<HashMap<IpAddr, Uuid>>>,
+}
+
+impl DeviceIpSnapshot {
+    /// Create an empty snapshot backed by the given repository. Call
+    /// [`Self::rebuild`] once at startup to populate it.
+    #[must_use]
+    pub fn new(devices: Arc<dyn DeviceRepository>) -> Self {
+        Self {
+            devices,
+            snapshot: Arc::new(ArcSwap::from_pointee(HashMap::new())),
+        }
+    }
+
+    /// Shared handle for hot-path consumers (the DNS server). Each query
+    /// does `snapshot.load().get(&ip)` — wait-free, no locks.
+    #[must_use]
+    pub fn snapshot(&self) -> Arc<ArcSwap<HashMap<IpAddr, Uuid>>> {
+        Arc::clone(&self.snapshot)
+    }
+
+    /// Rebuild the map from the devices table and atomically swap it in.
+    ///
+    /// Departed devices have `last_ip` cleared by discovery, but a stale
+    /// duplicate can still exist transiently (old device not yet re-seen
+    /// after its IP was handed to a new one). `last_seen` breaks the tie:
+    /// the most recently seen claimant of an IP wins.
+    pub async fn rebuild(&self) -> anyhow::Result<()> {
+        let mut devices = self.devices.find_all().await?;
+        devices.sort_by_key(|d| d.last_seen);
+
+        let mut map = HashMap::with_capacity(devices.len());
+        for device in devices {
+            if device.last_ip.is_empty() {
+                continue;
+            }
+            let Ok(ip) = device.last_ip.parse::<IpAddr>() else {
+                tracing::warn!(
+                    device_id = %device.id,
+                    last_ip = %device.last_ip,
+                    "skipping device with unparsable last_ip in IP snapshot: device_id={}, last_ip={}",
+                    device.id,
+                    device.last_ip
+                );
+                continue;
+            };
+            map.insert(ip, device.id);
+        }
+
+        let entry_count = map.len();
+        tracing::debug!(
+            entry_count,
+            "rebuilt device IP snapshot: entry_count={entry_count}"
+        );
+        self.snapshot.store(Arc::new(map));
+        Ok(())
+    }
+}

--- a/source/daemon/crates/wardnetd-services/src/device/mod.rs
+++ b/source/daemon/crates/wardnetd-services/src/device/mod.rs
@@ -1,10 +1,12 @@
 pub mod discovery;
 pub mod hostname_resolver;
+pub mod ip_snapshot;
 pub mod packet_capture;
 pub mod service;
 
 pub use discovery::{DeviceDiscoveryService, DeviceDiscoveryServiceImpl, ObservationResult};
 pub use hostname_resolver::HostnameResolver;
+pub use ip_snapshot::DeviceIpSnapshot;
 pub use packet_capture::{ObservedDevice, PacketCapture, PacketSource};
 pub use service::{DeviceService, DeviceServiceImpl};
 

--- a/source/daemon/crates/wardnetd-services/src/device/tests/ip_snapshot.rs
+++ b/source/daemon/crates/wardnetd-services/src/device/tests/ip_snapshot.rs
@@ -1,0 +1,277 @@
+use std::net::Ipv4Addr;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use uuid::Uuid;
+use wardnet_common::device::{Device, DeviceConnectionMode, DeviceType};
+use wardnet_common::routing::RoutingRule;
+
+use crate::device::ip_snapshot::DeviceIpSnapshot;
+use wardnetd_data::repository::DeviceRepository;
+use wardnetd_data::repository::device::DeviceRow;
+
+// -- Mock repository ------------------------------------------------------
+
+struct MockDeviceRepo {
+    devices: Vec<Device>,
+    /// When `true`, `find_all` returns an error instead of `devices`.
+    fail: bool,
+}
+
+impl MockDeviceRepo {
+    fn new(devices: Vec<Device>) -> Self {
+        Self {
+            devices,
+            fail: false,
+        }
+    }
+
+    fn failing() -> Self {
+        Self {
+            devices: Vec::new(),
+            fail: true,
+        }
+    }
+}
+
+#[async_trait]
+impl DeviceRepository for MockDeviceRepo {
+    async fn find_by_ip(&self, _ip: &str) -> anyhow::Result<Option<Device>> {
+        unimplemented!("not exercised by DeviceIpSnapshot")
+    }
+    async fn find_by_id(&self, _id: &str) -> anyhow::Result<Option<Device>> {
+        unimplemented!("not exercised by DeviceIpSnapshot")
+    }
+    async fn find_by_mac(&self, _mac: &str) -> anyhow::Result<Option<Device>> {
+        unimplemented!("not exercised by DeviceIpSnapshot")
+    }
+    async fn find_all(&self) -> anyhow::Result<Vec<Device>> {
+        if self.fail {
+            anyhow::bail!("mock: find_all failed");
+        }
+        Ok(self.devices.clone())
+    }
+    async fn insert(&self, _device: &DeviceRow) -> anyhow::Result<()> {
+        unimplemented!("not exercised by DeviceIpSnapshot")
+    }
+    async fn update_last_seen_and_ip(
+        &self,
+        _id: &str,
+        _ip: &str,
+        _last_seen: &str,
+        _mode: DeviceConnectionMode,
+    ) -> anyhow::Result<()> {
+        unimplemented!("not exercised by DeviceIpSnapshot")
+    }
+    async fn update_last_seen_batch(&self, _updates: &[(String, String)]) -> anyhow::Result<()> {
+        unimplemented!("not exercised by DeviceIpSnapshot")
+    }
+    async fn update_connection_mode(
+        &self,
+        _id: &str,
+        _mode: DeviceConnectionMode,
+    ) -> anyhow::Result<()> {
+        unimplemented!("not exercised by DeviceIpSnapshot")
+    }
+    async fn update_hostname(&self, _id: &str, _hostname: &str) -> anyhow::Result<()> {
+        unimplemented!("not exercised by DeviceIpSnapshot")
+    }
+    async fn update_name_and_type(
+        &self,
+        _id: &str,
+        _name: Option<&str>,
+        _device_type: &str,
+    ) -> anyhow::Result<()> {
+        unimplemented!("not exercised by DeviceIpSnapshot")
+    }
+    async fn find_stale(&self, _before: &str) -> anyhow::Result<Vec<Device>> {
+        unimplemented!("not exercised by DeviceIpSnapshot")
+    }
+    async fn find_rule_for_device(&self, _device_id: &str) -> anyhow::Result<Option<RoutingRule>> {
+        unimplemented!("not exercised by DeviceIpSnapshot")
+    }
+    async fn find_all_rules(&self) -> anyhow::Result<Vec<RoutingRule>> {
+        unimplemented!("not exercised by DeviceIpSnapshot")
+    }
+    async fn upsert_user_rule(
+        &self,
+        _device_id: &str,
+        _target_json: &str,
+        _now: &str,
+    ) -> anyhow::Result<()> {
+        unimplemented!("not exercised by DeviceIpSnapshot")
+    }
+    async fn find_devices_for_tunnel(&self, _tunnel_id: &str) -> anyhow::Result<Vec<Device>> {
+        unimplemented!("not exercised by DeviceIpSnapshot")
+    }
+    async fn switch_tunnel_rules_to_direct(
+        &self,
+        _tunnel_id: &str,
+        _now: &str,
+    ) -> anyhow::Result<Vec<String>> {
+        unimplemented!("not exercised by DeviceIpSnapshot")
+    }
+    async fn update_admin_locked(&self, _id: &str, _locked: bool) -> anyhow::Result<()> {
+        unimplemented!("not exercised by DeviceIpSnapshot")
+    }
+    async fn assign_zone(&self, _device_id: &str, _zone_id: &str) -> anyhow::Result<bool> {
+        unimplemented!("not exercised by DeviceIpSnapshot")
+    }
+    async fn count(&self) -> anyhow::Result<i64> {
+        unimplemented!("not exercised by DeviceIpSnapshot")
+    }
+    async fn update_dns_capture_settings(
+        &self,
+        _id: &str,
+        _enabled: Option<bool>,
+        _cap_count: Option<i64>,
+        _cap_days: Option<i64>,
+    ) -> anyhow::Result<bool> {
+        unimplemented!("not exercised by DeviceIpSnapshot")
+    }
+    async fn find_all_capture_enabled_ids(&self) -> anyhow::Result<Vec<String>> {
+        unimplemented!("not exercised by DeviceIpSnapshot")
+    }
+}
+
+// -- Helpers ----------------------------------------------------------------
+
+fn sample_device(id: &str, ip: &str, last_seen: &str) -> Device {
+    Device {
+        id: Uuid::parse_str(id).unwrap(),
+        mac: "AA:BB:CC:DD:EE:01".to_owned(),
+        name: None,
+        hostname: None,
+        manufacturer: None,
+        device_type: DeviceType::Phone,
+        first_seen: last_seen.parse().unwrap(),
+        last_seen: last_seen.parse().unwrap(),
+        last_ip: ip.to_owned(),
+        admin_locked: false,
+        zone_id: "00000000-0000-0000-0000-000000000201".parse().unwrap(),
+        dns_capture_enabled: false,
+        dns_capture_cap_count: 1000,
+        dns_capture_cap_days: 7,
+        connection_mode: DeviceConnectionMode::Lan,
+    }
+}
+
+// -- Tests --------------------------------------------------------------
+
+#[tokio::test]
+async fn new_snapshot_is_empty_before_rebuild() {
+    let repo = Arc::new(MockDeviceRepo::new(vec![]));
+    let snapshot = DeviceIpSnapshot::new(repo);
+
+    assert!(snapshot.snapshot().load().is_empty());
+}
+
+#[tokio::test]
+async fn rebuild_populates_snapshot_from_devices() {
+    let device_id = Uuid::new_v4();
+    let repo = Arc::new(MockDeviceRepo::new(vec![sample_device(
+        &device_id.to_string(),
+        "192.168.1.10",
+        "2026-03-07T00:00:00Z",
+    )]));
+    let snapshot = DeviceIpSnapshot::new(repo);
+
+    snapshot.rebuild().await.unwrap();
+
+    let map = snapshot.snapshot().load_full();
+    assert_eq!(map.len(), 1);
+    assert_eq!(
+        map.get(&std::net::IpAddr::V4(
+            "192.168.1.10".parse::<Ipv4Addr>().unwrap()
+        )),
+        Some(&device_id)
+    );
+}
+
+#[tokio::test]
+async fn rebuild_skips_devices_with_empty_last_ip() {
+    let repo = Arc::new(MockDeviceRepo::new(vec![sample_device(
+        &Uuid::new_v4().to_string(),
+        "",
+        "2026-03-07T00:00:00Z",
+    )]));
+    let snapshot = DeviceIpSnapshot::new(repo);
+
+    snapshot.rebuild().await.unwrap();
+
+    assert!(snapshot.snapshot().load().is_empty());
+}
+
+#[tokio::test]
+async fn rebuild_skips_devices_with_unparsable_last_ip() {
+    let repo = Arc::new(MockDeviceRepo::new(vec![sample_device(
+        &Uuid::new_v4().to_string(),
+        "not-an-ip",
+        "2026-03-07T00:00:00Z",
+    )]));
+    let snapshot = DeviceIpSnapshot::new(repo);
+
+    snapshot.rebuild().await.unwrap();
+
+    assert!(snapshot.snapshot().load().is_empty());
+}
+
+#[tokio::test]
+async fn rebuild_resolves_ip_collision_in_favor_of_most_recently_seen() {
+    // Two devices transiently claim the same IP (old device not yet re-seen
+    // after DHCP handed its address to a new one). The most recently seen
+    // claimant must win.
+    let stale_id = Uuid::new_v4();
+    let fresh_id = Uuid::new_v4();
+    let repo = Arc::new(MockDeviceRepo::new(vec![
+        sample_device(
+            &stale_id.to_string(),
+            "192.168.1.50",
+            "2026-03-07T00:00:00Z",
+        ),
+        sample_device(
+            &fresh_id.to_string(),
+            "192.168.1.50",
+            "2026-03-08T00:00:00Z",
+        ),
+    ]));
+    let snapshot = DeviceIpSnapshot::new(repo);
+
+    snapshot.rebuild().await.unwrap();
+
+    let map = snapshot.snapshot().load_full();
+    assert_eq!(map.len(), 1);
+    assert_eq!(
+        map.get(&std::net::IpAddr::V4(
+            "192.168.1.50".parse::<Ipv4Addr>().unwrap()
+        )),
+        Some(&fresh_id)
+    );
+}
+
+#[tokio::test]
+async fn rebuild_propagates_repository_error() {
+    let repo = Arc::new(MockDeviceRepo::failing());
+    let snapshot = DeviceIpSnapshot::new(repo);
+
+    assert!(snapshot.rebuild().await.is_err());
+}
+
+#[tokio::test]
+async fn snapshot_returns_shared_handle_updated_by_rebuild() {
+    let device_id = Uuid::new_v4();
+    let repo = Arc::new(MockDeviceRepo::new(vec![sample_device(
+        &device_id.to_string(),
+        "10.0.0.5",
+        "2026-03-07T00:00:00Z",
+    )]));
+    let snapshot = DeviceIpSnapshot::new(repo);
+
+    // Hold a handle taken before the rebuild — it must observe the swap.
+    let handle = snapshot.snapshot();
+    assert!(handle.load().is_empty());
+
+    snapshot.rebuild().await.unwrap();
+
+    assert_eq!(handle.load().len(), 1);
+}

--- a/source/daemon/crates/wardnetd-services/src/device/tests/mod.rs
+++ b/source/daemon/crates/wardnetd-services/src/device/tests/mod.rs
@@ -1,2 +1,3 @@
 mod device;
 mod discovery;
+mod ip_snapshot;

--- a/source/daemon/crates/wardnetd-services/src/dns/log_sink.rs
+++ b/source/daemon/crates/wardnetd-services/src/dns/log_sink.rs
@@ -23,7 +23,7 @@
 //! | `dns.queries` | `{outcome}` | Counter per outcome |
 //! | `dns.latency_ms` | `{outcome}` | Gauge per outcome |
 //! | `dns.queries.by_domain` | `{domain}` | Counter; blocked queries only |
-//! | `dns.queries.by_client` | `{client}` | Counter per client IP |
+//! | `dns.queries.by_client` | `{client, device_id?}` | Counter per client; `device_id` present when attributed at query time |
 
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -226,8 +226,17 @@ fn record_dns_stats(inst: &DnsStatInstruments, row: &QueryLogRow) {
     }
 
     let client = row.client_ip.replace('"', r#"\""#);
-    inst.by_client
-        .add(&format!(r#"{{"client":"{client}"}}"#), 1.0);
+    // `device_id` is present only when the DNS server resolved the querying
+    // device at query time — top-clients groups by it (falling back to
+    // `client` for unknown sources) so attribution survives DHCP churn.
+    // Keys stay sorted as the stats schema requires (client < device_id).
+    let labels = match &row.device_id {
+        Some(device_id) => {
+            format!(r#"{{"client":"{client}","device_id":"{device_id}"}}"#)
+        }
+        None => format!(r#"{{"client":"{client}"}}"#),
+    };
+    inst.by_client.add(&labels, 1.0);
 }
 
 /// Normalise a raw DNS result string into the canonical outcome label value.

--- a/source/daemon/crates/wardnetd-services/src/dns/service.rs
+++ b/source/daemon/crates/wardnetd-services/src/dns/service.rs
@@ -483,6 +483,7 @@ impl DnsService for DnsServiceImpl {
 
         let filter = QueryLogFilter {
             client_ip: params.client_ip,
+            device_id: params.device_id.map(|id| id.to_string()),
             domain: params.domain,
             result: params.result, // already Option<DnsQueryResult>
         };

--- a/source/daemon/crates/wardnetd-services/src/lib.rs
+++ b/source/daemon/crates/wardnetd-services/src/lib.rs
@@ -217,6 +217,10 @@ pub struct Services {
     /// `TlsRenewalRunner`; also called by the wizard (C9) and Settings (C10).
     pub tls: Arc<dyn TlsService>,
     pub discovery: Arc<dyn DeviceDiscoveryService>,
+    /// Lock-free IP → device-id map for the DNS hot path (write-time device
+    /// attribution of query logs and stats). Rebuilt by the device-snapshot
+    /// listener on device lifecycle events.
+    pub device_ip_snapshot: Arc<device::DeviceIpSnapshot>,
     pub log: Arc<dyn LogService>,
     pub vpn_provider: Arc<dyn VpnProviderService>,
     pub routing: Arc<dyn RoutingService>,
@@ -724,6 +728,8 @@ fn create_services(
         config,
     );
 
+    let device_ip_snapshot = Arc::new(device::DeviceIpSnapshot::new(device_repo.clone()));
+
     Services {
         auth: auth_service,
         backup: backup_service,
@@ -736,6 +742,7 @@ fn create_services(
         tls,
         log: log_service,
         discovery: discovery_service,
+        device_ip_snapshot,
         vpn_provider: vpn_provider_service,
         routing: routing_service,
         network_zone: network_zone_service,

--- a/source/daemon/crates/wardnetd-services/src/stats/service.rs
+++ b/source/daemon/crates/wardnetd-services/src/stats/service.rs
@@ -89,7 +89,14 @@ impl StatsService for StatsServiceImpl {
         let to = q.to.timestamp();
         let entries = self
             .repo
-            .top_n(&q.metric, &q.label_key, from, to, q.limit)
+            .top_n(
+                &q.metric,
+                &q.label_key,
+                q.fallback_label_key.as_deref(),
+                from,
+                to,
+                q.limit,
+            )
             .await
             .map_err(AppError::Internal)?;
         Ok(StatsTopResponse {

--- a/source/daemon/crates/wardnetd-services/src/stats/tests/service.rs
+++ b/source/daemon/crates/wardnetd-services/src/stats/tests/service.rs
@@ -123,21 +123,36 @@ impl StatsRepository for MemoryStatsRepo {
     async fn top_n(
         &self,
         metric: &str,
-        _label_key: &str,
+        label_key: &str,
+        fallback_label_key: Option<&str>,
         from: i64,
         to: i64,
         limit: u32,
     ) -> anyhow::Result<Vec<StatsTopEntry>> {
+        // Mirrors the SQL COALESCE semantics: group by `label_key`'s value,
+        // falling back to `fallback_label_key`'s; skip entries with neither.
+        let extract = |labels: &str, key: &str| -> Option<String> {
+            serde_json::from_str::<serde_json::Value>(labels)
+                .ok()?
+                .get(key)?
+                .as_str()
+                .map(ToOwned::to_owned)
+        };
         let guard = self.intraday.lock().unwrap();
-        let mut totals: std::collections::HashMap<String, f64> = std::collections::HashMap::new();
+        let mut totals: std::collections::HashMap<String, (String, f64)> =
+            std::collections::HashMap::new();
         for r in guard
             .iter()
             .filter(|r| r.metric == metric && r.bucket_ts >= from && r.bucket_ts <= to)
         {
-            *totals.entry(r.labels.clone()).or_insert(0.0) += r.value;
+            let key = extract(&r.labels, label_key)
+                .or_else(|| fallback_label_key.and_then(|f| extract(&r.labels, f)));
+            let Some(key) = key else { continue };
+            let entry = totals.entry(key).or_insert_with(|| (r.labels.clone(), 0.0));
+            entry.1 += r.value;
         }
         let mut entries: Vec<StatsTopEntry> = totals
-            .into_iter()
+            .into_values()
             .map(|(labels, total)| StatsTopEntry { labels, total })
             .collect();
         entries.sort_by(|a, b| {
@@ -476,6 +491,7 @@ async fn top_returns_forbidden_without_admin_context() {
     let q = StatsTopQuery {
         metric: "m".to_owned(),
         label_key: "outcome".to_owned(),
+        fallback_label_key: None,
         from: Utc::now(),
         to: Utc::now(),
         limit: 5,
@@ -506,6 +522,7 @@ async fn top_with_admin_context() {
     let q = StatsTopQuery {
         metric: "dns.queries".to_owned(),
         label_key: "domain".to_owned(),
+        fallback_label_key: None,
         from: Utc::now() - chrono::Duration::hours(1),
         to: Utc::now() + chrono::Duration::hours(1),
         limit: 5,

--- a/source/daemon/crates/wardnetd/src/device_snapshot_listener.rs
+++ b/source/daemon/crates/wardnetd/src/device_snapshot_listener.rs
@@ -1,0 +1,108 @@
+use std::sync::Arc;
+
+use tokio_util::sync::CancellationToken;
+use tracing::Instrument;
+use wardnet_common::event::WardnetEvent;
+
+use wardnetd_services::device::DeviceIpSnapshot;
+use wardnetd_services::event::EventPublisher;
+
+/// Background task that keeps the DNS hot-path IP → device-id snapshot
+/// current.
+///
+/// Subscribes to the event bus and triggers a full [`DeviceIpSnapshot`]
+/// rebuild on every event that can move an IP between devices. Mirrors
+/// [`crate::routing_listener::RoutingListener`]'s lifecycle.
+pub struct DeviceSnapshotListener {
+    cancel: CancellationToken,
+    handle: tokio::task::JoinHandle<()>,
+}
+
+impl DeviceSnapshotListener {
+    /// Start the listener.
+    ///
+    /// The `parent` span parents the `device_snapshot_listener` child span so
+    /// all task output carries the root version field.
+    pub fn start(
+        events: &Arc<dyn EventPublisher>,
+        snapshot: Arc<DeviceIpSnapshot>,
+        parent: &tracing::Span,
+    ) -> Self {
+        let cancel = CancellationToken::new();
+        let span = tracing::info_span!(parent: parent, "device_snapshot_listener");
+
+        let rx = events.subscribe();
+
+        let handle = tokio::spawn(event_loop(rx, snapshot, cancel.clone()).instrument(span));
+
+        Self { cancel, handle }
+    }
+
+    /// Cancel the background task and wait for it to finish.
+    pub async fn shutdown(self) {
+        self.cancel.cancel();
+        let _ = self.handle.await;
+        tracing::info!("device snapshot listener shut down");
+    }
+}
+
+async fn event_loop(
+    mut rx: tokio::sync::broadcast::Receiver<WardnetEvent>,
+    snapshot: Arc<DeviceIpSnapshot>,
+    cancel: CancellationToken,
+) {
+    loop {
+        tokio::select! {
+            () = cancel.cancelled() => break,
+            result = rx.recv() => {
+                match result {
+                    Ok(event) => {
+                        if is_relevant(&event) {
+                            drain_pending(&mut rx);
+                            rebuild(&snapshot).await;
+                        }
+                    }
+                    Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {
+                        // Missed events could include IP moves — rebuild
+                        // unconditionally to resync with the devices table.
+                        tracing::warn!(skipped = n, "device snapshot listener: lagged behind event bus: skipped={n}");
+                        rebuild(&snapshot).await;
+                    }
+                    Err(tokio::sync::broadcast::error::RecvError::Closed) => {
+                        tracing::info!("device snapshot listener: event bus closed");
+                        break;
+                    }
+                }
+            }
+        }
+    }
+}
+
+fn is_relevant(event: &WardnetEvent) -> bool {
+    matches!(
+        event,
+        WardnetEvent::DeviceDiscovered { .. }
+            | WardnetEvent::DeviceIpChanged { .. }
+            | WardnetEvent::DeviceGone { .. }
+    )
+}
+
+/// Collapse an event burst into one rebuild: a departure sweep or discovery
+/// scan publishes one event per device, and every rebuild is a full read of
+/// the devices table — draining whatever is already queued before rebuilding
+/// turns N back-to-back events into a single rebuild that sees all of them.
+/// (Same burst-collapsing rationale as the zone enforcer's FIX 6.) Dropping
+/// the drained events is safe because this listener reacts to every one of
+/// them identically, and irrelevant event types are ignored anyway.
+fn drain_pending(rx: &mut tokio::sync::broadcast::Receiver<WardnetEvent>) {
+    while matches!(
+        rx.try_recv(),
+        Ok(_) | Err(tokio::sync::broadcast::error::TryRecvError::Lagged(_))
+    ) {}
+}
+
+async fn rebuild(snapshot: &DeviceIpSnapshot) {
+    if let Err(e) = snapshot.rebuild().await {
+        tracing::warn!(error = %e, "failed to rebuild device IP snapshot: {e}");
+    }
+}

--- a/source/daemon/crates/wardnetd/src/dns/server.rs
+++ b/source/daemon/crates/wardnetd/src/dns/server.rs
@@ -121,6 +121,12 @@ pub struct UdpDnsServer {
     /// routing service. Maps a tunneled-device IP to `Tunnel(_)` only
     /// when that tunnel has `override_default_dns = true`.
     routing_snapshot: Arc<ArcSwap<HashMap<IpAddr, UpstreamId>>>,
+    /// Lock-free IP → device-id snapshot, kept current by the
+    /// device-snapshot listener. Consulted once per query so log rows and
+    /// stats carry the device identity as of query time — re-deriving it
+    /// at read time would misattribute traffic after DHCP hands the IP to
+    /// a different device.
+    device_snapshot: Arc<ArcSwap<HashMap<IpAddr, Uuid>>>,
     /// Tunnel repository — needed to translate `Tunnel(uuid)` from the
     /// routing snapshot into the interface name + DNS upstream we should
     /// forward to via `SO_BINDTODEVICE`.
@@ -195,6 +201,7 @@ impl UdpDnsServer {
         config: DnsConfig,
         dns_filter: Arc<dyn DnsFilterService>,
         routing_snapshot: Arc<ArcSwap<HashMap<IpAddr, UpstreamId>>>,
+        device_snapshot: Arc<ArcSwap<HashMap<IpAddr, Uuid>>>,
         tunnel_repo: Arc<dyn TunnelRepository>,
         events: Arc<dyn EventPublisher>,
     ) -> Self {
@@ -203,6 +210,7 @@ impl UdpDnsServer {
             SocketAddr::from(([0, 0, 0, 0], 53)),
             dns_filter,
             routing_snapshot,
+            device_snapshot,
             tunnel_repo,
             events,
         )
@@ -218,6 +226,7 @@ impl UdpDnsServer {
         bind_addr: SocketAddr,
         dns_filter: Arc<dyn DnsFilterService>,
         routing_snapshot: Arc<ArcSwap<HashMap<IpAddr, UpstreamId>>>,
+        device_snapshot: Arc<ArcSwap<HashMap<IpAddr, Uuid>>>,
         tunnel_repo: Arc<dyn TunnelRepository>,
         events: Arc<dyn EventPublisher>,
     ) -> Self {
@@ -271,6 +280,7 @@ impl UdpDnsServer {
             local_addr: Arc::new(std::sync::Mutex::new(None)),
             log_sink: None,
             routing_snapshot,
+            device_snapshot,
             tunnel_repo,
             tunnel_forwarders: Arc::new(RwLock::new(HashMap::new())),
             cache_invalidator_cancel,
@@ -343,6 +353,7 @@ impl DnsServer for UdpDnsServer {
         let running = Arc::clone(&self.running);
         let log_sink = self.log_sink.clone();
         let routing_snapshot = Arc::clone(&self.routing_snapshot);
+        let device_snapshot = Arc::clone(&self.device_snapshot);
         let tunnel_repo = Arc::clone(&self.tunnel_repo);
         let tunnel_forwarders = Arc::clone(&self.tunnel_forwarders);
         let authoritative_view = Arc::clone(&self.authoritative_view);
@@ -373,6 +384,7 @@ impl DnsServer for UdpDnsServer {
                 cancel,
                 tracker,
                 routing_snapshot,
+                device_snapshot,
                 tunnel_repo,
                 tunnel_forwarders,
                 authoritative_view,
@@ -505,6 +517,7 @@ async fn server_loop(
     cancel: CancellationToken,
     tracker: TaskTracker,
     routing_snapshot: Arc<ArcSwap<HashMap<IpAddr, UpstreamId>>>,
+    device_snapshot: Arc<ArcSwap<HashMap<IpAddr, Uuid>>>,
     tunnel_repo: Arc<dyn TunnelRepository>,
     tunnel_forwarders: Arc<RwLock<HashMap<Uuid, Arc<TunnelForwarderInfo>>>>,
     authoritative_view: Arc<ArcSwap<AuthoritativeView>>,
@@ -531,6 +544,7 @@ async fn server_loop(
                         let recursor = Arc::clone(&recursor);
                         let log_sink = log_sink.clone();
                         let routing_snapshot = Arc::clone(&routing_snapshot);
+                        let device_snapshot = Arc::clone(&device_snapshot);
                         let tunnel_repo = Arc::clone(&tunnel_repo);
                         let tunnel_forwarders = Arc::clone(&tunnel_forwarders);
                         let authoritative_view = Arc::clone(&authoritative_view);
@@ -552,6 +566,7 @@ async fn server_loop(
                                 &recursor,
                                 log_sink.as_deref(),
                                 &routing_snapshot,
+                                &device_snapshot,
                                 &tunnel_repo,
                                 &tunnel_forwarders,
                                 &authoritative_view,
@@ -586,6 +601,7 @@ async fn handle_query(
     recursor: &Arc<RwLock<Option<TokioRecursor>>>,
     log_sink: Option<&DnsLogSink>,
     routing_snapshot: &Arc<ArcSwap<HashMap<IpAddr, UpstreamId>>>,
+    device_snapshot: &Arc<ArcSwap<HashMap<IpAddr, Uuid>>>,
     tunnel_repo: &Arc<dyn TunnelRepository>,
     tunnel_forwarders: &Arc<RwLock<HashMap<Uuid, Arc<TunnelForwarderInfo>>>>,
     authoritative_view: &Arc<ArcSwap<AuthoritativeView>>,
@@ -604,6 +620,12 @@ async fn handle_query(
     let rtype = question.query_type();
     let start = std::time::Instant::now();
 
+    // Resolve the querying device once, from the point-in-time IP →
+    // device-id snapshot (wait-free load, no locks). Carried into every
+    // recorded log row and stat so the attribution survives DHCP later
+    // reassigning this IP to a different device. `None` = unknown client.
+    let device_id = device_snapshot.load().get(&src.ip()).copied();
+
     // 1. Rate limit (per-client token bucket). 0 disables; shed flooding
     // clients before any resolution work, returning REFUSED. The rate is
     // read lock-free from the limiter (no config lock on the hot path).
@@ -614,6 +636,7 @@ async fn handle_query(
             &domain,
             rtype,
             src,
+            device_id,
             DnsQueryResult::RateLimited.as_str(),
             None,
             start.elapsed(),
@@ -717,6 +740,7 @@ async fn handle_query(
             &domain,
             rtype,
             src,
+            device_id,
             DnsQueryResult::Authoritative.as_str(),
             None,
             start.elapsed(),
@@ -787,7 +811,16 @@ async fn handle_query(
             DnsQueryResult::AuthoritativeNxdomain.as_str()
         };
         tracing::trace!(%domain, ?rtype, result, "authoritative negative answer: {result}");
-        record_query(log_sink, &domain, rtype, src, result, None, start.elapsed());
+        record_query(
+            log_sink,
+            &domain,
+            rtype,
+            src,
+            device_id,
+            result,
+            None,
+            start.elapsed(),
+        );
         return Ok(());
     }
 
@@ -807,6 +840,7 @@ async fn handle_query(
                 &domain,
                 rtype,
                 src,
+                device_id,
                 DnsQueryResult::CacheHit.as_str(),
                 None,
                 start.elapsed(),
@@ -833,6 +867,7 @@ async fn handle_query(
                 &domain,
                 rtype,
                 src,
+                device_id,
                 DnsQueryResult::Blocked.as_str(),
                 None,
                 start.elapsed(),
@@ -869,6 +904,7 @@ async fn handle_query(
                 &domain,
                 rtype,
                 src,
+                device_id,
                 DnsQueryResult::Rewritten.as_str(),
                 None,
                 start.elapsed(),
@@ -896,6 +932,7 @@ async fn handle_query(
             &request,
             id,
             src,
+            device_id,
             &domain,
             rtype,
             start,
@@ -917,6 +954,7 @@ async fn handle_query(
                 &domain,
                 rtype,
                 src,
+                device_id,
                 DnsQueryResult::UpstreamError.as_str(),
                 Some(cond_upstream.ip().to_string()),
                 start.elapsed(),
@@ -939,6 +977,7 @@ async fn handle_query(
                     request,
                     id,
                     src,
+                    device_id,
                     &domain,
                     rtype,
                     start,
@@ -956,6 +995,7 @@ async fn handle_query(
                     request,
                     id,
                     src,
+                    device_id,
                     &domain,
                     rtype,
                     start,
@@ -978,6 +1018,7 @@ async fn handle_query(
                         &request,
                         id,
                         src,
+                        device_id,
                         &domain,
                         rtype,
                         start,
@@ -998,6 +1039,7 @@ async fn handle_query(
                             &domain,
                             rtype,
                             src,
+                            device_id,
                             DnsQueryResult::UpstreamError.as_str(),
                             Some(forwarder.upstream.ip().to_string()),
                             start.elapsed(),
@@ -1016,6 +1058,7 @@ async fn handle_query(
                         &domain,
                         rtype,
                         src,
+                        device_id,
                         DnsQueryResult::UpstreamError.as_str(),
                         None,
                         start.elapsed(),
@@ -1038,6 +1081,7 @@ async fn forward_via_default_resolver(
     request: Message,
     id: u16,
     src: SocketAddr,
+    device_id: Option<Uuid>,
     domain: &str,
     rtype: hickory_proto::rr::RecordType,
     start: std::time::Instant,
@@ -1059,6 +1103,7 @@ async fn forward_via_default_resolver(
                 &request,
                 id,
                 src,
+                device_id,
                 domain,
                 rtype,
                 start,
@@ -1084,6 +1129,7 @@ async fn forward_via_default_resolver(
                 &request,
                 id,
                 src,
+                device_id,
                 domain,
                 rtype,
                 start,
@@ -1106,6 +1152,7 @@ async fn forward_via_default_resolver(
                 domain,
                 rtype,
                 src,
+                device_id,
                 DnsQueryResult::UpstreamError.as_str(),
                 upstream,
                 elapsed,
@@ -1127,6 +1174,7 @@ async fn send_resolved(
     request: &Message,
     id: u16,
     src: SocketAddr,
+    device_id: Option<Uuid>,
     domain: &str,
     rtype: hickory_proto::rr::RecordType,
     start: std::time::Instant,
@@ -1159,6 +1207,7 @@ async fn send_resolved(
             domain,
             rtype,
             src,
+            device_id,
             DnsQueryResult::RebindingBlocked.as_str(),
             upstream_label,
             start.elapsed(),
@@ -1201,6 +1250,7 @@ async fn send_resolved(
         domain,
         rtype,
         src,
+        device_id,
         pass_result,
         upstream_label,
         elapsed,
@@ -1224,6 +1274,7 @@ pub(crate) async fn resolve_via_recursor(
     request: Message,
     id: u16,
     src: SocketAddr,
+    device_id: Option<Uuid>,
     domain: &str,
     rtype: hickory_proto::rr::RecordType,
     start: std::time::Instant,
@@ -1258,6 +1309,7 @@ pub(crate) async fn resolve_via_recursor(
         request,
         id,
         src,
+        device_id,
         domain,
         rtype,
         start,
@@ -1282,6 +1334,7 @@ pub(crate) async fn handle_recursor_outcome(
     request: Message,
     id: u16,
     src: SocketAddr,
+    device_id: Option<Uuid>,
     domain: &str,
     rtype: hickory_proto::rr::RecordType,
     start: std::time::Instant,
@@ -1307,6 +1360,7 @@ pub(crate) async fn handle_recursor_outcome(
                 &request,
                 id,
                 src,
+                device_id,
                 domain,
                 rtype,
                 start,
@@ -1333,6 +1387,7 @@ pub(crate) async fn handle_recursor_outcome(
                 &request,
                 id,
                 src,
+                device_id,
                 domain,
                 rtype,
                 start,
@@ -1362,6 +1417,7 @@ pub(crate) async fn handle_recursor_outcome(
                     request,
                     id,
                     src,
+                    device_id,
                     domain,
                     rtype,
                     start,
@@ -1376,6 +1432,7 @@ pub(crate) async fn handle_recursor_outcome(
                     domain,
                     rtype,
                     src,
+                    device_id,
                     DnsQueryResult::RecursorFailed.as_str(),
                     None,
                     start.elapsed(),
@@ -1397,6 +1454,7 @@ async fn forward_via_tunnel(
     _request: &Message,
     _id: u16,
     src: SocketAddr,
+    device_id: Option<Uuid>,
     domain: &str,
     rtype: hickory_proto::rr::RecordType,
     start: std::time::Instant,
@@ -1468,6 +1526,7 @@ async fn forward_via_tunnel(
         domain,
         rtype,
         src,
+        device_id,
         result,
         Some(forwarder.upstream.ip().to_string()),
         elapsed,
@@ -1555,6 +1614,7 @@ async fn relay_negative(
     request: &Message,
     id: u16,
     src: SocketAddr,
+    device_id: Option<Uuid>,
     domain: &str,
     rtype: hickory_proto::rr::RecordType,
     start: std::time::Instant,
@@ -1615,6 +1675,7 @@ async fn relay_negative(
         domain,
         rtype,
         src,
+        device_id,
         result,
         upstream_label,
         start.elapsed(),
@@ -1721,11 +1782,13 @@ fn bind_socket_to_device(_interface_name: &str) -> std::io::Result<UdpSocket> {
     UdpSocket::from_std(std_socket)
 }
 
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn record_query(
     sink: Option<&DnsLogSink>,
     domain: &str,
     rtype: hickory_proto::rr::RecordType,
     src: SocketAddr,
+    device_id: Option<Uuid>,
     result: &str,
     upstream: Option<String>,
     latency: std::time::Duration,
@@ -1740,7 +1803,7 @@ pub(crate) fn record_query(
         result: result.to_owned(),
         upstream,
         latency_ms: duration_to_ms(latency),
-        device_id: None,
+        device_id: device_id.map(|id| id.to_string()),
     };
     sink.record(row);
 }
@@ -1912,6 +1975,7 @@ async fn forward_via_conditional(
     request: &Message,
     id: u16,
     src: SocketAddr,
+    device_id: Option<Uuid>,
     domain: &str,
     rtype: hickory_proto::rr::RecordType,
     start: std::time::Instant,
@@ -2004,6 +2068,7 @@ async fn forward_via_conditional(
         domain,
         rtype,
         src,
+        device_id,
         result,
         Some(upstream.ip().to_string()),
         elapsed,

--- a/source/daemon/crates/wardnetd/src/dns/tests/server.rs
+++ b/source/daemon/crates/wardnetd/src/dns/tests/server.rs
@@ -55,6 +55,10 @@ fn empty_routing_snapshot() -> Arc<ArcSwap<HashMap<IpAddr, UpstreamId>>> {
     Arc::new(ArcSwap::from_pointee(HashMap::new()))
 }
 
+fn empty_device_snapshot() -> Arc<ArcSwap<HashMap<IpAddr, uuid::Uuid>>> {
+    Arc::new(ArcSwap::from_pointee(HashMap::new()))
+}
+
 fn stub_tunnel_repo() -> Arc<dyn TunnelRepository> {
     struct Stub;
     #[async_trait]
@@ -339,6 +343,7 @@ fn build_test_server(config: DnsConfig, bind_addr: SocketAddr) -> UdpDnsServer {
         bind_addr,
         stub_filter(),
         empty_routing_snapshot(),
+        empty_device_snapshot(),
         stub_tunnel_repo(),
         stub_events(),
     )
@@ -609,6 +614,7 @@ fn record_query_with_no_sink_is_a_noop() {
         "example.com",
         RecordType::A,
         src,
+        None,
         "blocked",
         None,
         Duration::from_millis(2),
@@ -628,6 +634,7 @@ async fn record_query_with_sink_pushes_a_row_with_normalized_domain() {
         "example.com.",
         RecordType::AAAA,
         src,
+        None,
         "passed",
         Some("1.1.1.1".into()),
         Duration::from_millis(7),
@@ -681,6 +688,7 @@ async fn server_records_query_after_handling_it() {
         loopback_ephemeral(),
         stub_filter(),
         empty_routing_snapshot(),
+        empty_device_snapshot(),
         stub_tunnel_repo(),
         stub_events(),
     )
@@ -953,6 +961,7 @@ fn build_with_filter(
         loopback_ephemeral(),
         filter,
         empty_routing_snapshot(),
+        empty_device_snapshot(),
         stub_tunnel_repo(),
         stub_events(),
     )
@@ -1074,6 +1083,7 @@ async fn handle_query_tunnel_branch_records_upstream_error_when_forward_fails() 
         loopback_ephemeral(),
         filter,
         snapshot,
+        empty_device_snapshot(),
         tunnel_repo,
         stub_events(),
     )
@@ -1559,6 +1569,7 @@ async fn dns_filter_rebuilt_event_flushes_response_cache() {
         loopback_ephemeral(),
         filter.clone() as Arc<dyn wardnetd_services::DnsFilterService>,
         empty_routing_snapshot(),
+        empty_device_snapshot(),
         stub_tunnel_repo(),
         bus.clone(),
     );
@@ -2226,6 +2237,7 @@ async fn recursor_unavailable_falls_back_to_forwarding_when_upstreams_set() {
         foo_com_request(),
         0xCAFE,
         src,
+        None,
         "foo.com",
         RecordType::A,
         std::time::Instant::now(),
@@ -2281,6 +2293,7 @@ async fn recursor_unavailable_servfails_when_no_upstreams() {
         foo_com_request(),
         0xCAFE,
         src,
+        None,
         "foo.com",
         RecordType::A,
         std::time::Instant::now(),
@@ -2382,6 +2395,7 @@ async fn run_recursor_outcome(
         request,
         0xCAFE,
         src,
+        None,
         "foo.com",
         rtype,
         std::time::Instant::now(),
@@ -2632,6 +2646,7 @@ async fn resolve_via_recursor_servfails_on_empty_query() {
         request,
         0xABCD,
         src,
+        None,
         "",
         RecordType::A,
         std::time::Instant::now(),

--- a/source/daemon/crates/wardnetd/src/lib.rs
+++ b/source/daemon/crates/wardnetd/src/lib.rs
@@ -27,6 +27,7 @@ pub mod tls_server;
 
 // Background tasks.
 pub mod device_detector;
+pub mod device_snapshot_listener;
 pub mod entitlement_listener;
 pub mod garp_learning;
 pub mod health_runner;

--- a/source/daemon/crates/wardnetd/src/main.rs
+++ b/source/daemon/crates/wardnetd/src/main.rs
@@ -22,6 +22,7 @@ use tracing_subscriber::util::SubscriberInitExt;
 use wardnet_common::auth::AuthContext;
 use wardnet_common::config::{ApplicationConfiguration, LogFormat, LogRotation, OtelConfig};
 use wardnetd::device_detector::DeviceDetector;
+use wardnetd::device_snapshot_listener::DeviceSnapshotListener;
 use wardnetd::entitlement_listener::EntitlementListener;
 use wardnetd::firewall_netlink::NetlinkFirewallManager;
 use wardnetd::garp_pnet::PnetGarpOps;
@@ -507,6 +508,21 @@ async fn run(
         config.tunnel.latency_probe_interval_secs,
         &root_span,
     );
+    // DNS hot-path IP → device-id snapshot: the listener must subscribe
+    // BEFORE any device-event publisher starts (the inbound-WG peer monitor
+    // below can publish on its immediate first tick, and the broadcast bus
+    // drops events with no subscriber), and the initial build runs after the
+    // subscribe so an event landing mid-build is buffered, not lost. A
+    // failed initial build is non-fatal: queries record without device
+    // attribution until the first successful rebuild.
+    let device_snapshot_listener = DeviceSnapshotListener::start(
+        &services.event_publisher,
+        services.device_ip_snapshot.clone(),
+        &root_span,
+    );
+    if let Err(e) = services.device_ip_snapshot.rebuild().await {
+        tracing::warn!(error = %e, "initial device IP snapshot build failed: {e}");
+    }
     // Inbound WireGuard peer liveness → device presence (#810). Always started:
     // `list_peers_for_monitor` naturally returns empty when the server is
     // disabled or has no peers, so the loop no-ops until a peer handshakes.
@@ -635,6 +651,7 @@ async fn run(
             wardnet_common::dns::DnsConfig::default(),
             services.dns_filter.clone(),
             services.routing.dns_upstream_snapshot(),
+            services.device_ip_snapshot.snapshot(),
             services.tunnel_repo.clone(),
             services.event_publisher.clone(),
         )
@@ -1058,6 +1075,7 @@ async fn run(
     }
     health_runner.shutdown().await;
     routing_listener.shutdown().await;
+    device_snapshot_listener.shutdown().await;
     zone_enforcement_listener.shutdown().await;
     entitlement_listener.shutdown().await;
     push_listener.shutdown().await;

--- a/source/daemon/crates/wardnetd/src/tests/device_snapshot_listener.rs
+++ b/source/daemon/crates/wardnetd/src/tests/device_snapshot_listener.rs
@@ -1,0 +1,320 @@
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use async_trait::async_trait;
+use chrono::Utc;
+use uuid::Uuid;
+use wardnet_common::device::{Device, DeviceConnectionMode};
+use wardnet_common::event::WardnetEvent;
+use wardnet_common::routing::RoutingRule;
+
+use wardnetd_data::repository::DeviceRepository;
+use wardnetd_data::repository::device::DeviceRow;
+use wardnetd_services::device::DeviceIpSnapshot;
+use wardnetd_services::event::{BroadcastEventBus, EventPublisher};
+
+use crate::device_snapshot_listener::DeviceSnapshotListener;
+
+// ---------------------------------------------------------------------------
+// MockDeviceRepo
+// ---------------------------------------------------------------------------
+
+/// Counts `find_all` calls so tests can assert whether a rebuild happened,
+/// without needing real device fixtures.
+struct MockDeviceRepo {
+    find_all_calls: AtomicUsize,
+    /// When `true`, `find_all` returns an error instead of an empty list.
+    fail: bool,
+}
+
+impl MockDeviceRepo {
+    fn new() -> Self {
+        Self {
+            find_all_calls: AtomicUsize::new(0),
+            fail: false,
+        }
+    }
+
+    fn failing() -> Self {
+        Self {
+            find_all_calls: AtomicUsize::new(0),
+            fail: true,
+        }
+    }
+
+    fn call_count(&self) -> usize {
+        self.find_all_calls.load(Ordering::SeqCst)
+    }
+}
+
+#[async_trait]
+impl DeviceRepository for MockDeviceRepo {
+    async fn find_by_ip(&self, _ip: &str) -> anyhow::Result<Option<Device>> {
+        unimplemented!("not exercised by DeviceSnapshotListener")
+    }
+    async fn find_by_id(&self, _id: &str) -> anyhow::Result<Option<Device>> {
+        unimplemented!("not exercised by DeviceSnapshotListener")
+    }
+    async fn find_by_mac(&self, _mac: &str) -> anyhow::Result<Option<Device>> {
+        unimplemented!("not exercised by DeviceSnapshotListener")
+    }
+    async fn find_all(&self) -> anyhow::Result<Vec<Device>> {
+        self.find_all_calls.fetch_add(1, Ordering::SeqCst);
+        if self.fail {
+            anyhow::bail!("mock: find_all failed");
+        }
+        Ok(Vec::new())
+    }
+    async fn insert(&self, _device: &DeviceRow) -> anyhow::Result<()> {
+        unimplemented!("not exercised by DeviceSnapshotListener")
+    }
+    async fn update_last_seen_and_ip(
+        &self,
+        _id: &str,
+        _ip: &str,
+        _last_seen: &str,
+        _mode: DeviceConnectionMode,
+    ) -> anyhow::Result<()> {
+        unimplemented!("not exercised by DeviceSnapshotListener")
+    }
+    async fn update_last_seen_batch(&self, _updates: &[(String, String)]) -> anyhow::Result<()> {
+        unimplemented!("not exercised by DeviceSnapshotListener")
+    }
+    async fn update_connection_mode(
+        &self,
+        _id: &str,
+        _mode: DeviceConnectionMode,
+    ) -> anyhow::Result<()> {
+        unimplemented!("not exercised by DeviceSnapshotListener")
+    }
+    async fn update_hostname(&self, _id: &str, _hostname: &str) -> anyhow::Result<()> {
+        unimplemented!("not exercised by DeviceSnapshotListener")
+    }
+    async fn update_name_and_type(
+        &self,
+        _id: &str,
+        _name: Option<&str>,
+        _device_type: &str,
+    ) -> anyhow::Result<()> {
+        unimplemented!("not exercised by DeviceSnapshotListener")
+    }
+    async fn find_stale(&self, _before: &str) -> anyhow::Result<Vec<Device>> {
+        unimplemented!("not exercised by DeviceSnapshotListener")
+    }
+    async fn find_rule_for_device(&self, _device_id: &str) -> anyhow::Result<Option<RoutingRule>> {
+        unimplemented!("not exercised by DeviceSnapshotListener")
+    }
+    async fn find_all_rules(&self) -> anyhow::Result<Vec<RoutingRule>> {
+        unimplemented!("not exercised by DeviceSnapshotListener")
+    }
+    async fn upsert_user_rule(
+        &self,
+        _device_id: &str,
+        _target_json: &str,
+        _now: &str,
+    ) -> anyhow::Result<()> {
+        unimplemented!("not exercised by DeviceSnapshotListener")
+    }
+    async fn find_devices_for_tunnel(&self, _tunnel_id: &str) -> anyhow::Result<Vec<Device>> {
+        unimplemented!("not exercised by DeviceSnapshotListener")
+    }
+    async fn switch_tunnel_rules_to_direct(
+        &self,
+        _tunnel_id: &str,
+        _now: &str,
+    ) -> anyhow::Result<Vec<String>> {
+        unimplemented!("not exercised by DeviceSnapshotListener")
+    }
+    async fn update_admin_locked(&self, _id: &str, _locked: bool) -> anyhow::Result<()> {
+        unimplemented!("not exercised by DeviceSnapshotListener")
+    }
+    async fn assign_zone(&self, _device_id: &str, _zone_id: &str) -> anyhow::Result<bool> {
+        unimplemented!("not exercised by DeviceSnapshotListener")
+    }
+    async fn count(&self) -> anyhow::Result<i64> {
+        unimplemented!("not exercised by DeviceSnapshotListener")
+    }
+    async fn update_dns_capture_settings(
+        &self,
+        _id: &str,
+        _enabled: Option<bool>,
+        _cap_count: Option<i64>,
+        _cap_days: Option<i64>,
+    ) -> anyhow::Result<bool> {
+        unimplemented!("not exercised by DeviceSnapshotListener")
+    }
+    async fn find_all_capture_enabled_ids(&self) -> anyhow::Result<Vec<String>> {
+        unimplemented!("not exercised by DeviceSnapshotListener")
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn device_discovered_triggers_rebuild() {
+    let bus: Arc<dyn EventPublisher> = Arc::new(BroadcastEventBus::new(16));
+    let repo = Arc::new(MockDeviceRepo::new());
+    let snapshot = Arc::new(DeviceIpSnapshot::new(repo.clone()));
+
+    let parent = tracing::info_span!("test");
+    let listener = DeviceSnapshotListener::start(&bus, snapshot, &parent);
+
+    bus.publish(WardnetEvent::DeviceDiscovered {
+        device_id: Uuid::new_v4(),
+        mac: "AA:BB:CC:DD:EE:01".to_owned(),
+        ip: "192.168.1.10".to_owned(),
+        hostname: None,
+        timestamp: Utc::now(),
+    });
+
+    tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+    listener.shutdown().await;
+
+    assert_eq!(repo.call_count(), 1);
+}
+
+#[tokio::test]
+async fn device_ip_changed_triggers_rebuild() {
+    let bus: Arc<dyn EventPublisher> = Arc::new(BroadcastEventBus::new(16));
+    let repo = Arc::new(MockDeviceRepo::new());
+    let snapshot = Arc::new(DeviceIpSnapshot::new(repo.clone()));
+
+    let parent = tracing::info_span!("test");
+    let listener = DeviceSnapshotListener::start(&bus, snapshot, &parent);
+
+    bus.publish(WardnetEvent::DeviceIpChanged {
+        device_id: Uuid::new_v4(),
+        mac: "AA:BB:CC:DD:EE:01".to_owned(),
+        old_ip: "192.168.1.10".to_owned(),
+        new_ip: "192.168.1.20".to_owned(),
+        timestamp: Utc::now(),
+    });
+
+    tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+    listener.shutdown().await;
+
+    assert_eq!(repo.call_count(), 1);
+}
+
+#[tokio::test]
+async fn device_gone_triggers_rebuild() {
+    let bus: Arc<dyn EventPublisher> = Arc::new(BroadcastEventBus::new(16));
+    let repo = Arc::new(MockDeviceRepo::new());
+    let snapshot = Arc::new(DeviceIpSnapshot::new(repo.clone()));
+
+    let parent = tracing::info_span!("test");
+    let listener = DeviceSnapshotListener::start(&bus, snapshot, &parent);
+
+    bus.publish(WardnetEvent::DeviceGone {
+        device_id: Uuid::new_v4(),
+        mac: "AA:BB:CC:DD:EE:01".to_owned(),
+        last_ip: "192.168.1.10".to_owned(),
+        timestamp: Utc::now(),
+    });
+
+    tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+    listener.shutdown().await;
+
+    assert_eq!(repo.call_count(), 1);
+}
+
+#[tokio::test]
+async fn unrelated_events_are_ignored() {
+    let bus: Arc<dyn EventPublisher> = Arc::new(BroadcastEventBus::new(16));
+    let repo = Arc::new(MockDeviceRepo::new());
+    let snapshot = Arc::new(DeviceIpSnapshot::new(repo.clone()));
+
+    let parent = tracing::info_span!("test");
+    let listener = DeviceSnapshotListener::start(&bus, snapshot, &parent);
+
+    bus.publish(WardnetEvent::TunnelStatsUpdated {
+        tunnel_id: Uuid::new_v4(),
+        status: wardnet_common::tunnel::TunnelStatus::Up,
+        bytes_tx: 1000,
+        bytes_rx: 2000,
+        last_handshake: None,
+        timestamp: Utc::now(),
+    });
+
+    tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+    listener.shutdown().await;
+
+    assert_eq!(
+        repo.call_count(),
+        0,
+        "an irrelevant event must not trigger a rebuild"
+    );
+}
+
+#[tokio::test]
+async fn shutdown_without_events_completes_cleanly() {
+    let bus: Arc<dyn EventPublisher> = Arc::new(BroadcastEventBus::new(16));
+    let repo = Arc::new(MockDeviceRepo::new());
+    let snapshot = Arc::new(DeviceIpSnapshot::new(repo.clone()));
+
+    let parent = tracing::info_span!("test");
+    let listener = DeviceSnapshotListener::start(&bus, snapshot, &parent);
+
+    listener.shutdown().await;
+
+    assert_eq!(repo.call_count(), 0);
+}
+
+#[tokio::test]
+async fn rebuild_error_does_not_panic() {
+    // Even if the rebuild errors, the listener loop must keep running —
+    // this is the "warn and continue" branch in `rebuild`.
+    let bus: Arc<dyn EventPublisher> = Arc::new(BroadcastEventBus::new(16));
+    let repo = Arc::new(MockDeviceRepo::failing());
+    let snapshot = Arc::new(DeviceIpSnapshot::new(repo.clone()));
+
+    let parent = tracing::info_span!("test");
+    let listener = DeviceSnapshotListener::start(&bus, snapshot, &parent);
+
+    bus.publish(WardnetEvent::DeviceDiscovered {
+        device_id: Uuid::new_v4(),
+        mac: "AA:BB:CC:DD:EE:01".to_owned(),
+        ip: "192.168.1.10".to_owned(),
+        hostname: None,
+        timestamp: Utc::now(),
+    });
+
+    tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+    listener.shutdown().await;
+
+    assert_eq!(repo.call_count(), 1);
+}
+
+#[tokio::test]
+async fn burst_of_relevant_events_collapses_into_fewer_rebuilds() {
+    // A departure sweep or discovery scan publishes one event per device;
+    // `drain_pending` should collapse a burst that's already queued by the
+    // time the handler runs into a single rebuild rather than one per event.
+    let bus: Arc<dyn EventPublisher> = Arc::new(BroadcastEventBus::new(16));
+    let repo = Arc::new(MockDeviceRepo::new());
+    let snapshot = Arc::new(DeviceIpSnapshot::new(repo.clone()));
+
+    let parent = tracing::info_span!("test");
+    let listener = DeviceSnapshotListener::start(&bus, snapshot, &parent);
+
+    for i in 0..5 {
+        bus.publish(WardnetEvent::DeviceDiscovered {
+            device_id: Uuid::new_v4(),
+            mac: format!("AA:BB:CC:DD:EE:{i:02}"),
+            ip: format!("192.168.1.{}", 10 + i),
+            hostname: None,
+            timestamp: Utc::now(),
+        });
+    }
+
+    tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+    listener.shutdown().await;
+
+    let calls = repo.call_count();
+    assert!(
+        (1..5).contains(&calls),
+        "expected the burst to collapse into fewer rebuilds than events, got {calls}"
+    );
+}

--- a/source/daemon/crates/wardnetd/src/tests/mod.rs
+++ b/source/daemon/crates/wardnetd/src/tests/mod.rs
@@ -1,4 +1,5 @@
 mod device_detector;
+mod device_snapshot_listener;
 mod firewall_netlink;
 mod garp_learning;
 mod health_runner;

--- a/source/sdk/wardnet-js/src/services/dns.ts
+++ b/source/sdk/wardnet-js/src/services/dns.ts
@@ -61,6 +61,7 @@ export class DnsService {
     if (params.offset !== undefined) parts.push(`offset=${params.offset}`);
     if (params.domain) parts.push(`domain=${enc(params.domain)}`);
     if (params.client_ip) parts.push(`client_ip=${enc(params.client_ip)}`);
+    if (params.device_id) parts.push(`device_id=${enc(params.device_id)}`);
     if (params.result) parts.push(`result=${enc(params.result)}`);
     const path = parts.length === 0 ? "/dns/log" : `/dns/log?${parts.join("&")}`;
     return this.client.request<ListQueryLogResponse>(path);

--- a/source/sdk/wardnet-js/src/services/stats.ts
+++ b/source/sdk/wardnet-js/src/services/stats.ts
@@ -65,6 +65,9 @@ export class StatsService {
       `to=${enc(q.to)}`,
       `limit=${q.limit}`,
     ];
+    if (q.fallback_label_key) {
+      parts.push(`fallback_label_key=${enc(q.fallback_label_key)}`);
+    }
     return this.client.request<StatsTopResponse>(`/stats/top?${parts.join("&")}`);
   }
 }

--- a/source/sdk/wardnet-js/src/types/dns.ts
+++ b/source/sdk/wardnet-js/src/types/dns.ts
@@ -170,6 +170,12 @@ export interface ListQueryLogParams {
   offset?: number;
   domain?: string;
   client_ip?: string;
+  /**
+   * Filter by the device attributed at query time (stable across DHCP
+   * reassignment, unlike `client_ip`). Rows from unknown sources have no
+   * device and only match `client_ip`.
+   */
+  device_id?: string;
   result?: DnsQueryResult;
 }
 

--- a/source/sdk/wardnet-js/src/types/stats.ts
+++ b/source/sdk/wardnet-js/src/types/stats.ts
@@ -39,6 +39,12 @@ export interface StatsQueryResponse {
 export interface StatsTopQuery {
   metric: string;
   label_key: string;
+  /**
+   * Label dimension to group by when `label_key` is absent from an
+   * entry's labels (e.g. rank by `device_id` falling back to `client`
+   * for queries from sources with no known device).
+   */
+  fallback_label_key?: string;
   from: string;
   to: string;
   limit: number;

--- a/source/web/src/hooks/useStats.ts
+++ b/source/web/src/hooks/useStats.ts
@@ -126,7 +126,11 @@ export function useDnsStatsDashboard(
         queryFn: () =>
           statsService.top({
             metric: "dns.queries.by_client",
-            label_key: "client",
+            // Rank by write-time device attribution so totals survive DHCP
+            // reassigning an IP; unattributed traffic falls back to
+            // grouping by its client IP rather than being dropped.
+            label_key: "device_id",
+            fallback_label_key: "client",
             from: topFrom,
             to: topTo,
             limit: 10,


### PR DESCRIPTION
## Problem

The DNS page's "Top clients" and the DNS query log identified clients by raw IP. Resolving IP → device at *read* time is wrong on a DHCP network: an IP observed in 24h-old data may since have been handed to a different device, so historical traffic would be attributed to whoever holds the IP *now*. The DNS Logs device filter had the same flaw (it resolved the chosen device to its current `last_ip` and filtered by IP).

## Approach

Capture device identity **once, at query time**, and carry the immutable device UUID forward:

- **`DeviceIpSnapshot`** — lock-free `ArcSwap<HashMap<IpAddr, Uuid>>` consulted per query on the DNS hot path (no DB reads), mirroring the routing `dns_upstream_snapshot` pattern. Rebuilt by a new **`DeviceSnapshotListener`** on `DeviceDiscovered` / `DeviceIpChanged` / `DeviceGone`, with event-burst coalescing (same rationale as zone enforcement's FIX 6). The listener subscribes **before** any device-event publisher starts so no startup event is lost.
- **Query log** — `record_query()` now populates the long-dormant `dns_query_log.device_id` column (existed since migration `20260414`, was always NULL). Side effect: the device DNS-capture pipeline gate (`DnsLogSink::record`) can now actually fire for capture-enabled devices — that's the feature working as designed.
- **Stats** — `dns.queries.by_client` labels become `{"client":ip,"device_id":uuid}` (`device_id` only when attributed). `top_n` gains an optional `fallback_label_key` with `COALESCE` grouping so unattributed traffic still surfaces grouped by IP rather than disappearing; `MAX(labels)` keeps the representative row deterministic. New `stats_intraday_device_id` expression index.
- **API/SDK** — `GET /api/dns/log` gains a `device_id` filter (the `client_ip` filter stays, now substring-match to suit the free-text input); `GET /api/stats/top` gains `fallback_label_key`. OpenAPI + TS SDK updated.
- **Admin-site** — Top clients ranks by device and renders name + icon linked to `/devices/:id` (current IP as secondary line; bare IP for unknown clients). DNS Logs: device dropdown filters by UUID, device cells resolve from the row's stored attribution, new free-text Client IP filter; both surfaces reuse the shared `HostCell`.
- **Mock seed** attributes devices identically, leaving one client unattributed to exercise the fallback rendering in dev.

**No backfill, intentionally**: pre-existing rows keep `device_id` NULL — back-attributing them via current IPs is exactly the misattribution this PR removes. Top-N self-heals within the 25h intraday retention.

## Verification

- `make check-daemon` (container: fmt + clippy `-D warnings` + full workspace tests) exit 0
- `make check-web` / `make check-sdk` green; admin-site 744/744 tests pass
- New tests: COALESCE fallback grouping (device aggregates across IPs; unattributed groups by IP), device_id query-log filter surviving DHCP churn, partial-IP substring filter
- Live verification against the mock: `/api/stats/top?label_key=device_id&fallback_label_key=client` returns attributed entries + IP fallback bucket; `/api/dns/log?device_id=…` returns only that device's rows
- Multi-agent code review run; all 8 findings fixed (startup subscribe race, exact-match IP filter, blank dropdown options, nondeterministic group labels, rebuild burst coalescing, HostCell reuse, duplicated top_n SQL, logging.md compliance)

## Merge Commit Message

feat(dns): attribute DNS logs and stats to devices at query time