### PR TITLE
fix(pwa): code-review follow-ups to the /app/ scope move

### DIFF
--- a/source/admin-app/src/index.css
+++ b/source/admin-app/src/index.css
@@ -96,22 +96,8 @@
   }
 }
 
-@keyframes slide-down {
-  from {
-    transform: translateY(-20px);
-    opacity: 0;
-  }
-  to {
-    transform: translateY(0);
-    opacity: 1;
-  }
-}
-
 @layer utilities {
   .animate-pulse-dot {
     animation: pulse-dot 2.4s infinite;
-  }
-  .animate-slide-down {
-    animation: slide-down 0.3s cubic-bezier(0.2, 0.8, 0.2, 1);
   }
 }

--- a/source/admin-app/src/sw.ts
+++ b/source/admin-app/src/sw.ts
@@ -19,12 +19,12 @@ registerPushHandlers(self, {
   badge: "icons/badge-96.png",
 });
 
-// Offline shell — all navigation requests fall back to the app-shell index
+// Offline shell — navigation requests fall back to the app-shell index.
+// Navigations are dispatched to the SW whose scope contains the destination
+// URL, so only `/admin-app/…` ones ever reach this route — no denylist
+// needed for the other surfaces or `/api`.
 const handler = createHandlerBoundToURL("/admin-app/index.html");
-const navigationRoute = new NavigationRoute(handler, {
-  denylist: [/^\/api/],
-});
-registerRoute(navigationRoute);
+registerRoute(new NavigationRoute(handler));
 
 self.addEventListener("message", (event) => {
   if (event.data?.type === "SKIP_WAITING") {

--- a/source/daemon/crates/wardnetd-api/src/api/tests/router.rs
+++ b/source/daemon/crates/wardnetd-api/src/api/tests/router.rs
@@ -200,14 +200,22 @@ async fn unknown_path_hits_fallback() {
 
 /// Paths outside every app surface — the user PWA's pre-move root tree — are
 /// permanently redirected into `/app/`, preserving path and query so old
-/// bookmarks, deep links, and installed start URLs keep landing. The redirect
-/// answers even when the box is not entitled (its target is what's gated).
+/// bookmarks, deep links, and installed start URLs keep landing; a slashless
+/// scope root is canonicalized to its trailing-slash URL so the served
+/// document is always inside its PWA scope. The redirects answer even when
+/// the box is not entitled (their targets are what's gated), and carry a
+/// bounded Cache-Control so a cached 308 can't permanently mask a path a
+/// future release starts serving.
 #[tokio::test]
 async fn legacy_root_paths_redirect_into_app_scope() {
     for (path, target) in [
         ("/", "/app/"),
         ("/dns", "/app/dns"),
         ("/routing?device=ab", "/app/routing?device=ab"),
+        ("/app", "/app/"),
+        ("/app?x=1", "/app/?x=1"),
+        ("/admin-app", "/admin-app/"),
+        ("/admin", "/admin/"),
     ] {
         for router in [full_router(), full_router_entitled()] {
             let req = Request::builder()
@@ -226,6 +234,15 @@ async fn legacy_root_paths_redirect_into_app_scope() {
                 .get(axum::http::header::LOCATION)
                 .and_then(|v| v.to_str().ok());
             assert_eq!(location, Some(target), "GET {path} Location header");
+            let cache_control = resp
+                .headers()
+                .get(axum::http::header::CACHE_CONTROL)
+                .and_then(|v| v.to_str().ok());
+            assert_eq!(
+                cache_control,
+                Some("max-age=86400"),
+                "GET {path} must bound how long the 308 may be cached"
+            );
         }
     }
 }

--- a/source/daemon/crates/wardnetd-api/src/web.rs
+++ b/source/daemon/crates/wardnetd-api/src/web.rs
@@ -43,22 +43,45 @@ enum Surface {
 }
 
 impl Surface {
-    /// Classify a (leading-slash-trimmed) request path into its app surface.
+    /// The path prefix (no slashes) each surface owns. Single source of
+    /// truth: [`Self::classify`] matches on it and the serving arm strips it,
+    /// so a surface path can never drift between the two.
+    const fn prefix(self) -> &'static str {
+        match self {
+            Self::AdminApp => "admin-app",
+            Self::AdminSite => "admin",
+            Self::UserApp => "app",
+        }
+    }
+
+    /// Classify a (leading-slash-trimmed) request path into its app surface
+    /// plus the tree-relative asset path.
+    ///
+    /// The empty asset path is returned both for the canonical scope root
+    /// (`app/`) and for the slashless form (`app`); the handler redirects the
+    /// slashless form to the trailing-slash URL, because a document served at
+    /// `/app` sits *outside* the PWA scope `/app/` (scope matching is string
+    /// prefix), where the service worker never controls it and the install
+    /// prompt can be withheld.
     ///
     /// `None` means the path matches no surface — the legacy root tree the
     /// user PWA occupied before it moved to `/app/`. Those are answered with
     /// a permanent redirect into `/app/` (see [`legacy_root_redirect`]) so
     /// pre-move bookmarks, deep links, and installed start URLs keep landing.
-    fn classify(raw_path: &str) -> Option<Self> {
-        if raw_path.starts_with("admin-app/") || raw_path == "admin-app" {
-            Some(Self::AdminApp)
-        } else if raw_path.starts_with("admin/") || raw_path == "admin" {
-            Some(Self::AdminSite)
-        } else if raw_path.starts_with("app/") || raw_path == "app" {
-            Some(Self::UserApp)
-        } else {
-            None
+    fn classify(raw_path: &str) -> Option<(Self, &str)> {
+        for surface in [Self::AdminApp, Self::AdminSite, Self::UserApp] {
+            // Boundary-checked prefix match: "admin-app/x" must not match the
+            // "admin" prefix, so the remainder has to be empty or start "/".
+            if let Some(rest) = raw_path.strip_prefix(surface.prefix()) {
+                if rest.is_empty() {
+                    return Some((surface, ""));
+                }
+                if let Some(asset_path) = rest.strip_prefix('/') {
+                    return Some((surface, asset_path));
+                }
+            }
         }
+        None
     }
 
     /// Whether this surface is a premium app, blocked unless the box is
@@ -81,7 +104,9 @@ impl Surface {
 /// based on path prefix, then serves static files with appropriate cache headers.
 ///
 /// - Paths outside every surface (the user PWA's pre-move root tree) get a
-///   permanent redirect into `/app/`, before any other handling.
+///   permanent redirect into `/app/`, before any other handling; a slashless
+///   scope root (`/app`) is canonicalized to its trailing-slash URL so the
+///   document always sits inside its PWA scope.
 /// - Unless the box is **entitled** (on the wardnet provider and not
 ///   suspended), the two premium surfaces (user PWA `/app/` and admin mobile
 ///   app `/admin-app/`) are short-circuited with a premium-required page; the
@@ -105,9 +130,20 @@ pub async fn static_handler(
     let raw_path = uri.path().trim_start_matches('/');
     let etag = format!("\"{RELEASE_VERSION}\"");
 
-    let Some(surface) = Surface::classify(raw_path) else {
+    let Some((surface, asset_path)) = Surface::classify(raw_path) else {
         return legacy_root_redirect(&uri);
     };
+
+    // Slashless scope root (`/app`, `/admin-app`, `/admin`): canonicalize to
+    // the trailing-slash URL instead of serving the shell in place, so every
+    // document URL is inside its PWA scope (see `Surface::classify`).
+    if raw_path.len() == surface.prefix().len() {
+        let target = match uri.query() {
+            Some(query) => format!("/{}/?{query}", surface.prefix()),
+            None => format!("/{}/", surface.prefix()),
+        };
+        return permanent_redirect(&target);
+    }
 
     // Entitlement gate — checked *before* the `.info`/304 shortcuts so a cached
     // build can't slip a premium surface past the block via `If-None-Match`. The
@@ -134,51 +170,44 @@ pub async fn static_handler(
         return (StatusCode::NOT_MODIFIED, [(header::ETAG, etag.as_str())]).into_response();
     }
 
-    match surface {
-        Surface::AdminApp => {
-            let asset_path = raw_path.strip_prefix("admin-app/").unwrap_or("");
-            serve_spa(
-                AdminAppAssets::get(asset_path),
-                AdminAppAssets::get("index.html"),
-                asset_path,
-                &etag,
-            )
-        }
-        Surface::AdminSite => {
-            let asset_path = raw_path.strip_prefix("admin/").unwrap_or("");
-            serve_spa(
-                AdminSiteAssets::get(asset_path),
-                AdminSiteAssets::get("index.html"),
-                asset_path,
-                &etag,
-            )
-        }
-        Surface::UserApp => {
-            let asset_path = raw_path.strip_prefix("app/").unwrap_or("");
-            serve_spa(
-                UserAssets::get(asset_path),
-                UserAssets::get("index.html"),
-                asset_path,
-                &etag,
-            )
-        }
-    }
+    let (file, fallback) = match surface {
+        Surface::AdminApp => (
+            AdminAppAssets::get(asset_path),
+            AdminAppAssets::get("index.html"),
+        ),
+        Surface::AdminSite => (
+            AdminSiteAssets::get(asset_path),
+            AdminSiteAssets::get("index.html"),
+        ),
+        Surface::UserApp => (UserAssets::get(asset_path), UserAssets::get("index.html")),
+    };
+    serve_spa(file, fallback, asset_path, &etag)
+}
+
+/// A 308 with an explicit, bounded cache lifetime. Hand-rolled (rather than
+/// `axum::response::Redirect::permanent`) because the Cache-Control header
+/// matters: browsers cache header-less permanent redirects until eviction, so
+/// an unbounded 308 would keep bouncing clients even after a future release
+/// claims the redirected path for something real (a new surface,
+/// `/.well-known/*`). One day keeps the permanent "update your bookmark"
+/// semantics while capping how long a stale redirect can mask a new resource.
+fn permanent_redirect(target: &str) -> Response {
+    (
+        StatusCode::PERMANENT_REDIRECT,
+        [
+            (header::LOCATION, target),
+            (header::CACHE_CONTROL, "max-age=86400"),
+        ],
+    )
+        .into_response()
 }
 
 /// Permanently redirect a legacy root-tree path into the user PWA's `/app/`
 /// scope, preserving the rest of the path and any query string — `/` lands on
 /// `/app/`, a pre-move deep link like `/dns?x=1` lands on `/app/dns?x=1`.
 fn legacy_root_redirect(uri: &Uri) -> Response {
-    let path = uri.path();
-    let target = match uri.query() {
-        Some(query) => format!("/app{path}?{query}"),
-        None => format!("/app{path}"),
-    };
-    (
-        StatusCode::PERMANENT_REDIRECT,
-        [(header::LOCATION, target.as_str())],
-    )
-        .into_response()
+    let path_and_query = uri.path_and_query().map_or(uri.path(), |pq| pq.as_str());
+    permanent_redirect(&format!("/app{path_and_query}"))
 }
 
 /// The page served at a premium surface when the box is not entitled — either

--- a/source/user-app/src/index.css
+++ b/source/user-app/src/index.css
@@ -97,22 +97,8 @@
   }
 }
 
-@keyframes slide-down {
-  from {
-    transform: translateY(-20px);
-    opacity: 0;
-  }
-  to {
-    transform: translateY(0);
-    opacity: 1;
-  }
-}
-
 @layer utilities {
   .animate-pulse-dot {
     animation: pulse-dot 2.4s infinite;
-  }
-  .animate-slide-down {
-    animation: slide-down 0.3s cubic-bezier(0.2, 0.8, 0.2, 1);
   }
 }

--- a/source/user-app/src/sw.ts
+++ b/source/user-app/src/sw.ts
@@ -22,13 +22,11 @@ registerPushHandlers(self, {
 
 // Offline shell — navigation requests fall back to the app-shell index.
 // This SW's scope is `/app/` (sibling to `/admin-app/`, so the two PWAs are
-// installable side by side); only navigations inside that scope ever reach
-// it. The `/api` denylist mirrors the admin-app SW as belt and braces.
+// installable side by side); navigations are dispatched to the SW whose
+// scope contains the destination URL, so only `/app/…` ones ever reach this
+// route — no denylist needed for the other surfaces or `/api`.
 const handler = createHandlerBoundToURL("/app/index.html");
-const navigationRoute = new NavigationRoute(handler, {
-  denylist: [/^\/api/],
-});
-registerRoute(navigationRoute);
+registerRoute(new NavigationRoute(handler));
 
 self.addEventListener("message", (event) => {
   if (event.data?.type === "SKIP_WAITING") {

--- a/source/web/src/components/InstallPrompt.tsx
+++ b/source/web/src/components/InstallPrompt.tsx
@@ -43,7 +43,21 @@ export function InstallPrompt({ icon }: InstallPromptProps) {
   }
 
   return (
-    <div className="mx-3 mt-3 flex animate-slide-down items-center gap-3 rounded-lg border border-line bg-card p-3.5 shadow-pop">
+    <div
+      className="mx-3 mt-3 flex items-center gap-3 rounded-lg border border-line bg-card p-3.5 shadow-pop"
+      style={{
+        animation: "wn-install-slide-down 0.3s cubic-bezier(0.2, 0.8, 0.2, 1)",
+      }}
+    >
+      {/* Self-contained keyframes (same pattern as admin-site's
+          DiscoveryPlaceholder) so consumers don't each have to duplicate an
+          animation utility in their own stylesheet. */}
+      <style>{`
+        @keyframes wn-install-slide-down {
+          from { transform: translateY(-20px); opacity: 0; }
+          to { transform: translateY(0); opacity: 1; }
+        }
+      `}</style>
       <img src={icon} alt="" className="h-9 w-9 shrink-0 rounded-[10px]" />
       <div className="min-w-0 flex-1">
         <Text


### PR DESCRIPTION
Follow-ups from the multi-agent code review of #925 (all six verified findings, ranked by the review):

1. **Slashless scope roots now redirect** — `GET /app` served the SPA shell in place at a document URL *outside* the PWA scope `/app/` (scope matching is string-prefix), so that entry point was uncontrolled by the service worker and could be refused installation — the exact flow #925 exists to fix. `/app`, `/admin-app`, and `/admin` now 308 to their trailing-slash URLs.
2. **Bounded redirect caching** — browsers cache header-less permanent redirects until eviction, so the catch-all 308 could permanently mask any root path a future release claims (`/.well-known/*`, a fourth surface). Every 308 now carries `Cache-Control: max-age=86400`.
3. **Surface prefixes single-sourced** — the `"app/"` / `"admin/"` / `"admin-app/"` literals were duplicated between `Surface::classify` and the match arms' `strip_prefix` calls; drift would silently serve `index.html` for every asset URL. `Surface::prefix()` is now the one source, `classify` returns the stripped asset path, and the three copy-paste arms collapse to one `serve_spa` call.
4. **Dead SW denylist removed** — `denylist: [/^\/api/]` could never match in either app's service worker (navigations are dispatched to the SW whose scope contains the destination, and neither `/app/…` nor `/admin-app/…` pathnames match `/^\/api/`). Deleted in both, comments corrected.
5. **Shared banner animation self-contained** — the `animate-slide-down` utility was duplicated byte-identically in both apps' `index.css` for a component that lives in `@wardnet/web`. The keyframes now ship inline in the component (same pattern as admin-site's `DiscoveryPlaceholder`); both per-app CSS copies deleted.
6. **Redirect construction simplified** — `legacy_root_redirect` now derives path+query in one `uri.path_and_query()` expression through a shared `permanent_redirect` helper (which stays hand-rolled deliberately: it must attach the Cache-Control header from item 2).

New coverage: the router redirect test now asserts the slashless canonicalizations and the Cache-Control bound on every 308.

## Verification

- `make check-daemon` (containerized fmt + clippy `-D warnings` + workspace tests): green
- `turbo type-check lint` (web, user-app, admin-app) + prettier: green
- Unit tests: 299 (web) + 86 (user-app) + 111 (admin-app): green
- `user-app` production build (injectManifest SW compile): green

## Merge Commit Message

fix(pwa): canonicalize slashless scope roots with bounded-cache 308s, single-source surface prefixes, and de-duplicate SW denylists and the install-banner animation (review follow-ups to #925)

https://claude.ai/code/session_01DWQL566nMcRvz9BFr9g7ts