### PR TITLE
fix(pwa): pin install-success toast to top, drop "Pi" wording on zones page

### DIFF
--- a/source/admin-site/src/components/features/ZonesCard.tsx
+++ b/source/admin-site/src/components/features/ZonesCard.tsx
@@ -421,11 +421,11 @@ function ZoneForm({
 
           <Field
             label="Admin UI reachable"
-            help="May devices in this zone reach the Pi's admin surfaces?"
+            help="May devices in this zone reach the wardnet admin surfaces?"
           >
             <div className="flex h-9 items-center justify-between">
               <Text size="sm" className="text-ink-3">
-                Reach the Pi's admin pages
+                Reach the wardnet admin site/app
               </Text>
               <Toggle
                 aria-label="Admin UI reachable"

--- a/source/web/src/components/InstallPrompt.tsx
+++ b/source/web/src/components/InstallPrompt.tsx
@@ -33,7 +33,7 @@ export function InstallPrompt({ icon }: InstallPromptProps) {
     try {
       const result = await promptInstall();
       if (result?.outcome === "accepted") {
-        toast.success("Added to home screen");
+        toast.success("Added to home screen", { position: "top-center" });
       }
     } catch {
       // Browser cancelled or the prompt is no longer available — dismiss silently.

--- a/source/web/tests/components/InstallPrompt.test.tsx
+++ b/source/web/tests/components/InstallPrompt.test.tsx
@@ -45,7 +45,9 @@ describe("InstallPrompt", () => {
     await userEvent.click(screen.getByRole("button", { name: /Install/ }));
 
     await waitFor(() =>
-      expect(toast.success).toHaveBeenCalledWith("Added to home screen"),
+      expect(toast.success).toHaveBeenCalledWith("Added to home screen", {
+        position: "top-center",
+      }),
     );
     // Dismissed → component removed.
     await waitFor(() =>


### PR DESCRIPTION
## Summary
- The unified `InstallPrompt` banner (#925) renders in-flow at the top of the layout, but its "Added to home screen" confirmation toast used the shared `Toaster`'s default bottom-right position, so a bottom-pinned "install banner" was still visible after that fix. Pins that toast to `top-center` to match.
- Swaps "Reach the Pi's admin pages" / "reach the Pi's admin surfaces" copy on the zones page for Pi-agnostic wording, since the daemon isn't constrained to run on a Raspberry Pi.

## Test plan
- [x] `make check-web` (type-check, lint, format:check) passes
- [ ] Manually verify in the user-app: accept the install prompt and confirm the "Added to home screen" toast appears top-center, not bottom-right
- [ ] Visually confirm zones page copy reads "Reach the wardnet admin site/app"

## Merge Commit Message
fix(pwa): pin install-success toast to top, drop "Pi" wording on zones page