### PR TITLE
fix(daemon): trust zone subnets in device discovery, not just the LAN /24

### DIFF
--- a/source/daemon/crates/wardnetd-api/src/api/tests/devices.rs
+++ b/source/daemon/crates/wardnetd-api/src/api/tests/devices.rs
@@ -450,6 +450,9 @@ impl DeviceDiscoveryService for MockDiscoveryService {
     async fn restore_devices(&self) -> Result<(), AppError> {
         Ok(())
     }
+    async fn rebuild_trusted_subnets(&self) -> Result<(), AppError> {
+        Ok(())
+    }
     async fn process_observation(
         &self,
         _obs: &wardnetd_services::device::packet_capture::ObservedDevice,

--- a/source/daemon/crates/wardnetd-api/src/tests/stubs.rs
+++ b/source/daemon/crates/wardnetd-api/src/tests/stubs.rs
@@ -604,6 +604,9 @@ impl DeviceDiscoveryService for StubDiscoveryService {
     async fn restore_devices(&self) -> Result<(), AppError> {
         Ok(())
     }
+    async fn rebuild_trusted_subnets(&self) -> Result<(), AppError> {
+        Ok(())
+    }
     async fn process_observation(
         &self,
         _obs: &wardnetd_services::device::packet_capture::ObservedDevice,

--- a/source/daemon/crates/wardnetd-services/src/device/discovery.rs
+++ b/source/daemon/crates/wardnetd-services/src/device/discovery.rs
@@ -2,6 +2,7 @@ use std::collections::{HashMap, VecDeque};
 use std::sync::Arc;
 use std::time::Instant;
 
+use arc_swap::ArcSwap;
 use async_trait::async_trait;
 use tokio::sync::RwLock;
 use uuid::Uuid;
@@ -88,6 +89,20 @@ pub trait DeviceDiscoveryService: Send + Sync {
     /// Loads all devices and populates the in-memory map. All devices are marked
     /// as gone since we do not know if they are present until we see packets.
     async fn restore_devices(&self) -> Result<(), AppError>;
+
+    /// Rebuild the cached set of trusted subnets (the LAN `/24` plus every
+    /// configured Network-Zone subnet).
+    ///
+    /// Observations from IPs outside every trusted subnet are ignored, so this
+    /// set must be refreshed whenever a zone's subnet changes — otherwise a
+    /// device DHCP-addressed inside a zone subnet outside the base LAN `/24`
+    /// would have all its observations silently dropped, freezing its
+    /// presence and starving zone enforcement of `DeviceIpChanged` events.
+    ///
+    /// Called once at startup and on every [`WardnetEvent::NetworkZoneChanged`].
+    /// A zone whose subnet CIDR fails to parse is logged and skipped rather than
+    /// failing the whole rebuild.
+    async fn rebuild_trusted_subnets(&self) -> Result<(), AppError>;
 
     /// Process a device observation from packet capture.
     async fn process_observation(
@@ -189,10 +204,18 @@ pub struct DeviceDiscoveryServiceImpl {
     system_config: Arc<dyn SystemConfigRepository>,
     events: Arc<dyn EventPublisher>,
     resolver: Arc<dyn HostnameResolver>,
-    /// LAN subnet — only observations from IPs within this range are processed.
-    /// Filters out return traffic from the internet (remote IPs arriving with
-    /// the router's MAC on the Ethernet frame).
+    /// Base LAN subnet — the Pi's own `/24`. The immutable seed of the trusted
+    /// subnet set, re-added on every [`Self::rebuild_trusted_subnets`].
     lan_subnet: ipnetwork::Ipv4Network,
+    /// Cached set of trusted subnets: the LAN `/24` plus every configured
+    /// Network-Zone subnet. Only observations from IPs inside one of these are
+    /// processed — this filters out return traffic from the internet (remote
+    /// IPs arriving with the router's MAC on the Ethernet frame).
+    ///
+    /// Held behind an `ArcSwap` so the per-observation hot path reads a
+    /// lock-free snapshot while zone-change events rebuild it in place, rather
+    /// than issuing a DB query per observation.
+    trusted_subnets: ArcSwap<Vec<ipnetwork::Ipv4Network>>,
     /// Wardnet's own LAN IP. Never a device, whatever ARP says (issue #886).
     lan_ip: std::net::Ipv4Addr,
     /// Per-MAC recent distinct-IP history, keyed by MAC. Feeds the flap detector
@@ -228,6 +251,9 @@ impl DeviceDiscoveryServiceImpl {
             events,
             resolver,
             lan_subnet,
+            // Seeded with just the LAN subnet; zone subnets are folded in by the
+            // startup + event-driven `rebuild_trusted_subnets` calls.
+            trusted_subnets: ArcSwap::from_pointee(vec![lan_subnet]),
             lan_ip,
             state: Arc::new(RwLock::new(HashMap::new())),
             ip_history: Arc::new(RwLock::new(HashMap::new())),
@@ -563,6 +589,11 @@ enum ObsAction {
 #[async_trait]
 impl DeviceDiscoveryService for DeviceDiscoveryServiceImpl {
     async fn restore_devices(&self) -> Result<(), AppError> {
+        // Fold the configured zone subnets into the trusted set before we start
+        // processing observations, so a device inside a zone subnet isn't dropped
+        // in the window between startup and the first zone-change event.
+        self.rebuild_trusted_subnets().await?;
+
         let devices = self.devices.find_all().await.map_err(AppError::Internal)?;
         let count = devices.len();
 
@@ -625,18 +656,39 @@ impl DeviceDiscoveryService for DeviceDiscoveryServiceImpl {
         Ok(())
     }
 
+    async fn rebuild_trusted_subnets(&self) -> Result<(), AppError> {
+        let zones = self.zones.find_all().await.map_err(AppError::Internal)?;
+
+        // Start from the base LAN subnet; every valid zone subnet is folded in.
+        let mut subnets: Vec<ipnetwork::Ipv4Network> = Vec::with_capacity(zones.len() + 1);
+        subnets.push(self.lan_subnet);
+        subnets.extend(crate::subnet::parse_zone_subnets(&zones).into_iter().map(|(_, net)| net));
+
+        tracing::debug!(
+            count = subnets.len(),
+            "device discovery: rebuilt trusted subnets: count={count}",
+            count = subnets.len(),
+        );
+        self.trusted_subnets.store(Arc::new(subnets));
+        Ok(())
+    }
+
     async fn process_observation(
         &self,
         obs: &ObservedDevice,
     ) -> Result<ObservationResult, AppError> {
-        // Filter out observations from IPs outside the LAN subnet.
-        // When the Pi is the gateway, return traffic from the internet arrives
-        // with the router's MAC but remote server IPs — ignore those.
+        // Filter out observations from IPs outside every trusted subnet (the LAN
+        // `/24` plus any configured Network-Zone subnet). When the Pi is the
+        // gateway, return traffic from the internet arrives with the router's MAC
+        // but remote server IPs — ignore those. A device DHCP-addressed inside a
+        // zone subnet is trusted here, so its presence and IP changes flow through
+        // to zone enforcement.
         let parsed_ip = obs.ip.parse::<std::net::Ipv4Addr>().ok();
-        if let Some(ip) = parsed_ip
-            && !self.lan_subnet.contains(ip)
-        {
-            return Ok(ObservationResult::Ignored);
+        if let Some(ip) = parsed_ip {
+            let trusted = self.trusted_subnets.load();
+            if !trusted.iter().any(|subnet| subnet.contains(ip)) {
+                return Ok(ObservationResult::Ignored);
+            }
         }
 
         // Serialize the full observe-then-persist sequence for this mac against

--- a/source/daemon/crates/wardnetd-services/src/device/discovery.rs
+++ b/source/daemon/crates/wardnetd-services/src/device/discovery.rs
@@ -662,7 +662,11 @@ impl DeviceDiscoveryService for DeviceDiscoveryServiceImpl {
         // Start from the base LAN subnet; every valid zone subnet is folded in.
         let mut subnets: Vec<ipnetwork::Ipv4Network> = Vec::with_capacity(zones.len() + 1);
         subnets.push(self.lan_subnet);
-        subnets.extend(crate::subnet::parse_zone_subnets(&zones).into_iter().map(|(_, net)| net));
+        subnets.extend(
+            crate::subnet::parse_zone_subnets(&zones)
+                .into_iter()
+                .map(|(_, net)| net),
+        );
 
         tracing::debug!(
             count = subnets.len(),

--- a/source/daemon/crates/wardnetd-services/src/device/tests/discovery.rs
+++ b/source/daemon/crates/wardnetd-services/src/device/tests/discovery.rs
@@ -9,7 +9,9 @@ use uuid::Uuid;
 use wardnet_common::device::{Device, DeviceConnectionMode, DeviceType};
 use wardnet_common::dhcp::{DhcpLease, DhcpLeaseLog, DhcpLeaseStatus, DhcpReservation};
 use wardnet_common::event::WardnetEvent;
-use wardnet_common::network_zone::{AllowedTargetKind, NetworkZone, ZoneProvenance, ZoneStance};
+use wardnet_common::network_zone::{
+    AllowedTargetKind, NetworkZone, ZoneProvenance, ZoneStance, ZoneSubnet,
+};
 use wardnet_common::routing::RoutingRule;
 
 use wardnet_common::auth::AuthContext;
@@ -377,6 +379,72 @@ impl NetworkZoneRepository for MockNetworkZoneRepo {
     }
 }
 
+/// A zone repo whose zone list can be swapped at runtime, so tests can exercise
+/// the trusted-subnet cache picking up a newly-configured zone subnet.
+struct MockZoneRepoWithSubnets {
+    zones: Mutex<Vec<NetworkZone>>,
+}
+
+impl MockZoneRepoWithSubnets {
+    fn new(zones: Vec<NetworkZone>) -> Self {
+        Self {
+            zones: Mutex::new(zones),
+        }
+    }
+
+    fn set_zones(&self, zones: Vec<NetworkZone>) {
+        *self.zones.lock().unwrap() = zones;
+    }
+}
+
+/// Build a zone carrying a per-zone subnet CIDR (the DHCP-mode subnet devices
+/// in the zone are addressed from).
+fn zone_with_subnet(cidr: &str) -> NetworkZone {
+    NetworkZone {
+        subnet: Some(ZoneSubnet {
+            cidr: cidr.to_owned(),
+        }),
+        ..trusted_zone()
+    }
+}
+
+#[async_trait]
+impl NetworkZoneRepository for MockZoneRepoWithSubnets {
+    async fn find_all(&self) -> anyhow::Result<Vec<NetworkZone>> {
+        Ok(self.zones.lock().unwrap().clone())
+    }
+    async fn find_by_id(&self, _id: &str) -> anyhow::Result<Option<NetworkZone>> {
+        Ok(Some(trusted_zone()))
+    }
+    async fn find_default(&self) -> anyhow::Result<NetworkZone> {
+        Ok(trusted_zone())
+    }
+    async fn find_default_for_new(&self) -> anyhow::Result<NetworkZone> {
+        Ok(trusted_zone())
+    }
+    async fn insert(&self, _zone: &NetworkZone) -> anyhow::Result<()> {
+        Ok(())
+    }
+    async fn update(&self, _zone: &NetworkZone) -> anyhow::Result<()> {
+        Ok(())
+    }
+    async fn delete(&self, _id: &str) -> anyhow::Result<()> {
+        Ok(())
+    }
+    async fn set_default(&self, _id: &str) -> anyhow::Result<()> {
+        Ok(())
+    }
+    async fn set_default_for_new(&self, _id: &str) -> anyhow::Result<()> {
+        Ok(())
+    }
+    async fn count_members(&self, _zone_id: &str) -> anyhow::Result<i64> {
+        Ok(0)
+    }
+    async fn member_counts(&self) -> anyhow::Result<std::collections::HashMap<String, i64>> {
+        Ok(std::collections::HashMap::new())
+    }
+}
+
 struct MockDhcpRepository {
     leases_by_mac: HashMap<String, Option<String>>,
 }
@@ -616,7 +684,108 @@ fn build_harness_with_resolver_and_dhcp(
     }
 }
 
+fn build_harness_with_zone_repo(zones: Arc<dyn NetworkZoneRepository>) -> TestHarness {
+    let repo = Arc::new(MockDeviceRepo::with_devices(Vec::new()));
+    let dhcp = Arc::new(MockDhcpRepository::empty());
+    let events = Arc::new(MockEventPublisher::new());
+    let resolver = Arc::new(MockHostnameResolver::new());
+    let system_config = Arc::new(MockSystemConfig::default());
+    let svc = DeviceDiscoveryServiceImpl::new(
+        repo.clone(),
+        zones,
+        dhcp,
+        system_config.clone(),
+        events.clone(),
+        resolver,
+        "192.168.1.0/24".parse().unwrap(),
+        std::net::Ipv4Addr::new(192, 168, 1, 1),
+    );
+
+    TestHarness {
+        svc,
+        repo,
+        events,
+        system_config,
+    }
+}
+
 // -- Tests ----------------------------------------------------------------
+
+/// An observation from an IP inside a configured zone subnet (outside the base
+/// LAN `/24`) is processed once the trusted-subnet cache has been rebuilt from
+/// the zone list — not dropped as off-LAN.
+#[tokio::test]
+async fn process_observation_accepts_zone_subnet_ip() {
+    let zones = Arc::new(MockZoneRepoWithSubnets::new(vec![zone_with_subnet(
+        "10.0.100.0/24",
+    )]));
+    let h = build_harness_with_zone_repo(zones);
+
+    // Fold the zone subnet into the trusted set (as startup / a zone event does).
+    h.svc.rebuild_trusted_subnets().await.unwrap();
+
+    let obs = sample_observation("aa:bb:cc:dd:ee:10", "10.0.100.50");
+    let result = h.svc.process_observation(&obs).await.unwrap();
+
+    assert!(
+        !matches!(result, ObservationResult::Ignored),
+        "expected the zone-subnet observation to be processed, got {result:?}"
+    );
+    assert!(
+        matches!(result, ObservationResult::NewDevice { .. }),
+        "expected a new device to be registered, got {result:?}"
+    );
+}
+
+/// An observation from a WAN-like IP outside the LAN and every zone subnet is
+/// still ignored (return traffic arriving with the router's MAC).
+#[tokio::test]
+async fn process_observation_ignores_wan_ip_outside_all_subnets() {
+    let zones = Arc::new(MockZoneRepoWithSubnets::new(vec![zone_with_subnet(
+        "10.0.100.0/24",
+    )]));
+    let h = build_harness_with_zone_repo(zones);
+    h.svc.rebuild_trusted_subnets().await.unwrap();
+
+    let obs = sample_observation("aa:bb:cc:dd:ee:11", "8.8.8.8");
+    let result = h.svc.process_observation(&obs).await.unwrap();
+
+    assert!(
+        matches!(result, ObservationResult::Ignored),
+        "expected a WAN IP to be ignored, got {result:?}"
+    );
+    assert!(
+        h.repo.inserted.lock().unwrap().is_empty(),
+        "no device should have been inserted for a WAN observation"
+    );
+}
+
+/// Rebuilding the trusted-subnet cache picks up a zone subnet added after the
+/// service was constructed: the same observation flips from Ignored to processed.
+#[tokio::test]
+async fn rebuild_trusted_subnets_picks_up_new_zone_subnet() {
+    // Start with a zone that has no subnet, so only the base LAN /24 is trusted.
+    let zones = Arc::new(MockZoneRepoWithSubnets::new(vec![trusted_zone()]));
+    let h = build_harness_with_zone_repo(zones.clone());
+    h.svc.rebuild_trusted_subnets().await.unwrap();
+
+    let obs = sample_observation("aa:bb:cc:dd:ee:12", "10.0.100.50");
+    let before = h.svc.process_observation(&obs).await.unwrap();
+    assert!(
+        matches!(before, ObservationResult::Ignored),
+        "expected the zone-subnet IP to be ignored before the subnet is configured, got {before:?}"
+    );
+
+    // Configure the zone subnet and rebuild — the same IP is now trusted.
+    zones.set_zones(vec![zone_with_subnet("10.0.100.0/24")]);
+    h.svc.rebuild_trusted_subnets().await.unwrap();
+
+    let after = h.svc.process_observation(&obs).await.unwrap();
+    assert!(
+        !matches!(after, ObservationResult::Ignored),
+        "expected the observation to be processed after the zone subnet is added, got {after:?}"
+    );
+}
 
 #[tokio::test]
 async fn process_observation_new_device() {

--- a/source/daemon/crates/wardnetd-services/src/subnet.rs
+++ b/source/daemon/crates/wardnetd-services/src/subnet.rs
@@ -8,11 +8,49 @@
 use std::net::Ipv4Addr;
 
 use ipnetwork::Ipv4Network;
+use uuid::Uuid;
+use wardnet_common::network_zone::NetworkZone;
 
 /// First host of a subnet (the Wardnet gateway alias): network + 1.
 #[must_use]
 pub fn gateway_for(net: Ipv4Network) -> Ipv4Addr {
     Ipv4Addr::from(u32::from(net.network()) + 1)
+}
+
+/// Parse every zone's configured subnet CIDR, paired with its zone id.
+///
+/// A zone whose CIDR fails to parse is logged and skipped rather than failing
+/// the whole batch — write-time validation
+/// (`NetworkZoneServiceImpl::validate_targets_and_subnet`) already rejects
+/// unparseable/non-private/oversized CIDRs, so this is defense-in-depth
+/// against direct DB edits or older data, not an expected runtime path.
+///
+/// Shared by device discovery's trusted-subnet cache and zone enforcement's
+/// gateway/isolation checks, so the "which subnets does this zone claim"
+/// answer can't drift between the two.
+#[must_use]
+pub fn parse_zone_subnets(zones: &[NetworkZone]) -> Vec<(Uuid, Ipv4Network)> {
+    zones
+        .iter()
+        .filter_map(|zone| {
+            let subnet = zone.subnet.as_ref()?;
+            match subnet.cidr.parse::<Ipv4Network>() {
+                Ok(net) => Some((zone.id, net)),
+                Err(e) => {
+                    tracing::warn!(
+                        zone_id = %zone.id,
+                        zone = %zone.name,
+                        cidr = %subnet.cidr,
+                        error = %e,
+                        "zone {zone} has an unparseable subnet CIDR {cidr}; skipping it",
+                        zone = zone.name,
+                        cidr = subnet.cidr,
+                    );
+                    None
+                }
+            }
+        })
+        .collect()
 }
 
 /// DHCP pool bounds within a subnet: (network+10 ..= broadcast-6). Returns None

--- a/source/daemon/crates/wardnetd-services/src/zone_enforcement/service.rs
+++ b/source/daemon/crates/wardnetd-services/src/zone_enforcement/service.rs
@@ -227,11 +227,9 @@ impl ZoneEnforcementServiceImpl {
                 return false;
             }
         };
-        zones
-            .iter()
-            .filter_map(|z| z.subnet.as_ref())
-            .filter_map(|s| s.cidr.parse::<Ipv4Network>().ok())
-            .any(|net| crate::subnet::gateway_for(net) == addr)
+        crate::subnet::parse_zone_subnets(&zones)
+            .into_iter()
+            .any(|(_, net)| crate::subnet::gateway_for(net) == addr)
     }
 
     /// Install a device IP's zone rules. On a live change (`flush = true`) the
@@ -572,18 +570,7 @@ impl ZoneEnforcementServiceImpl {
                 .map_err(AppError::Internal)?;
 
             // Parse the subnet CIDR of every zone that has one.
-            for zone in &zones {
-                if let Some(subnet) = &zone.subnet {
-                    match subnet.cidr.parse::<Ipv4Network>() {
-                        Ok(net) => {
-                            zone_nets.insert(zone.id, net);
-                        }
-                        Err(e) => {
-                            tracing::warn!(error = %e, zone_id = %zone.id, cidr = %subnet.cidr, "zone enforcer: invalid zone subnet, skipping");
-                        }
-                    }
-                }
-            }
+            zone_nets.extend(crate::subnet::parse_zone_subnets(&zones));
 
             // The set of distinct subnets = base + each zone subnet.
             let mut all_subnets: Vec<String> = vec![crate::subnet::canonical_cidr(base_cidr)];

--- a/source/daemon/crates/wardnetd/src/device_detector.rs
+++ b/source/daemon/crates/wardnetd/src/device_detector.rs
@@ -17,7 +17,7 @@ use crate::garp_learning;
 
 /// Background device detection orchestrator.
 ///
-/// Spawns six subtasks:
+/// Spawns seven subtasks:
 /// 1. Passive capture loop -- listens for ARP/IP packets, sends observations on mpsc channel
 /// 2. Observation processor -- receives from channel, calls discovery service, logs at info level
 /// 3. Batch flush loop -- every N seconds, flushes `last_seen` to DB
@@ -25,6 +25,9 @@ use crate::garp_learning;
 /// 5. Active ARP scanner -- every N seconds, broadcasts ARP requests for all IPs in subnet
 /// 6. Hostname listener -- subscribes to DHCP lease events and re-resolves
 ///    hostnames when a client supplies a new option-12 value
+/// 7. Zone-subnet listener -- subscribes to `NetworkZoneChanged` and rebuilds the
+///    discovery service's trusted-subnet filter so devices in a zone subnet are
+///    not dropped as off-LAN
 pub struct DeviceDetector {
     cancel: CancellationToken,
     handles: Vec<tokio::task::JoinHandle<()>>,
@@ -53,6 +56,7 @@ impl DeviceDetector {
         let span = tracing::info_span!(parent: parent, "device_detector");
 
         let event_rx = events.subscribe();
+        let zone_event_rx = events.subscribe();
 
         let capture_handle = tokio::spawn(
             capture_task(capture.clone(), interface.clone(), tx, cancel.clone())
@@ -94,7 +98,13 @@ impl DeviceDetector {
         );
 
         let hostname_handle = tokio::spawn(
-            hostname_listener_task(discovery, event_rx, cancel.clone()).instrument(span),
+            hostname_listener_task(discovery.clone(), event_rx, cancel.clone())
+                .instrument(span.clone()),
+        );
+
+        let zone_subnet_handle = tokio::spawn(
+            zone_subnet_listener_task(discovery, zone_event_rx, cancel.clone())
+                .instrument(span.clone()),
         );
 
         Self {
@@ -106,6 +116,7 @@ impl DeviceDetector {
                 departure_handle,
                 arp_handle,
                 hostname_handle,
+                zone_subnet_handle,
             ],
         }
     }
@@ -334,6 +345,63 @@ async fn hostname_listener_task(
                     }
                     Err(broadcast::error::RecvError::Closed) => {
                         tracing::info!("hostname listener: event bus closed");
+                        break;
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// Subscribe to Network-Zone change events and rebuild the discovery service's
+/// trusted-subnet filter whenever a zone is created, updated, or deleted.
+///
+/// A zone can carry its own subnet that DHCP assigns addresses from. Without
+/// this refresh the filter only knows the base LAN `/24`, so a device
+/// addressed inside a zone subnet outside that range would have every
+/// observation dropped as off-LAN — freezing its presence and starving zone
+/// enforcement of the `DeviceIpChanged` events it keys nftables rules on.
+async fn zone_subnet_listener_task(
+    discovery: Arc<dyn DeviceDiscoveryService>,
+    mut event_rx: broadcast::Receiver<WardnetEvent>,
+    cancel: CancellationToken,
+) {
+    loop {
+        tokio::select! {
+            () = cancel.cancelled() => break,
+            result = event_rx.recv() => {
+                match result {
+                    Ok(WardnetEvent::NetworkZoneChanged { .. }) => {
+                        if let Err(e) = discovery.rebuild_trusted_subnets().await {
+                            tracing::warn!(
+                                error = %e,
+                                "device discovery: failed to rebuild trusted subnets after zone change: {e}"
+                            );
+                        }
+                    }
+                    Ok(_) => {
+                        // Other events don't affect the trusted-subnet set.
+                    }
+                    Err(broadcast::error::RecvError::Lagged(n)) => {
+                        // A skipped event may have been the `NetworkZoneChanged`
+                        // for a zone deletion or subnet edit — without a forced
+                        // rebuild here, a removed zone's subnet would stay
+                        // trusted until some later, unrelated zone change
+                        // happened to fire one.
+                        tracing::warn!(
+                            skipped = n,
+                            "zone-subnet listener lagged behind event bus, skipped {n} events; \
+                             forcing a trusted-subnet rebuild"
+                        );
+                        if let Err(e) = discovery.rebuild_trusted_subnets().await {
+                            tracing::warn!(
+                                error = %e,
+                                "device discovery: failed to rebuild trusted subnets after lag: {e}"
+                            );
+                        }
+                    }
+                    Err(broadcast::error::RecvError::Closed) => {
+                        tracing::info!("zone-subnet listener: event bus closed");
                         break;
                     }
                 }

--- a/source/daemon/crates/wardnetd/src/tests/device_detector.rs
+++ b/source/daemon/crates/wardnetd/src/tests/device_detector.rs
@@ -162,6 +162,10 @@ impl DeviceDiscoveryService for MockDiscovery {
         Ok(())
     }
 
+    async fn rebuild_trusted_subnets(&self) -> Result<(), AppError> {
+        Ok(())
+    }
+
     async fn process_observation(
         &self,
         _obs: &ObservedDevice,

--- a/source/daemon/crates/wardnetd/src/tests/stubs.rs
+++ b/source/daemon/crates/wardnetd/src/tests/stubs.rs
@@ -248,6 +248,9 @@ impl DeviceDiscoveryService for StubDiscoveryService {
     async fn restore_devices(&self) -> Result<(), AppError> {
         unimplemented!()
     }
+    async fn rebuild_trusted_subnets(&self) -> Result<(), AppError> {
+        unimplemented!()
+    }
     async fn process_observation(
         &self,
         _obs: &ObservedDevice,


### PR DESCRIPTION
## Summary

- Device observations were filtered against a single hardcoded LAN `/24` computed once at startup. A device DHCP-addressed inside a Network Zone's own subnet (e.g. `10.0.100.0/24`) had every observation silently dropped as `ObservationResult::Ignored` — its `last_ip`/`last_seen` froze and it showed as "not detected" in the app.
- Worse: the same filter gates whether `WardnetEvent::DeviceIpChanged` fires, which zone enforcement uses to install/update nftables rules for a device's IP — so a device's zone-isolation rules could go stale for its actual current address.
- Replaces the static `lan_subnet` field with a `trusted_subnets: ArcSwap<Vec<Ipv4Network>>` cache (LAN `/24` + every configured zone subnet), rebuilt at startup and on `NetworkZoneChanged` events, with a defensive rebuild if the listener detects it lagged behind the event bus (a missed deletion event previously could leave a removed zone's subnet trusted indefinitely).
- Extracts the zone-subnet-CIDR-parsing loop — previously hand-rolled independently in discovery and twice more in `zone_enforcement/service.rs` — into a single shared `subnet::parse_zone_subnets()` helper so the three call sites can't drift.
- Fixes a stray missing `span.clone()` on the new listener's spawn to match the other six subtasks' instrumentation.

## Not addressed (flagging, not fixing)

Code review also surfaced that a zone's subnet has no maximum-size cap, so an admin could in principle configure something far broader than an actual LAN segment. I attempted a `/16` cap but reverted it — an existing test (`create_zone_accepts_the_canonical_private_12`) intentionally asserts a zone subnet as broad as the full `172.16.0.0/12` RFC1918 block must be accepted, so this is existing, deliberate product behavior, not a regression from this PR. Capping it would be a product decision, not a bug fix.

## Test plan

- [x] `cargo test -p wardnetd-services` — 113 passed, 0 failed (discovery, zone_enforcement, network_zone, subnet suites)
- [x] `cargo clippy -p wardnetd-services -p wardnetd-api --tests -- -D warnings` — clean
- [x] `cargo check -p wardnetd-services -p wardnetd-api --tests` — clean
- [ ] `wardnetd` itself only builds on Linux (netlink deps) — gated on CI, not locally reproducible on this macOS dev machine
- [x] Root-caused against a live daemon: confirmed via SSH that both affected devices' `last_ip`/`last_seen` were frozen at their pre-zone-move addresses in the production DB

## Merge Commit Message

fix(daemon): trust zone subnets in device discovery, not just the LAN /24

Device observations were filtered against a single hardcoded LAN /24, so a device DHCP-addressed inside a Network Zone's own subnet had every observation silently dropped, freezing its presence and starving zone enforcement of the DeviceIpChanged events it keys nftables rules on. Adds an ArcSwap-cached trusted-subnet set (LAN /24 + every zone subnet), rebuilt at startup and on zone-change events, and deduplicates the zone-subnet-parsing logic into a shared helper.