### PR TITLE
fix(tunnel): measure sustained throughput instead of a single burst download

### DIFF
--- a/source/daemon/Cargo.lock
+++ b/source/daemon/Cargo.lock
@@ -4332,6 +4332,7 @@ dependencies = [
  "cookie",
  "cookie_store",
  "futures-core",
+ "futures-util",
  "http",
  "http-body",
  "http-body-util",
@@ -4351,12 +4352,14 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-rustls",
+ "tokio-util",
  "tower",
  "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams",
  "web-sys",
  "webpki-roots 1.0.6",
 ]
@@ -6555,6 +6558,19 @@ dependencies = [
  "indexmap",
  "wasm-encoder",
  "wasmparser",
+]
+
+[[package]]
+name = "wasm-streams"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
 ]
 
 [[package]]

--- a/source/daemon/Cargo.toml
+++ b/source/daemon/Cargo.toml
@@ -134,7 +134,7 @@ mime_guess = "2"
 # https://crates.io/crates/clap
 clap = { version = "4", features = ["derive"] }
 # https://crates.io/crates/reqwest
-reqwest = { version = "0.12", default-features = false, features = ["json", "cookies", "rustls-tls"] }
+reqwest = { version = "0.12", default-features = false, features = ["json", "cookies", "rustls-tls", "stream"] }
 # https://crates.io/crates/tabled
 tabled = "0.21"
 # https://crates.io/crates/async-trait

--- a/source/daemon/crates/wardnet-common/src/config.rs
+++ b/source/daemon/crates/wardnet-common/src/config.rs
@@ -381,14 +381,35 @@ pub struct TunnelConfig {
     /// requires the same response shape.
     pub test_probe_url: String,
     /// URL the speed test downloads from to measure throughput. The default
-    /// is Cloudflare's `__down` endpoint requesting a 10 MB payload. The
-    /// download runs twice per speed test — once unbound (direct/WAN) and
-    /// once bound to the tunnel interface (`SO_BINDTODEVICE`) — so the
-    /// endpoint must serve the requested byte count over plain HTTPS.
+    /// is Cloudflare's `__down` endpoint requesting a 500 MB payload — sized
+    /// generously because each stream stops reading once the measure window
+    /// elapses (see `speed_test_measure_ms`), not once the payload is fully
+    /// downloaded, so this only needs to be large enough that no stream runs
+    /// dry mid-measurement even on a near-gigabit link. The download runs
+    /// twice per speed test — once unbound (direct/WAN) and once bound to
+    /// the tunnel interface (`SO_BINDTODEVICE`) — so the endpoint must serve
+    /// the requested byte count over plain HTTPS.
     pub speed_test_url: String,
     /// Number of ICMP echo samples taken per leg of a speed test to derive
     /// median latency and jitter. Defaults to 5.
     pub speed_test_latency_samples: u32,
+    /// Number of concurrent download streams per throughput leg. A single
+    /// TCP stream's throughput is capped by its bandwidth-delay product, so
+    /// one flow understates available bandwidth on higher-RTT paths (e.g.
+    /// through a tunnel) more than on a low-RTT direct path — running
+    /// several streams in parallel avoids that single-flow ceiling. Defaults
+    /// to 4.
+    pub speed_test_parallel_streams: u32,
+    /// Warm-up period (milliseconds) discarded from the start of each
+    /// stream's download before bytes count toward the throughput
+    /// calculation. Excludes connection setup and TCP slow-start from the
+    /// measurement. Defaults to 1000 (1s).
+    pub speed_test_warmup_ms: u64,
+    /// Duration (milliseconds), after the warm-up period, over which bytes
+    /// are counted toward the throughput calculation. Defaults to 4000
+    /// (4s) — long enough to average out short ISP burst-allowance windows,
+    /// short enough to keep total speed-test job time reasonable.
+    pub speed_test_measure_ms: u64,
 }
 
 impl Default for TunnelConfig {
@@ -400,8 +421,11 @@ impl Default for TunnelConfig {
             latency_probe_interval_secs: 60,
             latency_probe_target: "1.1.1.1".to_owned(),
             test_probe_url: "https://1.1.1.1/cdn-cgi/trace".to_owned(),
-            speed_test_url: "https://speed.cloudflare.com/__down?bytes=10000000".to_owned(),
+            speed_test_url: "https://speed.cloudflare.com/__down?bytes=500000000".to_owned(),
             speed_test_latency_samples: 5,
+            speed_test_parallel_streams: 4,
+            speed_test_warmup_ms: 1000,
+            speed_test_measure_ms: 4000,
         }
     }
 }

--- a/source/daemon/crates/wardnetd-services/src/tunnel/throughput_tester.rs
+++ b/source/daemon/crates/wardnetd-services/src/tunnel/throughput_tester.rs
@@ -26,7 +26,7 @@ pub struct ThroughputMeasurement {
     pub mbps: f64,
 }
 
-/// Downloads a fixed payload and measures the achieved throughput.
+/// Measures sustained download throughput against a configured URL.
 ///
 /// The download URL is fixed at construction (mirroring
 /// [`TunnelExitProbe`](crate::tunnel::exit_probe::TunnelExitProbe) and
@@ -35,6 +35,15 @@ pub struct ThroughputMeasurement {
 /// to it (Linux: `SO_BINDTODEVICE`) so the download traverses that tunnel;
 /// when `None`, the download runs **unbound** over the default route — the
 /// direct/WAN baseline the speed test compares the tunnel against.
+///
+/// Implementations should measure *sustained* throughput rather than timing
+/// a single fixed-size download end to end: a single-shot single-connection
+/// transfer is skewed by connection-setup time and TCP slow-start (worse at
+/// higher RTT, e.g. through a tunnel) and by the single-flow
+/// bandwidth-delay-product ceiling. The daemon's real implementation
+/// (`HttpThroughputTester` in the `wardnetd` crate) addresses this by
+/// running several concurrent streams over a fixed measurement window,
+/// discarding an initial warm-up period.
 #[async_trait]
 pub trait ThroughputTester: Send + Sync {
     /// Download the configured payload through `interface_name` (or the

--- a/source/daemon/crates/wardnetd/src/lib.rs
+++ b/source/daemon/crates/wardnetd/src/lib.rs
@@ -9,6 +9,7 @@ pub mod hostname_resolver;
 pub mod inbound_wg_interface_wireguard;
 pub mod packet_capture_pnet;
 pub mod policy_router_netlink;
+mod reqwest_client;
 pub mod tunnel_exit_probe;
 pub mod tunnel_interface_wireguard;
 pub mod tunnel_latency_prober;

--- a/source/daemon/crates/wardnetd/src/main.rs
+++ b/source/daemon/crates/wardnetd/src/main.rs
@@ -352,6 +352,9 @@ async fn run(
         )),
         tunnel_throughput_tester: Arc::new(HttpThroughputTester::new(
             config.tunnel.speed_test_url.clone(),
+            config.tunnel.speed_test_parallel_streams,
+            std::time::Duration::from_millis(config.tunnel.speed_test_warmup_ms),
+            std::time::Duration::from_millis(config.tunnel.speed_test_measure_ms),
         )),
         policy_router: Arc::new(
             NetlinkPolicyRouter::new(executor.clone())

--- a/source/daemon/crates/wardnetd/src/reqwest_client.rs
+++ b/source/daemon/crates/wardnetd/src/reqwest_client.rs
@@ -1,0 +1,18 @@
+//! Shared helper for building a `reqwest::Client` optionally bound to a
+//! network interface via `SO_BINDTODEVICE`.
+//!
+//! Used by every tunnel probe that needs to force traffic onto (or off of) a
+//! specific interface: [`crate::tunnel_exit_probe`] and
+//! [`crate::tunnel_throughput_tester`].
+
+/// Starts a `reqwest::ClientBuilder`, bound to `interface` via
+/// `SO_BINDTODEVICE` when `Some`. `None` leaves the socket unbound so it
+/// egresses the default route.
+#[cfg(target_os = "linux")]
+pub(crate) fn interface_bound_builder(interface: Option<&str>) -> reqwest::ClientBuilder {
+    let builder = reqwest::Client::builder();
+    match interface {
+        Some(iface) => builder.interface(iface),
+        None => builder,
+    }
+}

--- a/source/daemon/crates/wardnetd/src/tests/mod.rs
+++ b/source/daemon/crates/wardnetd/src/tests/mod.rs
@@ -18,6 +18,7 @@ mod tls_server;
 mod tunnel_idle;
 mod tunnel_interface_wireguard;
 mod tunnel_monitor;
+mod tunnel_throughput_tester;
 mod watchdog_hard;
 mod watchdog_soft;
 mod zone_enforcement_listener;

--- a/source/daemon/crates/wardnetd/src/tests/tunnel_throughput_tester.rs
+++ b/source/daemon/crates/wardnetd/src/tests/tunnel_throughput_tester.rs
@@ -1,0 +1,73 @@
+use std::time::Duration;
+
+use wardnetd_services::tunnel::throughput_tester::ThroughputError;
+
+use crate::tunnel_throughput_tester::{StreamOutcome, aggregate_throughput};
+
+fn outcome(bytes_in_window: u64, failed: bool) -> StreamOutcome {
+    StreamOutcome {
+        bytes_in_window,
+        failed,
+    }
+}
+
+#[test]
+fn all_streams_succeed_sums_bytes() {
+    let outcomes = vec![outcome(1_000_000, false), outcome(2_000_000, false)];
+    let result = aggregate_throughput(&outcomes, Duration::from_secs(1)).unwrap();
+    // (3_000_000 bytes * 8 bits) / 1e6 / 1s = 24 Mbps.
+    assert!((result.mbps - 24.0).abs() < 1e-9);
+}
+
+#[test]
+fn partial_failure_sums_only_successful_streams() {
+    let outcomes = vec![outcome(1_000_000, false), outcome(999_999_999, true)];
+    let result = aggregate_throughput(&outcomes, Duration::from_secs(1)).unwrap();
+    // The failed stream's bytes must not count toward the total.
+    assert!((result.mbps - 8.0).abs() < 1e-9);
+}
+
+#[test]
+fn all_streams_failed_errors() {
+    let outcomes = vec![outcome(0, true), outcome(0, true)];
+    let err = aggregate_throughput(&outcomes, Duration::from_secs(1)).unwrap_err();
+    assert!(matches!(err, ThroughputError::Download(_)));
+}
+
+#[test]
+fn zero_bytes_in_window_errors_rather_than_reporting_zero_mbps() {
+    let outcomes = vec![outcome(0, false)];
+    let err = aggregate_throughput(&outcomes, Duration::from_secs(4)).unwrap_err();
+    assert!(matches!(err, ThroughputError::Download(_)));
+}
+
+#[test]
+fn zero_measure_window_errors_instead_of_dividing_by_zero() {
+    let outcomes = vec![outcome(1_000_000, false)];
+    let err = aggregate_throughput(&outcomes, Duration::from_secs(0)).unwrap_err();
+    assert!(matches!(err, ThroughputError::Download(_)));
+}
+
+#[test]
+fn empty_outcomes_errors_via_all_failed_vacuous_truth() {
+    // `outcomes.iter().all(...)` on an empty slice is vacuously true, so
+    // this still errors rather than silently reporting a measurement — but
+    // `HttpThroughputTester::download` rejects `parallel_streams == 0`
+    // before ever reaching this function, so callers see a distinct,
+    // actionable message instead of this generic one.
+    let outcomes: Vec<StreamOutcome> = vec![];
+    let err = aggregate_throughput(&outcomes, Duration::from_secs(4)).unwrap_err();
+    assert!(matches!(err, ThroughputError::Download(_)));
+}
+
+#[test]
+fn longer_measure_window_yields_lower_mbps_for_same_bytes() {
+    let outcomes = vec![outcome(1_000_000, false)];
+    let short = aggregate_throughput(&outcomes, Duration::from_secs(1))
+        .unwrap()
+        .mbps;
+    let long = aggregate_throughput(&outcomes, Duration::from_secs(4))
+        .unwrap()
+        .mbps;
+    assert!(long < short);
+}

--- a/source/daemon/crates/wardnetd/src/tunnel_exit_probe.rs
+++ b/source/daemon/crates/wardnetd/src/tunnel_exit_probe.rs
@@ -38,9 +38,8 @@ impl ReqwestTunnelExitProbe {
 impl TunnelExitProbe for ReqwestTunnelExitProbe {
     #[cfg(target_os = "linux")]
     async fn probe(&self, interface: &str) -> Result<ExitInfo, ProbeError> {
-        let client = reqwest::Client::builder()
+        let client = crate::reqwest_client::interface_bound_builder(Some(interface))
             .timeout(PROBE_TIMEOUT)
-            .interface(interface)
             .build()
             .map_err(|e| ProbeError::Connect(format!("client build failed: {e}")))?;
 

--- a/source/daemon/crates/wardnetd/src/tunnel_throughput_tester.rs
+++ b/source/daemon/crates/wardnetd/src/tunnel_throughput_tester.rs
@@ -1,12 +1,20 @@
-//! Real `ThroughputTester` impl: times a fixed HTTP download to derive
-//! throughput, optionally bound to a tunnel interface.
+//! Real `ThroughputTester` impl: runs several concurrent HTTP downloads,
+//! discards an initial warm-up window, and sums bytes read over a fixed
+//! measure window afterward.
+//!
+//! A single-shot, single-connection download is prone to two skews: its
+//! timing includes DNS/TCP/TLS handshake and TCP slow-start (understating
+//! throughput, worse at higher RTT — e.g. through a tunnel), and a single
+//! TCP flow is capped by its bandwidth-delay product (also worse at higher
+//! RTT). Running several streams concurrently and discarding a warm-up
+//! prefix avoids both.
 //!
 //! Linux uses `SO_BINDTODEVICE` (via `reqwest::ClientBuilder::interface`) to
-//! force the outbound socket onto the tunnel interface for the tunnel leg;
-//! the direct leg builds an unbound client so it egresses the default (WAN)
-//! route. Other platforms return [`ThroughputError::Unsupported`] — the
-//! production daemon only runs on Linux; macOS/Windows builds reach the mock
-//! backend instead.
+//! force each stream's outbound socket onto the tunnel interface for the
+//! tunnel leg; the direct leg builds an unbound client so it egresses the
+//! default (WAN) route. Other platforms return [`ThroughputError::Unsupported`]
+//! — the production daemon only runs on Linux; macOS/Windows builds reach the
+//! mock backend instead.
 
 use std::time::{Duration, Instant};
 
@@ -16,22 +24,48 @@ use wardnetd_services::tunnel::throughput_tester::{
     ThroughputError, ThroughputMeasurement, ThroughputTester,
 };
 
-/// 30 s download budget — the acceptance target is "completes in under 30 s
-/// on a 100 Mbps tunnel", and a 10 MB payload at 100 Mbps takes under a
-/// second, so this only trips on a stalled or very slow link.
-const DOWNLOAD_TIMEOUT: Duration = Duration::from_secs(30);
+/// Extra grace added on top of `warmup + measure` to form each stream's
+/// safety-net timeout — covers connect/TLS setup and scheduling jitter
+/// without masking a legitimately slow but working link. Kept separate
+/// from `warmup`/`measure` (which are operator-configurable) so raising
+/// those config values can never make the safety net fire before the
+/// stream's own deadline logic gets to run.
+const CONNECT_GRACE: Duration = Duration::from_secs(15);
 
-/// Downloads `download_url` and measures throughput. The URL is fixed at
-/// construction from `tunnel.speed_test_url` (default: Cloudflare's `__down`
-/// endpoint requesting 10 MB).
+/// Outcome of a single stream's download attempt.
+pub(crate) struct StreamOutcome {
+    /// Bytes read while inside the `[warmup, warmup + measure)` window.
+    pub(crate) bytes_in_window: u64,
+    /// Whether this stream failed (timed out, connection error, non-success
+    /// status). Failed streams are excluded from the aggregate — see
+    /// [`aggregate_throughput`].
+    pub(crate) failed: bool,
+}
+
+/// Downloads `download_url` concurrently across several streams and measures
+/// sustained throughput. The URL, stream count, warm-up, and measure window
+/// are fixed at construction from the `tunnel.speed_test_*` config.
 pub struct HttpThroughputTester {
     download_url: String,
+    parallel_streams: u32,
+    warmup: Duration,
+    measure: Duration,
 }
 
 impl HttpThroughputTester {
     #[must_use]
-    pub fn new(download_url: String) -> Self {
-        Self { download_url }
+    pub fn new(
+        download_url: String,
+        parallel_streams: u32,
+        warmup: Duration,
+        measure: Duration,
+    ) -> Self {
+        Self {
+            download_url,
+            parallel_streams,
+            warmup,
+            measure,
+        }
     }
 }
 
@@ -42,61 +76,26 @@ impl ThroughputTester for HttpThroughputTester {
         &self,
         interface: Option<&str>,
     ) -> Result<ThroughputMeasurement, ThroughputError> {
-        let mut builder = reqwest::Client::builder().timeout(DOWNLOAD_TIMEOUT);
-        // `Some` binds the socket to the tunnel (tunnel leg); `None` leaves it
-        // unbound so it egresses the default WAN route (direct baseline).
-        if let Some(iface) = interface {
-            builder = builder.interface(iface);
+        if self.parallel_streams == 0 {
+            return Err(ThroughputError::Download(
+                "speed_test_parallel_streams must be at least 1".to_owned(),
+            ));
         }
-        let client = builder
+
+        // One client per leg, cloned into each stream: `reqwest::Client` is
+        // `Arc`-backed internally, so cloning is cheap and doesn't repeat
+        // DNS-resolver/TLS-config setup per stream — each clone still opens
+        // its own independent connection per concurrent request.
+        let client = crate::reqwest_client::interface_bound_builder(interface)
             .build()
             .map_err(|e| ThroughputError::Download(format!("client build failed: {e}")))?;
+        let stream_timeout = self.warmup + self.measure + CONNECT_GRACE;
 
-        let started = Instant::now();
-        let resp = client.get(&self.download_url).send().await.map_err(|e| {
-            if e.is_timeout() {
-                ThroughputError::Timeout(
-                    u64::try_from(DOWNLOAD_TIMEOUT.as_millis()).unwrap_or(u64::MAX),
-                )
-            } else {
-                ThroughputError::Download(e.to_string())
-            }
-        })?;
-
-        if !resp.status().is_success() {
-            return Err(ThroughputError::Download(format!(
-                "download returned HTTP {}",
-                resp.status()
-            )));
-        }
-
-        let body = resp.bytes().await.map_err(|e| {
-            if e.is_timeout() {
-                ThroughputError::Timeout(
-                    u64::try_from(DOWNLOAD_TIMEOUT.as_millis()).unwrap_or(u64::MAX),
-                )
-            } else {
-                ThroughputError::Download(format!("read body failed: {e}"))
-            }
-        })?;
-
-        let elapsed = started.elapsed().as_secs_f64();
-        let bytes = body.len();
-        if bytes == 0 {
-            return Err(ThroughputError::Download(
-                "download returned an empty body".to_owned(),
-            ));
-        }
-        if elapsed <= 0.0 {
-            return Err(ThroughputError::Download(
-                "download completed in zero time".to_owned(),
-            ));
-        }
-
-        // Megabits per second: bytes → bits (×8) → megabits (÷1e6) ÷ seconds.
-        #[allow(clippy::cast_precision_loss)]
-        let mbps = (bytes as f64 * 8.0) / 1_000_000.0 / elapsed;
-        Ok(ThroughputMeasurement { mbps })
+        let start = Instant::now();
+        let streams =
+            (0..self.parallel_streams).map(|_| self.run_stream(&client, start, stream_timeout));
+        let outcomes = futures::future::join_all(streams).await;
+        aggregate_throughput(&outcomes, self.measure)
     }
 
     #[cfg(not(target_os = "linux"))]
@@ -108,4 +107,110 @@ impl ThroughputTester for HttpThroughputTester {
             "SO_BINDTODEVICE is Linux-only; speed test requires Linux".to_owned(),
         ))
     }
+}
+
+#[cfg(target_os = "linux")]
+impl HttpThroughputTester {
+    /// Runs a single stream: reads the body via `client` and tallies bytes
+    /// read during `[warmup, warmup + measure)` measured from `start`. Stops
+    /// reading once the measure window ends, regardless of how much of the
+    /// payload remains. Wrapped in `stream_timeout` so a stalled connection
+    /// can't hang the whole speed test.
+    async fn run_stream(
+        &self,
+        client: &reqwest::Client,
+        start: Instant,
+        stream_timeout: Duration,
+    ) -> StreamOutcome {
+        use futures::StreamExt;
+
+        let attempt = async {
+            let resp = client
+                .get(&self.download_url)
+                .send()
+                .await
+                .map_err(|e| e.to_string())?;
+            if !resp.status().is_success() {
+                return Err(format!("download returned HTTP {}", resp.status()));
+            }
+
+            let deadline = start + self.warmup + self.measure;
+            let mut body = resp.bytes_stream();
+            let mut bytes_in_window: u64 = 0;
+            loop {
+                let remaining = deadline.saturating_duration_since(Instant::now());
+                if remaining.is_zero() {
+                    break;
+                }
+                tokio::select! {
+                    chunk = body.next() => {
+                        match chunk {
+                            Some(Ok(bytes)) => {
+                                let now = Instant::now();
+                                if now >= start + self.warmup && now < deadline {
+                                    bytes_in_window += bytes.len() as u64;
+                                }
+                            }
+                            Some(Err(e)) => return Err(e.to_string()),
+                            None => break,
+                        }
+                    }
+                    () = tokio::time::sleep(remaining) => break,
+                }
+            }
+            Ok(bytes_in_window)
+        };
+
+        match tokio::time::timeout(stream_timeout, attempt).await {
+            Ok(Ok(bytes_in_window)) => StreamOutcome {
+                bytes_in_window,
+                failed: false,
+            },
+            Ok(Err(_)) | Err(_) => StreamOutcome {
+                bytes_in_window: 0,
+                failed: true,
+            },
+        }
+    }
+}
+
+/// Aggregates per-stream outcomes into a single throughput measurement.
+/// Sums bytes read during the measure window by streams that didn't fail.
+/// Errors if every stream failed, if `measure` is zero (nothing to divide
+/// by), or if every non-failed stream delivered zero bytes in the window
+/// (indistinguishable from a stalled test, not a real measurement) — the
+/// last two mirror the "empty body" / "zero elapsed time" guards the
+/// previous single-shot implementation had. Pure and deterministic — no I/O
+/// or timing — so it's unit-tested directly rather than through real HTTP
+/// downloads.
+pub(crate) fn aggregate_throughput(
+    outcomes: &[StreamOutcome],
+    measure: Duration,
+) -> Result<ThroughputMeasurement, ThroughputError> {
+    if measure.is_zero() {
+        return Err(ThroughputError::Download(
+            "speed_test_measure_ms must be greater than zero".to_owned(),
+        ));
+    }
+    if outcomes.iter().all(|o| o.failed) {
+        return Err(ThroughputError::Download(
+            "all parallel download streams failed".to_owned(),
+        ));
+    }
+
+    let total_bytes: u64 = outcomes
+        .iter()
+        .filter(|o| !o.failed)
+        .map(|o| o.bytes_in_window)
+        .sum();
+    if total_bytes == 0 {
+        return Err(ThroughputError::Download(
+            "no bytes were read during the measure window".to_owned(),
+        ));
+    }
+
+    let secs = measure.as_secs_f64();
+    #[allow(clippy::cast_precision_loss)]
+    let mbps = (total_bytes as f64 * 8.0) / 1_000_000.0 / secs;
+    Ok(ThroughputMeasurement { mbps })
 }

--- a/source/marketing-site/content/docs/configuration.md
+++ b/source/marketing-site/content/docs/configuration.md
@@ -133,8 +133,11 @@ path = "/var/lib/wardnet/secrets"
 | `latency_probe_interval_secs` | `60` | How often to re-measure tunnel latency for the latency chart. |
 | `latency_probe_target` | `"1.1.1.1"` | Host pinged to measure tunnel latency. |
 | `test_probe_url` | `"https://1.1.1.1/cdn-cgi/trace"` | URL used for the tunnel connectivity test probe. |
-| `speed_test_url` | `"https://speed.cloudflare.com/__down?bytes=10000000"` | Download URL used by the tunnel speed test. |
+| `speed_test_url` | `"https://speed.cloudflare.com/__down?bytes=500000000"` | Download URL used by the tunnel speed test. Sized generously since each stream stops reading once `speed_test_measure_ms` elapses, not once the payload finishes. |
 | `speed_test_latency_samples` | `5` | Number of samples averaged for the speed test's latency reading. |
+| `speed_test_parallel_streams` | `4` | Concurrent download streams per throughput leg — avoids the single-TCP-flow bandwidth ceiling that understates tunnel throughput at higher RTT. |
+| `speed_test_warmup_ms` | `1000` | Warm-up period (ms) discarded from each stream before bytes count toward the measurement, excluding connection setup and TCP slow-start. |
+| `speed_test_measure_ms` | `4000` | Measurement window (ms), after warm-up, over which bytes are counted. Keep `speed_test_warmup_ms + speed_test_measure_ms` well under 15s — the daemon adds a fixed 15s connect/scheduling grace on top as a safety-net timeout, so a much larger window will make every stream time out. |
 
 Tunnel private keys are stored via `[secret_store]` (above), they are
 not configured here.

--- a/source/marketing-site/tests/pages/ApiReference.test.tsx
+++ b/source/marketing-site/tests/pages/ApiReference.test.tsx
@@ -137,13 +137,14 @@ describe("ApiReference", () => {
     expect(
       // Default 1s findByText timeout flakes on loaded CI runners (the
       // rejection → catch → setState → re-render chain lands just past it).
-      await screen.findByText(
-        /failed to load\. please refresh to try again/i,
-        undefined,
-        { timeout: 5_000 },
-      ),
+      await screen.findByText(/failed to load\. please refresh to try again/i, undefined, {
+        timeout: 5_000,
+      }),
     ).toBeInTheDocument();
-  });
+    // The per-test timeout must clear the injection wait (~1s) plus the 5s
+    // findByText above; vitest's 5s default equals the inner budget, so the
+    // outer bound could fire before findByText ever spent its allowance.
+  }, 15_000);
 
   it("loads the Scalar script and renders once it loads", async () => {
     delete window.Scalar;
@@ -159,6 +160,8 @@ describe("ApiReference", () => {
     window.Scalar = { createApiReference } as unknown as Window["Scalar"];
     script.onload?.(new Event("load"));
 
-    await waitFor(() => expect(createApiReference).toHaveBeenCalled());
-  });
+    // Same injection-then-render chain as the error case above, so give the
+    // wait (and the test) headroom over the default 1s to survive CI load.
+    await waitFor(() => expect(createApiReference).toHaveBeenCalled(), { timeout: 5_000 });
+  }, 15_000);
 });


### PR DESCRIPTION
## Summary
- The speed test's direct leg read ~2x real speed (ISP burst allowance + fast TCP slow-start at low RTT to the CDN edge) and the tunnel leg read ~4x under what an external tool measured over the same path (single-TCP-flow bandwidth-delay-product ceiling, worse at the tunnel's added RTT) — both artifacts of timing a single-shot, single-connection download end to end.
- Replaced the measurement with 4 (configurable) parallel streams over a fixed warm-up + measure window, discarding the warm-up prefix and summing bytes read in-window; degrades gracefully if some (not all) streams fail.
- Added validation for zero-byte/zero-duration/zero-stream misconfiguration that the previous single-shot implementation guarded against but the rewrite initially dropped, and derived the per-stream safety timeout from the now-configurable warm-up/measure window instead of a disconnected hardcoded constant.
- Extracted the interface-binding `reqwest` client builder into a shared helper used by both the throughput tester and the exit probe.
- Updated the `ThroughputTester` trait doc and the public config-reference docs (stale default, missing new fields) to match.

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo clippy -p wardnetd -p wardnetd-services --all-targets -- -D warnings`
- [x] `cargo test -p wardnetd -p wardnetd-services` (1217 tests, incl. new `tunnel_throughput_tester` aggregation unit tests and unchanged `speed_test` service-level tests against the mock backend)
- [ ] Manual: run a real speed test against a live tunnel and confirm direct/tunnel numbers track an external tool — not done in this session (no live daemon available); recommended before merge if practical.

## Merge Commit Message
fix(tunnel): measure sustained throughput instead of a single burst download