### PR TITLE
fix(tunnel): request a payload Cloudflare will actually serve

### DIFF
--- a/source/daemon/crates/wardnet-common/src/config.rs
+++ b/source/daemon/crates/wardnet-common/src/config.rs
@@ -381,14 +381,16 @@ pub struct TunnelConfig {
     /// requires the same response shape.
     pub test_probe_url: String,
     /// URL the speed test downloads from to measure throughput. The default
-    /// is Cloudflare's `__down` endpoint requesting a 500 MB payload — sized
-    /// generously because each stream stops reading once the measure window
-    /// elapses (see `speed_test_measure_ms`), not once the payload is fully
-    /// downloaded, so this only needs to be large enough that no stream runs
-    /// dry mid-measurement even on a near-gigabit link. The download runs
-    /// twice per speed test — once unbound (direct/WAN) and once bound to
-    /// the tunnel interface (`SO_BINDTODEVICE`) — so the endpoint must serve
-    /// the requested byte count over plain HTTPS.
+    /// is Cloudflare's `__down` endpoint requesting a 50 MB payload. That
+    /// endpoint only serves `bytes` values under 100 MB — at or above the cap
+    /// it answers `403` with no body, which fails every stream — so the
+    /// default deliberately sits well below it, leaving headroom in case the
+    /// cap tightens. A stream that drains the payload before the measure
+    /// window closes simply requests it again (see the throughput tester), so
+    /// size only trades re-request overhead against the cap, never accuracy.
+    /// The download runs twice per speed test — once unbound (direct/WAN) and
+    /// once bound to the tunnel interface (`SO_BINDTODEVICE`) — so the
+    /// endpoint must serve the requested byte count over plain HTTPS.
     pub speed_test_url: String,
     /// Number of ICMP echo samples taken per leg of a speed test to derive
     /// median latency and jitter. Defaults to 5.
@@ -421,7 +423,7 @@ impl Default for TunnelConfig {
             latency_probe_interval_secs: 60,
             latency_probe_target: "1.1.1.1".to_owned(),
             test_probe_url: "https://1.1.1.1/cdn-cgi/trace".to_owned(),
-            speed_test_url: "https://speed.cloudflare.com/__down?bytes=500000000".to_owned(),
+            speed_test_url: "https://speed.cloudflare.com/__down?bytes=50000000".to_owned(),
             speed_test_latency_samples: 5,
             speed_test_parallel_streams: 4,
             speed_test_warmup_ms: 1000,

--- a/source/daemon/crates/wardnet-common/src/tests/config.rs
+++ b/source/daemon/crates/wardnet-common/src/tests/config.rs
@@ -1,7 +1,7 @@
 use std::path::{Path, PathBuf};
 
 use crate::config::{
-    AdminConfig, ApplicationConfiguration, LogFormat, LogRotation, SecretStoreConfig,
+    AdminConfig, ApplicationConfiguration, LogFormat, LogRotation, SecretStoreConfig, TunnelConfig,
 };
 
 #[test]
@@ -46,6 +46,34 @@ fn defaults_when_file_missing() {
     assert!(!config.otel.enabled);
     assert_eq!(config.otel.endpoint, "http://localhost:4317");
     assert_eq!(config.otel.service_name, "wardnetd");
+}
+
+/// Cloudflare's `__down` endpoint serves the payload only while `bytes` stays
+/// under 100 MB — at or above that it answers `403` with no body, which the
+/// throughput tester surfaces as a non-success status, failing every stream
+/// ("all parallel download streams failed"). Shipping a default the endpoint
+/// refuses breaks the speed test on every box that hasn't overridden the URL,
+/// so pin the default below the cap.
+#[test]
+fn default_speed_test_url_requests_a_payload_cloudflare_will_serve() {
+    /// Smallest `bytes` value observed to return 403 rather than a payload.
+    const CLOUDFLARE_DOWN_BYTES_CAP: u64 = 100_000_000;
+
+    let config = TunnelConfig::default();
+    let bytes: u64 = config
+        .speed_test_url
+        .split_once("bytes=")
+        .expect("default speed_test_url should carry a bytes= query parameter")
+        .1
+        .parse()
+        .expect("bytes= should be a plain integer");
+
+    assert!(
+        bytes < CLOUDFLARE_DOWN_BYTES_CAP,
+        "default speed_test_url requests {bytes} bytes, at/above Cloudflare's \
+         {CLOUDFLARE_DOWN_BYTES_CAP}-byte cap — the endpoint will 403 and every \
+         stream will fail",
+    );
 }
 
 #[test]

--- a/source/daemon/crates/wardnetd/src/tunnel_throughput_tester.rs
+++ b/source/daemon/crates/wardnetd/src/tunnel_throughput_tester.rs
@@ -1,6 +1,8 @@
 //! Real `ThroughputTester` impl: runs several concurrent HTTP downloads,
 //! discards an initial warm-up window, and sums bytes read over a fixed
-//! measure window afterward.
+//! measure window afterward. Each stream re-requests the payload if it
+//! drains before the window closes, so the download endpoint's per-request
+//! size cap doesn't bound what the tester can measure.
 //!
 //! A single-shot, single-connection download is prone to two skews: its
 //! timing includes DNS/TCP/TLS handshake and TCP slow-start (understating
@@ -116,6 +118,16 @@ impl HttpThroughputTester {
     /// reading once the measure window ends, regardless of how much of the
     /// payload remains. Wrapped in `stream_timeout` so a stalled connection
     /// can't hang the whole speed test.
+    ///
+    /// Re-requests the payload whenever it drains before the window closes.
+    /// The endpoint caps how much a single request may ask for (Cloudflare's
+    /// `__down` refuses 100 MB or more), so on a fast enough link one request
+    /// cannot cover the whole window — and a stream that just stopped early
+    /// would contribute its bytes while [`aggregate_throughput`] still divided
+    /// by the full `measure`, understating throughput exactly on the fast
+    /// links this tester exists to measure. Re-requesting keeps bytes flowing
+    /// for the entire window, so payload size trades only re-request overhead
+    /// (roughly one RTT per refill on a kept-alive connection), not accuracy.
     async fn run_stream(
         &self,
         client: &reqwest::Client,
@@ -125,37 +137,45 @@ impl HttpThroughputTester {
         use futures::StreamExt;
 
         let attempt = async {
-            let resp = client
-                .get(&self.download_url)
-                .send()
-                .await
-                .map_err(|e| e.to_string())?;
-            if !resp.status().is_success() {
-                return Err(format!("download returned HTTP {}", resp.status()));
-            }
-
             let deadline = start + self.warmup + self.measure;
-            let mut body = resp.bytes_stream();
             let mut bytes_in_window: u64 = 0;
-            loop {
-                let remaining = deadline.saturating_duration_since(Instant::now());
-                if remaining.is_zero() {
+
+            'refill: loop {
+                if Instant::now() >= deadline {
                     break;
                 }
-                tokio::select! {
-                    chunk = body.next() => {
-                        match chunk {
-                            Some(Ok(bytes)) => {
-                                let now = Instant::now();
-                                if now >= start + self.warmup && now < deadline {
-                                    bytes_in_window += bytes.len() as u64;
-                                }
-                            }
-                            Some(Err(e)) => return Err(e.to_string()),
-                            None => break,
-                        }
+                let resp = client
+                    .get(&self.download_url)
+                    .send()
+                    .await
+                    .map_err(|e| e.to_string())?;
+                if !resp.status().is_success() {
+                    return Err(format!("download returned HTTP {}", resp.status()));
+                }
+
+                let mut body = resp.bytes_stream();
+                loop {
+                    let remaining = deadline.saturating_duration_since(Instant::now());
+                    if remaining.is_zero() {
+                        break 'refill;
                     }
-                    () = tokio::time::sleep(remaining) => break,
+                    tokio::select! {
+                        chunk = body.next() => {
+                            match chunk {
+                                Some(Ok(bytes)) => {
+                                    let now = Instant::now();
+                                    if now >= start + self.warmup && now < deadline {
+                                        bytes_in_window += bytes.len() as u64;
+                                    }
+                                }
+                                Some(Err(e)) => return Err(e.to_string()),
+                                // Payload drained; grab another to keep the
+                                // link saturated for the rest of the window.
+                                None => continue 'refill,
+                            }
+                        }
+                        () = tokio::time::sleep(remaining) => break 'refill,
+                    }
                 }
             }
             Ok(bytes_in_window)

--- a/source/marketing-site/content/docs/configuration.md
+++ b/source/marketing-site/content/docs/configuration.md
@@ -133,7 +133,7 @@ path = "/var/lib/wardnet/secrets"
 | `latency_probe_interval_secs` | `60` | How often to re-measure tunnel latency for the latency chart. |
 | `latency_probe_target` | `"1.1.1.1"` | Host pinged to measure tunnel latency. |
 | `test_probe_url` | `"https://1.1.1.1/cdn-cgi/trace"` | URL used for the tunnel connectivity test probe. |
-| `speed_test_url` | `"https://speed.cloudflare.com/__down?bytes=500000000"` | Download URL used by the tunnel speed test. Sized generously since each stream stops reading once `speed_test_measure_ms` elapses, not once the payload finishes. |
+| `speed_test_url` | `"https://speed.cloudflare.com/__down?bytes=50000000"` | Download URL used by the tunnel speed test. Cloudflare's `__down` answers `403` for `bytes` of 100 MB or more, which fails every stream, so keep this comfortably under that cap. Streams re-request the payload if it drains before `speed_test_measure_ms` elapses, so a larger size buys only fewer refills, not a better reading. |
 | `speed_test_latency_samples` | `5` | Number of samples averaged for the speed test's latency reading. |
 | `speed_test_parallel_streams` | `4` | Concurrent download streams per throughput leg — avoids the single-TCP-flow bandwidth ceiling that understates tunnel throughput at higher RTT. |
 | `speed_test_warmup_ms` | `1000` | Warm-up period (ms) discarded from each stream before bytes count toward the measurement, excluding connection setup and TCP slow-start. |


### PR DESCRIPTION
## Problem

The speed test has been failing on every box since #932 landed:

```
upstream unavailable: throughput download failed: throughput download failed: all parallel download streams failed
```

#932 raised the default `speed_test_url` to `bytes=500000000`, but Cloudflare's `__down` endpoint only serves the payload **below 100 MB** — at or above that it answers `403` with no body. Measured from a daemon box:

| `bytes=` | status |
| --- | --- |
| `50000000` | `200` |
| `99000000` | `200` |
| `100000000` | **`403`** |
| `500000000` (the new default) | **`403`** |

`run_stream` treats a non-success status as a stream failure, so all four streams fail identically and `aggregate_throughput` returns `all parallel download streams failed`. The pre-#932 default (10 MB) was under the cap, which is why this only broke now. Any box without a `[tunnel]` override — i.e. the default — has no working speed test.

CI stayed green because the existing tests only cover the pure `aggregate_throughput` function; nothing exercises the configured URL.

## Fix

**1. Default → `bytes=50000000`.** 2× headroom under the cap rather than sitting on it, so a tightened cap doesn't re-break it. Pinned by a test that fails with the exact production symptom, since a default the endpoint refuses is precisely what slipped through.

**2. Streams re-request a drained payload.** #932's rationale for the huge payload — *"large enough that no stream runs dry mid-measurement even on a near-gigabit link"* — cannot hold under a sub-100 MB cap: ~1 Gbps across 4 streams needs ~156 MB per stream to cover the 5s window. A drained stream stopped counting while `aggregate_throughput` still divided by the **full** measure window, silently understating throughput on exactly the fast links the parallel-stream rework exists to measure correctly. Re-requesting keeps bytes flowing for the whole window, so payload size now trades only refill overhead (~1 RTT on a kept-alive connection), never accuracy.

**3. Docs.** `config.rs` and the `configuration.md` table both documented the 500 MB default and its now-false rationale.

## Verification

- New config test reproduces the production failure (RED), then passes (GREEN).
- `cargo fmt --check` + `cargo clippy -p wardnetd -p wardnet-common --all-targets -- -D warnings` clean on Linux.
- `cargo test -p wardnetd --lib -- tunnel_throughput` → 7/7 pass.
- Against the real endpoint from a daemon box: 4 parallel streams all return `200` and sustain **~141 Mbps**, where a single stream read ~4 Mbps — which also vindicates #932's parallel-streams premise.

## Note

The `< 100 MB` cap is empirical — Cloudflare doesn't document it. The test comment records how it was measured.

## Merge Commit Message

fix(tunnel): request a payload Cloudflare will actually serve

The speed test failed on every default-config box since #932 raised
speed_test_url to 500 MB, which Cloudflare's __down endpoint refuses with
a 403 (it caps below 100 MB), failing every stream. Drop to 50 MB with
headroom under the cap, pin it with a test, and re-request a drained
payload so the sub-cap size can't understate throughput on fast links.

https://claude.ai/code/session_01WyBXDWnjHaoKbJDzKchNVN