### PR TITLE
fix(ci): record the coverage baseline from the same pool the gate measures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,8 +150,17 @@ jobs:
     # Gate each coverage job on the relevant change bucket (see pr.yml).
     with:
       run-daemon: ${{ needs.preflight.outputs.daemon == 'true' || needs.preflight.outputs.ci == 'true' }}
-      run-site: ${{ needs.preflight.outputs.site == 'true' || needs.preflight.outputs.ci == 'true' }}
-      run-frontend: ${{ needs.preflight.outputs['admin-web'] == 'true' || needs.preflight.outputs['admin-app'] == 'true' || needs.preflight.outputs['user-app'] == 'true' || needs.preflight.outputs.ci == 'true' }}
+      # site + frontend LCOVs merge into ONE "typescript" pool, and THIS
+      # workflow is what records the baseline PRs are judged against. Running
+      # only one of the two records a partial pool as if it were the whole:
+      # a push touching only `site` stored marketing-site's 98.02% over the
+      # real full-pool 92.68%, and every later PR — which pr.yml correctly
+      # makes run BOTH jobs — was then failed for a 4.3% "regression" it
+      # didn't cause. Keep these two conditions identical to each other and
+      # to pr.yml's, so the baseline always describes the same pool the PR
+      # gate measures.
+      run-site: ${{ needs.preflight.outputs.site == 'true' || needs.preflight.outputs['admin-web'] == 'true' || needs.preflight.outputs['admin-app'] == 'true' || needs.preflight.outputs['user-app'] == 'true' || needs.preflight.outputs.ci == 'true' }}
+      run-frontend: ${{ needs.preflight.outputs.site == 'true' || needs.preflight.outputs['admin-web'] == 'true' || needs.preflight.outputs['admin-app'] == 'true' || needs.preflight.outputs['user-app'] == 'true' || needs.preflight.outputs.ci == 'true' }}
     secrets: inherit
 
   tests-e2e:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -155,10 +155,12 @@ jobs:
     with:
       run-daemon: ${{ needs.preflight.outputs.daemon == 'true' || needs.preflight.outputs.ci == 'true' }}
       # site + frontend LCOVs merge into ONE "typescript" pool in bulwark's
-      # coverage gate, and the baseline is recorded from full main runs. If
-      # only one of the two jobs runs on a PR, the partial pool is compared
-      # against the full-pool baseline and fails as a phantom regression —
-      # so any TypeScript-area change must run BOTH coverage jobs.
+      # coverage gate, and the baseline is recorded by ci.yml on main. If
+      # only one of the two jobs runs, the partial pool is compared against
+      # a full-pool baseline (or recorded as one) and fails as a phantom
+      # regression — so any TypeScript-area change must run BOTH coverage
+      # jobs. ci.yml's matching conditions must stay identical to these; the
+      # two drifting apart is exactly what poisoned the baseline once.
       run-site: ${{ needs.preflight.outputs.site == 'true' || needs.preflight.outputs['admin-web'] == 'true' || needs.preflight.outputs['admin-app'] == 'true' || needs.preflight.outputs['user-app'] == 'true' || needs.preflight.outputs.ci == 'true' }}
       run-frontend: ${{ needs.preflight.outputs.site == 'true' || needs.preflight.outputs['admin-web'] == 'true' || needs.preflight.outputs['admin-app'] == 'true' || needs.preflight.outputs['user-app'] == 'true' || needs.preflight.outputs.ci == 'true' }}
     secrets: inherit


### PR DESCRIPTION
## Problem

Every PR touching TypeScript is currently failing the coverage gate with a regression it didn't cause:

```
rust: 86.3% (baseline 86.4%); typescript: 93.7% (baseline 98.0%, regressed 4.3%)
```

`bulwark` merges the **site** and **frontend** LCOVs into a single `typescript` pool. `pr.yml` already knows this and deliberately couples `run-site`/`run-frontend` so a PR always measures the whole pool. But **`ci.yml` — which records the baseline that `pr.yml` is judged against — gates the two independently**:

```yaml
# ci.yml (records baseline)                # pr.yml (checks against it)
run-site:     site || ci                   run-site:     site || admin-web || admin-app || user-app || ci
run-frontend: admin-web || admin-app       run-frontend: site || admin-web || admin-app || user-app || ci
              || user-app || ci
```

So a push to main touching only `site` runs site coverage, **skips** frontend coverage, and stores marketing-site's number as if it were the full pool. That is exactly what #932's `configuration.md` edit did on main:

```
Coverage / Site coverage:     success
Coverage / Frontend coverage: skipped     ← records a partial pool
Coverage / bulwark:           success     → typescript = 98.02
```

The recorded baselines show the corruption plainly:

| main commit | touched | recorded `typescript` |
| --- | --- | --- |
| `a0d37a2` (#930) | dns, http | 92.68 |
| `dd39901` (#931) | daemon only | 92.68 |
| `993a12a` (#932) | daemon + `configuration.md` (**site**, no `admin-*`) | **98.02** ← poisoned |

The real full-pool baseline is **92.68%**. PRs correctly measure both halves at **93.7%** and get compared against a site-only 98.02%, failing for a phantom 4.3% regression. Coverage had actually gone **up** (93.7% > 92.68%).

## Fix

Give `ci.yml` the same coupled conditions as `pr.yml`, so the baseline always describes the same pool the gate measures. Both files now note that the two must stay in lockstep — the drift between them is the whole bug.

## This PR cannot fix its own run

The gate still compares against the poisoned `993a12a` baseline, so **coverage will be red here too** — a CI change sets `ci=true`, runs both jobs, and yields the same ~93.7% vs 98.02%. That is expected and is the reason this needs an admin merge.

Merging re-records a correct full-pool baseline on main, which unblocks #933 and every subsequent TypeScript PR.

## Verification

- Both workflows parse as valid YAML.
- All four `run-site`/`run-frontend` conditions are now byte-identical across `ci.yml` and `pr.yml`.

## Merge Commit Message

fix(ci): record the coverage baseline from the same pool the gate measures

bulwark merges site + frontend LCOVs into one "typescript" pool, but
ci.yml gated the two jobs independently while pr.yml coupled them, so a
main push touching only `site` recorded a partial pool (98.02%) over the
real full-pool baseline (92.68%) and failed every later PR for a phantom
4.3% regression. Couple ci.yml's conditions to match pr.yml's.

https://claude.ai/code/session_01WyBXDWnjHaoKbJDzKchNVN