### PR TITLE
feat(ui): sort device and tunnel lists alphabetically, declutter DHCP note

### DIFF
--- a/source/admin-site/src/components/compound/DeviceSelect.tsx
+++ b/source/admin-site/src/components/compound/DeviceSelect.tsx
@@ -7,10 +7,22 @@ import {
 } from "@wardnet/web";
 import { DeviceIcon } from "@wardnet/web";
 import { Text } from "@wardnet/web";
+import { deviceDisplayName, sortByLabel } from "@wardnet/web";
+import { useCallback, useMemo } from "react";
 import type { Device } from "@wardnet/js";
 
+/** The option's primary line — also what the list sorts by, so the two can't
+ *  drift. Defers to the shared display name (rather than repeating its
+ *  fallback chain) so this dropdown orders a given device identically to the
+ *  devices table; `last_ip` is only a fallback *preference* ahead of the MAC. */
+function optionLabel(d: Device): string {
+  return deviceDisplayName(d, d.last_ip);
+}
+
 interface DeviceSelectProps {
-  /** Devices to choose from. Order is preserved. */
+  /** Devices to choose from. Rendered alphabetically by display name
+   *  regardless of the order passed in. A device whose `valueKey` field is
+   *  blank is omitted — it cannot be represented as an option. */
   devices: Device[];
   /** Currently selected value. Empty string = nothing selected (shows the
    *  sentinel/placeholder). */
@@ -62,7 +74,25 @@ export function DeviceSelect({
   id,
   triggerClassName,
 }: DeviceSelectProps) {
-  const keyOf = (d: Device) => (valueKey === "id" ? d.id : d.last_ip);
+  const keyOf = useCallback(
+    (d: Device) => (valueKey === "id" ? d.id : d.last_ip),
+    [valueKey],
+  );
+
+  // A device with a blank key cannot become an option: Radix reserves the
+  // empty string for "no selection" and throws on a SelectItem carrying one,
+  // which takes down the entire dropdown rather than just that row. Dropping
+  // such a device costs nothing — in IP mode a device with no IP is precisely
+  // the device an IP filter could never match, and `id` is a primary key, so
+  // in practice this only ever guards the IP mode.
+  const options = useMemo(
+    () =>
+      sortByLabel(
+        devices.filter((d) => keyOf(d)?.trim()),
+        optionLabel,
+      ),
+    [devices, keyOf],
+  );
   const selected = devices.find((d) => keyOf(d) === value);
   // Trigger label collapses to a single line (icon + name) so it fits
   // the narrow filter column. Dropdown items remain two-line so users
@@ -71,7 +101,7 @@ export function DeviceSelect({
     <span className="flex min-w-0 items-center gap-2">
       <DeviceIcon type={selected.device_type} size={16} />
       <Text as="span" weight="medium" className="truncate">
-        {selected.name || selected.hostname || selected.last_ip}
+        {optionLabel(selected)}
       </Text>
     </span>
   ) : (
@@ -104,16 +134,22 @@ export function DeviceSelect({
             <span className="text-ink-3">{anyLabel}</span>
           </SelectItem>
         )}
-        {!includeAny && devices.length === 0 && emptyLabel && (
+        {/* Keyed off the rendered options, not the raw prop: if every device
+            was filtered out for lacking a usable key, the dropdown is empty
+            and must say so rather than open onto nothing. */}
+        {!includeAny && options.length === 0 && emptyLabel && (
           <div className="px-2 py-1.5">
             <Text as="span" size="sm" className="text-ink-3">
               {emptyLabel}
             </Text>
           </div>
         )}
-        {devices.map((d) => {
-          const primary = d.name || d.hostname || d.last_ip;
-          const secondary = d.name || d.hostname ? d.last_ip : null;
+        {options.map((d) => {
+          const primary = optionLabel(d);
+          // Suppress the IP subtitle when the IP *is* the primary line —
+          // derived from the rendered label rather than re-testing
+          // name/hostname, so the two can't disagree.
+          const secondary = primary === d.last_ip ? null : d.last_ip;
           return (
             <SelectItem key={d.id} value={keyOf(d)}>
               <div className="flex items-center gap-2">

--- a/source/admin-site/src/components/compound/DhcpConfigCard.tsx
+++ b/source/admin-site/src/components/compound/DhcpConfigCard.tsx
@@ -1,4 +1,5 @@
 import { useMemo, useState } from "react";
+import { Info } from "lucide-react";
 import { Button } from "@wardnet/web";
 import {
   Card,
@@ -360,27 +361,38 @@ export function DhcpConfigCard({ config }: DhcpConfigCardProps) {
             </div>
             <div>
               <dt className="text-ink-3">Upstream DNS</dt>
-              <dd className={dnsEnabled ? "font-medium" : "font-mono text-xs"}>
+              <dd
+                className={`flex items-center gap-1.5 ${dnsEnabled ? "font-medium" : "font-mono text-xs"}`}
+              >
                 {dnsEnabled === undefined
                   ? "…"
                   : dnsEnabled
                     ? "Wardnet DNS"
                     : config.upstream_dns.join(", ") || "-"}
+                {/* "Wardnet DNS" is what NEW leases get. DHCP cannot push it to
+                    a device that already holds a lease, and a device resolving
+                    via its old server is silently unfiltered — so don't let this
+                    read as "every device is using Wardnet DNS right now". The
+                    caveat is a footnote, not a headline: it rides an info icon
+                    so it stops crowding the value it qualifies.
+
+                    `title` is the codebase's tooltip mechanism (see TunnelCard)
+                    — no hover-card primitive exists to reach for. It is
+                    keyboard- and touch-inert, so the note also stays on the
+                    enable/disable toast, which is where an admin acting on it
+                    actually sees it. */}
+                {dnsEnabled && (
+                  <span
+                    title={LEASE_RENEWAL_NOTE}
+                    aria-label={LEASE_RENEWAL_NOTE}
+                    role="img"
+                    data-testid="dhcp-dns-lease-note"
+                    className="inline-flex cursor-help text-ink-3"
+                  >
+                    <Info size={14} aria-hidden className="shrink-0" />
+                  </span>
+                )}
               </dd>
-              {/* "Wardnet DNS" is what NEW leases get. DHCP cannot push it to a
-                  device that already holds a lease, and a device resolving via
-                  its old server is silently unfiltered — so don't let this read
-                  as "every device is using Wardnet DNS right now". */}
-              {dnsEnabled && (
-                <Text
-                  as="p"
-                  size="xs"
-                  className="mt-1 text-ink-3"
-                  data-testid="dhcp-dns-lease-note"
-                >
-                  {LEASE_RENEWAL_NOTE}
-                </Text>
-              )}
             </div>
           </dl>
         </CardContent>

--- a/source/admin-site/src/components/compound/DhcpEntryTable.tsx
+++ b/source/admin-site/src/components/compound/DhcpEntryTable.tsx
@@ -9,6 +9,7 @@ import {
 } from "@/components/core/ui/data-table";
 import { DeviceIcon } from "@wardnet/web";
 import { Text } from "@wardnet/web";
+import { deviceDisplayName, sortByLabel } from "@wardnet/web";
 import { DiscoveryPlaceholder } from "@/components/compound/DiscoveryPlaceholder";
 import { HostCell, buildDeviceIndex } from "@/components/compound/HostCell";
 import { StatusBadge } from "@/components/compound/StatusBadge";
@@ -64,6 +65,22 @@ function reservationTypeBadge(): ReactNode {
   return <Pill variant="info">Static</Pill>;
 }
 
+/** The Host cell's primary line. Shared with the table's sort so rows are
+ *  ordered by the text the cell actually renders, not by raw MAC.
+ *
+ *  Precedence is the entry's own hostname over the device's — the lease said
+ *  so more recently — but the fallback chain itself is deviceDisplayName's, so
+ *  a blank hostname degrades to the MAC here exactly as it does everywhere
+ *  else rather than sorting as "" to the top of the table. */
+function hostLabel(entry: DhcpEntry, deviceIndex: Map<string, Device>): string {
+  const device = deviceIndex.get(entry.mac.toLowerCase());
+  return deviceDisplayName({
+    name: device?.name ?? null,
+    hostname: entry.hostname ?? device?.hostname ?? null,
+    mac: entry.mac,
+  });
+}
+
 function buildColumns(
   deviceIndex: Map<string, Device>,
 ): ColumnDef<DhcpEntry>[] {
@@ -74,8 +91,7 @@ function buildColumns(
       cell: ({ row }) => {
         const entry = row.original;
         const device = deviceIndex.get(entry.mac.toLowerCase());
-        const primary =
-          device?.name ?? entry.hostname ?? device?.hostname ?? entry.mac;
+        const primary = hostLabel(entry, deviceIndex);
         const secondary = primary === entry.mac ? null : entry.mac;
         const fallbackIcon =
           entry.kind === "reservation" ? (
@@ -227,15 +243,19 @@ export function DhcpEntryTable({
       return !(e.kind === "lease" && reservationIndex.has(e.mac.toLowerCase()));
     });
     const q = searchValue.trim().toLowerCase();
-    if (!q) return byGroup;
-    return byGroup.filter(
-      (e) =>
-        e.mac.toLowerCase().includes(q) ||
-        (e.hostname ?? "").toLowerCase().includes(q) ||
-        e.ip.toLowerCase().includes(q) ||
-        (e.description ?? "").toLowerCase().includes(q),
-    );
-  }, [entries, activeGroup, searchValue, reservationIndex]);
+    const matched = !q
+      ? byGroup
+      : byGroup.filter(
+          (e) =>
+            e.mac.toLowerCase().includes(q) ||
+            (e.hostname ?? "").toLowerCase().includes(q) ||
+            e.ip.toLowerCase().includes(q) ||
+            (e.description ?? "").toLowerCase().includes(q),
+        );
+    // Sorted here rather than on `entries` so the group counts above keep
+    // measuring the unsorted source lists.
+    return sortByLabel(matched, (e) => hostLabel(e, deviceIndex));
+  }, [entries, activeGroup, searchValue, reservationIndex, deviceIndex]);
 
   const columns = useMemo(() => buildColumns(deviceIndex), [deviceIndex]);
 

--- a/source/admin-site/src/components/compound/TunnelGrid.tsx
+++ b/source/admin-site/src/components/compound/TunnelGrid.tsx
@@ -1,9 +1,12 @@
+import { useMemo } from "react";
 import { Card, CardContent } from "@wardnet/web";
+import { sortByLabel } from "@wardnet/web";
 import { TunnelCard } from "./TunnelCard";
 import { EmptyStatePlaceholder } from "./EmptyStatePlaceholder";
 import type { Tunnel, ProviderInfo } from "@wardnet/js";
 
 interface TunnelGridProps {
+  /** Rendered alphabetically by label regardless of the order passed in. */
   tunnels: Tunnel[];
   providers: ProviderInfo[];
   isLoading: boolean;
@@ -22,6 +25,9 @@ export function TunnelGrid({
   onDelete,
   onAdd,
 }: TunnelGridProps) {
+  // Before the loading/empty early-returns: hook order must not depend on state.
+  const sorted = useMemo(() => sortByLabel(tunnels, (t) => t.label), [tunnels]);
+
   if (isLoading) {
     return (
       <Card>
@@ -48,7 +54,7 @@ export function TunnelGrid({
 
   return (
     <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
-      {tunnels.map((tunnel) => (
+      {sorted.map((tunnel) => (
         <TunnelCard
           key={tunnel.id}
           tunnel={tunnel}

--- a/source/admin-site/src/components/features/TunnelDevicesTable.tsx
+++ b/source/admin-site/src/components/features/TunnelDevicesTable.tsx
@@ -7,6 +7,7 @@ import {
   CardHeader,
   CardTitle,
   deviceDisplayName,
+  sortByLabel,
   Text,
 } from "@wardnet/web";
 import { DataTable } from "@/components/core/ui/data-table";
@@ -51,7 +52,10 @@ function buildColumns(): ColumnDef<Device>[] {
 export function TunnelDevicesTable({ tunnelId }: Props) {
   const navigate = useNavigate();
   const { data, isLoading, isError } = useTunnelDevices(tunnelId);
-  const devices = data?.devices ?? [];
+  const devices = useMemo(
+    () => sortByLabel(data?.devices ?? [], deviceDisplayName),
+    [data?.devices],
+  );
   const columns = useMemo(() => buildColumns(), []);
 
   return (

--- a/source/admin-site/src/pages/Devices.tsx
+++ b/source/admin-site/src/pages/Devices.tsx
@@ -3,7 +3,7 @@ import { useNavigate } from "react-router";
 import { PageHeader } from "@/components/compound/PageHeader";
 import { DeviceTable } from "@/components/compound/DeviceTable";
 import { DiscoveryPlaceholder } from "@/components/compound/DiscoveryPlaceholder";
-import { deviceDisplayName, useDevices } from "@wardnet/web";
+import { deviceDisplayName, sortByLabel, useDevices } from "@wardnet/web";
 import type { Device } from "@wardnet/js";
 
 type GroupId = "all" | "managed" | "unmanaged" | "recent";
@@ -30,14 +30,6 @@ function matchesSearch(d: Device, q: string): boolean {
     (d.last_ip ?? "").toLowerCase().includes(needle) ||
     (d.name ?? "").toLowerCase().includes(needle)
   );
-}
-
-function sortDevices(devices: Device[]): Device[] {
-  return [...devices].sort((a, b) => {
-    const nameA = deviceDisplayName(a).toLowerCase();
-    const nameB = deviceDisplayName(b).toLowerCase();
-    return nameA.localeCompare(nameB);
-  });
 }
 
 /** Devices page with grouped, searchable device table. */
@@ -72,7 +64,10 @@ export default function Devices() {
           : group === "recent"
             ? allDevices.filter((d) => isRecent(d, now))
             : allDevices;
-    return sortDevices(byGroup.filter((d) => matchesSearch(d, query)));
+    return sortByLabel(
+      byGroup.filter((d) => matchesSearch(d, query)),
+      deviceDisplayName,
+    );
   }, [allDevices, group, query, now]);
 
   function openDevice(id: string) {

--- a/source/admin-site/src/pages/DnsLogs.tsx
+++ b/source/admin-site/src/pages/DnsLogs.tsx
@@ -238,30 +238,42 @@ export default function DnsLogs() {
   // height (34px). The search input itself is the Domain filter.
   const filters = (
     <>
-      <DeviceSelect
-        id="device-filter"
-        devices={filterableDevices}
-        valueKey="id"
-        value={deviceId}
-        onChange={(id) => {
-          setDeviceId(id);
-          setPage(0);
-        }}
-        triggerClassName="select-trigger--md w-48"
-      />
-      {/* Free-text IP filter: the only handle on rows with no device
-          attribution (unknown sources, pre-attribution history). */}
-      <Input
-        id="client-ip-filter"
-        data-testid="dns-log-ip-filter"
-        className="w-36"
-        placeholder="Client IP…"
-        value={clientIp}
-        onChange={(e) => {
-          setClientIp(e.target.value);
-          setPage(0);
-        }}
-      />
+      {/* Device and client-IP are one question ("which client?") asked two
+          ways, so they're wrapped rather than left as toolbar siblings: the
+          toolbar is `flex-wrap`, and loose siblings let the IP box wrap onto
+          its own row away from the dropdown it belongs with.
+
+          The pair stays on one row at every width instead of being allowed to
+          wrap, so the controls narrow on small screens rather than pushing the
+          toolbar into horizontal scroll: `min-w-0` defeats the default
+          `min-width:auto` that would otherwise stop a flex item shrinking
+          below its content. At 360px the group is ~284px and fits. */}
+      <div className="flex min-w-0 items-center gap-3">
+        <DeviceSelect
+          id="device-filter"
+          devices={filterableDevices}
+          valueKey="id"
+          value={deviceId}
+          onChange={(id) => {
+            setDeviceId(id);
+            setPage(0);
+          }}
+          triggerClassName="select-trigger--md w-40 min-w-0 sm:w-48"
+        />
+        {/* Free-text IP filter: the only handle on rows with no device
+            attribution (unknown sources, pre-attribution history). */}
+        <Input
+          id="client-ip-filter"
+          data-testid="dns-log-ip-filter"
+          className="w-28 min-w-0 sm:w-36"
+          placeholder="Client IP…"
+          value={clientIp}
+          onChange={(e) => {
+            setClientIp(e.target.value);
+            setPage(0);
+          }}
+        />
+      </div>
       <Select
         value={result}
         onValueChange={(v) => {

--- a/source/admin-site/src/pages/Vpn.tsx
+++ b/source/admin-site/src/pages/Vpn.tsx
@@ -45,9 +45,9 @@ export default function Vpn() {
   const removePeer = useRemoveInboundWgPeer();
   const setPeerEnabled = useSetInboundWgPeerEnabled();
 
-  // The `?? []` fallbacks would mint a new array on every render while the
-  // queries are unresolved; memoising keeps the identities stable so the
-  // derived lists below (and DeviceSelect's sort) actually cache.
+  // Memoised so the `?? []` fallback cannot mint a fresh array identity on
+  // every render: the derived lists below depend on these, and DeviceSelect
+  // memoises its alphabetical sort on the `devices` prop it is handed.
   const peers = useMemo(() => peersData?.peers ?? [], [peersData?.peers]);
   const devices = useMemo(
     () => devicesData?.devices ?? [],

--- a/source/admin-site/src/pages/Vpn.tsx
+++ b/source/admin-site/src/pages/Vpn.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { Link } from "react-router";
 import {
   Card,
@@ -45,21 +45,35 @@ export default function Vpn() {
   const removePeer = useRemoveInboundWgPeer();
   const setPeerEnabled = useSetInboundWgPeerEnabled();
 
-  const peers = peersData?.peers ?? [];
-  const devices = devicesData?.devices ?? [];
+  // The `?? []` fallbacks would mint a new array on every render while the
+  // queries are unresolved; memoising keeps the identities stable so the
+  // derived lists below (and DeviceSelect's sort) actually cache.
+  const peers = useMemo(() => peersData?.peers ?? [], [peersData?.peers]);
+  const devices = useMemo(
+    () => devicesData?.devices ?? [],
+    [devicesData?.devices],
+  );
   // Only *managed* (admin-named) devices can be granted remote access — the
   // backend rejects unmanaged ones. A device with no name is still just
   // "discovered".
-  const managedDevices = devices.filter((d) => d.name != null);
+  const managedDevices = useMemo(
+    () => devices.filter((d) => d.name != null),
+    [devices],
+  );
   // Grantable = managed AND has no peer row yet. `connection_mode` is NOT a
   // reliable signal: the daemon only flips it to `remote` once the peer
   // actually handshakes (and clears it again on pause), so an offline /
   // freshly granted / paused device would still read `!== "remote"` and get
   // offered for a re-grant that the one-credential-per-device guard 409s.
-  const grantedDeviceIds = new Set(
-    peers.map((p) => p.device_id).filter((id): id is string => id !== null),
-  );
-  const grantable = managedDevices.filter((d) => !grantedDeviceIds.has(d.id));
+  // Memoised so the array identity is stable across renders: DeviceSelect
+  // memoises its alphabetical sort on the `devices` prop, and a fresh array
+  // every render would defeat that.
+  const grantable = useMemo(() => {
+    const grantedDeviceIds = new Set(
+      peers.map((p) => p.device_id).filter((id): id is string => id !== null),
+    );
+    return managedDevices.filter((d) => !grantedDeviceIds.has(d.id));
+  }, [managedDevices, peers]);
 
   // Local override for the listen-port input — `null` until the admin
   // edits it, so the field otherwise tracks the fetched config directly

--- a/source/admin-site/tests/components/compound/DeviceSelect.test.tsx
+++ b/source/admin-site/tests/components/compound/DeviceSelect.test.tsx
@@ -86,4 +86,102 @@ describe("DeviceSelect", () => {
     await user.click(within(listbox).getByText("Any device"));
     expect(onChange).toHaveBeenCalledWith("");
   });
+
+  // Order is the component's job, not the caller's — asserted on the rendered
+  // options so reverting the sort can't pass silently.
+  it("lists devices alphabetically regardless of the order passed in", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(
+      <DeviceSelect
+        devices={[
+          makeDevice({ id: "d1", name: "zeta", last_ip: "10.0.0.1" }),
+          makeDevice({ id: "d2", name: "Alpha", last_ip: "10.0.0.2" }),
+          makeDevice({ id: "d3", hostname: "beta", last_ip: "10.0.0.3" }),
+        ]}
+        value=""
+        onChange={vi.fn()}
+        includeAny={false}
+      />,
+    );
+    await user.click(screen.getByRole("combobox"));
+    const options = await screen.findAllByRole("option");
+    expect(options.map((o) => o.textContent)).toEqual([
+      expect.stringContaining("Alpha"),
+      expect.stringContaining("beta"),
+      expect.stringContaining("zeta"),
+    ]);
+  });
+
+  // Radix reserves "" for "no selection" and throws on a SelectItem carrying
+  // it, which would unmount the whole dropdown — not just the offending row.
+  // A device with no IP is also exactly what an IP filter can never match, so
+  // omitting it loses nothing.
+  it("omits a device with a blank key instead of crashing the dropdown", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(
+      <DeviceSelect
+        devices={[
+          makeDevice({ id: "d1", name: "Has IP", last_ip: "10.0.0.9" }),
+          makeDevice({ id: "d2", name: "No IP", last_ip: "" }),
+        ]}
+        value=""
+        onChange={vi.fn()}
+        includeAny={false}
+      />,
+    );
+    await user.click(screen.getByRole("combobox"));
+    const options = await screen.findAllByRole("option");
+    expect(options.map((o) => o.textContent)).toEqual([
+      expect.stringContaining("Has IP"),
+    ]);
+  });
+
+  it("shows the empty label when every device lacks a usable key", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(
+      <DeviceSelect
+        devices={[makeDevice({ id: "d1", name: "No IP", last_ip: "" })]}
+        value=""
+        onChange={vi.fn()}
+        includeAny={false}
+        emptyLabel="No selectable devices."
+      />,
+    );
+    await user.click(screen.getByRole("combobox"));
+    expect(
+      await screen.findByText("No selectable devices."),
+    ).toBeInTheDocument();
+    expect(screen.queryAllByRole("option")).toHaveLength(0);
+  });
+
+  // An unnamed device must resolve its label through the shared chain, so the
+  // dropdown and the devices table agree on where it belongs. Keyed by id
+  // because the IP-keyed mode drops a device with a blank IP (see above).
+  it("labels an unnamed device by IP, and a device with no IP by MAC", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(
+      <DeviceSelect
+        devices={[
+          makeDevice({ id: "d1", last_ip: "10.0.0.9" }),
+          makeDevice({
+            id: "d2",
+            name: "  ",
+            hostname: "",
+            last_ip: "",
+            mac: "AA:BB",
+          }),
+        ]}
+        valueKey="id"
+        value=""
+        onChange={vi.fn()}
+        includeAny={false}
+      />,
+    );
+    await user.click(screen.getByRole("combobox"));
+    const options = await screen.findAllByRole("option");
+    expect(options.map((o) => o.textContent)).toEqual([
+      expect.stringContaining("10.0.0.9"),
+      expect.stringContaining("AA:BB"),
+    ]);
+  });
 });

--- a/source/admin-site/tests/components/compound/DhcpConfigCard.test.tsx
+++ b/source/admin-site/tests/components/compound/DhcpConfigCard.test.tsx
@@ -91,10 +91,13 @@ describe("DhcpConfigCard", () => {
   // "Wardnet DNS" is what NEW leases get. DHCP cannot push it to a device
   // already holding a lease, and such a device resolves unfiltered without any
   // sign of it — so the read view must not imply the whole network is covered.
+  // The warning rides an info icon's tooltip rather than sitting inline, so
+  // assert on the accessible name: that is both what a screen reader announces
+  // and the only copy a sighted user can surface by hovering.
   it("warns that already-leased devices keep their old DNS until they reconnect", () => {
     mockDns.mockReturnValue({ data: { config: { enabled: true } } } as never);
     renderWithProviders(<DhcpConfigCard config={makeConfig()} />);
-    expect(screen.getByTestId("dhcp-dns-lease-note")).toHaveTextContent(
+    expect(screen.getByTestId("dhcp-dns-lease-note")).toHaveAccessibleName(
       /reconnect a device/i,
     );
   });

--- a/source/admin-site/tests/components/compound/DhcpConfigCard.test.tsx
+++ b/source/admin-site/tests/components/compound/DhcpConfigCard.test.tsx
@@ -212,6 +212,70 @@ describe("DhcpConfigCard", () => {
     expect(updateMutateAsync).toHaveBeenCalledOnce();
   });
 
+  // The validation gate is what stands between a typo and a DHCP scope that
+  // strands the network, so each rejection reason is worth pinning to the
+  // field that triggers it.
+  it("rejects an incomplete pool start", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<DhcpConfigCard config={makeConfig()} />);
+    await user.click(screen.getByTestId("dhcp-config-edit"));
+    const input = screen
+      .getByTestId("dhcp-pool-start")
+      .querySelectorAll("input")[0];
+    await user.click(input);
+    await user.keyboard("{Control>}a{/Control}{Backspace}");
+    expect(
+      await screen.findByText("Enter a complete pool start address."),
+    ).toBeInTheDocument();
+    expect(screen.getByTestId("dhcp-config-save")).toBeDisabled();
+  });
+
+  // Clearing an octet rather than pasting a partial string: Ipv4Input's paste
+  // handler only accepts a full dotted quad, so a partial paste is a no-op and
+  // would leave the field valid.
+  it("rejects an incomplete fallback router address", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<DhcpConfigCard config={makeConfig()} />);
+    await user.click(screen.getByTestId("dhcp-config-edit"));
+    const octets = screen.getByTestId("dhcp-router").querySelectorAll("input");
+    await user.click(octets[3]);
+    await user.keyboard("{Control>}a{/Control}{Backspace}");
+    expect(
+      await screen.findByText("Enter a complete fallback router address."),
+    ).toBeInTheDocument();
+  });
+
+  // A public router address would hand every client a gateway off the LAN.
+  it("rejects a non-private fallback router address", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<DhcpConfigCard config={makeConfig()} />);
+    await user.click(screen.getByTestId("dhcp-config-edit"));
+    const router = screen
+      .getByTestId("dhcp-router")
+      .querySelectorAll("input")[0];
+    await user.click(router);
+    await user.paste("8.8.8.8");
+    expect(
+      await screen.findByText(/Fallback router must be/),
+    ).toBeInTheDocument();
+  });
+
+  it("edits the lease duration and upstream DNS fields", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<DhcpConfigCard config={makeConfig()} />);
+    await user.click(screen.getByTestId("dhcp-config-edit"));
+
+    const lease = screen.getByLabelText(/Lease duration/i);
+    await user.clear(lease);
+    await user.type(lease, "3600");
+    expect(lease).toHaveValue(3600);
+
+    const dns = screen.getByLabelText(/Upstream DNS/i);
+    await user.clear(dns);
+    await user.type(dns, "9.9.9.9");
+    expect(dns).toHaveValue("9.9.9.9");
+  });
+
   it("renders an API error alert in edit mode when the update failed", async () => {
     const user = userEvent.setup();
     mockUpdate.mockReturnValue({

--- a/source/admin-site/tests/components/compound/DhcpEntryTable.test.tsx
+++ b/source/admin-site/tests/components/compound/DhcpEntryTable.test.tsx
@@ -208,4 +208,72 @@ describe("DhcpEntryTable", () => {
     await user.click(screen.getByText("Known laptop"));
     expect(onDeviceClick).toHaveBeenCalledWith("dev-42");
   });
+
+  it("orders rows alphabetically by the host label", () => {
+    renderWithProviders(
+      <DhcpEntryTable
+        {...noop}
+        leases={[
+          makeLease({
+            id: "l1",
+            mac_address: "AA:BB:CC:DD:EE:02",
+            hostname: "zeta",
+          }),
+          makeLease({
+            id: "l2",
+            mac_address: "AA:BB:CC:DD:EE:03",
+            hostname: "Alpha",
+          }),
+        ]}
+        reservations={[
+          makeReservation({
+            id: "r1",
+            mac_address: "AA:BB:CC:DD:EE:01",
+            hostname: "beta",
+          }),
+        ]}
+        devices={[]}
+        activeGroup="all"
+        searchValue=""
+      />,
+    );
+    const rows = screen.getAllByRole("row").slice(1); // drop the header row
+    const hosts = rows.map((r) => r.textContent);
+    expect(hosts).toEqual([
+      expect.stringContaining("Alpha"),
+      expect.stringContaining("beta"),
+      expect.stringContaining("zeta"),
+    ]);
+  });
+
+  // An empty hostname must degrade to the MAC, not sort as "" above every
+  // named row while rendering a blank cell.
+  it("falls back to the MAC for a blank hostname instead of sorting it first", () => {
+    renderWithProviders(
+      <DhcpEntryTable
+        {...noop}
+        leases={[
+          makeLease({
+            id: "l1",
+            mac_address: "ZZ:ZZ:ZZ:ZZ:ZZ:99",
+            hostname: "",
+          }),
+          makeLease({
+            id: "l2",
+            mac_address: "AA:BB:CC:DD:EE:03",
+            hostname: "Alpha",
+          }),
+        ]}
+        reservations={[]}
+        devices={[]}
+        activeGroup="all"
+        searchValue=""
+      />,
+    );
+    const rows = screen.getAllByRole("row").slice(1);
+    expect(rows.map((r) => r.textContent)).toEqual([
+      expect.stringContaining("Alpha"),
+      expect.stringContaining("ZZ:ZZ:ZZ:ZZ:ZZ:99"),
+    ]);
+  });
 });

--- a/source/admin-site/tests/components/compound/TunnelGrid.test.tsx
+++ b/source/admin-site/tests/components/compound/TunnelGrid.test.tsx
@@ -126,4 +126,29 @@ describe("TunnelGrid", () => {
     await user.click(deleteButtons[0]);
     expect(onDelete).toHaveBeenCalledWith("t1");
   });
+
+  // Card order is the grid's job. Asserted on the rendered sequence so
+  // dropping the sort can't pass silently.
+  it("renders tunnel cards alphabetically regardless of the order passed in", () => {
+    renderWithProviders(
+      <TunnelGrid
+        tunnels={[
+          makeTunnel({ id: "t1", label: "zeta" }),
+          makeTunnel({ id: "t2", label: "Alpha" }),
+          makeTunnel({ id: "t3", label: "beta" }),
+        ]}
+        providers={providers}
+        isLoading={false}
+        isError={false}
+        onDelete={vi.fn()}
+      />,
+    );
+    // Each card is a link wrapping the whole tunnel; assert on href order so
+    // the check is about sequence, not card markup.
+    expect(
+      screen.getAllByRole("link").map((a) => a.getAttribute("href")),
+    ).toEqual(
+      ["/tunnels/t2", "/tunnels/t3", "/tunnels/t1"], // Alpha, beta, zeta
+    );
+  });
 });

--- a/source/admin-site/tests/pages/DnsLogs.test.tsx
+++ b/source/admin-site/tests/pages/DnsLogs.test.tsx
@@ -241,4 +241,27 @@ describe("DnsLogs", () => {
     const row = screen.getByText("x.test").closest("tr")!;
     expect(within(row).getByText("9.9.9.9")).toBeInTheDocument();
   });
+
+  // The IP box is the only handle on rows with no device attribution, so it
+  // must actually narrow the live tail — not just hold text.
+  it("filters the live tail by client IP", async () => {
+    const user = userEvent.setup();
+    useDnsLogStore.setState({
+      connected: true,
+      entries: [
+        liveEvent({ client_ip: "10.232.1.10", domain: "kept.test" }),
+        liveEvent({
+          client_ip: "9.9.9.9",
+          device_id: null,
+          domain: "gone.test",
+        }),
+      ],
+    });
+    renderWithProviders(<DnsLogs />);
+    expect(screen.getByText("gone.test")).toBeInTheDocument();
+
+    await user.type(screen.getByTestId("dns-log-ip-filter"), "10.232.1.10");
+    expect(screen.getByText("kept.test")).toBeInTheDocument();
+    expect(screen.queryByText("gone.test")).not.toBeInTheDocument();
+  });
 });

--- a/source/admin-site/tests/pages/Vpn.test.tsx
+++ b/source/admin-site/tests/pages/Vpn.test.tsx
@@ -40,15 +40,60 @@ vi.mock("@wardnet/web", async (importOriginal) => {
 vi.mock("@/components/compound/PageHeader", () => ({
   PageHeader: ({ title }: { title: ReactNode }) => <h1>{title}</h1>,
 }));
+// Stand-ins that surface the callbacks as buttons: the page's contract with
+// these children is *what it does when they fire*, which a null mock hides.
 vi.mock("@/components/compound/InboundWgPeersTable", () => ({
-  InboundWgPeersTable: () => null,
+  InboundWgPeersTable: ({
+    peers,
+    onToggleEnabled,
+    onRevoke,
+  }: {
+    peers: { id: string; name: string; enabled: boolean }[];
+    onToggleEnabled: (p: unknown) => void;
+    onRevoke: (p: unknown) => void;
+  }) => (
+    <div>
+      {peers.map((p) => (
+        <div key={p.id}>
+          <button onClick={() => onToggleEnabled(p)}>toggle:{p.id}</button>
+          <button onClick={() => onRevoke(p)}>revoke:{p.id}</button>
+        </div>
+      ))}
+    </div>
+  ),
 }));
-// Stand-in that reports how many devices survived the grantable filter — the
-// page's real output here is *which* devices it offers, not how they render.
+vi.mock("@/components/features/InboundWgPeerGrantedModal", () => ({
+  InboundWgPeerGrantedModal: ({
+    peer,
+    onDismiss,
+  }: {
+    peer: { id: string } | null;
+    onDismiss: () => void;
+  }) =>
+    peer ? (
+      <div>
+        <span>granted-modal:{peer.id}</span>
+        <button onClick={onDismiss}>dismiss-granted</button>
+      </div>
+    ) : null,
+}));
+// Reports which devices survived the grantable filter, and lets a test pick
+// one — the page's real output here is *which* devices it offers.
 vi.mock("@/components/compound/DeviceSelect", () => ({
-  DeviceSelect: ({ devices }: { devices: { id: string }[] }) => (
+  DeviceSelect: ({
+    devices,
+    onChange,
+  }: {
+    devices: { id: string }[];
+    onChange: (v: string) => void;
+  }) => (
     <div data-testid="device-select">
       grantable:{devices.map((d) => d.id).join(",") || "none"}
+      {devices.map((d) => (
+        <button key={d.id} onClick={() => onChange(d.id)}>
+          pick:{d.id}
+        </button>
+      ))}
     </div>
   ),
 }));
@@ -177,6 +222,126 @@ describe("Vpn", () => {
     expect(
       screen.getByText(/Every managed device already has remote access/),
     ).toBeInTheDocument();
+  });
+
+  it("grants access to the picked device and shows the credential once", async () => {
+    const user = userEvent.setup();
+    const mutateAsync = vi.fn().mockResolvedValue({ id: "new-peer" });
+    useAddInboundWgPeer.mockReturnValue({ mutateAsync, isPending: false });
+    useDevices.mockReturnValue({
+      data: { devices: [makeDevice({ id: "d1", name: "Laptop" })] },
+    });
+    renderWithProviders(<Vpn />);
+    await user.click(screen.getByRole("button", { name: "Grant access" }));
+    await user.click(screen.getByRole("button", { name: "pick:d1" }));
+    await user.click(screen.getByRole("button", { name: "Grant" }));
+
+    expect(mutateAsync).toHaveBeenCalledWith({ device_id: "d1" });
+    // The credential is shown exactly once, on grant — it cannot be re-read.
+    expect(
+      await screen.findByText("granted-modal:new-peer"),
+    ).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "dismiss-granted" }));
+    expect(
+      screen.queryByText("granted-modal:new-peer"),
+    ).not.toBeInTheDocument();
+  });
+
+  // A failed grant must keep the panel and the selection so the admin can
+  // retry, and must not surface as an unhandled rejection.
+  it("keeps the grant panel open when the mutation rejects", async () => {
+    const user = userEvent.setup();
+    const mutateAsync = vi.fn().mockRejectedValue(new Error("409"));
+    useAddInboundWgPeer.mockReturnValue({ mutateAsync, isPending: false });
+    useDevices.mockReturnValue({
+      data: { devices: [makeDevice({ id: "d1", name: "Laptop" })] },
+    });
+    renderWithProviders(<Vpn />);
+    await user.click(screen.getByRole("button", { name: "Grant access" }));
+    await user.click(screen.getByRole("button", { name: "pick:d1" }));
+    await user.click(screen.getByRole("button", { name: "Grant" }));
+
+    expect(mutateAsync).toHaveBeenCalled();
+    expect(screen.getByRole("button", { name: "Grant" })).toBeInTheDocument();
+    expect(screen.queryByText(/granted-modal/)).not.toBeInTheDocument();
+  });
+
+  it("abandons the grant on cancel", async () => {
+    const user = userEvent.setup();
+    useDevices.mockReturnValue({
+      data: { devices: [makeDevice({ id: "d1", name: "Laptop" })] },
+    });
+    renderWithProviders(<Vpn />);
+    await user.click(screen.getByRole("button", { name: "Grant access" }));
+    await user.click(screen.getByRole("button", { name: "Cancel" }));
+    expect(
+      screen.queryByRole("button", { name: "Grant" }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Grant access" }),
+    ).toBeInTheDocument();
+  });
+
+  it("toggles the server and saves an edited listen port", async () => {
+    const user = userEvent.setup();
+    const mutate = vi.fn();
+    useSetInboundWgConfig.mockReturnValue({ mutate, isPending: false });
+    renderWithProviders(<Vpn />);
+
+    await user.click(screen.getByRole("switch"));
+    expect(mutate).toHaveBeenCalledWith({ enabled: false, listen_port: 51821 });
+
+    // By role: the "Listen port" caption is a <Text as="p">, not a <label
+    // htmlFor>, so the input has no accessible name to query by.
+    const port = screen.getByRole("spinbutton");
+    await user.clear(port);
+    await user.type(port, "51999");
+    await user.click(screen.getByRole("button", { name: "Save port" }));
+    expect(mutate).toHaveBeenCalledWith({ enabled: true, listen_port: 51999 });
+  });
+
+  it("pauses a peer by inverting its enabled flag", async () => {
+    const user = userEvent.setup();
+    const mutate = vi.fn();
+    useSetInboundWgPeerEnabled.mockReturnValue({ mutate, isPending: false });
+    useInboundWgPeers.mockReturnValue({
+      data: { peers: [makePeer({ id: "p1", enabled: true })] },
+      isLoading: false,
+    });
+    renderWithProviders(<Vpn />);
+    await user.click(screen.getByRole("button", { name: "toggle:p1" }));
+    expect(mutate).toHaveBeenCalledWith({ id: "p1", enabled: false });
+  });
+
+  it("revokes a peer only after the confirm dialog", async () => {
+    const user = userEvent.setup();
+    const mutate = vi.fn();
+    useRemoveInboundWgPeer.mockReturnValue({ mutate, isPending: false });
+    useInboundWgPeers.mockReturnValue({
+      data: { peers: [makePeer({ id: "p1", name: "Laptop" })] },
+      isLoading: false,
+    });
+    renderWithProviders(<Vpn />);
+    await user.click(screen.getByRole("button", { name: "revoke:p1" }));
+    expect(await screen.findByText("Revoke remote access")).toBeInTheDocument();
+    expect(mutate).not.toHaveBeenCalled();
+
+    await user.click(screen.getByRole("button", { name: "Revoke" }));
+    expect(mutate).toHaveBeenCalledWith("p1");
+  });
+
+  it("does not revoke when the confirm dialog is dismissed", async () => {
+    const user = userEvent.setup();
+    const mutate = vi.fn();
+    useRemoveInboundWgPeer.mockReturnValue({ mutate, isPending: false });
+    useInboundWgPeers.mockReturnValue({
+      data: { peers: [makePeer({ id: "p1" })] },
+      isLoading: false,
+    });
+    renderWithProviders(<Vpn />);
+    await user.click(screen.getByRole("button", { name: "revoke:p1" }));
+    await user.click(screen.getByRole("button", { name: "Cancel" }));
+    expect(mutate).not.toHaveBeenCalled();
   });
 
   it("hides the peers card while the server is disabled", () => {

--- a/source/admin-site/tests/pages/Vpn.test.tsx
+++ b/source/admin-site/tests/pages/Vpn.test.tsx
@@ -1,0 +1,193 @@
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { InboundWgPeerSummary } from "@wardnet/js";
+
+const {
+  useInboundWgConfig,
+  useSetInboundWgConfig,
+  useInboundWgPeers,
+  useAddInboundWgPeer,
+  useRemoveInboundWgPeer,
+  useSetInboundWgPeerEnabled,
+  useDevices,
+} = vi.hoisted(() => ({
+  useInboundWgConfig: vi.fn(),
+  useSetInboundWgConfig: vi.fn(),
+  useInboundWgPeers: vi.fn(),
+  useAddInboundWgPeer: vi.fn(),
+  useRemoveInboundWgPeer: vi.fn(),
+  useSetInboundWgPeerEnabled: vi.fn(),
+  useDevices: vi.fn(),
+}));
+
+vi.mock("@wardnet/web", async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return {
+    ...actual,
+    useInboundWgConfig,
+    useSetInboundWgConfig,
+    useInboundWgPeers,
+    useAddInboundWgPeer,
+    useRemoveInboundWgPeer,
+    useSetInboundWgPeerEnabled,
+    useDevices,
+    InboundWgBetaNotice: () => null,
+  };
+});
+
+vi.mock("@/components/compound/PageHeader", () => ({
+  PageHeader: ({ title }: { title: ReactNode }) => <h1>{title}</h1>,
+}));
+vi.mock("@/components/compound/InboundWgPeersTable", () => ({
+  InboundWgPeersTable: () => null,
+}));
+// Stand-in that reports how many devices survived the grantable filter — the
+// page's real output here is *which* devices it offers, not how they render.
+vi.mock("@/components/compound/DeviceSelect", () => ({
+  DeviceSelect: ({ devices }: { devices: { id: string }[] }) => (
+    <div data-testid="device-select">
+      grantable:{devices.map((d) => d.id).join(",") || "none"}
+    </div>
+  ),
+}));
+
+import Vpn from "@/pages/Vpn";
+import { makeDevice, renderWithProviders } from "../test-utils";
+
+function makePeer(over: Partial<InboundWgPeerSummary> = {}) {
+  return {
+    id: "p1",
+    name: "Laptop",
+    public_key: "key",
+    allowed_ip: "10.90.0.2/32",
+    enabled: true,
+    created_at: "2026-01-01T00:00:00Z",
+    device_id: "d1",
+    ...over,
+  } as InboundWgPeerSummary;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  useInboundWgConfig.mockReturnValue({
+    data: { enabled: true, listen_port: 51821 },
+    isLoading: false,
+  });
+  useSetInboundWgConfig.mockReturnValue({ mutate: vi.fn(), isPending: false });
+  useInboundWgPeers.mockReturnValue({ data: { peers: [] }, isLoading: false });
+  useAddInboundWgPeer.mockReturnValue({ mutate: vi.fn(), isPending: false });
+  useRemoveInboundWgPeer.mockReturnValue({ mutate: vi.fn(), isPending: false });
+  useSetInboundWgPeerEnabled.mockReturnValue({
+    mutate: vi.fn(),
+    isPending: false,
+  });
+  useDevices.mockReturnValue({ data: { devices: [] } });
+});
+
+describe("Vpn", () => {
+  it("renders the page heading", () => {
+    renderWithProviders(<Vpn />);
+    expect(screen.getByRole("heading", { name: /VPN/i })).toBeInTheDocument();
+  });
+
+  // Unmanaged (unnamed) devices are rejected by the backend, so they must
+  // never reach the picker.
+  it("offers only managed devices for a grant", async () => {
+    const user = userEvent.setup();
+    useDevices.mockReturnValue({
+      data: {
+        devices: [
+          makeDevice({ id: "d1", name: "Laptop" }),
+          makeDevice({ id: "d2", name: null, hostname: "discovered-only" }),
+        ],
+      },
+    });
+    renderWithProviders(<Vpn />);
+    await user.click(screen.getByRole("button", { name: "Grant access" }));
+    expect(screen.getByTestId("device-select")).toHaveTextContent(
+      "grantable:d1",
+    );
+  });
+
+  // A device that already holds a peer row would 409 on re-grant, so it drops
+  // out of the picker even though it is still managed.
+  it("excludes devices that already have a peer", async () => {
+    const user = userEvent.setup();
+    useDevices.mockReturnValue({
+      data: {
+        devices: [
+          makeDevice({ id: "d1", name: "Laptop" }),
+          makeDevice({ id: "d2", name: "Phone" }),
+        ],
+      },
+    });
+    useInboundWgPeers.mockReturnValue({
+      data: { peers: [makePeer({ device_id: "d1" })] },
+      isLoading: false,
+    });
+    renderWithProviders(<Vpn />);
+    await user.click(screen.getByRole("button", { name: "Grant access" }));
+    expect(screen.getByTestId("device-select")).toHaveTextContent(
+      "grantable:d2",
+    );
+  });
+
+  // A legacy peer row with no device link must not knock an unrelated device
+  // out of the picker.
+  it("ignores peers with no device link when computing grantable", async () => {
+    const user = userEvent.setup();
+    useDevices.mockReturnValue({
+      data: { devices: [makeDevice({ id: "d1", name: "Laptop" })] },
+    });
+    useInboundWgPeers.mockReturnValue({
+      data: { peers: [makePeer({ device_id: null })] },
+      isLoading: false,
+    });
+    renderWithProviders(<Vpn />);
+    await user.click(screen.getByRole("button", { name: "Grant access" }));
+    expect(screen.getByTestId("device-select")).toHaveTextContent(
+      "grantable:d1",
+    );
+  });
+
+  it("explains that a device must be named before it can be granted", () => {
+    useDevices.mockReturnValue({
+      data: { devices: [makeDevice({ id: "d2", name: null })] },
+    });
+    renderWithProviders(<Vpn />);
+    expect(
+      screen.getByText(/Only managed devices can be granted remote access/),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Grant access" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("reports when every managed device already has access", () => {
+    useDevices.mockReturnValue({
+      data: { devices: [makeDevice({ id: "d1", name: "Laptop" })] },
+    });
+    useInboundWgPeers.mockReturnValue({
+      data: { peers: [makePeer({ device_id: "d1" })] },
+      isLoading: false,
+    });
+    renderWithProviders(<Vpn />);
+    expect(
+      screen.getByText(/Every managed device already has remote access/),
+    ).toBeInTheDocument();
+  });
+
+  it("hides the peers card while the server is disabled", () => {
+    useInboundWgConfig.mockReturnValue({
+      data: { enabled: false, listen_port: 51821 },
+      isLoading: false,
+    });
+    useDevices.mockReturnValue({
+      data: { devices: [makeDevice({ id: "d1", name: "Laptop" })] },
+    });
+    renderWithProviders(<Vpn />);
+    expect(screen.queryByText("Peers")).not.toBeInTheDocument();
+  });
+});

--- a/source/web/src/components/RoutingSelector.tsx
+++ b/source/web/src/components/RoutingSelector.tsx
@@ -7,8 +7,10 @@ import {
   Text,
 } from "@wardnet/ui";
 import { Link } from "react-router";
+import { useMemo } from "react";
 import { WifiOffIcon } from "lucide-react";
 import { countryFlag } from "../lib/country";
+import { sortByLabel } from "../lib/utils";
 import type { RoutingTarget, TunnelSummary } from "@wardnet/js";
 
 const DIRECT_VALUE = "direct";
@@ -48,6 +50,8 @@ export function RoutingSelector({
   "data-testid": dataTestId,
 }: RoutingSelectorProps) {
   const selected = valueFromTarget(value, tunnels);
+  // Before the empty-state early-return: hook order must not depend on props.
+  const sorted = useMemo(() => sortByLabel(tunnels, (t) => t.label), [tunnels]);
 
   function handleChange(next: string) {
     if (next === DIRECT_VALUE) {
@@ -99,7 +103,7 @@ export function RoutingSelector({
             Direct (no VPN)
           </span>
         </SelectItem>
-        {tunnels.map((t) => {
+        {sorted.map((t) => {
           const flag = t.country_code ? countryFlag(t.country_code) : "";
           return (
             <SelectItem key={t.id} value={t.id}>

--- a/source/web/src/index.ts
+++ b/source/web/src/index.ts
@@ -43,6 +43,7 @@ export {
   apiRequestId,
   deviceDisplayName,
   suggestHostnameForMac,
+  sortByLabel,
 } from "./lib/utils";
 
 // Country / device helpers

--- a/source/web/src/lib/utils.ts
+++ b/source/web/src/lib/utils.ts
@@ -6,11 +6,61 @@ export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
 
-/** Canonical display name for a device: explicit name, else hostname, else MAC. */
+/** Treat blank as absent. The API hands back `""` for an unset hostname about
+ *  as often as it hands back null (see `normalizeDescription` in
+ *  DhcpEntryTable), and `??` alone would accept the empty string and render —
+ *  and sort — a nameless row. */
+function nonBlank(value: string | null | undefined): string | null {
+  return value?.trim() ? value : null;
+}
+
+/**
+ * Canonical display name for a device: explicit name, else hostname, else
+ * `fallback`, else MAC. Blank candidates are skipped, not rendered.
+ *
+ * `fallback` exists so surfaces that would rather show an IP than a MAC (the
+ * device dropdown) still resolve the name through *this* function. The
+ * alternative — each surface writing its own fallback chain — is what let the
+ * devices table order an unnamed device by MAC while the dropdown ordered the
+ * same device by IP. One chain, one ordering, everywhere. The MAC is the final
+ * fallback for every caller because it is the only field the API guarantees.
+ */
 export function deviceDisplayName(
   device: Pick<Device, "name" | "hostname" | "mac">,
+  fallback?: string | null,
 ): string {
-  return device.name ?? device.hostname ?? device.mac;
+  return (
+    nonBlank(device.name) ??
+    nonBlank(device.hostname) ??
+    nonBlank(fallback) ??
+    device.mac
+  );
+}
+
+/** Built once and reused: `localeCompare` with an options object constructs a
+ *  fresh collator on every call, and the comparator below runs O(n log n)
+ *  times per sort. `sensitivity: "base"` folds case and accents together, so
+ *  "iPad" and "Apple TV" order the way a reader expects, not by code point. */
+const labelCollator = new Intl.Collator(undefined, { sensitivity: "base" });
+
+/**
+ * Case-insensitive alphabetical sort by a caller-derived label, returning a
+ * new array (inputs are usually React Query data — never mutate it).
+ *
+ * The label is a callback rather than a field name because the string a list
+ * sorts by must be the same string it *renders*: devices fall back through
+ * name → hostname → IP/MAC, tunnels use their label, and a sort keyed on the
+ * wrong field silently orders rows by text the user cannot see.
+ *
+ * Labels are derived once per item rather than inside the comparator — the
+ * callback can be non-trivial (a Map lookup per device), and a comparator
+ * would re-run it ~2n·log n times.
+ */
+export function sortByLabel<T>(items: T[], label: (item: T) => string): T[] {
+  return items
+    .map((item) => ({ item, key: label(item) }))
+    .sort((a, b) => labelCollator.compare(a.key, b.key))
+    .map(({ item }) => item);
 }
 
 /** Strip a MAC to its 12 lowercase hex digits, or `null` if it isn't a

--- a/source/web/tests/components/RoutingSelector.test.tsx
+++ b/source/web/tests/components/RoutingSelector.test.tsx
@@ -89,4 +89,31 @@ describe("RoutingSelector", () => {
     await user.click(within(listbox).getByRole("option", { name: /Direct/ }));
     expect(onChange).toHaveBeenCalledWith({ type: "direct" });
   });
+
+  // Tunnels sort alphabetically, but "Direct (no VPN)" is a fixed first
+  // option, not a tunnel — it must stay pinned to the top.
+  it("lists tunnels alphabetically below a pinned Direct option", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(
+      <RoutingSelector
+        value={null}
+        onChange={vi.fn()}
+        tunnels={[
+          makeTunnel({ id: "t1", label: "zeta" }),
+          makeTunnel({ id: "t2", label: "Alpha" }),
+          makeTunnel({ id: "t3", label: "beta" }),
+        ]}
+        data-testid="routing"
+      />,
+    );
+    await user.click(screen.getByTestId("routing"));
+    const listbox = await screen.findByRole("listbox");
+    const options = within(listbox).getAllByRole("option");
+    expect(options.map((o) => o.textContent)).toEqual([
+      expect.stringContaining("Direct"),
+      expect.stringContaining("Alpha"),
+      expect.stringContaining("beta"),
+      expect.stringContaining("zeta"),
+    ]);
+  });
 });

--- a/source/web/tests/lib/utils.test.ts
+++ b/source/web/tests/lib/utils.test.ts
@@ -15,6 +15,7 @@ import {
   formatTimeShort,
   formatDateTime,
   timeAgo,
+  sortByLabel,
 } from "../../src/lib/utils";
 
 describe("cn", () => {
@@ -22,6 +23,35 @@ describe("cn", () => {
     expect(cn("px-2", "px-4")).toBe("px-4");
     const skip: string | false = false;
     expect(cn("a", skip && "b", "c")).toBe("a c");
+  });
+});
+
+describe("sortByLabel", () => {
+  it("orders by the derived label, ignoring case", () => {
+    const items = [{ n: "zeta" }, { n: "Alpha" }, { n: "beta" }];
+    expect(sortByLabel(items, (i) => i.n).map((i) => i.n)).toEqual([
+      "Alpha",
+      "beta",
+      "zeta",
+    ]);
+  });
+
+  // Callers pass React Query data straight in; mutating it would reorder the
+  // cache under other consumers.
+  it("returns a new array and leaves the input untouched", () => {
+    const items = [{ n: "b" }, { n: "a" }];
+    const sorted = sortByLabel(items, (i) => i.n);
+    expect(sorted).not.toBe(items);
+    expect(items.map((i) => i.n)).toEqual(["b", "a"]);
+  });
+
+  it("sorts naturally across accents rather than by code point", () => {
+    const items = [{ n: "Zoe" }, { n: "Ähnlich" }, { n: "apple" }];
+    expect(sortByLabel(items, (i) => i.n).map((i) => i.n)).toEqual([
+      "Ähnlich",
+      "apple",
+      "Zoe",
+    ]);
   });
 });
 
@@ -36,6 +66,36 @@ describe("deviceDisplayName", () => {
     expect(deviceDisplayName({ name: null, hostname: null, mac: "m" })).toBe(
       "m",
     );
+  });
+
+  // A DHCP client that sends an empty hostname must not produce a blank label
+  // that renders as nothing and sorts above every real name.
+  it("treats blank and whitespace-only candidates as absent", () => {
+    expect(deviceDisplayName({ name: "", hostname: "h", mac: "m" })).toBe("h");
+    expect(deviceDisplayName({ name: "   ", hostname: "", mac: "m" })).toBe(
+      "m",
+    );
+  });
+
+  it("uses the fallback ahead of the mac when one is given", () => {
+    expect(
+      deviceDisplayName({ name: null, hostname: null, mac: "m" }, "10.0.0.5"),
+    ).toBe("10.0.0.5");
+    expect(
+      deviceDisplayName({ name: "TV", hostname: null, mac: "m" }, "10.0.0.5"),
+    ).toBe("TV");
+  });
+
+  // The dropdown passes `last_ip` as the fallback. It is typed non-null, but a
+  // null slipping through must degrade to the MAC rather than yield a
+  // non-string that would throw the moment a sort compares it.
+  it("falls through a null/blank fallback to the mac", () => {
+    expect(
+      deviceDisplayName({ name: null, hostname: null, mac: "m" }, null),
+    ).toBe("m");
+    expect(
+      deviceDisplayName({ name: null, hostname: null, mac: "m" }, ""),
+    ).toBe("m");
   });
 });
 


### PR DESCRIPTION
## What

Four UI fixes, all requested together:

1. **Alphabetical ordering** for device lists, device dropdowns, tunnel cards, and tunnel dropdowns.
2. **DHCP lease-renewal caveat** moves from an inline paragraph to an info-icon tooltip.
3. **All DHCP/device lists sorted** alphabetically.
4. **DNS query log** — device dropdown and client-IP box share one row.

## How

Ordering routes through one shared `sortByLabel(items, labelFn)` in `@wardnet/web`, applied at **component** level (`DeviceSelect`, `TunnelGrid`, `RoutingSelector`, `DhcpEntryTable`, `TunnelDevicesTable`, `Devices`) so every call site inherits it rather than each caller pre-sorting.

The label is a callback, not a field name, because the string a list sorts by must be the string it *renders* — a sort keyed on a hidden field orders rows by text the user cannot see.

`deviceDisplayName` is now the single display-name chain, taking an optional `fallback` that slots in ahead of the MAC. Surfaces that prefer an IP over a MAC pass it as a fallback instead of writing a competing chain. Without this, the devices table ordered an unnamed device by MAC while the dropdown ordered the same device by IP — consistent within each list, inconsistent across them, which is what this PR set out to fix. Blank candidates are skipped, so an empty hostname degrades to the MAC rather than sorting as `""` above every named row.

## Notes for the reviewer

- **Tooltip mechanism**: there is no hover-card primitive in this codebase, so the note uses the native `title` attribute — the same mechanism `TunnelCard` already uses. That is keyboard- and touch-inert, so the full text **also stays on the enable/disable toast**, which is where an admin acting on it actually sees it. Worth a second opinion if we'd rather introduce a real Tooltip.
- **Latent crash fixed along the way**: `DeviceSelect` now omits devices whose key field is blank. Radix throws on an empty `SelectItem` value, which unmounts the entire dropdown rather than one row. Not reachable today (both consumers pass `valueKey="id"`), but `"ip"` is the default, so the next caller would have inherited it.
- **Not visually verified**: the tooltip and the DNS-log filter row are covered by tests and typecheck, but I did not drive them in a browser. The "fits at 360px" claim is arithmetic (~284px), not a measurement.
- `admin-app`'s Devices page still sorts online-first, then alphabetically within each group. That looked like a deliberate UX choice rather than an oversight, so I left it — say the word if it should be flat alphabetical.

## Testing

- `make check-web` + `make check-site` pass (type-check, lint, format).
- Tests across all four CI-covered packages pass: `admin-site` 751, `web` 306, `admin-app` 111, `user-app` 86.
- New rendered-order tests for `DeviceSelect`, `TunnelGrid`, `DhcpEntryTable`, `RoutingSelector` (which also pins "Direct" to the top). I confirmed they aren't tautological by reverting the sort — they fail — and by removing the blank-key guard, which reproduces the exact Radix error.
- `check-daemon` not run: this diff touches **zero** Rust files.

## Merge Commit Message

```
feat(ui): sort device and tunnel lists alphabetically, declutter DHCP note

Route every list/dropdown ordering through one shared sortByLabel helper and
make deviceDisplayName the single display-name chain, so a device sorts to the
same place on every surface. Move the DHCP lease-renewal caveat to an info-icon
tooltip, and keep the DNS-log device and client-IP filters on one row.
```

https://claude.ai/code/session_01TzreLNb6y4zkYiMi9xUTir
