### PR TITLE
docs: correct the v2026.07.00 targets table, and stop the skill reproducing it

### DIFF
--- a/.agents/skills/release-prep/SKILL.md
+++ b/.agents/skills/release-prep/SKILL.md
@@ -73,8 +73,24 @@ Template, modelled on `v2026.05.00.md`:
 - `## Upgrading` — auto-update flow as the default path; manual
   installer flow as the alternative. Repeat any `> [!IMPORTANT]`
   callouts here as concrete steps.
-- `## Targets in this release` — copy the platform list from the
-  previous release notes, adjust if the supported targets changed.
+- `## Targets in this release` — **derive** the list from the build
+  matrix in `.github/workflows/build-daemon.yml`. That matrix is what
+  actually produces the assets, so it is the only thing that can be
+  right. Do **not** copy the table from the previous release notes:
+  that copies a copy, and an error in it survives every release that
+  inherits it. Verify against what the last release really shipped —
+  if the two disagree, the notes are wrong, not the assets:
+
+  ```sh
+  gh release view v<previous> --json assets --jq '.assets[].name'
+  ```
+
+  > This is not hypothetical. An `armv7-unknown-linux-gnueabihf` row
+  > entered at `2026.06.00-beta.2`, rode the beta chain by copy, and
+  > reached the `2026.07.00` stable notes — promising a 32-bit tarball
+  > CI has never built, to exactly the Pi users most likely to need
+  > one. `v2026.05.03` had it right the whole time. Nobody checked the
+  > table against the matrix because the instruction never said to.
 
 Sourcing the changelog:
 
@@ -245,3 +261,10 @@ try to verify and reject.
 - **Auto-update assumes monotonic CalVer.** Don't reuse a CALVER for
   a re-tag; bump to the next free patch slot if you need to redo a
   release.
+- **Trusting the targets table because it was already there.** Every
+  other pitfall on this list is caught by a gate — `check-version`,
+  `check-openapi`, CI. This one is caught by nothing. It is prose,
+  sitting next to a generated asset list it is never diffed against,
+  and it stayed wrong across six releases precisely because each one
+  inherited it from the last. Derive it from `build-daemon.yml` and
+  diff it against `gh release view v<previous> --json assets`.

--- a/docs/releases/v2026.07.00.md
+++ b/docs/releases/v2026.07.00.md
@@ -104,9 +104,10 @@ curl -sSL https://wardnet.network/install.sh | bash
 
 | Target | Architecture |
 |--------|-------------|
-| Raspberry Pi 4 / 5 (`armv7` hard-float) | `armv7-unknown-linux-gnueabihf` |
-| Raspberry Pi 5 / CM5 (`aarch64`) | `aarch64-unknown-linux-gnu` |
-| Generic x86-64 Linux | `x86_64-unknown-linux-gnu` |
+| Raspberry Pi (3 and newer) and other `aarch64` Linux SBCs | `aarch64-unknown-linux-gnu` |
+| Mini-PCs, `x86_64` servers, and other non-Pi Linux hosts | `x86_64-unknown-linux-gnu` |
+
+Wardnet needs a 64-bit OS — there is no 32-bit (`armv7`) build. On a Raspberry Pi, use the 64-bit Raspberry Pi OS.
 
 ---
 


### PR DESCRIPTION
## What

Two commits: the **symptom** (the `v2026.07.00` notes promise an armv7 build that does not exist) and the **cause** (the release-prep skill told the author to copy that table from the previous release notes).

## The symptom

- `build-daemon.yml`'s matrix builds exactly two targets: `x86_64-unknown-linux-gnu`, `aarch64-unknown-linux-gnu`.
- `armv7` appears in **no** workflow.
- The published `v2026.07.00` release carries only `aarch64` and `x86_64` assets — the table and the asset list sit on the same page contradicting each other.

A Pi user on 32-bit Raspberry Pi OS reads "Raspberry Pi 4 / 5 (`armv7` hard-float)" and goes looking for a tarball that was never built.

Restores the two real targets (matching `v2026.05.03`) and says outright there is no 32-bit build — "my Pi isn't listed" is the question the bare omission provokes.

## The cause

> `## Targets in this release` — copy the platform list from the previous release notes, adjust if the supported targets changed.

This sources a **fact** from a **copy**. Copies inherit errors, and this one did: the armv7 row entered at `2026.06.00-beta.2` and rode the beta chain by copy into the stable notes. `v2026.05.03` had it right the whole time. Every release in between followed the skill correctly and made it worse — which is the tell that the instruction, not the author, was the defect.

The skill now says to **derive** the list from `build-daemon.yml`'s matrix — the thing that actually produces the assets, and so the only thing that can be right — and gives the command to diff the claim against what the last release really shipped:

```sh
gh release view v<previous> --json assets --jq '.assets[].name'
```

The armv7 incident is recorded inline. Without the example the instruction reads perfectly reasonable, and the next author has no reason to distrust a table that is already sitting there.

Also added to **Common pitfalls**, noting what makes it different from every other entry: the rest are caught by a gate (`check-version`, `check-openapi`, CI). This one is caught by nothing — it is prose next to a generated asset list it is never diffed against.

## Not fixed here

- **The published Release body** still shows the wrong table. `release-daemon.yml` builds it from the **tag's** copy of the notes (`actions/checkout` defaults to the triggering ref, which was `v2026.07.00`), so merging this PR does not touch it. It needs `gh release edit v2026.07.00 --notes-file docs/releases/v2026.07.00.md` — no re-tag, no rebuild, reversible. Awaiting the go-ahead.
- **The beta notes** (`2026.06.00-beta.2`, `2026.07.00-beta.1/2/3/5/6`) still carry the bad table. Their Release bodies are already published and editing the files would not change them.
- **Adjacent gap, left alone:** the changelog step says `git log v<previous>..origin/main`, but for a beta→stable promotion "previous" is ambiguous — last beta or last stable? They give very different changelogs, and I had to ask. Worth pinning, but out of scope here.

## Testing

Docs-only; no code paths touched. The claim was verified against the `build-daemon.yml` matrix and the real asset lists on both `v2026.07.00-beta.6` and the published `v2026.07.00`.

## Merge Commit Message

```
docs: correct the v2026.07.00 targets table, and stop the skill reproducing it

The notes promised an armv7 build CI never produces. Restore the two real
targets, and point the release-prep skill at the build matrix instead of telling
authors to copy the table from the previous release notes.
```

https://claude.ai/code/session_01TzreLNb6y4zkYiMi9xUTir
