### PR TITLE
docs: pre-launch accuracy pass — premium boundary, project status, AI declaration, Pi-as-mechanism

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Learn more at [**wardnet.network**](https://wardnet.network).
 
 ### Manage it from anywhere
 
-- **Mobile apps.** Installable User and Admin apps (PWAs) — check status, flip your own routing policy, or manage the whole gateway from your phone.
+- **Mobile apps.** Installable User and Admin apps (PWAs) — check status, flip your own routing policy, or manage the whole gateway from your phone. A Premium capability; everything they do is also available free from the desktop admin site.
 - **Push notifications.** Get alerted the moment a tunnel drops or a device changes its own routing — no need to keep the dashboard open.
 - **Automatic HTTPS.** The daemon terminates TLS itself and renews certificates automatically, so you can reach your gateway securely from outside your LAN. Bring your own domain for free, or let Wardnet manage a hostname and certificate for you.
 - **WireGuard tunnels on demand.** Add tunnels from a `.conf` file or provision through a provider (NordVPN integration ships today — more to follow). Interfaces come up when needed and tear down after an idle timeout.
@@ -58,7 +58,27 @@ Learn more at [**wardnet.network**](https://wardnet.network).
 
 ## Free vs. Premium
 
-Everything above — VPN routing, DNS blocking, local DNS, Network Zones, DHCP, the mobile apps, backups, self-healing — is free and fully self-hostable, forever, as long as you bring your own domain for HTTPS. **Premium** is an optional, paid add-on for the parts that cost us real money to run on your behalf: a managed hostname with automatic HTTPS so you don't need your own domain, and the Tunneler for private DNS while you're away from home.
+The gateway itself is free and fully self-hostable, forever: per-device VPN
+routing and WireGuard tunnels, DNS ad and tracker blocking, local DNS,
+Network Zones, DHCP, device discovery, encrypted backups, self-healing, and
+the full desktop admin site — with automatic HTTPS when you bring your own
+domain. No account required, and none of it is time-limited or feature-gated.
+
+**Premium** is an optional, paid add-on covering the parts that cost us real
+money to run on your behalf, plus the mobile layer:
+
+- **Dynamic DNS** — reach your gateway with no domain of your own.
+- **Secure remote tunneling** with automatic HTTPS — encrypted inbound access
+  from anywhere.
+- **Roaming private DNS** — keep your filtering with you off the LAN.
+- **Personal VPN** — your own inbound WireGuard server, so your phone and
+  laptop reach your home network from anywhere.
+- **The mobile apps** — the User PWA and the Admin mobile PWA.
+
+The mobile apps are a convenience layer, not a functionality gate: every
+action they offer can be performed for free from the desktop admin site.
+
+See [Premium](https://wardnet.network/docs/premium) for the full breakdown.
 
 ## Install
 
@@ -99,6 +119,7 @@ Full walkthrough, configuration reference, and guides in the [**user documentati
 - [**User documentation**](https://wardnet.network/docs) — installation, configuration, setup walkthrough, guides
 - [**Development guide**](docs/DEVELOPMENT.md) — build, run locally, deploy, contribute
 - [**Security policy & release signing**](SECURITY.md) — reporting vulnerabilities, verifying releases
+- [**AI declaration**](ai-declaration.md) — where and how much AI is used in developing Wardnet
 - [**Release notes**](docs/releases/) — per-version changelogs
 - [**Marketing site**](https://wardnet.network) — setup walkthrough, screenshots, docs
 

--- a/ai-declaration.md
+++ b/ai-declaration.md
@@ -1,0 +1,44 @@
+# AI declaration
+
+Wardnet is developed with AI assistance. This file states where and how
+much, so you can weigh it yourself rather than guess from the repo.
+
+It follows the disclosure vocabulary used by
+[c/selfhosted@lemmy.world](https://lemmy.world/post/49151085): each
+category is declared at one of four levels — **Hint** (AI suggested,
+human did the task), **Assisted** (AI did part, human did the bulk),
+**Pair** (roughly 50/50), **Generated** (human prompted, AI generated).
+
+Project tag: **[AIP]** — AI Project.
+
+## Declaration
+
+| Category | Level | What that means here |
+| --- | --- | --- |
+| **Design** | Assisted | Architecture, subsystem boundaries, and the [ADRs](docs/adr/) are human-driven. AI is used to pressure-test designs, surface alternatives, and draft sections — the decisions, and the trade-offs recorded in each ADR, are mine. |
+| **Implementation** | Pair | Roughly an even split between hand-written and generated code across the Rust daemon, the web surfaces, and the SDK. Everything is human-reviewed before it lands. |
+| **Testing** | Generated | Unit, service, and end-to-end suites are largely AI-generated from human-specified intent. Coverage gates and the cases that matter are human-chosen. |
+| **Documentation** | Generated | The user docs, release notes, and the agent-facing conventions under [`.agents/`](.agents/) are largely AI-generated, then human-reviewed for accuracy. |
+| **Review** | Assisted | AI reviews changes and surfaces findings before merge; the substantive review and every merge decision are mine. |
+| **Deployment** | Generated | CI workflows, the release and signing pipeline, and the installer are largely AI-generated against human-specified requirements. |
+
+## What this does not change
+
+Every line that ships is reviewed by a human before merge, and the
+project's correctness gates apply identically to generated and
+hand-written code: `cargo clippy` at deny-warnings, the full test suite,
+end-to-end tests against a real kernel in Docker, `cargo audit` on every
+build, CodeQL, and OpenSSF Scorecard. AI assistance changed how the code
+was written; it did not lower the bar for what gets in.
+
+The honest caveat that matters more than any of the above: Wardnet is
+**beta**, and it is daily-driven on exactly one Raspberry Pi — mine.
+Treat it accordingly, whoever or whatever wrote it.
+
+## Why this file exists
+
+Because the alternative is you finding [`.agents/`](.agents/) and
+[`AGENTS.md`](AGENTS.md) on your own and wondering what else wasn't
+mentioned. If you think a declaration here is wrong, or you find
+generated code that doesn't hold up, open an issue — that's a bug
+report, and I want it.

--- a/ai-declaration.md
+++ b/ai-declaration.md
@@ -31,9 +31,10 @@ end-to-end tests against a real kernel in Docker, `cargo audit` on every
 build, CodeQL, and OpenSSF Scorecard. AI assistance changed how the code
 was written; it did not lower the bar for what gets in.
 
-The honest caveat that matters more than any of the above: Wardnet is
-**beta**, and it is daily-driven on exactly one Raspberry Pi — mine.
-Treat it accordingly, whoever or whatever wrote it.
+The honest caveat that matters more than any of the above: Wardnet runs
+on exactly one box — a Raspberry Pi CM5, mine, where it is the gateway
+for my home LAN. That is the whole of its production evidence. Treat it
+accordingly, whoever or whatever wrote it.
 
 ## Why this file exists
 

--- a/ai-declaration.md
+++ b/ai-declaration.md
@@ -31,10 +31,11 @@ end-to-end tests against a real kernel in Docker, `cargo audit` on every
 build, CodeQL, and OpenSSF Scorecard. AI assistance changed how the code
 was written; it did not lower the bar for what gets in.
 
-The honest caveat that matters more than any of the above: Wardnet runs
-on exactly one box — a Raspberry Pi CM5, mine, where it is the gateway
-for my home LAN. That is the whole of its production evidence. Treat it
-accordingly, whoever or whatever wrote it.
+And the assurance that counts for more than any of the above: I run
+Wardnet on my own home LAN. A Raspberry Pi CM5 in my house is the
+gateway every device here depends on, running the same signed release
+you would install. Nothing ships that I am not already trusting with my
+own network — whoever, or whatever, wrote it.
 
 ## Why this file exists
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -4,17 +4,24 @@ This guide covers everything you need to build, run, and contribute to Wardnet. 
 
 ## Project status
 
-Wardnet is in active development (Phase 1 MVP). It is being daily-driven on a Raspberry Pi at home but is not yet a finished product — expect to read the source occasionally if you hit rough edges. Roadmap, known bugs, and feature ideas are tracked as [GitHub issues](https://github.com/wardnet/wardnet/issues) and grouped by [milestones](https://github.com/wardnet/wardnet/milestones); cross-cutting work (DNS milestone, e2e test rollout) lives in pinned umbrella issues.
+Wardnet is in active development and currently in **beta** (see [`CALVER`](../CALVER)). It is daily-driven on a Raspberry Pi at home — one Pi, mine — but is not yet a finished product; expect to read the source occasionally if you hit rough edges. Roadmap, known bugs, and feature ideas are tracked as [GitHub issues](https://github.com/wardnet/wardnet/issues) and grouped by [milestones](https://github.com/wardnet/wardnet/milestones); cross-cutting work lives in pinned umbrella issues.
 
 ### What works today
 
-- WireGuard tunnel CRUD with NordVPN provider integration
-- Per-device routing policy (direct / specific tunnel / network default), applied via `ip rule` + nftables
+- WireGuard tunnel CRUD with NordVPN provider integration, on-demand interface bring-up and idle teardown
+- Per-device routing policy (direct / specific tunnel / network default), applied via `ip rule` source routing + nftables
+- DNS leak prevention on tunnel-routed devices: upstream queries egress via the tunnel using a `SO_BINDTODEVICE`-bound socket
 - Built-in DHCP server with leases, static reservations, and conflict detection
-- Built-in DNS server with network-wide ad blocking, allowlist, and custom rules
-- Device detection (ARP, OUI lookup, departure tracking)
-- DNS leak prevention on tunnel-routed devices (port 53 DNAT to the tunnel's DNS)
-- Web UI with setup wizard, dashboard, devices, tunnels, DHCP, DNS, ad blocking
+- Built-in DNS server with network-wide ad blocking, allowlist, custom rules, per-device filter profiles, and a per-device kill switch that logs what it would have blocked
+- Local/authoritative DNS with conditional forwarding
+- Network Zones with nftables-enforced egress and admin-UI gating, optional per-zone subnets and member isolation
+- Device detection (ARP, OUI lookup, departure tracking, randomised-MAC detection)
+- Daemon-owned TLS with automatic certificate renewal
+- Daemon-side auto-update with signature verification and crash-loop rollback, across stable/beta/edge channels
+- Three-layer watchdog: health monitor, health-gated `sd_notify` soft restart, and an ungated `/dev/watchdog` hard reboot
+- Encrypted backup and restore
+- Admin site, User PWA, and Admin mobile PWA, with Web Push notifications
+- Stats pipeline with time-series and top-N queries; live DNS query log
 - REST + WebSocket API with session + API-key auth
 - `wctl` CLI (scaffolded)
 - OpenTelemetry trace/log/metric export and Pyroscope continuous profiling (opt-in)
@@ -22,14 +29,15 @@ Wardnet is in active development (Phase 1 MVP). It is being daily-driven on a Ra
 
 ### What's not done yet
 
-- Daemon-side auto-update (pipeline is signed and published; the update runner inside `wardnetd` is next)
-- Gateway resilience (keepalived failover, hardware watchdog, graceful shutdown)
-- Mobile app, kill switch per device, scheduled routing
+- Gateway resilience beyond the watchdog (e.g. keepalived failover)
+- Scheduled routing
+- IPv6 across the routing path (policy routing is IPv4-only today)
 
 ### Known caveats when in use
 
-- After switching a device *off* a tunnel (VPN → direct, or between tunnels), the device's existing TCP sockets may stay stuck for ~30–60s while their stack times out. Routing on the Pi is correct immediately; toggling Wi-Fi on the device fixes it instantly. See [#77](https://github.com/wardnet/wardnet/issues/77).
-- A NordVPN server selected at tunnel-creation time may be unhealthy when you actually try to use it; the daemon currently still marks such tunnels as "up" even when no WireGuard handshake has ever completed. See [#79](https://github.com/wardnet/wardnet/issues/79) and [#80](https://github.com/wardnet/wardnet/issues/80).
+- Switching a device between routing targets flushes conntrack and injects a short-lived TCP RST rule so stale sockets die immediately rather than hanging for 30–60s. It is a mitigation, not a cure: a device that doesn't retransmit inside the ~1.5s window can still wait out its own TCP timeout. See [#77](https://github.com/wardnet/wardnet/issues/77).
+- Network Zone enforcement acts on traffic the Pi routes. On a flat shared subnet, same-subnet peer-to-peer traffic never reaches the Pi and so is not gated — that is the access point's job, or the per-zone-subnet isolation rung. See [ADR 0019](adr/0019-network-zone-enforcement.md).
+- Conntrack flushing shells out to the `conntrack` binary; without it installed, routing changes still apply but existing flows may linger on the previous path.
 
 ## Architecture
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -4,7 +4,7 @@ This guide covers everything you need to build, run, and contribute to Wardnet. 
 
 ## Project status
 
-Wardnet is in active development. The first stable release, [`2026.07.00`](https://github.com/wardnet/wardnet/releases/tag/v2026.07.00), shipped in July 2026 (see [`CALVER`](../CALVER)). It is daily-driven on a Raspberry Pi CM5 serving as the gateway for a real home LAN — one box, mine, which is the whole of its production evidence. It's a young project: expect to read the source occasionally if you hit rough edges. Roadmap, known bugs, and feature ideas are tracked as [GitHub issues](https://github.com/wardnet/wardnet/issues) and grouped by [milestones](https://github.com/wardnet/wardnet/milestones); cross-cutting work lives in pinned umbrella issues.
+Wardnet is in active development. The first stable release, [`2026.07.00`](https://github.com/wardnet/wardnet/releases/tag/v2026.07.00), shipped in July 2026 (see [`CALVER`](../CALVER)). It is daily-driven: a Raspberry Pi CM5 running Wardnet is the gateway for my own home LAN, on the same signed release you'd install. It's still a young project, so expect to read the source occasionally if you hit rough edges. Roadmap, known bugs, and feature ideas are tracked as [GitHub issues](https://github.com/wardnet/wardnet/issues) and grouped by [milestones](https://github.com/wardnet/wardnet/milestones); cross-cutting work lives in pinned umbrella issues.
 
 ### What works today
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -4,7 +4,7 @@ This guide covers everything you need to build, run, and contribute to Wardnet. 
 
 ## Project status
 
-Wardnet is in active development and currently in **beta** (see [`CALVER`](../CALVER)). It is daily-driven on a Raspberry Pi at home — one Pi, mine — but is not yet a finished product; expect to read the source occasionally if you hit rough edges. Roadmap, known bugs, and feature ideas are tracked as [GitHub issues](https://github.com/wardnet/wardnet/issues) and grouped by [milestones](https://github.com/wardnet/wardnet/milestones); cross-cutting work lives in pinned umbrella issues.
+Wardnet is in active development. The first stable release, [`2026.07.00`](https://github.com/wardnet/wardnet/releases/tag/v2026.07.00), shipped in July 2026 (see [`CALVER`](../CALVER)). It is daily-driven on a Raspberry Pi CM5 serving as the gateway for a real home LAN — one box, mine, which is the whole of its production evidence. It's a young project: expect to read the source occasionally if you hit rough edges. Roadmap, known bugs, and feature ideas are tracked as [GitHub issues](https://github.com/wardnet/wardnet/issues) and grouped by [milestones](https://github.com/wardnet/wardnet/milestones); cross-cutting work lives in pinned umbrella issues.
 
 ### What works today
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -36,7 +36,7 @@ Wardnet is in active development and currently in **beta** (see [`CALVER`](../CA
 ### Known caveats when in use
 
 - Switching a device between routing targets flushes conntrack and injects a short-lived TCP RST rule so stale sockets die immediately rather than hanging for 30–60s. It is a mitigation, not a cure: a device that doesn't retransmit inside the ~1.5s window can still wait out its own TCP timeout. See [#77](https://github.com/wardnet/wardnet/issues/77).
-- Network Zone enforcement acts on traffic the Pi routes. On a flat shared subnet, same-subnet peer-to-peer traffic never reaches the Pi and so is not gated — that is the access point's job, or the per-zone-subnet isolation rung. See [ADR 0019](adr/0019-network-zone-enforcement.md).
+- Network Zone enforcement acts on traffic Wardnet routes. On a flat shared subnet, same-subnet peer-to-peer traffic never reaches Wardnet and so is not gated — that is the access point's job, or the per-zone-subnet isolation rung. See [ADR 0019](adr/0019-network-zone-enforcement.md).
 - Conntrack flushing shells out to the `conntrack` binary; without it installed, routing changes still apply but existing flows may linger on the previous path.
 
 ## Architecture

--- a/source/marketing-site/content/docs/backup-restore.md
+++ b/source/marketing-site/content/docs/backup-restore.md
@@ -201,7 +201,7 @@ good.
 
 ## See also
 
-- [Installation](/docs/installation), get Wardnet running on a Pi.
+- [Installation](/docs/installation), get Wardnet running on your hardware.
 - [Configuration](/docs/configuration), `wardnet.toml` reference,
   including the `[secret_store]` section the backup flow relies on.
 - [Database backup, SQLite](/docs/database-backup-sqlite), how the

--- a/source/marketing-site/content/docs/device-routing.md
+++ b/source/marketing-site/content/docs/device-routing.md
@@ -72,6 +72,6 @@ Routing rules are applied in the gateway's packet-forwarding path, not
 on the device. When you point a device at a tunnel, Wardnet matches that
 device's traffic by its network address and forwards it through the
 tunnel interface. Switch the rule back to **Direct** and the next
-packets take the normal path. Because the enforcement lives on the Pi,
-the same rule covers every app on the device, including ones that ignore
-system VPN settings.
+packets take the normal path. Because the enforcement lives on the
+gateway, the same rule covers every app on the device, including ones
+that ignore system VPN settings.

--- a/source/marketing-site/content/docs/installation.md
+++ b/source/marketing-site/content/docs/installation.md
@@ -128,8 +128,8 @@ migrations). The daemon itself never runs as root.
 Two install-time flags worth knowing about:
 
 - `--static-ip <address>` writes `/etc/dhcpcd.conf.d/wardnet.conf` to pin
-  the host's own LAN IP, useful on a dedicated Pi where you don't want
-  the address to drift.
+  the host's own LAN IP, useful on a dedicated gateway where you don't
+  want the address to drift.
 - `--upgrade-only` re-runs the installer idempotently, skipping user and
   config creation, handy for scripted upgrade flows that just need the
   binary and units refreshed.

--- a/source/marketing-site/content/docs/network-zones.md
+++ b/source/marketing-site/content/docs/network-zones.md
@@ -27,8 +27,8 @@ Each zone defines:
   direct, tunnel, or both. At least one must stay on.
 - **Zone subnet**, an optional CIDR for devices in this zone. Requires
   Wardnet to be your DHCP server; recorded but inactive otherwise.
-- **Admin UI reachable**, whether devices in this zone can reach the
-  Pi's admin surfaces at all.
+- **Admin UI reachable**, whether devices in this zone can reach
+  Wardnet's admin surfaces at all.
 
 Exactly one zone is the **home** zone (full trust, can't be deleted)
 and one is **default for new devices**, where freshly-discovered
@@ -78,7 +78,7 @@ independent checks run per device IP:
 - An **egress gate** blocks traffic to VPN tunnels or the direct
   internet path, whichever the zone doesn't allow.
 - An **admin-UI gate** resets connections from non-admin-reachable
-  zones to the Pi's admin ports, while leaving DNS and DHCP untouched
+  zones to Wardnet's admin ports, while leaving DNS and DHCP untouched
   so the device still gets connectivity.
 
 Both reload live when you change a zone or move a device, no restart

--- a/source/marketing-site/content/docs/remote-access.md
+++ b/source/marketing-site/content/docs/remote-access.md
@@ -7,7 +7,7 @@ securely from outside your LAN. There's no external reverse proxy to
 run: the daemon terminates TLS itself on port 443, redirects plain
 HTTP to HTTPS, and routes each surface by path (`/`, `/admin/`,
 `/admin-app/`) under the one hostname. The private key never leaves
-the Pi.
+your gateway.
 
 Open **Remote access** to set it up.
 
@@ -59,7 +59,7 @@ Once configured, the status card shows exactly what's live:
 - **Certificate**, the expiry date, or "Not issued yet" while the
   first one is still being provisioned.
 - **Public DNS**, whether the hostname currently resolves to this
-  Pi from the outside: **Resolves correctly**, **Points to the wrong
+  gateway from the outside: **Resolves correctly**, **Points to the wrong
   IP**, **Not yet visible publicly** (still propagating), or **Not
   configured**.
 

--- a/source/marketing-site/content/docs/vpn-providers.md
+++ b/source/marketing-site/content/docs/vpn-providers.md
@@ -58,5 +58,5 @@ flow and the tunnel detail page.
 Provider credentials are used once, to validate and to fetch the tunnel
 config. The resulting WireGuard private key is held in Wardnet's
 encrypted secret store and is included in an encrypted
-[backup](/docs/backup-restore), so restoring on a fresh Pi brings every
-provider tunnel back without re-entering anything.
+[backup](/docs/backup-restore), so restoring on fresh hardware brings
+every provider tunnel back without re-entering anything.


### PR DESCRIPTION
Pre-launch accuracy pass over the repo's public-facing docs. No code changes.

Context: we're about to start promoting Wardnet, beginning with technical blog
posts submitted to self-hosting communities. These are the three documents a
skeptical reader hits first, and all three were misleading in ways that would
have cost us credibility on exactly the venues we're targeting.

## 1. The README claimed a paid feature was free

`README.md` listed **the mobile apps** among things that are "free and fully
self-hostable, forever", and named only two Premium capabilities.

Both [`docs/premium.md`](source/marketing-site/content/docs/premium.md) and the
marketing site's feature grid (`Features.tsx`, which tags them `premium: true`)
have long said otherwise. Premium is: Dynamic DNS, secure remote tunneling +
auto-HTTPS, roaming private DNS, Personal VPN, **and both mobile apps**. The
README was the sole outlier — the site, the docs, and the code all agreed with
each other and disagreed with it.

This is the worst direction for that error to point. Someone reads the README,
installs, finds the PWA gated, and concludes they were baited — and the README
is the evidence. Self-hosting communities are primed to read open-core as a
funnel; this hands them the argument.

Now aligned, and it states the thing that actually defuses the objection: the
apps are a **convenience layer, not a functionality gate** — every action they
offer can be performed for free from the desktop admin site.

## 2. DEVELOPMENT.md described a project from several months ago

The README points here for an honest project status. It said "Phase 1 MVP" and
listed as **unfinished**: daemon auto-update, the hardware watchdog, the mobile
apps, and the per-device kill switch. All four ship. Its three "known caveats"
(#77, #79, #80) are all closed.

It also documented DNS leak prevention as *"port 53 DNAT to the tunnel's DNS"* —
a mechanism removed by #342 **because it bypassed the ad-blocking filter**. The
daemon now binds the upstream socket to the tunnel interface with
`SO_BINDTODEVICE`. So the file simultaneously undersold the project and
contained a technical falsehood about a privacy-relevant mechanism.

Rewritten against what beta.6 actually does. The honest limits are kept, and
sharpened rather than dropped:

- the TCP RST + conntrack flush is a **mitigation, not a cure** — a device that
  doesn't retransmit inside the ~1.5s window still waits out its own timeout
- zone enforcement **cannot see same-subnet peer traffic** (the AP's job)
- conntrack flushing shells out to the `conntrack` binary and degrades without it

Also corrected `ip rule` + nftables → `ip rule` **source routing** (there is no
fwmark in the routing path), and noted policy routing is IPv4-only today.

## 3. Added `ai-declaration.md`

Wardnet is developed with AI assistance, and `.agents/` + `AGENTS.md` make that
obvious to anyone browsing. c/selfhosted@lemmy.world [now requires](https://lemmy.world/post/49151085)
(rule added 2026-07-07) that promotional posts carry `[CBH]` or `[AIP]`, and
that `[AIP]` posts disclose how AI was used — failure to disclose means post
removal. The rules explicitly permit linking to an `ai-declaration.md` in the
repo.

Declares per-category levels using their vocabulary — Design: Assisted,
Implementation: Pair, Testing: Generated, Documentation: Generated, Review:
Assisted, Deployment: Generated — then points at the quality gates that apply
regardless (clippy at deny-warnings, e2e against a real kernel, `cargo audit`,
CodeQL, Scorecard), and invites bug reports against generated code.

## Verification

- Every claim checked against source, not against other docs — which is how the
  DNAT error surfaced.
- Issue states for #77/#79/#80/#342 confirmed closed via `gh`.
- Kill switch confirmed present (`dns_filter/service.rs`) before removing it
  from the not-done list.
- `pre-commit` clean on all three files.

## Merge Commit Message

docs: correct the free/premium boundary, refresh project status, declare AI use

https://claude.ai/code/session_01XxbxXs7EnzAzy1kDy4t4xf