### PR TITLE
docs: mark push notifications as Premium in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Learn more at [**wardnet.network**](https://wardnet.network).
 ### Manage it from anywhere
 
 - **Mobile apps.** Installable User and Admin apps (PWAs) — check status, flip your own routing policy, or manage the whole gateway from your phone. A Premium capability; everything they do is also available free from the desktop admin site.
-- **Push notifications.** Get alerted the moment a tunnel drops or a device changes its own routing — no need to keep the dashboard open.
+- **Push notifications.** Get alerted the moment a tunnel drops or a device changes its own routing — no need to keep the dashboard open. Delivered to the mobile apps, and Premium along with them.
 - **Automatic HTTPS.** The daemon terminates TLS itself and renews certificates automatically, so you can reach your gateway securely from outside your LAN. Bring your own domain for free, or let Wardnet manage a hostname and certificate for you.
 - **WireGuard tunnels on demand.** Add tunnels from a `.conf` file or provision through a provider (NordVPN integration ships today — more to follow). Interfaces come up when needed and tear down after an idle timeout.
 
@@ -73,10 +73,13 @@ money to run on your behalf, plus the mobile layer:
 - **Roaming private DNS** — keep your filtering with you off the LAN.
 - **Personal VPN** — your own inbound WireGuard server, so your phone and
   laptop reach your home network from anywhere.
-- **The mobile apps** — the User PWA and the Admin mobile PWA.
+- **The mobile apps** — the User PWA and the Admin mobile PWA, and the push
+  notifications they deliver.
 
 The mobile apps are a convenience layer, not a functionality gate: every
-action they offer can be performed for free from the desktop admin site.
+action they offer can be performed for free from the desktop admin site. The
+one thing that genuinely needs them is push — alerts are delivered to the
+installed apps, so they arrive with them.
 
 See [Premium](https://wardnet.network/docs/premium) for the full breakdown.
 


### PR DESCRIPTION
Follow-up to #938. Same class of error, one line below a bullet that PR fixed.

## The problem

Push notifications are delivered **only to the installed PWAs**, by design.
Confirmed in the code, not just asserted:

- `web/src/hooks/usePushNotifications.ts` is imported by exactly two callers —
  `admin-app/src/pages/System.tsx` and `user-app/src/pages/Settings.tsx`.
- The free desktop admin site never subscribes. It only *mentions* push, in a
  `QuarantineSettingsCard` description.

Both PWAs are Premium. Therefore push is unreachable on the free tier — but
`README.md` listed it as a plain bullet with no marker, directly beneath the
mobile-apps bullet that #938 tagged as Premium. So the README still advertised
a paid-only capability as generally available.

## The subtler half

The reassurance line added in #938:

> The mobile apps are a convenience layer, not a functionality gate: every
> action they offer can be performed for free from the desktop admin site.

That's true for **actions** — and it's the right point to make, because it's
what defuses the "paywalled features" objection honestly.

But push isn't an action you *perform*. It's an alert delivered *to* you, and a
free user cannot receive one by any route. So a sentence written to say "there's
no capability gap here" was quietly concealing the one real gap. That is exactly
the sort of line a skeptic finds, quotes, and uses to argue the whole boundary is
being soft-pedalled.

Now stated outright rather than left to be discovered:

> The one thing that genuinely needs them is push — alerts are delivered to the
> installed apps, so they arrive with them.

Volunteering the gap costs a sentence. Being caught omitting it costs the thread.

## Note (not fixed here)

`admin-site`'s `QuarantineSettingsCard` lets a free admin toggle a setting whose
description says it "controls whether admins get a push notification to review
them" — a notification that account can never receive. Harmless, but it's a
papercut someone will report. Flagging rather than folding UI changes into a
docs PR.

## Verification

- Push consumers traced through the source; the design claim is confirmed, not assumed.
- The marketing site already scopes this correctly — `Features.tsx` mentions push *inside* the Mobile apps card, which is tagged `premium: true`. README was the outlier again.
- `pre-commit` clean.

## Merge Commit Message

docs: mark push notifications as Premium in the README

https://claude.ai/code/session_01XxbxXs7EnzAzy1kDy4t4xf