### PR TITLE
fix(admin-site): round DNS stat window totals to whole queries

### DIFF
--- a/source/admin-site/src/components/features/DnsStatsSection.tsx
+++ b/source/admin-site/src/components/features/DnsStatsSection.tsx
@@ -109,7 +109,11 @@ export function DnsStatsSection({ range }: Props) {
         blocked += p.blocked;
       }
     }
-    return { total, blocked };
+    // Chart points are pre-aggregated bucket values, so summing them yields a
+    // fractional result. A query count is a whole number by definition, and
+    // these totals feed both the "Window total" subtitle and (when zoomed) the
+    // Queries/Blocked stat cards, so round once here rather than at each site.
+    return { total: Math.round(total), blocked: Math.round(blocked) };
   }, [chartSeries, zoom]);
 
   // When zoomed, show the window duration instead of the range label and


### PR DESCRIPTION
## What

The DNS **Queries over time** chart points are pre-aggregated bucket values that carry fractional components. Summing them for the window totals produced fractional numbers, which surfaced in two places:

- the **"Window total"** subtitle under the chart, and
- the **Queries / Blocked** stat cards when the chart is zoomed (the cards then read from the zoomed window sum).

A query count is a whole number by definition, so this reads as a bug.

## Change

Round `total` and `blocked` once at the aggregation site in `DnsStatsSection`, so every consumer (subtitle and both stat cards) shows integers. No behavior change for the already-integer non-zoomed path.

## Testing

- `make check-web` (type-check + lint + format:check for `@wardnet/admin-site` and `@wardnet/web`) passes.
- Existing `DnsStatsSection.test.tsx` fixtures use whole-number totals, so assertions are unaffected.

## Merge Commit Message

fix(admin-site): round DNS stat window totals to whole queries

Chart points are pre-aggregated bucket values with fractional components; summing them for the window totals (the "Window total" subtitle and the zoomed Queries/Blocked stat cards) produced fractions. Round once at the aggregation site so every consumer shows whole query counts.
