### PR TITLE
chore(mock): enrich demo seed — zones, story devices, DNS attribution (#941)

### DIFF
--- a/source/daemon/crates/wardnetd-mock/src/seed.rs
+++ b/source/daemon/crates/wardnetd-mock/src/seed.rs
@@ -2,7 +2,9 @@
 //!
 //! Populates realistic but entirely fake data via repositories so the web UI
 //! has something to display without requiring a real Pi deployment:
-//! devices (laptop, phone, TV, tablet, `IoT`), two `WireGuard` tunnels, a
+//! devices (laptop, phone, TV, tablet, `IoT`) spread across the Trusted /
+//! `IoT` / Guest zones with one cross-zone casting exception, `WireGuard`
+//! tunnels, a
 //! disabled DNS blocklist with a few custom rules, and a single routing rule.
 //!
 //! Admin credentials are **not** seeded — the setup wizard runs on every
@@ -10,6 +12,9 @@
 
 use chrono::{Datelike, Duration, Utc};
 use uuid::Uuid;
+use wardnet_common::zone_exception::{
+    ExceptionEndpoint, ExceptionEndpointKind, ServiceSet, ServiceSpec, ZoneException,
+};
 use wardnetd_data::RepositoryFactory;
 use wardnetd_data::repository::{
     AllowlistRow, CustomRuleRow, DeviceRow, DhcpLeaseRow, DhcpReservationRow, IntradayStatRow,
@@ -30,6 +35,11 @@ pub struct SeededIds {
 /// deduplicate against existing rows.
 #[allow(clippy::too_many_lines)]
 pub async fn populate(factory: &dyn RepositoryFactory) -> anyhow::Result<SeededIds> {
+    // System-zone UUIDs seeded by the `network_zones` migration.
+    const ZONE_TRUSTED: &str = "00000000-0000-0000-0000-000000000201";
+    const ZONE_IOT: &str = "00000000-0000-0000-0000-000000000202";
+    const ZONE_GUEST: &str = "00000000-0000-0000-0000-000000000203";
+
     let device_repo = factory.device();
     let tunnel_repo = factory.tunnel();
     let dns_repo = factory.dns();
@@ -44,6 +54,9 @@ pub async fn populate(factory: &dyn RepositoryFactory) -> anyhow::Result<SeededI
     // ------------------------------------------------------------------
     // Devices
     // ------------------------------------------------------------------
+    // Spreading the demo devices across all three system zones (rather than
+    // parking everyone in Trusted) gives the Zones page a non-zero member count
+    // per zone and sets up a real cross-zone (casting) boundary below.
     let devices = [
         (
             "AA:BB:CC:11:22:01",
@@ -52,6 +65,7 @@ pub async fn populate(factory: &dyn RepositoryFactory) -> anyhow::Result<SeededI
             "laptop",
             "127.0.0.1",
             Duration::minutes(2),
+            ZONE_TRUSTED,
         ),
         (
             "AA:BB:CC:11:22:02",
@@ -60,6 +74,7 @@ pub async fn populate(factory: &dyn RepositoryFactory) -> anyhow::Result<SeededI
             "phone",
             "192.168.1.42",
             Duration::seconds(30),
+            ZONE_TRUSTED,
         ),
         (
             "AA:BB:CC:11:22:03",
@@ -68,6 +83,7 @@ pub async fn populate(factory: &dyn RepositoryFactory) -> anyhow::Result<SeededI
             "tv",
             "192.168.1.55",
             Duration::minutes(10),
+            ZONE_IOT,
         ),
         (
             "AA:BB:CC:11:22:04",
@@ -76,6 +92,7 @@ pub async fn populate(factory: &dyn RepositoryFactory) -> anyhow::Result<SeededI
             "tablet",
             "192.168.1.67",
             Duration::hours(4),
+            ZONE_GUEST,
         ),
         (
             "AA:BB:CC:11:22:05",
@@ -84,6 +101,7 @@ pub async fn populate(factory: &dyn RepositoryFactory) -> anyhow::Result<SeededI
             "iot",
             "192.168.1.78",
             Duration::minutes(1),
+            ZONE_IOT,
         ),
     ];
 
@@ -92,7 +110,11 @@ pub async fn populate(factory: &dyn RepositoryFactory) -> anyhow::Result<SeededI
     // The device the user PWA resolves `/devices/me` to in local dev — tracked
     // by IP (not insertion order) so it stays correct if the seed list changes.
     let mut localhost_device_id: Option<Uuid> = None;
-    for (mac, hostname, manufacturer, device_type, ip, last_seen_ago) in devices {
+    // Endpoints of the demo casting exception (phone in Trusted → TV in IoT),
+    // captured by hostname so they survive reordering of the seed list.
+    let mut casting_from_id: Option<Uuid> = None;
+    let mut casting_to_id: Option<Uuid> = None;
+    for (mac, hostname, manufacturer, device_type, ip, last_seen_ago, zone_id) in devices {
         let id = Uuid::new_v4();
         let first_seen = (now - Duration::days(7)).to_rfc3339();
         let last_seen = (now - last_seen_ago).to_rfc3339();
@@ -106,9 +128,8 @@ pub async fn populate(factory: &dyn RepositoryFactory) -> anyhow::Result<SeededI
             first_seen,
             last_seen,
             last_ip: ip.to_owned(),
-            // Seeded demo devices are the owner's known devices → Trusted zone
-            // (seeded by the network_zones migration; allows direct + tunnel).
-            zone_id: "00000000-0000-0000-0000-000000000201".to_owned(),
+            // Zone assigned per-device above (network_zones migration UUIDs).
+            zone_id: zone_id.to_owned(),
             // Demo devices are LAN-discovered.
             connection_mode: wardnet_common::device::DeviceConnectionMode::Lan,
         };
@@ -116,6 +137,11 @@ pub async fn populate(factory: &dyn RepositoryFactory) -> anyhow::Result<SeededI
         device_ids.push(id);
         if ip == "127.0.0.1" {
             localhost_device_id = Some(id);
+        }
+        match hostname {
+            Some("alice-phone") => casting_from_id = Some(id),
+            Some("living-room-tv") => casting_to_id = Some(id),
+            _ => {}
         }
         device_lease_inputs.push((
             id,
@@ -140,6 +166,38 @@ pub async fn populate(factory: &dyn RepositoryFactory) -> anyhow::Result<SeededI
             .update_dns_capture_settings(&localhost_id.to_string(), Some(true), None, None)
             .await?;
         tracing::debug!(device_id = %localhost_id, "enabled DNS capture on localhost device");
+    }
+
+    // ------------------------------------------------------------------
+    // Cross-zone (casting) exception — the phone (Trusted) is allowed to reach
+    // the living-room TV (IoT) over the curated casting port set, so the Zones
+    // page's exceptions card renders a real entry instead of an empty state.
+    // ------------------------------------------------------------------
+    if let (Some(from_id), Some(to_id)) = (casting_from_id, casting_to_id) {
+        let exception = ZoneException {
+            id: Uuid::new_v4(),
+            from: ExceptionEndpoint {
+                kind: ExceptionEndpointKind::Device,
+                id: from_id,
+            },
+            to: ExceptionEndpoint {
+                kind: ExceptionEndpointKind::Device,
+                id: to_id,
+            },
+            service: ServiceSpec::Preset {
+                set: ServiceSet::Casting,
+            },
+            // Casting needs discovery/streaming traffic in both directions.
+            bidirectional: true,
+            created_at: now,
+            updated_at: now,
+        };
+        factory.zone_exception().insert(&exception).await?;
+        tracing::debug!(
+            from = %from_id,
+            to = %to_id,
+            "seeded casting exception: phone → living-room TV",
+        );
     }
 
     // ------------------------------------------------------------------

--- a/source/daemon/crates/wardnetd-mock/src/seed.rs
+++ b/source/daemon/crates/wardnetd-mock/src/seed.rs
@@ -103,6 +103,54 @@ pub async fn populate(factory: &dyn RepositoryFactory) -> anyhow::Result<SeededI
             Duration::minutes(1),
             ZONE_IOT,
         ),
+        // The "things that can't run a VPN" cohort — the devices the origin
+        // story is about. Cameras / doorbell / vacuum sit in IoT; the media
+        // boxes are trusted home devices.
+        (
+            "AA:BB:CC:11:22:06",
+            Some("hallway-camera"),
+            Some("Reolink"),
+            "iot",
+            "192.168.1.56",
+            Duration::minutes(3),
+            ZONE_IOT,
+        ),
+        (
+            "AA:BB:CC:11:22:07",
+            Some("smart-doorbell"),
+            Some("Ring"),
+            "iot",
+            "192.168.1.57",
+            Duration::seconds(45),
+            ZONE_IOT,
+        ),
+        (
+            "AA:BB:CC:11:22:08",
+            Some("robot-vacuum"),
+            Some("iRobot"),
+            "iot",
+            "192.168.1.58",
+            Duration::hours(2),
+            ZONE_IOT,
+        ),
+        (
+            "AA:BB:CC:11:22:09",
+            Some("games-console"),
+            Some("Sony"),
+            "game_console",
+            "192.168.1.60",
+            Duration::minutes(20),
+            ZONE_TRUSTED,
+        ),
+        (
+            "AA:BB:CC:11:22:0A",
+            Some("set-top-box"),
+            Some("Roku"),
+            "settop_box",
+            "192.168.1.61",
+            Duration::hours(1),
+            ZONE_TRUSTED,
+        ),
     ];
 
     let mut device_ids = Vec::with_capacity(devices.len());
@@ -223,7 +271,10 @@ pub async fn populate(factory: &dyn RepositoryFactory) -> anyhow::Result<SeededI
         dhcp_repo.insert_lease(&lease).await?;
     }
 
-    if let Some((_, mac, hostname, ip)) = device_lease_inputs.last() {
+    if let Some((_, mac, hostname, ip)) = device_lease_inputs
+        .iter()
+        .find(|(_, _, hostname, _)| hostname.as_deref() == Some("smart-plug-kitchen"))
+    {
         let reservation = DhcpReservationRow {
             id: Uuid::new_v4().to_string(),
             mac_address: mac.clone(),
@@ -376,21 +427,19 @@ pub async fn populate(factory: &dyn RepositoryFactory) -> anyhow::Result<SeededI
     // deterministically from `now` so the dev experience is reproducible
     // across `make run-dev` restarts.
     // ------------------------------------------------------------------
-    // (device_id, ip) pairs: seeded rows carry write-time device
-    // attribution just like the real DNS server records it. The last
-    // client is left unattributed so the dev UI exercises the
-    // unknown-source fallback rendering too.
-    let dns_clients: Vec<(Option<String>, String)> = {
-        let last = device_lease_inputs.len().saturating_sub(1);
-        device_lease_inputs
-            .iter()
-            .enumerate()
-            .map(|(i, (id, _, _, ip))| {
-                let device_id = (i != last).then(|| id.to_string());
-                (device_id, ip.clone())
-            })
-            .collect()
-    };
+    // (device_id, ip) pairs: every seeded row carries write-time device
+    // attribution, exactly as the real DNS server records it (the
+    // `DeviceIpSnapshot` resolves the client IP to a device id when the query
+    // is logged). Attributing every client keeps a known device from showing
+    // up twice in Top clients — once by device id and once by a bare IP — the
+    // failure mode issue #941 flagged, which was a seed artifact rather than a
+    // product bug (top-N ranks by device id and only falls back to the raw IP
+    // for genuinely unattributed traffic, so it never merges an IP back onto a
+    // device — an IP can be reassigned by DHCP).
+    let dns_clients: Vec<(Option<String>, String)> = device_lease_inputs
+        .iter()
+        .map(|(id, _, _, ip)| (Some(id.to_string()), ip.clone()))
+        .collect();
     let log_rows = generate_dns_query_log(&dns_clients, now);
     let total_log_rows = log_rows.len();
     for chunk in log_rows.chunks(256) {

--- a/source/daemon/crates/wardnetd-mock/src/tests/seed.rs
+++ b/source/daemon/crates/wardnetd-mock/src/tests/seed.rs
@@ -24,12 +24,12 @@ async fn populate_inserts_expected_demo_data() {
         .await
         .expect("populate should succeed");
 
-    assert_eq!(ids.device_ids.len(), 5, "should seed 5 devices");
+    assert_eq!(ids.device_ids.len(), 10, "should seed 10 devices");
     assert_eq!(ids.tunnel_ids.len(), 3, "should seed 3 tunnels");
 
     // Verify via repository reads.
     let devices = factory.device().find_all().await.unwrap();
-    assert_eq!(devices.len(), 5);
+    assert_eq!(devices.len(), 10);
 
     let tunnels = factory.tunnel().find_all().await.unwrap();
     assert_eq!(tunnels.len(), 3);


### PR DESCRIPTION
## What

Enriches the mock's demo seed so every zone-related surface renders real data and the demo device roster matches the marketing origin story, and corrects DNS client attribution to mirror the real daemon (which also fixes the visible duplicate in #941).

## Changes (`wardnetd-mock/src/seed.rs`)

- **Zone spread.** The five original devices were all in Trusted; now they span all three system zones, and one **bidirectional casting exception** (`alice-phone` Trusted ↔ `living-room-tv` IoT, `ServiceSet::Casting`) is seeded so the exceptions card isn't empty.
- **Story devices.** Adds the five "can't run a VPN" devices the origin post is about: `hallway-camera`, `smart-doorbell`, `robot-vacuum` (IoT) and `games-console`, `set-top-box` (Trusted). Ten demo devices total. Zones are now **Trusted 4 / IoT 5 / Guest 1**.
- **DNS attribution (#941).** Every seeded `dns.queries.by_client` row now carries a write-time `device_id`, exactly as the real DNS server records it via the `DeviceIpSnapshot`. Previously the last client was left permanently unattributed, which made a known device appear **twice** in Top clients — once by device, once as a bare IP. That was a seed artifact, not a product bug: `top_n` ranks by `device_id` and only falls back to the raw `client` IP for genuinely unattributed traffic, and deliberately never merges an IP back onto a device (an IP can be reassigned by DHCP). Fixes the duplicate reported in **#941**.
- Pins the demo DHCP reservation to the smart plug by hostname (it is no longer the last seeded device).

## Testing

- `make check-daemon` passes (clippy + fmt + full workspace test suite; the `wardnetd-mock` seed integration test now expects 10 devices).
- Verified in the running admin UI: Zones shows Trusted 4 / IoT 5 / Guest 1 + the casting exception; DNS Top Clients lists all 10 devices by name with **no duplicate and no bare-IP row**.

## Merge Commit Message

chore(mock): spread demo devices across zones, add story devices, attribute every DNS client

Spread the demo devices across Trusted/IoT/Guest, add a phone↔TV casting exception, add the five "can't run a VPN" story devices (10 total), and attribute every seeded DNS client at write time so a known device no longer appears twice in Top clients (fixes the duplicate seed artifact in #941). Device count 5→10; seed test updated.
