### PR TITLE
fix(install): enable net.ipv4.ip_forward on bare-metal install

### DIFF
--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -582,6 +582,26 @@ for unit in wardnetd.service wardnetd-rollback.service wardnet-postupgrade.servi
         chmod 0644 "/etc/systemd/system/$unit"
     fi
 done
+
+# 6b. IP forwarding. Per-device VPN routing forwards LAN traffic into the
+#     WireGuard tunnels, which requires net.ipv4.ip_forward=1. The daemon
+#     runs as an unprivileged user (User=wardnet, no CAP_DAC_OVERRIDE) and
+#     cannot write /proc/sys itself, so enable it here rather than leaving it
+#     to chance. Bare-metal only: in container mode the container's networking
+#     owns forwarding (`docker run --sysctl`, or host/macvlan) and /proc/sys is
+#     read-only to the container anyway — see the Docker install docs.
+if [[ -z "$CONTAINER_MODE" ]]; then
+    install -d -m 0755 /etc/sysctl.d
+    printf '# Wardnet: per-device VPN routing forwards LAN traffic through WireGuard.\nnet.ipv4.ip_forward = 1\n' \
+        > /etc/sysctl.d/99-wardnet.conf
+    chmod 0644 /etc/sysctl.d/99-wardnet.conf
+    # Apply immediately (installer runs as root); the drop-in makes it persist.
+    sysctl -q -w net.ipv4.ip_forward=1 2>/dev/null \
+        || echo 1 > /proc/sys/net/ipv4/ip_forward 2>/dev/null \
+        || true
+    echo "Enabled IP forwarding (net.ipv4.ip_forward=1); persisted in /etc/sysctl.d/99-wardnet.conf"
+fi
+
 if [[ -z "$CONTAINER_MODE" ]]; then
     systemctl daemon-reload
 fi

--- a/source/marketing-site/content/docs/installation.md
+++ b/source/marketing-site/content/docs/installation.md
@@ -120,6 +120,7 @@ Verification flow the installer runs, in order:
 | `/etc/systemd/system/wardnet-postupgrade.service` | Runs one-off migrations shipped with an upgrade, when a release includes them. |
 | `/usr/local/libexec/wardnet/runner/wardnet-postupgrade-runner` | Root-owned post-upgrade migration runner. |
 | `/var/lib/wardnet/postupgrade/`, `/var/lib/wardnet-postupgrade/` | Post-upgrade migration state. |
+| `/etc/sysctl.d/99-wardnet.conf` | Enables `net.ipv4.ip_forward=1` so per-device VPN routing can forward LAN traffic through the tunnels. |
 
 The `wardnet` system user owns all of the above (except the root-owned
 post-upgrade runner, which needs elevated privileges to apply
@@ -213,12 +214,28 @@ fires the `wardnetd-rollback.service` unit after three failures within
 
 ```bash
 sudo systemctl disable --now wardnetd
+sudo systemctl disable --now wardnet-postupgrade.service
 sudo rm -f /etc/systemd/system/wardnetd.service
 sudo rm -f /etc/systemd/system/wardnetd-rollback.service
 sudo rm -f /etc/systemd/system/wardnet-postupgrade.service
 sudo rm -f /usr/local/bin/wardnetd /usr/local/bin/wardnetd.old
 sudo rm -rf /etc/wardnet /var/lib/wardnet /var/log/wardnet
 sudo rm -rf /usr/local/libexec/wardnet /var/lib/wardnet-postupgrade
+sudo rm -f /etc/sysctl.d/99-wardnet.conf
+sudo rm -f /etc/dhcpcd.conf.d/wardnet.conf
 sudo userdel wardnet
 sudo systemctl daemon-reload
 ```
+
+This removes everything the installer created. Two notes:
+
+- `/etc/dhcpcd.conf.d/wardnet.conf` only exists if you installed with
+  `--static-ip`; the `rm -f` is a harmless no-op otherwise.
+- Removing `/etc/sysctl.d/99-wardnet.conf` stops IP forwarding from
+  persisting across reboots, but the running kernel keeps
+  `net.ipv4.ip_forward=1` until the next reboot. Leave the setting alone
+  if anything else on the host relies on forwarding.
+
+**This deletes your configuration and data** (the SQLite database,
+WireGuard keys, and secrets under `/var/lib/wardnet`). Take an
+[encrypted backup](/docs/backup-restore) first if you might want it back.


### PR DESCRIPTION
## The bug

Per-device VPN routing forwards LAN traffic into the WireGuard tunnels, which requires `net.ipv4.ip_forward=1`. Nothing enabled it on a bare-metal install:

- `install.sh` had no `ip_forward` / `sysctl.d` handling.
- `wardnetd.service` runs `User=wardnet` with `CAP_NET_ADMIN CAP_NET_RAW CAP_NET_BIND_SERVICE` (no `CAP_DAC_OVERRIDE`) and no `ExecStartPre`.
- The daemon's `enable_ip_forwarding()` states in its own comment that it cannot write `/proc/sys/net/ipv4/ip_forward` under that user, and its `sysctl -w` fallback hits the same DAC wall.

So on a genuinely fresh box where nothing else set it, `ip_forward` stayed at the kernel default (`0`) and per-device routing silently didn't forward. (Existing Pis often work because forwarding got enabled some other way earlier.)

## Fix

- **`install.sh`** writes `/etc/sysctl.d/99-wardnet.conf` (`net.ipv4.ip_forward = 1`) and applies it immediately (the installer runs as root, with a `/proc/sys` fallback if `sysctl` is unavailable). **Bare-metal only** — container mode skips it, since the container's networking owns forwarding (`docker run --sysctl`, or host/macvlan) and `/proc/sys` is read-only to the container. It also runs under `--upgrade-only`, so re-running the installer fixes already-affected boxes.

## Docs (`installation.md`)

- Added the drop-in to the **"What the installer sets up"** table.
- **Completed the Uninstall steps** (validation): they were already missing `/etc/dhcpcd.conf.d/wardnet.conf` (created by `--static-ip`); added that and the new `/etc/sysctl.d/99-wardnet.conf`, plus `systemctl disable --now wardnet-postupgrade.service`, and a data-loss caution.

## Scope

Docker networking (host vs macvlan, DHCP/HTTPS ports) is deliberately **not** here — it's the follow-up Docker-install rework.

## Testing

`bash -n` and `shellcheck` clean (CI enforces shellcheck via pre-commit). Docs page still renders (DocsArticle tests pass).

## Merge Commit Message

fix(install): enable net.ipv4.ip_forward on bare-metal install

The installer never enabled IP forwarding, and the daemon can't set it under its unprivileged user, so per-device VPN routing silently failed to forward on fresh installs. install.sh now writes /etc/sysctl.d/99-wardnet.conf and applies it (bare-metal only; containers handle forwarding via their networking). Also completes the documented Uninstall steps (dhcpcd + sysctl.d drop-ins, postupgrade disable).
