### PR TITLE
docs: fix Docker networking (host/macvlan/bridge) and reframe the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,11 +13,11 @@
 
 **Your network. Your rules.**
 
-Wardnet is a self-hosted network privacy gateway you run on your own hardware — a Raspberry Pi, a mini-PC, or any Linux host. It sits alongside your existing home or small-office router and acts as the warden of every device's connection to the internet: routing traffic through per-device VPN tunnels, blocking ads and trackers at the DNS level, running your own local DNS, and giving you full control from a dashboard — on your desktop or right from your phone.
+Wardnet is a self-hosted network privacy gateway you run on your own hardware (a Raspberry Pi, a mini-PC, or any Linux host). It sits alongside your existing home or small-office router and acts as the warden of every device's connection to the internet: routing traffic through per-device VPN tunnels, blocking ads and trackers at the DNS level, running your own local DNS, isolating IoT and guest devices into locked-down zones, and giving you full control from a dashboard on your desktop or right from your phone.
 
-**Think of it as a Pi-hole replacement with per-device VPN routing, network segmentation, and mobile apps built in.** Network-wide ad and tracker blocking (bring your existing Pi-hole blocklists), WireGuard tunnels you can assign to individual devices, and locked-down zones for IoT and guest devices — in one signed binary, one dashboard, no cloud account required.
+**Think of it as a Pi-hole replacement with per-device VPN routing, network segmentation, and mobile apps built in.** Network-wide ad and tracker blocking (bring your existing Pi-hole blocklists), WireGuard tunnels you can assign to individual devices, and locked-down zones for IoT and guest devices, all in one signed binary, one dashboard, no cloud account required.
 
-Devices that can't run VPN software themselves — smart TVs, consoles, IoT — get the same protection at the gateway level automatically. One host, one binary, no third-party dashboard.
+Devices that can't run VPN software themselves (smart TVs, consoles, IoT) get the same protection at the gateway level automatically. One host, one binary, no third-party dashboard.
 
 Learn more at [**wardnet.network**](https://wardnet.network).
 
@@ -25,30 +25,30 @@ Learn more at [**wardnet.network**](https://wardnet.network).
 
 ### Network protection
 
-- **Per-device VPN routing.** Send the kids' TV through one tunnel, your laptop through another, and the printer direct — or through the default. Policies apply instantly via `ip rule` + nftables.
-- **Network-wide ad and tracker blocking.** DNS-level filtering with cron-refreshed blocklists (StevenBlack, OISD, AdGuard, or bring your own), allowlists for exceptions, and custom filter rules — plus per-device filter profiles (Ad Blocking, Parental Controls, Malware & Phishing) so different family members or devices can run different rules. A per-device kill switch still logs what it *would* have blocked.
+- **Per-device VPN routing.** Send the kids' TV through one tunnel, your laptop through another, and the printer direct, or through the default. Policies apply instantly via `ip rule` + nftables.
+- **Network-wide ad and tracker blocking.** DNS-level filtering with cron-refreshed blocklists (StevenBlack, OISD, AdGuard, or bring your own), allowlists for exceptions, and custom filter rules, plus per-device filter profiles (Ad Blocking, Parental Controls, Malware & Phishing) so different family members or devices can run different rules. A per-device kill switch still logs what it *would* have blocked.
 - **Your own local DNS.** Answer custom domains on your LAN (`nas.home`, `printer.lan`) with your own A/AAAA/CNAME/TXT/MX/SRV records, and forward specific domains to specific upstream resolvers with automatic failover or fastest-server selection.
-- **Network Zones.** Put IoT, guest, and kids' devices into locked-down zones enforced at the firewall — no admin-UI access, no bypassing a mandated tunnel — with exceptions for things like casting to a TV in another zone.
-- **Built-in DHCP server.** Lease management, static MAC-to-IP reservations, conflict detection, audit trail. Disable your existing DHCP source when you're ready — not before.
+- **Network Zones.** Put IoT, guest, and kids' devices into locked-down zones enforced at the firewall (no admin-UI access, no bypassing a mandated tunnel), with exceptions for things like casting to a TV in another zone.
+- **Built-in DHCP server.** Lease management, static MAC-to-IP reservations, conflict detection, audit trail. Disable your existing DHCP source when you're ready, not before.
 - **Automatic device discovery.** ARP scanning plus IEEE OUI vendor lookup (~39k entries embedded in the binary) identifies new devices as they join. Randomised-MAC detection flags modern phones.
 
 ### Manage it from anywhere
 
-- **Mobile apps.** Installable User and Admin apps (PWAs) — check status, flip your own routing policy, or manage the whole gateway from your phone. A Premium capability; everything they do is also available free from the desktop admin site.
-- **Push notifications.** Get alerted the moment a tunnel drops or a device changes its own routing — no need to keep the dashboard open. Delivered to the mobile apps, and Premium along with them.
+- **Mobile apps.** Installable User and Admin apps (PWAs): check status, flip your own routing policy, or manage the whole gateway from your phone. A Premium capability; everything they do is also available free from the desktop admin site.
+- **Push notifications.** Get alerted the moment a tunnel drops or a device changes its own routing, with no need to keep the dashboard open. Delivered to the mobile apps, and Premium along with them.
 - **Automatic HTTPS.** The daemon terminates TLS itself and renews certificates automatically, so you can reach your gateway securely from outside your LAN. Bring your own domain for free, or let Wardnet manage a hostname and certificate for you.
-- **WireGuard tunnels on demand.** Add tunnels from a `.conf` file or provision through a provider (NordVPN integration ships today — more to follow). Interfaces come up when needed and tear down after an idle timeout.
+- **WireGuard tunnels on demand.** Add tunnels from a `.conf` file or provision through a provider (NordVPN integration ships today, more to follow). Interfaces come up when needed and tear down after an idle timeout.
 
 ### See what's happening
 
-- **Live stats and DNS query logs.** Time-series charts, top-domain and top-client breakdowns, per-tunnel throughput and latency — right on the dashboard, with a live-tailing query log.
-- **One-click tunnel verification.** Confirm a VPN routing rule is actually doing what you configured — exit IP, country, and latency, at a glance.
+- **Live stats and DNS query logs.** Time-series charts, top-domain and top-client breakdowns, per-tunnel throughput and latency, right on the dashboard, with a live-tailing query log.
+- **One-click tunnel verification.** Confirm a VPN routing rule is actually doing what you configured: exit IP, country, and latency, at a glance.
 
 ### It just keeps running
 
-- **Self-healing.** A layered watchdog restarts a frozen service — or reboots the host if it has to — and tunnels reconnect automatically if their interface disappears.
+- **Self-healing.** A layered watchdog restarts a frozen service (or reboots the host if it has to), and tunnels reconnect automatically if their interface disappears.
 - **Signed, safe auto-updates.** Updates apply themselves and roll back automatically on a crash loop, with an opt-in beta channel for early access.
-- **Encrypted backup and restore.** Export your entire configuration — devices, policies, tunnels, DNS records, secrets — to one encrypted file, and restore it on new hardware in minutes.
+- **Encrypted backup and restore.** Export your entire configuration (devices, policies, tunnels, DNS records, secrets) to one encrypted file, and restore it on new hardware in minutes.
 
 ### Built for trust
 
@@ -61,24 +61,24 @@ Learn more at [**wardnet.network**](https://wardnet.network).
 The gateway itself is free and fully self-hostable, forever: per-device VPN
 routing and WireGuard tunnels, DNS ad and tracker blocking, local DNS,
 Network Zones, DHCP, device discovery, encrypted backups, self-healing, and
-the full desktop admin site — with automatic HTTPS when you bring your own
+the full desktop admin site, with automatic HTTPS when you bring your own
 domain. No account required, and none of it is time-limited or feature-gated.
 
 **Premium** is an optional, paid add-on covering the parts that cost us real
 money to run on your behalf, plus the mobile layer:
 
-- **Dynamic DNS** — reach your gateway with no domain of your own.
-- **Secure remote tunneling** with automatic HTTPS — encrypted inbound access
+- **Dynamic DNS**: reach your gateway with no domain of your own.
+- **Secure remote tunneling** with automatic HTTPS: encrypted inbound access
   from anywhere.
-- **Roaming private DNS** — keep your filtering with you off the LAN.
-- **Personal VPN** — your own inbound WireGuard server, so your phone and
+- **Roaming private DNS**: keep your filtering with you off the LAN.
+- **Personal VPN**: your own inbound WireGuard server, so your phone and
   laptop reach your home network from anywhere.
-- **The mobile apps** — the User PWA and the Admin mobile PWA, and the push
+- **The mobile apps**: the User PWA and the Admin mobile PWA, and the push
   notifications they deliver.
 
 The mobile apps are a convenience layer, not a functionality gate: every
 action they offer can be performed for free from the desktop admin site. The
-one thing that genuinely needs them is push — alerts are delivered to the
+one thing that genuinely needs them is push: alerts are delivered to the
 installed apps, so they arrive with them.
 
 See [Premium](https://wardnet.network/docs/premium) for the full breakdown.
@@ -87,19 +87,41 @@ See [Premium](https://wardnet.network/docs/premium) for the full breakdown.
 
 ### Run with Docker
 
+A gateway runs DHCP, DNS, and HTTPS directly on your LAN, so the simplest
+setup is **host networking**: the daemon binds the host's own interfaces
+(web UI on 7411, DNS on 53, DHCP on 67, automatic HTTPS on 80/443, plus
+WireGuard), and DHCP broadcasts reach real LAN clients.
+
 ```sh
+# Enable IP forwarding on the host (persists across reboots):
+echo 'net.ipv4.ip_forward=1' | sudo tee /etc/sysctl.d/99-wardnet.conf
+sudo sysctl --system
+
 docker run -d \
   --name wardnetd \
+  --network host \
   --cap-add NET_ADMIN --cap-add NET_RAW \
   --device /dev/net/tun \
-  --sysctl net.ipv4.ip_forward=1 \
   --tmpfs /run --tmpfs /run/lock \
-  -p 7411:7411 \
   -v wardnet-data:/var/lib/wardnet \
   ghcr.io/wardnet/wardnetd:latest
 ```
 
-Open **http://localhost:7411** to complete the setup wizard. Auto-update and crash-loop rollback work inside the container because systemd runs as PID 1, but recreating the container resets to the image's baked-in version — only `docker restart` preserves an auto-updated binary. See [`source/daemon/examples/docker-compose.yaml`](source/daemon/examples/docker-compose.yaml) for a reference compose file with all networking options documented.
+Open **http://localhost:7411** to complete the setup wizard.
+
+Host networking needs ports 53/67/80/443/7411 free on the host, which is
+ideal on a dedicated gateway box. Two alternatives are documented, with a
+reference compose file, in the [Docker install guide](https://wardnet.network/docs/installation)
+and [`source/daemon/examples/docker-compose.yaml`](source/daemon/examples/docker-compose.yaml):
+give Wardnet its own LAN IP with a **macvlan** network (good when it
+shares a host with other services), or run a **bridge** with published
+ports for just the web UI, DNS, and tunnels (it cannot serve DHCP to LAN
+clients).
+
+Auto-update and crash-loop rollback work inside the container because
+systemd runs as PID 1. One caveat: recreating the container resets to the
+image's baked-in version, so use `docker restart` (not `rm` + `run`) to
+preserve an auto-updated binary.
 
 ### Bare-metal install
 
@@ -119,31 +141,31 @@ Full walkthrough, configuration reference, and guides in the [**user documentati
 
 ## Documentation
 
-- [**User documentation**](https://wardnet.network/docs) — installation, configuration, setup walkthrough, guides
-- [**Development guide**](docs/DEVELOPMENT.md) — build, run locally, deploy, contribute
-- [**Security policy & release signing**](SECURITY.md) — reporting vulnerabilities, verifying releases
-- [**AI declaration**](ai-declaration.md) — where and how much AI is used in developing Wardnet
-- [**Release notes**](docs/releases/) — per-version changelogs
-- [**Marketing site**](https://wardnet.network) — setup walkthrough, screenshots, docs
+- [**User documentation**](https://wardnet.network/docs): installation, configuration, setup walkthrough, guides
+- [**Development guide**](docs/DEVELOPMENT.md): build, run locally, deploy, contribute
+- [**Security policy & release signing**](SECURITY.md): reporting vulnerabilities, verifying releases
+- [**AI declaration**](ai-declaration.md): where and how much AI is used in developing Wardnet
+- [**Release notes**](docs/releases/): per-version changelogs
+- [**Marketing site**](https://wardnet.network): setup walkthrough, screenshots, docs
 
 ## Project status
 
-Wardnet is in active development. It's daily-driven on a single Pi at home, but expect rough edges — read the [development guide](docs/DEVELOPMENT.md#project-status) for a full picture of what works today, what's missing, and known caveats. Roadmap and known work-in-flight live in [GitHub issues](https://github.com/wardnet/wardnet/issues), grouped by [milestones](https://github.com/wardnet/wardnet/milestones).
+Wardnet is in active development. It's daily-driven on a single Pi at home, but expect rough edges; read the [development guide](docs/DEVELOPMENT.md#project-status) for a full picture of what works today, what's missing, and known caveats. Roadmap and known work-in-flight live in [GitHub issues](https://github.com/wardnet/wardnet/issues), grouped by [milestones](https://github.com/wardnet/wardnet/milestones).
 
 ![Repobeats analytics image](https://repobeats.axiom.co/api/embed/542b52b1295b4c6d2f98aee099989eded7862c46.svg "Repobeats analytics image")
 
 ## Contributing
 
-Contributions welcome. Start with the [development guide](docs/DEVELOPMENT.md) and the [agent/contributor conventions](AGENTS.md). For security issues, please use [GitHub's private vulnerability reporting](https://github.com/wardnet/wardnet/security/advisories/new) — see [SECURITY.md](SECURITY.md) for details.
+Contributions welcome. Start with the [development guide](docs/DEVELOPMENT.md) and the [agent/contributor conventions](AGENTS.md). For security issues, please use [GitHub's private vulnerability reporting](https://github.com/wardnet/wardnet/security/advisories/new), see [SECURITY.md](SECURITY.md) for details.
 
 ## License
 
-The daemon (`source/daemon/`) is [GPL-3.0-or-later](LICENSE) — it links
+The daemon (`source/daemon/`) is [GPL-3.0-or-later](LICENSE): it links
 [`rustables`](https://crates.io/crates/rustables), which is GPL-3.0-or-later,
 and Rust links statically, so the compiled binary is a combined work.
 
 The `@wardnet/js` SDK and the web/app frontends stay
-[MIT](source/sdk/wardnet-js/LICENSE) — you can build against the SDK without
+[MIT](source/sdk/wardnet-js/LICENSE): you can build against the SDK without
 inheriting GPL obligations.
 
 See [LICENSING.md](LICENSING.md) for the full breakdown.

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -582,6 +582,26 @@ for unit in wardnetd.service wardnetd-rollback.service wardnet-postupgrade.servi
         chmod 0644 "/etc/systemd/system/$unit"
     fi
 done
+
+# 6b. IP forwarding. Per-device VPN routing forwards LAN traffic into the
+#     WireGuard tunnels, which requires net.ipv4.ip_forward=1. The daemon
+#     runs as an unprivileged user (User=wardnet, no CAP_DAC_OVERRIDE) and
+#     cannot write /proc/sys itself, so enable it here rather than leaving it
+#     to chance. Bare-metal only: in container mode the container's networking
+#     owns forwarding (`docker run --sysctl`, or host/macvlan) and /proc/sys is
+#     read-only to the container anyway — see the Docker install docs.
+if [[ -z "$CONTAINER_MODE" ]]; then
+    install -d -m 0755 /etc/sysctl.d
+    printf '# Wardnet: per-device VPN routing forwards LAN traffic through WireGuard.\nnet.ipv4.ip_forward = 1\n' \
+        > /etc/sysctl.d/99-wardnet.conf
+    chmod 0644 /etc/sysctl.d/99-wardnet.conf
+    # Apply immediately (installer runs as root); the drop-in makes it persist.
+    sysctl -q -w net.ipv4.ip_forward=1 2>/dev/null \
+        || echo 1 > /proc/sys/net/ipv4/ip_forward 2>/dev/null \
+        || true
+    echo "Enabled IP forwarding (net.ipv4.ip_forward=1); persisted in /etc/sysctl.d/99-wardnet.conf"
+fi
+
 if [[ -z "$CONTAINER_MODE" ]]; then
     systemctl daemon-reload
 fi

--- a/source/daemon/examples/docker-compose.yaml
+++ b/source/daemon/examples/docker-compose.yaml
@@ -1,16 +1,25 @@
 # wardnetd reference compose.
 #
-# Copy this file to your project, adjust the configuration, and run:
+# Copy this file to your project, adjust, and run:
 #   docker compose up -d
 #
-# The daemon needs a few host-level permissions to manage WireGuard interfaces,
-# nftables rules, and DHCP/DNS sockets. None of these require `privileged: true`.
+# A gateway runs DHCP, DNS, and HTTPS directly on your LAN, so how you network
+# the container matters more than which ports you publish. This file defaults
+# to HOST networking: the simplest setup, and the only bridge-free way DHCP
+# broadcasts reach real LAN clients. Two alternatives are documented at the
+# bottom: macvlan (its own LAN IP) and a bridge (web UI + DNS + tunnels, no
+# DHCP). None of this requires `privileged: true`.
 
 services:
   wardnetd:
     image: ghcr.io/wardnet/wardnetd:latest
     container_name: wardnetd
     restart: unless-stopped
+
+    # HOST networking: the daemon binds the host's own interfaces directly (web
+    # UI 7411, DNS 53, DHCP 67, automatic HTTPS 80/443, WireGuard), and DHCP
+    # broadcasts reach LAN clients. Needs those ports free on the host.
+    network_mode: host
 
     # NET_ADMIN — create/configure WireGuard interfaces, add ip rules, manage nftables.
     # NET_RAW   — raw sockets used by the packet-capture device detector.
@@ -22,27 +31,17 @@ services:
     devices:
       - /dev/net/tun
 
-    # IP forwarding is required to route LAN traffic through WireGuard tunnels.
-    sysctls:
-      net.ipv4.ip_forward: "1"
+    # IP forwarding is required to route LAN traffic through WireGuard. With host
+    # networking, enable it on the HOST — Docker rejects network sysctls in this
+    # mode, so `sysctls:` / `--sysctl` do not apply here:
+    #   echo 'net.ipv4.ip_forward=1' | sudo tee /etc/sysctl.d/99-wardnet.conf
+    #   sudo sysctl --system
 
     # systemd (PID 1) requires a writable /run. Do not use a named volume here —
     # systemd's runtime state must not persist across container restarts.
     tmpfs:
       - /run
       - /run/lock
-
-    ports:
-      # Web UI and daemon API. Open this to any host that needs dashboard access.
-      - "7411:7411/tcp"
-      # DNS: publish only on the LAN-facing interface if your host has multiple.
-      # Example: - "192.168.1.1:53:53/udp"
-      - "53:53/udp"
-      - "53:53/tcp"
-      # DHCP: UDP broadcast — the container must share the LAN bridge for DHCP
-      # to reach clients. Binding the port alone is not sufficient; see the
-      # network section below or use `network_mode: host` for simple setups.
-      - "67:67/udp"
 
     volumes:
       # Persistent state: database, WireGuard keys, staged updates, logs.
@@ -51,10 +50,47 @@ services:
       # Optional: override the default configuration.
       # - ./wardnet.toml:/etc/wardnet/wardnet.toml:ro
 
-    # Optional: attach the container directly to the host network so DHCP
-    # broadcasts reach LAN clients without additional bridge configuration.
-    # Comment out the `ports` section above when using this.
-    # network_mode: host
-
 volumes:
   wardnet-data:
+
+# ── Alternative networking modes ──────────────────────────────────────────
+#
+# macvlan — give the container its OWN MAC + IP on the LAN (good when the host
+# runs other services, so wardnetd doesn't collide with host ports). Caveats:
+# the Docker host cannot reach the container by default; the IP must sit
+# outside both your router's DHCP pool and the pool wardnetd hands out; the NIC
+# must allow promiscuous mode (most WiFi APs reject macvlan, and it is
+# unavailable on Docker Desktop). Enable ip_forward on the host, as above.
+# Replace `network_mode: host` on the service with:
+#
+#   services:
+#     wardnetd:
+#       networks:
+#         wardnet_lan:
+#           ipv4_address: 192.168.1.2   # outside all DHCP pools
+#   networks:
+#     wardnet_lan:
+#       driver: macvlan
+#       driver_opts:
+#         parent: eth0                  # your LAN NIC
+#       ipam:
+#         config:
+#           - subnet: 192.168.1.0/24
+#             gateway: 192.168.1.1
+#
+# bridge — keep your router's DHCP and use wardnetd only for the web UI, DNS,
+# and tunnels (point clients' DNS at the Docker host's IP). This CANNOT run
+# wardnetd's DHCP server: DHCP needs LAN broadcast, which a NAT bridge does not
+# carry. Replace `network_mode: host` on the service with published ports and
+# the sysctl (which works in this mode, since the container has its own netns):
+#
+#   services:
+#     wardnetd:
+#       sysctls:
+#         net.ipv4.ip_forward: "1"
+#       ports:
+#         - "7411:7411/tcp"
+#         - "53:53/tcp"
+#         - "53:53/udp"
+#         # - "80:80/tcp"    # add 80 + 443 to serve automatic HTTPS here
+#         # - "443:443/tcp"

--- a/source/marketing-site/content/docs/installation.md
+++ b/source/marketing-site/content/docs/installation.md
@@ -7,6 +7,92 @@ the container.
 
 ## Run with Docker
 
+A gateway runs DHCP, DNS, and HTTPS **directly on your LAN**, so how you
+network the container matters more than which ports you publish. Pick one
+of the three modes below.
+
+### Host networking (recommended)
+
+The daemon shares the host's network stack and binds the host's interfaces
+directly: web UI on 7411, DNS on 53, DHCP on 67, automatic HTTPS on 80/443,
+plus WireGuard. DHCP broadcasts reach real LAN clients, and there's nothing
+to publish. This is the simplest setup and behaves just like a bare-metal
+install.
+
+```bash
+# Enable IP forwarding on the host (persists across reboots):
+echo 'net.ipv4.ip_forward=1' | sudo tee /etc/sysctl.d/99-wardnet.conf
+sudo sysctl --system
+
+docker run -d \
+  --name wardnetd \
+  --network host \
+  --cap-add NET_ADMIN --cap-add NET_RAW \
+  --device /dev/net/tun \
+  --tmpfs /run --tmpfs /run/lock \
+  -v wardnet-data:/var/lib/wardnet \
+  ghcr.io/wardnet/wardnetd:latest
+```
+
+Open **http://localhost:7411** to complete the setup wizard.
+
+| Flag | Why |
+| --- | --- |
+| `--network host` | Puts the daemon on the LAN directly, so DHCP broadcasts reach clients and DNS/HTTPS bind the real interfaces. |
+| `--cap-add NET_ADMIN` | Create/configure WireGuard interfaces, manage nftables and `ip rule`. |
+| `--cap-add NET_RAW` | Raw sockets for the packet-capture device detector. |
+| `--device /dev/net/tun` | WireGuard tunnels use the tun device. |
+| `--tmpfs /run --tmpfs /run/lock` | systemd (PID 1) needs a writable, non-persistent `/run`. |
+| `-v wardnet-data:/var/lib/wardnet` | Persistent state: database, WireGuard keys, staged updates. |
+
+`net.ipv4.ip_forward` is enabled on the **host** (above), not via
+`docker run --sysctl`, because Docker rejects network sysctls when a
+container shares the host network namespace. Host networking also needs
+ports 53/67/80/443/7411 free on the host, so run it on a box dedicated to
+Wardnet (for example, don't leave `systemd-resolved` bound to `:53`).
+
+### Its own LAN IP with macvlan (advanced)
+
+If Wardnet shares a host with other services, give the container its **own
+MAC and IP on the LAN** with a macvlan network, so it doesn't collide with
+the host's ports and clients point at a dedicated gateway address:
+
+```bash
+# Replace eth0 with your LAN NIC, and the subnet/gateway/IP with your LAN's.
+docker network create -d macvlan \
+  --subnet 192.168.1.0/24 --gateway 192.168.1.1 \
+  -o parent=eth0 wardnet-lan
+
+docker run -d \
+  --name wardnetd \
+  --network wardnet-lan --ip 192.168.1.2 \
+  --cap-add NET_ADMIN --cap-add NET_RAW \
+  --device /dev/net/tun \
+  --tmpfs /run --tmpfs /run/lock \
+  -v wardnet-data:/var/lib/wardnet \
+  ghcr.io/wardnet/wardnetd:latest
+```
+
+macvlan caveats worth knowing before you choose it:
+
+- **The Docker host can't reach the container** over the network by default
+  (and vice versa); it's a macvlan limitation. If you need host-to-daemon
+  access, add a macvlan "shim" interface on the host.
+- The chosen IP (`192.168.1.2` above) must sit **outside** both your
+  router's DHCP pool and the pool Wardnet hands out.
+- It needs the NIC in promiscuous mode: fine on wired NICs, but **most WiFi
+  access points reject macvlan**, and it doesn't work on Docker Desktop
+  (macOS/Windows).
+- Enable `ip_forward` on the host, same as the host-networking mode above.
+
+### Bridge with published ports (web UI, DNS, and tunnels only)
+
+To keep your **existing router's DHCP** and use Wardnet only for the
+dashboard, DNS ad-blocking, and tunnel management, a normal bridge with
+published ports is enough; point your clients' DNS at the Docker **host's**
+IP. This mode **cannot run Wardnet's DHCP server**: DHCP relies on LAN
+broadcast, which a NAT bridge doesn't carry.
+
 ```bash
 docker run -d \
   --name wardnetd \
@@ -16,30 +102,16 @@ docker run -d \
   --tmpfs /run --tmpfs /run/lock \
   -p 7411:7411 \
   -p 53:53/tcp -p 53:53/udp \
-  -p 67:67/udp \
   -v wardnet-data:/var/lib/wardnet \
   ghcr.io/wardnet/wardnetd:latest
 ```
 
-Open **http://localhost:7411** to complete the setup wizard.
+Add `-p 80:80 -p 443:443` to serve automatic HTTPS for remote access here
+rather than through Premium tunneling. In this mode `--sysctl
+net.ipv4.ip_forward=1` works, because the container has its own bridged
+network namespace.
 
-The flags are required:
-
-| Flag | Why |
-| --- | --- |
-| `--cap-add NET_ADMIN` | Create/configure WireGuard interfaces, manage nftables and `ip rule`. |
-| `--cap-add NET_RAW` | Raw sockets for the packet-capture device detector. |
-| `--device /dev/net/tun` | WireGuard tunnels use the tun device. |
-| `--sysctl net.ipv4.ip_forward=1` | Required to route LAN traffic through WireGuard tunnels. |
-| `--tmpfs /run --tmpfs /run/lock` | systemd (PID 1) needs a writable, non-persistent `/run`. |
-| `-p 53:53/tcp -p 53:53/udp` | DNS resolution and ad-blocking for LAN clients. |
-| `-p 67:67/udp` | DHCP server, if you want Wardnet handing out leases. |
-| `-v wardnet-data:/var/lib/wardnet` | Persistent state: database, WireGuard keys, staged updates. |
-
-Skip the DNS/DHCP port mappings if you only want the web UI and tunnel
-management, and plan to keep your existing router's DNS/DHCP in place.
-
-A reference compose file with all options documented is at
+A reference compose file covering all three modes is at
 [`source/daemon/examples/docker-compose.yaml`](https://github.com/wardnet/wardnet/blob/main/source/daemon/examples/docker-compose.yaml).
 
 ### Auto-update in Docker

--- a/source/marketing-site/content/docs/installation.md
+++ b/source/marketing-site/content/docs/installation.md
@@ -120,6 +120,7 @@ Verification flow the installer runs, in order:
 | `/etc/systemd/system/wardnet-postupgrade.service` | Runs one-off migrations shipped with an upgrade, when a release includes them. |
 | `/usr/local/libexec/wardnet/runner/wardnet-postupgrade-runner` | Root-owned post-upgrade migration runner. |
 | `/var/lib/wardnet/postupgrade/`, `/var/lib/wardnet-postupgrade/` | Post-upgrade migration state. |
+| `/etc/sysctl.d/99-wardnet.conf` | Enables `net.ipv4.ip_forward=1` so per-device VPN routing can forward LAN traffic through the tunnels. |
 
 The `wardnet` system user owns all of the above (except the root-owned
 post-upgrade runner, which needs elevated privileges to apply
@@ -213,12 +214,28 @@ fires the `wardnetd-rollback.service` unit after three failures within
 
 ```bash
 sudo systemctl disable --now wardnetd
+sudo systemctl disable --now wardnet-postupgrade.service
 sudo rm -f /etc/systemd/system/wardnetd.service
 sudo rm -f /etc/systemd/system/wardnetd-rollback.service
 sudo rm -f /etc/systemd/system/wardnet-postupgrade.service
 sudo rm -f /usr/local/bin/wardnetd /usr/local/bin/wardnetd.old
 sudo rm -rf /etc/wardnet /var/lib/wardnet /var/log/wardnet
 sudo rm -rf /usr/local/libexec/wardnet /var/lib/wardnet-postupgrade
+sudo rm -f /etc/sysctl.d/99-wardnet.conf
+sudo rm -f /etc/dhcpcd.conf.d/wardnet.conf
 sudo userdel wardnet
 sudo systemctl daemon-reload
 ```
+
+This removes everything the installer created. Two notes:
+
+- `/etc/dhcpcd.conf.d/wardnet.conf` only exists if you installed with
+  `--static-ip`; the `rm -f` is a harmless no-op otherwise.
+- Removing `/etc/sysctl.d/99-wardnet.conf` stops IP forwarding from
+  persisting across reboots, but the running kernel keeps
+  `net.ipv4.ip_forward=1` until the next reboot. Leave the setting alone
+  if anything else on the host relies on forwarding.
+
+**This deletes your configuration and data** (the SQLite database,
+WireGuard keys, and secrets under `/var/lib/wardnet`). Take an
+[encrypted backup](/docs/backup-restore) first if you might want it back.


### PR DESCRIPTION
> Stacked on #949 (installer `ip_forward` fix) — merge that first; GitHub will retarget this to `main`.

## The problem

The Docker install instructions couldn't actually run a gateway:

- The **README** published only `7411` — no DNS, no DHCP.
- The **docs** published `-p 53` and `-p 67:67/udp`, but `-p 67` **cannot serve DHCP to real LAN clients**: DHCP relies on LAN broadcast, which a NAT bridge doesn't carry. (The e2e DHCP spec only passes because it puts the daemon and a test `dhclient` on the *same Docker bridge* — a test-only arrangement, not how real LAN clients connect.)
- **Nothing** published `80/443`, so the daemon's automatic HTTPS for remote access had no path.
- `--sysctl net.ipv4.ip_forward=1` is silently incompatible with the host networking that DHCP actually needs.

## The fix — three documented modes

Reworked the README, `docs/installation.md`, and the reference compose (`source/daemon/examples/docker-compose.yaml`, now **host-networking by default**) to document, correctly:

1. **Host networking (recommended)** — the daemon binds the host's interfaces (7411, 53, 67, 80/443, WireGuard); DHCP broadcasts reach LAN clients; `ip_forward` is set on the **host** (Docker rejects net sysctls in this mode).
2. **macvlan (advanced)** — its own MAC/IP on the LAN, with the real caveats: host↔container is blocked by default, the IP must sit outside all DHCP pools, needs promiscuous mode (WiFi APs usually reject it; not on Docker Desktop).
3. **Bridge (limited)** — web UI + DNS + tunnels only; explicitly **cannot** run Wardnet's DHCP; `--sysctl` works here.

## README review pass (per maintainer)

- Removed **all 32 em dashes** in favour of commas / colons / parentheses (higher confidence in the review process).
- Added **Network Zones** to the opening paragraph's feature list.

## Testing

Reference compose validates as YAML with `network_mode: host`; README has zero em dashes; docs pages still render (DocsArticle tests pass).

## Merge Commit Message

docs: fix Docker networking (host/macvlan/bridge) and reframe the README

Document three correct Docker networking modes (host default, macvlan advanced, bridge limited) across the README, installation guide, and reference compose — the old instructions couldn't run DHCP/HTTPS at all. Also remove every em dash from the README and add Network Zones to its opening paragraph.
