### PR TITLE
fix(fuzz): build fuzz targets for a custom triple to fix the CFLite image build (#587)

### DIFF
--- a/.clusterfuzzlite/README.md
+++ b/.clusterfuzzlite/README.md
@@ -10,9 +10,23 @@ bundle archiver, SQLite restore, and bundle-manifest JSON.
   copies the repo, and stages `build.sh`.
 - `build.sh` — invoked inside the image at build time. Runs
   `cargo build` (not `cargo fuzz build`) against `source/daemon/fuzz/`
-  with sanitizer flags set via target-specific `RUSTFLAGS` so
-  proc-macro crates are not instrumented, then copies the resulting
-  binaries into `$OUT/`.
+  for a **custom target triple** (`x86_64-wardnet-linux-gnu`, a
+  byte-for-byte copy of the `x86_64-unknown-linux-gnu` spec under a
+  different name), then copies the resulting binaries into `$OUT/`.
+
+  The custom triple is the fix for #587: on the OSS-Fuzz image the
+  host triple equals the fuzz target triple, so nothing — rustflags,
+  `CFLAGS`, `[target.*]` config — can be scoped to the fuzz binaries
+  without also hitting host-side builds. In particular the image's
+  global sanitizer `CFLAGS` leak into build-script C compiles for
+  proc-macro dependencies (`libsqlite3-sys` under `sqlx-macros`), and
+  the resulting proc-macro `.so` fails to dlopen inside rustc with
+  `undefined symbol: __sancov_lowest_stack`. With a distinct target
+  name, sanitizer rustflags and C flags are pinned to
+  `CARGO_TARGET_X86_64_WARDNET_LINUX_GNU_RUSTFLAGS` /
+  `CFLAGS_x86_64_wardnet_linux_gnu` while host builds stay clean; the
+  binaries remain ABI-identical to plain gnu and run unmodified in
+  the CFLite runner.
 
 Fuzz targets and harnesses live at `source/daemon/fuzz/` — a
 **standalone** cargo workspace (the daemon workspace excludes it)

--- a/.clusterfuzzlite/build.sh
+++ b/.clusterfuzzlite/build.sh
@@ -140,6 +140,12 @@ coverage)
     ;;
 esac
 
+# Link with LLD: the image's /usr/bin/ld is an old BFD binutils that
+# chokes on the build-std compiler_builtins rlib ("file format not
+# recognized"); lld ships with the image's clang and handles the
+# modern object files fine.
+TARGET_RUSTFLAGS+=" -Clink-arg=-fuse-ld=lld"
+
 export CARGO_TARGET_X86_64_WARDNET_LINUX_GNU_RUSTFLAGS="$TARGET_RUSTFLAGS"
 unset RUSTFLAGS 2>/dev/null || true
 

--- a/.clusterfuzzlite/build.sh
+++ b/.clusterfuzzlite/build.sh
@@ -27,47 +27,144 @@ TOOLCHAIN=$(awk -F '"' '/^channel/ {print $2}' rust-toolchain.toml)
 rustup toolchain install "$TOOLCHAIN" --profile minimal --component rust-src
 export RUSTUP_TOOLCHAIN="$TOOLCHAIN"
 
+# ── Custom fuzz target triple (fix for #587) ─────────────────────
+# On this image the host triple equals the fuzz target triple
+# (x86_64-unknown-linux-gnu), which makes it impossible to scope
+# instrumentation to the fuzz binaries: every per-target knob
+# (CARGO_TARGET_*_RUSTFLAGS, CFLAGS_<triple>, [target.<triple>]
+# config) hits host-side builds (proc-macros, build scripts) too,
+# because they share the same triple name.
+#
+# The actual #587 failure enters through C code: the image's global
+# CFLAGS carry `-fsanitize=address ... -fsanitize=fuzzer-no-link`,
+# the cc crate applies them to build-script C compiles for BOTH
+# host and target, and rustc bundles native static libs wholesale
+# into dylib crates — so the host sqlx-macros proc-macro .so ends up
+# containing sancov-instrumented sqlite3 objects (via libsqlite3-sys)
+# and fails to dlopen inside rustc with
+# `undefined symbol: __sancov_lowest_stack`. RUSTFLAGS-level fixes
+# can never touch that path, which is why every attempt recorded in
+# #587 failed.
+#
+# Fix: build the fuzz binaries for a *custom* target triple that is
+# byte-for-byte the x86_64-unknown-linux-gnu spec under a different
+# name. The binaries stay ABI-identical to plain gnu (they run
+# unmodified in the CFLite runner), but cargo/cc now see distinct
+# host and target platforms, so instrumentation — Rust flags AND C
+# flags — can be scoped to the fuzz target alone while host builds
+# stay pristine. (x86_64-unknown-linux-musl was evaluated instead
+# and is a dead end: rustc rejects `-Zsanitizer=address` with
+# statically linked musl, and a dynamically linked musl binary won't
+# run on the glibc runner.)
+FUZZ_TRIPLE=x86_64-wardnet-linux-gnu
+rustc -Zunstable-options --print target-spec-json \
+    --target x86_64-unknown-linux-gnu > "/tmp/$FUZZ_TRIPLE.json"
+
+# std for the custom triple is built from source via -Zbuild-std
+# (rustc refuses the prebuilt gnu rlibs — E0461 — because rlib
+# metadata embeds the triple name). That also gets us an
+# ASan-instrumented std, same as `cargo fuzz` does. The prebuilt
+# sanitizer runtime staticlibs carry no triple stamp though, so
+# stage just those into the custom triple's rustlib dir where rustc
+# looks them up.
+SYSROOT=$(rustc --print sysroot)
+mkdir -p "$SYSROOT/lib/rustlib/$FUZZ_TRIPLE/lib"
+ln -sf "$SYSROOT/lib/rustlib/x86_64-unknown-linux-gnu/lib/"librustc-*_rt.*.a \
+    "$SYSROOT/lib/rustlib/$FUZZ_TRIPLE/lib/"
+
+# ── Scope the image's sanitizer C flags to the fuzz target ───────
+# Keep the poisoned CFLAGS/CXXFLAGS for C code that is linked into
+# the fuzz binaries (bundled sqlite3 — ASan there is a feature), but
+# scrub them from the plain vars the cc crate uses for host builds,
+# so proc-macro/build-script C stays uninstrumented and loadable.
+export "CFLAGS_${FUZZ_TRIPLE//-/_}=${CFLAGS:-}"
+export "CXXFLAGS_${FUZZ_TRIPLE//-/_}=${CXXFLAGS:-}"
+strip_sanitize() {
+    local out="" f
+    for f in $1; do
+        case "$f" in
+        -fsanitize=*|-fsanitize-*|-fprofile-*|-fcoverage-*) ;;
+        *) out+=" $f" ;;
+        esac
+    done
+    echo "$out"
+}
+export CFLAGS="$(strip_sanitize "${CFLAGS:-}")"
+export CXXFLAGS="$(strip_sanitize "${CXXFLAGS:-}")"
+
 # ── Target-specific RUSTFLAGS ────────────────────────────────────
 # cargo-fuzz sets sanitizer + coverage flags via global RUSTFLAGS,
-# which also instruments proc-macro crates (sqlx-macros, etc.).
-# Proc-macros are host-side compiler plugins loaded via dlopen —
-# they don't link against the sanitizer runtime, so symbols like
-# __sancov_lowest_stack are undefined at load time, failing the
-# build.
+# which also instruments proc-macro crates. Bypass `cargo fuzz build`
+# and call `cargo build` directly, placing all instrumentation flags
+# in the *target-specific* CARGO_TARGET_<triple>_RUSTFLAGS so they
+# apply only to the fuzz binaries, not to host-side compiles.
 #
-# Fix: bypass `cargo fuzz build` and call `cargo build` directly,
-# placing all instrumentation flags in the *target-specific*
-# CARGO_TARGET_<triple>_RUSTFLAGS so they apply only to the fuzz
-# binaries, not to proc-macros compiled for the host.
-TARGET=x86_64-unknown-linux-gnu
+# The flags branch on $SANITIZER (set by the CFLite action):
+# `address` for the batch/prune jobs, `coverage` for the weekly
+# coverage report, which needs source-based coverage instrumentation
+# instead of sancov/ASan (mirrors upstream base-builder `compile`).
+case "${SANITIZER:-address}" in
+coverage)
+    # -Cinstrument-coverage normally injects the `profiler_builtins`
+    # runtime crate, which -Zbuild-std cannot provide (instrumented
+    # `core` would need it before it can be built). Disable the crate
+    # injection and satisfy the __llvm_profile_* references at link
+    # time with compiler-rt's C profile runtime instead — same
+    # runtime, minus the bootstrap cycle.
+    PROFILE_RT=$("${CC:-clang}" -print-file-name=libclang_rt.profile-x86_64.a)
+    if [ ! -f "$PROFILE_RT" ]; then
+        PROFILE_RT=$("${CC:-clang}" -print-file-name=libclang_rt.profile.a)
+    fi
+    TARGET_RUSTFLAGS=""
+    TARGET_RUSTFLAGS+=" --cfg fuzzing"
+    TARGET_RUSTFLAGS+=" -Cinstrument-coverage"
+    TARGET_RUSTFLAGS+=" -Zno-profiler-runtime"
+    TARGET_RUSTFLAGS+=" -Clink-arg=$PROFILE_RT"
+    TARGET_RUSTFLAGS+=" -Cdebuginfo=1"
+    TARGET_RUSTFLAGS+=" -Cforce-frame-pointers"
+    ;;
+*)
+    TARGET_RUSTFLAGS=""
+    TARGET_RUSTFLAGS+=" -Cpasses=sancov-module"
+    TARGET_RUSTFLAGS+=" -Cllvm-args=-sanitizer-coverage-level=4"
+    TARGET_RUSTFLAGS+=" -Cllvm-args=-sanitizer-coverage-inline-8bit-counters"
+    TARGET_RUSTFLAGS+=" -Cllvm-args=-sanitizer-coverage-pc-table"
+    TARGET_RUSTFLAGS+=" -Cllvm-args=-sanitizer-coverage-trace-compares"
+    TARGET_RUSTFLAGS+=" --cfg fuzzing"
+    TARGET_RUSTFLAGS+=" -Cllvm-args=-simplifycfg-branch-fold-threshold=0"
+    TARGET_RUSTFLAGS+=" -Zsanitizer=address"
+    TARGET_RUSTFLAGS+=" -Cllvm-args=-sanitizer-coverage-stack-depth"
+    TARGET_RUSTFLAGS+=" -Ccodegen-units=1"
+    TARGET_RUSTFLAGS+=" -Cdebuginfo=1"
+    TARGET_RUSTFLAGS+=" -Cforce-frame-pointers"
+    ;;
+esac
 
-TARGET_RUSTFLAGS=""
-TARGET_RUSTFLAGS+=" -Cpasses=sancov-module"
-TARGET_RUSTFLAGS+=" -Cllvm-args=-sanitizer-coverage-level=4"
-TARGET_RUSTFLAGS+=" -Cllvm-args=-sanitizer-coverage-inline-8bit-counters"
-TARGET_RUSTFLAGS+=" -Cllvm-args=-sanitizer-coverage-pc-table"
-TARGET_RUSTFLAGS+=" -Cllvm-args=-sanitizer-coverage-trace-compares"
-TARGET_RUSTFLAGS+=" --cfg fuzzing"
-TARGET_RUSTFLAGS+=" -Cllvm-args=-simplifycfg-branch-fold-threshold=0"
-TARGET_RUSTFLAGS+=" -Zsanitizer=address"
-TARGET_RUSTFLAGS+=" -Cllvm-args=-sanitizer-coverage-stack-depth"
-TARGET_RUSTFLAGS+=" -Ccodegen-units=1"
-TARGET_RUSTFLAGS+=" -Cdebuginfo=1"
-TARGET_RUSTFLAGS+=" -Cforce-frame-pointers"
-
-export CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUSTFLAGS="$TARGET_RUSTFLAGS"
+export CARGO_TARGET_X86_64_WARDNET_LINUX_GNU_RUSTFLAGS="$TARGET_RUSTFLAGS"
 unset RUSTFLAGS 2>/dev/null || true
+
+# Point cargo/cc at the host toolchain for the custom triple — the
+# cc crate would otherwise hunt for an x86_64-wardnet-linux-gnu-gcc
+# cross-compiler. clang as linker driver mirrors the image's
+# CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER and is what locates
+# the image's libc++ / prebuilt libFuzzer for libfuzzer-sys.
+export CARGO_TARGET_X86_64_WARDNET_LINUX_GNU_LINKER="${CC:-clang}"
+export "CC_${FUZZ_TRIPLE//-/_}=${CC:-clang}"
+export "CXX_${FUZZ_TRIPLE//-/_}=${CXX:-clang++}"
+export "AR_${FUZZ_TRIPLE//-/_}=ar"
 
 export ASAN_OPTIONS="${ASAN_OPTIONS:+$ASAN_OPTIONS:}detect_odr_violation=0"
 
 cargo build \
+    -Zjson-target-spec \
+    -Zbuild-std \
     --manifest-path Cargo.toml \
-    --target "$TARGET" \
+    --target "/tmp/$FUZZ_TRIPLE.json" \
     --release \
     --config 'profile.release.debug="line-tables-only"' \
     --bins
 
 FUZZ_TARGETS=(archiver_unpack sqlite_restore bundle_manifest)
 for target in "${FUZZ_TARGETS[@]}"; do
-    cp "target/${TARGET}/release/${target}" "$OUT/"
+    cp "target/${FUZZ_TRIPLE}/release/${target}" "$OUT/"
 done

--- a/.github/workflows/fuzzing-maintenance.yml
+++ b/.github/workflows/fuzzing-maintenance.yml
@@ -11,12 +11,8 @@ name: Fuzzing (maintenance)
 # (or the GH Pages URL once that branch is Pages-enabled).
 
 on:
-  # Scheduled runs are disabled while the ClusterFuzzLite image build is
-  # broken — corpus/coverage maintenance is pointless when no fuzzers
-  # build. See #587. workflow_dispatch is kept for manual use; restore the
-  # schedule once #587 is resolved.
-  #   schedule:
-  #     - cron: "0 3 * * 0"
+  schedule:
+    - cron: "0 3 * * 0"
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/fuzzing-scheduled.yml
+++ b/.github/workflows/fuzzing-scheduled.yml
@@ -23,15 +23,8 @@ name: Fuzzing (scheduled)
 # run catches regressions within half a day anyway.
 
 on:
-  # Scheduled runs are disabled: the ClusterFuzzLite image build cannot
-  # currently succeed (host == fuzz target triple makes cargo link the
-  # instrumented sqlx-core rlib into the host sqlx-macros proc-macro,
-  # which then fails to dlopen on __sancov_lowest_stack). See #587.
-  # The cron is removed so the perpetually failing build stops generating
-  # noise; workflow_dispatch is kept so the build can be re-run by hand
-  # while working the fix. Restore the schedule once #587 is resolved.
-  #   schedule:
-  #     - cron: "0 */12 * * *"
+  schedule:
+    - cron: "0 */12 * * *"
   workflow_dispatch:
 
 permissions:

--- a/source/daemon/fuzz/Cargo.lock
+++ b/source/daemon/fuzz/Cargo.lock
@@ -19,6 +19,52 @@ dependencies = [
 ]
 
 [[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher 0.4.4",
+ "cpufeatures 0.2.17",
+]
+
+[[package]]
+name = "aes"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1fc76eaeac4c9164506c466d4ffdd8ec9d0c5bf57ee97177c4d8eceb3a0e138"
+dependencies = [
+ "cipher 0.5.2",
+ "cpubits",
+ "cpufeatures 0.3.0",
+]
+
+[[package]]
+name = "aes-gcm"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
+dependencies = [
+ "aead",
+ "aes 0.8.4",
+ "cipher 0.4.4",
+ "ctr",
+ "ghash",
+ "subtle",
+]
+
+[[package]]
+name = "aes-keywrap"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10b6f24a1f796bc46415a1d0d18dc0a8203ccba088acf5def3291c4f61225522"
+dependencies = [
+ "aes 0.9.1",
+ "byteorder",
+]
+
+[[package]]
 name = "age"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -40,7 +86,7 @@ dependencies = [
  "scrypt",
  "sha2 0.10.9",
  "subtle",
- "x25519-dalek",
+ "x25519-dalek 2.0.1",
  "zeroize",
 ]
 
@@ -117,6 +163,18 @@ dependencies = [
  "cpufeatures 0.2.17",
  "password-hash",
 ]
+
+[[package]]
+name = "arrayref"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
+
+[[package]]
+name = "arrayvec"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
 
 [[package]]
 name = "asn1-rs"
@@ -281,6 +339,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "base16ct"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
+
+[[package]]
 name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -314,6 +378,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d86b93f97252c47b41663388e6d155714a9d0c398b99f1005cbc5f978b29f445"
 
 [[package]]
+name = "binstring"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0669d5a35b64fdb5ab7fb19cae13148b6b5cbdf4b8247faf54ece47f699c8cef"
+
+[[package]]
 name = "bit-vec"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -338,6 +408,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
 dependencies = [
  "digest 0.10.7",
+]
+
+[[package]]
+name = "blake2b_simd"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b79834656f71332577234b50bfc009996f7449e0c056884e6a02492ded0ca2f3"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "constant_time_eq",
 ]
 
 [[package]]
@@ -407,7 +488,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
 dependencies = [
  "cfg-if",
- "cipher",
+ "cipher 0.4.4",
  "cpufeatures 0.2.17",
 ]
 
@@ -430,7 +511,7 @@ checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
 dependencies = [
  "aead",
  "chacha20 0.9.1",
- "cipher",
+ "cipher 0.4.4",
  "poly1305",
  "zeroize",
 ]
@@ -456,8 +537,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
  "crypto-common 0.1.7",
- "inout",
+ "inout 0.1.4",
  "zeroize",
+]
+
+[[package]]
+name = "cipher"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8cf2a2c93cd704877c0858356ed03480ff301ee950b43f1cbe4573b088bfa6c"
+dependencies = [
+ "crypto-common 0.2.2",
+ "inout 0.2.2",
 ]
 
 [[package]]
@@ -474,6 +565,17 @@ name = "cmov"
 version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
+
+[[package]]
+name = "coarsetime"
+version = "0.1.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e58eb270476aa4fc7843849f8a35063e8743b4dbcdf6dd0f8ea0886980c204c2"
+dependencies = [
+ "libc",
+ "wasix",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "combine"
@@ -505,6 +607,12 @@ name = "const-oid"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
+name = "constant_time_eq"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 
 [[package]]
 name = "cookie"
@@ -559,6 +667,12 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "cpubits"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15b85f9c39137c3a891689859392b1bd49812121d0d61c9caf00d46ed5ce06ae"
 
 [[package]]
 name = "cpufeatures"
@@ -636,12 +750,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
+name = "crypto-bigint"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
+dependencies = [
+ "generic-array",
+ "rand_core 0.6.4",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
+ "rand_core 0.6.4",
  "typenum",
 ]
 
@@ -651,7 +778,24 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
 dependencies = [
+ "getrandom 0.4.2",
  "hybrid-array",
+ "rand_core 0.10.1",
+]
+
+[[package]]
+name = "ct-codecs"
+version = "1.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49fb0c6640b4507ebd99ff67677009e381ba5eee1d14df78de4a3d16eb123c39"
+
+[[package]]
+name = "ctr"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
+dependencies = [
+ "cipher 0.4.4",
 ]
 
 [[package]]
@@ -673,10 +817,24 @@ dependencies = [
  "cpufeatures 0.2.17",
  "curve25519-dalek-derive",
  "digest 0.10.7",
- "fiat-crypto",
+ "fiat-crypto 0.2.9",
  "rustc_version",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5eed333089e2e1c1ac8c6c0398e5e2497b4c9926ca6d0365ed1e099afa5bc23"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "curve25519-dalek-derive",
+ "fiat-crypto 0.3.0",
+ "rustc_version",
+ "subtle",
 ]
 
 [[package]]
@@ -703,6 +861,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
  "const-oid 0.9.6",
+ "pem-rfc7468",
+ "zeroize",
+]
+
+[[package]]
+name = "der"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a69dedd701da44b0536442edf09c81a64b0ab97a7a4a5e3d1971f00027cbc63d"
+dependencies = [
+ "const-oid 0.10.2",
  "zeroize",
 ]
 
@@ -736,6 +905,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
+ "const-oid 0.9.6",
  "crypto-common 0.1.7",
  "subtle",
 ]
@@ -795,13 +965,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
+name = "ecdsa"
+version = "0.16.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
+dependencies = [
+ "der 0.7.10",
+ "digest 0.10.7",
+ "elliptic-curve",
+ "rfc6979",
+ "signature 2.2.0",
+ "spki 0.7.3",
+]
+
+[[package]]
+name = "ece-native"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30d8e2c05464ca407a32663c1f119abd2a0f8d948879c160fc6cf5b86b6c05d6"
+dependencies = [
+ "aes-gcm",
+ "hkdf 0.12.4",
+ "sha2 0.10.9",
+]
+
+[[package]]
 name = "ed25519"
 version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
 dependencies = [
- "pkcs8",
- "signature",
+ "pkcs8 0.10.2",
+ "signature 2.2.0",
+]
+
+[[package]]
+name = "ed25519-compact"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c24599140dc39d7a81e4476e7573d41bbc18e07c803900298e522a5fbcfbfb6"
+dependencies = [
+ "ct-codecs",
+ "getrandom 0.4.2",
 ]
 
 [[package]]
@@ -810,7 +1015,7 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
 dependencies = [
- "curve25519-dalek",
+ "curve25519-dalek 4.1.3",
  "ed25519",
  "serde",
  "sha2 0.10.9",
@@ -825,6 +1030,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "elliptic-curve"
+version = "0.13.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
+dependencies = [
+ "base16ct",
+ "crypto-bigint",
+ "digest 0.10.7",
+ "ff",
+ "generic-array",
+ "group",
+ "hkdf 0.12.4",
+ "pem-rfc7468",
+ "pkcs8 0.10.2",
+ "rand_core 0.6.4",
+ "sec1",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -874,10 +1100,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ff"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
+dependencies = [
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
 name = "fiat-crypto"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
+
+[[package]]
+name = "fiat-crypto"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64cd1e32ddd350061ae6edb1b082d7c54915b5c672c389143b9a63403a109f24"
 
 [[package]]
 name = "filetime"
@@ -1109,6 +1351,7 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+ "zeroize",
 ]
 
 [[package]]
@@ -1145,11 +1388,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 6.0.0",
  "rand_core 0.10.1",
  "wasip2",
  "wasip3",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "ghash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
+dependencies = [
+ "opaque-debug",
+ "polyval",
+]
+
+[[package]]
+name = "group"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
+dependencies = [
+ "ff",
+ "rand_core 0.6.4",
+ "subtle",
 ]
 
 [[package]]
@@ -1277,6 +1543,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "hmac-sha1-compact"
+version = "1.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0b3ba31f6dc772cc8221ce81dbbbd64fa1e668255a6737d95eeace59b5a8823"
+
+[[package]]
+name = "hmac-sha256"
+version = "1.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec9d92d097f4749b64e8cc33d924d9f40a2d4eb91402b458014b781f5733d60f"
+dependencies = [
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "hmac-sha512"
+version = "1.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "019ece39bbefc17f13f677a690328cb978dbf6790e141a3c24e66372cb38588b"
+dependencies = [
+ "digest 0.10.7",
+]
+
+[[package]]
 name = "http"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1327,6 +1617,7 @@ version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
 dependencies = [
+ "ctutils",
  "typenum",
 ]
 
@@ -1367,7 +1658,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots",
+ "webpki-roots 1.0.7",
 ]
 
 [[package]]
@@ -1614,6 +1905,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "inout"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4250ce6452e92010fdf7268ccc5d14faa80bb12fc741938534c58f16804e03c7"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "instant-acme"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1672,12 +1972,9 @@ checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
 name = "ipnetwork"
-version = "0.20.0"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf466541e9d546596ee94f9f69590f89473455f88372423e0008fc1a7daf100e"
-dependencies = [
- "serde",
-]
+checksum = "cf370abdafd54d13e54a620e8c3e1145f28e46cc9d704bc6d94414559df41763"
 
 [[package]]
 name = "itoa"
@@ -1756,10 +2053,63 @@ dependencies = [
 ]
 
 [[package]]
+name = "jwt-simple"
+version = "0.12.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f45048cd18221c81d27dd4621d51df25b33f11b68655d79f67a9f9d3eb48fecc"
+dependencies = [
+ "anyhow",
+ "binstring",
+ "blake2b_simd",
+ "coarsetime",
+ "ct-codecs",
+ "ed25519-compact",
+ "hmac-sha1-compact",
+ "hmac-sha256",
+ "hmac-sha512",
+ "k256",
+ "p256",
+ "p384",
+ "rand 0.8.6",
+ "serde",
+ "serde_json",
+ "superboring",
+ "thiserror 2.0.18",
+ "zeroize",
+]
+
+[[package]]
+name = "k256"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6e3919bbaa2945715f0bb6d3934a173d1e9a59ac23767fbaaef277265a7411b"
+dependencies = [
+ "cfg-if",
+ "ecdsa",
+ "elliptic-curve",
+ "once_cell",
+ "sha2 0.10.9",
+ "signature 2.2.0",
+]
+
+[[package]]
+name = "keccak"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e24a010dd405bd7ed803e5253182815b41bf2e6a80cc3bfc066658e03a198aa"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+dependencies = [
+ "spin",
+]
 
 [[package]]
 name = "leb128fmt"
@@ -1782,6 +2132,12 @@ dependencies = [
  "arbitrary",
  "cc",
 ]
+
+[[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libsqlite3-sys"
@@ -1904,6 +2260,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "ml-dsa"
+version = "0.1.0-rc.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "163f15320f3fba11760c373af52d7f69d638482c2c350d877fb06513b1c3137c"
+dependencies = [
+ "const-oid 0.10.2",
+ "crypto-common 0.2.2",
+ "ctutils",
+ "hybrid-array",
+ "module-lattice",
+ "pkcs8 0.11.0",
+ "sha3",
+ "signature 3.0.0",
+]
+
+[[package]]
+name = "module-lattice"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c61b87c9683ab7cb1c6871d261ad5479b6b10ceb52c4352aaca3b5d35a8febe"
+dependencies = [
+ "ctutils",
+ "hybrid-array",
+ "num-traits",
+]
+
+[[package]]
 name = "multer"
 version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1959,6 +2342,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint-dig"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e661dda6640fad38e827a6d4a310ff4763082116fe217f279885c97f511bb0b7"
+dependencies = [
+ "lazy_static",
+ "libm",
+ "num-integer",
+ "num-iter",
+ "num-traits",
+ "rand 0.8.6",
+ "smallvec",
+ "zeroize",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1974,12 +2373,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-iter"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c92800bd69a1eac91786bcfe9da64a897eb72911b8dc3095decbd07429e8048b"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -2071,6 +2481,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
+name = "p256"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2 0.10.9",
+]
+
+[[package]]
+name = "p384"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe42f1670a52a47d448f14b6a5c61dd78fce51856e68edaa38f7ae3a46b8d6b6"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2 0.10.9",
+]
+
+[[package]]
 name = "parking"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2128,6 +2562,15 @@ checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
 dependencies = [
  "base64 0.22.1",
  "serde_core",
+]
+
+[[package]]
+name = "pem-rfc7468"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
 ]
 
 [[package]]
@@ -2205,13 +2648,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "pkcs1"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
+dependencies = [
+ "der 0.7.10",
+ "pkcs8 0.10.2",
+ "spki 0.7.3",
+]
+
+[[package]]
 name = "pkcs8"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
 dependencies = [
- "der",
- "spki",
+ "der 0.7.10",
+ "spki 0.7.3",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "451913da69c775a56034ea8d9003d27ee8948e12443eae7c038ba100a4f21cb7"
+dependencies = [
+ "der 0.8.1",
+ "spki 0.8.0",
 ]
 
 [[package]]
@@ -2226,6 +2690,18 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
 dependencies = [
+ "cpufeatures 0.2.17",
+ "opaque-debug",
+ "universal-hash",
+]
+
+[[package]]
+name = "polyval"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
+dependencies = [
+ "cfg-if",
  "cpufeatures 0.2.17",
  "opaque-debug",
  "universal-hash",
@@ -2269,6 +2745,15 @@ checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
  "syn",
+]
+
+[[package]]
+name = "primeorder"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
+dependencies = [
+ "elliptic-curve",
 ]
 
 [[package]]
@@ -2534,6 +3019,7 @@ dependencies = [
  "cookie",
  "cookie_store",
  "futures-core",
+ "futures-util",
  "http",
  "http-body",
  "http-body-util",
@@ -2553,14 +3039,26 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-rustls",
+ "tokio-util",
  "tower",
  "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams",
  "web-sys",
- "webpki-roots",
+ "webpki-roots 1.0.7",
+]
+
+[[package]]
+name = "rfc6979"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
+dependencies = [
+ "hmac 0.12.1",
+ "subtle",
 ]
 
 [[package]]
@@ -2575,6 +3073,27 @@ dependencies = [
  "libc",
  "untrusted 0.9.0",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rsa"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
+dependencies = [
+ "const-oid 0.9.6",
+ "digest 0.10.7",
+ "num-bigint-dig",
+ "num-integer",
+ "num-traits",
+ "pkcs1",
+ "pkcs8 0.10.2",
+ "rand_core 0.6.4",
+ "sha2 0.10.9",
+ "signature 2.2.0",
+ "spki 0.7.3",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -2748,7 +3267,7 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97a22f5af31f73a954c10289c93e8a50cc23d971e80ee446f1f6f7137a088213"
 dependencies = [
- "cipher",
+ "cipher 0.4.4",
 ]
 
 [[package]]
@@ -2784,6 +3303,20 @@ dependencies = [
  "pbkdf2",
  "salsa20",
  "sha2 0.10.9",
+]
+
+[[package]]
+name = "sec1"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
+dependencies = [
+ "base16ct",
+ "der 0.7.10",
+ "generic-array",
+ "pkcs8 0.10.2",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -2963,6 +3496,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha3"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be176f1a57ce4e3d31c1a166222d9768de5954f811601fb7ca06fc8203905ce1"
+dependencies = [
+ "digest 0.11.3",
+ "keccak",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2993,7 +3536,18 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
+ "digest 0.10.7",
  "rand_core 0.6.4",
+]
+
+[[package]]
+name = "signature"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28d567dcbaf0049cb8ac2608a76cd95ff9e4412e1899d389ee400918ca7537f5"
+dependencies = [
+ "digest 0.11.3",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -3065,7 +3619,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
 dependencies = [
  "base64ct",
- "der",
+ "der 0.7.10",
+]
+
+[[package]]
+name = "spki"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d9efca8738c78ee9484207732f728b1ef517bbb1833d6fc0879ca898a522f6f"
+dependencies = [
+ "base64ct",
+ "der 0.8.1",
 ]
 
 [[package]]
@@ -3275,6 +3839,22 @@ name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
+name = "superboring"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ad752f6ecf1cde1cd92cff4400137c5d92d376f78bb901d2807a35dba5872a7"
+dependencies = [
+ "aes-gcm",
+ "aes-keywrap",
+ "getrandom 0.2.17",
+ "hmac-sha256",
+ "hmac-sha512",
+ "ml-dsa",
+ "rand 0.8.6",
+ "rsa",
+]
 
 [[package]]
 name = "syn"
@@ -3496,8 +4076,12 @@ checksum = "8f72a05e828585856dacd553fba484c242c46e391fb0e58917c942ee9202915c"
 dependencies = [
  "futures-util",
  "log",
+ "rustls",
+ "rustls-pki-types",
  "tokio",
+ "tokio-rustls",
  "tungstenite",
+ "webpki-roots 0.26.11",
 ]
 
 [[package]]
@@ -3701,6 +4285,8 @@ dependencies = [
  "httparse",
  "log",
  "rand 0.9.4",
+ "rustls",
+ "rustls-pki-types",
  "sha1 0.10.6",
  "thiserror 2.0.18",
 ]
@@ -3888,7 +4474,7 @@ dependencies = [
 
 [[package]]
 name = "wardnet-common"
-version = "0.4.1"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3917,7 +4503,7 @@ dependencies = [
 
 [[package]]
 name = "wardnetd-data"
-version = "0.4.1"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "argon2",
@@ -3936,7 +4522,7 @@ dependencies = [
 
 [[package]]
 name = "wardnetd-services"
-version = "0.4.1"
+version = "0.6.1"
 dependencies = [
  "age",
  "anyhow",
@@ -3952,6 +4538,7 @@ dependencies = [
  "futures",
  "hex",
  "hickory-proto",
+ "http",
  "instant-acme",
  "ipnetwork",
  "minisign-verify",
@@ -3968,6 +4555,7 @@ dependencies = [
  "tar",
  "thiserror 2.0.18",
  "tokio",
+ "tokio-tungstenite",
  "tokio-util",
  "tower",
  "tracing",
@@ -3975,6 +4563,8 @@ dependencies = [
  "uuid",
  "wardnet-common",
  "wardnetd-data",
+ "web-push-native",
+ "x25519-dalek 3.0.0",
  "x509-parser",
 ]
 
@@ -4000,6 +4590,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
  "wit-bindgen 0.51.0",
+]
+
+[[package]]
+name = "wasix"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae86f02046da16a333a9129d31451423e1657737ecdafed4193838a5f54c5cfe"
+dependencies = [
+ "wasi",
 ]
 
 [[package]]
@@ -4080,6 +4679,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-streams"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "wasmparser"
 version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4089,6 +4701,23 @@ dependencies = [
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
+]
+
+[[package]]
+name = "web-push-native"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2175ef28a9a693fa88f322d88484f702a340da864a449a2b6b2a1fe26db712f3"
+dependencies = [
+ "aes-gcm",
+ "base64ct",
+ "ece-native",
+ "hkdf 0.12.4",
+ "http",
+ "jwt-simple",
+ "p256",
+ "serde",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -4118,6 +4747,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d46a5a140e6f7afeccd8eae97eff335163939eac8b929834875168b29b3d267"
 dependencies = [
  "rustls-pki-types",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.7",
 ]
 
 [[package]]
@@ -4553,10 +5191,20 @@ version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7e468321c81fb07fa7f4c636c3972b9100f0346e5b6a9f2bd0603a52f7ed277"
 dependencies = [
- "curve25519-dalek",
+ "curve25519-dalek 4.1.3",
  "rand_core 0.6.4",
  "serde",
  "zeroize",
+]
+
+[[package]]
+name = "x25519-dalek"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7e8131a03190127fb2263afc72b322ecadae46b6ff8c6f399ff5d02f5559af6"
+dependencies = [
+ "curve25519-dalek 5.0.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]

--- a/source/daemon/fuzz/fuzz_targets/sqlite_restore.rs
+++ b/source/daemon/fuzz/fuzz_targets/sqlite_restore.rs
@@ -42,11 +42,17 @@ fn fuzz_db_path() -> PathBuf {
 }
 
 fuzz_target!(|data: &[u8]| {
+    // Force the `Lazy` from outside the runtime: its initializer calls
+    // `RUNTIME.block_on`, which panics ("Cannot start a runtime from
+    // within a runtime") if the first deref happens inside the
+    // `block_on` below.
+    //
+    // `SqlitePool` is `Arc`-backed internally, so `clone()` is cheap
+    // and the real pool underneath is shared across every fuzz
+    // iteration in this process.
+    let pool = POOL.clone();
     RUNTIME.block_on(async {
-        // `SqlitePool` is `Arc`-backed internally, so `clone()` is cheap
-        // and the real pool underneath is shared across every fuzz
-        // iteration in this process.
-        let dumper = SqliteDumper::new(POOL.clone(), fuzz_db_path());
+        let dumper = SqliteDumper::new(pool, fuzz_db_path());
         let _ = dumper.restore(data).await;
     });
 });


### PR DESCRIPTION
The ClusterFuzzLite image build has never succeeded. #587 blamed cargo
host/target link-graph unification, but the failure actually enters
through C code: the OSS-Fuzz image exports global CFLAGS carrying
`-fsanitize=address ... -fsanitize=fuzzer-no-link`, the cc crate
applies them to build-script C compiles for host units too, and rustc
bundles native static libs wholesale into dylib crates. The host
sqlx-macros proc-macro .so therefore contains the entire
sancov/ASan-instrumented sqlite3 (via libsqlite3-sys) and fails to
dlopen inside rustc with `undefined symbol: __sancov_lowest_stack`,
killing the build of the sqlx facade. No RUSTFLAGS-level fix can reach
that path, which is why every attempt recorded in #587 failed.
Reproduced locally byte-for-byte by replaying the image environment,
and confirmed the .so bundles sqlite3 (281 sqlite3_* symbols).

Fix: build the fuzz binaries for x86_64-wardnet-linux-gnu, a
byte-for-byte copy of the x86_64-unknown-linux-gnu target spec under a
different name. Cargo/cc then treat host and target as distinct
platforms, so sanitizer rustflags AND C flags can be scoped to the
fuzz target (CARGO_TARGET_X86_64_WARDNET_LINUX_GNU_RUSTFLAGS,
CFLAGS_x86_64_wardnet_linux_gnu) while host builds get scrubbed
CFLAGS. The binaries stay ABI-identical to plain gnu and run
unmodified in the CFLite runner. std comes from -Zbuild-std (rustc
rejects the prebuilt gnu rlibs for a renamed triple, E0461) which
also yields an instrumented std, same as cargo-fuzz; the un-stamped
prebuilt sanitizer runtime staticlibs are staged into the custom
triple's rustlib dir. musl (the leading candidate in #587) is a dead
end: rustc rejects ASan with statically linked musl, and dynamically
linked musl binaries won't run on the glibc CFLite runner.

Also in this change:
- build.sh now honors $SANITIZER: the weekly coverage job builds with
  -Cinstrument-coverage (+ compiler-rt profile runtime via
  -Zno-profiler-runtime, sidestepping the profiler_builtins/build-std
  bootstrap cycle) instead of always getting ASan flags.
- Fix sqlite_restore harness: the POOL Lazy was initialized inside
  RUNTIME.block_on while its initializer itself calls block_on, so
  every input crashed with "Cannot start a runtime from within a
  runtime". Never caught because the fuzzers never built in CI.
- Refresh the fuzz workspace Cargo.lock (stale vs. the path crates'
  current dependency trees; cargo was silently re-resolving on every
  CI build).
- Re-enable the fuzzing-scheduled (12h) and fuzzing-maintenance
  (weekly) crons that were parked while the build was broken.

Verified locally against a faithful replica of the base-builder-rust
environment: address build produces instrumented fuzzers (sancov +
ASan symbols present, proc-macro .so clean) that run under libFuzzer;
coverage build produces .profraw-emitting fuzzers; the pre-fix script
reproduces the exact #587 error under the same environment.

Fixes #587