### PR TITLE
fix(common): redact WireGuard private_key and preshared_key in Debug impls

### DIFF
--- a/source/daemon/crates/wardnet-common/src/tests/wireguard_config.rs
+++ b/source/daemon/crates/wardnet-common/src/tests/wireguard_config.rs
@@ -1,4 +1,4 @@
-use crate::wireguard_config::{WgConfigError, parse};
+use crate::wireguard_config::{WgConfigError, WgInterfaceConfig, WgPeerConfig, parse};
 
 #[test]
 fn parse_minimal_config() {
@@ -166,4 +166,55 @@ fn handle_windows_line_endings() {
         "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
     );
     assert_eq!(config.peers.len(), 1);
+}
+
+#[test]
+fn interface_config_debug_redacts_private_key() {
+    let iface = WgInterfaceConfig {
+        private_key: "SECRET-PRIVATE-KEY-DO-NOT-LEAK=".to_owned(),
+        address: vec!["10.0.0.1/24".to_owned()],
+        listen_port: Some(51820),
+        dns: vec!["1.1.1.1".to_owned()],
+    };
+    let rendered = format!("{iface:?}");
+    assert!(!rendered.contains("SECRET-PRIVATE-KEY-DO-NOT-LEAK="));
+    assert!(rendered.contains("[REDACTED]"));
+    // Non-secret fields still render verbatim.
+    assert!(rendered.contains("10.0.0.1/24"));
+    assert!(rendered.contains("51820"));
+    assert!(rendered.contains("1.1.1.1"));
+}
+
+#[test]
+fn peer_config_debug_redacts_preshared_key() {
+    let peer = WgPeerConfig {
+        public_key: "PUBLIC-KEY-VISIBLE=".to_owned(),
+        endpoint: Some("203.0.113.1:51820".to_owned()),
+        allowed_ips: vec!["0.0.0.0/0".to_owned()],
+        preshared_key: Some("SECRET-PSK-DO-NOT-LEAK=".to_owned()),
+        persistent_keepalive: Some(25),
+    };
+    let rendered = format!("{peer:?}");
+    assert!(!rendered.contains("SECRET-PSK-DO-NOT-LEAK="));
+    assert!(rendered.contains("[REDACTED]"));
+    // Non-secret fields (including the public key) still render verbatim.
+    assert!(rendered.contains("PUBLIC-KEY-VISIBLE="));
+    assert!(rendered.contains("203.0.113.1:51820"));
+    assert!(rendered.contains("0.0.0.0/0"));
+    assert!(rendered.contains("25"));
+}
+
+#[test]
+fn peer_config_debug_without_preshared_key_shows_none() {
+    let peer = WgPeerConfig {
+        public_key: "PUBLIC-KEY-VISIBLE=".to_owned(),
+        endpoint: None,
+        allowed_ips: vec![],
+        preshared_key: None,
+        persistent_keepalive: None,
+    };
+    let rendered = format!("{peer:?}");
+    // Absence of a PSK renders as `None`, not `[REDACTED]`.
+    assert!(rendered.contains("preshared_key: None"));
+    assert!(!rendered.contains("[REDACTED]"));
 }

--- a/source/daemon/crates/wardnet-common/src/wireguard_config.rs
+++ b/source/daemon/crates/wardnet-common/src/wireguard_config.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 /// Parsed `[Interface]` section of a `WireGuard` config file.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, utoipa::ToSchema)]
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize, utoipa::ToSchema)]
 pub struct WgInterfaceConfig {
     pub private_key: String,
     pub address: Vec<String>,
@@ -9,14 +9,49 @@ pub struct WgInterfaceConfig {
     pub dns: Vec<String>,
 }
 
+// Redact `private_key` — the tunnel's WireGuard private key, the
+// highest-value secret in the system — so a stray `tracing::debug!(?config)`
+// anywhere on the import path can't write it to the log file. The derived
+// impl would leak it unconditionally.
+impl std::fmt::Debug for WgInterfaceConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("WgInterfaceConfig")
+            .field("private_key", &"[REDACTED]")
+            .field("address", &self.address)
+            .field("listen_port", &self.listen_port)
+            .field("dns", &self.dns)
+            .finish()
+    }
+}
+
 /// Parsed `[Peer]` section of a `WireGuard` config file.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, utoipa::ToSchema)]
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize, utoipa::ToSchema)]
 pub struct WgPeerConfig {
     pub public_key: String,
     pub endpoint: Option<String>,
     pub allowed_ips: Vec<String>,
     pub preshared_key: Option<String>,
     pub persistent_keepalive: Option<u16>,
+}
+
+// Redact `preshared_key` so a stray `tracing::debug!(?peer)` can't leak the
+// PSK. `TunnelConfig` (tunnel.rs) embeds `WgPeerConfig` by value and keeps
+// its derived `Debug`, which picks up this redaction transparently via the
+// field's own impl. `Some` renders as `[REDACTED]`, `None` verbatim, so the
+// presence of a PSK is not itself hidden.
+impl std::fmt::Debug for WgPeerConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("WgPeerConfig")
+            .field("public_key", &self.public_key)
+            .field("endpoint", &self.endpoint)
+            .field("allowed_ips", &self.allowed_ips)
+            .field(
+                "preshared_key",
+                &self.preshared_key.as_ref().map(|_| "[REDACTED]"),
+            )
+            .field("persistent_keepalive", &self.persistent_keepalive)
+            .finish()
+    }
 }
 
 /// Complete parsed `WireGuard` configuration file.


### PR DESCRIPTION
## Summary

Closes #837.

`WgInterfaceConfig.private_key` and `WgPeerConfig.preshared_key` derived `Debug`, so the WireGuard tunnel private key and PSK — the highest-value secrets in the system — would render in plaintext under any `{:?}` formatting. A stray `debug!(?config)` or a value folded into an `anyhow` error context anywhere on the import path could write these secrets straight to the log file. This closes that hardening gap by applying the crate's existing secret-redaction convention (already used for `AdminConfig.password`, `ProviderCredentials`, `ExportBackupRequest.passphrase`, etc.) to the one place it was missing.

## Changes

- Replaced the derived `Debug` on `WgInterfaceConfig` and `WgPeerConfig` with manual `impl Debug` that redacts `private_key` and `preshared_key`:
  - `private_key` always renders as `"[REDACTED]"`.
  - `preshared_key` renders as `Some("[REDACTED]")` when set and `None` when absent, so the *presence* of a PSK is not itself hidden.
  - All other fields (`address`, `listen_port`, `dns`, `public_key`, `endpoint`, `allowed_ips`, `persistent_keepalive`) still render verbatim — redaction is field-scoped, not blanket.
- No change needed for `TunnelConfig` (tunnel.rs): it embeds `WgPeerConfig` by value and keeps its derived `Debug`, which now picks up the redaction transparently via the field's own impl. Confirmed this is the only transitive path.

## Tests

Added unit tests colocated with the existing parser tests in `src/tests/wireguard_config.rs`:
- `interface_config_debug_redacts_private_key` — secret absent, `[REDACTED]` present, non-secret fields still rendered.
- `peer_config_debug_redacts_preshared_key` — PSK absent, public key and other fields still rendered.
- `peer_config_debug_without_preshared_key_shows_none` — absent PSK shows as `None`, not `[REDACTED]`.

`cargo test -p wardnet-common` passes (147 tests); `cargo clippy -p wardnet-common` is clean. Coverage does not decrease — only tests were added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01815xHMyA4eQBBJcGj3xiu7

---
_Generated by [Claude Code](https://claude.ai/code/session_01815xHMyA4eQBBJcGj3xiu7)_