### PR TITLE
fix(dhcp): bound attacker-controlled hlen to stop a one-packet server_loop panic

### DIFF
--- a/source/daemon/crates/wardnetd/src/dhcp/server.rs
+++ b/source/daemon/crates/wardnetd/src/dhcp/server.rs
@@ -247,6 +247,21 @@ pub(crate) async fn server_loop(
             }
         };
 
+        // Bound the wire-supplied hardware-address length before any
+        // `chaddr()` call: `dhcproto` slices its fixed 16-byte chaddr array
+        // by `hlen`, so an attacker-controlled hlen > 16 would panic and
+        // silently kill the whole server loop (issue #829). This guard also
+        // covers the `request.chaddr()` calls in `build_response`/`build_nak`,
+        // which only ever see messages that passed this loop.
+        if usize::from(msg.hlen()) > 16 {
+            tracing::debug!(
+                hlen = msg.hlen(),
+                %src_addr,
+                "dropping DHCP message with invalid hlen"
+            );
+            continue;
+        }
+
         let Some(msg_type) = msg.opts().msg_type() else {
             tracing::debug!("DHCP message has no message type option, ignoring");
             continue;

--- a/source/daemon/crates/wardnetd/src/dhcp/server.rs
+++ b/source/daemon/crates/wardnetd/src/dhcp/server.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 
 use async_trait::async_trait;
-use dhcproto::v4::{DhcpOption, Flags, Message, MessageType, Opcode, OptionCode};
+use dhcproto::v4::{DhcpOption, Flags, HType, Message, MessageType, Opcode, OptionCode};
 use dhcproto::{Decodable, Decoder, Encodable, Encoder};
 use tokio::net::UdpSocket;
 use tokio::sync::Mutex;
@@ -247,17 +247,24 @@ pub(crate) async fn server_loop(
             }
         };
 
-        // Bound the wire-supplied hardware-address length before any
-        // `chaddr()` call: `dhcproto` slices its fixed 16-byte chaddr array
-        // by `hlen`, so an attacker-controlled hlen > 16 would panic and
-        // silently kill the whole server loop (issue #829). This guard also
-        // covers the `request.chaddr()` calls in `build_response`/`build_nak`,
-        // which only ever see messages that passed this loop.
-        if usize::from(msg.hlen()) > 16 {
+        // A legitimate DHCP client on this network is always Ethernet or
+        // Wi-Fi: htype 1 with a 6-byte hardware address. Enforcing that
+        // before any `chaddr()` call bounds the wire-supplied `hlen` —
+        // `dhcproto` slices its fixed 16-byte chaddr array by `hlen`, so an
+        // attacker-controlled hlen > 16 would panic and silently kill the
+        // whole server loop (issue #829) — and rejects degenerate identities
+        // (hlen 0-5 would become truncated or empty MAC lease keys). This
+        // guard also covers the `request.chaddr()` calls in
+        // `build_response`/`build_nak`, which only ever see messages that
+        // passed this loop.
+        let htype = msg.htype();
+        let hlen = msg.hlen();
+        if htype != HType::Eth || hlen != 6 {
             tracing::debug!(
-                hlen = msg.hlen(),
+                ?htype,
+                hlen,
                 %src_addr,
-                "dropping DHCP message with invalid hlen"
+                "dropping DHCP message with non-Ethernet hardware address: htype={htype:?}, hlen={hlen}, src={src_addr}"
             );
             continue;
         }
@@ -435,6 +442,12 @@ fn extract_requested_ip(msg: &Message) -> Ipv4Addr {
 /// its request was rejected and it must restart the handshake. The server
 /// identifier is taken from the device's resolved per-zone scope (#737).
 pub(crate) fn build_nak(request: &Message, scope: &DhcpScope) -> Message {
+    // `request.chaddr()` panics when the wire-supplied hlen exceeds the
+    // fixed 16-byte chaddr array; callers must bound it first (issue #829).
+    debug_assert!(
+        request.hlen() <= 16,
+        "build_nak requires a message whose hlen was bounded before dispatch (issue #829)"
+    );
     let server_ip = scope.gateway_ip;
 
     let mut response = Message::default();
@@ -458,6 +471,12 @@ pub(crate) fn build_response(
     lease: &DhcpLease,
     scope: &DhcpScope,
 ) -> Message {
+    // `request.chaddr()` panics when the wire-supplied hlen exceeds the
+    // fixed 16-byte chaddr array; callers must bound it first (issue #829).
+    debug_assert!(
+        request.hlen() <= 16,
+        "build_response requires a message whose hlen was bounded before dispatch (issue #829)"
+    );
     // Wardnet's IP within this scope: the LAN IP for the base pool, or the Pi's
     // per-zone gateway alias for a zone subnet (#737).
     let server_ip = scope.gateway_ip;
@@ -534,6 +553,19 @@ pub(crate) async fn send_response(socket: &dyn DhcpSocket, msg: &Message, dest: 
     if let Err(e) = socket.send_to(&buf, dest).await {
         tracing::error!(error = %e, dest = %dest, "failed to send DHCP response to {dest}: {e}");
     }
+}
+
+/// Decode a DHCP message from untrusted wire bytes, rejecting any message
+/// whose wire-supplied `hlen` overruns the fixed 16-byte BOOTP `chaddr`
+/// field. `dhcproto` slices its `[u8; 16]` chaddr array by `hlen`, so
+/// calling `chaddr()` on such a message panics (issue #829). Every decode
+/// of raw wire bytes must go through this bound (or a stricter guard, like
+/// `server_loop`'s Ethernet-only check) before the message reaches code
+/// that may touch `chaddr()`.
+pub(crate) fn decode_bounded(packet: &[u8]) -> Option<Message> {
+    Message::decode(&mut Decoder::new(packet))
+        .ok()
+        .filter(|msg| msg.hlen() <= 16)
 }
 
 /// Format the first 6 bytes of a hardware address as a MAC string.

--- a/source/daemon/crates/wardnetd/src/dhcp/tests/server.rs
+++ b/source/daemon/crates/wardnetd/src/dhcp/tests/server.rs
@@ -1161,6 +1161,100 @@ async fn server_loop_handles_discover_then_request_sequence() {
 }
 
 // ---------------------------------------------------------------------------
+// server_loop: attacker-controlled hlen (issue #829)
+// ---------------------------------------------------------------------------
+
+/// Encode `msg` and overwrite the BOOTP `hlen` field (byte offset 2) with an
+/// attacker-controlled value. `dhcproto`'s `set_chaddr` clamps `hlen` to 16,
+/// so an oversized value can only be produced by patching the raw bytes —
+/// exactly what an attacker on the wire would send.
+fn encode_with_hlen(msg: &Message, hlen: u8) -> Vec<u8> {
+    let mut buf = Vec::with_capacity(512);
+    let mut encoder = Encoder::new(&mut buf);
+    msg.encode(&mut encoder).unwrap();
+    buf[2] = hlen;
+    buf
+}
+
+#[tokio::test]
+async fn server_loop_drops_oversized_hlen_and_keeps_serving() {
+    let lease = test_lease();
+    let mock_service = Arc::new(MockDhcpService::new(lease.clone()));
+    let service: Arc<dyn DhcpService> = Arc::clone(&mock_service) as Arc<dyn DhcpService>;
+    let socket = Arc::new(MockDhcpSocket::new());
+
+    // Valid option-53 DISCOVERs whose wire hlen exceeds the 16-byte chaddr
+    // array — both the minimal (17) and maximal (255) malicious values.
+    let malicious = build_discover([0xde, 0xad, 0xbe, 0xef, 0x00, 0x01]);
+    socket
+        .push_packet(encode_with_hlen(&malicious, 17), client_addr())
+        .await;
+    socket
+        .push_packet(encode_with_hlen(&malicious, 255), client_addr())
+        .await;
+
+    // A legitimate DISCOVER after the malicious packets: it only gets an
+    // OFFER if the loop survived (did not panic on the oversized hlen).
+    let valid = build_discover([0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff]);
+    socket.push_message(&valid, client_addr()).await;
+
+    let socket = run_server_loop_until_idle(socket, service).await;
+
+    let messages = socket.sent_messages().await;
+    assert_eq!(
+        messages.len(),
+        1,
+        "malicious packets must be dropped and the valid DISCOVER must still get an OFFER"
+    );
+    assert_eq!(messages[0].0.opts().msg_type(), Some(MessageType::Offer));
+
+    // The service must never have seen the malicious packets.
+    let calls = mock_service.recorded_calls().await;
+    assert_eq!(calls.len(), 1);
+    assert_eq!(calls[0].0, "assign_lease");
+    assert_eq!(calls[0].1, "aa:bb:cc:dd:ee:ff");
+}
+
+#[tokio::test]
+async fn udp_server_survives_oversized_hlen_packet() {
+    let lease = test_lease();
+    let service: Arc<dyn DhcpService> = Arc::new(MockDhcpService::new(lease.clone()));
+    let socket = Arc::new(MockDhcpSocket::new());
+    let socket_dyn: Arc<dyn DhcpSocket> = Arc::clone(&socket) as Arc<dyn DhcpSocket>;
+
+    let server = UdpDhcpServer::with_socket(service, socket_dyn);
+    server.start().await.unwrap();
+
+    // One unauthenticated packet with hlen > 16 must not kill the task.
+    let malicious = build_discover([0xde, 0xad, 0xbe, 0xef, 0x00, 0x01]);
+    socket
+        .push_packet(encode_with_hlen(&malicious, 255), client_addr())
+        .await;
+    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
+    assert!(
+        server.is_running(),
+        "server must still be running after an oversized-hlen packet"
+    );
+
+    // And it must still actually serve: a valid DISCOVER gets an OFFER,
+    // proving is_running() reflects a live loop rather than a stale flag.
+    let valid = build_discover([0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff]);
+    socket.push_message(&valid, client_addr()).await;
+    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
+    let messages = socket.sent_messages().await;
+    assert_eq!(
+        messages.len(),
+        1,
+        "a valid DISCOVER after the malicious packet must still be answered"
+    );
+    assert_eq!(messages[0].0.opts().msg_type(), Some(MessageType::Offer));
+
+    server.stop().await.unwrap();
+}
+
+// ---------------------------------------------------------------------------
 // server_loop: recv error recovery
 // ---------------------------------------------------------------------------
 

--- a/source/daemon/crates/wardnetd/src/dhcp/tests/server.rs
+++ b/source/daemon/crates/wardnetd/src/dhcp/tests/server.rs
@@ -55,10 +55,7 @@ impl MockDhcpSocket {
 
     /// Push an encoded DHCP message into the incoming queue.
     async fn push_message(&self, msg: &Message, src: SocketAddr) {
-        let mut buf = Vec::with_capacity(512);
-        let mut encoder = Encoder::new(&mut buf);
-        msg.encode(&mut encoder).unwrap();
-        self.push_packet(buf, src).await;
+        self.push_packet(encode_message(msg), src).await;
     }
 
     /// Return all packets sent via `send_to`.
@@ -299,6 +296,27 @@ fn build_release(mac: [u8; 6]) -> Message {
 /// A fake client address for incoming packets.
 fn client_addr() -> SocketAddr {
     "192.168.1.50:68".parse().unwrap()
+}
+
+/// Encode a DHCP message to wire bytes.
+fn encode_message(msg: &Message) -> Vec<u8> {
+    let mut buf = Vec::with_capacity(512);
+    let mut encoder = Encoder::new(&mut buf);
+    msg.encode(&mut encoder).unwrap();
+    buf
+}
+
+/// Poll the mock socket until at least `count` responses have been sent.
+/// Returns as soon as the server loop has actually produced the output,
+/// with a hard 2-second deadline instead of a fixed lower bound of sleep.
+async fn wait_for_sent(socket: &MockDhcpSocket, count: usize) {
+    tokio::time::timeout(std::time::Duration::from_secs(2), async {
+        while socket.outgoing.lock().await.len() < count {
+            tokio::time::sleep(std::time::Duration::from_millis(2)).await;
+        }
+    })
+    .await
+    .expect("timed out waiting for the DHCP server to send responses");
 }
 
 /// Run `server_loop` with the given socket and service, returning the socket
@@ -1169,10 +1187,16 @@ async fn server_loop_handles_discover_then_request_sequence() {
 /// so an oversized value can only be produced by patching the raw bytes —
 /// exactly what an attacker on the wire would send.
 fn encode_with_hlen(msg: &Message, hlen: u8) -> Vec<u8> {
-    let mut buf = Vec::with_capacity(512);
-    let mut encoder = Encoder::new(&mut buf);
-    msg.encode(&mut encoder).unwrap();
+    let mut buf = encode_message(msg);
     buf[2] = hlen;
+    buf
+}
+
+/// Encode `msg` and overwrite the BOOTP `htype` field (byte offset 1),
+/// crafting a non-Ethernet hardware type without dhcproto's setters.
+fn encode_with_htype(msg: &Message, htype: u8) -> Vec<u8> {
+    let mut buf = encode_message(msg);
+    buf[1] = htype;
     buf
 }
 
@@ -1225,23 +1249,24 @@ async fn udp_server_survives_oversized_hlen_packet() {
     let server = UdpDhcpServer::with_socket(service, socket_dyn);
     server.start().await.unwrap();
 
-    // One unauthenticated packet with hlen > 16 must not kill the task.
+    // One unauthenticated packet with hlen > 16 must not kill the task. The
+    // valid DISCOVER queued behind it only gets an OFFER if the loop survived
+    // (the FIFO socket guarantees the malicious packet was consumed first).
     let malicious = build_discover([0xde, 0xad, 0xbe, 0xef, 0x00, 0x01]);
     socket
         .push_packet(encode_with_hlen(&malicious, 255), client_addr())
         .await;
-    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    let valid = build_discover([0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff]);
+    socket.push_message(&valid, client_addr()).await;
 
+    wait_for_sent(&socket, 1).await;
+
+    // The OFFER above proves is_running() reflects a live loop rather than
+    // a stale flag left behind by a panicked task.
     assert!(
         server.is_running(),
         "server must still be running after an oversized-hlen packet"
     );
-
-    // And it must still actually serve: a valid DISCOVER gets an OFFER,
-    // proving is_running() reflects a live loop rather than a stale flag.
-    let valid = build_discover([0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff]);
-    socket.push_message(&valid, client_addr()).await;
-    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
 
     let messages = socket.sent_messages().await;
     assert_eq!(
@@ -1252,6 +1277,65 @@ async fn udp_server_survives_oversized_hlen_packet() {
     assert_eq!(messages[0].0.opts().msg_type(), Some(MessageType::Offer));
 
     server.stop().await.unwrap();
+}
+
+#[tokio::test]
+async fn server_loop_drops_non_ethernet_hardware_addresses() {
+    let lease = test_lease();
+    let mock_service = Arc::new(MockDhcpService::new(lease.clone()));
+    let service: Arc<dyn DhcpService> = Arc::clone(&mock_service) as Arc<dyn DhcpService>;
+    let socket = Arc::new(MockDhcpSocket::new());
+
+    // A legitimate DHCP client on this network is always Ethernet/Wi-Fi:
+    // htype 1 with a 6-byte hardware address. hlen 0-5 would otherwise
+    // become truncated or empty MAC strings used as lease-store identity
+    // keys; hlen 7-16 and foreign htypes are not real clients here.
+    let malicious = build_discover([0xde, 0xad, 0xbe, 0xef, 0x00, 0x02]);
+    for packet in [
+        encode_with_hlen(&malicious, 0),
+        encode_with_hlen(&malicious, 5),
+        encode_with_hlen(&malicious, 16),
+        encode_with_htype(&malicious, 6), // htype 6 = IEEE 802, hlen still 6
+    ] {
+        socket.push_packet(packet, client_addr()).await;
+    }
+
+    let valid = build_discover([0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff]);
+    socket.push_message(&valid, client_addr()).await;
+
+    let socket = run_server_loop_until_idle(socket, service).await;
+
+    let messages = socket.sent_messages().await;
+    assert_eq!(
+        messages.len(),
+        1,
+        "non-Ethernet hardware addresses must be dropped; only the valid DISCOVER gets an OFFER"
+    );
+    assert_eq!(messages[0].0.opts().msg_type(), Some(MessageType::Offer));
+
+    // The lease service must never see the degenerate identities.
+    let calls = mock_service.recorded_calls().await;
+    assert_eq!(calls.len(), 1);
+    assert_eq!(calls[0].0, "assign_lease");
+    assert_eq!(calls[0].1, "aa:bb:cc:dd:ee:ff");
+}
+
+/// The shared wire-decode bound used by every non-server decode site (the
+/// pnet network probe): oversized `hlen` is rejected at decode time so no
+/// later `chaddr()` call can panic, while any in-bounds `hlen` still decodes.
+#[test]
+fn decode_bounded_rejects_oversized_hlen() {
+    let msg = build_discover([0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff]);
+
+    assert!(server::decode_bounded(&encode_with_hlen(&msg, 17)).is_none());
+    assert!(server::decode_bounded(&encode_with_hlen(&msg, 255)).is_none());
+
+    // In-bounds hlen values decode, including the 16-byte boundary.
+    assert!(server::decode_bounded(&encode_message(&msg)).is_some());
+    assert!(server::decode_bounded(&encode_with_hlen(&msg, 16)).is_some());
+
+    // Undecodable bytes are rejected, not panicked on.
+    assert!(server::decode_bounded(&[0xde, 0xad]).is_none());
 }
 
 // ---------------------------------------------------------------------------

--- a/source/daemon/crates/wardnetd/src/system/pnet_network_probe.rs
+++ b/source/daemon/crates/wardnetd/src/system/pnet_network_probe.rs
@@ -20,7 +20,7 @@ use std::time::{Duration, Instant};
 
 use async_trait::async_trait;
 use dhcproto::v4::{DhcpOption, Flags, Message, MessageType, Opcode};
-use dhcproto::{Decodable, Decoder, Encodable, Encoder};
+use dhcproto::{Encodable, Encoder};
 use pnet::datalink::{self, Channel, Config};
 use pnet::packet::Packet;
 use pnet::packet::arp::{ArpOperations, ArpPacket};

--- a/source/daemon/crates/wardnetd/src/system/pnet_network_probe.rs
+++ b/source/daemon/crates/wardnetd/src/system/pnet_network_probe.rs
@@ -323,7 +323,9 @@ fn parse_dhcp_offer(frame: &[u8], xid: u32) -> Option<Ipv4Addr> {
     if udp.get_source() != 67 || udp.get_destination() != 68 {
         return None;
     }
-    let msg = Message::decode(&mut Decoder::new(udp.payload())).ok()?;
+    // Bounded decode: rejects wire hlen > 16 so a future `chaddr()` use
+    // here can never hit dhcproto's slice panic (issue #829).
+    let msg = crate::dhcp::server::decode_bounded(udp.payload())?;
     if msg.xid() != xid {
         return None;
     }


### PR DESCRIPTION
Fixes #829.

## Problem

Any device on the LAN could permanently kill DHCP with a single unauthenticated UDP packet: `server_loop` called `msg.chaddr()` without validating the wire-supplied BOOTP `hlen`, and `dhcproto` 0.15 slices its fixed 16-byte `chaddr` array by `hlen` (`&self.chaddr[..(self.hlen as usize)]`), panicking for `hlen > 16`. The panic unwound out of the spawned task before either `running.store(false)` site, so `is_running()` stayed `true`, the DHCP health check kept reporting UP, and neither watchdog ever restarted the wedged service.

## Fix

- **Ethernet-only guard** at the top of the receive loop, right after `Message::decode` succeeds and before the first `chaddr()` call: anything that isn't `htype` 1 with `hlen` 6 is dropped with a debug log carrying `htype`, `hlen`, and `src_addr`. This bounds the attacker-controlled `hlen` (17..=255 can no longer reach `chaddr()`), and also rejects degenerate identities — `hlen` 0–5 previously flowed through `format_mac` into truncated or empty MAC strings used as lease-store identity keys. This is the hardening the issue suggested as ideal. The guard also covers the `request.chaddr()` calls in `build_response`/`build_nak` (the previously latent call sites), because the reply path only handles messages that passed the loop; both functions additionally `debug_assert!` the bounded-`hlen` precondition so a future direct caller can't silently reintroduce the panic.
- **Shared `decode_bounded` helper** enforcing the 16-byte `chaddr` bound at decode time, used by `parse_dhcp_offer` in the pnet network probe — the daemon's only other wire-facing `Message::decode` site, which was safe only because it happens not to call `chaddr()` today.
- No changes to `dhcproto` — the input is bounded in our own packet handling, per the issue.

## Tests (TDD — red first, then green)

All behavioral changes were test-first, confirmed failing before the corresponding code change:

- `server_loop_drops_oversized_hlen_and_keeps_serving` — raw-bytes DISCOVERs with `hlen` 17 and 255 (crafted by patching byte 2 of a validly-encoded message, since `set_chaddr` clamps `hlen`) followed by a valid DISCOVER; exactly one OFFER is sent and the service never sees the malicious packets. Red with the exact panic from the issue: `range end index 255 out of range for slice of length 16`.
- `udp_server_survives_oversized_hlen_packet` — through the real `UdpDhcpServer` start/stop path, asserts `is_running()` is still `true` after the malicious packet *and* a subsequent valid DISCOVER still gets an OFFER (so the flag reflects a live loop, not a stale one). Uses a poll-with-deadline wait, no fixed sleeps.
- `server_loop_drops_non_ethernet_hardware_addresses` — `hlen` 0, 5, and 16, and a foreign `htype` (IEEE 802) are all dropped; the lease service never sees the degenerate identities; a valid DISCOVER still gets its OFFER.
- `decode_bounded_rejects_oversized_hlen` — the shared helper rejects `hlen` 17/255 and garbage bytes, accepts `hlen` up to the 16-byte boundary.

Existing happy-path regression tests (`server_loop_responds_to_discover_with_offer`, `..._request_with_ack`, `..._discover_then_request_sequence`) cover the valid DISCOVER/OFFER/REQUEST/ACK flow and pass unchanged. The health check in `wardnetd-services/src/health/checks.rs` is untouched — with the panic prevented, its `is_running()` dependency is accurate again.

An adversarial multi-agent review (8 finder angles + verification pass) ran over the initial fix; all seven surviving findings are addressed in the second commit.

## Checks

- `make check-daemon` (fmt `--check`, clippy `--all-targets -- -D warnings`, `cargo test --workspace`) — green on both commits.
- All new guard/helper lines are exercised by the new tests, so coverage does not decrease.