### PR TITLE
fix(daemon): actually delete the WireGuard interface in TunnelInterface::remove

### DIFF
--- a/source/daemon/crates/wardnetd-services/src/inbound_wg/service.rs
+++ b/source/daemon/crates/wardnetd-services/src/inbound_wg/service.rs
@@ -502,10 +502,14 @@ impl InboundWgService for InboundWgServiceImpl {
                 .remove_inbound_wg_accept()
                 .await
                 .map_err(AppError::Internal)?;
-            self.interface
-                .tear_down_server(INBOUND_WG_INTERFACE)
-                .await
-                .map_err(AppError::Internal)?;
+            // A teardown failure must not block the disable: persisting
+            // enabled=false below is what reconcile acts on (a propagated
+            // error here would leave the server "enabled" and let reconcile
+            // resurrect it), and a leftover interface is reaped by the next
+            // ensure_server. Disabling is always allowed — see above.
+            if let Err(e) = self.interface.tear_down_server(INBOUND_WG_INTERFACE).await {
+                tracing::warn!("failed to tear down inbound wireguard server: {e}");
+            }
 
             self.system_config
                 .set_inbound_wg_enabled(false)

--- a/source/daemon/crates/wardnetd-services/src/inbound_wg/tests/service.rs
+++ b/source/daemon/crates/wardnetd-services/src/inbound_wg/tests/service.rs
@@ -286,6 +286,9 @@ struct MockInterface {
     /// When set, `add_peer` returns an error instead of recording the peer —
     /// used to exercise the service's row-rollback compensating action.
     fail_add_peer: AtomicBool,
+    /// When set, `tear_down_server` returns an error — used to verify a
+    /// disable still persists enabled=false when the teardown fails.
+    fail_tear_down: AtomicBool,
 }
 
 #[async_trait]
@@ -295,6 +298,9 @@ impl InboundWgInterface for MockInterface {
         Ok(())
     }
     async fn tear_down_server(&self, interface_name: &str) -> anyhow::Result<()> {
+        if self.fail_tear_down.load(Ordering::SeqCst) {
+            anyhow::bail!("mock interface: tear_down_server failure");
+        }
         self.tear_downs
             .lock()
             .unwrap()
@@ -529,6 +535,24 @@ async fn disable_is_allowed_without_entitlement() {
         .expect("disable is allowed without Premium");
     assert!(!resp.enabled);
     assert!(!h.system_config.inbound_wg_enabled().await.unwrap());
+}
+
+#[tokio::test]
+async fn disable_persists_even_when_interface_teardown_fails() {
+    let h = harness();
+    auth_context::with_context(admin_ctx(), h.service.set_config(true, 51821))
+        .await
+        .expect("enable while entitled");
+    h.interface.fail_tear_down.store(true, Ordering::SeqCst);
+
+    let resp = auth_context::with_context(admin_ctx(), h.service.set_config(false, 51821))
+        .await
+        .expect("disable succeeds despite the interface teardown failing");
+    assert!(!resp.enabled);
+    assert!(
+        !h.system_config.inbound_wg_enabled().await.unwrap(),
+        "enabled=false must be persisted so reconcile cannot resurrect the server"
+    );
 }
 
 #[tokio::test]

--- a/source/daemon/crates/wardnetd/src/inbound_wg_interface_wireguard.rs
+++ b/source/daemon/crates/wardnetd/src/inbound_wg_interface_wireguard.rs
@@ -112,20 +112,18 @@ impl InboundWgInterface for WireGuardInboundInterface {
     }
 
     async fn tear_down_server(&self, interface_name: &str) -> anyhow::Result<()> {
-        // Best-effort delete: an absent interface is the expected steady state
-        // when the server was never enabled, so a failure here is non-fatal.
-        let output = tokio::process::Command::new("ip")
-            .args(["link", "delete", interface_name])
-            .output()
-            .await?;
-        if output.status.success() {
-            tracing::info!(interface = %interface_name, "inbound wireguard server torn down");
+        // An absent interface is the expected steady state when the server
+        // was never enabled, so it is an idempotent no-op. Real failures
+        // (e.g. permission errors) propagate instead of being swallowed.
+        if crate::wireguard_interface::delete_wireguard_interface(interface_name)? {
+            tracing::info!(
+                interface = %interface_name,
+                "inbound wireguard server {interface_name} torn down"
+            );
         } else {
-            let stderr = String::from_utf8_lossy(&output.stderr);
             tracing::debug!(
                 interface = %interface_name,
-                "inbound wireguard tear-down skipped (interface absent?): {}",
-                stderr.trim()
+                "inbound wireguard server {interface_name} already absent, nothing to tear down"
             );
         }
         Ok(())

--- a/source/daemon/crates/wardnetd/src/inbound_wg_interface_wireguard.rs
+++ b/source/daemon/crates/wardnetd/src/inbound_wg_interface_wireguard.rs
@@ -44,6 +44,10 @@ impl InboundWgInterface for WireGuardInboundInterface {
         // crash so re-creation doesn't hit "Address already assigned". The
         // service re-adds every enabled peer immediately after this call, so
         // dropping the interface's current peers here is safe and intentional.
+        // Deliberately an `ip link` shell-out, not `delete_wireguard_interface`:
+        // it also reaps links the WireGuard netlink family cannot see (wrong
+        // type or partially created), which `tear_down_server` classifies as
+        // absent and leaves behind.
         let check = tokio::process::Command::new("ip")
             .args(["link", "show", &config.interface_name])
             .output()

--- a/source/daemon/crates/wardnetd/src/inbound_wg_interface_wireguard.rs
+++ b/source/daemon/crates/wardnetd/src/inbound_wg_interface_wireguard.rs
@@ -44,24 +44,11 @@ impl InboundWgInterface for WireGuardInboundInterface {
         // crash so re-creation doesn't hit "Address already assigned". The
         // service re-adds every enabled peer immediately after this call, so
         // dropping the interface's current peers here is safe and intentional.
-        // Deliberately an `ip link` shell-out, not `delete_wireguard_interface`:
-        // it also reaps links the WireGuard netlink family cannot see (wrong
-        // type or partially created), which `tear_down_server` classifies as
-        // absent and leaves behind.
-        let check = tokio::process::Command::new("ip")
-            .args(["link", "show", &config.interface_name])
-            .output()
-            .await;
-        if check.is_ok_and(|o| o.status.success()) {
-            tracing::info!(
-                interface = %config.interface_name,
-                "removing stale inbound wireguard interface before re-creation"
-            );
-            let _ = tokio::process::Command::new("ip")
-                .args(["link", "delete", &config.interface_name])
-                .output()
-                .await;
-        }
+        crate::wireguard_interface::remove_stale_link(
+            &config.interface_name,
+            "inbound wireguard interface",
+        )
+        .await;
 
         // Configure the server key + listen port (this creates the interface).
         DeviceUpdate::new()
@@ -119,17 +106,10 @@ impl InboundWgInterface for WireGuardInboundInterface {
         // An absent interface is the expected steady state when the server
         // was never enabled, so it is an idempotent no-op. Real failures
         // (e.g. permission errors) propagate instead of being swallowed.
-        if crate::wireguard_interface::delete_wireguard_interface(interface_name)? {
-            tracing::info!(
-                interface = %interface_name,
-                "inbound wireguard server {interface_name} torn down"
-            );
-        } else {
-            tracing::debug!(
-                interface = %interface_name,
-                "inbound wireguard server {interface_name} already absent, nothing to tear down"
-            );
-        }
+        crate::wireguard_interface::delete_wireguard_interface(
+            interface_name,
+            "inbound wireguard server",
+        )?;
         Ok(())
     }
 
@@ -181,8 +161,17 @@ impl InboundWgInterface for WireGuardInboundInterface {
             .parse()
             .map_err(|e| anyhow::anyhow!("invalid interface name: {e}"))?;
 
-        let Ok(device) = Device::get(&iface, Backend::default()) else {
-            return Ok(Vec::new());
+        let device = match Device::get(&iface, Backend::default()) {
+            Ok(device) => device,
+            // Absent interface (server disabled) — no peers to report.
+            Err(e) if crate::wireguard_interface::is_interface_absent_error(&e) => {
+                return Ok(Vec::new());
+            }
+            Err(e) => {
+                return Err(anyhow::anyhow!(
+                    "failed to query inbound wireguard server {interface_name} peers: {e}"
+                ));
+            }
         };
 
         Ok(device

--- a/source/daemon/crates/wardnetd/src/lib.rs
+++ b/source/daemon/crates/wardnetd/src/lib.rs
@@ -14,6 +14,7 @@ pub mod tunnel_exit_probe;
 pub mod tunnel_interface_wireguard;
 pub mod tunnel_latency_prober;
 pub mod tunnel_throughput_tester;
+pub mod wireguard_interface;
 
 // DHCP/DNS server implementations.
 pub mod dhcp;

--- a/source/daemon/crates/wardnetd/src/tests/inbound_wg_interface_wireguard.rs
+++ b/source/daemon/crates/wardnetd/src/tests/inbound_wg_interface_wireguard.rs
@@ -1,12 +1,14 @@
-//! Pure-function tests for the inbound `WireGuard` interface impl.
-//!
-//! Deliberately does NOT touch the kernel / netlink — only the pure
-//! `peer_stats_from` mapping is exercised here, matching how
-//! `tunnel_interface_wireguard`'s own test file is scoped.
+//! Tests for the inbound `WireGuard` interface impl: the pure
+//! `peer_stats_from` mapping, plus opt-in (`#[ignore]`) kernel round-trips
+//! for `tear_down_server`, matching how `tunnel_interface_wireguard`'s own
+//! test file is scoped.
 
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
-use crate::inbound_wg_interface_wireguard::peer_stats_from;
+use crate::inbound_wg_interface_wireguard::{WireGuardInboundInterface, peer_stats_from};
+use crate::wireguard_interface::is_interface_absent_error;
+use wardnetd_services::inbound_wg::interface::InboundWgInterface;
+use wireguard_control::{Backend, Device, DeviceUpdate, InterfaceName, Key};
 
 #[test]
 fn maps_fields_and_converts_handshake_time() {
@@ -36,4 +38,59 @@ fn now_handshake_round_trips_within_a_second() {
     let got = stats.last_handshake.expect("handshake present");
     let expected = chrono::DateTime::<chrono::Utc>::from(now);
     assert!((got - expected).num_seconds().abs() <= 1);
+}
+
+/// Full kernel round-trip for `tear_down_server()`: stand up a real
+/// `WireGuard` interface with a configured private key, then assert the
+/// tear-down actually deletes it.
+///
+/// Requires `CAP_NET_ADMIN` and kernel `WireGuard` support, so it is ignored
+/// by default; run with `cargo test -p wardnetd -- --ignored kernel_`.
+#[tokio::test]
+#[ignore = "requires CAP_NET_ADMIN and kernel WireGuard support"]
+async fn kernel_tear_down_server_deletes_interface() {
+    let name = "wgtest832c";
+    let iface: InterfaceName = name.parse().unwrap();
+
+    let apply_result = DeviceUpdate::new()
+        .set_private_key(Key::generate_private())
+        .apply(&iface, Backend::Kernel);
+    if let Err(e) = &apply_result
+        && e.raw_os_error() == Some(libc::EOPNOTSUPP)
+    {
+        eprintln!("skipping: this kernel has no WireGuard support ({e})");
+        return;
+    }
+    apply_result.expect("failed to create kernel wireguard interface (needs CAP_NET_ADMIN)");
+    Device::get(&iface, Backend::Kernel).expect("interface should exist after apply");
+
+    WireGuardInboundInterface
+        .tear_down_server(name)
+        .await
+        .expect("tear_down_server should succeed on an existing interface");
+
+    let err = Device::get(&iface, Backend::Kernel)
+        .expect_err("interface should be gone after tear_down_server()");
+    assert!(
+        is_interface_absent_error(&err),
+        "expected a not-found error after tear-down, got: {err}"
+    );
+}
+
+/// `tear_down_server()` on an interface that does not exist is an idempotent
+/// success — the expected steady state when the server was never enabled.
+#[tokio::test]
+#[ignore = "requires CAP_NET_ADMIN and kernel WireGuard support"]
+async fn kernel_tear_down_server_absent_interface_is_idempotent() {
+    let name = "wgtest832d";
+    let iface: InterfaceName = name.parse().unwrap();
+    assert!(
+        Device::get(&iface, Backend::Kernel).is_err(),
+        "precondition: interface must not exist"
+    );
+
+    WireGuardInboundInterface
+        .tear_down_server(name)
+        .await
+        .expect("tear_down_server of an absent interface should be an idempotent no-op");
 }

--- a/source/daemon/crates/wardnetd/src/tests/inbound_wg_interface_wireguard.rs
+++ b/source/daemon/crates/wardnetd/src/tests/inbound_wg_interface_wireguard.rs
@@ -40,6 +40,36 @@ fn now_handshake_round_trips_within_a_second() {
     assert!((got - expected).num_seconds().abs() <= 1);
 }
 
+/// `peer_stats` on an interface that does not exist must never fabricate
+/// peers: an absent-classified error yields an empty list, an unprivileged
+/// environment surfaces the real error as `Err` — a non-empty `Ok` is wrong
+/// everywhere.
+#[tokio::test]
+async fn peer_stats_nonexistent_interface_reports_no_peers() {
+    if let Ok(stats) = WireGuardInboundInterface.peer_stats("wgtest832w").await {
+        assert!(
+            stats.is_empty(),
+            "a nonexistent interface cannot have peers"
+        );
+    }
+}
+
+/// `tear_down_server()` on a nonexistent interface never panics; where the
+/// environment surfaces an error (e.g. unprivileged), the message names the
+/// interface.
+#[tokio::test]
+async fn tear_down_server_nonexistent_interface_errors_name_the_interface() {
+    if let Err(e) = WireGuardInboundInterface
+        .tear_down_server("wgtest832u")
+        .await
+    {
+        assert!(
+            e.to_string().contains("wgtest832u"),
+            "error should name the interface: {e}"
+        );
+    }
+}
+
 /// Full kernel round-trip for `tear_down_server()`: stand up a real
 /// `WireGuard` interface with a configured private key, then assert the
 /// tear-down actually deletes it.

--- a/source/daemon/crates/wardnetd/src/tests/inbound_wg_interface_wireguard.rs
+++ b/source/daemon/crates/wardnetd/src/tests/inbound_wg_interface_wireguard.rs
@@ -52,16 +52,13 @@ async fn kernel_tear_down_server_deletes_interface() {
     let name = "wgtest832c";
     let iface: InterfaceName = name.parse().unwrap();
 
-    let apply_result = DeviceUpdate::new()
-        .set_private_key(Key::generate_private())
-        .apply(&iface, Backend::Kernel);
-    if let Err(e) = &apply_result
-        && e.raw_os_error() == Some(libc::EOPNOTSUPP)
-    {
-        eprintln!("skipping: this kernel has no WireGuard support ({e})");
+    // Self-heal from a previous failed run that leaked the interface.
+    let _ = crate::wireguard_interface::delete_wireguard_interface(name);
+
+    let update = DeviceUpdate::new().set_private_key(Key::generate_private());
+    if !super::apply_or_skip_kernel(update, &iface) {
         return;
     }
-    apply_result.expect("failed to create kernel wireguard interface (needs CAP_NET_ADMIN)");
     Device::get(&iface, Backend::Kernel).expect("interface should exist after apply");
 
     WireGuardInboundInterface

--- a/source/daemon/crates/wardnetd/src/tests/inbound_wg_interface_wireguard.rs
+++ b/source/daemon/crates/wardnetd/src/tests/inbound_wg_interface_wireguard.rs
@@ -53,7 +53,7 @@ async fn kernel_tear_down_server_deletes_interface() {
     let iface: InterfaceName = name.parse().unwrap();
 
     // Self-heal from a previous failed run that leaked the interface.
-    let _ = crate::wireguard_interface::delete_wireguard_interface(name);
+    let _ = crate::wireguard_interface::delete_wireguard_interface(name, "wireguard interface");
 
     let update = DeviceUpdate::new().set_private_key(Key::generate_private());
     if !super::apply_or_skip_kernel(update, &iface) {

--- a/source/daemon/crates/wardnetd/src/tests/mod.rs
+++ b/source/daemon/crates/wardnetd/src/tests/mod.rs
@@ -24,3 +24,24 @@ mod watchdog_hard;
 mod watchdog_soft;
 mod wireguard_interface;
 mod zone_enforcement_listener;
+
+/// Apply `update` to a kernel `WireGuard` interface for an opt-in `kernel_*`
+/// test, returning `false` when this kernel has no `WireGuard` support (the
+/// caller should skip the test).
+///
+/// Panics on any other failure (e.g. missing `CAP_NET_ADMIN`).
+pub fn apply_or_skip_kernel(
+    update: wireguard_control::DeviceUpdate,
+    iface: &wireguard_control::InterfaceName,
+) -> bool {
+    match update.apply(iface, wireguard_control::Backend::Kernel) {
+        Ok(()) => true,
+        Err(e) if e.raw_os_error() == Some(libc::EOPNOTSUPP) => {
+            eprintln!("skipping: this kernel has no WireGuard support ({e})");
+            false
+        }
+        Err(e) => {
+            panic!("failed to create kernel wireguard interface (needs CAP_NET_ADMIN): {e}")
+        }
+    }
+}

--- a/source/daemon/crates/wardnetd/src/tests/mod.rs
+++ b/source/daemon/crates/wardnetd/src/tests/mod.rs
@@ -22,4 +22,5 @@ mod tunnel_monitor;
 mod tunnel_throughput_tester;
 mod watchdog_hard;
 mod watchdog_soft;
+mod wireguard_interface;
 mod zone_enforcement_listener;

--- a/source/daemon/crates/wardnetd/src/tests/tunnel_interface_wireguard.rs
+++ b/source/daemon/crates/wardnetd/src/tests/tunnel_interface_wireguard.rs
@@ -1,6 +1,7 @@
 use crate::tunnel_interface_wireguard::{
-    PeerStatsInput, WireGuardTunnelInterface, aggregate_peer_stats, is_interface_absent_error,
+    PeerStatsInput, WireGuardTunnelInterface, aggregate_peer_stats,
 };
+use crate::wireguard_interface::is_interface_absent_error;
 use std::time::{Duration, SystemTime};
 use wardnetd_services::tunnel::interface::TunnelInterface;
 use wireguard_control::{Backend, Device, DeviceUpdate, InterfaceName, Key, PeerConfigBuilder};
@@ -171,49 +172,6 @@ fn aggregate_three_peers_with_mixed_handshakes() {
         Some(chrono::DateTime::<chrono::Utc>::from(t2)),
         "t2 (300) is the latest"
     );
-}
-
-#[test]
-fn absent_error_enodev_is_absent() {
-    let err = std::io::Error::from_raw_os_error(libc::ENODEV);
-    assert!(is_interface_absent_error(&err));
-}
-
-#[test]
-fn absent_error_enoent_is_absent() {
-    let err = std::io::Error::from_raw_os_error(libc::ENOENT);
-    assert!(is_interface_absent_error(&err));
-}
-
-/// A `NotFound` error without a raw OS errno (e.g. synthesized by the
-/// userspace backend) still counts as "interface absent".
-#[test]
-fn absent_error_not_found_kind_without_errno_is_absent() {
-    let err = std::io::Error::new(std::io::ErrorKind::NotFound, "no such socket");
-    assert!(is_interface_absent_error(&err));
-}
-
-/// A stale userspace control socket with no `wireguard-go` listening surfaces
-/// as `ECONNREFUSED` — the interface is effectively dead, so it counts as
-/// absent (the old empty-`apply` path returned Ok here too).
-#[test]
-fn absent_error_econnrefused_is_absent() {
-    let err = std::io::Error::from_raw_os_error(libc::ECONNREFUSED);
-    assert!(is_interface_absent_error(&err));
-}
-
-/// A permission error is a real failure, not an absent interface — `remove()`
-/// must propagate it instead of pretending the removal was a no-op.
-#[test]
-fn absent_error_eperm_is_not_absent() {
-    let err = std::io::Error::from_raw_os_error(libc::EPERM);
-    assert!(!is_interface_absent_error(&err));
-}
-
-#[test]
-fn absent_error_other_kind_is_not_absent() {
-    let err = std::io::Error::other("netlink payload mismatch");
-    assert!(!is_interface_absent_error(&err));
 }
 
 /// Full kernel round-trip for `remove()`: stand up a real `WireGuard` interface

--- a/source/daemon/crates/wardnetd/src/tests/tunnel_interface_wireguard.rs
+++ b/source/daemon/crates/wardnetd/src/tests/tunnel_interface_wireguard.rs
@@ -1,5 +1,9 @@
-use crate::tunnel_interface_wireguard::{PeerStatsInput, aggregate_peer_stats};
+use crate::tunnel_interface_wireguard::{
+    PeerStatsInput, WireGuardTunnelInterface, aggregate_peer_stats, is_interface_absent_error,
+};
 use std::time::{Duration, SystemTime};
+use wardnetd_services::tunnel::interface::TunnelInterface;
+use wireguard_control::{Backend, Device, DeviceUpdate, InterfaceName, Key, PeerConfigBuilder};
 
 #[test]
 fn aggregate_empty_peers() {
@@ -167,6 +171,115 @@ fn aggregate_three_peers_with_mixed_handshakes() {
         Some(chrono::DateTime::<chrono::Utc>::from(t2)),
         "t2 (300) is the latest"
     );
+}
+
+#[test]
+fn absent_error_enodev_is_absent() {
+    let err = std::io::Error::from_raw_os_error(libc::ENODEV);
+    assert!(is_interface_absent_error(&err));
+}
+
+#[test]
+fn absent_error_enoent_is_absent() {
+    let err = std::io::Error::from_raw_os_error(libc::ENOENT);
+    assert!(is_interface_absent_error(&err));
+}
+
+/// A `NotFound` error without a raw OS errno (e.g. synthesized by the
+/// userspace backend) still counts as "interface absent".
+#[test]
+fn absent_error_not_found_kind_without_errno_is_absent() {
+    let err = std::io::Error::new(std::io::ErrorKind::NotFound, "no such socket");
+    assert!(is_interface_absent_error(&err));
+}
+
+/// A stale userspace control socket with no `wireguard-go` listening surfaces
+/// as `ECONNREFUSED` — the interface is effectively dead, so it counts as
+/// absent (the old empty-`apply` path returned Ok here too).
+#[test]
+fn absent_error_econnrefused_is_absent() {
+    let err = std::io::Error::from_raw_os_error(libc::ECONNREFUSED);
+    assert!(is_interface_absent_error(&err));
+}
+
+/// A permission error is a real failure, not an absent interface — `remove()`
+/// must propagate it instead of pretending the removal was a no-op.
+#[test]
+fn absent_error_eperm_is_not_absent() {
+    let err = std::io::Error::from_raw_os_error(libc::EPERM);
+    assert!(!is_interface_absent_error(&err));
+}
+
+#[test]
+fn absent_error_other_kind_is_not_absent() {
+    let err = std::io::Error::other("netlink payload mismatch");
+    assert!(!is_interface_absent_error(&err));
+}
+
+/// Full kernel round-trip for `remove()`: stand up a real `WireGuard` interface
+/// with a configured private key and peer, then assert `remove()` actually
+/// deletes it (not merely re-applies an empty config on top).
+///
+/// Requires `CAP_NET_ADMIN` and kernel `WireGuard` support, so it is ignored by
+/// default; run with `cargo test -p wardnetd -- --ignored kernel_`.
+#[tokio::test]
+#[ignore = "requires CAP_NET_ADMIN and kernel WireGuard support"]
+async fn kernel_remove_deletes_configured_interface() {
+    let name = "wgtest832a";
+    let iface: InterfaceName = name.parse().unwrap();
+
+    // Configure the interface directly via netlink (what `create()` does,
+    // minus the address assignment that needs iproute2).
+    let apply_result = DeviceUpdate::new()
+        .set_private_key(Key::generate_private())
+        .add_peer(PeerConfigBuilder::new(
+            &Key::generate_private().get_public(),
+        ))
+        .apply(&iface, Backend::Kernel);
+    if let Err(e) = &apply_result
+        && e.raw_os_error() == Some(libc::EOPNOTSUPP)
+    {
+        eprintln!("skipping: this kernel has no WireGuard support ({e})");
+        return;
+    }
+    apply_result.expect("failed to create kernel wireguard interface (needs CAP_NET_ADMIN)");
+
+    let device = Device::get(&iface, Backend::Kernel).expect("interface should exist after apply");
+    assert!(
+        device.private_key.is_some(),
+        "private key should be configured before removal"
+    );
+    assert_eq!(device.peers.len(), 1, "peer should be configured");
+
+    WireGuardTunnelInterface
+        .remove(name)
+        .await
+        .expect("remove() should succeed on an existing interface");
+
+    let err =
+        Device::get(&iface, Backend::Kernel).expect_err("interface should be gone after remove()");
+    assert!(
+        is_interface_absent_error(&err),
+        "expected a not-found error after removal, got: {err}"
+    );
+}
+
+/// `remove()` on an interface that does not exist is an idempotent success:
+/// no error, nothing to remove.
+#[tokio::test]
+#[ignore = "requires CAP_NET_ADMIN and kernel WireGuard support"]
+async fn kernel_remove_absent_interface_is_idempotent() {
+    let name = "wgtest832b";
+    let iface: InterfaceName = name.parse().unwrap();
+    assert!(
+        Device::get(&iface, Backend::Kernel).is_err(),
+        "precondition: interface must not exist"
+    );
+
+    WireGuardTunnelInterface
+        .remove(name)
+        .await
+        .expect("remove() of an absent interface should be an idempotent no-op");
 }
 
 #[test]

--- a/source/daemon/crates/wardnetd/src/tests/tunnel_interface_wireguard.rs
+++ b/source/daemon/crates/wardnetd/src/tests/tunnel_interface_wireguard.rs
@@ -187,7 +187,7 @@ async fn kernel_remove_deletes_configured_interface() {
     let iface: InterfaceName = name.parse().unwrap();
 
     // Self-heal from a previous failed run that leaked the interface.
-    let _ = crate::wireguard_interface::delete_wireguard_interface(name);
+    let _ = crate::wireguard_interface::delete_wireguard_interface(name, "wireguard interface");
 
     // Configure the interface directly via netlink (what `create()` does,
     // minus the address assignment that needs iproute2).

--- a/source/daemon/crates/wardnetd/src/tests/tunnel_interface_wireguard.rs
+++ b/source/daemon/crates/wardnetd/src/tests/tunnel_interface_wireguard.rs
@@ -186,21 +186,19 @@ async fn kernel_remove_deletes_configured_interface() {
     let name = "wgtest832a";
     let iface: InterfaceName = name.parse().unwrap();
 
+    // Self-heal from a previous failed run that leaked the interface.
+    let _ = crate::wireguard_interface::delete_wireguard_interface(name);
+
     // Configure the interface directly via netlink (what `create()` does,
     // minus the address assignment that needs iproute2).
-    let apply_result = DeviceUpdate::new()
+    let update = DeviceUpdate::new()
         .set_private_key(Key::generate_private())
         .add_peer(PeerConfigBuilder::new(
             &Key::generate_private().get_public(),
-        ))
-        .apply(&iface, Backend::Kernel);
-    if let Err(e) = &apply_result
-        && e.raw_os_error() == Some(libc::EOPNOTSUPP)
-    {
-        eprintln!("skipping: this kernel has no WireGuard support ({e})");
+        ));
+    if !super::apply_or_skip_kernel(update, &iface) {
         return;
     }
-    apply_result.expect("failed to create kernel wireguard interface (needs CAP_NET_ADMIN)");
 
     let device = Device::get(&iface, Backend::Kernel).expect("interface should exist after apply");
     assert!(

--- a/source/daemon/crates/wardnetd/src/tests/tunnel_interface_wireguard.rs
+++ b/source/daemon/crates/wardnetd/src/tests/tunnel_interface_wireguard.rs
@@ -174,6 +174,29 @@ fn aggregate_three_peers_with_mixed_handshakes() {
     );
 }
 
+/// `get_stats` on an interface that does not exist must never fabricate
+/// stats: an absent-classified error yields `Ok(None)`, an unprivileged
+/// environment surfaces the real error as `Err` — `Ok(Some(_))` is wrong
+/// everywhere.
+#[tokio::test]
+async fn get_stats_nonexistent_interface_reports_no_stats() {
+    if let Ok(stats) = WireGuardTunnelInterface.get_stats("wgtest832z").await {
+        assert!(stats.is_none(), "a nonexistent interface cannot have stats");
+    }
+}
+
+/// `remove()` on a nonexistent interface never panics; where the environment
+/// surfaces an error (e.g. unprivileged), the message names the interface.
+#[tokio::test]
+async fn remove_nonexistent_interface_errors_name_the_interface() {
+    if let Err(e) = WireGuardTunnelInterface.remove("wgtest832v").await {
+        assert!(
+            e.to_string().contains("wgtest832v"),
+            "error should name the interface: {e}"
+        );
+    }
+}
+
 /// Full kernel round-trip for `remove()`: stand up a real `WireGuard` interface
 /// with a configured private key and peer, then assert `remove()` actually
 /// deletes it (not merely re-applies an empty config on top).

--- a/source/daemon/crates/wardnetd/src/tests/wireguard_interface.rs
+++ b/source/daemon/crates/wardnetd/src/tests/wireguard_interface.rs
@@ -1,0 +1,63 @@
+//! Tests for the shared `WireGuard` interface removal helpers.
+//!
+//! Only the pure error classifier and the argument-validation path are
+//! exercised here — the netlink round-trips are covered by the opt-in
+//! `kernel_*` tests in `tunnel_interface_wireguard` and
+//! `inbound_wg_interface_wireguard`.
+
+use crate::wireguard_interface::{delete_wireguard_interface, is_interface_absent_error};
+
+#[test]
+fn absent_error_enodev_is_absent() {
+    let err = std::io::Error::from_raw_os_error(libc::ENODEV);
+    assert!(is_interface_absent_error(&err));
+}
+
+#[test]
+fn absent_error_enoent_is_absent() {
+    let err = std::io::Error::from_raw_os_error(libc::ENOENT);
+    assert!(is_interface_absent_error(&err));
+}
+
+/// A `NotFound` error without a raw OS errno (e.g. synthesized by the
+/// userspace backend) still counts as "interface absent".
+#[test]
+fn absent_error_not_found_kind_without_errno_is_absent() {
+    let err = std::io::Error::new(std::io::ErrorKind::NotFound, "no such socket");
+    assert!(is_interface_absent_error(&err));
+}
+
+/// A stale userspace control socket with no `wireguard-go` listening surfaces
+/// as `ECONNREFUSED` — the interface is effectively dead, so it counts as
+/// absent (the old empty-`apply` path returned Ok here too).
+#[test]
+fn absent_error_econnrefused_is_absent() {
+    let err = std::io::Error::from_raw_os_error(libc::ECONNREFUSED);
+    assert!(is_interface_absent_error(&err));
+}
+
+/// A permission error is a real failure, not an absent interface — removal
+/// must propagate it instead of pretending it was a no-op.
+#[test]
+fn absent_error_eperm_is_not_absent() {
+    let err = std::io::Error::from_raw_os_error(libc::EPERM);
+    assert!(!is_interface_absent_error(&err));
+}
+
+#[test]
+fn absent_error_other_kind_is_not_absent() {
+    let err = std::io::Error::other("netlink payload mismatch");
+    assert!(!is_interface_absent_error(&err));
+}
+
+/// An interface name the kernel would reject (too long) fails validation
+/// before any netlink traffic.
+#[test]
+fn delete_rejects_invalid_interface_name() {
+    let err = delete_wireguard_interface("this-name-is-far-too-long-for-an-interface")
+        .expect_err("invalid interface name should be rejected");
+    assert!(
+        err.to_string().contains("invalid interface name"),
+        "unexpected error: {err}"
+    );
+}

--- a/source/daemon/crates/wardnetd/src/tests/wireguard_interface.rs
+++ b/source/daemon/crates/wardnetd/src/tests/wireguard_interface.rs
@@ -54,8 +54,11 @@ fn absent_error_other_kind_is_not_absent() {
 /// before any netlink traffic.
 #[test]
 fn delete_rejects_invalid_interface_name() {
-    let err = delete_wireguard_interface("this-name-is-far-too-long-for-an-interface")
-        .expect_err("invalid interface name should be rejected");
+    let err = delete_wireguard_interface(
+        "this-name-is-far-too-long-for-an-interface",
+        "wireguard interface",
+    )
+    .expect_err("invalid interface name should be rejected");
     assert!(
         err.to_string().contains("invalid interface name"),
         "unexpected error: {err}"

--- a/source/daemon/crates/wardnetd/src/tests/wireguard_interface.rs
+++ b/source/daemon/crates/wardnetd/src/tests/wireguard_interface.rs
@@ -5,7 +5,9 @@
 //! `kernel_*` tests in `tunnel_interface_wireguard` and
 //! `inbound_wg_interface_wireguard`.
 
-use crate::wireguard_interface::{delete_wireguard_interface, is_interface_absent_error};
+use crate::wireguard_interface::{
+    delete_wireguard_interface, is_interface_absent_error, remove_stale_link,
+};
 
 #[test]
 fn absent_error_enodev_is_absent() {
@@ -48,6 +50,27 @@ fn absent_error_eperm_is_not_absent() {
 fn absent_error_other_kind_is_not_absent() {
     let err = std::io::Error::other("netlink payload mismatch");
     assert!(!is_interface_absent_error(&err));
+}
+
+/// Deleting an interface that does not exist must never report a removal.
+///
+/// The exact outcome depends on the environment — an absent-classified error
+/// (no such device, or no `WireGuard` genl family at all) yields `Ok(false)`,
+/// while an unprivileged environment surfaces a permission error as `Err` —
+/// but `Ok(true)` ("removed") is wrong everywhere.
+#[tokio::test]
+async fn delete_nonexistent_interface_is_not_a_removal() {
+    if let Ok(removed) = delete_wireguard_interface("wgtest832x", "wireguard interface") {
+        assert!(!removed, "a nonexistent interface cannot have been removed");
+    }
+}
+
+/// `remove_stale_link` on a nonexistent interface is a silent no-op: the
+/// `ip link show` probe fails (whether `ip` is missing or the link is), so
+/// no delete is attempted.
+#[tokio::test]
+async fn remove_stale_link_is_noop_when_interface_absent() {
+    remove_stale_link("wgtest832y", "wireguard interface").await;
 }
 
 /// An interface name the kernel would reject (too long) fails validation

--- a/source/daemon/crates/wardnetd/src/tunnel_interface_wireguard.rs
+++ b/source/daemon/crates/wardnetd/src/tunnel_interface_wireguard.rs
@@ -45,6 +45,23 @@ pub fn aggregate_peer_stats(peers: &[PeerStatsInput]) -> TunnelStats {
     }
 }
 
+/// Whether an error from [`Device::get`] means the interface does not exist,
+/// as opposed to a real failure (e.g. a permission error).
+///
+/// The kernel backend surfaces a missing interface as `ENODEV` ("No such
+/// device"); the userspace backend reports a missing control socket as
+/// `ENOENT`/`NotFound`, and a stale socket file left behind by a crashed
+/// `wireguard-go` as `ConnectionRefused`. All mean there is nothing live to
+/// remove, which [`TunnelInterface::remove`] treats as idempotent success.
+#[must_use]
+pub fn is_interface_absent_error(err: &std::io::Error) -> bool {
+    matches!(err.raw_os_error(), Some(libc::ENODEV | libc::ENOENT))
+        || matches!(
+            err.kind(),
+            std::io::ErrorKind::NotFound | std::io::ErrorKind::ConnectionRefused
+        )
+}
+
 /// Production [`TunnelInterface`] implementation backed by the `wireguard-control` crate.
 ///
 /// Communicates via netlink on Linux (kernel backend) and userspace
@@ -192,13 +209,34 @@ impl TunnelInterface for WireGuardTunnelInterface {
             .parse()
             .map_err(|e| anyhow::anyhow!("invalid interface name: {e}"))?;
 
-        // Apply an empty update — the interface is removed when the last
-        // reference is dropped on most backends. Use a minimal no-op update
-        // so the kernel removes it.
-        DeviceUpdate::new().apply(&iface, Backend::default())?;
-
-        tracing::info!(interface = %interface_name, "wireguard interface removed");
-        Ok(())
+        // `Device::delete` is the crate's real removal path (netlink `DelLink`
+        // on the Linux kernel backend). Applying an empty `DeviceUpdate` here
+        // would only layer a no-op config change on top of the existing
+        // interface — the kernel backend never deletes on `apply`. An
+        // absent-classified error from either the get or the delete (the
+        // interface can vanish between the two, e.g. a concurrent teardown)
+        // means the desired end state is already reached.
+        match Device::get(&iface, Backend::default()).and_then(Device::delete) {
+            Ok(()) => {
+                tracing::info!(
+                    interface = %interface_name,
+                    "wireguard interface {interface_name} removed"
+                );
+                Ok(())
+            }
+            Err(e) if is_interface_absent_error(&e) => {
+                // Already gone — removal is idempotent, but nothing was
+                // removed, so don't log as if something was.
+                tracing::debug!(
+                    interface = %interface_name,
+                    "wireguard interface {interface_name} already absent, nothing to remove"
+                );
+                Ok(())
+            }
+            Err(e) => Err(anyhow::anyhow!(
+                "failed to remove wireguard interface {interface_name}: {e}"
+            )),
+        }
     }
 
     async fn get_stats(&self, interface_name: &str) -> anyhow::Result<Option<TunnelStats>> {

--- a/source/daemon/crates/wardnetd/src/tunnel_interface_wireguard.rs
+++ b/source/daemon/crates/wardnetd/src/tunnel_interface_wireguard.rs
@@ -73,6 +73,9 @@ impl TunnelInterface for WireGuardTunnelInterface {
 
         // Remove any stale interface left over from a previous daemon run or crash.
         // This prevents "Address already assigned" errors when re-creating.
+        // Deliberately an `ip link` shell-out, not `delete_wireguard_interface`:
+        // it also reaps links the WireGuard netlink family cannot see (wrong
+        // type or partially created), which `remove()` classifies as absent.
         let check = tokio::process::Command::new("ip")
             .args(["link", "show", &params.interface_name])
             .output()

--- a/source/daemon/crates/wardnetd/src/tunnel_interface_wireguard.rs
+++ b/source/daemon/crates/wardnetd/src/tunnel_interface_wireguard.rs
@@ -73,23 +73,11 @@ impl TunnelInterface for WireGuardTunnelInterface {
 
         // Remove any stale interface left over from a previous daemon run or crash.
         // This prevents "Address already assigned" errors when re-creating.
-        // Deliberately an `ip link` shell-out, not `delete_wireguard_interface`:
-        // it also reaps links the WireGuard netlink family cannot see (wrong
-        // type or partially created), which `remove()` classifies as absent.
-        let check = tokio::process::Command::new("ip")
-            .args(["link", "show", &params.interface_name])
-            .output()
-            .await;
-        if check.is_ok_and(|o| o.status.success()) {
-            tracing::info!(
-                interface = %params.interface_name,
-                "removing stale wireguard interface before re-creation"
-            );
-            let _ = tokio::process::Command::new("ip")
-                .args(["link", "delete", &params.interface_name])
-                .output()
-                .await;
-        }
+        crate::wireguard_interface::remove_stale_link(
+            &params.interface_name,
+            "wireguard interface",
+        )
+        .await;
 
         let private_key = Key(private_key);
         let peer_key = Key(peer_public_key);
@@ -191,19 +179,10 @@ impl TunnelInterface for WireGuardTunnelInterface {
     }
 
     async fn remove(&self, interface_name: &str) -> anyhow::Result<()> {
-        if crate::wireguard_interface::delete_wireguard_interface(interface_name)? {
-            tracing::info!(
-                interface = %interface_name,
-                "wireguard interface {interface_name} removed"
-            );
-        } else {
-            // Already gone — removal is idempotent, but nothing was removed,
-            // so don't log as if something was.
-            tracing::debug!(
-                interface = %interface_name,
-                "wireguard interface {interface_name} already absent, nothing to remove"
-            );
-        }
+        crate::wireguard_interface::delete_wireguard_interface(
+            interface_name,
+            "wireguard interface",
+        )?;
         Ok(())
     }
 
@@ -212,8 +191,17 @@ impl TunnelInterface for WireGuardTunnelInterface {
             .parse()
             .map_err(|e| anyhow::anyhow!("invalid interface name: {e}"))?;
 
-        let Ok(device) = Device::get(&iface, Backend::default()) else {
-            return Ok(None);
+        let device = match Device::get(&iface, Backend::default()) {
+            Ok(device) => device,
+            // Absent interface is a normal state (tunnel down) — no stats.
+            Err(e) if crate::wireguard_interface::is_interface_absent_error(&e) => {
+                return Ok(None);
+            }
+            Err(e) => {
+                return Err(anyhow::anyhow!(
+                    "failed to query wireguard interface {interface_name} stats: {e}"
+                ));
+            }
         };
 
         let peers: Vec<PeerStatsInput> = device

--- a/source/daemon/crates/wardnetd/src/tunnel_interface_wireguard.rs
+++ b/source/daemon/crates/wardnetd/src/tunnel_interface_wireguard.rs
@@ -45,23 +45,6 @@ pub fn aggregate_peer_stats(peers: &[PeerStatsInput]) -> TunnelStats {
     }
 }
 
-/// Whether an error from [`Device::get`] means the interface does not exist,
-/// as opposed to a real failure (e.g. a permission error).
-///
-/// The kernel backend surfaces a missing interface as `ENODEV` ("No such
-/// device"); the userspace backend reports a missing control socket as
-/// `ENOENT`/`NotFound`, and a stale socket file left behind by a crashed
-/// `wireguard-go` as `ConnectionRefused`. All mean there is nothing live to
-/// remove, which [`TunnelInterface::remove`] treats as idempotent success.
-#[must_use]
-pub fn is_interface_absent_error(err: &std::io::Error) -> bool {
-    matches!(err.raw_os_error(), Some(libc::ENODEV | libc::ENOENT))
-        || matches!(
-            err.kind(),
-            std::io::ErrorKind::NotFound | std::io::ErrorKind::ConnectionRefused
-        )
-}
-
 /// Production [`TunnelInterface`] implementation backed by the `wireguard-control` crate.
 ///
 /// Communicates via netlink on Linux (kernel backend) and userspace
@@ -205,38 +188,20 @@ impl TunnelInterface for WireGuardTunnelInterface {
     }
 
     async fn remove(&self, interface_name: &str) -> anyhow::Result<()> {
-        let iface: InterfaceName = interface_name
-            .parse()
-            .map_err(|e| anyhow::anyhow!("invalid interface name: {e}"))?;
-
-        // `Device::delete` is the crate's real removal path (netlink `DelLink`
-        // on the Linux kernel backend). Applying an empty `DeviceUpdate` here
-        // would only layer a no-op config change on top of the existing
-        // interface — the kernel backend never deletes on `apply`. An
-        // absent-classified error from either the get or the delete (the
-        // interface can vanish between the two, e.g. a concurrent teardown)
-        // means the desired end state is already reached.
-        match Device::get(&iface, Backend::default()).and_then(Device::delete) {
-            Ok(()) => {
-                tracing::info!(
-                    interface = %interface_name,
-                    "wireguard interface {interface_name} removed"
-                );
-                Ok(())
-            }
-            Err(e) if is_interface_absent_error(&e) => {
-                // Already gone — removal is idempotent, but nothing was
-                // removed, so don't log as if something was.
-                tracing::debug!(
-                    interface = %interface_name,
-                    "wireguard interface {interface_name} already absent, nothing to remove"
-                );
-                Ok(())
-            }
-            Err(e) => Err(anyhow::anyhow!(
-                "failed to remove wireguard interface {interface_name}: {e}"
-            )),
+        if crate::wireguard_interface::delete_wireguard_interface(interface_name)? {
+            tracing::info!(
+                interface = %interface_name,
+                "wireguard interface {interface_name} removed"
+            );
+        } else {
+            // Already gone — removal is idempotent, but nothing was removed,
+            // so don't log as if something was.
+            tracing::debug!(
+                interface = %interface_name,
+                "wireguard interface {interface_name} already absent, nothing to remove"
+            );
         }
+        Ok(())
     }
 
     async fn get_stats(&self, interface_name: &str) -> anyhow::Result<Option<TunnelStats>> {

--- a/source/daemon/crates/wardnetd/src/wireguard_interface.rs
+++ b/source/daemon/crates/wardnetd/src/wireguard_interface.rs
@@ -1,0 +1,53 @@
+//! Shared removal helpers for the `wireguard-control`-backed interface
+//! implementations
+//! ([`WireGuardTunnelInterface`](crate::tunnel_interface_wireguard::WireGuardTunnelInterface)
+//! and
+//! [`WireGuardInboundInterface`](crate::inbound_wg_interface_wireguard::WireGuardInboundInterface)),
+//! so both delete interfaces through one mechanism with one error
+//! classification.
+
+use wireguard_control::{Backend, Device, InterfaceName};
+
+/// Whether an error from [`Device::get`] or [`Device::delete`] means the
+/// interface does not exist, as opposed to a real failure (e.g. a permission
+/// error).
+///
+/// The kernel backend surfaces a missing interface as `ENODEV` ("No such
+/// device"); the userspace backend reports a missing control socket as
+/// `ENOENT`/`NotFound`, and a stale socket file left behind by a crashed
+/// `wireguard-go` as `ConnectionRefused`. All mean there is nothing live to
+/// remove, which [`delete_wireguard_interface`] treats as idempotent success.
+#[must_use]
+pub fn is_interface_absent_error(err: &std::io::Error) -> bool {
+    matches!(err.raw_os_error(), Some(libc::ENODEV | libc::ENOENT))
+        || matches!(
+            err.kind(),
+            std::io::ErrorKind::NotFound | std::io::ErrorKind::ConnectionRefused
+        )
+}
+
+/// Delete a `WireGuard` interface by name.
+///
+/// `Device::delete` is the crate's real removal path (netlink `DelLink` on
+/// the Linux kernel backend). Applying an empty `DeviceUpdate` instead would
+/// only layer a no-op config change on top of the existing interface — the
+/// kernel backend never deletes on `apply`.
+///
+/// Returns `Ok(true)` when an interface was actually removed and `Ok(false)`
+/// when it was already absent (idempotent no-op). An absent-classified error
+/// from either the get or the delete (the interface can vanish between the
+/// two, e.g. a concurrent teardown) counts as already absent. Real failures
+/// (e.g. permission errors) are returned as `Err`.
+pub fn delete_wireguard_interface(interface_name: &str) -> anyhow::Result<bool> {
+    let iface: InterfaceName = interface_name
+        .parse()
+        .map_err(|e| anyhow::anyhow!("invalid interface name: {e}"))?;
+
+    match Device::get(&iface, Backend::default()).and_then(Device::delete) {
+        Ok(()) => Ok(true),
+        Err(e) if is_interface_absent_error(&e) => Ok(false),
+        Err(e) => Err(anyhow::anyhow!(
+            "failed to remove wireguard interface {interface_name}: {e}"
+        )),
+    }
+}

--- a/source/daemon/crates/wardnetd/src/wireguard_interface.rs
+++ b/source/daemon/crates/wardnetd/src/wireguard_interface.rs
@@ -26,28 +26,66 @@ pub fn is_interface_absent_error(err: &std::io::Error) -> bool {
         )
 }
 
-/// Delete a `WireGuard` interface by name.
+/// Delete a `WireGuard` interface by name, logging the outcome.
 ///
 /// `Device::delete` is the crate's real removal path (netlink `DelLink` on
 /// the Linux kernel backend). Applying an empty `DeviceUpdate` instead would
 /// only layer a no-op config change on top of the existing interface — the
 /// kernel backend never deletes on `apply`.
 ///
+/// `label` names the interface kind in log and error messages (e.g.
+/// "wireguard interface", "inbound wireguard server").
+///
 /// Returns `Ok(true)` when an interface was actually removed and `Ok(false)`
-/// when it was already absent (idempotent no-op). An absent-classified error
-/// from either the get or the delete (the interface can vanish between the
-/// two, e.g. a concurrent teardown) counts as already absent. Real failures
-/// (e.g. permission errors) are returned as `Err`.
-pub fn delete_wireguard_interface(interface_name: &str) -> anyhow::Result<bool> {
+/// when it was already absent (idempotent no-op; logged at debug, not as a
+/// removal). An absent-classified error from either the get or the delete
+/// (the interface can vanish between the two, e.g. a concurrent teardown)
+/// counts as already absent. Real failures (e.g. permission errors) are
+/// returned as `Err`.
+pub fn delete_wireguard_interface(interface_name: &str, label: &str) -> anyhow::Result<bool> {
     let iface: InterfaceName = interface_name
         .parse()
         .map_err(|e| anyhow::anyhow!("invalid interface name: {e}"))?;
 
     match Device::get(&iface, Backend::default()).and_then(Device::delete) {
-        Ok(()) => Ok(true),
-        Err(e) if is_interface_absent_error(&e) => Ok(false),
+        Ok(()) => {
+            tracing::info!(interface = %interface_name, "{label} {interface_name} removed");
+            Ok(true)
+        }
+        Err(e) if is_interface_absent_error(&e) => {
+            tracing::debug!(
+                interface = %interface_name,
+                "{label} {interface_name} already absent, nothing to remove"
+            );
+            Ok(false)
+        }
         Err(e) => Err(anyhow::anyhow!(
-            "failed to remove wireguard interface {interface_name}: {e}"
+            "failed to remove {label} {interface_name}: {e}"
         )),
+    }
+}
+
+/// Best-effort removal of any same-named link via `ip link`, regardless of
+/// link type.
+///
+/// Deliberately a shell-out rather than [`delete_wireguard_interface`]: the
+/// `WireGuard` netlink family cannot see links of the wrong type or ones
+/// left partially created by a crash, while `ip link delete` reaps them all.
+/// Used by the create paths to clear stale interfaces before re-creating
+/// (avoiding "Address already assigned" errors).
+pub async fn remove_stale_link(interface_name: &str, label: &str) {
+    let check = tokio::process::Command::new("ip")
+        .args(["link", "show", interface_name])
+        .output()
+        .await;
+    if check.is_ok_and(|o| o.status.success()) {
+        tracing::info!(
+            interface = %interface_name,
+            "removing stale {label} {interface_name} before re-creation"
+        );
+        let _ = tokio::process::Command::new("ip")
+            .args(["link", "delete", interface_name])
+            .output()
+            .await;
     }
 }


### PR DESCRIPTION
Fixes #832

## Problem

`TunnelInterface::remove()` never removed anything: it applied an empty `DeviceUpdate`, which the `wireguard-control` kernel backend implements as create-or-update (`add_del(iface, true)` + empty config). The interface survived every tunnel delete/disable/provider switch with its private key and peer intact, while the unconditional "wireguard interface removed" log claimed success. The sibling inbound path had the opposite defect: `tear_down_server` swallowed every failure (including EPERM) as "interface absent?".

## Fix

- New shared module `wireguard_interface` with:
  - `delete_wireguard_interface(name, label)` — the crate's real removal path (`Device::get(...).and_then(Device::delete)`, netlink `DelLink`), returning whether an interface was actually removed and logging removed vs already-absent accordingly;
  - `is_interface_absent_error()` — classifies ENODEV / ENOENT / `NotFound` / `ConnectionRefused` (stale userspace control socket) from **either** the get or the delete as "nothing live to remove" (idempotent, covers the race where the interface vanishes between the two calls); real errors (e.g. EPERM) propagate;
  - `remove_stale_link(name, label)` — the previously-duplicated `ip link` stale-cleanup from `create()`/`ensure_server()`, documented as deliberately a shell-out because it reaps links the WireGuard netlink family cannot see.
- `TunnelInterface::remove()` and `InboundWgInterface::tear_down_server()` both delete through the shared path with the same error semantics — the divergence between the two implementations is gone.
- Inbound disable stays resilient: the service treats interface teardown as best-effort (warn + continue) so `enabled=false` always persists and reconcile can never resurrect a server the user disabled.
- `get_stats()`/`peer_stats()` no longer swallow every `Device::get` failure: absent still means "no stats/peers", real failures surface to callers (which log-and-continue or fail fast with the real cause).
- "removed" is only logged when a removal actually happened; new log lines interpolate the interface name per `.agents/logging.md`.

## Tests

- 6 unit tests for the absent-error classifier + an argument-validation test for the shared helper.
- 4 opt-in kernel round-trip tests (`#[ignore]`, run with `cargo test -p wardnetd -- --ignored kernel_`): create a real netlink interface with configured key (+peer for the tunnel case) and assert it is absent after `remove()` / `tear_down_server()`, plus both already-absent idempotent cases. They self-heal from previously leaked interfaces and skip gracefully on kernels without WireGuard support.
- New service test: disable persists `enabled=false` even when the interface teardown fails.

## Acceptance criteria from #832

- [x] `remove()` calls `Device::delete()`; the device is confirmed absent afterward via `Device::get`
- [x] Test exercises `remove()` against a real kernel WireGuard interface with key/peer, plus the already-absent idempotent case
- [x] "wireguard interface removed" only fires when removal actually happened
- [x] Coverage does not decrease (verified vs `main` baseline with `make coverage-daemon`)
- [x] No regression to `create()`'s stale-interface cleanup path (extracted verbatim into `remove_stale_link`, same commands and semantics)

`make check-daemon` (fmt, clippy `-D warnings`, full workspace tests) passes.

## Review notes

Two rounds of adversarial review ran on this branch; all confirmed findings are fixed in it (delete-time race classification, stale-socket `ECONNREFUSED`, disable-path resurrection, logging conventions, test/code dedup). Deliberately kept as-is: the `ip link` shell-outs in the create paths (replacing them with the netlink delete would regress crash recovery for genl-invisible links — now documented in the helper), and the inline blocking netlink calls (established pattern of these impls; teardown is cold-path).