### PR TITLE
fix(nftables): keep the zone_isolation jump rule from being reconciled away

### DIFF
--- a/source/daemon/crates/wardnetd/src/firewall_netlink.rs
+++ b/source/daemon/crates/wardnetd/src/firewall_netlink.rs
@@ -253,15 +253,25 @@ pub(crate) fn inbound_wg_iface_exact_value() -> Vec<u8> {
 }
 
 /// The device IP a zone rule is keyed on: the final `:`-delimited segment of a
-/// `wardnet:zone:<kind>:<ip>` comment. IPv4 only (no `:` in the address), which
-/// matches the daemon's IPv4-only device model.
-fn zone_rule_ip(comment: &str) -> Option<&str> {
-    comment.starts_with(ZONE_COMMENT_PREFIX).then(|| {
-        comment
-            .rsplit(':')
-            .next()
-            .expect("rsplit always yields at least one element")
-    })
+/// `wardnet:zone:<kind>:<ip>` comment, returned only when that segment is a valid
+/// IPv4 literal. IPv4 only (no `:` in the address), which matches the daemon's
+/// IPv4-only device model.
+///
+/// The IP check is what keeps the per-device namespace disjoint from the
+/// zone-subsystem control rules that share `ZONE_COMMENT_PREFIX` but carry no
+/// device IP — the base-forward jump `wardnet:zone:isojump` and the isolation
+/// ACCEPT rules `wardnet:zone:allow`. Without it, `isojump` reads as a device
+/// "IP" and the orphan sweep deletes the FORWARD→`zone_isolation` jump on every
+/// boot, silently disabling all L3 zone isolation.
+pub(crate) fn zone_rule_ip(comment: &str) -> Option<&str> {
+    if !comment.starts_with(ZONE_COMMENT_PREFIX) {
+        return None;
+    }
+    let tail = comment
+        .rsplit(':')
+        .next()
+        .expect("rsplit always yields at least one element");
+    tail.parse::<Ipv4Addr>().is_ok().then_some(tail)
 }
 
 /// Parse a `"a.b.c.d/prefix"` string into an [`IpNetwork`] for the network
@@ -714,13 +724,15 @@ impl FirewallManager for NetlinkFirewallManager {
     }
 
     async fn remove_zone_rules(&self, device_ip: &str) -> anyhow::Result<()> {
-        let suffix = format!(":{device_ip}");
+        let key = device_ip.to_owned();
         let removed = run_blocking(move || {
             let mut all = Vec::new();
             for chain_name in [FORWARD, INPUT] {
-                let r = delete_rules_where(chain_name, |c| {
-                    c.starts_with(ZONE_COMMENT_PREFIX) && c.ends_with(&suffix)
-                })?;
+                // Match on the parsed device-IP key rather than a raw `:<ip>`
+                // suffix: `zone_rule_ip` rejects any comment whose tail isn't a
+                // valid IPv4, so a control rule like `wardnet:zone:isojump` can
+                // never be selected here even if `key` were "isojump".
+                let r = delete_rules_where(chain_name, |c| zone_rule_ip(c) == Some(key.as_str()))?;
                 all.extend(r);
             }
             Ok(all)

--- a/source/daemon/crates/wardnetd/src/tests/firewall_netlink.rs
+++ b/source/daemon/crates/wardnetd/src/tests/firewall_netlink.rs
@@ -6,7 +6,7 @@
 //! UDATA TLV codec that drives restart-survivable rule identification.
 
 use crate::firewall_netlink::{
-    IFNAMSIZ, comment_udata, inbound_wg_iface_exact_value, parse_comment_udata,
+    IFNAMSIZ, comment_udata, inbound_wg_iface_exact_value, parse_comment_udata, zone_rule_ip,
 };
 
 #[test]
@@ -67,6 +67,77 @@ fn parse_comment_udata_returns_none_when_no_comment_tlv() {
     // Only a non-comment TLV present.
     let data = [7u8, 1, 0x42];
     assert_eq!(parse_comment_udata(&data), None);
+}
+
+#[test]
+fn zone_rule_ip_keys_device_gates_on_their_ipv4() {
+    // The per-device egress and admin-UI gates are IP-keyed; their trailing
+    // segment is a real device IP and must decode as one so orphan cleanup and
+    // re-keying keep working.
+    assert_eq!(
+        zone_rule_ip("wardnet:zone:egress:192.168.1.10"),
+        Some("192.168.1.10")
+    );
+    assert_eq!(
+        zone_rule_ip("wardnet:zone:adminui:10.0.0.5"),
+        Some("10.0.0.5")
+    );
+}
+
+#[test]
+fn zone_rule_ip_rejects_zone_control_comments() {
+    // The base-forward jump and the isolation ACCEPT rules share the zone
+    // comment prefix but carry no device IP. Treating their trailing segment as
+    // an "IP" is exactly what let orphan cleanup delete the jump rule (and, with
+    // it, silently disable all L3 zone isolation for the boot).
+    assert_eq!(zone_rule_ip("wardnet:zone:isojump"), None);
+    assert_eq!(zone_rule_ip("wardnet:zone:allow"), None);
+    // A truncated/empty tail is not an IP either.
+    assert_eq!(zone_rule_ip("wardnet:zone:"), None);
+    assert_eq!(zone_rule_ip("wardnet:zone:not-an-ip"), None);
+}
+
+#[test]
+fn zone_rule_ip_ignores_foreign_comment_namespaces() {
+    // Comments outside `wardnet:zone:` are never device zone rules, even when
+    // their trailing segment happens to be an IP.
+    assert_eq!(zone_rule_ip("wardnet:inbound-wg:listen"), None);
+    assert_eq!(zone_rule_ip("wardnet:dns:192.168.1.100"), None);
+    assert_eq!(zone_rule_ip("wardnet:wg_ward0"), None);
+}
+
+#[test]
+fn isojump_only_table_produces_no_orphans_and_survives_removal() {
+    // Regression for the startup collision: right after `routing.reconcile()`
+    // installs the FORWARD→zone_isolation jump but before any device rule
+    // exists, the wardnet table's FORWARD/INPUT comments are just the jump's.
+    // `list_zone_rule_ips` and `remove_zone_rules` both key on `zone_rule_ip`, so
+    // model that state through the same gate the socket layer uses.
+    let forward_input_comments = ["wardnet:zone:isojump"];
+
+    // `list_zone_rule_ips` derives its orphan candidates via `zone_rule_ip`; the
+    // control jump must not surface as a device IP, or reconcile would delete it.
+    let orphan_candidates: Vec<&str> = forward_input_comments
+        .iter()
+        .filter_map(|c| zone_rule_ip(c))
+        .collect();
+    assert!(
+        orphan_candidates.is_empty(),
+        "isojump control rule must not be listed as a device IP: {orphan_candidates:?}"
+    );
+
+    // `remove_zone_rules(device_ip)` selects rules where `zone_rule_ip == ip`, so
+    // no reachable device_ip — including the "isojump" literal the old suffix
+    // match keyed on — can ever match the jump rule's comment.
+    for device_ip in ["isojump", "192.168.1.10", "10.0.0.1"] {
+        let would_delete = forward_input_comments
+            .iter()
+            .any(|c| zone_rule_ip(c) == Some(device_ip));
+        assert!(
+            !would_delete,
+            "remove_zone_rules({device_ip}) must not match the isojump jump rule"
+        );
+    }
 }
 
 #[test]


### PR DESCRIPTION
## Summary

The `FORWARD → zone_isolation` jump rule (comment `wardnet:zone:isojump`) was being installed by `routing.reconcile()` and then deleted moments later by `zone_enforcement.reconcile()` on every daemon startup.

The jump rule's comment lives under the shared per-device zone prefix `wardnet:zone:`, and `zone_rule_ip` returned the trailing `:`-delimited segment (`"isojump"`) without checking that it was actually an address. The orphan sweep in `zone_enforcement::reconcile` therefore saw `"isojump"` as a device-keyed rule, found no matching device, and had `remove_zone_rules` delete it as a stale orphan (its `:isojump` suffix match hit the jump rule's own comment).

Net effect: the base FORWARD chain was left with no jump into `zone_isolation`, so all Network-Zone L3 isolation — cross-subnet zone denies and member-isolation peer drops — was silently unenforced for the whole boot, with both reconcile passes reporting success and no error surfaced.

## Fix

- `zone_rule_ip` now only returns the trailing segment when it parses as a valid `Ipv4Addr`, so control comments like `isojump` (and the isolation `allow` rules) are never mistaken for device-keyed rules. This closes the `list_zone_rule_ips` path.
- `remove_zone_rules` now keys on that same parsed IP (`zone_rule_ip(c) == Some(ip)`) instead of a raw `:<ip>` suffix match, so a control comment can never be selected for deletion even on a direct call.

The per-device egress (`wardnet:zone:egress:`) and admin-UI (`wardnet:zone:adminui:`) gates stay IP-keyed and are unaffected. Startup ordering in `main.rs` is unchanged.

## Tests

Added regression tests over the shared `zone_rule_ip` gate (the actual collision site):

- device egress/admin-UI comments still decode to their IPv4 key;
- `isojump`, `allow`, empty, and non-IP tails all resolve to `None`;
- foreign comment namespaces are ignored even when their tail is an IP;
- an `isojump`-only table produces zero orphan candidates and survives a `remove_zone_rules` pass for any device IP (including the `"isojump"` literal the old suffix match keyed on).

`make check-daemon` passes locally (fmt, clippy `--all-targets -D warnings`, full workspace test suite).

> Note: the end-to-end "real nftables table across a full startup reconcile" check belongs to the e2e harness — the existing `zone_enforcement` unit mock returns a configured IP set directly rather than parsing real comments, which is why this collision wasn't caught there.

Closes #828