### PR TITLE
fix(openapi): align spec with runtime nullability, auth schemes, and tags

### DIFF
--- a/.agents/code-conventions.md
+++ b/.agents/code-conventions.md
@@ -52,7 +52,10 @@
 - Every endpoint handler carries a `#[utoipa::path(...)]` attribute with `method`, `path`, `tag`, `description`, `request_body`, `responses`, `security`.
 - Route modules expose `pub fn register(router: OpenApiRouter<AppState>) -> OpenApiRouter<AppState>` that attaches routes via `utoipa_axum::routes!`.
 - DTOs in `wardnet-common::api` derive `utoipa::ToSchema`.
-- `#[schema(value_type = String)]` required for `Ipv4Addr` / `IpAddr` fields — utoipa 5.4 doesn't ship `ToSchema` impls for them.
+- `Ipv4Addr` / `IpAddr` fields need a manual `value_type` annotation — utoipa doesn't ship `ToSchema` impls for them. Match the annotation to the field's shape, or the published schema lies about nullability:
+  - plain field → `#[schema(value_type = String)]`
+  - `Option<...>` field → `#[schema(value_type = Option<String>)]`
+  - `Option<...>` **response** field (always serialized, as `null` when unset) → add `required`: `#[schema(required, value_type = Option<String>)]`
 
 ## SQL query strings
 

--- a/.agents/code-conventions.md
+++ b/.agents/code-conventions.md
@@ -49,7 +49,8 @@
 
 ## OpenAPI annotations (daemon)
 
-- Every endpoint handler carries a `#[utoipa::path(...)]` attribute with `method`, `path`, `tag`, `description`, `request_body`, `responses`, `security`.
+- Every endpoint handler carries a `#[utoipa::path(...)]` attribute with `method`, `path`, `tag`, `description`, `request_body`, `responses`.
+- Authentication is declared once, document-level: `ApiDoc`'s `security(("session_cookie" = []), ("bearer_auth" = []))` default applies to every operation. Handlers do **not** repeat it — only deliberately unauthenticated endpoints add `security(())` to opt out (a forgotten annotation therefore documents the endpoint as authenticated, the safe direction).
 - Route modules expose `pub fn register(router: OpenApiRouter<AppState>) -> OpenApiRouter<AppState>` that attaches routes via `utoipa_axum::routes!`.
 - DTOs in `wardnet-common::api` derive `utoipa::ToSchema`.
 - `Ipv4Addr` / `IpAddr` fields need a manual `value_type` annotation — utoipa doesn't ship `ToSchema` impls for them. Match the annotation to the field's shape, or the published schema lies about nullability:

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -3002,7 +3002,10 @@
         },
         "security": [
           {
-            "admin_auth": []
+            "session_cookie": []
+          },
+          {
+            "bearer_auth": []
           }
         ]
       },
@@ -3087,7 +3090,10 @@
         },
         "security": [
           {
-            "admin_auth": []
+            "session_cookie": []
+          },
+          {
+            "bearer_auth": []
           }
         ]
       }
@@ -14506,7 +14512,7 @@
     "/api/network/zones/exceptions": {
       "get": {
         "tags": [
-          "zone_exceptions"
+          "zone-exceptions"
         ],
         "description": "List every cross-zone exception. Admin only.",
         "operationId": "list_exceptions",
@@ -14629,7 +14635,7 @@
       },
       "post": {
         "tags": [
-          "zone_exceptions"
+          "zone-exceptions"
         ],
         "description": "Create a cross-zone exception. Both endpoints must exist and differ; a custom port list must be non-empty with valid ranges. Admin only.",
         "operationId": "create_exception",
@@ -14796,7 +14802,7 @@
     "/api/network/zones/exceptions/{id}": {
       "get": {
         "tags": [
-          "zone_exceptions"
+          "zone-exceptions"
         ],
         "description": "Fetch a single cross-zone exception. Admin only.",
         "operationId": "get_exception",
@@ -14963,7 +14969,7 @@
       },
       "put": {
         "tags": [
-          "zone_exceptions"
+          "zone-exceptions"
         ],
         "description": "Partially update a cross-zone exception. Every field is optional; the resolved exception is re-validated. Admin only.",
         "operationId": "update_exception",
@@ -15172,7 +15178,7 @@
       },
       "delete": {
         "tags": [
-          "zone_exceptions"
+          "zone-exceptions"
         ],
         "description": "Delete a cross-zone exception. Admin only.",
         "operationId": "delete_exception",
@@ -24009,15 +24015,17 @@
         "description": "Response for POST /api/network/dhcp-self-probe.\n\nThe wizard's primary-mode step 3 uses this to verify Wardnet now\nowns LAN DHCP after the operator disabled it on their router:\n\n- `wardnet_responded == true && foreign_responded == false` → ready\n  to advance.\n- `foreign_responded == true` → re-show the disable-DHCP guide;\n  `foreign_server_ip` lets the wizard call out which device is\n  still answering.",
         "required": [
           "wardnet_responded",
-          "foreign_responded",
-          "foreign_server_ip"
+          "foreign_responded"
         ],
         "properties": {
           "foreign_responded": {
             "type": "boolean"
           },
           "foreign_server_ip": {
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "wardnet_responded": {
             "type": "boolean"
@@ -24079,9 +24087,6 @@
       "DiscoverGatewayMacRequest": {
         "type": "object",
         "description": "Request body for POST /api/network/discover-gateway-mac.\n\nAll fields optional. If `mac` is provided the daemon skips the ARP\nprobe and just persists the value (validated). Otherwise it probes\nthe gateway IP from `GET /api/network/status`; `target_ip` lets a\ncaller override that for testing or when the gateway differs from\nthe kernel's default route.",
-        "required": [
-          "target_ip"
-        ],
         "properties": {
           "mac": {
             "type": [
@@ -24090,7 +24095,10 @@
             ]
           },
           "target_ip": {
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           }
         }
       },
@@ -25606,7 +25614,6 @@
         "required": [
           "interface",
           "ip",
-          "gateway",
           "dhcp_source"
         ],
         "properties": {
@@ -25614,7 +25621,10 @@
             "$ref": "#/components/schemas/DhcpSource"
           },
           "gateway": {
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "interface": {
             "type": "string"
@@ -28307,16 +28317,36 @@
       "description": "Unauthenticated daemon info"
     },
     {
+      "name": "health",
+      "description": "Unauthenticated liveness/readiness probe"
+    },
+    {
       "name": "devices",
       "description": "Device discovery and routing"
+    },
+    {
+      "name": "network",
+      "description": "LAN interface status and gateway discovery"
     },
     {
       "name": "network_zones",
       "description": "Network Zones: device policy buckets"
     },
     {
+      "name": "zone-exceptions",
+      "description": "Cross-zone exceptions: admin-granted allowances between isolated zones"
+    },
+    {
+      "name": "rule-requests",
+      "description": "Device-initiated firewall rule requests and admin decisions"
+    },
+    {
       "name": "tunnels",
       "description": "WireGuard tunnel lifecycle"
+    },
+    {
+      "name": "inbound-wg",
+      "description": "Inbound WireGuard remote-access server and peers"
     },
     {
       "name": "providers",
@@ -28357,6 +28387,10 @@
     {
       "name": "push",
       "description": "Web Push subscriptions and VAPID key"
+    },
+    {
+      "name": "backup",
+      "description": "Encrypted configuration export / import and snapshots"
     }
   ]
 }

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -114,15 +114,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "session_cookie": []
-          },
-          {
-            "bearer_auth": []
-          }
-        ]
+        }
       }
     },
     "/api/backup/export": {
@@ -286,15 +278,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "session_cookie": []
-          },
-          {
-            "bearer_auth": []
-          }
-        ]
+        }
       }
     },
     "/api/backup/import/apply": {
@@ -453,15 +437,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "session_cookie": []
-          },
-          {
-            "bearer_auth": []
-          }
-        ]
+        }
       }
     },
     "/api/backup/import/preview": {
@@ -621,15 +597,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "session_cookie": []
-          },
-          {
-            "bearer_auth": []
-          }
-        ]
+        }
       }
     },
     "/api/backup/snapshots": {
@@ -746,15 +714,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "session_cookie": []
-          },
-          {
-            "bearer_auth": []
-          }
-        ]
+        }
       }
     },
     "/api/backup/status": {
@@ -871,15 +831,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "session_cookie": []
-          },
-          {
-            "bearer_auth": []
-          }
-        ]
+        }
       }
     },
     "/api/ddns": {
@@ -989,15 +941,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "session_cookie": []
-          },
-          {
-            "bearer_auth": []
-          }
-        ]
+        }
       }
     },
     "/api/ddns/check": {
@@ -1125,15 +1069,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "session_cookie": []
-          },
-          {
-            "bearer_auth": []
-          }
-        ]
+        }
       }
     },
     "/api/ddns/cloudflare": {
@@ -1292,15 +1228,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "session_cookie": []
-          },
-          {
-            "bearer_auth": []
-          }
-        ]
+        }
       }
     },
     "/api/ddns/enroll": {
@@ -1452,15 +1380,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "session_cookie": []
-          },
-          {
-            "bearer_auth": []
-          }
-        ]
+        }
       }
     },
     "/api/ddns/enrollment-code": {
@@ -1612,15 +1532,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "session_cookie": []
-          },
-          {
-            "bearer_auth": []
-          }
-        ]
+        }
       }
     },
     "/api/ddns/register": {
@@ -1779,15 +1691,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "session_cookie": []
-          },
-          {
-            "bearer_auth": []
-          }
-        ]
+        }
       }
     },
     "/api/ddns/resolution-check": {
@@ -1904,15 +1808,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "session_cookie": []
-          },
-          {
-            "bearer_auth": []
-          }
-        ]
+        }
       }
     },
     "/api/ddns/status": {
@@ -2029,15 +1925,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "session_cookie": []
-          },
-          {
-            "bearer_auth": []
-          }
-        ]
+        }
       }
     },
     "/api/devices": {
@@ -2154,15 +2042,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "session_cookie": []
-          },
-          {
-            "bearer_auth": []
-          }
-        ]
+        }
       }
     },
     "/api/devices/me": {
@@ -2720,15 +2600,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "session_cookie": []
-          },
-          {
-            "bearer_auth": []
-          }
-        ]
+        }
       },
       "put": {
         "tags": [
@@ -2929,15 +2801,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "session_cookie": []
-          },
-          {
-            "bearer_auth": []
-          }
-        ]
+        }
       }
     },
     "/api/devices/{id}/dns-capture": {
@@ -2999,15 +2863,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "session_cookie": []
-          },
-          {
-            "bearer_auth": []
-          }
-        ]
+        }
       },
       "patch": {
         "tags": [
@@ -3087,15 +2943,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "session_cookie": []
-          },
-          {
-            "bearer_auth": []
-          }
-        ]
+        }
       }
     },
     "/api/devices/{id}/zone": {
@@ -3298,15 +3146,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "session_cookie": []
-          },
-          {
-            "bearer_auth": []
-          }
-        ]
+        }
       }
     },
     "/api/dhcp/config": {
@@ -3423,15 +3263,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "session_cookie": []
-          },
-          {
-            "bearer_auth": []
-          }
-        ]
+        }
       },
       "put": {
         "tags": [
@@ -3588,15 +3420,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "session_cookie": []
-          },
-          {
-            "bearer_auth": []
-          }
-        ]
+        }
       }
     },
     "/api/dhcp/config/preview": {
@@ -3755,15 +3579,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "session_cookie": []
-          },
-          {
-            "bearer_auth": []
-          }
-        ]
+        }
       }
     },
     "/api/dhcp/config/toggle": {
@@ -3922,15 +3738,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "session_cookie": []
-          },
-          {
-            "bearer_auth": []
-          }
-        ]
+        }
       }
     },
     "/api/dhcp/leases": {
@@ -4047,15 +3855,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "session_cookie": []
-          },
-          {
-            "bearer_auth": []
-          }
-        ]
+        }
       }
     },
     "/api/dhcp/leases/{id}": {
@@ -4216,15 +4016,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "session_cookie": []
-          },
-          {
-            "bearer_auth": []
-          }
-        ]
+        }
       }
     },
     "/api/dhcp/reservations": {
@@ -4341,15 +4133,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "session_cookie": []
-          },
-          {
-            "bearer_auth": []
-          }
-        ]
+        }
       },
       "post": {
         "tags": [
@@ -4506,15 +4290,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "session_cookie": []
-          },
-          {
-            "bearer_auth": []
-          }
-        ]
+        }
       }
     },
     "/api/dhcp/reservations/{id}": {
@@ -4675,15 +4451,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "session_cookie": []
-          },
-          {
-            "bearer_auth": []
-          }
-        ]
+        }
       }
     },
     "/api/dhcp/status": {
@@ -4800,15 +4568,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "session_cookie": []
-          },
-          {
-            "bearer_auth": []
-          }
-        ]
+        }
       }
     },
     "/api/dns/cache/flush": {
@@ -4925,15 +4685,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "session_cookie": []
-          },
-          {
-            "bearer_auth": []
-          }
-        ]
+        }
       }
     },
     "/api/dns/config": {
@@ -5050,15 +4802,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "session_cookie": []
-          },
-          {
-            "bearer_auth": []
-          }
-        ]
+        }
       },
       "put": {
         "tags": [
@@ -5215,15 +4959,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "session_cookie": []
-          },
-          {
-            "bearer_auth": []
-          }
-        ]
+        }
       }
     },
     "/api/dns/config/toggle": {
@@ -5382,15 +5118,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "session_cookie": []
-          },
-          {
-            "bearer_auth": []
-          }
-        ]
+        }
       }
     },
     "/api/dns/filter/config": {
@@ -5507,15 +5235,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "session_cookie": []
-          },
-          {
-            "bearer_auth": []
-          }
-        ]
+        }
       },
       "put": {
         "tags": [
@@ -5704,15 +5424,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "session_cookie": []
-          },
-          {
-            "bearer_auth": []
-          }
-        ]
+        }
       }
     },
     "/api/dns/filter/devices": {
@@ -5843,15 +5555,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "session_cookie": []
-          },
-          {
-            "bearer_auth": []
-          }
-        ]
+        }
       }
     },
     "/api/dns/filter/devices/{device_id}": {
@@ -5980,15 +5684,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "session_cookie": []
-          },
-          {
-            "bearer_auth": []
-          }
-        ]
+        }
       },
       "put": {
         "tags": [
@@ -6189,15 +5885,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "session_cookie": []
-          },
-          {
-            "bearer_auth": []
-          }
-        ]
+        }
       }
     },
     "/api/dns/filter/profiles": {
@@ -6314,15 +6002,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "session_cookie": []
-          },
-          {
-            "bearer_auth": []
-          }
-        ]
+        }
       },
       "post": {
         "tags": [
@@ -6479,15 +6159,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "session_cookie": []
-          },
-          {
-            "bearer_auth": []
-          }
-        ]
+        }
       }
     },
     "/api/dns/filter/profiles/{profile_id}": {
@@ -6648,15 +6320,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "session_cookie": []
-          },
-          {
-            "bearer_auth": []
-          }
-        ]
+        }
       },
       "put": {
         "tags": [
@@ -6857,15 +6521,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "session_cookie": []
-          },
-          {
-            "bearer_auth": []
-          }
-        ]
+        }
       },
       "delete": {
         "tags": [
@@ -7027,15 +6683,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "session_cookie": []
-          },
-          {
-            "bearer_auth": []
-          }
-        ]
+        }
       }
     },
     "/api/dns/filter/profiles/{profile_id}/allowlist": {
@@ -7196,15 +6844,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "session_cookie": []
-          },
-          {
-            "bearer_auth": []
-          }
-        ]
+        }
       },
       "post": {
         "tags": [
@@ -7405,15 +7045,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "session_cookie": []
-          },
-          {
-            "bearer_auth": []
-          }
-        ]
+        }
       }
     },
     "/api/dns/filter/profiles/{profile_id}/allowlist/{id}": {
@@ -7584,15 +7216,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "session_cookie": []
-          },
-          {
-            "bearer_auth": []
-          }
-        ]
+        }
       }
     },
     "/api/dns/filter/profiles/{profile_id}/blocklists": {
@@ -7753,15 +7377,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "session_cookie": []
-          },
-          {
-            "bearer_auth": []
-          }
-        ]
+        }
       },
       "post": {
         "tags": [
@@ -7962,15 +7578,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "session_cookie": []
-          },
-          {
-            "bearer_auth": []
-          }
-        ]
+        }
       }
     },
     "/api/dns/filter/profiles/{profile_id}/blocklists/{id}": {
@@ -8183,15 +7791,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "session_cookie": []
-          },
-          {
-            "bearer_auth": []
-          }
-        ]
+        }
       },
       "delete": {
         "tags": [
@@ -8360,15 +7960,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "session_cookie": []
-          },
-          {
-            "bearer_auth": []
-          }
-        ]
+        }
       }
     },
     "/api/dns/filter/profiles/{profile_id}/blocklists/{id}/refresh": {
@@ -8539,15 +8131,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "session_cookie": []
-          },
-          {
-            "bearer_auth": []
-          }
-        ]
+        }
       }
     },
     "/api/dns/filter/profiles/{profile_id}/rules": {
@@ -8708,15 +8292,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "session_cookie": []
-          },
-          {
-            "bearer_auth": []
-          }
-        ]
+        }
       },
       "post": {
         "tags": [
@@ -8917,15 +8493,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "session_cookie": []
-          },
-          {
-            "bearer_auth": []
-          }
-        ]
+        }
       }
     },
     "/api/dns/filter/profiles/{profile_id}/rules/{id}": {
@@ -9138,15 +8706,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "session_cookie": []
-          },
-          {
-            "bearer_auth": []
-          }
-        ]
+        }
       },
       "delete": {
         "tags": [
@@ -9315,15 +8875,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "session_cookie": []
-          },
-          {
-            "bearer_auth": []
-          }
-        ]
+        }
       }
     },
     "/api/dns/local/forwarding": {
@@ -9440,15 +8992,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "session_cookie": []
-          },
-          {
-            "bearer_auth": []
-          }
-        ]
+        }
       },
       "post": {
         "tags": [
@@ -9605,15 +9149,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "session_cookie": []
-          },
-          {
-            "bearer_auth": []
-          }
-        ]
+        }
       }
     },
     "/api/dns/local/forwarding/{id}": {
@@ -9774,15 +9310,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "session_cookie": []
-          },
-          {
-            "bearer_auth": []
-          }
-        ]
+        }
       },
       "put": {
         "tags": [
@@ -9983,15 +9511,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "session_cookie": []
-          },
-          {
-            "bearer_auth": []
-          }
-        ]
+        }
       },
       "delete": {
         "tags": [
@@ -10150,15 +9670,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "session_cookie": []
-          },
-          {
-            "bearer_auth": []
-          }
-        ]
+        }
       }
     },
     "/api/dns/local/records": {
@@ -10275,15 +9787,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "session_cookie": []
-          },
-          {
-            "bearer_auth": []
-          }
-        ]
+        }
       },
       "post": {
         "tags": [
@@ -10472,15 +9976,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "session_cookie": []
-          },
-          {
-            "bearer_auth": []
-          }
-        ]
+        }
       }
     },
     "/api/dns/local/records/{id}": {
@@ -10641,15 +10137,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "session_cookie": []
-          },
-          {
-            "bearer_auth": []
-          }
-        ]
+        }
       },
       "put": {
         "tags": [
@@ -10850,15 +10338,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "session_cookie": []
-          },
-          {
-            "bearer_auth": []
-          }
-        ]
+        }
       },
       "delete": {
         "tags": [
@@ -11017,15 +10497,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "session_cookie": []
-          },
-          {
-            "bearer_auth": []
-          }
-        ]
+        }
       }
     },
     "/api/dns/local/zones": {
@@ -11142,15 +10614,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "session_cookie": []
-          },
-          {
-            "bearer_auth": []
-          }
-        ]
+        }
       },
       "post": {
         "tags": [
@@ -11307,15 +10771,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "session_cookie": []
-          },
-          {
-            "bearer_auth": []
-          }
-        ]
+        }
       }
     },
     "/api/dns/local/zones/{id}": {
@@ -11476,15 +10932,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "session_cookie": []
-          },
-          {
-            "bearer_auth": []
-          }
-        ]
+        }
       },
       "put": {
         "tags": [
@@ -11685,15 +11133,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "session_cookie": []
-          },
-          {
-            "bearer_auth": []
-          }
-        ]
+        }
       },
       "delete": {
         "tags": [
@@ -11852,15 +11292,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "session_cookie": []
-          },
-          {
-            "bearer_auth": []
-          }
-        ]
+        }
       }
     },
     "/api/dns/local/zones/{id}/records": {
@@ -12021,15 +11453,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "session_cookie": []
-          },
-          {
-            "bearer_auth": []
-          }
-        ]
+        }
       }
     },
     "/api/dns/log": {
@@ -12256,15 +11680,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "session_cookie": []
-          },
-          {
-            "bearer_auth": []
-          }
-        ]
+        }
       }
     },
     "/api/dns/status": {
@@ -12381,15 +11797,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "session_cookie": []
-          },
-          {
-            "bearer_auth": []
-          }
-        ]
+        }
       }
     },
     "/api/inbound-wg/config": {
@@ -12506,15 +11914,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "session_cookie": []
-          },
-          {
-            "bearer_auth": []
-          }
-        ]
+        }
       },
       "put": {
         "tags": [
@@ -12639,15 +12039,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "session_cookie": []
-          },
-          {
-            "bearer_auth": []
-          }
-        ]
+        }
       }
     },
     "/api/inbound-wg/peers": {
@@ -12764,15 +12156,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "session_cookie": []
-          },
-          {
-            "bearer_auth": []
-          }
-        ]
+        }
       },
       "post": {
         "tags": [
@@ -12961,15 +12345,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "session_cookie": []
-          },
-          {
-            "bearer_auth": []
-          }
-        ]
+        }
       }
     },
     "/api/inbound-wg/peers/{id}": {
@@ -13123,15 +12499,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "session_cookie": []
-          },
-          {
-            "bearer_auth": []
-          }
-        ]
+        }
       },
       "patch": {
         "tags": [
@@ -13300,15 +12668,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "session_cookie": []
-          },
-          {
-            "bearer_auth": []
-          }
-        ]
+        }
       }
     },
     "/api/info": {
@@ -13503,15 +12863,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "session_cookie": []
-          },
-          {
-            "bearer_auth": []
-          }
-        ]
+        }
       }
     },
     "/api/network/dhcp-self-probe": {
@@ -13628,15 +12980,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "session_cookie": []
-          },
-          {
-            "bearer_auth": []
-          }
-        ]
+        }
       }
     },
     "/api/network/discover-gateway-mac": {
@@ -13783,15 +13127,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "session_cookie": []
-          },
-          {
-            "bearer_auth": []
-          }
-        ]
+        }
       }
     },
     "/api/network/quarantine-new-devices": {
@@ -13908,15 +13244,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "session_cookie": []
-          },
-          {
-            "bearer_auth": []
-          }
-        ]
+        }
       },
       "put": {
         "tags": [
@@ -14073,15 +13401,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "session_cookie": []
-          },
-          {
-            "bearer_auth": []
-          }
-        ]
+        }
       }
     },
     "/api/network/status": {
@@ -14198,15 +13518,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "session_cookie": []
-          },
-          {
-            "bearer_auth": []
-          }
-        ]
+        }
       }
     },
     "/api/network/zones": {
@@ -14323,15 +13635,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "session_cookie": []
-          },
-          {
-            "bearer_auth": []
-          }
-        ]
+        }
       },
       "post": {
         "tags": [
@@ -14498,15 +13802,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "session_cookie": []
-          },
-          {
-            "bearer_auth": []
-          }
-        ]
+        }
       }
     },
     "/api/network/zones/exceptions": {
@@ -14623,15 +13919,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "session_cookie": []
-          },
-          {
-            "bearer_auth": []
-          }
-        ]
+        }
       },
       "post": {
         "tags": [
@@ -14788,15 +14076,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "session_cookie": []
-          },
-          {
-            "bearer_auth": []
-          }
-        ]
+        }
       }
     },
     "/api/network/zones/exceptions/{id}": {
@@ -14957,15 +14237,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "session_cookie": []
-          },
-          {
-            "bearer_auth": []
-          }
-        ]
+        }
       },
       "put": {
         "tags": [
@@ -15166,15 +14438,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "session_cookie": []
-          },
-          {
-            "bearer_auth": []
-          }
-        ]
+        }
       },
       "delete": {
         "tags": [
@@ -15333,15 +14597,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "session_cookie": []
-          },
-          {
-            "bearer_auth": []
-          }
-        ]
+        }
       }
     },
     "/api/network/zones/{id}": {
@@ -15502,15 +14758,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "session_cookie": []
-          },
-          {
-            "bearer_auth": []
-          }
-        ]
+        }
       },
       "put": {
         "tags": [
@@ -15721,15 +14969,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "session_cookie": []
-          },
-          {
-            "bearer_auth": []
-          }
-        ]
+        }
       },
       "delete": {
         "tags": [
@@ -15898,15 +15138,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "session_cookie": []
-          },
-          {
-            "bearer_auth": []
-          }
-        ]
+        }
       }
     },
     "/api/providers": {
@@ -16023,15 +15255,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "session_cookie": []
-          },
-          {
-            "bearer_auth": []
-          }
-        ]
+        }
       }
     },
     "/api/providers/{id}/countries": {
@@ -16191,15 +15415,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "session_cookie": []
-          },
-          {
-            "bearer_auth": []
-          }
-        ]
+        }
       }
     },
     "/api/providers/{id}/servers": {
@@ -16401,15 +15617,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "session_cookie": []
-          },
-          {
-            "bearer_auth": []
-          }
-        ]
+        }
       }
     },
     "/api/providers/{id}/setup": {
@@ -16611,15 +15819,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "session_cookie": []
-          },
-          {
-            "bearer_auth": []
-          }
-        ]
+        }
       }
     },
     "/api/providers/{id}/validate": {
@@ -16821,15 +16021,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "session_cookie": []
-          },
-          {
-            "bearer_auth": []
-          }
-        ]
+        }
       }
     },
     "/api/push/notifications": {
@@ -16940,15 +16132,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "session_cookie": []
-          },
-          {
-            "bearer_auth": []
-          }
-        ]
+        }
       },
       "delete": {
         "tags": [
@@ -17041,15 +16225,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "session_cookie": []
-          },
-          {
-            "bearer_auth": []
-          }
-        ]
+        }
       }
     },
     "/api/push/subscriptions": {
@@ -17319,15 +16495,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "session_cookie": []
-          },
-          {
-            "bearer_auth": []
-          }
-        ]
+        }
       }
     },
     "/api/rule-requests/{id}": {
@@ -17529,15 +16697,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "session_cookie": []
-          },
-          {
-            "bearer_auth": []
-          }
-        ]
+        }
       }
     },
     "/api/setup": {
@@ -17738,15 +16898,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "session_cookie": []
-          },
-          {
-            "bearer_auth": []
-          }
-        ]
+        }
       }
     },
     "/api/setup/status": {
@@ -17964,15 +17116,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "session_cookie": []
-          },
-          {
-            "bearer_auth": []
-          }
-        ]
+        }
       }
     },
     "/api/stats/top": {
@@ -18148,15 +17292,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "session_cookie": []
-          },
-          {
-            "bearer_auth": []
-          }
-        ]
+        }
       }
     },
     "/api/system/default-policy": {
@@ -18273,15 +17409,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "session_cookie": []
-          },
-          {
-            "bearer_auth": []
-          }
-        ]
+        }
       },
       "put": {
         "tags": [
@@ -18416,15 +17544,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "session_cookie": []
-          },
-          {
-            "bearer_auth": []
-          }
-        ]
+        }
       }
     },
     "/api/system/errors": {
@@ -18541,15 +17661,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "session_cookie": []
-          },
-          {
-            "bearer_auth": []
-          }
-        ]
+        }
       }
     },
     "/api/system/logs/download": {
@@ -18671,15 +17783,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "session_cookie": []
-          },
-          {
-            "bearer_auth": []
-          }
-        ]
+        }
       }
     },
     "/api/system/reboot": {
@@ -18790,15 +17894,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "session_cookie": []
-          },
-          {
-            "bearer_auth": []
-          }
-        ]
+        }
       }
     },
     "/api/system/restart": {
@@ -18909,15 +18005,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "session_cookie": []
-          },
-          {
-            "bearer_auth": []
-          }
-        ]
+        }
       }
     },
     "/api/system/shutdown": {
@@ -19028,15 +18116,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "session_cookie": []
-          },
-          {
-            "bearer_auth": []
-          }
-        ]
+        }
       }
     },
     "/api/system/shutdown/acknowledge": {
@@ -19147,15 +18227,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "session_cookie": []
-          },
-          {
-            "bearer_auth": []
-          }
-        ]
+        }
       }
     },
     "/api/system/status": {
@@ -19272,15 +18344,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "session_cookie": []
-          },
-          {
-            "bearer_auth": []
-          }
-        ]
+        }
       }
     },
     "/api/tls/status": {
@@ -19397,15 +18461,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "session_cookie": []
-          },
-          {
-            "bearer_auth": []
-          }
-        ]
+        }
       }
     },
     "/api/tunnels": {
@@ -19522,15 +18578,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "session_cookie": []
-          },
-          {
-            "bearer_auth": []
-          }
-        ]
+        }
       },
       "post": {
         "tags": [
@@ -19687,15 +18735,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "session_cookie": []
-          },
-          {
-            "bearer_auth": []
-          }
-        ]
+        }
       }
     },
     "/api/tunnels/{id}": {
@@ -19856,15 +18896,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "session_cookie": []
-          },
-          {
-            "bearer_auth": []
-          }
-        ]
+        }
       },
       "delete": {
         "tags": [
@@ -20023,15 +19055,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "session_cookie": []
-          },
-          {
-            "bearer_auth": []
-          }
-        ]
+        }
       }
     },
     "/api/tunnels/{id}/devices": {
@@ -20192,15 +19216,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "session_cookie": []
-          },
-          {
-            "bearer_auth": []
-          }
-        ]
+        }
       }
     },
     "/api/tunnels/{id}/dns-override": {
@@ -20371,15 +19387,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "session_cookie": []
-          },
-          {
-            "bearer_auth": []
-          }
-        ]
+        }
       }
     },
     "/api/tunnels/{id}/rebuild": {
@@ -20540,15 +19548,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "session_cookie": []
-          },
-          {
-            "bearer_auth": []
-          }
-        ]
+        }
       }
     },
     "/api/tunnels/{id}/speed-test": {
@@ -20741,15 +19741,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "session_cookie": []
-          },
-          {
-            "bearer_auth": []
-          }
-        ]
+        }
       }
     },
     "/api/tunnels/{id}/speed-test/results": {
@@ -20910,15 +19902,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "session_cookie": []
-          },
-          {
-            "bearer_auth": []
-          }
-        ]
+        }
       }
     },
     "/api/tunnels/{id}/test": {
@@ -21143,15 +20127,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "session_cookie": []
-          },
-          {
-            "bearer_auth": []
-          }
-        ]
+        }
       }
     },
     "/api/update/check": {
@@ -21268,15 +20244,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "session_cookie": []
-          },
-          {
-            "bearer_auth": []
-          }
-        ]
+        }
       }
     },
     "/api/update/config": {
@@ -21435,15 +20403,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "session_cookie": []
-          },
-          {
-            "bearer_auth": []
-          }
-        ]
+        }
       }
     },
     "/api/update/history": {
@@ -21573,15 +20533,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "session_cookie": []
-          },
-          {
-            "bearer_auth": []
-          }
-        ]
+        }
       }
     },
     "/api/update/install": {
@@ -21741,15 +20693,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "session_cookie": []
-          },
-          {
-            "bearer_auth": []
-          }
-        ]
+        }
       }
     },
     "/api/update/rollback": {
@@ -21866,15 +20810,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "session_cookie": []
-          },
-          {
-            "bearer_auth": []
-          }
-        ]
+        }
       }
     },
     "/api/update/status": {
@@ -21991,15 +20927,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "session_cookie": []
-          },
-          {
-            "bearer_auth": []
-          }
-        ]
+        }
       }
     },
     "/api/users/me": {
@@ -22094,15 +21022,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "session_cookie": []
-          },
-          {
-            "bearer_auth": []
-          }
-        ]
+        }
       }
     },
     "/health": {
@@ -28301,6 +27221,14 @@
       }
     }
   },
+  "security": [
+    {
+      "session_cookie": []
+    },
+    {
+      "bearer_auth": []
+    }
+  ],
   "tags": [
     {
       "name": "auth",

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -13797,7 +13797,7 @@
     "/api/network/quarantine-new-devices": {
       "get": {
         "tags": [
-          "network_zones"
+          "network-zones"
         ],
         "description": "Read the new-device quarantine toggle (issue #738). When on, a freshly-discovered device lands in the default-for-new zone (as always) and admins get a push to approve it. Off by default. Admin only.",
         "operationId": "get_quarantine_new_devices",
@@ -13920,7 +13920,7 @@
       },
       "put": {
         "tags": [
-          "network_zones"
+          "network-zones"
         ],
         "description": "Enable or disable new-device quarantine (issue #738). Placement is unchanged either way (new devices always land in the default-for-new zone); the toggle only controls whether admins are notified to approve. Admin only.",
         "operationId": "set_quarantine_new_devices",
@@ -14212,7 +14212,7 @@
     "/api/network/zones": {
       "get": {
         "tags": [
-          "network_zones"
+          "network-zones"
         ],
         "description": "List every Network Zone with its current member count. Admin only.",
         "operationId": "list_zones",
@@ -14335,7 +14335,7 @@
       },
       "post": {
         "tags": [
-          "network_zones"
+          "network-zones"
         ],
         "description": "Create a Network Zone. `provenance` is forced to manual and default flags are never set on create (use PUT to promote). Admin only.",
         "operationId": "create_zone",
@@ -15347,7 +15347,7 @@
     "/api/network/zones/{id}": {
       "get": {
         "tags": [
-          "network_zones"
+          "network-zones"
         ],
         "description": "Fetch a single Network Zone with its member count. Admin only.",
         "operationId": "get_zone",
@@ -15514,7 +15514,7 @@
       },
       "put": {
         "tags": [
-          "network_zones"
+          "network-zones"
         ],
         "description": "Partially update a Network Zone. Setting `is_default` or `is_default_for_new` to true promotes this zone; false is rejected (flags only move by promoting another zone). System zones are editable but not deletable. Admin only.",
         "operationId": "update_zone",
@@ -15733,7 +15733,7 @@
       },
       "delete": {
         "tags": [
-          "network_zones"
+          "network-zones"
         ],
         "description": "Delete a Network Zone. Rejected for system zones, the anchor (default) zone, or zones that still have member devices. Admin only.",
         "operationId": "delete_zone",
@@ -24015,7 +24015,8 @@
         "description": "Response for POST /api/network/dhcp-self-probe.\n\nThe wizard's primary-mode step 3 uses this to verify Wardnet now\nowns LAN DHCP after the operator disabled it on their router:\n\n- `wardnet_responded == true && foreign_responded == false` → ready\n  to advance.\n- `foreign_responded == true` → re-show the disable-DHCP guide;\n  `foreign_server_ip` lets the wizard call out which device is\n  still answering.",
         "required": [
           "wardnet_responded",
-          "foreign_responded"
+          "foreign_responded",
+          "foreign_server_ip"
         ],
         "properties": {
           "foreign_responded": {
@@ -25614,6 +25615,7 @@
         "required": [
           "interface",
           "ip",
+          "gateway",
           "dhcp_source"
         ],
         "properties": {
@@ -28329,7 +28331,7 @@
       "description": "LAN interface status and gateway discovery"
     },
     {
-      "name": "network_zones",
+      "name": "network-zones",
       "description": "Network Zones: device policy buckets"
     },
     {

--- a/source/daemon/crates/wardnet-common/src/api.rs
+++ b/source/daemon/crates/wardnet-common/src/api.rs
@@ -811,7 +811,7 @@ pub struct NetworkStatusResponse {
     pub interface: String,
     #[schema(value_type = String)]
     pub ip: std::net::Ipv4Addr,
-    #[schema(value_type = String)]
+    #[schema(value_type = Option<String>)]
     pub gateway: Option<std::net::Ipv4Addr>,
     pub dhcp_source: DhcpSource,
     /// Upstream router MAC persisted by the wizard's discover step, if
@@ -839,7 +839,7 @@ pub enum RouterMacSource {
 #[derive(Debug, Default, Serialize, Deserialize, utoipa::ToSchema)]
 pub struct DiscoverGatewayMacRequest {
     pub mac: Option<String>,
-    #[schema(value_type = String)]
+    #[schema(value_type = Option<String>)]
     pub target_ip: Option<std::net::Ipv4Addr>,
 }
 
@@ -864,7 +864,7 @@ pub struct DiscoverGatewayMacResponse {
 pub struct DhcpSelfProbeResponse {
     pub wardnet_responded: bool,
     pub foreign_responded: bool,
-    #[schema(value_type = String)]
+    #[schema(value_type = Option<String>)]
     pub foreign_server_ip: Option<std::net::Ipv4Addr>,
 }
 

--- a/source/daemon/crates/wardnet-common/src/api.rs
+++ b/source/daemon/crates/wardnet-common/src/api.rs
@@ -811,7 +811,10 @@ pub struct NetworkStatusResponse {
     pub interface: String,
     #[schema(value_type = String)]
     pub ip: std::net::Ipv4Addr,
-    #[schema(value_type = Option<String>)]
+    // `required` keeps the key in the schema's `required` list: serde always
+    // serializes this field (as `null` when unset), so the accurate contract
+    // is required-but-nullable, not optional.
+    #[schema(required, value_type = Option<String>)]
     pub gateway: Option<std::net::Ipv4Addr>,
     pub dhcp_source: DhcpSource,
     /// Upstream router MAC persisted by the wizard's discover step, if
@@ -864,7 +867,8 @@ pub struct DiscoverGatewayMacResponse {
 pub struct DhcpSelfProbeResponse {
     pub wardnet_responded: bool,
     pub foreign_responded: bool,
-    #[schema(value_type = Option<String>)]
+    // Required-but-nullable, same reasoning as `NetworkStatusResponse::gateway`.
+    #[schema(required, value_type = Option<String>)]
     pub foreign_server_ip: Option<std::net::Ipv4Addr>,
 }
 

--- a/source/daemon/crates/wardnetd-api/src/api/auth.rs
+++ b/source/daemon/crates/wardnetd-api/src/api/auth.rs
@@ -90,10 +90,6 @@ pub async fn login(
         (status = 403, description = "Session was not created with remember_me", body = ApiError),
         (status = 500, description = "Internal server error", body = ApiError),
     ),
-    security(
-        ("session_cookie" = []),
-        ("bearer_auth" = []),
-    ),
 )]
 pub async fn refresh(
     State(state): State<AppState>,

--- a/source/daemon/crates/wardnetd-api/src/api/backup.rs
+++ b/source/daemon/crates/wardnetd-api/src/api/backup.rs
@@ -53,10 +53,6 @@ pub fn register(router: OpenApiRouter<AppState>) -> OpenApiRouter<AppState> {
         (status = 200, description = "Current backup subsystem status", body = BackupStatusResponse),
         AuthErrors,
     ),
-    security(
-        ("session_cookie" = []),
-        ("bearer_auth" = []),
-    ),
 )]
 pub async fn status(
     State(state): State<AppState>,
@@ -83,10 +79,6 @@ pub async fn status(
         ),
         AuthErrors,
         BadRequest,
-    ),
-    security(
-        ("session_cookie" = []),
-        ("bearer_auth" = []),
     ),
 )]
 pub async fn export(
@@ -130,10 +122,6 @@ pub async fn export(
         AuthErrors,
         BadRequest,
     ),
-    security(
-        ("session_cookie" = []),
-        ("bearer_auth" = []),
-    ),
 )]
 pub async fn preview_import(
     State(state): State<AppState>,
@@ -165,10 +153,6 @@ pub async fn preview_import(
         AuthErrors,
         BadRequest,
     ),
-    security(
-        ("session_cookie" = []),
-        ("bearer_auth" = []),
-    ),
 )]
 pub async fn apply_import(
     State(state): State<AppState>,
@@ -188,10 +172,6 @@ pub async fn apply_import(
     responses(
         (status = 200, description = "Retained .bak-<ts> snapshots", body = ListSnapshotsResponse),
         AuthErrors,
-    ),
-    security(
-        ("session_cookie" = []),
-        ("bearer_auth" = []),
     ),
 )]
 pub async fn list_snapshots(

--- a/source/daemon/crates/wardnetd-api/src/api/ddns.rs
+++ b/source/daemon/crates/wardnetd-api/src/api/ddns.rs
@@ -107,7 +107,6 @@ fn spawn_provisioning(state: &AppState, admin_id: Uuid) {
         AuthErrors,
         BadRequest,
     ),
-    security(("session_cookie" = []), ("bearer_auth" = [])),
 )]
 pub async fn ddns_enrollment_code(
     State(state): State<AppState>,
@@ -135,7 +134,6 @@ pub async fn ddns_enrollment_code(
         AuthErrors,
         BadRequest,
     ),
-    security(("session_cookie" = []), ("bearer_auth" = [])),
 )]
 pub async fn ddns_enroll(
     State(state): State<AppState>,
@@ -158,7 +156,6 @@ pub async fn ddns_enroll(
         (status = 200, description = "Availability result", body = DdnsCheckResponse),
         AuthErrors,
     ),
-    security(("session_cookie" = []), ("bearer_auth" = [])),
 )]
 pub async fn ddns_check(
     State(state): State<AppState>,
@@ -184,7 +181,6 @@ pub async fn ddns_check(
         AuthErrors,
         BadRequest,
     ),
-    security(("session_cookie" = []), ("bearer_auth" = [])),
 )]
 pub async fn ddns_register(
     State(state): State<AppState>,
@@ -220,7 +216,6 @@ pub async fn ddns_register(
         AuthErrors,
         BadRequest,
     ),
-    security(("session_cookie" = []), ("bearer_auth" = [])),
 )]
 pub async fn ddns_cloudflare(
     State(state): State<AppState>,
@@ -251,7 +246,6 @@ pub async fn ddns_cloudflare(
         (status = 200, description = "DDNS status", body = DdnsStatusResponse),
         AuthErrors,
     ),
-    security(("session_cookie" = []), ("bearer_auth" = [])),
 )]
 pub async fn ddns_status(
     State(state): State<AppState>,
@@ -279,7 +273,6 @@ pub async fn ddns_status(
         (status = 200, description = "Resolution-check result", body = DdnsResolutionCheckResponse),
         AuthErrors,
     ),
-    security(("session_cookie" = []), ("bearer_auth" = [])),
 )]
 pub async fn ddns_resolution_check(
     State(state): State<AppState>,
@@ -301,7 +294,6 @@ pub async fn ddns_resolution_check(
         (status = 204, description = "Remote access torn down (or already absent)"),
         AuthErrors,
     ),
-    security(("session_cookie" = []), ("bearer_auth" = [])),
 )]
 pub async fn ddns_teardown(
     State(state): State<AppState>,

--- a/source/daemon/crates/wardnetd-api/src/api/devices.rs
+++ b/source/daemon/crates/wardnetd-api/src/api/devices.rs
@@ -188,10 +188,6 @@ fn enrich_device(
         (status = 200, description = "List of devices with DHCP status", body = ListDevicesResponse),
         AuthErrors,
     ),
-    security(
-        ("session_cookie" = []),
-        ("bearer_auth" = []),
-    ),
 )]
 pub async fn list_devices(
     State(state): State<AppState>,
@@ -225,10 +221,6 @@ pub async fn list_devices(
         AuthErrors,
         NotFound,
         BadRequest,
-    ),
-    security(
-        ("session_cookie" = []),
-        ("bearer_auth" = []),
     ),
 )]
 pub async fn get_device(
@@ -272,10 +264,6 @@ pub async fn get_device(
         AuthErrors,
         NotFound,
         BadRequest,
-    ),
-    security(
-        ("session_cookie" = []),
-        ("bearer_auth" = []),
     ),
 )]
 pub async fn update_device(
@@ -348,10 +336,6 @@ pub async fn update_device(
         AuthErrors,
         NotFound,
         BadRequest,
-    ),
-    security(
-        ("session_cookie" = []),
-        ("bearer_auth" = []),
     ),
 )]
 pub async fn assign_device_zone(

--- a/source/daemon/crates/wardnetd-api/src/api/dhcp.rs
+++ b/source/daemon/crates/wardnetd-api/src/api/dhcp.rs
@@ -49,10 +49,6 @@ const PATH_STATUS: &str = "/api/dhcp/status";
         (status = 200, description = "Current DHCP configuration", body = DhcpConfigResponse),
         AuthErrors,
     ),
-    security(
-        ("session_cookie" = []),
-        ("bearer_auth" = []),
-    ),
 )]
 pub async fn get_config(
     State(state): State<AppState>,
@@ -74,10 +70,6 @@ pub async fn get_config(
         (status = 200, description = "Updated DHCP configuration", body = DhcpConfigResponse),
         AuthErrors,
         BadRequest,
-    ),
-    security(
-        ("session_cookie" = []),
-        ("bearer_auth" = []),
     ),
 )]
 pub async fn update_config(
@@ -107,10 +99,6 @@ pub async fn update_config(
         AuthErrors,
         BadRequest,
     ),
-    security(
-        ("session_cookie" = []),
-        ("bearer_auth" = []),
-    ),
 )]
 pub async fn preview_config(
     State(state): State<AppState>,
@@ -133,10 +121,6 @@ pub async fn preview_config(
         (status = 200, description = "Updated DHCP configuration", body = DhcpConfigResponse),
         AuthErrors,
         BadRequest,
-    ),
-    security(
-        ("session_cookie" = []),
-        ("bearer_auth" = []),
     ),
 )]
 pub async fn toggle(
@@ -184,10 +168,6 @@ pub async fn toggle(
         (status = 200, description = "Active DHCP leases", body = ListDhcpLeasesResponse),
         AuthErrors,
     ),
-    security(
-        ("session_cookie" = []),
-        ("bearer_auth" = []),
-    ),
 )]
 pub async fn list_leases(
     State(state): State<AppState>,
@@ -210,10 +190,6 @@ pub async fn list_leases(
         AuthErrors,
         NotFound,
     ),
-    security(
-        ("session_cookie" = []),
-        ("bearer_auth" = []),
-    ),
 )]
 pub async fn revoke_lease(
     State(state): State<AppState>,
@@ -233,10 +209,6 @@ pub async fn revoke_lease(
     responses(
         (status = 200, description = "Static DHCP reservations", body = ListDhcpReservationsResponse),
         AuthErrors,
-    ),
-    security(
-        ("session_cookie" = []),
-        ("bearer_auth" = []),
     ),
 )]
 pub async fn list_reservations(
@@ -258,10 +230,6 @@ pub async fn list_reservations(
         (status = 201, description = "Reservation created", body = CreateDhcpReservationResponse),
         AuthErrors,
         BadRequest,
-    ),
-    security(
-        ("session_cookie" = []),
-        ("bearer_auth" = []),
     ),
 )]
 pub async fn create_reservation(
@@ -285,10 +253,6 @@ pub async fn create_reservation(
         AuthErrors,
         NotFound,
     ),
-    security(
-        ("session_cookie" = []),
-        ("bearer_auth" = []),
-    ),
 )]
 pub async fn delete_reservation(
     State(state): State<AppState>,
@@ -308,10 +272,6 @@ pub async fn delete_reservation(
     responses(
         (status = 200, description = "DHCP server status and pool usage", body = DhcpStatusResponse),
         AuthErrors,
-    ),
-    security(
-        ("session_cookie" = []),
-        ("bearer_auth" = []),
     ),
 )]
 pub async fn status(

--- a/source/daemon/crates/wardnetd-api/src/api/dns.rs
+++ b/source/daemon/crates/wardnetd-api/src/api/dns.rs
@@ -35,10 +35,6 @@ pub fn register(router: OpenApiRouter<AppState>) -> OpenApiRouter<AppState> {
         (status = 200, description = "Current DNS configuration", body = DnsConfigResponse),
         AuthErrors,
     ),
-    security(
-        ("session_cookie" = []),
-        ("bearer_auth" = []),
-    ),
 )]
 pub async fn get_config(
     State(state): State<AppState>,
@@ -58,10 +54,6 @@ pub async fn get_config(
         (status = 200, description = "Updated DNS configuration", body = DnsConfigResponse),
         AuthErrors,
         BadRequest,
-    ),
-    security(
-        ("session_cookie" = []),
-        ("bearer_auth" = []),
     ),
 )]
 pub async fn update_config(
@@ -83,10 +75,6 @@ pub async fn update_config(
         (status = 200, description = "Updated DNS configuration", body = DnsConfigResponse),
         AuthErrors,
         BadRequest,
-    ),
-    security(
-        ("session_cookie" = []),
-        ("bearer_auth" = []),
     ),
 )]
 pub async fn toggle(
@@ -125,10 +113,6 @@ pub async fn toggle(
         (status = 200, description = "DNS server status and cache stats", body = DnsStatusResponse),
         AuthErrors,
     ),
-    security(
-        ("session_cookie" = []),
-        ("bearer_auth" = []),
-    ),
 )]
 pub async fn status(
     State(state): State<AppState>,
@@ -155,10 +139,6 @@ pub async fn status(
         (status = 200, description = "Cache flushed", body = DnsCacheFlushResponse),
         AuthErrors,
     ),
-    security(
-        ("session_cookie" = []),
-        ("bearer_auth" = []),
-    ),
 )]
 pub async fn flush_cache(
     State(state): State<AppState>,
@@ -181,10 +161,6 @@ pub async fn flush_cache(
         (status = 200, description = "Page of query log entries", body = ListQueryLogResponse),
         AuthErrors,
         BadRequest,
-    ),
-    security(
-        ("session_cookie" = []),
-        ("bearer_auth" = []),
     ),
 )]
 pub async fn list_query_log(

--- a/source/daemon/crates/wardnetd-api/src/api/dns_capture.rs
+++ b/source/daemon/crates/wardnetd-api/src/api/dns_capture.rs
@@ -38,7 +38,6 @@ pub fn register(router: OpenApiRouter<AppState>) -> OpenApiRouter<AppState> {
         (status = 404, description = "Device not found", body = ApiError),
         (status = 500, description = "Internal server error", body = ApiError),
     ),
-    security(("session_cookie" = []), ("bearer_auth" = [])),
 )]
 pub async fn get_dns_capture_settings(
     State(state): State<AppState>,
@@ -65,7 +64,6 @@ pub async fn get_dns_capture_settings(
         (status = 404, description = "Device not found", body = ApiError),
         (status = 500, description = "Internal server error", body = ApiError),
     ),
-    security(("session_cookie" = []), ("bearer_auth" = [])),
 )]
 pub async fn update_dns_capture_settings(
     State(state): State<AppState>,

--- a/source/daemon/crates/wardnetd-api/src/api/dns_capture.rs
+++ b/source/daemon/crates/wardnetd-api/src/api/dns_capture.rs
@@ -38,7 +38,7 @@ pub fn register(router: OpenApiRouter<AppState>) -> OpenApiRouter<AppState> {
         (status = 404, description = "Device not found", body = ApiError),
         (status = 500, description = "Internal server error", body = ApiError),
     ),
-    security(("admin_auth" = [])),
+    security(("session_cookie" = []), ("bearer_auth" = [])),
 )]
 pub async fn get_dns_capture_settings(
     State(state): State<AppState>,
@@ -65,7 +65,7 @@ pub async fn get_dns_capture_settings(
         (status = 404, description = "Device not found", body = ApiError),
         (status = 500, description = "Internal server error", body = ApiError),
     ),
-    security(("admin_auth" = [])),
+    security(("session_cookie" = []), ("bearer_auth" = [])),
 )]
 pub async fn update_dns_capture_settings(
     State(state): State<AppState>,

--- a/source/daemon/crates/wardnetd-api/src/api/dns_filter.rs
+++ b/source/daemon/crates/wardnetd-api/src/api/dns_filter.rs
@@ -52,7 +52,6 @@ pub fn register(router: OpenApiRouter<AppState>) -> OpenApiRouter<AppState> {
         (status = 200, description = "Profiles list", body = ListProfilesResponse),
         AuthErrors,
     ),
-    security(("session_cookie" = []), ("bearer_auth" = [])),
 )]
 pub async fn list_profiles(
     State(state): State<AppState>,
@@ -72,7 +71,6 @@ pub async fn list_profiles(
         AuthErrors,
         BadRequest,
     ),
-    security(("session_cookie" = []), ("bearer_auth" = [])),
 )]
 pub async fn create_profile(
     State(state): State<AppState>,
@@ -94,7 +92,6 @@ pub async fn create_profile(
         AuthErrors,
         NotFound,
     ),
-    security(("session_cookie" = []), ("bearer_auth" = [])),
 )]
 pub async fn get_profile(
     State(state): State<AppState>,
@@ -119,7 +116,6 @@ pub async fn get_profile(
         NotFound,
         BadRequest,
     ),
-    security(("session_cookie" = []), ("bearer_auth" = [])),
 )]
 pub async fn update_profile(
     State(state): State<AppState>,
@@ -149,7 +145,6 @@ pub async fn update_profile(
         AuthErrors,
         NotFound,
     ),
-    security(("session_cookie" = []), ("bearer_auth" = [])),
 )]
 pub async fn delete_profile(
     State(state): State<AppState>,
@@ -177,7 +172,6 @@ pub async fn delete_profile(
         AuthErrors,
         NotFound,
     ),
-    security(("session_cookie" = []), ("bearer_auth" = [])),
 )]
 pub async fn list_blocklists(
     State(state): State<AppState>,
@@ -205,7 +199,6 @@ pub async fn list_blocklists(
         BadRequest,
         NotFound,
     ),
-    security(("session_cookie" = []), ("bearer_auth" = [])),
 )]
 pub async fn create_blocklist(
     State(state): State<AppState>,
@@ -236,7 +229,6 @@ pub async fn create_blocklist(
         NotFound,
         BadRequest,
     ),
-    security(("session_cookie" = []), ("bearer_auth" = [])),
 )]
 pub async fn update_blocklist(
     State(state): State<AppState>,
@@ -266,7 +258,6 @@ pub async fn update_blocklist(
         AuthErrors,
         NotFound,
     ),
-    security(("session_cookie" = []), ("bearer_auth" = [])),
 )]
 pub async fn delete_blocklist(
     State(state): State<AppState>,
@@ -295,7 +286,6 @@ pub async fn delete_blocklist(
         AuthErrors,
         NotFound,
     ),
-    security(("session_cookie" = []), ("bearer_auth" = [])),
 )]
 pub async fn refresh_blocklist(
     State(state): State<AppState>,
@@ -322,7 +312,6 @@ pub async fn refresh_blocklist(
         AuthErrors,
         NotFound,
     ),
-    security(("session_cookie" = []), ("bearer_auth" = [])),
 )]
 pub async fn list_allowlist(
     State(state): State<AppState>,
@@ -350,7 +339,6 @@ pub async fn list_allowlist(
         BadRequest,
         NotFound,
     ),
-    security(("session_cookie" = []), ("bearer_auth" = [])),
 )]
 pub async fn create_allowlist_entry(
     State(state): State<AppState>,
@@ -379,7 +367,6 @@ pub async fn create_allowlist_entry(
         AuthErrors,
         NotFound,
     ),
-    security(("session_cookie" = []), ("bearer_auth" = [])),
 )]
 pub async fn delete_allowlist_entry(
     State(state): State<AppState>,
@@ -407,7 +394,6 @@ pub async fn delete_allowlist_entry(
         AuthErrors,
         NotFound,
     ),
-    security(("session_cookie" = []), ("bearer_auth" = [])),
 )]
 pub async fn list_custom_rules(
     State(state): State<AppState>,
@@ -435,7 +421,6 @@ pub async fn list_custom_rules(
         BadRequest,
         NotFound,
     ),
-    security(("session_cookie" = []), ("bearer_auth" = [])),
 )]
 pub async fn create_custom_rule(
     State(state): State<AppState>,
@@ -466,7 +451,6 @@ pub async fn create_custom_rule(
         NotFound,
         BadRequest,
     ),
-    security(("session_cookie" = []), ("bearer_auth" = [])),
 )]
 pub async fn update_custom_rule(
     State(state): State<AppState>,
@@ -496,7 +480,6 @@ pub async fn update_custom_rule(
         AuthErrors,
         NotFound,
     ),
-    security(("session_cookie" = []), ("bearer_auth" = [])),
 )]
 pub async fn delete_custom_rule(
     State(state): State<AppState>,
@@ -525,7 +508,6 @@ pub async fn delete_custom_rule(
         (status = 200, description = "Device settings", body = ListDeviceFilterSettingsResponse),
         AuthErrors,
     ),
-    security(("session_cookie" = []), ("bearer_auth" = [])),
 )]
 pub async fn list_device_settings(
     State(state): State<AppState>,
@@ -552,7 +534,6 @@ pub async fn list_device_settings(
         (status = 200, description = "Device settings", body = GetDeviceFilterSettingsResponse),
         AuthErrors,
     ),
-    security(("session_cookie" = []), ("bearer_auth" = [])),
 )]
 pub async fn get_device_settings(
     State(state): State<AppState>,
@@ -581,7 +562,6 @@ pub async fn get_device_settings(
         BadRequest,
         NotFound,
     ),
-    security(("session_cookie" = []), ("bearer_auth" = [])),
 )]
 pub async fn update_device_settings(
     State(state): State<AppState>,
@@ -609,7 +589,6 @@ pub async fn update_device_settings(
         (status = 200, description = "Filter config", body = DnsFilterConfigResponse),
         AuthErrors,
     ),
-    security(("session_cookie" = []), ("bearer_auth" = [])),
 )]
 pub async fn get_filter_config(
     State(state): State<AppState>,
@@ -630,7 +609,6 @@ pub async fn get_filter_config(
         BadRequest,
         NotFound,
     ),
-    security(("session_cookie" = []), ("bearer_auth" = [])),
 )]
 pub async fn update_filter_config(
     State(state): State<AppState>,

--- a/source/daemon/crates/wardnetd-api/src/api/dns_local.rs
+++ b/source/daemon/crates/wardnetd-api/src/api/dns_local.rs
@@ -50,7 +50,6 @@ pub fn register(router: OpenApiRouter<AppState>) -> OpenApiRouter<AppState> {
         (status = 200, description = "Zones list", body = ListZonesResponse),
         AuthErrors,
     ),
-    security(("session_cookie" = []), ("bearer_auth" = [])),
 )]
 pub async fn list_zones(
     State(state): State<AppState>,
@@ -70,7 +69,6 @@ pub async fn list_zones(
         AuthErrors,
         BadRequest,
     ),
-    security(("session_cookie" = []), ("bearer_auth" = [])),
 )]
 pub async fn create_zone(
     State(state): State<AppState>,
@@ -92,7 +90,6 @@ pub async fn create_zone(
         AuthErrors,
         NotFound,
     ),
-    security(("session_cookie" = []), ("bearer_auth" = [])),
 )]
 pub async fn get_zone(
     State(state): State<AppState>,
@@ -115,7 +112,6 @@ pub async fn get_zone(
         NotFound,
         BadRequest,
     ),
-    security(("session_cookie" = []), ("bearer_auth" = [])),
 )]
 pub async fn update_zone(
     State(state): State<AppState>,
@@ -138,7 +134,6 @@ pub async fn update_zone(
         AuthErrors,
         NotFound,
     ),
-    security(("session_cookie" = []), ("bearer_auth" = [])),
 )]
 pub async fn delete_zone(
     State(state): State<AppState>,
@@ -159,7 +154,6 @@ pub async fn delete_zone(
         AuthErrors,
         NotFound,
     ),
-    security(("session_cookie" = []), ("bearer_auth" = [])),
 )]
 pub async fn list_zone_records(
     State(state): State<AppState>,
@@ -180,7 +174,6 @@ pub async fn list_zone_records(
         (status = 200, description = "Records list", body = ListRecordsResponse),
         AuthErrors,
     ),
-    security(("session_cookie" = []), ("bearer_auth" = [])),
 )]
 pub async fn list_records(
     State(state): State<AppState>,
@@ -201,7 +194,6 @@ pub async fn list_records(
         NotFound,
         BadRequest,
     ),
-    security(("session_cookie" = []), ("bearer_auth" = [])),
 )]
 pub async fn create_record(
     State(state): State<AppState>,
@@ -223,7 +215,6 @@ pub async fn create_record(
         AuthErrors,
         NotFound,
     ),
-    security(("session_cookie" = []), ("bearer_auth" = [])),
 )]
 pub async fn get_record(
     State(state): State<AppState>,
@@ -246,7 +237,6 @@ pub async fn get_record(
         NotFound,
         BadRequest,
     ),
-    security(("session_cookie" = []), ("bearer_auth" = [])),
 )]
 pub async fn update_record(
     State(state): State<AppState>,
@@ -270,7 +260,6 @@ pub async fn update_record(
         AuthErrors,
         NotFound,
     ),
-    security(("session_cookie" = []), ("bearer_auth" = [])),
 )]
 pub async fn delete_record(
     State(state): State<AppState>,
@@ -292,7 +281,6 @@ pub async fn delete_record(
         (status = 200, description = "Forwarding rules list", body = ListForwardingRulesResponse),
         AuthErrors,
     ),
-    security(("session_cookie" = []), ("bearer_auth" = [])),
 )]
 pub async fn list_forwarding_rules(
     State(state): State<AppState>,
@@ -314,7 +302,6 @@ pub async fn list_forwarding_rules(
         AuthErrors,
         BadRequest,
     ),
-    security(("session_cookie" = []), ("bearer_auth" = [])),
 )]
 pub async fn create_forwarding_rule(
     State(state): State<AppState>,
@@ -339,7 +326,6 @@ pub async fn create_forwarding_rule(
         AuthErrors,
         NotFound,
     ),
-    security(("session_cookie" = []), ("bearer_auth" = [])),
 )]
 pub async fn get_forwarding_rule(
     State(state): State<AppState>,
@@ -364,7 +350,6 @@ pub async fn get_forwarding_rule(
         NotFound,
         BadRequest,
     ),
-    security(("session_cookie" = []), ("bearer_auth" = [])),
 )]
 pub async fn update_forwarding_rule(
     State(state): State<AppState>,
@@ -391,7 +376,6 @@ pub async fn update_forwarding_rule(
         AuthErrors,
         NotFound,
     ),
-    security(("session_cookie" = []), ("bearer_auth" = [])),
 )]
 pub async fn delete_forwarding_rule(
     State(state): State<AppState>,

--- a/source/daemon/crates/wardnetd-api/src/api/inbound_wg.rs
+++ b/source/daemon/crates/wardnetd-api/src/api/inbound_wg.rs
@@ -33,10 +33,6 @@ pub fn register(router: OpenApiRouter<AppState>) -> OpenApiRouter<AppState> {
         (status = 200, description = "Current inbound WireGuard config", body = InboundWgConfigResponse),
         AuthErrors,
     ),
-    security(
-        ("session_cookie" = []),
-        ("bearer_auth" = []),
-    ),
 )]
 pub async fn get_config(
     State(state): State<AppState>,
@@ -61,10 +57,6 @@ pub async fn get_config(
         (status = 200, description = "Inbound WireGuard config applied", body = InboundWgConfigResponse),
         AuthErrors,
     ),
-    security(
-        ("session_cookie" = []),
-        ("bearer_auth" = []),
-    ),
 )]
 pub async fn set_config(
     State(state): State<AppState>,
@@ -88,10 +80,6 @@ pub async fn set_config(
     responses(
         (status = 200, description = "Configured inbound peers", body = ListInboundWgPeersResponse),
         AuthErrors,
-    ),
-    security(
-        ("session_cookie" = []),
-        ("bearer_auth" = []),
     ),
 )]
 pub async fn list_peers(
@@ -120,10 +108,6 @@ pub async fn list_peers(
         AuthErrors,
         Conflict,
         NotFound,
-    ),
-    security(
-        ("session_cookie" = []),
-        ("bearer_auth" = []),
     ),
 )]
 pub async fn add_peer(
@@ -169,10 +153,6 @@ async fn build_endpoint(state: &AppState) -> Result<Option<String>, AppError> {
         AuthErrors,
         NotFound,
     ),
-    security(
-        ("session_cookie" = []),
-        ("bearer_auth" = []),
-    ),
 )]
 pub async fn remove_peer(
     State(state): State<AppState>,
@@ -198,10 +178,6 @@ pub async fn remove_peer(
         (status = 200, description = "Peer state applied", body = InboundWgPeerSummary),
         AuthErrors,
         NotFound,
-    ),
-    security(
-        ("session_cookie" = []),
-        ("bearer_auth" = []),
     ),
 )]
 pub async fn set_peer_enabled(

--- a/source/daemon/crates/wardnetd-api/src/api/jobs.rs
+++ b/source/daemon/crates/wardnetd-api/src/api/jobs.rs
@@ -29,10 +29,6 @@ pub fn register(router: OpenApiRouter<AppState>) -> OpenApiRouter<AppState> {
         AuthErrors,
         NotFound,
     ),
-    security(
-        ("session_cookie" = []),
-        ("bearer_auth" = []),
-    ),
 )]
 pub async fn get_job(
     State(state): State<AppState>,

--- a/source/daemon/crates/wardnetd-api/src/api/network.rs
+++ b/source/daemon/crates/wardnetd-api/src/api/network.rs
@@ -34,10 +34,6 @@ pub fn register(router: OpenApiRouter<AppState>) -> OpenApiRouter<AppState> {
         (status = 200, description = "Current LAN interface state", body = NetworkStatusResponse),
         AuthErrors,
     ),
-    security(
-        ("session_cookie" = []),
-        ("bearer_auth" = []),
-    ),
 )]
 pub async fn status(
     State(state): State<AppState>,
@@ -66,10 +62,6 @@ pub async fn status(
         (status = 404, description = "ARP probe got no reply", body = wardnet_common::api::ApiError),
         AuthErrors,
     ),
-    security(
-        ("session_cookie" = []),
-        ("bearer_auth" = []),
-    ),
 )]
 pub async fn discover_gateway_mac(
     State(state): State<AppState>,
@@ -93,10 +85,6 @@ pub async fn discover_gateway_mac(
     responses(
         (status = 200, description = "Probe complete", body = DhcpSelfProbeResponse),
         AuthErrors,
-    ),
-    security(
-        ("session_cookie" = []),
-        ("bearer_auth" = []),
     ),
 )]
 pub async fn dhcp_self_probe(

--- a/source/daemon/crates/wardnetd-api/src/api/network_zone.rs
+++ b/source/daemon/crates/wardnetd-api/src/api/network_zone.rs
@@ -34,7 +34,7 @@ pub fn register(router: OpenApiRouter<AppState>) -> OpenApiRouter<AppState> {
 #[utoipa::path(
     get,
     path = "/api/network/zones",
-    tag = "network_zones",
+    tag = "network-zones",
     description = "List every Network Zone with its current member count. \
                    Admin only.",
     responses(
@@ -54,7 +54,7 @@ pub async fn list_zones(
 #[utoipa::path(
     post,
     path = "/api/network/zones",
-    tag = "network_zones",
+    tag = "network-zones",
     description = "Create a Network Zone. `provenance` is forced to manual and \
                    default flags are never set on create (use PUT to promote). \
                    Admin only.",
@@ -82,7 +82,7 @@ pub async fn create_zone(
 #[utoipa::path(
     get,
     path = "/api/network/zones/{id}",
-    tag = "network_zones",
+    tag = "network-zones",
     description = "Fetch a single Network Zone with its member count. Admin only.",
     params(("id" = Uuid, Path, description = "Zone id")),
     responses(
@@ -104,7 +104,7 @@ pub async fn get_zone(
 #[utoipa::path(
     put,
     path = "/api/network/zones/{id}",
-    tag = "network_zones",
+    tag = "network-zones",
     description = "Partially update a Network Zone. Setting `is_default` or \
                    `is_default_for_new` to true promotes this zone; false is \
                    rejected (flags only move by promoting another zone). System \
@@ -133,7 +133,7 @@ pub async fn update_zone(
 #[utoipa::path(
     delete,
     path = "/api/network/zones/{id}",
-    tag = "network_zones",
+    tag = "network-zones",
     description = "Delete a Network Zone. Rejected for system zones, the anchor \
                    (default) zone, or zones that still have member devices. \
                    Admin only.",
@@ -158,7 +158,7 @@ pub async fn delete_zone(
 #[utoipa::path(
     get,
     path = "/api/network/quarantine-new-devices",
-    tag = "network_zones",
+    tag = "network-zones",
     description = "Read the new-device quarantine toggle (issue #738). When on, a \
                    freshly-discovered device lands in the default-for-new zone (as \
                    always) and admins get a push to approve it. Off by default. \
@@ -183,7 +183,7 @@ pub async fn get_quarantine_new_devices(
 #[utoipa::path(
     put,
     path = "/api/network/quarantine-new-devices",
-    tag = "network_zones",
+    tag = "network-zones",
     description = "Enable or disable new-device quarantine (issue #738). Placement \
                    is unchanged either way (new devices always land in the \
                    default-for-new zone); the toggle only controls whether admins \

--- a/source/daemon/crates/wardnetd-api/src/api/network_zone.rs
+++ b/source/daemon/crates/wardnetd-api/src/api/network_zone.rs
@@ -41,7 +41,6 @@ pub fn register(router: OpenApiRouter<AppState>) -> OpenApiRouter<AppState> {
         (status = 200, description = "Zones list", body = ListNetworkZonesResponse),
         AuthErrors,
     ),
-    security(("session_cookie" = []), ("bearer_auth" = [])),
 )]
 pub async fn list_zones(
     State(state): State<AppState>,
@@ -65,7 +64,6 @@ pub async fn list_zones(
         BadRequest,
         (status = 409, description = "Name already in use", body = wardnet_common::api::ApiError),
     ),
-    security(("session_cookie" = []), ("bearer_auth" = [])),
 )]
 pub async fn create_zone(
     State(state): State<AppState>,
@@ -90,7 +88,6 @@ pub async fn create_zone(
         AuthErrors,
         NotFound,
     ),
-    security(("session_cookie" = []), ("bearer_auth" = [])),
 )]
 pub async fn get_zone(
     State(state): State<AppState>,
@@ -118,7 +115,6 @@ pub async fn get_zone(
         BadRequest,
         (status = 409, description = "Name already in use", body = wardnet_common::api::ApiError),
     ),
-    security(("session_cookie" = []), ("bearer_auth" = [])),
 )]
 pub async fn update_zone(
     State(state): State<AppState>,
@@ -144,7 +140,6 @@ pub async fn update_zone(
         NotFound,
         (status = 409, description = "System / default / non-empty zone", body = wardnet_common::api::ApiError),
     ),
-    security(("session_cookie" = []), ("bearer_auth" = [])),
 )]
 pub async fn delete_zone(
     State(state): State<AppState>,
@@ -167,7 +162,6 @@ pub async fn delete_zone(
         (status = 200, description = "Current toggle state", body = QuarantineNewDevicesResponse),
         AuthErrors,
     ),
-    security(("session_cookie" = []), ("bearer_auth" = [])),
 )]
 pub async fn get_quarantine_new_devices(
     State(state): State<AppState>,
@@ -194,7 +188,6 @@ pub async fn get_quarantine_new_devices(
         AuthErrors,
         BadRequest,
     ),
-    security(("session_cookie" = []), ("bearer_auth" = [])),
 )]
 pub async fn set_quarantine_new_devices(
     State(state): State<AppState>,

--- a/source/daemon/crates/wardnetd-api/src/api/providers.rs
+++ b/source/daemon/crates/wardnetd-api/src/api/providers.rs
@@ -34,10 +34,6 @@ pub fn register(router: OpenApiRouter<AppState>) -> OpenApiRouter<AppState> {
         (status = 200, description = "Registered VPN providers", body = ListProvidersResponse),
         AuthErrors,
     ),
-    security(
-        ("session_cookie" = []),
-        ("bearer_auth" = []),
-    ),
 )]
 pub async fn list_providers(
     State(state): State<AppState>,
@@ -61,10 +57,6 @@ pub async fn list_providers(
         AuthErrors,
         NotFound,
         BadRequest,
-    ),
-    security(
-        ("session_cookie" = []),
-        ("bearer_auth" = []),
     ),
 )]
 pub async fn validate_credentials(
@@ -92,10 +84,6 @@ pub async fn validate_credentials(
         AuthErrors,
         NotFound,
     ),
-    security(
-        ("session_cookie" = []),
-        ("bearer_auth" = []),
-    ),
 )]
 pub async fn list_countries(
     State(state): State<AppState>,
@@ -121,10 +109,6 @@ pub async fn list_countries(
         AuthErrors,
         NotFound,
         BadRequest,
-    ),
-    security(
-        ("session_cookie" = []),
-        ("bearer_auth" = []),
     ),
 )]
 pub async fn list_servers(
@@ -152,10 +136,6 @@ pub async fn list_servers(
         AuthErrors,
         NotFound,
         BadRequest,
-    ),
-    security(
-        ("session_cookie" = []),
-        ("bearer_auth" = []),
     ),
 )]
 pub async fn setup_tunnel(

--- a/source/daemon/crates/wardnetd-api/src/api/push.rs
+++ b/source/daemon/crates/wardnetd-api/src/api/push.rs
@@ -124,10 +124,6 @@ pub struct NotificationsQuery {
         AuthErrors,
         (status = 500, description = "Internal server error", body = ApiError),
     ),
-    security(
-        ("session_cookie" = []),
-        ("bearer_auth" = []),
-    ),
 )]
 pub async fn list_notifications(
     State(state): State<AppState>,
@@ -164,10 +160,6 @@ pub async fn list_notifications(
         (status = 200, description = "Feed cleared", body = PushSubscriptionResponse),
         AuthErrors,
         (status = 500, description = "Internal server error", body = ApiError),
-    ),
-    security(
-        ("session_cookie" = []),
-        ("bearer_auth" = []),
     ),
 )]
 pub async fn clear_notifications(

--- a/source/daemon/crates/wardnetd-api/src/api/rule_requests.rs
+++ b/source/daemon/crates/wardnetd-api/src/api/rule_requests.rs
@@ -97,7 +97,6 @@ pub async fn list_my_rule_requests(
         AuthErrors,
         (status = 500, description = "Internal server error", body = ApiError),
     ),
-    security(("session_cookie" = []), ("bearer_auth" = [])),
 )]
 pub async fn list_rule_requests(
     State(state): State<AppState>,
@@ -123,7 +122,6 @@ pub async fn list_rule_requests(
         BadRequest,
         NotFound,
     ),
-    security(("session_cookie" = []), ("bearer_auth" = [])),
 )]
 pub async fn decide_rule_request(
     State(state): State<AppState>,

--- a/source/daemon/crates/wardnetd-api/src/api/setup.rs
+++ b/source/daemon/crates/wardnetd-api/src/api/setup.rs
@@ -99,10 +99,6 @@ pub async fn setup(
         (status = 400, description = "Invalid transition", body = ApiError),
         AuthErrors,
     ),
-    security(
-        ("session_cookie" = []),
-        ("bearer_auth" = []),
-    ),
 )]
 pub async fn setup_advance(
     State(state): State<AppState>,

--- a/source/daemon/crates/wardnetd-api/src/api/stats.rs
+++ b/source/daemon/crates/wardnetd-api/src/api/stats.rs
@@ -27,10 +27,6 @@ pub fn register(router: OpenApiRouter<AppState>) -> OpenApiRouter<AppState> {
         (status = 200, description = "Stats query result", body = StatsQueryResponse),
         AuthErrors,
     ),
-    security(
-        ("session_cookie" = []),
-        ("bearer_auth" = []),
-    ),
 )]
 pub async fn query(
     State(state): State<AppState>,
@@ -53,10 +49,6 @@ pub async fn query(
     responses(
         (status = 200, description = "Top-N query result", body = StatsTopResponse),
         AuthErrors,
-    ),
-    security(
-        ("session_cookie" = []),
-        ("bearer_auth" = []),
     ),
 )]
 pub async fn top(

--- a/source/daemon/crates/wardnetd-api/src/api/system.rs
+++ b/source/daemon/crates/wardnetd-api/src/api/system.rs
@@ -45,10 +45,6 @@ pub fn register(router: OpenApiRouter<AppState>) -> OpenApiRouter<AppState> {
         (status = 200, description = "System status (version, uptime, counts)", body = SystemStatusResponse),
         AuthErrors,
     ),
-    security(
-        ("session_cookie" = []),
-        ("bearer_auth" = []),
-    ),
 )]
 pub async fn status(
     State(state): State<AppState>,
@@ -68,10 +64,6 @@ pub async fn status(
     responses(
         (status = 200, description = "Log file stream", content_type = "application/octet-stream", body = Vec<u8>),
         AuthErrors,
-    ),
-    security(
-        ("session_cookie" = []),
-        ("bearer_auth" = []),
     ),
 )]
 pub async fn download_logs(
@@ -110,10 +102,6 @@ pub async fn download_logs(
         (status = 204, description = "Restart scheduled"),
         AuthErrors,
     ),
-    security(
-        ("session_cookie" = []),
-        ("bearer_auth" = []),
-    ),
 )]
 pub async fn restart(
     State(state): State<AppState>,
@@ -142,10 +130,6 @@ pub async fn restart(
         (status = 204, description = "Reboot scheduled"),
         AuthErrors,
     ),
-    security(
-        ("session_cookie" = []),
-        ("bearer_auth" = []),
-    ),
 )]
 pub async fn reboot(
     State(state): State<AppState>,
@@ -173,10 +157,6 @@ pub async fn reboot(
         (status = 204, description = "Shutdown scheduled"),
         AuthErrors,
     ),
-    security(
-        ("session_cookie" = []),
-        ("bearer_auth" = []),
-    ),
 )]
 pub async fn shutdown(
     State(state): State<AppState>,
@@ -197,10 +177,6 @@ pub async fn shutdown(
     responses(
         (status = 200, description = "Current default policy", body = SetDefaultPolicyResponse),
         AuthErrors,
-    ),
-    security(
-        ("session_cookie" = []),
-        ("bearer_auth" = []),
     ),
 )]
 pub async fn get_default_policy(
@@ -225,10 +201,6 @@ pub async fn get_default_policy(
         (status = 200, description = "Default policy updated", body = SetDefaultPolicyResponse),
         (status = 400, description = "Invalid policy", body = wardnet_common::api::ApiError),
         AuthErrors,
-    ),
-    security(
-        ("session_cookie" = []),
-        ("bearer_auth" = []),
     ),
 )]
 pub async fn set_default_policy(
@@ -265,10 +237,6 @@ pub async fn set_default_policy(
     responses(
         (status = 204, description = "Acknowledgement recorded"),
         AuthErrors,
-    ),
-    security(
-        ("session_cookie" = []),
-        ("bearer_auth" = []),
     ),
 )]
 pub async fn acknowledge_shutdown(
@@ -320,10 +288,6 @@ pub struct RecentErrorsResponse {
     responses(
         (status = 200, description = "Recent warnings and errors", body = RecentErrorsResponse),
         AuthErrors,
-    ),
-    security(
-        ("session_cookie" = []),
-        ("bearer_auth" = []),
     ),
 )]
 pub async fn recent_errors(

--- a/source/daemon/crates/wardnetd-api/src/api/tests/openapi.rs
+++ b/source/daemon/crates/wardnetd-api/src/api/tests/openapi.rs
@@ -178,6 +178,85 @@ fn api_doc_authenticated_endpoint_references_both_schemes() {
     );
 }
 
+/// Visit every operation in the serialized spec, yielding
+/// `(path, method, operation)` for each HTTP-method entry under `paths`.
+fn for_each_operation(
+    doc: &serde_json::Value,
+    mut visit: impl FnMut(&str, &str, &serde_json::Value),
+) {
+    const METHODS: [&str; 7] = ["get", "put", "post", "delete", "patch", "head", "options"];
+    let paths = doc["paths"].as_object().expect("paths block must exist");
+    for (path, item) in paths {
+        for method in METHODS {
+            let op = &item[method];
+            if !op.is_null() {
+                visit(path, method, op);
+            }
+        }
+    }
+}
+
+#[test]
+fn every_security_requirement_references_a_registered_scheme() {
+    // The spot-check above only covers /api/devices. This walks the whole
+    // document: any scheme name an operation references must exist in
+    // `components.securitySchemes`, otherwise generated clients silently
+    // send no credentials and validators reject the spec.
+    let doc = api_doc_json();
+    let registered: Vec<String> = doc["components"]["securitySchemes"]
+        .as_object()
+        .expect("securitySchemes block must exist")
+        .keys()
+        .cloned()
+        .collect();
+
+    for_each_operation(&doc, |path, method, op| {
+        let Some(requirements) = op["security"].as_array() else {
+            return;
+        };
+        for entry in requirements {
+            // An empty `{}` entry is the marker for "no auth required".
+            for name in entry.as_object().into_iter().flat_map(|o| o.keys()) {
+                assert!(
+                    registered.iter().any(|r| r == name),
+                    "{method} {path} references security scheme {name:?}, \
+                     which is not registered (have: {registered:?})"
+                );
+            }
+        }
+    });
+}
+
+#[test]
+fn operation_tags_match_the_declared_tag_list() {
+    // Two-way check: every tag an operation uses must be declared on ApiDoc
+    // (otherwise it renders undescribed in Scalar), and every declared tag
+    // must be used by at least one operation (otherwise it's dead weight).
+    let doc = api_doc_json();
+    let declared: std::collections::BTreeSet<String> = doc["tags"]
+        .as_array()
+        .expect("top-level tags block must exist")
+        .iter()
+        .map(|t| t["name"].as_str().expect("tag name is a string").to_owned())
+        .collect();
+
+    let mut used = std::collections::BTreeSet::new();
+    for_each_operation(&doc, |_, _, op| {
+        for tag in op["tags"].as_array().into_iter().flatten() {
+            used.insert(tag.as_str().expect("operation tag is a string").to_owned());
+        }
+    });
+
+    assert_eq!(
+        used,
+        declared,
+        "operation tags and ApiDoc's declared tags have drifted apart \
+         (missing declarations: {:?}; declared but unused: {:?})",
+        used.difference(&declared).collect::<Vec<_>>(),
+        declared.difference(&used).collect::<Vec<_>>()
+    );
+}
+
 // ---------------------------------------------------------------------------
 // HTML + static assets
 // ---------------------------------------------------------------------------

--- a/source/daemon/crates/wardnetd-api/src/api/tests/openapi.rs
+++ b/source/daemon/crates/wardnetd-api/src/api/tests/openapi.rs
@@ -157,13 +157,14 @@ fn api_doc_unauthenticated_endpoint_has_empty_security() {
 
 #[test]
 fn api_doc_authenticated_endpoint_references_both_schemes() {
-    // /api/devices is admin-gated; it should list both accepted schemes.
+    // Admin-gated endpoints accept both schemes via the document-level
+    // security default rather than per-operation annotations. Check the
+    // default lists both, then check the representative admin endpoint
+    // carries no override — absence is what makes the default apply.
     let doc = api_doc_json();
-    let security = doc["paths"]["/api/devices"]["get"]["security"]
+    let names: Vec<String> = doc["security"]
         .as_array()
-        .expect("admin-gated endpoint must declare security")
-        .clone();
-    let names: Vec<String> = security
+        .expect("document-level security default must exist")
         .iter()
         .flat_map(|entry| {
             entry
@@ -174,7 +175,13 @@ fn api_doc_authenticated_endpoint_references_both_schemes() {
         .collect();
     assert!(
         names.iter().any(|n| n == "session_cookie") && names.iter().any(|n| n == "bearer_auth"),
-        "admin-gated endpoint should reference both schemes, got {names:?}"
+        "document security default should reference both schemes, got {names:?}"
+    );
+
+    assert!(
+        doc["paths"]["/api/devices"]["get"]["security"].is_null(),
+        "admin-gated endpoint should inherit the document default, \
+         not declare its own security"
     );
 }
 
@@ -200,10 +207,16 @@ fn for_each_operation(
 
 #[test]
 fn every_security_requirement_references_a_registered_scheme() {
-    // The spot-check above only covers /api/devices. This walks the whole
-    // document: any scheme name an operation references must exist in
+    // The spot-check above only covers the document default. This walks the
+    // whole document: any scheme name referenced anywhere — the document
+    // default or a per-operation override — must exist in
     // `components.securitySchemes`, otherwise generated clients silently
     // send no credentials and validators reject the spec.
+    //
+    // Operations without a `security` key are fine by construction: they
+    // inherit the document default, so a handler that forgets an annotation
+    // is documented as authenticated (the safe direction). Only deliberate
+    // opt-outs (`security(())`) and explicit overrides appear per-operation.
     let doc = api_doc_json();
     let registered: Vec<String> = doc["components"]["securitySchemes"]
         .as_object()
@@ -212,30 +225,34 @@ fn every_security_requirement_references_a_registered_scheme() {
         .cloned()
         .collect();
 
-    for_each_operation(&doc, |path, method, op| {
-        // Every operation must declare security explicitly — a handler whose
-        // `#[utoipa::path]` omits the attribute serializes with no `security`
-        // key at all, and generated clients would send no credentials to it.
-        // Public endpoints opt out visibly with `security(())`.
-        let requirements = op["security"].as_array().unwrap_or_else(|| {
-            panic!(
-                "{method} {path} declares no security requirements; every \
-                 operation needs a security(...) attribute — use security(()) \
-                 for deliberately unauthenticated endpoints"
-            )
-        });
+    let check_requirements = |context: &str, requirements: &[serde_json::Value]| {
         for entry in requirements {
             let entry = entry.as_object().unwrap_or_else(|| {
-                panic!("{method} {path}: security requirement entry must be an object, got {entry}")
+                panic!("{context}: security requirement entry must be an object, got {entry}")
             });
             // An empty `{}` object is the no-auth marker and yields no keys.
             for name in entry.keys() {
                 assert!(
                     registered.iter().any(|r| r == name),
-                    "{method} {path} references security scheme {name:?}, \
+                    "{context} references security scheme {name:?}, \
                      which is not registered (have: {registered:?})"
                 );
             }
+        }
+    };
+
+    let default = doc["security"]
+        .as_array()
+        .expect("document-level security default must exist");
+    assert!(
+        !default.is_empty(),
+        "document-level security default must not be empty"
+    );
+    check_requirements("document security default", default);
+
+    for_each_operation(&doc, |path, method, op| {
+        if let Some(requirements) = op["security"].as_array() {
+            check_requirements(&format!("{method} {path}"), requirements);
         }
     });
 }

--- a/source/daemon/crates/wardnetd-api/src/api/tests/openapi.rs
+++ b/source/daemon/crates/wardnetd-api/src/api/tests/openapi.rs
@@ -184,7 +184,9 @@ fn for_each_operation(
     doc: &serde_json::Value,
     mut visit: impl FnMut(&str, &str, &serde_json::Value),
 ) {
-    const METHODS: [&str; 7] = ["get", "put", "post", "delete", "patch", "head", "options"];
+    const METHODS: [&str; 8] = [
+        "get", "put", "post", "delete", "patch", "head", "options", "trace",
+    ];
     let paths = doc["paths"].as_object().expect("paths block must exist");
     for (path, item) in paths {
         for method in METHODS {
@@ -211,12 +213,23 @@ fn every_security_requirement_references_a_registered_scheme() {
         .collect();
 
     for_each_operation(&doc, |path, method, op| {
-        let Some(requirements) = op["security"].as_array() else {
-            return;
-        };
+        // Every operation must declare security explicitly — a handler whose
+        // `#[utoipa::path]` omits the attribute serializes with no `security`
+        // key at all, and generated clients would send no credentials to it.
+        // Public endpoints opt out visibly with `security(())`.
+        let requirements = op["security"].as_array().unwrap_or_else(|| {
+            panic!(
+                "{method} {path} declares no security requirements; every \
+                 operation needs a security(...) attribute — use security(()) \
+                 for deliberately unauthenticated endpoints"
+            )
+        });
         for entry in requirements {
-            // An empty `{}` entry is the marker for "no auth required".
-            for name in entry.as_object().into_iter().flat_map(|o| o.keys()) {
+            let entry = entry.as_object().unwrap_or_else(|| {
+                panic!("{method} {path}: security requirement entry must be an object, got {entry}")
+            });
+            // An empty `{}` object is the no-auth marker and yields no keys.
+            for name in entry.keys() {
                 assert!(
                     registered.iter().any(|r| r == name),
                     "{method} {path} references security scheme {name:?}, \
@@ -255,6 +268,48 @@ fn operation_tags_match_the_declared_tag_list() {
         used.difference(&declared).collect::<Vec<_>>(),
         declared.difference(&used).collect::<Vec<_>>()
     );
+}
+
+#[test]
+fn optional_ip_fields_are_nullable_with_accurate_presence() {
+    // `Option<Ipv4Addr>` fields carry a manual `value_type` annotation
+    // (utoipa has no ToSchema for Ipv4Addr), which makes it easy to copy the
+    // non-nullable `String` form from a neighbouring non-Option field and
+    // silently publish a client-breaking schema. Pin the contract for the
+    // three fields that have already drifted once:
+    //
+    // - response fields (`gateway`, `foreign_server_ip`) are serialized on
+    //   every response (as explicit `null` when unset) → required + nullable;
+    // - the request field (`target_ip`) may be omitted by callers entirely
+    //   → not required + nullable.
+    let doc = api_doc_json();
+    let schemas = &doc["components"]["schemas"];
+
+    let is_nullable = |schema: &str, field: &str| {
+        let ty = &schemas[schema]["properties"][field]["type"];
+        ty.as_array().is_some_and(|t| t.iter().any(|v| v == "null"))
+    };
+    let is_required = |schema: &str, field: &str| {
+        schemas[schema]["required"]
+            .as_array()
+            .is_some_and(|r| r.iter().any(|v| v == field))
+    };
+
+    for (schema, field, required) in [
+        ("NetworkStatusResponse", "gateway", true),
+        ("DhcpSelfProbeResponse", "foreign_server_ip", true),
+        ("DiscoverGatewayMacRequest", "target_ip", false),
+    ] {
+        assert!(
+            is_nullable(schema, field),
+            "{schema}.{field} must be nullable in the published schema"
+        );
+        assert_eq!(
+            is_required(schema, field),
+            required,
+            "{schema}.{field} presence contract drifted: expected required = {required}"
+        );
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/source/daemon/crates/wardnetd-api/src/api/tls.rs
+++ b/source/daemon/crates/wardnetd-api/src/api/tls.rs
@@ -33,7 +33,6 @@ pub fn register(router: OpenApiRouter<AppState>) -> OpenApiRouter<AppState> {
         (status = 200, description = "TLS provisioning status", body = TlsStatusResponse),
         AuthErrors,
     ),
-    security(("session_cookie" = []), ("bearer_auth" = [])),
 )]
 pub async fn tls_status(
     State(state): State<AppState>,

--- a/source/daemon/crates/wardnetd-api/src/api/tunnels.rs
+++ b/source/daemon/crates/wardnetd-api/src/api/tunnels.rs
@@ -40,10 +40,6 @@ pub fn register(router: OpenApiRouter<AppState>) -> OpenApiRouter<AppState> {
         (status = 200, description = "Configured tunnels", body = ListTunnelsResponse),
         AuthErrors,
     ),
-    security(
-        ("session_cookie" = []),
-        ("bearer_auth" = []),
-    ),
 )]
 pub async fn list_tunnels(
     State(state): State<AppState>,
@@ -65,10 +61,6 @@ pub async fn list_tunnels(
         (status = 201, description = "Tunnel imported", body = CreateTunnelResponse),
         AuthErrors,
         BadRequest,
-    ),
-    security(
-        ("session_cookie" = []),
-        ("bearer_auth" = []),
     ),
 )]
 pub async fn create_tunnel(
@@ -92,10 +84,6 @@ pub async fn create_tunnel(
         AuthErrors,
         NotFound,
     ),
-    security(
-        ("session_cookie" = []),
-        ("bearer_auth" = []),
-    ),
 )]
 pub async fn get_tunnel(
     State(state): State<AppState>,
@@ -117,10 +105,6 @@ pub async fn get_tunnel(
         (status = 200, description = "Devices using the tunnel", body = TunnelDevicesResponse),
         AuthErrors,
         NotFound,
-    ),
-    security(
-        ("session_cookie" = []),
-        ("bearer_auth" = []),
     ),
 )]
 pub async fn list_tunnel_devices(
@@ -144,10 +128,6 @@ pub async fn list_tunnel_devices(
         (status = 200, description = "Tunnel deleted", body = DeleteTunnelResponse),
         AuthErrors,
         NotFound,
-    ),
-    security(
-        ("session_cookie" = []),
-        ("bearer_auth" = []),
     ),
 )]
 pub async fn delete_tunnel(
@@ -175,10 +155,6 @@ pub async fn delete_tunnel(
         NotFound,
         Conflict,
         UpstreamUnavailable,
-    ),
-    security(
-        ("session_cookie" = []),
-        ("bearer_auth" = []),
     ),
 )]
 pub async fn test_tunnel(
@@ -208,10 +184,6 @@ pub async fn test_tunnel(
         NotFound,
         Conflict,
     ),
-    security(
-        ("session_cookie" = []),
-        ("bearer_auth" = []),
-    ),
 )]
 pub async fn start_speed_test(
     State(state): State<AppState>,
@@ -234,10 +206,6 @@ pub async fn start_speed_test(
         (status = 200, description = "Speed test history", body = TunnelSpeedTestHistoryResponse),
         AuthErrors,
         NotFound,
-    ),
-    security(
-        ("session_cookie" = []),
-        ("bearer_auth" = []),
     ),
 )]
 pub async fn list_speed_tests(
@@ -266,10 +234,6 @@ pub async fn list_speed_tests(
         AuthErrors,
         NotFound,
     ),
-    security(
-        ("session_cookie" = []),
-        ("bearer_auth" = []),
-    ),
 )]
 pub async fn update_tunnel_dns_override(
     State(state): State<AppState>,
@@ -296,10 +260,6 @@ pub async fn update_tunnel_dns_override(
         (status = 200, description = "Tunnel rebuild initiated", body = RebuildTunnelResponse),
         AuthErrors,
         NotFound,
-    ),
-    security(
-        ("session_cookie" = []),
-        ("bearer_auth" = []),
     ),
 )]
 pub async fn rebuild_tunnel(

--- a/source/daemon/crates/wardnetd-api/src/api/update.rs
+++ b/source/daemon/crates/wardnetd-api/src/api/update.rs
@@ -62,10 +62,6 @@ const HISTORY_LIMIT_MAX: u32 = 100;
         (status = 200, description = "Current auto-update status", body = UpdateStatusResponse),
         AuthErrors,
     ),
-    security(
-        ("session_cookie" = []),
-        ("bearer_auth" = []),
-    ),
 )]
 pub async fn status(
     State(state): State<AppState>,
@@ -84,10 +80,6 @@ pub async fn status(
     responses(
         (status = 200, description = "Manifest refresh result", body = UpdateCheckResponse),
         AuthErrors,
-    ),
-    security(
-        ("session_cookie" = []),
-        ("bearer_auth" = []),
     ),
 )]
 pub async fn check(
@@ -111,10 +103,6 @@ pub async fn check(
         AuthErrors,
         BadRequest,
     ),
-    security(
-        ("session_cookie" = []),
-        ("bearer_auth" = []),
-    ),
 )]
 pub async fn install(
     State(state): State<AppState>,
@@ -135,10 +123,6 @@ pub async fn install(
     responses(
         (status = 200, description = "Rollback initiated", body = RollbackResponse),
         AuthErrors,
-    ),
-    security(
-        ("session_cookie" = []),
-        ("bearer_auth" = []),
     ),
 )]
 pub async fn rollback(
@@ -161,10 +145,6 @@ pub async fn rollback(
         AuthErrors,
         BadRequest,
     ),
-    security(
-        ("session_cookie" = []),
-        ("bearer_auth" = []),
-    ),
 )]
 pub async fn update_config(
     State(state): State<AppState>,
@@ -186,10 +166,6 @@ pub async fn update_config(
     responses(
         (status = 200, description = "Update history", body = UpdateHistoryResponse),
         AuthErrors,
-    ),
-    security(
-        ("session_cookie" = []),
-        ("bearer_auth" = []),
     ),
 )]
 pub async fn history(

--- a/source/daemon/crates/wardnetd-api/src/api/users.rs
+++ b/source/daemon/crates/wardnetd-api/src/api/users.rs
@@ -27,10 +27,6 @@ pub fn register(router: OpenApiRouter<AppState>) -> OpenApiRouter<AppState> {
         AuthErrors,
         (status = 500, description = "Internal server error", body = ApiError),
     ),
-    security(
-        ("session_cookie" = []),
-        ("bearer_auth" = []),
-    ),
 )]
 pub async fn me(
     State(state): State<AppState>,

--- a/source/daemon/crates/wardnetd-api/src/api/zone_exception.rs
+++ b/source/daemon/crates/wardnetd-api/src/api/zone_exception.rs
@@ -32,7 +32,7 @@ pub fn register(router: OpenApiRouter<AppState>) -> OpenApiRouter<AppState> {
 #[utoipa::path(
     get,
     path = "/api/network/zones/exceptions",
-    tag = "zone_exceptions",
+    tag = "zone-exceptions",
     description = "List every cross-zone exception. Admin only.",
     responses(
         (status = 200, description = "Exceptions list", body = ListZoneExceptionsResponse),
@@ -51,7 +51,7 @@ pub async fn list_exceptions(
 #[utoipa::path(
     post,
     path = "/api/network/zones/exceptions",
-    tag = "zone_exceptions",
+    tag = "zone-exceptions",
     description = "Create a cross-zone exception. Both endpoints must exist and \
                    differ; a custom port list must be non-empty with valid \
                    ranges. Admin only.",
@@ -81,7 +81,7 @@ pub async fn create_exception(
 #[utoipa::path(
     get,
     path = "/api/network/zones/exceptions/{id}",
-    tag = "zone_exceptions",
+    tag = "zone-exceptions",
     description = "Fetch a single cross-zone exception. Admin only.",
     params(("id" = Uuid, Path, description = "Exception id")),
     responses(
@@ -103,7 +103,7 @@ pub async fn get_exception(
 #[utoipa::path(
     put,
     path = "/api/network/zones/exceptions/{id}",
-    tag = "zone_exceptions",
+    tag = "zone-exceptions",
     description = "Partially update a cross-zone exception. Every field is \
                    optional; the resolved exception is re-validated. Admin only.",
     params(("id" = Uuid, Path, description = "Exception id")),
@@ -132,7 +132,7 @@ pub async fn update_exception(
 #[utoipa::path(
     delete,
     path = "/api/network/zones/exceptions/{id}",
-    tag = "zone_exceptions",
+    tag = "zone-exceptions",
     description = "Delete a cross-zone exception. Admin only.",
     params(("id" = Uuid, Path, description = "Exception id")),
     responses(

--- a/source/daemon/crates/wardnetd-api/src/api/zone_exception.rs
+++ b/source/daemon/crates/wardnetd-api/src/api/zone_exception.rs
@@ -38,7 +38,6 @@ pub fn register(router: OpenApiRouter<AppState>) -> OpenApiRouter<AppState> {
         (status = 200, description = "Exceptions list", body = ListZoneExceptionsResponse),
         AuthErrors,
     ),
-    security(("session_cookie" = []), ("bearer_auth" = [])),
 )]
 pub async fn list_exceptions(
     State(state): State<AppState>,
@@ -61,7 +60,6 @@ pub async fn list_exceptions(
         AuthErrors,
         BadRequest,
     ),
-    security(("session_cookie" = []), ("bearer_auth" = [])),
 )]
 pub async fn create_exception(
     State(state): State<AppState>,
@@ -89,7 +87,6 @@ pub async fn create_exception(
         AuthErrors,
         NotFound,
     ),
-    security(("session_cookie" = []), ("bearer_auth" = [])),
 )]
 pub async fn get_exception(
     State(state): State<AppState>,
@@ -114,7 +111,6 @@ pub async fn get_exception(
         NotFound,
         BadRequest,
     ),
-    security(("session_cookie" = []), ("bearer_auth" = [])),
 )]
 pub async fn update_exception(
     State(state): State<AppState>,
@@ -140,7 +136,6 @@ pub async fn update_exception(
         AuthErrors,
         NotFound,
     ),
-    security(("session_cookie" = []), ("bearer_auth" = [])),
 )]
 pub async fn delete_exception(
     State(state): State<AppState>,

--- a/source/daemon/crates/wardnetd-api/src/openapi.rs
+++ b/source/daemon/crates/wardnetd-api/src/openapi.rs
@@ -19,9 +19,16 @@ use wardnetd_services::version::RELEASE_VERSION;
 /// Root `OpenAPI` document for the Wardnet daemon.
 ///
 /// Carries the document metadata (title, description, license), the tag list
-/// used to group endpoints in the generated UI, and — through
-/// [`SecurityAddon`] — the `session_cookie` and `bearer_auth` security schemes
-/// referenced by every admin-gated handler.
+/// used to group endpoints in the generated UI, the document-level security
+/// default, and — through [`SecurityAddon`] — the `session_cookie` and
+/// `bearer_auth` security schemes it references.
+///
+/// The `security(...)` block below applies to every operation that does not
+/// declare its own: admin-gated handlers need no per-operation annotation,
+/// and a handler that forgets one is documented as authenticated (the safe
+/// direction) instead of silently shipping as public. Deliberately
+/// unauthenticated endpoints opt out visibly with `security(())` in their
+/// `#[utoipa::path]` attribute.
 #[derive(OpenApi)]
 #[openapi(
     info(
@@ -38,6 +45,10 @@ use wardnetd_services::version::RELEASE_VERSION;
         license(name = "GPL-3.0-or-later")
     ),
     modifiers(&SecurityAddon),
+    security(
+        ("session_cookie" = []),
+        ("bearer_auth" = []),
+    ),
     tags(
         (name = "auth", description = "Session login / logout"),
         (name = "users", description = "Authenticated admin identity"),
@@ -66,14 +77,14 @@ use wardnetd_services::version::RELEASE_VERSION;
 )]
 pub struct ApiDoc;
 
-/// Declares the two authentication mechanisms every admin-gated handler
-/// references by name:
+/// Declares the two authentication mechanisms the document-level security
+/// default references by name:
 ///
 /// - `session_cookie` — the `wardnet_session` cookie issued by `POST /api/auth/login`.
 /// - `bearer_auth` — an opaque API key supplied via `Authorization: Bearer <key>`.
 ///
-/// Both are registered as reusable components so handlers only need to list
-/// the scheme name in their `security(...)` block.
+/// Both are registered as reusable components; [`ApiDoc`]'s `security(...)`
+/// block applies them to every operation that doesn't override it.
 struct SecurityAddon;
 
 /// Wardnet logo lockup (mark + WARDNET wordmark, dark-surface variant) served

--- a/source/daemon/crates/wardnetd-api/src/openapi.rs
+++ b/source/daemon/crates/wardnetd-api/src/openapi.rs
@@ -46,7 +46,7 @@ use wardnetd_services::version::RELEASE_VERSION;
         (name = "health", description = "Unauthenticated liveness/readiness probe"),
         (name = "devices", description = "Device discovery and routing"),
         (name = "network", description = "LAN interface status and gateway discovery"),
-        (name = "network_zones", description = "Network Zones: device policy buckets"),
+        (name = "network-zones", description = "Network Zones: device policy buckets"),
         (name = "zone-exceptions", description = "Cross-zone exceptions: admin-granted allowances between isolated zones"),
         (name = "rule-requests", description = "Device-initiated firewall rule requests and admin decisions"),
         (name = "tunnels", description = "WireGuard tunnel lifecycle"),

--- a/source/daemon/crates/wardnetd-api/src/openapi.rs
+++ b/source/daemon/crates/wardnetd-api/src/openapi.rs
@@ -43,9 +43,14 @@ use wardnetd_services::version::RELEASE_VERSION;
         (name = "users", description = "Authenticated admin identity"),
         (name = "setup", description = "First-run setup wizard"),
         (name = "info", description = "Unauthenticated daemon info"),
+        (name = "health", description = "Unauthenticated liveness/readiness probe"),
         (name = "devices", description = "Device discovery and routing"),
+        (name = "network", description = "LAN interface status and gateway discovery"),
         (name = "network_zones", description = "Network Zones: device policy buckets"),
+        (name = "zone-exceptions", description = "Cross-zone exceptions: admin-granted allowances between isolated zones"),
+        (name = "rule-requests", description = "Device-initiated firewall rule requests and admin decisions"),
         (name = "tunnels", description = "WireGuard tunnel lifecycle"),
+        (name = "inbound-wg", description = "Inbound WireGuard remote-access server and peers"),
         (name = "providers", description = "VPN provider integration"),
         (name = "dhcp", description = "DHCP server configuration, leases, and reservations"),
         (name = "dns", description = "DNS resolver, ad-blocking, filters"),
@@ -56,6 +61,7 @@ use wardnetd_services::version::RELEASE_VERSION;
         (name = "stats", description = "Generic pre-aggregating time-series and top-N stats"),
         (name = "update", description = "Auto-update and rollback"),
         (name = "push", description = "Web Push subscriptions and VAPID key"),
+        (name = "backup", description = "Encrypted configuration export / import and snapshots"),
     )
 )]
 pub struct ApiDoc;


### PR DESCRIPTION
Closes #845.

The published OpenAPI contract (`docs/openapi.json`) had drifted from what the daemon actually does, in three ways:

**Nullable `Ipv4Addr` fields typed as required strings.** `NetworkStatusResponse::gateway`, `DiscoverGatewayMacRequest::target_ip`, and `DhcpSelfProbeResponse::foreign_server_ip` are all `Option<Ipv4Addr>` at runtime but were annotated `#[schema(value_type = String)]`, so the spec listed them as required non-nullable strings. Generated clients would break the moment the daemon returned `null` or a caller omitted the field. All three are now nullable (`value_type = Option<String>`), with presence semantics matched to how each field actually behaves on the wire: the two response fields are additionally marked `#[schema(required)]` because serde always serializes them (as explicit `null` when unset) — required-but-nullable, agreeing with the handwritten SDK types — while `target_ip`, a request field callers may omit entirely, is optional-and-nullable.

**Undeclared `admin_auth` security scheme.** The two admin `dns_capture` handlers referenced an `admin_auth` scheme that was never registered in `components.securitySchemes` — validators reject the document and generated clients attach no credentials to those calls. Rather than just correcting the two typos, the root cause is gone: the 135 identical per-operation `security(("session_cookie" = []), ("bearer_auth" = []))` annotations are replaced by a single document-level security default on `ApiDoc`. Per OpenAPI semantics the default applies to every operation that doesn't declare its own, so both failure modes of the old scheme disappear — a misspelled scheme name can no longer be introduced per-handler, and a handler that forgets the annotation is now documented as authenticated (the safe direction) instead of silently shipping as public. The 15 deliberately unauthenticated endpoints keep a visible `security(())` opt-out. Runtime auth is unchanged throughout (enforced by the `AdminAuth` extractor, untouched); this is spec-only.

**Missing / miscased tag declarations.** `health`, `network`, `backup`, `rule-requests`, and `inbound-wg` were used by handlers but never declared on `ApiDoc`, so they rendered without descriptions in Scalar. Added them, and finished the kebab-case normalization of the tag namespace: `zone_exceptions` → `zone-exceptions` and `network_zones` → `network-zones` (the last snake_case multiword tags).

`docs/openapi.json` regenerated via `make openapi` in each commit, so `check-openapi` stays green.

To keep these drift classes from shipping silently again, the spec tests now walk the whole document instead of spot-checking `/api/devices`:
- `every_security_requirement_references_a_registered_scheme` — the document-level default must exist, be non-empty, and reference only registered schemes, and every per-operation override (the `security(())` opt-outs included) must be well-formed with registered scheme names;
- `api_doc_authenticated_endpoint_references_both_schemes` — the default lists both accepted schemes, and the representative admin endpoint inherits it rather than declaring its own;
- `operation_tags_match_the_declared_tag_list` — the set of tags used by operations must exactly equal the set declared on `ApiDoc` (both directions, so dead declared tags fail too);
- `optional_ip_fields_are_nullable_with_accurate_presence` — pins the nullability and presence contract of the three previously drifted fields, since `check-openapi` only compares the committed JSON to the generator output, not the spec to serde behavior.

The operation walker covers all eight HTTP methods including `trace`. The whole-document tests fail against the pre-fix annotations and pass now (verified by reverting the source files locally and re-running).

The OpenAPI section of `.agents/code-conventions.md` is updated to document both new conventions — the `Option` / `required` annotation variants for address fields, and the document-level security default (its previous wording literally prescribed the non-nullable form and the per-handler security blocks this PR removes).

All `wardnetd-api` + `wardnet-common` tests pass (481), clippy and rustfmt clean.