### PR TITLE
docs(daemon): add crates.io URL comments to wardnetd-mock and fuzz manifests

### DIFF
--- a/source/daemon/crates/wardnetd-mock/Cargo.toml
+++ b/source/daemon/crates/wardnetd-mock/Cargo.toml
@@ -18,23 +18,39 @@ name = "wardnetd_mock"
 path = "src/lib.rs"
 
 [dependencies]
+# Internal
 wardnet-common.workspace = true
 wardnetd-api.workspace = true
 wardnetd-data.workspace = true
 wardnetd-services.workspace = true
 
+# https://crates.io/crates/anyhow
 anyhow.workspace = true
+# https://crates.io/crates/async-trait
 async-trait.workspace = true
+# https://crates.io/crates/chrono
 chrono.workspace = true
+# https://crates.io/crates/clap
 clap.workspace = true
+# https://crates.io/crates/ipnetwork
 ipnetwork.workspace = true
+# https://crates.io/crates/rand
 rand.workspace = true
+# https://crates.io/crates/reqwest
 reqwest.workspace = true
+# https://crates.io/crates/serde
 serde.workspace = true
+# https://crates.io/crates/serde_json
 serde_json.workspace = true
+# https://crates.io/crates/tokio
 tokio.workspace = true
+# https://crates.io/crates/tokio-util
 tokio-util.workspace = true
+# https://crates.io/crates/tracing
 tracing.workspace = true
+# https://crates.io/crates/tracing-subscriber
 tracing-subscriber.workspace = true
+# https://crates.io/crates/uuid
 uuid.workspace = true
+# https://crates.io/crates/axum
 axum.workspace = true

--- a/source/daemon/fuzz/Cargo.toml
+++ b/source/daemon/fuzz/Cargo.toml
@@ -21,16 +21,21 @@ cargo-fuzz = true
 [workspace]
 
 [dependencies]
+# https://crates.io/crates/libfuzzer-sys
 libfuzzer-sys = "0.4"
 
+# https://crates.io/crates/tokio
 # Shared runtime for the async harnesses. "rt-multi-thread" is
 # sufficient; we don't need the full feature set.
 tokio = { version = "1", features = ["rt-multi-thread", "fs", "macros"] }
+# https://crates.io/crates/once_cell
 once_cell = "1"
 
+# https://crates.io/crates/sqlx
 # Needed to construct a throwaway SqlitePool for the sqlite_restore
 # harness (SqliteDumper::new takes a pool it later replaces).
 sqlx = { version = "0.9", default-features = false, features = ["runtime-tokio", "sqlite"] }
+# https://crates.io/crates/serde_json
 serde_json = "1"
 
 # Production crates under fuzz — path deps, no versions, so the fuzz


### PR DESCRIPTION
Closes #846

`wardnetd-mock/Cargo.toml` and `fuzz/Cargo.toml` were the last two daemon manifests not following the dependency comment convention from `.agents/code-conventions.md` §Dependencies.

Changes:
- `crates/wardnetd-mock/Cargo.toml`: added a `# https://crates.io/crates/...` comment above each of the 15 external dependencies and grouped the 4 `wardnet*` path deps under an `# Internal` header, matching the sibling crates (`wctl`, `wardnetd`, `wardnetd-services`, ...).
- `fuzz/Cargo.toml`: added the URL comment above the 5 crates.io dependencies (`libfuzzer-sys`, `tokio`, `once_cell`, `sqlx`, `serde_json`). The existing rationale comments for `tokio` and `sqlx` stay in place beneath the URL line, same URL-then-prose pattern the workspace root uses for `socket2`/`rustables`.

Comment-only change — no versions, features, or code touched. Verified `cargo check -p wardnetd-mock` and `cargo check` in the fuzz workspace both still pass.