### PR TITLE
fix(postupgrade): heal null state arrays and surface artifact read errors

### DIFF
--- a/source/daemon/Cargo.lock
+++ b/source/daemon/Cargo.lock
@@ -6246,6 +6246,7 @@ dependencies = [
  "tempfile",
  "tracing",
  "tracing-subscriber",
+ "wardnet-postupgrade",
 ]
 
 [[package]]

--- a/source/daemon/Cargo.toml
+++ b/source/daemon/Cargo.toml
@@ -41,6 +41,7 @@ missing_panics_doc = "allow"
 [workspace.dependencies]
 # Internal
 wardnet-common = { path = "crates/wardnet-common" }
+wardnet-postupgrade = { path = "crates/wardnet-postupgrade" }
 wardnetd-api = { path = "crates/wardnetd-api" }
 wardnetd-data = { path = "crates/wardnetd-data" }
 wardnetd-mock = { path = "crates/wardnetd-mock" }

--- a/source/daemon/crates/wardnet-postupgrade-runner/Cargo.toml
+++ b/source/daemon/crates/wardnet-postupgrade-runner/Cargo.toml
@@ -38,5 +38,10 @@ tracing-subscriber.workspace = true
 [dev-dependencies]
 # https://crates.io/crates/minisign
 minisign.workspace = true
+# Test-only: proves state.json written by this crate's recovery paths
+# still parses through the migration runner's typed schema. Must never
+# become a runtime dependency — the runner is the trust anchor and only
+# ever execs the migration runner from a verified payload.
+wardnet-postupgrade.workspace = true
 # https://crates.io/crates/tempfile
 tempfile.workspace = true

--- a/source/daemon/crates/wardnet-postupgrade-runner/src/lib.rs
+++ b/source/daemon/crates/wardnet-postupgrade-runner/src/lib.rs
@@ -64,6 +64,12 @@ pub enum RunOutcome {
     /// so this branch is reached only on a hand-deleted file or an
     /// ancient tarball that predates the framework.
     NoPayload,
+    /// The payload or signature exists but could not be read (payload
+    /// path is a directory, permission error, failing disk). Distinct
+    /// from [`RunOutcome::NoPayload`]: something *is* staged, so
+    /// pretending nothing happened would silently skip an update. The
+    /// runner logs ERROR and exits nonzero.
+    ArtifactReadFailed(anyhow::Error),
     /// Signature verification failed. The runner logs ERROR, records
     /// the failure into `state.json`, and exits nonzero.
     VerifyFailed(anyhow::Error),
@@ -115,11 +121,12 @@ impl Runner {
             }
         }
 
-        let Some((payload, signature)) =
-            verify::read_artifacts(&self.payload_path, &self.signature_path)
-        else {
-            return RunOutcome::NoPayload;
-        };
+        let (payload, signature) =
+            match verify::read_artifacts(&self.payload_path, &self.signature_path) {
+                Ok(Some(pair)) => pair,
+                Ok(None) => return RunOutcome::NoPayload,
+                Err(e) => return RunOutcome::ArtifactReadFailed(e),
+            };
 
         if let Err(e) = verify::verify(self.public_key, &payload, &signature) {
             // Record the failure best-effort; if state.json itself is

--- a/source/daemon/crates/wardnet-postupgrade-runner/src/lib.rs
+++ b/source/daemon/crates/wardnet-postupgrade-runner/src/lib.rs
@@ -68,19 +68,22 @@ pub enum RunOutcome {
     /// path is a directory, permission error, failing disk). Distinct
     /// from [`RunOutcome::NoPayload`]: something *is* staged, so
     /// pretending nothing happened would silently skip an update. The
-    /// runner logs ERROR and exits nonzero.
+    /// runner records the failure into `state.json`, logs ERROR, and
+    /// exits nonzero.
     ArtifactReadFailed(anyhow::Error),
     /// Signature verification failed. The runner logs ERROR, records
     /// the failure into `state.json`, and exits nonzero.
     VerifyFailed(anyhow::Error),
     /// `memfd_create` or `fexecve` failed. Successful exec replaces
     /// the process and never returns this variant. Very rare in
-    /// practice (kernel out of memory, seccomp policy mismatch).
+    /// practice (kernel out of memory, seccomp policy mismatch). The
+    /// failure is recorded into `state.json`.
     ExecFailed(anyhow::Error),
     /// Privileged swap of `<live>` could not be completed (signature
-    /// failure, missing wardnetd entry, fs error). The runner exits
-    /// nonzero so systemd refuses to start `wardnetd.service` against
-    /// an unverified binary.
+    /// failure, missing wardnetd entry, fs error). The runner records
+    /// the failure into `state.json` and exits nonzero so systemd
+    /// refuses to start `wardnetd.service` against an unverified
+    /// binary.
     SwapFailed(anyhow::Error),
 }
 
@@ -117,6 +120,7 @@ impl Runner {
                 tracing::info!(%live, "wardnetd rolled back to previous binary at {live}");
             }
             swap::SwapOutcome::Failed(e) => {
+                self.record_runner_failure("swap", &e);
                 return RunOutcome::SwapFailed(e);
             }
         }
@@ -125,7 +129,10 @@ impl Runner {
             match verify::read_artifacts(&self.payload_path, &self.signature_path) {
                 Ok(Some(pair)) => pair,
                 Ok(None) => return RunOutcome::NoPayload,
-                Err(e) => return RunOutcome::ArtifactReadFailed(e),
+                Err(e) => {
+                    self.record_runner_failure("artifact-read", &e);
+                    return RunOutcome::ArtifactReadFailed(e);
+                }
             };
 
         if let Err(e) = verify::verify(self.public_key, &payload, &signature) {
@@ -148,7 +155,29 @@ impl Runner {
 
         match exec::exec_memfd("wardnet-postupgrade", &payload, args) {
             Ok(never) => match never {},
-            Err(e) => RunOutcome::ExecFailed(e),
+            Err(e) => {
+                self.record_runner_failure("exec", &e);
+                RunOutcome::ExecFailed(e)
+            }
+        }
+    }
+
+    /// Best-effort mirror of the verification-failure recording above:
+    /// every boot-blocking outcome should be visible in state.json,
+    /// not only signature failures. Never fails the run — the ERROR
+    /// log + nonzero exit must reach the journal regardless.
+    fn record_runner_failure(&self, stage: &str, err: &anyhow::Error) {
+        let now = chrono::Utc::now();
+        if let Err(state_err) =
+            state::record_runner_failure(&self.state_path, stage, &format!("{err:#}"), now)
+        {
+            let path = self.state_path.display().to_string();
+            tracing::warn!(
+                %state_err,
+                %path,
+                %stage,
+                "could not record {stage} failure to {path}: {state_err}",
+            );
         }
     }
 }

--- a/source/daemon/crates/wardnet-postupgrade-runner/src/main.rs
+++ b/source/daemon/crates/wardnet-postupgrade-runner/src/main.rs
@@ -28,6 +28,16 @@ fn main() {
             );
             std::process::exit(0);
         }
+        RunOutcome::ArtifactReadFailed(e) => {
+            let error = format!("{e:#}");
+            let payload = runner.payload_path.display().to_string();
+            tracing::error!(
+                %error,
+                %payload,
+                "could not read staged postupgrade artifacts for {payload}: {error}",
+            );
+            std::process::exit(4);
+        }
         RunOutcome::VerifyFailed(e) => {
             tracing::error!(
                 error = %e,

--- a/source/daemon/crates/wardnet-postupgrade-runner/src/main.rs
+++ b/source/daemon/crates/wardnet-postupgrade-runner/src/main.rs
@@ -29,13 +29,11 @@ fn main() {
             std::process::exit(0);
         }
         RunOutcome::ArtifactReadFailed(e) => {
+            // The error chain names the file that failed (payload or
+            // signature); repeating the payload path here would point
+            // the operator at the wrong file half the time.
             let error = format!("{e:#}");
-            let payload = runner.payload_path.display().to_string();
-            tracing::error!(
-                %error,
-                %payload,
-                "could not read staged postupgrade artifacts for {payload}: {error}",
-            );
+            tracing::error!(%error, "could not read staged postupgrade artifacts: {error}");
             std::process::exit(4);
         }
         RunOutcome::VerifyFailed(e) => {

--- a/source/daemon/crates/wardnet-postupgrade-runner/src/state.rs
+++ b/source/daemon/crates/wardnet-postupgrade-runner/src/state.rs
@@ -1,10 +1,11 @@
 //! Best-effort state.json writer for verification failures.
 //!
-//! On verify failure the runner records who/why/when into the
-//! root-only state file so operators can diagnose without scraping
-//! systemd journals. The migration runner (`wardnet-postupgrade`)
-//! owns the rest of the state schema; this module touches only the
-//! `last_verification_failure` field.
+//! On a boot-blocking failure the runner records who/why/when into
+//! the root-only state file so operators can diagnose without
+//! scraping systemd journals. The migration runner
+//! (`wardnet-postupgrade`) owns the rest of the state schema; this
+//! module touches only the `last_verification_failure` and
+//! `last_runner_failure` fields.
 
 use std::path::Path;
 
@@ -35,6 +36,8 @@ struct State {
     failed: Vec<serde_json::Value>,
     #[serde(default)]
     last_verification_failure: Option<VerificationFailure>,
+    #[serde(default)]
+    last_runner_failure: Option<RunnerFailure>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -43,14 +46,49 @@ struct VerificationFailure {
     at: DateTime<Utc>,
 }
 
-/// Append a verification-failure record to `state.json`, preserving
-/// any `applied`/`failed` arrays already written by the migration
-/// runner. Atomic write-then-rename, root-only file.
+#[derive(Debug, Serialize, Deserialize)]
+struct RunnerFailure {
+    stage: String,
+    error: String,
+    at: DateTime<Utc>,
+}
+
+/// Record a signature-verification failure into `state.json`,
+/// preserving any `applied`/`failed` arrays already written by the
+/// migration runner. Atomic write-then-rename, root-only file.
 pub fn record_verification_failure(
     state_path: &Path,
     error_message: &str,
     now: DateTime<Utc>,
 ) -> anyhow::Result<()> {
+    update_state(state_path, |state| {
+        state.last_verification_failure = Some(VerificationFailure {
+            error: error_message.to_owned(),
+            at: now,
+        });
+    })
+}
+
+/// Record a non-verification runner failure (artifact read, binary
+/// swap, exec) into `state.json`, so a boot-blocked daemon is
+/// diagnosable from the state file alongside verification failures.
+pub fn record_runner_failure(
+    state_path: &Path,
+    stage: &str,
+    error_message: &str,
+    now: DateTime<Utc>,
+) -> anyhow::Result<()> {
+    update_state(state_path, |state| {
+        state.last_runner_failure = Some(RunnerFailure {
+            stage: stage.to_owned(),
+            error: error_message.to_owned(),
+            at: now,
+        });
+    })
+}
+
+/// Load-or-start-fresh, apply `mutate`, write back atomically.
+fn update_state(state_path: &Path, mutate: impl FnOnce(&mut State)) -> anyhow::Result<()> {
     if let Some(parent) = state_path.parent() {
         std::fs::create_dir_all(parent)
             .with_context(|| format!("could not create state directory {}", parent.display()))?;
@@ -78,10 +116,7 @@ pub fn record_verification_failure(
             )));
         }
     };
-    state.last_verification_failure = Some(VerificationFailure {
-        error: error_message.to_owned(),
-        at: now,
-    });
+    mutate(&mut state);
 
     let serialized = serde_json::to_vec_pretty(&state).context("serialize state.json")?;
     let tmp = state_path.with_extension("json.tmp");

--- a/source/daemon/crates/wardnet-postupgrade-runner/src/state.rs
+++ b/source/daemon/crates/wardnet-postupgrade-runner/src/state.rs
@@ -85,7 +85,8 @@ pub fn record_verification_failure(
 
     let serialized = serde_json::to_vec_pretty(&state).context("serialize state.json")?;
     let tmp = state_path.with_extension("json.tmp");
-    std::fs::write(&tmp, &serialized).with_context(|| format!("write {} failed", tmp.display()))?;
+    write_root_only(&tmp, &serialized)
+        .with_context(|| format!("write {} failed", tmp.display()))?;
     std::fs::rename(&tmp, state_path).with_context(|| {
         format!(
             "rename {} -> {} failed",
@@ -93,5 +94,32 @@ pub fn record_verification_failure(
             state_path.display()
         )
     })?;
+    Ok(())
+}
+
+/// Write `bytes` to `path` with mode 0600. The rename that follows
+/// carries the tmp file's permissions to state.json, so this is what
+/// upholds the file's documented root-only mode — a plain
+/// `std::fs::write` would leave it world-readable (0644).
+fn write_root_only(path: &Path, bytes: &[u8]) -> std::io::Result<()> {
+    use std::io::Write;
+
+    let mut options = std::fs::OpenOptions::new();
+    options.write(true).create(true).truncate(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(0o600);
+    }
+    let mut file = options.open(path)?;
+    file.write_all(bytes)?;
+    // The creation mode does not apply when the file already exists —
+    // a stale tmp from an interrupted earlier run keeps its old mode —
+    // so tighten it explicitly either way.
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        file.set_permissions(std::fs::Permissions::from_mode(0o600))?;
+    }
     Ok(())
 }

--- a/source/daemon/crates/wardnet-postupgrade-runner/src/state.rs
+++ b/source/daemon/crates/wardnet-postupgrade-runner/src/state.rs
@@ -101,25 +101,42 @@ pub fn record_verification_failure(
 /// carries the tmp file's permissions to state.json, so this is what
 /// upholds the file's documented root-only mode — a plain
 /// `std::fs::write` would leave it world-readable (0644).
+///
+/// Mirrored in `wardnet-postupgrade/src/state.rs` (same manual-sync
+/// rule as the schema above) — apply changes to both copies.
 fn write_root_only(path: &Path, bytes: &[u8]) -> std::io::Result<()> {
     use std::io::Write;
 
+    // Drop any stale tmp from an interrupted earlier run before
+    // creating a fresh inode (`create_new`). Reusing the old inode
+    // would keep its old (possibly world-readable) mode, and a chmod
+    // cannot revoke an fd someone already holds on it — an unlinked
+    // inode's readers only ever see the bytes that were theirs.
+    match std::fs::remove_file(path) {
+        Ok(()) => {}
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+        Err(e) => return Err(e),
+    }
     let mut options = std::fs::OpenOptions::new();
-    options.write(true).create(true).truncate(true);
+    options.write(true).create_new(true);
     #[cfg(unix)]
     {
         use std::os::unix::fs::OpenOptionsExt;
         options.mode(0o600);
     }
     let mut file = options.open(path)?;
-    file.write_all(bytes)?;
-    // The creation mode does not apply when the file already exists —
-    // a stale tmp from an interrupted earlier run keeps its old mode —
-    // so tighten it explicitly either way.
+    // The creation mode is masked by umask (only ever tighter than
+    // 0600); normalize to exactly the documented mode while the file
+    // is still empty.
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
         file.set_permissions(std::fs::Permissions::from_mode(0o600))?;
     }
+    file.write_all(bytes)?;
+    // Flush to disk before the caller renames over state.json, so a
+    // power loss right after the rename cannot replay a zero-length
+    // file where the old state used to be.
+    file.sync_all()?;
     Ok(())
 }

--- a/source/daemon/crates/wardnet-postupgrade-runner/src/state.rs
+++ b/source/daemon/crates/wardnet-postupgrade-runner/src/state.rs
@@ -14,14 +14,25 @@ use serde::{Deserialize, Serialize};
 
 /// Schema mirrors `wardnet-postupgrade::state::State`. Kept in sync
 /// manually because the runner cannot depend on the migration runner
-/// crate (the runner is the trust anchor; the migration runner is the
-/// thing it execs).
+/// crate at runtime (the runner is the trust anchor; the migration
+/// runner is the thing it execs). A dev-dependency enforces the
+/// contract in tests instead.
+///
+/// `applied`/`failed` are `Vec<Value>` rather than bare `Value`:
+/// entries pass through opaquely either way, but the `Vec` makes the
+/// array shape part of the parse. The migration runner's typed schema
+/// rejects an explicit JSON `null` for these fields, so a file
+/// carrying one (written by older runner versions recovering from a
+/// corrupt file) must fail deserialization here and take the
+/// start-fresh branch below — which rewrites it as `[]` and unblocks
+/// `State::load` on the next boot. Serialized `Vec::default()` is
+/// `[]`, so the derived `Default` is safe to write back.
 #[derive(Debug, Default, Serialize, Deserialize)]
 struct State {
     #[serde(default)]
-    applied: serde_json::Value,
+    applied: Vec<serde_json::Value>,
     #[serde(default)]
-    failed: serde_json::Value,
+    failed: Vec<serde_json::Value>,
     #[serde(default)]
     last_verification_failure: Option<VerificationFailure>,
 }
@@ -46,12 +57,20 @@ pub fn record_verification_failure(
     }
 
     let mut state: State = match std::fs::read(state_path) {
-        Ok(bytes) => serde_json::from_slice(&bytes).unwrap_or_default(),
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => State {
-            applied: serde_json::Value::Array(Vec::new()),
-            failed: serde_json::Value::Array(Vec::new()),
-            last_verification_failure: None,
-        },
+        Ok(bytes) => serde_json::from_slice(&bytes).unwrap_or_else(|e| {
+            // Corrupt or schema-invalid state.json (truncated
+            // mid-write, or null arrays from an older runner). Losing
+            // the applied/failed history is the lesser evil versus
+            // refusing to record the verification failure at all.
+            let path = state_path.display().to_string();
+            tracing::warn!(
+                error = %e,
+                %path,
+                "existing state at {path} is unusable; starting fresh: {e}",
+            );
+            State::default()
+        }),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => State::default(),
         Err(e) => {
             return Err(anyhow::Error::from(e).context(format!(
                 "could not read existing state at {}",

--- a/source/daemon/crates/wardnet-postupgrade-runner/src/swap.rs
+++ b/source/daemon/crates/wardnet-postupgrade-runner/src/swap.rs
@@ -124,11 +124,15 @@ pub fn run(paths: &SwapPaths, public_key: &str) -> SwapOutcome {
         };
     }
 
-    let Some((tarball, signature)) =
-        verify::read_artifacts(&paths.pending_tarball, &paths.pending_signature)
-    else {
-        return SwapOutcome::NoOp;
-    };
+    let (tarball, signature) =
+        match verify::read_artifacts(&paths.pending_tarball, &paths.pending_signature) {
+            Ok(Some(pair)) => pair,
+            Ok(None) => return SwapOutcome::NoOp,
+            // A staged tarball we cannot read is not "nothing staged" —
+            // exit nonzero so the failed update surfaces instead of the
+            // host silently booting the old binary.
+            Err(e) => return SwapOutcome::Failed(e.context("read pending update artifacts")),
+        };
 
     if let Err(e) = verify::verify(public_key, &tarball, &signature) {
         return SwapOutcome::Failed(e.context("pending tarball signature verification failed"));

--- a/source/daemon/crates/wardnet-postupgrade-runner/src/tests/runner.rs
+++ b/source/daemon/crates/wardnet-postupgrade-runner/src/tests/runner.rs
@@ -108,6 +108,11 @@ fn unreadable_payload_returns_artifact_read_failed() {
         format!("{err:#}").contains("failed to read payload"),
         "expected payload-read context"
     );
+
+    // The failure is diagnosable from state.json, not only journald.
+    let state: serde_json::Value =
+        serde_json::from_slice(&std::fs::read(dir.path().join("state.json")).unwrap()).unwrap();
+    assert_eq!(state["last_runner_failure"]["stage"], "artifact-read");
 }
 
 #[test]
@@ -164,6 +169,10 @@ fn exec_failed_when_verified_payload_is_not_an_executable() {
         format!("{err:#}").contains("fexecve failed"),
         "expected fexecve-failure message"
     );
+
+    let state: serde_json::Value =
+        serde_json::from_slice(&std::fs::read(dir.path().join("state.json")).unwrap()).unwrap();
+    assert_eq!(state["last_runner_failure"]["stage"], "exec");
 }
 
 #[test]
@@ -360,4 +369,8 @@ fn swap_failure_short_circuits_run() {
         b"OLD wardnetd",
         "live binary must be untouched on swap failure",
     );
+
+    let state: serde_json::Value =
+        serde_json::from_slice(&std::fs::read(dir.path().join("state.json")).unwrap()).unwrap();
+    assert_eq!(state["last_runner_failure"]["stage"], "swap");
 }

--- a/source/daemon/crates/wardnet-postupgrade-runner/src/tests/runner.rs
+++ b/source/daemon/crates/wardnet-postupgrade-runner/src/tests/runner.rs
@@ -1,9 +1,9 @@
-//! End-to-end tests for `Runner::run` covering all three return
-//! variants: `NoPayload` (either file missing), `VerifyFailed`
-//! (signature mismatched against embedded pubkey), and `ExecFailed`
-//! (verify passes but `fexecve` rejects the bytes as a non-executable
-//! image — driven here with a throwaway keypair signing garbage
-//! bytes).
+//! End-to-end tests for `Runner::run` covering its return variants:
+//! `NoPayload` (either file missing), `ArtifactReadFailed` (staged
+//! file present but unreadable), `VerifyFailed` (signature mismatched
+//! against embedded pubkey), `ExecFailed` (verify passes but `fexecve`
+//! rejects the bytes as a non-executable image — driven here with a
+//! throwaway keypair signing garbage bytes), and the swap arms.
 //!
 //! Successful exec replaces the test process, so the success branch
 //! is only reachable from a real systemd unit invocation. The
@@ -85,6 +85,28 @@ fn no_payload_when_signature_file_missing() {
     assert!(
         matches!(outcome, RunOutcome::NoPayload),
         "expected NoPayload, got {outcome:?}"
+    );
+}
+
+#[test]
+fn unreadable_payload_returns_artifact_read_failed() {
+    // Payload path exists but is a directory: unlike the missing-file
+    // cases above this must NOT resolve to `NoPayload` — an update is
+    // staged and can't be read, so the runner has to exit nonzero
+    // instead of reporting a clean no-op.
+    let dir = TempDir::new().unwrap();
+    std::fs::create_dir(dir.path().join("postupgrade.bin")).unwrap();
+    std::fs::write(dir.path().join("postupgrade.minisig"), b"sig").unwrap();
+
+    let runner = build_runner(dir.path(), "untrusted comment: x\nAAAA");
+    let argv = [CString::new("p").unwrap()];
+    let outcome = runner.run(&argv);
+    let RunOutcome::ArtifactReadFailed(err) = outcome else {
+        panic!("expected ArtifactReadFailed, got {outcome:?}");
+    };
+    assert!(
+        format!("{err:#}").contains("failed to read payload"),
+        "expected payload-read context"
     );
 }
 

--- a/source/daemon/crates/wardnet-postupgrade-runner/src/tests/state.rs
+++ b/source/daemon/crates/wardnet-postupgrade-runner/src/tests/state.rs
@@ -148,6 +148,30 @@ fn absent_array_fields_are_rewritten_as_empty_arrays() {
     assert!(state.failed.is_empty());
 }
 
+#[cfg(unix)]
+#[test]
+fn state_file_is_written_root_only() {
+    use std::os::unix::fs::PermissionsExt;
+
+    // state.json is documented root-only (0600). The rename carries
+    // the tmp file's mode, so the rewrite must end at 0600 even when
+    // the previous file — or a stale tmp from an interrupted run —
+    // was left world-readable.
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("state.json");
+    std::fs::write(&path, b"{}").unwrap();
+    std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o644)).unwrap();
+    let tmp = dir.path().join("state.json.tmp");
+    std::fs::write(&tmp, b"stale").unwrap();
+    std::fs::set_permissions(&tmp, std::fs::Permissions::from_mode(0o644)).unwrap();
+
+    let now = chrono::Utc::now();
+    record_verification_failure(&path, "boom", now).unwrap();
+
+    let mode = std::fs::metadata(&path).unwrap().permissions().mode() & 0o777;
+    assert_eq!(mode, 0o600, "state.json must be root-only, got {mode:o}");
+}
+
 #[test]
 fn read_error_other_than_not_found_returns_err() {
     // Pass a directory as state_path. `std::fs::read` returns an

--- a/source/daemon/crates/wardnet-postupgrade-runner/src/tests/state.rs
+++ b/source/daemon/crates/wardnet-postupgrade-runner/src/tests/state.rs
@@ -3,7 +3,7 @@
 use chrono::TimeZone;
 use tempfile::TempDir;
 
-use crate::state::record_verification_failure;
+use crate::state::{record_runner_failure, record_verification_failure};
 
 #[test]
 fn writes_fresh_state_when_file_absent() {
@@ -146,6 +146,60 @@ fn absent_array_fields_are_rewritten_as_empty_arrays() {
         .expect("migration runner must parse state with defaulted arrays");
     assert!(state.applied.is_empty());
     assert!(state.failed.is_empty());
+}
+
+#[test]
+fn runner_failure_round_trips_through_migration_runner_schema() {
+    // Non-verification failures (artifact read, swap, exec) are
+    // recorded next to verification failures and must survive both
+    // directions of the manually-synced schema: written here, loaded
+    // by the migration runner's typed State, and not clobbering an
+    // existing verification record.
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("state.json");
+    let now = chrono::Utc.with_ymd_and_hms(2026, 5, 4, 12, 0, 0).unwrap();
+    record_verification_failure(&path, "bad signature", now).unwrap();
+    record_runner_failure(&path, "swap", "tarball unreadable", now).unwrap();
+
+    let state = wardnet_postupgrade::State::load(&path)
+        .expect("migration runner must parse state with a runner failure");
+    let failure = state.last_runner_failure.expect("runner failure recorded");
+    assert_eq!(failure.stage, "swap");
+    assert_eq!(failure.error, "tarball unreadable");
+    let verification = state
+        .last_verification_failure
+        .expect("verification record preserved alongside");
+    assert_eq!(verification.error, "bad signature");
+}
+
+#[test]
+fn write_root_only_matches_migration_runner_copy() {
+    // The 0600 writer is mirror-copied into wardnet-postupgrade (the
+    // runner cannot share code with the crate it execs), same rule as
+    // the schema. The schema mirror is pinned by the round-trip tests
+    // above; this pins the writer: a fix applied to one copy fails CI
+    // until the other copy matches byte-for-byte.
+    fn helper_body(source: &str) -> &str {
+        let start = source
+            .find("fn write_root_only")
+            .expect("write_root_only present");
+        let len = source[start..]
+            .find("\n}")
+            .expect("write_root_only closing brace");
+        &source[start..start + len + 2]
+    }
+
+    let ours = include_str!("../state.rs");
+    let theirs_path = concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/../wardnet-postupgrade/src/state.rs"
+    );
+    let theirs = std::fs::read_to_string(theirs_path).expect("read sibling state.rs");
+    assert_eq!(
+        helper_body(ours),
+        helper_body(&theirs),
+        "write_root_only diverged between the two crates; apply the change to both copies"
+    );
 }
 
 #[cfg(unix)]

--- a/source/daemon/crates/wardnet-postupgrade-runner/src/tests/state.rs
+++ b/source/daemon/crates/wardnet-postupgrade-runner/src/tests/state.rs
@@ -21,13 +21,16 @@ fn writes_fresh_state_when_file_absent() {
 
 #[test]
 fn preserves_applied_and_failed_arrays() {
+    // Seed a schema-valid history exactly as the migration runner
+    // writes it, so the preservation contract is proven through the
+    // typed loader, not just against loosely-shaped fixture JSON.
     let dir = TempDir::new().unwrap();
     let path = dir.path().join("state.json");
     std::fs::write(
         &path,
         br#"{
-            "applied": [{"id": "0001_keep_me"}],
-            "failed":  [{"id": "0002_keep_me_too"}]
+            "applied": [{"id": "0001_keep_me", "applied_at": "2026-05-01T00:00:00Z"}],
+            "failed":  [{"id": "0002_keep_me_too", "error": "exit 1", "at": "2026-05-02T00:00:00Z"}]
         }"#,
     )
     .unwrap();
@@ -39,6 +42,11 @@ fn preserves_applied_and_failed_arrays() {
     assert_eq!(v["applied"][0]["id"], "0001_keep_me");
     assert_eq!(v["failed"][0]["id"], "0002_keep_me_too");
     assert_eq!(v["last_verification_failure"]["error"], "tamper");
+
+    let state = wardnet_postupgrade::State::load(&path)
+        .expect("migration runner must parse state with preserved history");
+    assert!(state.is_applied("0001_keep_me"));
+    assert_eq!(state.failed[0].id, "0002_keep_me_too");
 }
 
 #[test]
@@ -67,6 +75,77 @@ fn invalid_json_falls_back_to_default_state() {
 
     let v: serde_json::Value = serde_json::from_slice(&std::fs::read(&path).unwrap()).unwrap();
     assert_eq!(v["last_verification_failure"]["error"], "boom");
+    // The fresh state must use empty arrays, not `null` — the
+    // migration runner's typed schema rejects `null` for its `Vec`
+    // fields, and a `null` here would keep it exiting nonzero (and
+    // wardnetd blocked) long after the original failure was resolved.
+    assert!(v["applied"].is_array(), "applied must be [], got {v}");
+    assert!(v["failed"].is_array(), "failed must be [], got {v}");
+}
+
+#[test]
+fn corrupt_recovery_output_loads_via_migration_runner_schema() {
+    // Cross-crate contract: the two State schemas are kept in sync by
+    // hand, and the corrupt-recovery path once wrote `applied: null`,
+    // which `wardnet-postupgrade::State::load` rejects — a transient
+    // corrupt file plus one verification failure became a permanent
+    // boot block. Round-trip through the real typed loader to pin the
+    // contract down.
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("state.json");
+    std::fs::write(&path, b"{ truncated garbage").unwrap();
+
+    let now = chrono::Utc::now();
+    record_verification_failure(&path, "boom", now).expect("recover from corrupt json");
+
+    let state = wardnet_postupgrade::State::load(&path)
+        .expect("migration runner must parse state written by the recovery path");
+    assert!(state.applied.is_empty());
+    assert!(state.failed.is_empty());
+    let failure = state
+        .last_verification_failure
+        .expect("failure record preserved");
+    assert_eq!(failure.error, "boom");
+}
+
+#[test]
+fn explicit_null_arrays_are_healed_to_empty_arrays() {
+    // Older runner versions recovering from a corrupt file wrote
+    // "applied": null / "failed": null — the exact shape the migration
+    // runner's typed schema rejects. Such a file must not survive
+    // another recording round-trip: the Vec-typed fields refuse the
+    // null on parse, the start-fresh branch takes over, and the
+    // rewritten file loads cleanly again.
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("state.json");
+    std::fs::write(&path, br#"{"applied": null, "failed": null}"#).unwrap();
+
+    let now = chrono::Utc::now();
+    record_verification_failure(&path, "boom", now).expect("recover from legacy null arrays");
+
+    let state = wardnet_postupgrade::State::load(&path)
+        .expect("migration runner must parse the healed state");
+    assert!(state.applied.is_empty());
+    assert!(state.failed.is_empty());
+}
+
+#[test]
+fn absent_array_fields_are_rewritten_as_empty_arrays() {
+    // Same contract for a structurally-valid file that lacks the
+    // applied/failed keys: serde's field defaults must fill them with
+    // `[]`, never `null`, so the rewritten file still loads through
+    // the migration runner's typed schema.
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("state.json");
+    std::fs::write(&path, br#"{"last_verification_failure": null}"#).unwrap();
+
+    let now = chrono::Utc::now();
+    record_verification_failure(&path, "boom", now).expect("record over sparse state");
+
+    let state = wardnet_postupgrade::State::load(&path)
+        .expect("migration runner must parse state with defaulted arrays");
+    assert!(state.applied.is_empty());
+    assert!(state.failed.is_empty());
 }
 
 #[test]

--- a/source/daemon/crates/wardnet-postupgrade-runner/src/tests/swap.rs
+++ b/source/daemon/crates/wardnet-postupgrade-runner/src/tests/swap.rs
@@ -60,6 +60,31 @@ fn no_pending_files_is_noop() {
 }
 
 #[test]
+fn unreadable_pending_tarball_fails_instead_of_noop() {
+    // A staged-but-unreadable tarball (here: the pending path is a
+    // directory) must resolve to `Failed`, not `NoOp` — otherwise a
+    // botched staging looks like "no update pending" and the host
+    // silently boots the old binary with exit code 0.
+    let dir = TempDir::new().unwrap();
+    let p = paths(dir.path());
+    std::fs::write(&p.live_binary, b"OLD wardnetd").unwrap();
+
+    std::fs::create_dir(&p.pending_tarball).unwrap();
+    std::fs::write(&p.pending_signature, b"sig").unwrap();
+
+    let outcome = swap::run(&p, "untrusted comment: x\nAAAA");
+    let SwapOutcome::Failed(err) = outcome else {
+        panic!("expected Failed, got {outcome:?}");
+    };
+    let chain = format!("{err:#}");
+    assert!(
+        chain.contains("read pending update artifacts"),
+        "expected artifact-read context, got: {chain}"
+    );
+    assert_eq!(std::fs::read(&p.live_binary).unwrap(), b"OLD wardnetd");
+}
+
+#[test]
 fn signature_mismatch_fails_and_preserves_live_binary() {
     let dir = TempDir::new().unwrap();
     let p = paths(dir.path());

--- a/source/daemon/crates/wardnet-postupgrade-runner/src/tests/verify.rs
+++ b/source/daemon/crates/wardnet-postupgrade-runner/src/tests/verify.rs
@@ -85,7 +85,8 @@ fn read_artifacts_returns_none_on_missing_payload() {
     let dir = TempDir::new().expect("tempdir");
     // signature exists, payload does not
     std::fs::write(dir.path().join("sig"), b"sig").unwrap();
-    let result = read_artifacts(&dir.path().join("missing.bin"), &dir.path().join("sig"));
+    let result = read_artifacts(&dir.path().join("missing.bin"), &dir.path().join("sig"))
+        .expect("missing payload is not an error");
     assert!(result.is_none());
 }
 
@@ -96,7 +97,8 @@ fn read_artifacts_returns_none_on_missing_signature() {
     let result = read_artifacts(
         &dir.path().join("payload.bin"),
         &dir.path().join("missing.minisig"),
-    );
+    )
+    .expect("missing signature is not an error");
     assert!(result.is_none());
 }
 
@@ -109,34 +111,46 @@ fn read_artifacts_returns_bytes_when_both_present() {
         &dir.path().join("payload.bin"),
         &dir.path().join("payload.minisig"),
     )
+    .expect("read ok")
     .expect("both files present");
     assert_eq!(p, b"payload");
     assert_eq!(s, b"sig");
 }
 
 #[test]
-fn read_artifacts_returns_none_when_payload_path_is_a_directory() {
+fn read_artifacts_returns_err_when_payload_path_is_a_directory() {
     // `std::fs::read` on a directory returns an `Err` whose kind is
-    // not `NotFound`, exercising the unhappy I/O branch the runner
-    // logs as an ERROR before returning None.
+    // not `NotFound`. Something *is* staged but can't be read — that
+    // must surface as `Err`, not be conflated with the benign
+    // "nothing staged" `None`.
     let dir = TempDir::new().unwrap();
     let dir_as_payload = dir.path().join("a-directory");
     std::fs::create_dir(&dir_as_payload).unwrap();
     std::fs::write(dir.path().join("sig"), b"sig").unwrap();
 
-    let result = read_artifacts(&dir_as_payload, &dir.path().join("sig"));
-    assert!(result.is_none());
+    let err = read_artifacts(&dir_as_payload, &dir.path().join("sig"))
+        .expect_err("unreadable payload must surface as Err");
+    let chain = format!("{err:#}");
+    assert!(
+        chain.contains("failed to read payload"),
+        "expected payload-read context, got: {chain}"
+    );
 }
 
 #[test]
-fn read_artifacts_returns_none_when_signature_path_is_a_directory() {
+fn read_artifacts_returns_err_when_signature_path_is_a_directory() {
     let dir = TempDir::new().unwrap();
     std::fs::write(dir.path().join("payload.bin"), b"payload").unwrap();
     let dir_as_sig = dir.path().join("a-directory");
     std::fs::create_dir(&dir_as_sig).unwrap();
 
-    let result = read_artifacts(&dir.path().join("payload.bin"), &dir_as_sig);
-    assert!(result.is_none());
+    let err = read_artifacts(&dir.path().join("payload.bin"), &dir_as_sig)
+        .expect_err("unreadable signature must surface as Err");
+    let chain = format!("{err:#}");
+    assert!(
+        chain.contains("failed to read signature"),
+        "expected signature-read context, got: {chain}"
+    );
 }
 
 #[test]

--- a/source/daemon/crates/wardnet-postupgrade-runner/src/verify.rs
+++ b/source/daemon/crates/wardnet-postupgrade-runner/src/verify.rs
@@ -13,10 +13,14 @@ pub fn read_artifacts(
     payload: &Path,
     signature: &Path,
 ) -> anyhow::Result<Option<(Vec<u8>, Vec<u8>)>> {
-    let Some(payload_bytes) = read_optional(payload, "payload")? else {
+    // Signature first: it is a few hundred bytes, while the payload
+    // can be a multi-megabyte tarball. A half-staged update (payload
+    // present, signature never written) short-circuits here without
+    // paying a full payload read on every boot.
+    let Some(signature_bytes) = read_optional(signature, "signature")? else {
         return Ok(None);
     };
-    let Some(signature_bytes) = read_optional(signature, "signature")? else {
+    let Some(payload_bytes) = read_optional(payload, "payload")? else {
         return Ok(None);
     };
     Ok(Some((payload_bytes, signature_bytes)))

--- a/source/daemon/crates/wardnet-postupgrade-runner/src/verify.rs
+++ b/source/daemon/crates/wardnet-postupgrade-runner/src/verify.rs
@@ -4,38 +4,36 @@ use std::path::Path;
 
 use anyhow::Context;
 
-/// Read the payload + detached signature from disk. Returns `None` if
-/// either file is missing — the caller maps this to exit-0 (nothing
+/// Read the payload + detached signature from disk. Returns `Ok(None)`
+/// if either file is missing — the caller maps this to exit-0 (nothing
 /// to do) per the framework's "tolerate missing payload" contract.
-/// Any other I/O error is surfaced as `Err`.
-pub fn read_artifacts(payload: &Path, signature: &Path) -> Option<(Vec<u8>, Vec<u8>)> {
-    let payload_bytes = match std::fs::read(payload) {
-        Ok(b) => b,
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return None,
-        Err(e) => {
-            tracing::error!(
-                error = %e,
-                path = %payload.display(),
-                "failed to read payload at {path}: {e}",
-                path = payload.display(),
-            );
-            return None;
-        }
+/// Any other I/O error is surfaced as `Err`: a staged-but-unreadable
+/// artifact must fail loudly, not masquerade as "nothing staged".
+pub fn read_artifacts(
+    payload: &Path,
+    signature: &Path,
+) -> anyhow::Result<Option<(Vec<u8>, Vec<u8>)>> {
+    let Some(payload_bytes) = read_optional(payload, "payload")? else {
+        return Ok(None);
     };
-    let signature_bytes = match std::fs::read(signature) {
-        Ok(b) => b,
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return None,
-        Err(e) => {
-            tracing::error!(
-                error = %e,
-                path = %signature.display(),
-                "failed to read signature at {path}: {e}",
-                path = signature.display(),
-            );
-            return None;
-        }
+    let Some(signature_bytes) = read_optional(signature, "signature")? else {
+        return Ok(None);
     };
-    Some((payload_bytes, signature_bytes))
+    Ok(Some((payload_bytes, signature_bytes)))
+}
+
+/// Read a file that is allowed to be absent. `NotFound` is the benign
+/// `None`; any other I/O error is a hard `Err` so both artifact reads
+/// keep the same missing-vs-unreadable policy.
+fn read_optional(path: &Path, what: &str) -> anyhow::Result<Option<Vec<u8>>> {
+    match std::fs::read(path) {
+        Ok(b) => Ok(Some(b)),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(e) => {
+            Err(anyhow::Error::from(e)
+                .context(format!("failed to read {what} at {}", path.display())))
+        }
+    }
 }
 
 /// Verify a detached minisign signature over `payload` using the

--- a/source/daemon/crates/wardnet-postupgrade/src/state.rs
+++ b/source/daemon/crates/wardnet-postupgrade/src/state.rs
@@ -79,7 +79,7 @@ impl State {
         }
         let bytes = serde_json::to_vec_pretty(self).context("serialize state")?;
         let tmp = path.with_extension("json.tmp");
-        std::fs::write(&tmp, &bytes).with_context(|| format!("writing {}", tmp.display()))?;
+        write_root_only(&tmp, &bytes).with_context(|| format!("writing {}", tmp.display()))?;
         std::fs::rename(&tmp, path)
             .with_context(|| format!("rename {} -> {}", tmp.display(), path.display()))?;
         Ok(())
@@ -90,4 +90,31 @@ impl State {
     pub fn is_applied(&self, id: &str) -> bool {
         self.applied.iter().any(|e| e.id == id)
     }
+}
+
+/// Write `bytes` to `path` with mode 0600. The rename in `save`
+/// carries the tmp file's permissions to state.json, so this is what
+/// upholds the root-only mode documented at the top of this module —
+/// a plain `std::fs::write` would leave it world-readable (0644).
+fn write_root_only(path: &Path, bytes: &[u8]) -> std::io::Result<()> {
+    use std::io::Write;
+
+    let mut options = std::fs::OpenOptions::new();
+    options.write(true).create(true).truncate(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(0o600);
+    }
+    let mut file = options.open(path)?;
+    file.write_all(bytes)?;
+    // The creation mode does not apply when the file already exists —
+    // a stale tmp from an interrupted earlier run keeps its old mode —
+    // so tighten it explicitly either way.
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        file.set_permissions(std::fs::Permissions::from_mode(0o600))?;
+    }
+    Ok(())
 }

--- a/source/daemon/crates/wardnet-postupgrade/src/state.rs
+++ b/source/daemon/crates/wardnet-postupgrade/src/state.rs
@@ -33,6 +33,13 @@ pub struct State {
     /// not touch this field — it only ever runs after verification
     /// has succeeded.
     pub last_verification_failure: Option<VerificationFailure>,
+    /// Recorded by `wardnet-postupgrade-runner` when a boot-time step
+    /// other than signature verification fails: reading the staged
+    /// artifacts, the privileged binary swap, or the exec of the
+    /// verified payload. Like `last_verification_failure`, this exists
+    /// so operators can diagnose a boot-blocked daemon from state.json
+    /// without scraping systemd journals.
+    pub last_runner_failure: Option<RunnerFailure>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -50,6 +57,14 @@ pub struct FailedEntry {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct VerificationFailure {
+    pub error: String,
+    pub at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RunnerFailure {
+    /// Which runner step failed: `artifact-read`, `swap`, or `exec`.
+    pub stage: String,
     pub error: String,
     pub at: DateTime<Utc>,
 }
@@ -147,9 +162,9 @@ fn write_root_only(path: &Path, bytes: &[u8]) -> std::io::Result<()> {
         file.set_permissions(std::fs::Permissions::from_mode(0o600))?;
     }
     file.write_all(bytes)?;
-    // Flush to disk before `save` renames over state.json, so a power
-    // loss right after the rename cannot replay a zero-length file
-    // where the old state used to be.
+    // Flush to disk before the caller renames over state.json, so a
+    // power loss right after the rename cannot replay a zero-length
+    // file where the old state used to be.
     file.sync_all()?;
     Ok(())
 }

--- a/source/daemon/crates/wardnet-postupgrade/src/state.rs
+++ b/source/daemon/crates/wardnet-postupgrade/src/state.rs
@@ -57,10 +57,28 @@ pub struct VerificationFailure {
 impl State {
     /// Read state from disk. Returns `Default::default()` when the
     /// file is absent — first run on a fresh host.
+    ///
+    /// Also reconciles the file's mode back to the documented 0600:
+    /// older releases wrote state.json world-readable (0644), and on a
+    /// healthy host nothing ever rewrites the file, so load — which
+    /// runs on every boot — is the one place that reliably sees it.
+    /// Best-effort: a chmod failure must not block migrations.
     pub fn load(path: &Path) -> anyhow::Result<Self> {
         match std::fs::read(path) {
-            Ok(bytes) => serde_json::from_slice(&bytes)
-                .with_context(|| format!("parsing state file {}", path.display())),
+            Ok(bytes) => {
+                #[cfg(unix)]
+                {
+                    use std::os::unix::fs::PermissionsExt;
+                    if let Ok(meta) = std::fs::metadata(path)
+                        && meta.permissions().mode() & 0o077 != 0
+                    {
+                        let _ =
+                            std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600));
+                    }
+                }
+                serde_json::from_slice(&bytes)
+                    .with_context(|| format!("parsing state file {}", path.display()))
+            }
             Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(State::default()),
             Err(e) => {
                 Err(anyhow::Error::from(e)
@@ -96,25 +114,42 @@ impl State {
 /// carries the tmp file's permissions to state.json, so this is what
 /// upholds the root-only mode documented at the top of this module —
 /// a plain `std::fs::write` would leave it world-readable (0644).
+///
+/// Mirrored in `wardnet-postupgrade-runner/src/state.rs` (same
+/// manual-sync rule as the schema) — apply changes to both copies.
 fn write_root_only(path: &Path, bytes: &[u8]) -> std::io::Result<()> {
     use std::io::Write;
 
+    // Drop any stale tmp from an interrupted earlier run before
+    // creating a fresh inode (`create_new`). Reusing the old inode
+    // would keep its old (possibly world-readable) mode, and a chmod
+    // cannot revoke an fd someone already holds on it — an unlinked
+    // inode's readers only ever see the bytes that were theirs.
+    match std::fs::remove_file(path) {
+        Ok(()) => {}
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+        Err(e) => return Err(e),
+    }
     let mut options = std::fs::OpenOptions::new();
-    options.write(true).create(true).truncate(true);
+    options.write(true).create_new(true);
     #[cfg(unix)]
     {
         use std::os::unix::fs::OpenOptionsExt;
         options.mode(0o600);
     }
     let mut file = options.open(path)?;
-    file.write_all(bytes)?;
-    // The creation mode does not apply when the file already exists —
-    // a stale tmp from an interrupted earlier run keeps its old mode —
-    // so tighten it explicitly either way.
+    // The creation mode is masked by umask (only ever tighter than
+    // 0600); normalize to exactly the documented mode while the file
+    // is still empty.
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
         file.set_permissions(std::fs::Permissions::from_mode(0o600))?;
     }
+    file.write_all(bytes)?;
+    // Flush to disk before `save` renames over state.json, so a power
+    // loss right after the rename cannot replay a zero-length file
+    // where the old state used to be.
+    file.sync_all()?;
     Ok(())
 }

--- a/source/daemon/crates/wardnet-postupgrade/src/tests/state.rs
+++ b/source/daemon/crates/wardnet-postupgrade/src/tests/state.rs
@@ -85,6 +85,28 @@ fn save_keeps_state_file_root_only() {
     assert_eq!(mode, 0o600, "state.json must be root-only, got {mode:o}");
 }
 
+#[cfg(unix)]
+#[test]
+fn load_reconciles_world_readable_state_to_root_only() {
+    use std::os::unix::fs::PermissionsExt;
+
+    // Older releases wrote state.json 0644 and a healthy host never
+    // rewrites it, so load — which runs every boot — tightens the
+    // mode back to the documented 0600.
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("state.json");
+    State::default().save(&path).unwrap();
+    std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o644)).unwrap();
+
+    State::load(&path).expect("load");
+
+    let mode = std::fs::metadata(&path).unwrap().permissions().mode() & 0o777;
+    assert_eq!(
+        mode, 0o600,
+        "load must tighten legacy world-readable state, got {mode:o}"
+    );
+}
+
 #[test]
 fn load_returns_err_on_invalid_json() {
     let dir = TempDir::new().unwrap();

--- a/source/daemon/crates/wardnet-postupgrade/src/tests/state.rs
+++ b/source/daemon/crates/wardnet-postupgrade/src/tests/state.rs
@@ -63,6 +63,28 @@ fn is_applied_matches_by_id() {
     assert!(!state.is_applied("0002"));
 }
 
+#[cfg(unix)]
+#[test]
+fn save_keeps_state_file_root_only() {
+    use std::os::unix::fs::PermissionsExt;
+
+    // The module doc pins state.json at mode 0600. The write-then-
+    // rename must uphold that even when overwriting a file (or a
+    // stale tmp) that was left world-readable.
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("state.json");
+    std::fs::write(&path, b"{}").unwrap();
+    std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o644)).unwrap();
+    let tmp = dir.path().join("state.json.tmp");
+    std::fs::write(&tmp, b"stale").unwrap();
+    std::fs::set_permissions(&tmp, std::fs::Permissions::from_mode(0o644)).unwrap();
+
+    State::default().save(&path).expect("save");
+
+    let mode = std::fs::metadata(&path).unwrap().permissions().mode() & 0o777;
+    assert_eq!(mode, 0o600, "state.json must be root-only, got {mode:o}");
+}
+
 #[test]
 fn load_returns_err_on_invalid_json() {
     let dir = TempDir::new().unwrap();

--- a/source/daemon/crates/wardnet-postupgrade/src/tests/state.rs
+++ b/source/daemon/crates/wardnet-postupgrade/src/tests/state.rs
@@ -3,7 +3,7 @@
 use chrono::TimeZone;
 use tempfile::TempDir;
 
-use crate::state::{AppliedEntry, FailedEntry, State};
+use crate::state::{AppliedEntry, FailedEntry, RunnerFailure, State};
 
 #[test]
 fn load_returns_default_when_file_missing() {
@@ -30,7 +30,7 @@ fn save_then_load_roundtrip() {
             error: "oops".into(),
             at: now,
         }],
-        last_verification_failure: None,
+        ..Default::default()
     };
     state.save(&path).unwrap();
 
@@ -39,6 +39,30 @@ fn save_then_load_roundtrip() {
     assert_eq!(loaded.applied[0].id, "0001");
     assert_eq!(loaded.failed.len(), 1);
     assert_eq!(loaded.failed[0].id, "0002");
+}
+
+#[test]
+fn save_preserves_runner_failure_record() {
+    // `last_runner_failure` is written by the trust-anchor runner;
+    // this crate's save must carry it through unchanged so a later
+    // migration run doesn't erase the diagnosis.
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("state.json");
+    let now = chrono::Utc.with_ymd_and_hms(2026, 5, 4, 12, 0, 0).unwrap();
+    let state = State {
+        last_runner_failure: Some(RunnerFailure {
+            stage: "swap".into(),
+            error: "tarball unreadable".into(),
+            at: now,
+        }),
+        ..Default::default()
+    };
+    state.save(&path).unwrap();
+
+    let loaded = State::load(&path).expect("load");
+    let failure = loaded.last_runner_failure.expect("record preserved");
+    assert_eq!(failure.stage, "swap");
+    assert_eq!(failure.error, "tarball unreadable");
 }
 
 #[test]


### PR DESCRIPTION
Closes #836.

Both error-handling fallbacks in `wardnet-postupgrade-runner` could quietly defeat the boot gate they exist to protect. This fixes the two failure modes from the issue, adds the cross-crate contract test, and hardens the state-file write path that the fix touches.

## state.rs — corrupt-recovery wrote `null` arrays

`record_verification_failure`'s corrupt-JSON branch used `unwrap_or_default()`, and `serde_json::Value::default()` is `Null` — so recovery rewrote `applied`/`failed` as `null` instead of `[]`. The migration runner's typed `State` (`Vec` fields) rejects an explicit `null`, so `State::load` kept failing with exit 2 and, via `RequiredBy=wardnetd.service`, kept `wardnetd` from booting even after the original signature problem was cleared.

Rather than patching just that branch, the runner-side fields are now `Vec<serde_json::Value>` (entries stay opaque; only the array shape is load-bearing). That makes the bad shape unrepresentable:

- `Vec::default()` serializes as `[]`, so the derived `Default` is safe again and both start-fresh branches share it.
- Absent keys fill as `[]` via `#[serde(default)]`.
- A file already poisoned with explicit `null`s by an older runner now *fails* the parse and is routed through the same start-fresh recovery — the next recording round-trip heals it instead of preserving the `null` forever.

The two `State` schemas are documented as kept in sync manually (the runner can't depend on the migration runner crate at runtime — it's the trust anchor). A new test-only dev-dependency on `wardnet-postupgrade` pins the contract instead: recovery output, sparse files, legacy-null files, and preserved history are all round-tripped through the real `State::load`.

## verify.rs — I/O errors collapsed into "nothing staged"

`read_artifacts` documented "any other I/O error is surfaced as `Err`" but returned `Option`, mapping every read failure to the same `None` as the benign missing-file case — a staged-but-unreadable update looked like a clean no-op with exit 0. It now returns `anyhow::Result<Option<(Vec<u8>, Vec<u8>)>>`:

- `NotFound` on either file → `Ok(None)`, unchanged benign no-op.
- Any other I/O error → `Err`, matching the doc comment.
- `swap::run` maps the error to `SwapOutcome::Failed` (nonzero exit, pending files left in place for diagnosis).
- `Runner::run` maps it to a new `RunOutcome::ArtifactReadFailed`, which `main` logs and exits 4 on — distinct from `NoPayload` because something *is* staged and skipping it silently would lose an update.

The old tests asserting `None` for the unreadable-artifact branch encoded the bug; they now assert `Err`, and new tests cover both callers' propagation. The signature (a few hundred bytes) is now read before the payload (potentially a multi-MB tarball), so a half-staged update doesn't cost a full tarball read on every boot.

## Every boot-blocking failure is now diagnosable from state.json

Verification failures were the only outcome recorded into `state.json`, yet artifact-read, swap, and exec failures gate `wardnetd` startup just the same — the documented no-journal diagnosis path showed a clean state file while the daemon was down. Both schemas gain a `last_runner_failure` field (`{stage, error, at}`, stage one of `artifact-read`/`swap`/`exec`), written best-effort by the runner on each of those paths and preserved by the migration runner's `save`. Round-trip tests cover it through the typed loader, and the three runner tests assert the record lands.

## state.json permissions and durability

The state module docs pin `state.json` at `root:root` mode 0600, but both writers built the tmp file with `std::fs::write` (0644 under the default umask) and the atomic rename carried that mode onto the state file. Both crates now write through a `write_root_only` helper that:

- unlinks any stale tmp and creates a fresh inode with `create_new` + mode 0600 — reusing the old inode would keep its old world-readable mode, and a chmod can't revoke an fd another process already holds on it;
- normalizes to exactly 0600 while the file is still empty (creation mode is umask-masked);
- fsyncs before the rename (matching the polkit rule writer), so a power cut right after the swap can't replay a zero-length `state.json`.

`State::load` additionally reconciles the mode of files written 0644 by older releases — on a healthy host nothing ever rewrites `state.json`, so load (which runs every boot) is the reliable place to tighten it, best-effort so a chmod failure can't block migrations.

The mirrored `write_root_only` copies are pinned by a tripwire test that fails CI when the two crates' helper bodies diverge, matching how the schema mirror is enforced.

## Checks

- `cargo fmt`, `cargo clippy --all-targets -- -D warnings`, `cargo test --workspace` all pass.
- Coverage on the two crates: 87.58% lines vs 86.53% on main — no decrease.