### PR TITLE
fix(dns): age cached TTLs on hit and make cache eviction O(1) at capacity

### DIFF
--- a/source/daemon/crates/wardnetd-services/src/dns/cache.rs
+++ b/source/daemon/crates/wardnetd-services/src/dns/cache.rs
@@ -1,10 +1,13 @@
 use std::collections::{HashMap, VecDeque};
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{Duration, Instant};
 
 use hickory_proto::op::Message;
 use hickory_proto::rr::RecordType;
 
 use wardnet_common::dns::UpstreamId;
+
+use crate::dns_filter::filter::normalize;
 
 type CacheKey = (UpstreamId, String, RecordType);
 
@@ -23,9 +26,18 @@ struct CachedEntry {
     seq: u64,
 }
 
+impl CachedEntry {
+    fn is_expired(&self) -> bool {
+        self.inserted_at.elapsed() >= self.ttl
+    }
+}
+
 /// TTL-aware DNS response cache with FIFO eviction at capacity.
 ///
-/// Thread-safe via external `tokio::sync::RwLock` wrapping.
+/// Thread-safe via external `tokio::sync::RwLock` wrapping. Lookups take
+/// `&self` (hit/miss counters are atomic), so concurrent per-query tasks
+/// share a read lock on the hit path; only inserts and invalidation need
+/// the write lock.
 ///
 /// Keys carry an [`UpstreamId`] alongside the (domain, qtype) pair so
 /// queries from devices that resolve via different upstream pools (e.g.
@@ -34,19 +46,28 @@ struct CachedEntry {
 ///
 /// Eviction is backed by `insertion_order`, a queue of `(key, seq)` slots
 /// appended on every insert. Each slot is popped at most once, so making
-/// room at capacity is amortized O(1) instead of a full scan of the map —
-/// this runs under the write lock every per-query task contends on, so a
-/// scan there would make insert latency grow with cache size. Slots go
-/// stale when their entry is overwritten, invalidated, or expires; they
-/// are skipped on pop and periodically compacted away.
+/// room at capacity is amortized O(1) instead of a full scan of the map.
+/// Slots go stale when their entry is overwritten or invalidated; they are
+/// skipped on pop and compacted away once they outnumber live entries.
+/// Expired entries are reclaimed by a batch sweep every
+/// `capacity / EXPIRED_SWEEP_DIVISOR` at-capacity inserts, which amortizes
+/// the O(n) sweep to O(1) per insert while keeping dead entries from
+/// pinning capacity and starving out live ones.
 pub struct DnsCache {
     entries: HashMap<CacheKey, CachedEntry>,
     insertion_order: VecDeque<(CacheKey, u64)>,
     next_seq: u64,
     capacity: usize,
-    hits: u64,
-    misses: u64,
+    /// At-capacity inserts since the last expired-entry sweep.
+    inserts_since_sweep: usize,
+    hits: AtomicU64,
+    misses: AtomicU64,
 }
+
+/// The expired-entry sweep runs every `capacity / EXPIRED_SWEEP_DIVISOR`
+/// at-capacity inserts (at least every insert for tiny caches), bounding
+/// its amortized cost to O(`EXPIRED_SWEEP_DIVISOR`) per insert.
+const EXPIRED_SWEEP_DIVISOR: usize = 4;
 
 impl DnsCache {
     /// Create a new cache with the given maximum capacity.
@@ -57,41 +78,45 @@ impl DnsCache {
             insertion_order: VecDeque::with_capacity(capacity),
             next_seq: 0,
             capacity,
-            hits: 0,
-            misses: 0,
+            inserts_since_sweep: 0,
+            hits: AtomicU64::new(0),
+            misses: AtomicU64::new(0),
         }
     }
 
     /// Look up a cached response keyed by upstream pool. Returns `None`
-    /// if not found or expired.
+    /// if not found or expired. Expired entries are left for the eviction
+    /// machinery to reclaim so lookups stay shared-access.
     ///
-    /// The returned message's answer/authority TTLs are aged down by the
-    /// entry's time in cache, so a client hitting near the end of the
-    /// entry's lifetime can't over-cache the records downstream for their
-    /// full original TTL again.
-    pub fn get(
-        &mut self,
-        upstream: UpstreamId,
-        domain: &str,
-        rtype: RecordType,
-    ) -> Option<Message> {
+    /// The returned message's record TTLs are aged down by the entry's
+    /// time in cache and capped at the entry's remaining lifetime, so a
+    /// client hitting near the end of the entry's lifetime can't
+    /// over-cache the records downstream — neither past their original
+    /// TTL nor past the admin's `ttl_max` clamp.
+    pub fn get(&self, upstream: UpstreamId, domain: &str, rtype: RecordType) -> Option<Message> {
         let key = (upstream, canonical_domain(domain), rtype);
 
         let Some(entry) = self.entries.get(&key) else {
-            self.misses += 1;
+            self.misses.fetch_add(1, Ordering::Relaxed);
             return None;
         };
 
         let age = entry.inserted_at.elapsed();
         if age >= entry.ttl {
-            self.entries.remove(&key);
-            self.misses += 1;
+            self.misses.fetch_add(1, Ordering::Relaxed);
             return None;
         }
 
-        self.hits += 1;
+        self.hits.fetch_add(1, Ordering::Relaxed);
         let mut response = entry.response.clone();
-        age_record_ttls(&mut response, age.as_secs());
+        // Whole seconds for both, so a fresh hit (sub-second age) doesn't
+        // round the remaining lifetime down below the original TTL.
+        let elapsed = age.as_secs();
+        age_record_ttls(
+            &mut response,
+            elapsed,
+            entry.ttl.as_secs().saturating_sub(elapsed),
+        );
         Some(response)
     }
 
@@ -120,6 +145,11 @@ impl DnsCache {
 
         // Only a brand-new key grows the map; overwrites reuse the slot.
         if self.entries.len() >= self.capacity && !self.entries.contains_key(&key) {
+            self.inserts_since_sweep += 1;
+            if self.inserts_since_sweep >= (self.capacity / EXPIRED_SWEEP_DIVISOR).max(1) {
+                self.inserts_since_sweep = 0;
+                self.evict_expired();
+            }
             self.evict_oldest();
         }
 
@@ -145,6 +175,10 @@ impl DnsCache {
         let before = self.entries.len() as u64;
         self.entries
             .retain(|(_, cached_domain, _), _| cached_domain != &d);
+        // A mass invalidation can orphan many queue slots at once; reclaim
+        // them here rather than leaving the next insert to wade through
+        // them under the hot-path write lock.
+        self.compact_insertion_order();
         before - self.entries.len() as u64
     }
 
@@ -156,7 +190,8 @@ impl DnsCache {
         count
     }
 
-    /// Current number of entries.
+    /// Current number of entries, including expired ones not yet reclaimed
+    /// by the batch sweep.
     #[must_use]
     pub fn len(&self) -> usize {
         self.entries.len()
@@ -172,30 +207,44 @@ impl DnsCache {
     #[must_use]
     #[allow(clippy::cast_precision_loss)]
     pub fn hit_rate(&self) -> f64 {
-        let total = self.hits + self.misses;
+        let hits = self.hits();
+        let total = hits + self.misses();
         if total == 0 {
             0.0
         } else {
-            self.hits as f64 / total as f64
+            hits as f64 / total as f64
         }
     }
 
     /// Total cache hits.
     #[must_use]
     pub fn hits(&self) -> u64 {
-        self.hits
+        self.hits.load(Ordering::Relaxed)
     }
 
     /// Total cache misses.
     #[must_use]
     pub fn misses(&self) -> u64 {
-        self.misses
+        self.misses.load(Ordering::Relaxed)
+    }
+
+    /// Batch-remove every expired entry, then the queue slots orphaned by
+    /// the removals. O(n), but run at most once per
+    /// `capacity / EXPIRED_SWEEP_DIVISOR` at-capacity inserts, so the cost
+    /// amortizes to O(1) per insert. Without it, FIFO eviction would keep
+    /// removing the oldest *live* entry while newer already-expired ones
+    /// sat on capacity.
+    fn evict_expired(&mut self) {
+        self.entries.retain(|_, entry| !entry.is_expired());
+        let entries = &self.entries;
+        self.insertion_order
+            .retain(|(key, seq)| entries.get(key).is_some_and(|e| e.seq == *seq));
     }
 
     /// Evict entries oldest-first until there is room for one more. Stale
     /// slots — whose entry was overwritten (sequence mismatch) or already
-    /// removed by invalidation/expiry — are popped and discarded without
-    /// touching a live entry.
+    /// removed by invalidation or the expired sweep — are popped and
+    /// discarded without touching a live entry.
     fn evict_oldest(&mut self) {
         while self.entries.len() >= self.capacity {
             let Some((key, seq)) = self.insertion_order.pop_front() else {
@@ -207,10 +256,10 @@ impl DnsCache {
         }
     }
 
-    /// Drop stale queue slots once they outnumber live entries. Only
-    /// removals that bypass the queue (invalidation, expiry on `get`,
-    /// overwrites) leave stale slots behind, so each compaction pays for
-    /// the removals that preceded it — amortized O(1) per insert.
+    /// Drop stale queue slots once they outnumber live entries. Removals
+    /// that bypass the queue (invalidation, the expired sweep, overwrites)
+    /// leave stale slots behind, so each compaction pays for the removals
+    /// that preceded it — amortized O(1) per mutation.
     fn compact_insertion_order(&mut self) {
         let threshold = self
             .entries
@@ -243,29 +292,40 @@ impl DnsCache {
 
     /// Test hook: current number of eviction-queue slots, live and stale.
     #[cfg(test)]
+    #[must_use]
     pub(crate) fn insertion_order_len(&self) -> usize {
         self.insertion_order.len()
     }
 }
 
-/// Age the answer/authority TTLs of a cached response by its time in cache,
-/// flooring at 1 so a still-valid entry never serves a zero (or wrapped)
-/// TTL. Additionals are left alone: cached responses don't carry any, and
-/// OPT pseudo-records overload the TTL field with EDNS flags.
-fn age_record_ttls(response: &mut Message, elapsed_secs: u64) {
+/// Age a cached response's record TTLs by its time in cache, and cap them
+/// at the entry's remaining lifetime so the admin's `ttl_max` clamp bounds
+/// what downstream resolvers cache, not just how long this cache keeps the
+/// entry. Nonzero TTLs floor at 1 so a still-valid entry never serves a
+/// wrapped TTL; a TTL of 0 is an upstream do-not-cache signal and is left
+/// alone. All three record sections are aged — the forwarding paths cache
+/// the full upstream message, which can carry glue records in additionals
+/// (OPT never appears there; hickory parses it into `Message::edns`).
+fn age_record_ttls(response: &mut Message, elapsed_secs: u64, remaining_secs: u64) {
     let elapsed = u32::try_from(elapsed_secs).unwrap_or(u32::MAX);
+    let remaining = u32::try_from(remaining_secs).unwrap_or(u32::MAX);
     for record in response
         .answers
         .iter_mut()
         .chain(response.authorities.iter_mut())
+        .chain(response.additionals.iter_mut())
     {
-        record.ttl = record.ttl.saturating_sub(elapsed).max(1);
+        if record.ttl == 0 {
+            continue;
+        }
+        record.ttl = record.ttl.saturating_sub(elapsed).min(remaining).max(1);
     }
 }
 
 /// Canonical cache-key form of a domain: lowercase, no trailing dot. The
 /// server inserts wire-format FQDNs ("foo.com.") while eviction callers pass
-/// bare names ("foo.com"); both must map to the same key.
+/// bare names ("foo.com"); both must map to the same key. Delegates to the
+/// filter's normalizer so every DNS path agrees on canonical form.
 fn canonical_domain(domain: &str) -> String {
-    domain.trim_end_matches('.').to_ascii_lowercase()
+    normalize(domain)
 }

--- a/source/daemon/crates/wardnetd-services/src/dns/cache.rs
+++ b/source/daemon/crates/wardnetd-services/src/dns/cache.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, VecDeque};
 use std::time::{Duration, Instant};
 
 use hickory_proto::op::Message;
@@ -6,20 +6,24 @@ use hickory_proto::rr::RecordType;
 
 use wardnet_common::dns::UpstreamId;
 
+type CacheKey = (UpstreamId, String, RecordType);
+
+/// Once the eviction queue holds this many slots for an empty-ish cache it
+/// gets compacted regardless of the live-entry count, so a small cache can't
+/// keep a long tail of stale slots alive.
+const ORDER_COMPACT_FLOOR: usize = 64;
+
 /// A cached DNS response with TTL-aware expiration.
 struct CachedEntry {
     response: Message,
     inserted_at: Instant,
     ttl: Duration,
+    /// Matches this entry to its slot in `insertion_order`; an overwrite
+    /// bumps the sequence, leaving the old slot stale.
+    seq: u64,
 }
 
-impl CachedEntry {
-    fn is_expired(&self) -> bool {
-        self.inserted_at.elapsed() >= self.ttl
-    }
-}
-
-/// TTL-aware DNS response cache with LRU-style eviction.
+/// TTL-aware DNS response cache with FIFO eviction at capacity.
 ///
 /// Thread-safe via external `tokio::sync::RwLock` wrapping.
 ///
@@ -27,8 +31,18 @@ impl CachedEntry {
 /// queries from devices that resolve via different upstream pools (e.g.
 /// a tunneled device with `override_default_dns = true` vs a LAN device)
 /// don't accidentally share cached answers — see issue #342.
+///
+/// Eviction is backed by `insertion_order`, a queue of `(key, seq)` slots
+/// appended on every insert. Each slot is popped at most once, so making
+/// room at capacity is amortized O(1) instead of a full scan of the map —
+/// this runs under the write lock every per-query task contends on, so a
+/// scan there would make insert latency grow with cache size. Slots go
+/// stale when their entry is overwritten, invalidated, or expires; they
+/// are skipped on pop and periodically compacted away.
 pub struct DnsCache {
-    entries: HashMap<(UpstreamId, String, RecordType), CachedEntry>,
+    entries: HashMap<CacheKey, CachedEntry>,
+    insertion_order: VecDeque<(CacheKey, u64)>,
+    next_seq: u64,
     capacity: usize,
     hits: u64,
     misses: u64,
@@ -40,6 +54,8 @@ impl DnsCache {
     pub fn new(capacity: usize) -> Self {
         Self {
             entries: HashMap::with_capacity(capacity),
+            insertion_order: VecDeque::with_capacity(capacity),
+            next_seq: 0,
             capacity,
             hits: 0,
             misses: 0,
@@ -48,25 +64,35 @@ impl DnsCache {
 
     /// Look up a cached response keyed by upstream pool. Returns `None`
     /// if not found or expired.
+    ///
+    /// The returned message's answer/authority TTLs are aged down by the
+    /// entry's time in cache, so a client hitting near the end of the
+    /// entry's lifetime can't over-cache the records downstream for their
+    /// full original TTL again.
     pub fn get(
         &mut self,
         upstream: UpstreamId,
         domain: &str,
         rtype: RecordType,
-    ) -> Option<&Message> {
+    ) -> Option<Message> {
         let key = (upstream, canonical_domain(domain), rtype);
 
-        // Check if entry exists and is not expired.
-        let expired = self.entries.get(&key).is_none_or(CachedEntry::is_expired);
+        let Some(entry) = self.entries.get(&key) else {
+            self.misses += 1;
+            return None;
+        };
 
-        if expired {
+        let age = entry.inserted_at.elapsed();
+        if age >= entry.ttl {
             self.entries.remove(&key);
             self.misses += 1;
             return None;
         }
 
         self.hits += 1;
-        self.entries.get(&key).map(|e| &e.response)
+        let mut response = entry.response.clone();
+        age_record_ttls(&mut response, age.as_secs());
+        Some(response)
     }
 
     /// Insert a response into the cache with the given TTL, keyed by the
@@ -90,25 +116,26 @@ impl DnsCache {
             return;
         }
 
-        // Evict expired entries if at capacity.
-        if self.entries.len() >= self.capacity {
-            self.evict_expired();
-        }
+        let key = (upstream, canonical_domain(domain), rtype);
 
-        // If still at capacity, evict oldest entry.
-        if self.entries.len() >= self.capacity {
+        // Only a brand-new key grows the map; overwrites reuse the slot.
+        if self.entries.len() >= self.capacity && !self.entries.contains_key(&key) {
             self.evict_oldest();
         }
 
-        let key = (upstream, canonical_domain(domain), rtype);
+        let seq = self.next_seq;
+        self.next_seq += 1;
+        self.insertion_order.push_back((key.clone(), seq));
         self.entries.insert(
             key,
             CachedEntry {
                 response,
                 inserted_at: Instant::now(),
                 ttl: Duration::from_secs(u64::from(ttl)),
+                seq,
             },
         );
+        self.compact_insertion_order();
     }
 
     /// Remove all cache entries for `domain` across all upstream pools and
@@ -125,6 +152,7 @@ impl DnsCache {
     pub fn flush(&mut self) -> u64 {
         let count = self.entries.len() as u64;
         self.entries.clear();
+        self.insertion_order.clear();
         count
     }
 
@@ -164,21 +192,74 @@ impl DnsCache {
         self.misses
     }
 
-    /// Remove all expired entries.
-    fn evict_expired(&mut self) {
-        self.entries.retain(|_, entry| !entry.is_expired());
+    /// Evict entries oldest-first until there is room for one more. Stale
+    /// slots — whose entry was overwritten (sequence mismatch) or already
+    /// removed by invalidation/expiry — are popped and discarded without
+    /// touching a live entry.
+    fn evict_oldest(&mut self) {
+        while self.entries.len() >= self.capacity {
+            let Some((key, seq)) = self.insertion_order.pop_front() else {
+                break;
+            };
+            if self.entries.get(&key).is_some_and(|e| e.seq == seq) {
+                self.entries.remove(&key);
+            }
+        }
     }
 
-    /// Remove the oldest entry (by insertion time).
-    fn evict_oldest(&mut self) {
-        if let Some(oldest_key) = self
+    /// Drop stale queue slots once they outnumber live entries. Only
+    /// removals that bypass the queue (invalidation, expiry on `get`,
+    /// overwrites) leave stale slots behind, so each compaction pays for
+    /// the removals that preceded it — amortized O(1) per insert.
+    fn compact_insertion_order(&mut self) {
+        let threshold = self
             .entries
-            .iter()
-            .min_by_key(|(_, e)| e.inserted_at)
-            .map(|(k, _)| k.clone())
-        {
-            self.entries.remove(&oldest_key);
+            .len()
+            .saturating_mul(2)
+            .max(ORDER_COMPACT_FLOOR);
+        if self.insertion_order.len() < threshold {
+            return;
         }
+        let entries = &self.entries;
+        self.insertion_order
+            .retain(|(key, seq)| entries.get(key).is_some_and(|e| e.seq == *seq));
+    }
+
+    /// Test hook: shift an entry's insertion time into the past to simulate
+    /// time spent in cache without sleeping.
+    #[cfg(test)]
+    pub(crate) fn backdate(
+        &mut self,
+        upstream: UpstreamId,
+        domain: &str,
+        rtype: RecordType,
+        by: Duration,
+    ) {
+        let key = (upstream, canonical_domain(domain), rtype);
+        if let Some(entry) = self.entries.get_mut(&key) {
+            entry.inserted_at -= by;
+        }
+    }
+
+    /// Test hook: current number of eviction-queue slots, live and stale.
+    #[cfg(test)]
+    pub(crate) fn insertion_order_len(&self) -> usize {
+        self.insertion_order.len()
+    }
+}
+
+/// Age the answer/authority TTLs of a cached response by its time in cache,
+/// flooring at 1 so a still-valid entry never serves a zero (or wrapped)
+/// TTL. Additionals are left alone: cached responses don't carry any, and
+/// OPT pseudo-records overload the TTL field with EDNS flags.
+fn age_record_ttls(response: &mut Message, elapsed_secs: u64) {
+    let elapsed = u32::try_from(elapsed_secs).unwrap_or(u32::MAX);
+    for record in response
+        .answers
+        .iter_mut()
+        .chain(response.authorities.iter_mut())
+    {
+        record.ttl = record.ttl.saturating_sub(elapsed).max(1);
     }
 }
 

--- a/source/daemon/crates/wardnetd-services/src/dns/tests/cache.rs
+++ b/source/daemon/crates/wardnetd-services/src/dns/tests/cache.rs
@@ -303,7 +303,7 @@ fn aged_ttl_floors_at_one_and_never_wraps() {
 }
 
 #[test]
-fn expired_entry_is_evicted_on_lookup() {
+fn expired_entry_is_not_served() {
     let mut cache = DnsCache::new(100);
     cache.insert(
         DEFAULT,
@@ -322,8 +322,151 @@ fn expired_entry_is_evicted_on_lookup() {
     );
 
     assert!(cache.get(DEFAULT, "example.com", RecordType::A).is_none());
-    assert!(cache.is_empty(), "expired entry must be removed on lookup");
     assert_eq!(cache.misses(), 1);
+
+    // A fresh insert for the same key overwrites the expired entry and
+    // serves again.
+    cache.insert(
+        DEFAULT,
+        "example.com",
+        RecordType::A,
+        make_answer_response("example.com.", 300),
+        300,
+        0,
+        86400,
+    );
+    assert_eq!(cache.len(), 1);
+    assert!(cache.get(DEFAULT, "example.com", RecordType::A).is_some());
+}
+
+#[test]
+fn sweep_reclaims_expired_entries_before_evicting_live_ones() {
+    // At capacity, expired entries must be swept out rather than letting
+    // FIFO eviction remove the oldest still-live entry while dead ones
+    // keep occupying capacity.
+    let mut cache = DnsCache::new(4);
+    cache.insert(
+        DEFAULT,
+        "keep.com",
+        RecordType::A,
+        make_response(),
+        300,
+        0,
+        86400,
+    );
+    for domain in ["e1.com", "e2.com", "e3.com"] {
+        cache.insert(
+            DEFAULT,
+            domain,
+            RecordType::A,
+            make_response(),
+            30,
+            0,
+            86400,
+        );
+        cache.backdate(DEFAULT, domain, RecordType::A, Duration::from_mins(1));
+    }
+    assert_eq!(cache.len(), 4);
+
+    cache.insert(
+        DEFAULT,
+        "new.com",
+        RecordType::A,
+        make_response(),
+        300,
+        0,
+        86400,
+    );
+
+    assert!(
+        cache.get(DEFAULT, "keep.com", RecordType::A).is_some(),
+        "the oldest live entry must survive while expired entries exist"
+    );
+    assert!(cache.get(DEFAULT, "new.com", RecordType::A).is_some());
+    assert_eq!(
+        cache.len(),
+        2,
+        "the sweep must reclaim all expired entries, correcting len()"
+    );
+}
+
+#[test]
+fn served_ttl_capped_by_remaining_entry_lifetime() {
+    let mut cache = DnsCache::new(100);
+    // Record TTL far above the admin's ttl_max clamp: the entry lives for
+    // 300s, and served TTLs must never promise more than what's left of
+    // that, or downstream caches outlive the cap.
+    cache.insert(
+        DEFAULT,
+        "example.com",
+        RecordType::A,
+        make_answer_response("example.com.", 86400),
+        86400,
+        0,
+        300,
+    );
+    cache.backdate(
+        DEFAULT,
+        "example.com",
+        RecordType::A,
+        Duration::from_secs(100),
+    );
+
+    let hit = cache
+        .get(DEFAULT, "example.com", RecordType::A)
+        .expect("entry is still within its clamped 300s lifetime");
+    assert_eq!(
+        hit.answers[0].ttl, 200,
+        "served TTL must be capped at the entry's remaining lifetime"
+    );
+}
+
+#[test]
+fn zero_ttl_record_is_not_inflated() {
+    let mut cache = DnsCache::new(100);
+    let mut resp = make_answer_response("example.com.", 300);
+    // An upstream TTL of 0 means "do not cache this record"; aging must
+    // never raise it to 1.
+    resp.add_authority(Record::from_rdata(
+        Name::from_str_relaxed("example.com.").expect("authority name"),
+        0,
+        RData::A(A(Ipv4Addr::new(192, 0, 2, 2))),
+    ));
+    cache.insert(DEFAULT, "example.com", RecordType::A, resp, 300, 0, 86400);
+
+    let hit = cache
+        .get(DEFAULT, "example.com", RecordType::A)
+        .expect("hit");
+    assert_eq!(hit.authorities[0].ttl, 0, "TTL 0 must be preserved");
+    assert_eq!(hit.answers[0].ttl, 300);
+}
+
+#[test]
+fn hit_ages_additional_record_ttls() {
+    // The forwarding paths cache the full upstream message, so glue
+    // records in the additionals section must age like everything else.
+    let mut cache = DnsCache::new(100);
+    let mut resp = make_answer_response("example.com.", 300);
+    resp.add_additional(Record::from_rdata(
+        Name::from_str_relaxed("glue.example.com.").expect("glue name"),
+        300,
+        RData::A(A(Ipv4Addr::new(192, 0, 2, 3))),
+    ));
+    cache.insert(DEFAULT, "example.com", RecordType::A, resp, 300, 0, 86400);
+    cache.backdate(
+        DEFAULT,
+        "example.com",
+        RecordType::A,
+        Duration::from_mins(2),
+    );
+
+    let hit = cache
+        .get(DEFAULT, "example.com", RecordType::A)
+        .expect("hit");
+    assert_eq!(
+        hit.additionals[0].ttl, 180,
+        "additional-section TTLs must shrink by time spent in cache"
+    );
 }
 
 #[test]

--- a/source/daemon/crates/wardnetd-services/src/dns/tests/cache.rs
+++ b/source/daemon/crates/wardnetd-services/src/dns/tests/cache.rs
@@ -1,5 +1,9 @@
+use std::net::Ipv4Addr;
+use std::time::Duration;
+
 use hickory_proto::op::{Message, OpCode};
-use hickory_proto::rr::RecordType;
+use hickory_proto::rr::rdata::{A, SOA};
+use hickory_proto::rr::{Name, RData, Record, RecordType};
 use uuid::Uuid;
 use wardnet_common::dns::UpstreamId;
 
@@ -7,6 +11,17 @@ use crate::dns::cache::DnsCache;
 
 fn make_response() -> Message {
     Message::response(0, OpCode::Query)
+}
+
+fn make_answer_response(domain: &str, ttl: u32) -> Message {
+    let mut resp = make_response();
+    let name = Name::from_str_relaxed(domain).expect("answer name");
+    resp.add_answer(Record::from_rdata(
+        name,
+        ttl,
+        RData::A(A(Ipv4Addr::new(192, 0, 2, 1))),
+    ));
+    resp
 }
 
 const DEFAULT: UpstreamId = UpstreamId::Default;
@@ -197,6 +212,266 @@ fn different_record_types_cached_separately() {
     assert_eq!(cache.len(), 2);
     assert!(cache.get(DEFAULT, "a.com", RecordType::A).is_some());
     assert!(cache.get(DEFAULT, "a.com", RecordType::AAAA).is_some());
+}
+
+#[test]
+fn hit_ages_answer_and_authority_ttls() {
+    let mut cache = DnsCache::new(100);
+    let mut resp = make_answer_response("example.com.", 300);
+    let soa = SOA::new(
+        Name::from_str_relaxed("ns.example.com.").expect("mname"),
+        Name::from_str_relaxed("hostmaster.example.com.").expect("rname"),
+        1,
+        3600,
+        600,
+        86400,
+        60,
+    );
+    resp.add_authority(Record::from_rdata(
+        Name::from_str_relaxed("example.com.").expect("soa name"),
+        300,
+        RData::SOA(soa),
+    ));
+    cache.insert(DEFAULT, "example.com", RecordType::A, resp, 300, 0, 86400);
+    cache.backdate(
+        DEFAULT,
+        "example.com",
+        RecordType::A,
+        Duration::from_mins(2),
+    );
+
+    let hit = cache
+        .get(DEFAULT, "example.com", RecordType::A)
+        .expect("entry is still within its 300s lifetime");
+    assert_eq!(
+        hit.answers[0].ttl, 180,
+        "answer TTL must shrink by time spent in cache"
+    );
+    assert_eq!(
+        hit.authorities[0].ttl, 180,
+        "authority TTL must shrink by time spent in cache"
+    );
+}
+
+#[test]
+fn fresh_hit_serves_ttl_no_larger_than_inserted() {
+    let mut cache = DnsCache::new(100);
+    cache.insert(
+        DEFAULT,
+        "example.com",
+        RecordType::A,
+        make_answer_response("example.com.", 300),
+        300,
+        0,
+        86400,
+    );
+    let hit = cache
+        .get(DEFAULT, "example.com", RecordType::A)
+        .expect("hit");
+    assert!(hit.answers[0].ttl <= 300);
+    assert!(hit.answers[0].ttl >= 1);
+}
+
+#[test]
+fn aged_ttl_floors_at_one_and_never_wraps() {
+    let mut cache = DnsCache::new(100);
+    // The record carries a 30s TTL but the admin floor keeps the entry
+    // alive for 300s, so a late hit ages the record past zero.
+    cache.insert(
+        DEFAULT,
+        "example.com",
+        RecordType::A,
+        make_answer_response("example.com.", 30),
+        30,
+        300,
+        86400,
+    );
+    cache.backdate(
+        DEFAULT,
+        "example.com",
+        RecordType::A,
+        Duration::from_mins(2),
+    );
+
+    let hit = cache
+        .get(DEFAULT, "example.com", RecordType::A)
+        .expect("entry is still within its clamped 300s lifetime");
+    assert_eq!(
+        hit.answers[0].ttl, 1,
+        "TTL must floor at 1, not go to zero or wrap"
+    );
+}
+
+#[test]
+fn expired_entry_is_evicted_on_lookup() {
+    let mut cache = DnsCache::new(100);
+    cache.insert(
+        DEFAULT,
+        "example.com",
+        RecordType::A,
+        make_answer_response("example.com.", 300),
+        300,
+        0,
+        86400,
+    );
+    cache.backdate(
+        DEFAULT,
+        "example.com",
+        RecordType::A,
+        Duration::from_mins(5),
+    );
+
+    assert!(cache.get(DEFAULT, "example.com", RecordType::A).is_none());
+    assert!(cache.is_empty(), "expired entry must be removed on lookup");
+    assert_eq!(cache.misses(), 1);
+}
+
+#[test]
+fn overwritten_entry_survives_its_stale_queue_slot() {
+    let mut cache = DnsCache::new(2);
+    cache.insert(
+        DEFAULT,
+        "a.com",
+        RecordType::A,
+        make_response(),
+        300,
+        0,
+        86400,
+    );
+    cache.insert(
+        DEFAULT,
+        "b.com",
+        RecordType::A,
+        make_response(),
+        300,
+        0,
+        86400,
+    );
+    // Overwrite a.com: its original queue slot goes stale, b.com becomes
+    // the oldest live entry.
+    cache.insert(
+        DEFAULT,
+        "a.com",
+        RecordType::A,
+        make_response(),
+        300,
+        0,
+        86400,
+    );
+    cache.insert(
+        DEFAULT,
+        "c.com",
+        RecordType::A,
+        make_response(),
+        300,
+        0,
+        86400,
+    );
+
+    assert_eq!(cache.len(), 2);
+    assert!(
+        cache.get(DEFAULT, "a.com", RecordType::A).is_some(),
+        "re-inserted entry must not be evicted through its stale slot"
+    );
+    assert!(cache.get(DEFAULT, "b.com", RecordType::A).is_none());
+    assert!(cache.get(DEFAULT, "c.com", RecordType::A).is_some());
+}
+
+#[test]
+fn eviction_skips_slots_of_invalidated_entries() {
+    let mut cache = DnsCache::new(2);
+    cache.insert(
+        DEFAULT,
+        "a.com",
+        RecordType::A,
+        make_response(),
+        300,
+        0,
+        86400,
+    );
+    cache.insert(
+        DEFAULT,
+        "b.com",
+        RecordType::A,
+        make_response(),
+        300,
+        0,
+        86400,
+    );
+    assert_eq!(cache.invalidate_domain("a.com"), 1);
+    cache.insert(
+        DEFAULT,
+        "c.com",
+        RecordType::A,
+        make_response(),
+        300,
+        0,
+        86400,
+    );
+    cache.insert(
+        DEFAULT,
+        "d.com",
+        RecordType::A,
+        make_response(),
+        300,
+        0,
+        86400,
+    );
+
+    assert_eq!(cache.len(), 2);
+    assert!(
+        cache.get(DEFAULT, "b.com", RecordType::A).is_none(),
+        "b.com is the oldest live entry once a.com's slot is stale"
+    );
+    assert!(cache.get(DEFAULT, "c.com", RecordType::A).is_some());
+    assert!(cache.get(DEFAULT, "d.com", RecordType::A).is_some());
+}
+
+#[test]
+fn insert_at_capacity_keeps_eviction_work_bounded() {
+    // Every insert past capacity should retire exactly one queue slot, so
+    // the queue tracks the live-entry count instead of growing with the
+    // total number of inserts (the old implementation re-scanned the whole
+    // map per insert).
+    let mut cache = DnsCache::new(64);
+    for i in 0..5_000 {
+        let domain = format!("host{i}.example.com");
+        cache.insert(
+            DEFAULT,
+            &domain,
+            RecordType::A,
+            make_response(),
+            300,
+            0,
+            86400,
+        );
+        assert!(cache.len() <= 64);
+        assert!(
+            cache.insertion_order_len() <= 128,
+            "eviction queue must stay proportional to capacity, not inserts"
+        );
+    }
+}
+
+#[test]
+fn repeated_overwrites_compact_stale_queue_slots() {
+    let mut cache = DnsCache::new(1000);
+    for _ in 0..10_000 {
+        cache.insert(
+            DEFAULT,
+            "example.com",
+            RecordType::A,
+            make_response(),
+            300,
+            0,
+            86400,
+        );
+    }
+    assert_eq!(cache.len(), 1);
+    assert!(
+        cache.insertion_order_len() <= 64,
+        "stale slots from overwrites must be compacted away"
+    );
 }
 
 #[test]

--- a/source/daemon/crates/wardnetd/src/dns/pipeline.rs
+++ b/source/daemon/crates/wardnetd/src/dns/pipeline.rs
@@ -493,7 +493,7 @@ impl QueryPipeline {
         //    bleed into a LAN device's lookup of the same domain (or vice
         //    versa).
         let cached = {
-            let mut cache_guard = self.cache.write().await;
+            let cache_guard = self.cache.read().await;
             cache_guard.get(upstream_id, &domain, rtype)
         };
         if let Some(mut response) = cached {

--- a/source/daemon/crates/wardnetd/src/dns/pipeline.rs
+++ b/source/daemon/crates/wardnetd/src/dns/pipeline.rs
@@ -492,26 +492,26 @@ impl QueryPipeline {
         // 1. Cache, keyed by upstream so a tunneled device's answer doesn't
         //    bleed into a LAN device's lookup of the same domain (or vice
         //    versa).
-        {
+        let cached = {
             let mut cache_guard = self.cache.write().await;
-            if let Some(cached) = cache_guard.get(upstream_id, &domain, rtype) {
-                let mut response = cached.clone();
-                response.metadata.id = id;
-                let bytes = response.to_bytes()?;
-                reply.send_to(&bytes, src).await?;
-                tracing::trace!(%domain, ?rtype, ?upstream_id, "cache hit");
-                record_query(
-                    log_sink,
-                    &domain,
-                    rtype,
-                    src,
-                    device_id,
-                    DnsQueryResult::CacheHit.as_str(),
-                    None,
-                    start.elapsed(),
-                );
-                return Ok(());
-            }
+            cache_guard.get(upstream_id, &domain, rtype)
+        };
+        if let Some(mut response) = cached {
+            response.metadata.id = id;
+            let bytes = response.to_bytes()?;
+            reply.send_to(&bytes, src).await?;
+            tracing::trace!(%domain, ?rtype, ?upstream_id, "cache hit");
+            record_query(
+                log_sink,
+                &domain,
+                rtype,
+                src,
+                device_id,
+                DnsQueryResult::CacheHit.as_str(),
+                None,
+                start.elapsed(),
+            );
+            return Ok(());
         }
 
         // 2. Filter.


### PR DESCRIPTION
Closes #833 

Fixes the two remaining defects from #833 (the key-normalization bug was already fixed in #896, which added `canonical_domain` and the trailing-dot test).

## TTL aging on cache hits

`DnsCache::get` returned the stored message with its original upstream TTLs, so a client hitting near the end of an entry's lifetime would over-cache the records downstream for up to ~2× their real TTL. On a hit, record TTLs in all three sections are now decremented by the entry's time in cache — the answer and authority sections, and additionals too, since the tunnel and conditional forwarding paths cache the full parsed upstream message, which can carry glue records there (OPT never appears in additionals; hickory parses it into the message's `edns` field).

Two more bounds apply on top of plain aging:

- served TTLs are capped at the entry's **remaining clamped lifetime**, so `cache_ttl_max_secs` bounds what downstream resolvers cache rather than only how long this cache keeps the entry (previously a record with a TTL above the max clamp was served with that oversized TTL);
- nonzero TTLs floor at 1 so a still-valid entry never serves a zero or wrapped TTL, while records upstream explicitly marked TTL 0 (do-not-cache) are passed through untouched instead of being inflated to 1.

`get` now returns an owned, aged `Message` instead of `&Message`.

## O(1) amortized eviction at capacity

Insert-at-capacity ran two full O(n) scans over the entry map (`evict_expired`'s retain, then `evict_oldest`'s `min_by_key`) while holding the single write lock that every per-query task contends on, so insert latency grew with cache size on the hot path.

Eviction is now backed by an insertion-ordered `VecDeque` of `(key, seq)` slots:

- every insert pushes one slot; making room pops from the front, so each slot is popped at most once — amortized O(1) per insert, no map scans;
- a per-entry sequence number ties a slot to the exact insert that created it, so slots orphaned by overwrites or `invalidate_domain` are skipped on pop instead of evicting a live entry;
- stale slots are compacted away once they outnumber live entries; per-domain invalidation compacts in place, so a mass invalidation can't leave the next insert to wade through stale slots under the write lock.

Expired entries are reclaimed by a periodic batch sweep — every `capacity / 4` at-capacity inserts — which keeps insert amortized O(1) while preventing two failure modes of pure FIFO: evicting the oldest still-live entry while newer already-expired entries occupy capacity, and `len()` (surfaced as `cache_size` in the API/dashboard) staying pinned at capacity by dead entries.

## Hit path takes the read lock

Lookups no longer need exclusive access: hit/miss counters are atomic, expired entries are left for the sweep instead of being removed inline, and `get` takes `&self` — so concurrent cache hits share a read lock and proceed in parallel, while only inserts and invalidation serialize on the write lock. The lock is also released before the reply is sent on the socket instead of being held across the await.

Cache keys now reuse the filter's `normalize` helper instead of duplicating the trim/lowercase rule in a second place.

## Tests

Coverage in `wardnetd-services/src/dns/tests/cache.rs` grew from 10 to 22 tests, using a test-only `backdate` hook so no sleeping is involved:

- hit ages answer, authority, and additional-section TTLs by time in cache
- served TTL is capped at the entry's remaining clamped lifetime
- TTL-0 records are never inflated; aged TTLs floor at 1 and never wrap
- expired entries are not served, and the batch sweep reclaims them before FIFO eviction touches a live entry (also correcting `len()`)
- an overwritten key survives eviction of its stale queue slot; eviction skips slots of invalidated entries
- 5k inserts through a capacity-64 cache keep the eviction queue bounded by capacity; 10k overwrites of one key leave the queue compacted

`cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, and `cargo test --workspace` all pass locally.