### PR TITLE
fix(services): add auth guards to log and stats service methods

### DIFF
--- a/source/daemon/crates/wardnetd-api/src/api/logs_ws.rs
+++ b/source/daemon/crates/wardnetd-api/src/api/logs_ws.rs
@@ -6,6 +6,7 @@ use tokio::sync::broadcast;
 
 use crate::api::middleware::AdminAuth;
 use crate::state::AppState;
+use wardnetd_services::error::AppError;
 use wardnetd_services::logging::stream::LogEntry;
 
 /// Client command sent over the WebSocket to change filters.
@@ -45,9 +46,9 @@ pub async fn logs_ws(
     State(state): State<AppState>,
     _auth: AdminAuth,
     ws: WebSocketUpgrade,
-) -> impl IntoResponse {
-    let rx = state.log_service().subscribe();
-    ws.on_upgrade(move |socket| handle_socket(socket, rx))
+) -> Result<impl IntoResponse, AppError> {
+    let rx = state.log_service().subscribe()?;
+    Ok(ws.on_upgrade(move |socket| handle_socket(socket, rx)))
 }
 
 async fn handle_socket(mut socket: WebSocket, mut rx: broadcast::Receiver<LogEntry>) {

--- a/source/daemon/crates/wardnetd-api/src/api/system.rs
+++ b/source/daemon/crates/wardnetd-api/src/api/system.rs
@@ -329,12 +329,12 @@ pub struct RecentErrorsResponse {
 pub async fn recent_errors(
     State(state): State<AppState>,
     _auth: AdminAuth,
-) -> Json<RecentErrorsResponse> {
+) -> Result<Json<RecentErrorsResponse>, AppError> {
     let errors = state
         .log_service()
-        .get_recent_errors()
+        .get_recent_errors()?
         .into_iter()
         .map(ApiErrorEntry::from)
         .collect();
-    Json(RecentErrorsResponse { errors })
+    Ok(Json(RecentErrorsResponse { errors }))
 }

--- a/source/daemon/crates/wardnetd-api/src/api/tests/system.rs
+++ b/source/daemon/crates/wardnetd-api/src/api/tests/system.rs
@@ -570,10 +570,10 @@ async fn recent_errors_returns_populated_errors() {
 
     #[async_trait]
     impl LogService for MockLogServiceWithErrors {
-        fn subscribe(&self) -> tokio::sync::broadcast::Receiver<LogEntry> {
+        fn subscribe(&self) -> Result<tokio::sync::broadcast::Receiver<LogEntry>, AppError> {
             let (tx, rx) = tokio::sync::broadcast::channel(1);
             drop(tx);
-            rx
+            Ok(rx)
         }
         fn get_recent_errors(&self) -> Result<Vec<ErrorEntry>, AppError> {
             Ok(vec![
@@ -712,10 +712,10 @@ async fn download_logs_returns_text_when_log_exists() {
 
     #[async_trait]
     impl LogService for MockLogServiceWithContent {
-        fn subscribe(&self) -> tokio::sync::broadcast::Receiver<LogEntry> {
+        fn subscribe(&self) -> Result<tokio::sync::broadcast::Receiver<LogEntry>, AppError> {
             let (tx, rx) = tokio::sync::broadcast::channel(1);
             drop(tx);
-            rx
+            Ok(rx)
         }
         fn get_recent_errors(&self) -> Result<Vec<ErrorEntry>, AppError> {
             Ok(Vec::new())
@@ -810,10 +810,10 @@ async fn download_logs_formats_non_json_lines_as_is() {
 
     #[async_trait]
     impl LogService for MockLogServicePlainText {
-        fn subscribe(&self) -> tokio::sync::broadcast::Receiver<LogEntry> {
+        fn subscribe(&self) -> Result<tokio::sync::broadcast::Receiver<LogEntry>, AppError> {
             let (tx, rx) = tokio::sync::broadcast::channel(1);
             drop(tx);
-            rx
+            Ok(rx)
         }
         fn get_recent_errors(&self) -> Result<Vec<ErrorEntry>, AppError> {
             Ok(Vec::new())
@@ -892,10 +892,10 @@ async fn download_logs_finds_dated_file() {
 
     #[async_trait]
     impl LogService for MockLogServiceDated {
-        fn subscribe(&self) -> tokio::sync::broadcast::Receiver<LogEntry> {
+        fn subscribe(&self) -> Result<tokio::sync::broadcast::Receiver<LogEntry>, AppError> {
             let (tx, rx) = tokio::sync::broadcast::channel(1);
             drop(tx);
-            rx
+            Ok(rx)
         }
         fn get_recent_errors(&self) -> Result<Vec<ErrorEntry>, AppError> {
             Ok(Vec::new())
@@ -974,10 +974,10 @@ async fn download_logs_no_file_returns_500() {
 
     #[async_trait]
     impl LogService for MockLogServiceNoFile {
-        fn subscribe(&self) -> tokio::sync::broadcast::Receiver<LogEntry> {
+        fn subscribe(&self) -> Result<tokio::sync::broadcast::Receiver<LogEntry>, AppError> {
             let (tx, rx) = tokio::sync::broadcast::channel(1);
             drop(tx);
-            rx
+            Ok(rx)
         }
         fn get_recent_errors(&self) -> Result<Vec<ErrorEntry>, AppError> {
             Ok(Vec::new())

--- a/source/daemon/crates/wardnetd-api/src/api/tests/system.rs
+++ b/source/daemon/crates/wardnetd-api/src/api/tests/system.rs
@@ -575,8 +575,8 @@ async fn recent_errors_returns_populated_errors() {
             drop(tx);
             rx
         }
-        fn get_recent_errors(&self) -> Vec<ErrorEntry> {
-            vec![
+        fn get_recent_errors(&self) -> Result<Vec<ErrorEntry>, AppError> {
+            Ok(vec![
                 ErrorEntry {
                     level: "ERROR".to_owned(),
                     message: "boom".to_owned(),
@@ -589,7 +589,7 @@ async fn recent_errors_returns_populated_errors() {
                     target: "test".to_owned(),
                     timestamp: chrono::Utc::now(),
                 },
-            ]
+            ])
         }
         async fn list_log_files(&self) -> Result<Vec<LogFileInfo>, AppError> {
             Ok(Vec::new())
@@ -717,8 +717,8 @@ async fn download_logs_returns_text_when_log_exists() {
             drop(tx);
             rx
         }
-        fn get_recent_errors(&self) -> Vec<ErrorEntry> {
-            Vec::new()
+        fn get_recent_errors(&self) -> Result<Vec<ErrorEntry>, AppError> {
+            Ok(Vec::new())
         }
         async fn list_log_files(&self) -> Result<Vec<LogFileInfo>, AppError> {
             Ok(Vec::new())
@@ -815,8 +815,8 @@ async fn download_logs_formats_non_json_lines_as_is() {
             drop(tx);
             rx
         }
-        fn get_recent_errors(&self) -> Vec<ErrorEntry> {
-            Vec::new()
+        fn get_recent_errors(&self) -> Result<Vec<ErrorEntry>, AppError> {
+            Ok(Vec::new())
         }
         async fn list_log_files(&self) -> Result<Vec<LogFileInfo>, AppError> {
             Ok(Vec::new())
@@ -897,8 +897,8 @@ async fn download_logs_finds_dated_file() {
             drop(tx);
             rx
         }
-        fn get_recent_errors(&self) -> Vec<ErrorEntry> {
-            Vec::new()
+        fn get_recent_errors(&self) -> Result<Vec<ErrorEntry>, AppError> {
+            Ok(Vec::new())
         }
         async fn list_log_files(&self) -> Result<Vec<LogFileInfo>, AppError> {
             Ok(Vec::new())
@@ -979,8 +979,8 @@ async fn download_logs_no_file_returns_500() {
             drop(tx);
             rx
         }
-        fn get_recent_errors(&self) -> Vec<ErrorEntry> {
-            Vec::new()
+        fn get_recent_errors(&self) -> Result<Vec<ErrorEntry>, AppError> {
+            Ok(Vec::new())
         }
         async fn list_log_files(&self) -> Result<Vec<LogFileInfo>, AppError> {
             Ok(Vec::new())

--- a/source/daemon/crates/wardnetd-api/src/tests/stubs.rs
+++ b/source/daemon/crates/wardnetd-api/src/tests/stubs.rs
@@ -1015,10 +1015,10 @@ impl TunnelService for StubTunnelService {
 pub struct StubLogService;
 #[async_trait]
 impl LogService for StubLogService {
-    fn subscribe(&self) -> broadcast::Receiver<LogEntry> {
+    fn subscribe(&self) -> Result<broadcast::Receiver<LogEntry>, AppError> {
         let (tx, rx) = broadcast::channel(1);
         drop(tx);
-        rx
+        Ok(rx)
     }
     fn get_recent_errors(&self) -> Result<Vec<ErrorEntry>, AppError> {
         Ok(Vec::new())

--- a/source/daemon/crates/wardnetd-api/src/tests/stubs.rs
+++ b/source/daemon/crates/wardnetd-api/src/tests/stubs.rs
@@ -1020,8 +1020,8 @@ impl LogService for StubLogService {
         drop(tx);
         rx
     }
-    fn get_recent_errors(&self) -> Vec<ErrorEntry> {
-        Vec::new()
+    fn get_recent_errors(&self) -> Result<Vec<ErrorEntry>, AppError> {
+        Ok(Vec::new())
     }
     async fn list_log_files(&self) -> Result<Vec<LogFileInfo>, AppError> {
         Ok(Vec::new())

--- a/source/daemon/crates/wardnetd-services/src/logging/service.rs
+++ b/source/daemon/crates/wardnetd-services/src/logging/service.rs
@@ -6,6 +6,7 @@ use chrono::{DateTime, Utc};
 use serde::Serialize;
 use tokio::sync::broadcast;
 
+use crate::auth_context;
 use crate::error::AppError;
 
 use super::component::{BoxedLayer, LogComponent};
@@ -33,7 +34,7 @@ pub trait LogService: Send + Sync {
     fn subscribe(&self) -> broadcast::Receiver<LogEntry>;
 
     /// Return the most recent errors and warnings.
-    fn get_recent_errors(&self) -> Vec<ErrorEntry>;
+    fn get_recent_errors(&self) -> Result<Vec<ErrorEntry>, AppError>;
 
     /// List all available log files with metadata.
     async fn list_log_files(&self) -> Result<Vec<LogFileInfo>, AppError>;
@@ -92,11 +93,13 @@ impl LogService for LogServiceImpl {
         self.stream.subscribe()
     }
 
-    fn get_recent_errors(&self) -> Vec<ErrorEntry> {
-        self.error_notifier.get_recent_errors()
+    fn get_recent_errors(&self) -> Result<Vec<ErrorEntry>, AppError> {
+        auth_context::require_admin()?;
+        Ok(self.error_notifier.get_recent_errors())
     }
 
     async fn list_log_files(&self) -> Result<Vec<LogFileInfo>, AppError> {
+        auth_context::require_admin()?;
         let candidates = discover_log_files(&self.log_path).await?;
         let active_path = find_active_log_path(&self.log_path, &candidates);
 
@@ -133,6 +136,7 @@ impl LogService for LogServiceImpl {
     }
 
     async fn download_log_file(&self, name: Option<&str>) -> Result<String, AppError> {
+        auth_context::require_admin()?;
         let target_path = if let Some(name) = name {
             // Resolve within the log directory — prevent path traversal.
             let dir = self

--- a/source/daemon/crates/wardnetd-services/src/logging/service.rs
+++ b/source/daemon/crates/wardnetd-services/src/logging/service.rs
@@ -31,7 +31,7 @@ pub struct LogFileInfo {
 #[async_trait]
 pub trait LogService: Send + Sync {
     /// Subscribe to receive live log entries over WebSocket.
-    fn subscribe(&self) -> broadcast::Receiver<LogEntry>;
+    fn subscribe(&self) -> Result<broadcast::Receiver<LogEntry>, AppError>;
 
     /// Return the most recent errors and warnings.
     fn get_recent_errors(&self) -> Result<Vec<ErrorEntry>, AppError>;
@@ -46,12 +46,17 @@ pub trait LogService: Send + Sync {
     /// Collect tracing layers from all log components.
     ///
     /// Called once during startup to compose layers into the subscriber.
+    /// No auth guard — runs before the HTTP surface exists.
     fn tracing_layers(&self) -> Vec<BoxedLayer>;
 
     /// Start all log components (begin capturing events).
+    /// No auth guard — called from the startup/shutdown lifecycle, not on
+    /// behalf of a request.
     fn start_all(&self);
 
     /// Stop all log components.
+    /// No auth guard — called from the startup/shutdown lifecycle, not on
+    /// behalf of a request.
     fn stop_all(&self);
 }
 
@@ -89,8 +94,9 @@ impl LogServiceImpl {
 
 #[async_trait]
 impl LogService for LogServiceImpl {
-    fn subscribe(&self) -> broadcast::Receiver<LogEntry> {
-        self.stream.subscribe()
+    fn subscribe(&self) -> Result<broadcast::Receiver<LogEntry>, AppError> {
+        auth_context::require_admin()?;
+        Ok(self.stream.subscribe())
     }
 
     fn get_recent_errors(&self) -> Result<Vec<ErrorEntry>, AppError> {

--- a/source/daemon/crates/wardnetd-services/src/logging/tests/service.rs
+++ b/source/daemon/crates/wardnetd-services/src/logging/tests/service.rs
@@ -6,7 +6,10 @@ use std::sync::Arc;
 
 use tracing_subscriber::layer::SubscriberExt;
 use uuid::Uuid;
+use wardnet_common::auth::AuthContext;
 
+use crate::auth_context;
+use crate::error::AppError;
 use crate::logging::error_notifier::ErrorNotifierService;
 use crate::logging::service::{LogService, LogServiceImpl};
 use crate::logging::stream::LogStreamService;
@@ -19,6 +22,12 @@ fn build_service() -> (LogServiceImpl, PathBuf) {
     let dir = std::env::temp_dir().join(format!("wardnet-test-logs-{}", Uuid::new_v4()));
     let log_path = dir.join("wardnetd.log");
     (LogServiceImpl::new(stream, errors, log_path.clone()), dir)
+}
+
+fn admin_ctx() -> AuthContext {
+    AuthContext::Admin {
+        admin_id: Uuid::new_v4(),
+    }
 }
 
 #[test]
@@ -54,16 +63,54 @@ fn subscribe_returns_receiver() {
     let _rx = svc.subscribe();
 }
 
-#[test]
-fn get_recent_errors_is_empty_initially() {
+#[tokio::test]
+async fn get_recent_errors_is_empty_initially() {
     let (svc, _dir) = build_service();
-    assert!(svc.get_recent_errors().is_empty());
+    let recent = auth_context::with_context(admin_ctx(), async { svc.get_recent_errors() })
+        .await
+        .unwrap();
+    assert!(recent.is_empty());
+}
+
+#[tokio::test]
+async fn get_recent_errors_forbidden_without_admin_context() {
+    let (svc, _dir) = build_service();
+    let res = svc.get_recent_errors();
+    assert!(matches!(res, Err(AppError::Forbidden(_))));
+}
+
+#[tokio::test]
+async fn list_log_files_forbidden_without_admin_context() {
+    let (svc, dir) = build_service();
+    tokio::fs::create_dir_all(&dir).await.unwrap();
+    tokio::fs::write(dir.join("wardnetd.log"), b"secret")
+        .await
+        .unwrap();
+
+    let res = svc.list_log_files().await;
+    assert!(matches!(res, Err(AppError::Forbidden(_))));
+
+    let _ = tokio::fs::remove_dir_all(&dir).await;
+}
+
+#[tokio::test]
+async fn download_log_file_forbidden_without_admin_context() {
+    let (svc, dir) = build_service();
+    tokio::fs::create_dir_all(&dir).await.unwrap();
+    tokio::fs::write(dir.join("wardnetd.log"), b"secret")
+        .await
+        .unwrap();
+
+    let res = svc.download_log_file(None).await;
+    assert!(matches!(res, Err(AppError::Forbidden(_))));
+
+    let _ = tokio::fs::remove_dir_all(&dir).await;
 }
 
 #[tokio::test]
 async fn list_log_files_missing_directory_errors() {
     let (svc, dir) = build_service();
-    let res = svc.list_log_files().await;
+    let res = auth_context::with_context(admin_ctx(), svc.list_log_files()).await;
     // Directory does not exist — should surface an Internal error.
     assert!(res.is_err(), "expected error for missing directory");
     let _ = tokio::fs::remove_dir_all(&dir).await;
@@ -79,7 +126,9 @@ async fn list_log_files_returns_files() {
     let rotated = dir.join("wardnetd.log.2026-04-12");
     tokio::fs::write(&rotated, b"older").await.unwrap();
 
-    let files = svc.list_log_files().await.unwrap();
+    let files = auth_context::with_context(admin_ctx(), svc.list_log_files())
+        .await
+        .unwrap();
     assert!(files.len() >= 2);
     // Exactly one file should be marked active.
     assert_eq!(files.iter().filter(|f| f.active).count(), 1);
@@ -97,7 +146,9 @@ async fn download_log_file_returns_content() {
         .await
         .unwrap();
 
-    let content = svc.download_log_file(None).await.unwrap();
+    let content = auth_context::with_context(admin_ctx(), svc.download_log_file(None))
+        .await
+        .unwrap();
     assert!(content.contains("plain text line"));
 
     let _ = tokio::fs::remove_dir_all(&dir).await;
@@ -109,7 +160,8 @@ async fn download_log_file_rejects_path_traversal() {
     tokio::fs::create_dir_all(&dir).await.unwrap();
 
     // A name with a traversal segment should be rejected.
-    let res = svc.download_log_file(Some("../etc/passwd")).await;
+    let res =
+        auth_context::with_context(admin_ctx(), svc.download_log_file(Some("../etc/passwd"))).await;
     assert!(res.is_err(), "path traversal should be rejected");
 
     let _ = tokio::fs::remove_dir_all(&dir).await;
@@ -133,7 +185,9 @@ async fn layers_published_via_service_capture_events() {
     let entry = rx.recv().await.unwrap();
     assert_eq!(entry.level, "ERROR");
     // Error notifier captures it too.
-    let recent = svc.get_recent_errors();
+    let recent = auth_context::with_context(admin_ctx(), async { svc.get_recent_errors() })
+        .await
+        .unwrap();
     assert_eq!(recent.len(), 1);
     assert_eq!(recent[0].level, "ERROR");
 }
@@ -147,10 +201,12 @@ async fn download_log_file_by_name_returns_content() {
     let rotated = dir.join("wardnetd.log.2026-04-12");
     tokio::fs::write(&rotated, b"rotated line\n").await.unwrap();
 
-    let content = svc
-        .download_log_file(Some("wardnetd.log.2026-04-12"))
-        .await
-        .unwrap();
+    let content = auth_context::with_context(
+        admin_ctx(),
+        svc.download_log_file(Some("wardnetd.log.2026-04-12")),
+    )
+    .await
+    .unwrap();
     assert!(content.contains("rotated line"));
 
     let _ = tokio::fs::remove_dir_all(&dir).await;
@@ -168,7 +224,9 @@ async fn download_log_file_formats_json_lines() {
         .await
         .unwrap();
 
-    let content = svc.download_log_file(None).await.unwrap();
+    let content = auth_context::with_context(admin_ctx(), svc.download_log_file(None))
+        .await
+        .unwrap();
     assert!(content.contains("2026-04-17T12:00:00Z"));
     assert!(content.contains("INFO"));
     assert!(content.contains("wardnetd"));
@@ -184,7 +242,11 @@ async fn download_log_file_missing_file_errors() {
     let (svc, dir) = build_service();
     tokio::fs::create_dir_all(&dir).await.unwrap();
 
-    let res = svc.download_log_file(Some("wardnetd.log.absent")).await;
+    let res = auth_context::with_context(
+        admin_ctx(),
+        svc.download_log_file(Some("wardnetd.log.absent")),
+    )
+    .await;
     assert!(res.is_err(), "missing file should error");
 
     let _ = tokio::fs::remove_dir_all(&dir).await;
@@ -197,7 +259,7 @@ async fn download_log_file_no_files_not_found() {
     let (svc, dir) = build_service();
     tokio::fs::create_dir_all(&dir).await.unwrap();
 
-    let res = svc.download_log_file(None).await;
+    let res = auth_context::with_context(admin_ctx(), svc.download_log_file(None)).await;
     assert!(res.is_err(), "no files should surface an error");
 
     let _ = tokio::fs::remove_dir_all(&dir).await;
@@ -215,7 +277,9 @@ async fn list_log_files_ignores_unrelated_files() {
         .await
         .unwrap();
 
-    let files = svc.list_log_files().await.unwrap();
+    let files = auth_context::with_context(admin_ctx(), svc.list_log_files())
+        .await
+        .unwrap();
     assert_eq!(files.len(), 1);
     assert_eq!(files[0].name, "wardnetd.log");
     assert!(files[0].active);
@@ -234,7 +298,9 @@ async fn list_log_files_picks_newest_as_active_when_configured_missing() {
     tokio::fs::write(&older, b"older").await.unwrap();
     tokio::fs::write(&newer, b"newer").await.unwrap();
 
-    let files = svc.list_log_files().await.unwrap();
+    let files = auth_context::with_context(admin_ctx(), svc.list_log_files())
+        .await
+        .unwrap();
     assert_eq!(files.len(), 2);
     // Exactly one should be active. It must be the lexicographically-greatest
     // (the one find_active_log_path picks when configured file is absent).
@@ -258,7 +324,9 @@ async fn list_log_files_orders_by_modified_desc() {
         .await
         .unwrap();
 
-    let files = svc.list_log_files().await.unwrap();
+    let files = auth_context::with_context(admin_ctx(), svc.list_log_files())
+        .await
+        .unwrap();
     // Sorted newest-first: each entry's modified_at should be >= the next.
     for pair in files.windows(2) {
         assert!(pair[0].modified_at >= pair[1].modified_at);

--- a/source/daemon/crates/wardnetd-services/src/logging/tests/service.rs
+++ b/source/daemon/crates/wardnetd-services/src/logging/tests/service.rs
@@ -55,12 +55,14 @@ fn start_all_then_stop_all_is_idempotent() {
     svc.stop_all();
 }
 
-#[test]
-fn subscribe_returns_receiver() {
+#[tokio::test]
+async fn subscribe_returns_receiver() {
     let (svc, _dir) = build_service();
     // Ensure the service is active so events flow.
     svc.start_all();
-    let _rx = svc.subscribe();
+    let _rx = auth_context::with_context(admin_ctx(), async { svc.subscribe() })
+        .await
+        .unwrap();
 }
 
 #[tokio::test]
@@ -81,30 +83,23 @@ async fn get_recent_errors_forbidden_without_admin_context() {
 
 #[tokio::test]
 async fn list_log_files_forbidden_without_admin_context() {
-    let (svc, dir) = build_service();
-    tokio::fs::create_dir_all(&dir).await.unwrap();
-    tokio::fs::write(dir.join("wardnetd.log"), b"secret")
-        .await
-        .unwrap();
-
+    let (svc, _dir) = build_service();
     let res = svc.list_log_files().await;
     assert!(matches!(res, Err(AppError::Forbidden(_))));
-
-    let _ = tokio::fs::remove_dir_all(&dir).await;
 }
 
 #[tokio::test]
 async fn download_log_file_forbidden_without_admin_context() {
-    let (svc, dir) = build_service();
-    tokio::fs::create_dir_all(&dir).await.unwrap();
-    tokio::fs::write(dir.join("wardnetd.log"), b"secret")
-        .await
-        .unwrap();
-
+    let (svc, _dir) = build_service();
     let res = svc.download_log_file(None).await;
     assert!(matches!(res, Err(AppError::Forbidden(_))));
+}
 
-    let _ = tokio::fs::remove_dir_all(&dir).await;
+#[tokio::test]
+async fn subscribe_forbidden_without_admin_context() {
+    let (svc, _dir) = build_service();
+    let res = svc.subscribe();
+    assert!(matches!(res, Err(AppError::Forbidden(_))));
 }
 
 #[tokio::test]
@@ -171,7 +166,9 @@ async fn download_log_file_rejects_path_traversal() {
 async fn layers_published_via_service_capture_events() {
     let (svc, _dir) = build_service();
     svc.start_all();
-    let mut rx = svc.subscribe();
+    let mut rx = auth_context::with_context(admin_ctx(), async { svc.subscribe() })
+        .await
+        .unwrap();
 
     // The subscriber type would be awkward to spell with two boxed layers, so
     // compose the Vec<BoxedLayer> directly — `Vec<L>` implements `Layer<S>`.

--- a/source/daemon/crates/wardnetd-services/src/stats/flush_runner.rs
+++ b/source/daemon/crates/wardnetd-services/src/stats/flush_runner.rs
@@ -13,9 +13,12 @@ use std::time::Duration;
 use tokio::time::Instant;
 use tokio_util::sync::CancellationToken;
 use tracing::Instrument;
+use uuid::Uuid;
+use wardnet_common::auth::AuthContext;
 
 use super::buffer::StatsBuffer;
 use super::service::StatsService;
+use crate::auth_context;
 use crate::db_busy::retry_on_busy;
 
 /// How often the buffer is drained and flushed to `stats_intraday`.
@@ -150,7 +153,12 @@ async fn perform_flush(buffer: &Arc<StatsBuffer>, service: &Arc<dyn StatsService
         FLUSH_BUSY_BACKOFF,
         || {
             let rows = rows.clone();
-            service.run_flush(rows)
+            auth_context::with_context(
+                AuthContext::Admin {
+                    admin_id: Uuid::nil(),
+                },
+                service.run_flush(rows),
+            )
         },
     )
     .await;
@@ -166,7 +174,10 @@ async fn perform_flush(buffer: &Arc<StatsBuffer>, service: &Arc<dyn StatsService
 }
 
 async fn perform_maintenance(service: &Arc<dyn StatsService>) {
-    if let Err(e) = service.run_maintenance().await {
+    let admin_ctx = AuthContext::Admin {
+        admin_id: Uuid::nil(),
+    };
+    if let Err(e) = auth_context::with_context(admin_ctx, service.run_maintenance()).await {
         tracing::warn!(
             error = %e,
             "stats maintenance tick failed: {e}"

--- a/source/daemon/crates/wardnetd-services/src/stats/flush_runner.rs
+++ b/source/daemon/crates/wardnetd-services/src/stats/flush_runner.rs
@@ -147,18 +147,16 @@ async fn perform_flush(buffer: &Arc<StatsBuffer>, service: &Arc<dyn StatsService
     // takes the rows by value, so each attempt clones them — fine,
     // batches are bounded and the clone is only paid on retry, which
     // should be rare under the 30 s `busy_timeout`.
+    let admin_ctx = AuthContext::Admin {
+        admin_id: Uuid::nil(),
+    };
     let result = retry_on_busy(
         FLUSH_OPERATION,
         FLUSH_BUSY_RETRIES,
         FLUSH_BUSY_BACKOFF,
         || {
             let rows = rows.clone();
-            auth_context::with_context(
-                AuthContext::Admin {
-                    admin_id: Uuid::nil(),
-                },
-                service.run_flush(rows),
-            )
+            auth_context::with_context(admin_ctx.clone(), service.run_flush(rows))
         },
     )
     .await;

--- a/source/daemon/crates/wardnetd-services/src/stats/service.rs
+++ b/source/daemon/crates/wardnetd-services/src/stats/service.rs
@@ -31,9 +31,15 @@ pub trait StatsService: Send + Sync {
     async fn top(&self, q: StatsTopQuery) -> Result<StatsTopResponse, AppError>;
 
     /// Flush a batch of pre-drained buffer rows into `stats_intraday`.
+    ///
+    /// Requires an admin [`AuthContext`](wardnet_common::auth::AuthContext);
+    /// background callers must wrap the call in `auth_context::with_context`.
     async fn run_flush(&self, rows: Vec<IntradayStatRow>) -> anyhow::Result<()>;
 
     /// Rollup intraday → hourly → daily and trim past-retention rows.
+    ///
+    /// Requires an admin [`AuthContext`](wardnet_common::auth::AuthContext);
+    /// background callers must wrap the call in `auth_context::with_context`.
     async fn run_maintenance(&self) -> anyhow::Result<()>;
 }
 

--- a/source/daemon/crates/wardnetd-services/src/stats/service.rs
+++ b/source/daemon/crates/wardnetd-services/src/stats/service.rs
@@ -106,6 +106,7 @@ impl StatsService for StatsServiceImpl {
     }
 
     async fn run_flush(&self, rows: Vec<IntradayStatRow>) -> anyhow::Result<()> {
+        auth_context::require_admin()?;
         if rows.is_empty() {
             return Ok(());
         }
@@ -113,6 +114,7 @@ impl StatsService for StatsServiceImpl {
     }
 
     async fn run_maintenance(&self) -> anyhow::Result<()> {
+        auth_context::require_admin()?;
         let now = Utc::now();
 
         // ── Hourly rollup ─────────────────────────────────────────────────────

--- a/source/daemon/crates/wardnetd-services/src/stats/tests/flush_runner.rs
+++ b/source/daemon/crates/wardnetd-services/src/stats/tests/flush_runner.rs
@@ -5,6 +5,7 @@ use async_trait::async_trait;
 use wardnet_common::stats::{StatsQueryResponse, StatsTopResponse};
 use wardnetd_data::repository::IntradayStatRow;
 
+use crate::auth_context;
 use crate::error::AppError;
 use crate::stats::buffer::StatsBuffer;
 use crate::stats::flush_runner::StatsFlushRunner;
@@ -14,14 +15,30 @@ use crate::stats::service::StatsService;
 struct SpyService {
     flush_calls: Mutex<u32>,
     maintenance_calls: Mutex<u32>,
+    /// Whether every call so far arrived with an admin `AuthContext` set —
+    /// mirrors what the real service's `require_admin()` guard checks.
+    admin_ctx_on_every_call: Mutex<bool>,
 }
 
 impl SpyService {
+    fn new() -> Self {
+        Self {
+            admin_ctx_on_every_call: Mutex::new(true),
+            ..Self::default()
+        }
+    }
     fn flush_count(&self) -> u32 {
         *self.flush_calls.lock().unwrap()
     }
     fn maintenance_count(&self) -> u32 {
         *self.maintenance_calls.lock().unwrap()
+    }
+    fn saw_admin_ctx_on_every_call(&self) -> bool {
+        *self.admin_ctx_on_every_call.lock().unwrap()
+    }
+    fn record_ctx(&self) {
+        let is_admin = auth_context::try_current().is_some_and(|c| c.is_admin());
+        *self.admin_ctx_on_every_call.lock().unwrap() &= is_admin;
     }
 }
 
@@ -40,12 +57,14 @@ impl StatsService for SpyService {
         unimplemented!()
     }
     async fn run_flush(&self, rows: Vec<IntradayStatRow>) -> anyhow::Result<()> {
+        self.record_ctx();
         if !rows.is_empty() {
             *self.flush_calls.lock().unwrap() += 1;
         }
         Ok(())
     }
     async fn run_maintenance(&self) -> anyhow::Result<()> {
+        self.record_ctx();
         *self.maintenance_calls.lock().unwrap() += 1;
         Ok(())
     }
@@ -54,7 +73,7 @@ impl StatsService for SpyService {
 #[tokio::test(start_paused = true)]
 async fn startup_runs_maintenance_immediately() {
     let buffer = StatsBuffer::new();
-    let service = Arc::new(SpyService::default());
+    let service = Arc::new(SpyService::new());
     let runner = StatsFlushRunner::start_with_intervals(
         buffer,
         service.clone() as Arc<dyn StatsService>,
@@ -74,12 +93,16 @@ async fn startup_runs_maintenance_immediately() {
         service.maintenance_count() >= 1,
         "maintenance must run immediately on startup"
     );
+    assert!(
+        service.saw_admin_ctx_on_every_call(),
+        "runner must establish an admin AuthContext before calling run_maintenance"
+    );
 }
 
 #[tokio::test]
 async fn shutdown_flushes_non_empty_buffer() {
     let buffer = StatsBuffer::new();
-    let service = Arc::new(SpyService::default());
+    let service = Arc::new(SpyService::new());
     let runner = StatsFlushRunner::start_with_intervals(
         buffer.clone(),
         service.clone() as Arc<dyn StatsService>,
@@ -95,12 +118,16 @@ async fn shutdown_flushes_non_empty_buffer() {
         service.flush_count() >= 1,
         "shutdown must trigger a final flush of any buffered rows"
     );
+    assert!(
+        service.saw_admin_ctx_on_every_call(),
+        "runner must establish an admin AuthContext before calling run_flush"
+    );
 }
 
 #[tokio::test]
 async fn periodic_flush_drains_buffer() {
     let buffer = StatsBuffer::new();
-    let service = Arc::new(SpyService::default());
+    let service = Arc::new(SpyService::new());
     let runner = StatsFlushRunner::start_with_intervals(
         buffer.clone(),
         service.clone() as Arc<dyn StatsService>,
@@ -121,7 +148,7 @@ async fn periodic_flush_drains_buffer() {
 #[tokio::test]
 async fn empty_buffer_is_not_flushed() {
     let buffer = StatsBuffer::new();
-    let service = Arc::new(SpyService::default());
+    let service = Arc::new(SpyService::new());
     let runner = StatsFlushRunner::start_with_intervals(
         buffer,
         service.clone() as Arc<dyn StatsService>,

--- a/source/daemon/crates/wardnetd-services/src/stats/tests/flush_runner.rs
+++ b/source/daemon/crates/wardnetd-services/src/stats/tests/flush_runner.rs
@@ -15,30 +15,14 @@ use crate::stats::service::StatsService;
 struct SpyService {
     flush_calls: Mutex<u32>,
     maintenance_calls: Mutex<u32>,
-    /// Whether every call so far arrived with an admin `AuthContext` set —
-    /// mirrors what the real service's `require_admin()` guard checks.
-    admin_ctx_on_every_call: Mutex<bool>,
 }
 
 impl SpyService {
-    fn new() -> Self {
-        Self {
-            admin_ctx_on_every_call: Mutex::new(true),
-            ..Self::default()
-        }
-    }
     fn flush_count(&self) -> u32 {
         *self.flush_calls.lock().unwrap()
     }
     fn maintenance_count(&self) -> u32 {
         *self.maintenance_calls.lock().unwrap()
-    }
-    fn saw_admin_ctx_on_every_call(&self) -> bool {
-        *self.admin_ctx_on_every_call.lock().unwrap()
-    }
-    fn record_ctx(&self) {
-        let is_admin = auth_context::try_current().is_some_and(|c| c.is_admin());
-        *self.admin_ctx_on_every_call.lock().unwrap() &= is_admin;
     }
 }
 
@@ -56,15 +40,18 @@ impl StatsService for SpyService {
     ) -> Result<StatsTopResponse, AppError> {
         unimplemented!()
     }
+    // The spy guards like the real StatsServiceImpl, so the count
+    // assertions below also fail if the runner ever stops establishing
+    // an admin AuthContext around its calls.
     async fn run_flush(&self, rows: Vec<IntradayStatRow>) -> anyhow::Result<()> {
-        self.record_ctx();
+        auth_context::require_admin()?;
         if !rows.is_empty() {
             *self.flush_calls.lock().unwrap() += 1;
         }
         Ok(())
     }
     async fn run_maintenance(&self) -> anyhow::Result<()> {
-        self.record_ctx();
+        auth_context::require_admin()?;
         *self.maintenance_calls.lock().unwrap() += 1;
         Ok(())
     }
@@ -73,7 +60,7 @@ impl StatsService for SpyService {
 #[tokio::test(start_paused = true)]
 async fn startup_runs_maintenance_immediately() {
     let buffer = StatsBuffer::new();
-    let service = Arc::new(SpyService::new());
+    let service = Arc::new(SpyService::default());
     let runner = StatsFlushRunner::start_with_intervals(
         buffer,
         service.clone() as Arc<dyn StatsService>,
@@ -91,18 +78,14 @@ async fn startup_runs_maintenance_immediately() {
     runner.shutdown().await;
     assert!(
         service.maintenance_count() >= 1,
-        "maintenance must run immediately on startup"
-    );
-    assert!(
-        service.saw_admin_ctx_on_every_call(),
-        "runner must establish an admin AuthContext before calling run_maintenance"
+        "maintenance must run immediately on startup (with an admin AuthContext established)"
     );
 }
 
 #[tokio::test]
 async fn shutdown_flushes_non_empty_buffer() {
     let buffer = StatsBuffer::new();
-    let service = Arc::new(SpyService::new());
+    let service = Arc::new(SpyService::default());
     let runner = StatsFlushRunner::start_with_intervals(
         buffer.clone(),
         service.clone() as Arc<dyn StatsService>,
@@ -116,18 +99,14 @@ async fn shutdown_flushes_non_empty_buffer() {
     runner.shutdown().await;
     assert!(
         service.flush_count() >= 1,
-        "shutdown must trigger a final flush of any buffered rows"
-    );
-    assert!(
-        service.saw_admin_ctx_on_every_call(),
-        "runner must establish an admin AuthContext before calling run_flush"
+        "shutdown must trigger a final flush of any buffered rows (with an admin AuthContext established)"
     );
 }
 
 #[tokio::test]
 async fn periodic_flush_drains_buffer() {
     let buffer = StatsBuffer::new();
-    let service = Arc::new(SpyService::new());
+    let service = Arc::new(SpyService::default());
     let runner = StatsFlushRunner::start_with_intervals(
         buffer.clone(),
         service.clone() as Arc<dyn StatsService>,
@@ -148,7 +127,7 @@ async fn periodic_flush_drains_buffer() {
 #[tokio::test]
 async fn empty_buffer_is_not_flushed() {
     let buffer = StatsBuffer::new();
-    let service = Arc::new(SpyService::new());
+    let service = Arc::new(SpyService::default());
     let runner = StatsFlushRunner::start_with_intervals(
         buffer,
         service.clone() as Arc<dyn StatsService>,

--- a/source/daemon/crates/wardnetd-services/src/stats/tests/service.rs
+++ b/source/daemon/crates/wardnetd-services/src/stats/tests/service.rs
@@ -194,17 +194,40 @@ fn hourly(metric: &str, labels: &str, hour_ts: i64, value: f64, kind: &str) -> H
 #[tokio::test]
 async fn run_flush_empty_is_noop() {
     let svc = make_service();
-    svc.run_flush(vec![]).await.unwrap();
+    auth_context::with_context(admin_ctx(), svc.run_flush(vec![]))
+        .await
+        .unwrap();
 }
 
 #[tokio::test]
 async fn run_flush_delegates_rows_to_repo() {
     let repo = Arc::new(MemoryStatsRepo::default());
     let svc = StatsServiceImpl::new(repo.clone());
-    svc.run_flush(vec![intraday("m", "{}", 0, 1.0)])
-        .await
-        .unwrap();
+    auth_context::with_context(
+        admin_ctx(),
+        svc.run_flush(vec![intraday("m", "{}", 0, 1.0)]),
+    )
+    .await
+    .unwrap();
     assert_eq!(repo.intraday.lock().unwrap().len(), 1);
+}
+
+#[tokio::test]
+async fn run_flush_forbidden_without_admin_context() {
+    let repo = Arc::new(MemoryStatsRepo::default());
+    let svc = StatsServiceImpl::new(repo.clone());
+    let err = svc
+        .run_flush(vec![intraday("m", "{}", 0, 1.0)])
+        .await
+        .unwrap_err();
+    assert!(matches!(
+        err.downcast_ref::<AppError>(),
+        Some(AppError::Forbidden(_))
+    ));
+    assert!(
+        repo.intraday.lock().unwrap().is_empty(),
+        "no rows may be written without an admin context"
+    );
 }
 
 // ── query ─────────────────────────────────────────────────────────────────────
@@ -540,5 +563,17 @@ async fn top_with_admin_context() {
 #[tokio::test]
 async fn run_maintenance_completes_without_error() {
     let svc = make_service();
-    svc.run_maintenance().await.unwrap();
+    auth_context::with_context(admin_ctx(), svc.run_maintenance())
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn run_maintenance_forbidden_without_admin_context() {
+    let svc = make_service();
+    let err = svc.run_maintenance().await.unwrap_err();
+    assert!(matches!(
+        err.downcast_ref::<AppError>(),
+        Some(AppError::Forbidden(_))
+    ));
 }

--- a/source/daemon/crates/wardnetd/src/tests/stubs.rs
+++ b/source/daemon/crates/wardnetd/src/tests/stubs.rs
@@ -1066,8 +1066,10 @@ impl wardnetd_services::logging::LogService for StubLogService {
         drop(tx);
         rx
     }
-    fn get_recent_errors(&self) -> Vec<wardnetd_services::logging::error_notifier::ErrorEntry> {
-        Vec::new()
+    fn get_recent_errors(
+        &self,
+    ) -> Result<Vec<wardnetd_services::logging::error_notifier::ErrorEntry>, AppError> {
+        Ok(Vec::new())
     }
     async fn list_log_files(
         &self,

--- a/source/daemon/crates/wardnetd/src/tests/stubs.rs
+++ b/source/daemon/crates/wardnetd/src/tests/stubs.rs
@@ -1061,10 +1061,12 @@ pub struct StubLogService;
 
 #[async_trait]
 impl wardnetd_services::logging::LogService for StubLogService {
-    fn subscribe(&self) -> broadcast::Receiver<wardnetd_services::logging::stream::LogEntry> {
+    fn subscribe(
+        &self,
+    ) -> Result<broadcast::Receiver<wardnetd_services::logging::stream::LogEntry>, AppError> {
         let (tx, rx) = broadcast::channel(1);
         drop(tx);
-        rx
+        Ok(rx)
     }
     fn get_recent_errors(
         &self,


### PR DESCRIPTION
Closes #841

Adds the missing service-layer auth backstop to `LogService` and `StatsService`, per the hard requirement in `.agents/auth.md`. Neither gap is exploitable today (all reachable handlers are `AdminAuth`-gated and the flush runner is never reachable over HTTP), so this is purely defense-in-depth — handler-level gating is untouched.

**LogService**

- `list_log_files`, `download_log_file`, and `subscribe` now open with `auth_context::require_admin()?`. `subscribe` streams the same log data the download path protects, so it gets the same treatment — converted to `Result<Receiver<LogEntry>, AppError>` following the `DnsService::subscribe_query_stream` precedent; the `logs_ws` handler propagates the error (the guard runs in the handler body, before the WS upgrade, where the auth context is still in scope).
- `get_recent_errors` is converted to `Result<Vec<ErrorEntry>, AppError>` so it can carry the same guard, rather than leaving it as an undocumented exception (it doesn't fit any of the three sanctioned categories). The `recent_errors` handler propagates the error; the OpenAPI annotation already documents auth errors, so the spec is unchanged.
- The remaining unguarded methods (`tracing_layers`, `start_all`, `stop_all`) are startup/shutdown-lifecycle methods and now carry the documented-exception comments `.agents/auth.md` rule 2 requires.

**StatsService**

- `run_flush` and `run_maintenance` now open with `auth_context::require_admin()?` (the `AppError::Forbidden` converts into the `anyhow::Result` return type), matching the sibling `query`/`top` methods, and the trait docs state the admin-context requirement so callers don't discover it at runtime.
- `StatsFlushRunner` establishes `AuthContext::Admin { admin_id: Uuid::nil() }` via `auth_context::with_context(...)` around both calls, following the same pattern as `session_cleanup_runner`, `db_maintenance_runner`, and `tunnel_idle`. For the flush path the context is hoisted per the query-log runner's convention and cloned inside the `retry_on_busy` closure so every retry attempt carries it.

**Tests**

- New service-level tests assert `Forbidden` for `subscribe`/`get_recent_errors`/`list_log_files`/`download_log_file`/`run_flush`/`run_maintenance` when no admin context is set, and that `run_flush` writes nothing in that case.
- Existing service tests now wrap calls in `auth_context::with_context(...)` per the documented test pattern.
- The flush-runner spy guards with `require_admin()` exactly like the real service, so the existing count assertions fail if the runner ever stops establishing the context.
- Existing handler-level tests (`download_logs_requires_authentication`, `recent_errors_requires_authentication`) are untouched and still pass.

`make check-daemon` equivalents pass locally: `cargo fmt`, `cargo clippy --all-targets -- -D warnings`, and `cargo test --workspace` (2,450+ tests, 0 failures). Coverage only gains here — new tests added, none removed, and every new guard line is exercised on both the allow and deny paths.