### PR TITLE
fix(tunnel): reset default routing policy when its tunnel is deleted

### DIFF
--- a/source/daemon/crates/wardnet-common/src/event.rs
+++ b/source/daemon/crates/wardnet-common/src/event.rs
@@ -238,8 +238,13 @@ pub enum WardnetEvent {
         timestamp: DateTime<Utc>,
     },
     /// The global default routing policy changed (e.g. `"direct"` → a tunnel
-    /// UUID). Emitted by `RoutingService::set_default_policy`. The Network-Zone
-    /// enforcer (issue #736) consumes this to re-validate every `Default`-ruled
+    /// UUID). Emitted by `RoutingService::set_default_policy`, and by
+    /// `TunnelService::delete_tunnel` when the deleted tunnel *was* the default
+    /// policy (the policy is reset to `"direct"` so it never dangles). Two
+    /// consumers: the routing listener syncs the routing engine's in-memory
+    /// policy and re-resolves `Default`-ruled devices (a no-op for
+    /// `set_default_policy`'s own emission, which does both inline), and the
+    /// Network-Zone enforcer (issue #736) re-validates every `Default`-ruled
     /// device against its zone: a policy flip can silently resolve a device's
     /// `Default` rule to a target its zone forbids (the one edge the #735
     /// write-time gate cannot catch), so the enforcer unbinds any now-forbidden

--- a/source/daemon/crates/wardnet-common/src/event.rs
+++ b/source/daemon/crates/wardnet-common/src/event.rs
@@ -241,14 +241,13 @@ pub enum WardnetEvent {
     /// UUID). Emitted by `RoutingService::set_default_policy`, and by
     /// `TunnelService::delete_tunnel` when the deleted tunnel *was* the default
     /// policy (the policy is reset to `"direct"` so it never dangles). Two
-    /// consumers: the routing listener syncs the routing engine's in-memory
-    /// policy and re-resolves `Default`-ruled devices (a no-op for
-    /// `set_default_policy`'s own emission, which does both inline), and the
-    /// Network-Zone enforcer (issue #736) re-validates every `Default`-ruled
-    /// device against its zone: a policy flip can silently resolve a device's
-    /// `Default` rule to a target its zone forbids (the one edge the #735
-    /// write-time gate cannot catch), so the enforcer unbinds any now-forbidden
-    /// tunnel binding back to direct.
+    /// consumers: the routing listener re-applies `Default`-ruled devices
+    /// against the persisted policy, and the Network-Zone enforcer (issue
+    /// #736) re-validates every `Default`-ruled device against its zone: a
+    /// policy flip can silently resolve a device's `Default` rule to a target
+    /// its zone forbids (the one edge the #735 write-time gate cannot catch),
+    /// so the enforcer unbinds any now-forbidden tunnel binding back to
+    /// direct.
     DefaultPolicyChanged {
         policy: String,
         timestamp: DateTime<Utc>,

--- a/source/daemon/crates/wardnetd-api/src/api/tests/system.rs
+++ b/source/daemon/crates/wardnetd-api/src/api/tests/system.rs
@@ -279,8 +279,8 @@ impl RoutingService for MockRoutingService {
             Err(e) => Err(clone_app_error(e)),
         }
     }
-    async fn handle_default_policy_changed(&self, policy: &str) -> Result<(), AppError> {
-        self.inner.handle_default_policy_changed(policy).await
+    async fn handle_default_policy_changed(&self) -> Result<(), AppError> {
+        self.inner.handle_default_policy_changed().await
     }
     fn dns_upstream_snapshot(
         &self,

--- a/source/daemon/crates/wardnetd-api/src/api/tests/system.rs
+++ b/source/daemon/crates/wardnetd-api/src/api/tests/system.rs
@@ -279,6 +279,9 @@ impl RoutingService for MockRoutingService {
             Err(e) => Err(clone_app_error(e)),
         }
     }
+    async fn handle_default_policy_changed(&self, policy: &str) -> Result<(), AppError> {
+        self.inner.handle_default_policy_changed(policy).await
+    }
     fn dns_upstream_snapshot(
         &self,
     ) -> std::sync::Arc<

--- a/source/daemon/crates/wardnetd-api/src/tests/stubs.rs
+++ b/source/daemon/crates/wardnetd-api/src/tests/stubs.rs
@@ -731,7 +731,7 @@ impl RoutingService for StubRoutingService {
     async fn default_policy(&self) -> Result<String, AppError> {
         Ok("direct".to_owned())
     }
-    async fn handle_default_policy_changed(&self, _policy: &str) -> Result<(), AppError> {
+    async fn handle_default_policy_changed(&self) -> Result<(), AppError> {
         Ok(())
     }
     fn dns_upstream_snapshot(

--- a/source/daemon/crates/wardnetd-api/src/tests/stubs.rs
+++ b/source/daemon/crates/wardnetd-api/src/tests/stubs.rs
@@ -731,6 +731,9 @@ impl RoutingService for StubRoutingService {
     async fn default_policy(&self) -> Result<String, AppError> {
         Ok("direct".to_owned())
     }
+    async fn handle_default_policy_changed(&self, _policy: &str) -> Result<(), AppError> {
+        Ok(())
+    }
     fn dns_upstream_snapshot(
         &self,
     ) -> std::sync::Arc<

--- a/source/daemon/crates/wardnetd-data/src/repository/sqlite/system_config.rs
+++ b/source/daemon/crates/wardnetd-data/src/repository/sqlite/system_config.rs
@@ -128,6 +128,21 @@ impl SystemConfigRepository for SqliteSystemConfigRepository {
         Ok(())
     }
 
+    async fn reset_default_policy_from(&self, expected: &str) -> anyhow::Result<bool> {
+        // Single conditional UPDATE so the compare-and-set is atomic: a
+        // concurrent policy write that lands between the caller's read and
+        // this statement changes the stored value, the WHERE clause stops
+        // matching, and the reset is skipped instead of clobbering it.
+        let result = sqlx::query(
+            "UPDATE system_config SET value = 'direct' \
+             WHERE key = 'default_policy' AND value = ?",
+        )
+        .bind(expected)
+        .execute(&self.pools.write)
+        .await?;
+        Ok(result.rows_affected() > 0)
+    }
+
     async fn device_count(&self) -> anyhow::Result<i64> {
         let count = sqlx::query_scalar::<_, i64>("SELECT COUNT(*) FROM devices")
             .fetch_one(&self.pools.read)

--- a/source/daemon/crates/wardnetd-data/src/repository/system_config.rs
+++ b/source/daemon/crates/wardnetd-data/src/repository/system_config.rs
@@ -161,6 +161,25 @@ pub trait SystemConfigRepository: Send + Sync {
         self.set("default_policy", policy).await
     }
 
+    /// Reset the global default routing policy to `"direct"`, but only if
+    /// it still holds `expected`. Returns whether the reset was applied.
+    ///
+    /// Used by tunnel deletion to clear a policy that points at the tunnel
+    /// being removed without clobbering a concurrent
+    /// [`Self::set_default_policy`] write: if the stored value no longer
+    /// matches `expected`, another writer won and the reset is skipped.
+    /// This default implementation is a non-atomic read-compare-write for
+    /// in-memory test doubles; the `SQLite` implementation overrides it with
+    /// a single conditional `UPDATE` so the compare-and-set is atomic.
+    async fn reset_default_policy_from(&self, expected: &str) -> anyhow::Result<bool> {
+        if self.get("default_policy").await?.as_deref() == Some(expected) {
+            self.set("default_policy", "direct").await?;
+            Ok(true)
+        } else {
+            Ok(false)
+        }
+    }
+
     /// Read the current setup-wizard step.
     ///
     /// One of: `admin`, `network`, `dhcp`, `router_mac`, `tunnel`,

--- a/source/daemon/crates/wardnetd-data/src/repository/tests/system_config.rs
+++ b/source/daemon/crates/wardnetd-data/src/repository/tests/system_config.rs
@@ -323,6 +323,45 @@ async fn default_policy_round_trip() {
 }
 
 #[tokio::test]
+async fn reset_default_policy_from_is_conditional() {
+    let pool = test_pool().await;
+    let repo = SqliteSystemConfigRepository::new(pool);
+
+    // Unset key: nothing matches, nothing is written.
+    assert!(
+        !repo
+            .reset_default_policy_from("10000000-0000-0000-0000-000000000001")
+            .await
+            .unwrap()
+    );
+    assert!(repo.get_default_policy().await.unwrap().is_none());
+
+    let tunnel_uuid = "10000000-0000-0000-0000-000000000001";
+    repo.set_default_policy(tunnel_uuid).await.unwrap();
+
+    // Wrong expected value: the stored policy survives untouched — this
+    // is what protects a concurrent set_default_policy from being
+    // clobbered by a tunnel deletion.
+    assert!(
+        !repo
+            .reset_default_policy_from("20000000-0000-0000-0000-000000000002")
+            .await
+            .unwrap()
+    );
+    assert_eq!(
+        repo.get_default_policy().await.unwrap().as_deref(),
+        Some(tunnel_uuid)
+    );
+
+    // Matching expected value: reset applies.
+    assert!(repo.reset_default_policy_from(tunnel_uuid).await.unwrap());
+    assert_eq!(
+        repo.get_default_policy().await.unwrap().as_deref(),
+        Some("direct")
+    );
+}
+
+#[tokio::test]
 async fn wizard_step_round_trip() {
     let pool = test_pool().await;
     let repo = SqliteSystemConfigRepository::new(pool);

--- a/source/daemon/crates/wardnetd-services/src/lib.rs
+++ b/source/daemon/crates/wardnetd-services/src/lib.rs
@@ -641,6 +641,7 @@ fn create_services(
     let tunnel_service: Arc<dyn TunnelService> = Arc::new(TunnelServiceImpl::new(
         tunnel_repo.clone(),
         device_repo.clone(),
+        system_config_repo.clone(),
         backends.tunnel_interface.clone(),
         backends.tunnel_exit_probe.clone(),
         backends.tunnel_latency_prober.clone(),

--- a/source/daemon/crates/wardnetd-services/src/routing/service.rs
+++ b/source/daemon/crates/wardnetd-services/src/routing/service.rs
@@ -108,34 +108,36 @@ pub trait RoutingService: Send + Sync {
     /// Update the global default routing policy.
     ///
     /// Validates `policy` (must be `"direct"` or a tunnel UUID),
-    /// persists it to `system_config`, and updates the in-memory
-    /// state used by [`Self::apply_rule`] to resolve
-    /// [`RoutingTarget::Default`]. Devices whose stored rule is
-    /// `RoutingTarget::Default` will pick up the new policy on
-    /// their next apply or reconcile.
+    /// persists it to `system_config`, updates the in-memory state used
+    /// by [`Self::apply_rule`] to resolve [`RoutingTarget::Default`],
+    /// and publishes `DefaultPolicyChanged`. Already-routed
+    /// `Default`-ruled devices are re-applied by the routing listener
+    /// reacting to that event (via
+    /// [`Self::handle_default_policy_changed`]), not inline — new
+    /// resolves see the new policy immediately, existing kernel state
+    /// follows a moment later.
     async fn set_default_policy(&self, policy: &str) -> Result<(), AppError>;
 
     /// Read the current global default routing policy.
     async fn default_policy(&self) -> Result<String, AppError>;
 
-    /// Absorb a default-policy change that was persisted outside this
-    /// service and re-resolve `Default`-ruled devices against it.
+    /// Re-read the persisted default policy, sync the in-memory copy,
+    /// and re-apply every `Default`-ruled device against it.
     ///
-    /// [`Self::set_default_policy`] is the normal write path, but the
-    /// policy can also be rewritten by tunnel deletion (a tunnel that
-    /// *is* the default policy is reset to `"direct"` so the config
-    /// never dangles). The tunnel service persists that reset and
-    /// announces it via
+    /// This is the single mechanism that makes a policy change take
+    /// effect on already-routed devices. [`Self::set_default_policy`] is
+    /// one writer; tunnel deletion is the other (a tunnel that *is* the
+    /// default policy is reset to `"direct"` so the config never
+    /// dangles). Both persist first and then announce via
     /// [`wardnet_common::event::WardnetEvent::DefaultPolicyChanged`];
-    /// the routing listener forwards the event here so the in-memory
-    /// policy used by [`Self::apply_rule`] catches up and affected
-    /// devices re-route immediately. A no-op when the in-memory value
-    /// already matches (i.e. the change originated from
-    /// [`Self::set_default_policy`], which syncs and re-applies inline
-    /// before publishing).
+    /// the routing listener forwards every such event here, and also
+    /// calls this after a lagged event-bus receiver may have dropped
+    /// one. The persisted value is re-read rather than trusted from the
+    /// event payload so out-of-order or dropped events always converge
+    /// on the database's state.
     ///
     /// No auth guard — callers wrap this in `auth_context::with_context(...)`.
-    async fn handle_default_policy_changed(&self, policy: &str) -> Result<(), AppError>;
+    async fn handle_default_policy_changed(&self) -> Result<(), AppError>;
 
     /// Lock-free, atomically swappable snapshot of `device_ip → UpstreamId`
     /// for the DNS server's per-query upstream selection.
@@ -288,6 +290,32 @@ impl RoutingServiceImpl {
         )
     }
 
+    /// Write `policy` into the in-memory default-policy cache, returning
+    /// whether the stored value actually changed. Shared by
+    /// [`RoutingService::set_default_policy`] and
+    /// [`RoutingService::handle_default_policy_changed`] so the
+    /// poisoned-lock handling cannot drift between the two write paths
+    /// (the read side is likewise centralized in
+    /// [`Self::current_default_policy`]).
+    fn write_cached_policy(&self, policy: &str) -> Result<bool, AppError> {
+        match self.default_policy.write() {
+            Ok(mut guard) => {
+                if *guard == policy {
+                    Ok(false)
+                } else {
+                    policy.clone_into(&mut guard);
+                    Ok(true)
+                }
+            }
+            Err(e) => {
+                tracing::error!(error = %e, "default_policy lock poisoned during write");
+                Err(AppError::Internal(anyhow::anyhow!(
+                    "default_policy lock poisoned"
+                )))
+            }
+        }
+    }
+
     /// Re-apply every device whose *stored DB rule* is
     /// `RoutingTarget::Default`. The cached `applied` entry holds the
     /// already-resolved target (e.g. Direct) which `apply_rule`'s
@@ -303,45 +331,43 @@ impl RoutingServiceImpl {
     /// the rest. `apply_rule` already falls back to direct on its
     /// own internal failures.
     async fn reapply_default_ruled_devices(&self) -> Result<(), AppError> {
+        // Two batched queries instead of a per-device rule lookup: the
+        // rule set is loaded once and joined against the device list in
+        // memory.
         let devices = self.devices.find_all().await.map_err(AppError::Internal)?;
+        let default_ruled: HashSet<Uuid> = self
+            .devices
+            .find_all_rules()
+            .await
+            .map_err(AppError::Internal)?
+            .into_iter()
+            .filter(|rule| matches!(rule.target, RoutingTarget::Default))
+            .map(|rule| rule.device_id)
+            .collect();
         let mut reapplied = 0u32;
         for device in &devices {
-            let rule = match self
-                .devices
-                .find_rule_for_device(&device.id.to_string())
-                .await
-            {
-                Ok(Some(rule)) => rule,
-                Ok(None) => continue,
-                Err(e) => {
-                    tracing::warn!(
-                        error = %e,
-                        device_id = %device.id,
-                        "failed to load routing rule while re-applying default policy"
-                    );
-                    continue;
-                }
-            };
-            if !matches!(rule.target, RoutingTarget::Default) {
+            if !default_ruled.contains(&device.id) {
                 continue;
             }
             if let Err(e) = self
                 .apply_rule(device.id, &device.last_ip, &RoutingTarget::Default)
                 .await
             {
+                let device_id = device.id;
                 tracing::warn!(
                     error = %e,
-                    device_id = %device.id,
-                    "failed to re-apply default policy for device"
+                    device_id = %device_id,
+                    "failed to re-apply default policy for device {device_id}: {e}"
                 );
             } else {
                 reapplied += 1;
             }
         }
+        let total_devices = devices.len();
         tracing::info!(
             reapplied,
-            total_devices = devices.len(),
-            "re-applied default routing policy across devices"
+            total_devices,
+            "re-applied default routing policy across devices: {reapplied}/{total_devices}"
         );
 
         Ok(())
@@ -1514,30 +1540,27 @@ impl RoutingService for RoutingServiceImpl {
             .await
             .map_err(AppError::Internal)?;
 
-        match self.default_policy.write() {
-            Ok(mut guard) => policy.clone_into(&mut guard),
-            Err(e) => {
-                tracing::error!(error = %e, "default_policy lock poisoned during write");
-                return Err(AppError::Internal(anyhow::anyhow!(
-                    "default_policy lock poisoned"
-                )));
-            }
-        }
+        // Update the cache immediately so concurrent resolves and the
+        // policy GET never observe the old value between the DB write and
+        // the listener's reaction below.
+        self.write_cached_policy(policy)?;
 
-        tracing::info!(policy, "default routing policy updated");
+        tracing::info!(policy, "default routing policy updated to {policy}");
 
-        // Announce the change so the Network-Zone enforcer (#736) can
-        // re-validate `Default`-ruled devices against their zones and unbind
-        // any tunnel binding a device's zone now forbids. Published *before*
-        // the re-apply sweep below so the enforcer never observes a stale
-        // policy; the enforcer only reads zones + devices, so ordering against
-        // the re-apply is benign.
+        // Announce the change. Two consumers react: the Network-Zone
+        // enforcer (#736) re-validates `Default`-ruled devices against
+        // their zones and unbinds any tunnel binding a device's zone now
+        // forbids, and the routing listener re-applies `Default`-ruled
+        // devices via `handle_default_policy_changed`. The re-apply is
+        // event-driven rather than inline so this admin call returns
+        // without waiting on the kernel walk, and so both policy writers
+        // (this method and tunnel deletion) converge through one path.
         self.events.publish(WardnetEvent::DefaultPolicyChanged {
             policy: policy.to_owned(),
             timestamp: chrono::Utc::now(),
         });
 
-        self.reapply_default_ruled_devices().await
+        Ok(())
     }
 
     async fn default_policy(&self) -> Result<String, AppError> {
@@ -1545,32 +1568,37 @@ impl RoutingService for RoutingServiceImpl {
         Ok(self.current_default_policy())
     }
 
-    async fn handle_default_policy_changed(&self, policy: &str) -> Result<(), AppError> {
+    async fn handle_default_policy_changed(&self) -> Result<(), AppError> {
         // No auth guard — invoked from the routing listener, which already
         // runs inside an `auth_context::with_context(Admin)` wrapper.
-        match self.default_policy.write() {
-            Ok(mut guard) => {
-                if *guard == policy {
-                    // Already in sync — the change came through
-                    // `set_default_policy`, which updated the cache and
-                    // re-applied devices before publishing the event.
-                    return Ok(());
-                }
-                policy.clone_into(&mut guard);
-            }
-            Err(e) => {
-                tracing::error!(error = %e, "default_policy lock poisoned during sync");
-                return Err(AppError::Internal(anyhow::anyhow!(
-                    "default_policy lock poisoned"
-                )));
-            }
+        //
+        // The persisted policy is re-read here instead of trusting the
+        // event payload: publishes are not atomic with their DB writes, so
+        // a stale payload could otherwise overwrite a newer value. Reading
+        // the source of truth makes the last handler run converge on the
+        // final persisted state regardless of event ordering or drops.
+        let Some(policy) = self
+            .system_config
+            .get_default_policy()
+            .await
+            .map_err(AppError::Internal)?
+        else {
+            // Policy key unset (pre-bootstrap) — nothing to sync against.
+            return Ok(());
+        };
+
+        if self.write_cached_policy(&policy)? {
+            tracing::info!(
+                policy,
+                "synced default routing policy from persisted change to {policy}"
+            );
         }
 
-        tracing::info!(
-            policy,
-            "absorbed externally persisted default routing policy change"
-        );
-
+        // Always sweep, even when the cache was already current: for
+        // changes originating in `set_default_policy` the cache is updated
+        // inline before the event is published, so an in-sync cache says
+        // nothing about whether devices have been re-applied yet.
+        // `apply_rule`'s short-circuit makes a redundant sweep cheap.
         self.reapply_default_ruled_devices().await
     }
 

--- a/source/daemon/crates/wardnetd-services/src/routing/service.rs
+++ b/source/daemon/crates/wardnetd-services/src/routing/service.rs
@@ -118,6 +118,25 @@ pub trait RoutingService: Send + Sync {
     /// Read the current global default routing policy.
     async fn default_policy(&self) -> Result<String, AppError>;
 
+    /// Absorb a default-policy change that was persisted outside this
+    /// service and re-resolve `Default`-ruled devices against it.
+    ///
+    /// [`Self::set_default_policy`] is the normal write path, but the
+    /// policy can also be rewritten by tunnel deletion (a tunnel that
+    /// *is* the default policy is reset to `"direct"` so the config
+    /// never dangles). The tunnel service persists that reset and
+    /// announces it via
+    /// [`wardnet_common::event::WardnetEvent::DefaultPolicyChanged`];
+    /// the routing listener forwards the event here so the in-memory
+    /// policy used by [`Self::apply_rule`] catches up and affected
+    /// devices re-route immediately. A no-op when the in-memory value
+    /// already matches (i.e. the change originated from
+    /// [`Self::set_default_policy`], which syncs and re-applies inline
+    /// before publishing).
+    ///
+    /// No auth guard — callers wrap this in `auth_context::with_context(...)`.
+    async fn handle_default_policy_changed(&self, policy: &str) -> Result<(), AppError>;
+
     /// Lock-free, atomically swappable snapshot of `device_ip → UpstreamId`
     /// for the DNS server's per-query upstream selection.
     ///
@@ -267,6 +286,65 @@ impl RoutingServiceImpl {
             },
             |guard| guard.clone(),
         )
+    }
+
+    /// Re-apply every device whose *stored DB rule* is
+    /// `RoutingTarget::Default`. The cached `applied` entry holds the
+    /// already-resolved target (e.g. Direct) which `apply_rule`'s
+    /// phase-1 short-circuit compares against — without this walk,
+    /// already-routed devices keep flowing through the *previous*
+    /// policy until something else (IP change, tunnel up/down)
+    /// triggers a re-apply. A policy switch is supposed to take
+    /// effect immediately, not "next time something happens to the
+    /// device", so iterate now.
+    ///
+    /// Errors per device are logged and swallowed — one device
+    /// failing to re-route shouldn't abort the policy change for
+    /// the rest. `apply_rule` already falls back to direct on its
+    /// own internal failures.
+    async fn reapply_default_ruled_devices(&self) -> Result<(), AppError> {
+        let devices = self.devices.find_all().await.map_err(AppError::Internal)?;
+        let mut reapplied = 0u32;
+        for device in &devices {
+            let rule = match self
+                .devices
+                .find_rule_for_device(&device.id.to_string())
+                .await
+            {
+                Ok(Some(rule)) => rule,
+                Ok(None) => continue,
+                Err(e) => {
+                    tracing::warn!(
+                        error = %e,
+                        device_id = %device.id,
+                        "failed to load routing rule while re-applying default policy"
+                    );
+                    continue;
+                }
+            };
+            if !matches!(rule.target, RoutingTarget::Default) {
+                continue;
+            }
+            if let Err(e) = self
+                .apply_rule(device.id, &device.last_ip, &RoutingTarget::Default)
+                .await
+            {
+                tracing::warn!(
+                    error = %e,
+                    device_id = %device.id,
+                    "failed to re-apply default policy for device"
+                );
+            } else {
+                reapplied += 1;
+            }
+        }
+        tracing::info!(
+            reapplied,
+            total_devices = devices.len(),
+            "re-applied default routing policy across devices"
+        );
+
+        Ok(())
     }
 
     /// Resolve `RoutingTarget::Default` into a concrete target based on the
@@ -1459,67 +1537,41 @@ impl RoutingService for RoutingServiceImpl {
             timestamp: chrono::Utc::now(),
         });
 
-        // Re-apply every device whose *stored DB rule* is
-        // RoutingTarget::Default. The cached `applied` entry holds the
-        // already-resolved target (e.g. Direct) which apply_rule's
-        // phase-1 short-circuit compares against — without this walk,
-        // already-routed devices keep flowing through the *previous*
-        // policy until something else (IP change, tunnel up/down)
-        // triggers a re-apply. The policy switch is supposed to take
-        // effect immediately, not "next time something happens to the
-        // device", so iterate now.
-        //
-        // Errors per device are logged and swallowed — one device
-        // failing to re-route shouldn't abort the policy change for
-        // the rest. apply_rule already falls back to direct on its
-        // own internal failures.
-        let devices = self.devices.find_all().await.map_err(AppError::Internal)?;
-        let mut reapplied = 0u32;
-        for device in &devices {
-            let rule = match self
-                .devices
-                .find_rule_for_device(&device.id.to_string())
-                .await
-            {
-                Ok(Some(rule)) => rule,
-                Ok(None) => continue,
-                Err(e) => {
-                    tracing::warn!(
-                        error = %e,
-                        device_id = %device.id,
-                        "failed to load routing rule while re-applying default policy"
-                    );
-                    continue;
-                }
-            };
-            if !matches!(rule.target, RoutingTarget::Default) {
-                continue;
-            }
-            if let Err(e) = self
-                .apply_rule(device.id, &device.last_ip, &RoutingTarget::Default)
-                .await
-            {
-                tracing::warn!(
-                    error = %e,
-                    device_id = %device.id,
-                    "failed to re-apply default policy for device"
-                );
-            } else {
-                reapplied += 1;
-            }
-        }
-        tracing::info!(
-            reapplied,
-            total_devices = devices.len(),
-            "re-applied default routing policy across devices"
-        );
-
-        Ok(())
+        self.reapply_default_ruled_devices().await
     }
 
     async fn default_policy(&self) -> Result<String, AppError> {
         auth_context::require_admin()?;
         Ok(self.current_default_policy())
+    }
+
+    async fn handle_default_policy_changed(&self, policy: &str) -> Result<(), AppError> {
+        // No auth guard — invoked from the routing listener, which already
+        // runs inside an `auth_context::with_context(Admin)` wrapper.
+        match self.default_policy.write() {
+            Ok(mut guard) => {
+                if *guard == policy {
+                    // Already in sync — the change came through
+                    // `set_default_policy`, which updated the cache and
+                    // re-applied devices before publishing the event.
+                    return Ok(());
+                }
+                policy.clone_into(&mut guard);
+            }
+            Err(e) => {
+                tracing::error!(error = %e, "default_policy lock poisoned during sync");
+                return Err(AppError::Internal(anyhow::anyhow!(
+                    "default_policy lock poisoned"
+                )));
+            }
+        }
+
+        tracing::info!(
+            policy,
+            "absorbed externally persisted default routing policy change"
+        );
+
+        self.reapply_default_ruled_devices().await
     }
 
     fn dns_upstream_snapshot(&self) -> Arc<ArcSwap<HashMap<IpAddr, UpstreamId>>> {

--- a/source/daemon/crates/wardnetd-services/src/routing/tests/routing.rs
+++ b/source/daemon/crates/wardnetd-services/src/routing/tests/routing.rs
@@ -2331,3 +2331,112 @@ async fn set_default_policy_does_not_touch_explicit_targets() {
         "policy change must not re-apply devices with explicit targets: {nl:?}"
     );
 }
+
+#[tokio::test]
+async fn handle_default_policy_changed_syncs_and_reapplies_default_ruled_devices() {
+    // Mirrors the tunnel-deletion path: the default policy points at a
+    // tunnel, a Default-ruled device routes through it, and then the
+    // policy is reset to "direct" *outside* this service (persisted by
+    // the tunnel service, announced via DefaultPolicyChanged). The
+    // handler must update the in-memory policy and re-route the device
+    // — without it, the cache keeps the deleted tunnel's UUID and every
+    // later resolve falls back to direct only via the NotFound path.
+    let d1 = sample_device(device_id_1(), "192.168.1.10");
+    let mut rules = HashMap::new();
+    rules.insert(
+        DEVICE_1_ID.to_owned(),
+        RoutingRule {
+            device_id: device_id_1(),
+            target: RoutingTarget::Default,
+            created_by: RuleCreator::User,
+        },
+    );
+    let ts = setup_with_devices_and_tunnel(
+        vec![d1],
+        rules,
+        Some(sample_tunnel(tunnel_id_1(), "wg_ward0", TunnelStatus::Up)),
+        Some(sample_tunnel_config(vec!["1.1.1.1".to_owned()])),
+        tunnel_id_1().to_string(),
+    );
+
+    // Initial apply under policy=tunnel → device routes through it.
+    as_admin(
+        ts.routing
+            .apply_rule(device_id_1(), "192.168.1.10", &RoutingTarget::Default),
+    )
+    .await
+    .unwrap();
+    {
+        let nl = ts.netlink_calls.lock().await;
+        assert!(
+            nl.iter().any(|c| c.starts_with("add_ip_rule:192.168.1.10")),
+            "Default → Tunnel should add an ip rule: {nl:?}"
+        );
+    }
+
+    // Absorb the externally persisted reset to "direct".
+    as_admin(ts.routing.handle_default_policy_changed("direct"))
+        .await
+        .unwrap();
+
+    assert_eq!(
+        as_admin(ts.routing.default_policy()).await.unwrap(),
+        "direct",
+        "in-memory policy must catch up with the external change"
+    );
+    let nl = ts.netlink_calls.lock().await;
+    assert!(
+        nl.iter()
+            .any(|c| c.starts_with("remove_ip_rule:192.168.1.10")),
+        "Default-ruled device must be re-routed off the removed policy tunnel: {nl:?}"
+    );
+}
+
+#[tokio::test]
+async fn handle_default_policy_changed_noop_when_already_in_sync() {
+    // When the in-memory policy already matches, the event originated
+    // from set_default_policy (which re-applies devices inline before
+    // publishing) — the handler must not run a second sweep.
+    let d1 = sample_device(device_id_1(), "192.168.1.10");
+    let mut rules = HashMap::new();
+    rules.insert(
+        DEVICE_1_ID.to_owned(),
+        RoutingRule {
+            device_id: device_id_1(),
+            target: RoutingTarget::Default,
+            created_by: RuleCreator::User,
+        },
+    );
+    let ts = setup_with_devices_and_tunnel(
+        vec![d1],
+        rules,
+        Some(sample_tunnel(tunnel_id_1(), "wg_ward0", TunnelStatus::Up)),
+        Some(sample_tunnel_config(vec!["1.1.1.1".to_owned()])),
+        tunnel_id_1().to_string(),
+    );
+
+    as_admin(
+        ts.routing
+            .apply_rule(device_id_1(), "192.168.1.10", &RoutingTarget::Default),
+    )
+    .await
+    .unwrap();
+    let baseline = ts.netlink_calls.lock().await.len();
+
+    as_admin(
+        ts.routing
+            .handle_default_policy_changed(&tunnel_id_1().to_string()),
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(
+        ts.netlink_calls.lock().await.len(),
+        baseline,
+        "an in-sync policy event must not touch kernel state"
+    );
+    assert_eq!(
+        as_admin(ts.routing.default_policy()).await.unwrap(),
+        tunnel_id_1().to_string(),
+    );
+}

--- a/source/daemon/crates/wardnetd-services/src/routing/tests/routing.rs
+++ b/source/daemon/crates/wardnetd-services/src/routing/tests/routing.rs
@@ -714,6 +714,9 @@ impl FirewallManager for MockNftables {
 #[allow(dead_code)]
 struct TestSetup {
     routing: RoutingServiceImpl,
+    /// Exposed so tests can persist a policy change behind the routing
+    /// service's back, simulating the tunnel-deletion write path.
+    system_config: Arc<MockSystemConfigRepo>,
     netlink_calls: Arc<Mutex<Vec<String>>>,
     nftables_calls: Arc<Mutex<Vec<String>>>,
     bring_ups: Arc<Mutex<Vec<Uuid>>>,
@@ -860,7 +863,7 @@ fn setup_with_devices_and_tunnel(
         add_tcp_reset_reject_fail: add_tcp_reset_reject_fail.clone(),
     });
 
-    let system_config: Arc<dyn SystemConfigRepository> = Arc::new(MockSystemConfigRepo::new(&[(
+    let system_config = Arc::new(MockSystemConfigRepo::new(&[(
         "default_policy",
         &default_policy,
     )]));
@@ -871,7 +874,7 @@ fn setup_with_devices_and_tunnel(
         tunnel_svc,
         netlink,
         nftables,
-        system_config,
+        system_config.clone(),
         Arc::new(crate::event::BroadcastEventBus::new(16)),
         default_policy,
         "eth0".to_owned(),
@@ -879,6 +882,7 @@ fn setup_with_devices_and_tunnel(
 
     TestSetup {
         routing,
+        system_config,
         netlink_calls,
         nftables_calls,
         bring_ups,
@@ -936,8 +940,7 @@ fn setup_with_orphaned_rules(
         add_tcp_reset_reject_fail: add_tcp_reset_reject_fail.clone(),
     });
 
-    let system_config: Arc<dyn SystemConfigRepository> =
-        Arc::new(MockSystemConfigRepo::new(&[("default_policy", "direct")]));
+    let system_config = Arc::new(MockSystemConfigRepo::new(&[("default_policy", "direct")]));
 
     let routing = RoutingServiceImpl::new(
         device_repo,
@@ -945,7 +948,7 @@ fn setup_with_orphaned_rules(
         tunnel_svc,
         netlink,
         nftables,
-        system_config,
+        system_config.clone(),
         Arc::new(crate::event::BroadcastEventBus::new(16)),
         "direct".to_owned(),
         "eth0".to_owned(),
@@ -953,6 +956,7 @@ fn setup_with_orphaned_rules(
 
     TestSetup {
         routing,
+        system_config,
         netlink_calls,
         nftables_calls,
         bring_ups,
@@ -1001,8 +1005,7 @@ fn setup_with_route_add_failures(failures: u32) -> TestSetup {
         add_tcp_reset_reject_fail: add_tcp_reset_reject_fail.clone(),
     });
 
-    let system_config: Arc<dyn SystemConfigRepository> =
-        Arc::new(MockSystemConfigRepo::new(&[("default_policy", "direct")]));
+    let system_config = Arc::new(MockSystemConfigRepo::new(&[("default_policy", "direct")]));
 
     let routing = RoutingServiceImpl::new(
         device_repo,
@@ -1010,7 +1013,7 @@ fn setup_with_route_add_failures(failures: u32) -> TestSetup {
         tunnel_svc,
         netlink,
         nftables,
-        system_config,
+        system_config.clone(),
         Arc::new(crate::event::BroadcastEventBus::new(16)),
         "direct".to_owned(),
         "eth0".to_owned(),
@@ -1018,6 +1021,7 @@ fn setup_with_route_add_failures(failures: u32) -> TestSetup {
 
     TestSetup {
         routing,
+        system_config,
         netlink_calls,
         nftables_calls,
         bring_ups,
@@ -2266,9 +2270,13 @@ async fn set_default_policy_reapplies_already_routed_default_devices() {
         );
     }
 
-    // Flip the policy. Internally this should walk devices with a
-    // Default DB rule and re-apply, picking up the new tunnel.
+    // Flip the policy, then run the handler the routing listener invokes
+    // on the resulting DefaultPolicyChanged event — the re-apply of
+    // already-routed devices is event-driven, not inline in the setter.
     as_admin(ts.routing.set_default_policy(&tunnel_id_1().to_string()))
+        .await
+        .unwrap();
+    as_admin(ts.routing.handle_default_policy_changed())
         .await
         .unwrap();
 
@@ -2313,9 +2321,12 @@ async fn set_default_policy_does_not_touch_explicit_targets() {
     let baseline = ts.netlink_calls.lock().await.len();
     drop(ts.netlink_calls.lock().await);
 
-    // Flip the default policy — should NOT re-apply explicit-Direct
-    // devices.
+    // Flip the default policy and run the event-driven re-apply — it
+    // should NOT touch explicit-Direct devices.
     as_admin(ts.routing.set_default_policy(&tunnel_id_1().to_string()))
+        .await
+        .unwrap();
+    as_admin(ts.routing.handle_default_policy_changed())
         .await
         .unwrap();
 
@@ -2336,10 +2347,11 @@ async fn set_default_policy_does_not_touch_explicit_targets() {
 async fn handle_default_policy_changed_syncs_and_reapplies_default_ruled_devices() {
     // Mirrors the tunnel-deletion path: the default policy points at a
     // tunnel, a Default-ruled device routes through it, and then the
-    // policy is reset to "direct" *outside* this service (persisted by
-    // the tunnel service, announced via DefaultPolicyChanged). The
-    // handler must update the in-memory policy and re-route the device
-    // — without it, the cache keeps the deleted tunnel's UUID and every
+    // policy is reset to "direct" *behind the routing service's back*
+    // (persisted by the tunnel service, announced via
+    // DefaultPolicyChanged). The handler must re-read the persisted
+    // policy, update the in-memory copy, and re-route the device —
+    // without it, the cache keeps the deleted tunnel's UUID and every
     // later resolve falls back to direct only via the NotFound path.
     let d1 = sample_device(device_id_1(), "192.168.1.10");
     let mut rules = HashMap::new();
@@ -2374,15 +2386,17 @@ async fn handle_default_policy_changed_syncs_and_reapplies_default_ruled_devices
         );
     }
 
-    // Absorb the externally persisted reset to "direct".
-    as_admin(ts.routing.handle_default_policy_changed("direct"))
+    // Persist the reset outside the routing service, then deliver the
+    // event trigger.
+    ts.system_config.set_default_policy("direct").await.unwrap();
+    as_admin(ts.routing.handle_default_policy_changed())
         .await
         .unwrap();
 
     assert_eq!(
         as_admin(ts.routing.default_policy()).await.unwrap(),
         "direct",
-        "in-memory policy must catch up with the external change"
+        "in-memory policy must catch up with the persisted change"
     );
     let nl = ts.netlink_calls.lock().await;
     assert!(
@@ -2393,10 +2407,12 @@ async fn handle_default_policy_changed_syncs_and_reapplies_default_ruled_devices
 }
 
 #[tokio::test]
-async fn handle_default_policy_changed_noop_when_already_in_sync() {
-    // When the in-memory policy already matches, the event originated
-    // from set_default_policy (which re-applies devices inline before
-    // publishing) — the handler must not run a second sweep.
+async fn handle_default_policy_changed_is_idempotent_when_policy_unchanged() {
+    // A redundant trigger (set_default_policy's own event after the
+    // cache was updated inline, or the listener's resync after event
+    // lag) must not disturb kernel state: the sweep re-runs but
+    // apply_rule's short-circuit sees the already-applied target and
+    // makes no kernel calls.
     let d1 = sample_device(device_id_1(), "192.168.1.10");
     let mut rules = HashMap::new();
     rules.insert(
@@ -2423,17 +2439,14 @@ async fn handle_default_policy_changed_noop_when_already_in_sync() {
     .unwrap();
     let baseline = ts.netlink_calls.lock().await.len();
 
-    as_admin(
-        ts.routing
-            .handle_default_policy_changed(&tunnel_id_1().to_string()),
-    )
-    .await
-    .unwrap();
+    as_admin(ts.routing.handle_default_policy_changed())
+        .await
+        .unwrap();
 
     assert_eq!(
         ts.netlink_calls.lock().await.len(),
         baseline,
-        "an in-sync policy event must not touch kernel state"
+        "a redundant policy trigger must not touch kernel state"
     );
     assert_eq!(
         as_admin(ts.routing.default_policy()).await.unwrap(),

--- a/source/daemon/crates/wardnetd-services/src/routing/tests/routing.rs
+++ b/source/daemon/crates/wardnetd-services/src/routing/tests/routing.rs
@@ -2407,6 +2407,29 @@ async fn handle_default_policy_changed_syncs_and_reapplies_default_ruled_devices
 }
 
 #[tokio::test]
+async fn handle_default_policy_changed_noops_when_policy_unset() {
+    // Pre-bootstrap state: the default_policy key does not exist yet.
+    // The handler has nothing to sync against and must leave the
+    // in-memory policy and kernel state untouched.
+    let ts = setup_with_devices_and_tunnel(vec![], HashMap::new(), None, None, "direct".to_owned());
+    ts.system_config.delete("default_policy").await.unwrap();
+
+    as_admin(ts.routing.handle_default_policy_changed())
+        .await
+        .unwrap();
+
+    assert_eq!(
+        as_admin(ts.routing.default_policy()).await.unwrap(),
+        "direct",
+        "an unset persisted policy must not disturb the in-memory value"
+    );
+    assert!(
+        ts.netlink_calls.lock().await.is_empty(),
+        "an unset persisted policy must not trigger a sweep"
+    );
+}
+
+#[tokio::test]
 async fn handle_default_policy_changed_is_idempotent_when_policy_unchanged() {
     // A redundant trigger (set_default_policy's own event after the
     // cache was updated inline, or the listener's resync after event

--- a/source/daemon/crates/wardnetd-services/src/tunnel/service.rs
+++ b/source/daemon/crates/wardnetd-services/src/tunnel/service.rs
@@ -27,9 +27,9 @@ use crate::tunnel::interface::{
 use crate::tunnel::latency_prober::{LatencyProbeError, TunnelLatencyProber};
 use crate::tunnel::throughput_tester::ThroughputTester;
 use crate::vpn::resolver::{EmptyServerListError, ServerResolver};
-use wardnetd_data::repository::TunnelRepository;
 use wardnetd_data::repository::tunnel::TunnelRow;
 use wardnetd_data::repository::tunnel_speed_test::{SpeedTestRow, TunnelSpeedTestRepository};
+use wardnetd_data::repository::{SystemConfigRepository, TunnelRepository};
 use wardnetd_data::secret_store::SecretStore;
 
 use crate::tunnel::key_store::{KeyStore, KeyStoreAdapter};
@@ -147,6 +147,10 @@ pub trait TunnelService: Send + Sync {
 pub struct TunnelServiceImpl {
     tunnels: Arc<dyn TunnelRepository>,
     devices: Arc<dyn wardnetd_data::repository::DeviceRepository>,
+    /// Holds the global `default_policy`. Read on deletion so a tunnel
+    /// that *is* the default policy resets it to `"direct"` instead of
+    /// leaving a dangling tunnel UUID behind.
+    system_config: Arc<dyn SystemConfigRepository>,
     tunnel_interface: Arc<dyn TunnelInterface>,
     exit_probe: Arc<dyn TunnelExitProbe>,
     latency_prober: Arc<dyn TunnelLatencyProber>,
@@ -240,6 +244,7 @@ impl TunnelServiceImpl {
     pub fn new(
         tunnels: Arc<dyn TunnelRepository>,
         devices: Arc<dyn wardnetd_data::repository::DeviceRepository>,
+        system_config: Arc<dyn SystemConfigRepository>,
         tunnel_interface: Arc<dyn TunnelInterface>,
         exit_probe: Arc<dyn TunnelExitProbe>,
         latency_prober: Arc<dyn TunnelLatencyProber>,
@@ -256,6 +261,7 @@ impl TunnelServiceImpl {
         Self {
             tunnels,
             devices,
+            system_config,
             tunnel_interface,
             exit_probe,
             latency_prober,
@@ -277,6 +283,7 @@ impl TunnelServiceImpl {
     pub(crate) fn with_key_store(
         tunnels: Arc<dyn TunnelRepository>,
         devices: Arc<dyn wardnetd_data::repository::DeviceRepository>,
+        system_config: Arc<dyn SystemConfigRepository>,
         tunnel_interface: Arc<dyn TunnelInterface>,
         exit_probe: Arc<dyn TunnelExitProbe>,
         latency_prober: Arc<dyn TunnelLatencyProber>,
@@ -292,6 +299,7 @@ impl TunnelServiceImpl {
         Self {
             tunnels,
             devices,
+            system_config,
             tunnel_interface,
             exit_probe,
             latency_prober,
@@ -1183,6 +1191,35 @@ impl TunnelService for TunnelServiceImpl {
                     });
                 }
             }
+        }
+
+        // The global default policy may also point at this tunnel. Reset it
+        // to "direct" in the same step, mirroring the explicit-rule switch
+        // above, so `Default`-ruled devices degrade the same way at the
+        // same time — instead of the config keeping a dangling tunnel UUID
+        // that silently resolves to direct on each later lookup.
+        let default_policy = self
+            .system_config
+            .get_default_policy()
+            .await
+            .map_err(AppError::Internal)?;
+        if default_policy.as_deref() == Some(id.to_string().as_str()) {
+            self.system_config
+                .set_default_policy("direct")
+                .await
+                .map_err(AppError::Internal)?;
+            tracing::info!(
+                tunnel_id = %id,
+                "deleted tunnel was the default routing policy, reset policy to direct"
+            );
+            // Announce the reset so the routing engine re-resolves
+            // `Default`-ruled devices immediately and the Network-Zone
+            // enforcer (#736) re-clamps them, rather than each device
+            // degrading lazily on its next resolve.
+            self.events.publish(WardnetEvent::DefaultPolicyChanged {
+                policy: "direct".to_owned(),
+                timestamp: chrono::Utc::now(),
+            });
         }
 
         // If the kernel interface is configured, tear it down first.

--- a/source/daemon/crates/wardnetd-services/src/tunnel/service.rs
+++ b/source/daemon/crates/wardnetd-services/src/tunnel/service.rs
@@ -1198,28 +1198,48 @@ impl TunnelService for TunnelServiceImpl {
         // above, so `Default`-ruled devices degrade the same way at the
         // same time — instead of the config keeping a dangling tunnel UUID
         // that silently resolves to direct on each later lookup.
+        //
+        // The stored policy is matched through `from_default_policy` — the
+        // same interpreter the routing engine resolves with — not raw string
+        // equality: `set_default_policy` stores the admin-supplied string
+        // verbatim, and the UUID parser accepts non-canonical forms
+        // (uppercase, braced, un-hyphenated) that would defeat an exact
+        // compare while still routing through this tunnel.
         let default_policy = self
             .system_config
             .get_default_policy()
             .await
             .map_err(AppError::Internal)?;
-        if default_policy.as_deref() == Some(id.to_string().as_str()) {
-            self.system_config
-                .set_default_policy("direct")
+        let policy_targets_tunnel = default_policy.as_deref().is_some_and(|p| {
+            matches!(
+                wardnet_common::routing::RoutingTarget::from_default_policy(p),
+                wardnet_common::routing::RoutingTarget::Tunnel { tunnel_id } if tunnel_id == id
+            )
+        });
+        if policy_targets_tunnel {
+            // Conditional on the exact stored value so a concurrent
+            // `set_default_policy` write is never clobbered: if it lands
+            // in between, the compare-and-set misses and that writer's own
+            // event covers the change.
+            let reset = self
+                .system_config
+                .reset_default_policy_from(default_policy.as_deref().unwrap_or_default())
                 .await
                 .map_err(AppError::Internal)?;
-            tracing::info!(
-                tunnel_id = %id,
-                "deleted tunnel was the default routing policy, reset policy to direct"
-            );
-            // Announce the reset so the routing engine re-resolves
-            // `Default`-ruled devices immediately and the Network-Zone
-            // enforcer (#736) re-clamps them, rather than each device
-            // degrading lazily on its next resolve.
-            self.events.publish(WardnetEvent::DefaultPolicyChanged {
-                policy: "direct".to_owned(),
-                timestamp: chrono::Utc::now(),
-            });
+            if reset {
+                tracing::info!(
+                    tunnel_id = %id,
+                    "deleted tunnel {id} was the default routing policy, reset policy to direct"
+                );
+                // Announce the reset so the routing engine re-resolves
+                // `Default`-ruled devices immediately and the Network-Zone
+                // enforcer (#736) re-clamps them, rather than each device
+                // degrading lazily on its next resolve.
+                self.events.publish(WardnetEvent::DefaultPolicyChanged {
+                    policy: "direct".to_owned(),
+                    timestamp: chrono::Utc::now(),
+                });
+            }
         }
 
         // If the kernel interface is configured, tear it down first.

--- a/source/daemon/crates/wardnetd-services/src/tunnel/tests/tunnel.rs
+++ b/source/daemon/crates/wardnetd-services/src/tunnel/tests/tunnel.rs
@@ -994,9 +994,13 @@ pub(super) struct TestHarness {
     pub(super) jobs: Arc<dyn JobService>,
 }
 
-pub(super) fn build_harness() -> TestHarness {
+/// Single construction point for the tunnel-service test harness; the
+/// named entry points below vary only the dependency a test cares about.
+fn build_harness_inner(
+    device_repo: Arc<dyn DeviceRepository>,
+    server_resolver: Arc<dyn ServerResolver>,
+) -> TestHarness {
     let repo = Arc::new(MockTunnelRepo::new());
-    let device_repo: Arc<dyn DeviceRepository> = Arc::new(MockDeviceRepoForTunnel);
     let tunnel_iface = Arc::new(MockTunnelInterface::new());
     let keys = Arc::new(MockKeyStore::new());
     let system_config = Arc::new(MockSystemConfigRepo::new());
@@ -1005,7 +1009,6 @@ pub(super) fn build_harness() -> TestHarness {
     let latency_prober = Arc::new(MockTunnelLatencyProber::new());
     let stats_buffer = StatsBuffer::new();
     let meter = Arc::new(Meter::new(stats_buffer.clone()));
-    let server_resolver: Arc<dyn ServerResolver> = Arc::new(MockServerResolver);
 
     let throughput_tester = Arc::new(MockThroughputTester::new());
     let speed_test_repo = Arc::new(MockSpeedTestRepo::new());
@@ -1042,104 +1045,21 @@ pub(super) fn build_harness() -> TestHarness {
         speed_test_repo,
         jobs,
     }
+}
+
+pub(super) fn build_harness() -> TestHarness {
+    build_harness_inner(
+        Arc::new(MockDeviceRepoForTunnel),
+        Arc::new(MockServerResolver),
+    )
 }
 
 fn build_harness_with_device_repo(device_repo: Arc<dyn DeviceRepository>) -> TestHarness {
-    let repo = Arc::new(MockTunnelRepo::new());
-    let tunnel_iface = Arc::new(MockTunnelInterface::new());
-    let keys = Arc::new(MockKeyStore::new());
-    let system_config = Arc::new(MockSystemConfigRepo::new());
-    let events = Arc::new(MockEventPublisher::new());
-    let exit_probe = Arc::new(MockTunnelExitProbe::new());
-    let latency_prober = Arc::new(MockTunnelLatencyProber::new());
-    let stats_buffer = StatsBuffer::new();
-    let meter = Arc::new(Meter::new(stats_buffer.clone()));
-    let server_resolver: Arc<dyn ServerResolver> = Arc::new(MockServerResolver);
-
-    let throughput_tester = Arc::new(MockThroughputTester::new());
-    let speed_test_repo = Arc::new(MockSpeedTestRepo::new());
-    let jobs: Arc<dyn JobService> = JobServiceImpl::new();
-
-    let svc = TunnelServiceImpl::with_key_store(
-        repo.clone(),
-        device_repo,
-        system_config.clone(),
-        tunnel_iface.clone(),
-        exit_probe.clone(),
-        latency_prober.clone(),
-        throughput_tester.clone(),
-        keys.clone(),
-        events.clone(),
-        meter,
-        server_resolver,
-        jobs.clone(),
-        speed_test_repo.clone(),
-        3,
-    );
-
-    TestHarness {
-        svc: Arc::new(svc),
-        tunnels: repo,
-        tunnel_iface,
-        system_config,
-        events,
-        keys,
-        stats_buffer,
-        exit_probe,
-        latency_prober,
-        throughput_tester,
-        speed_test_repo,
-        jobs,
-    }
+    build_harness_inner(device_repo, Arc::new(MockServerResolver))
 }
 
 fn build_harness_with_resolver(server_resolver: Arc<dyn ServerResolver>) -> TestHarness {
-    let repo = Arc::new(MockTunnelRepo::new());
-    let device_repo: Arc<dyn DeviceRepository> = Arc::new(MockDeviceRepoForTunnel);
-    let tunnel_iface = Arc::new(MockTunnelInterface::new());
-    let keys = Arc::new(MockKeyStore::new());
-    let system_config = Arc::new(MockSystemConfigRepo::new());
-    let events = Arc::new(MockEventPublisher::new());
-    let exit_probe = Arc::new(MockTunnelExitProbe::new());
-    let latency_prober = Arc::new(MockTunnelLatencyProber::new());
-    let stats_buffer = StatsBuffer::new();
-    let meter = Arc::new(Meter::new(stats_buffer.clone()));
-
-    let throughput_tester = Arc::new(MockThroughputTester::new());
-    let speed_test_repo = Arc::new(MockSpeedTestRepo::new());
-    let jobs: Arc<dyn JobService> = JobServiceImpl::new();
-
-    let svc = TunnelServiceImpl::with_key_store(
-        repo.clone(),
-        device_repo,
-        system_config.clone(),
-        tunnel_iface.clone(),
-        exit_probe.clone(),
-        latency_prober.clone(),
-        throughput_tester.clone(),
-        keys.clone(),
-        events.clone(),
-        meter,
-        server_resolver,
-        jobs.clone(),
-        speed_test_repo.clone(),
-        3,
-    );
-
-    TestHarness {
-        svc: Arc::new(svc),
-        tunnels: repo,
-        tunnel_iface,
-        system_config,
-        events,
-        keys,
-        stats_buffer,
-        exit_probe,
-        latency_prober,
-        throughput_tester,
-        speed_test_repo,
-        jobs,
-    }
+    build_harness_inner(Arc::new(MockDeviceRepoForTunnel), server_resolver)
 }
 
 fn sample_request() -> CreateTunnelRequest {
@@ -1570,6 +1490,46 @@ async fn delete_tunnel_resets_default_policy_pointing_at_it() {
             WardnetEvent::DefaultPolicyChanged { policy, .. } if policy == "direct"
         )),
         "deletion of the default-policy tunnel must publish DefaultPolicyChanged: {events:?}"
+    );
+}
+
+#[tokio::test]
+async fn delete_tunnel_resets_default_policy_stored_in_non_canonical_form() {
+    // set_default_policy stores the admin-supplied string verbatim and the
+    // UUID parser accepts non-canonical encodings, so the policy can
+    // reference this tunnel as e.g. an uppercase UUID. The reset must
+    // match by parsed identity, not by exact string.
+    let h = build_harness();
+    let resp = auth_context::with_context(admin_ctx(), h.svc.import_tunnel(sample_request()))
+        .await
+        .unwrap();
+    let id = resp.tunnel.id;
+
+    h.system_config
+        .set_default_policy(&id.to_string().to_uppercase())
+        .await
+        .unwrap();
+
+    auth_context::with_context(admin_ctx(), h.svc.delete_tunnel(id))
+        .await
+        .unwrap();
+
+    assert_eq!(
+        h.system_config
+            .get_default_policy()
+            .await
+            .unwrap()
+            .as_deref(),
+        Some("direct"),
+        "a non-canonically encoded default policy must still be reset"
+    );
+    let events = h.events.published_events();
+    assert!(
+        events.iter().any(|e| matches!(
+            e,
+            WardnetEvent::DefaultPolicyChanged { policy, .. } if policy == "direct"
+        )),
+        "the reset must publish DefaultPolicyChanged: {events:?}"
     );
 }
 

--- a/source/daemon/crates/wardnetd-services/src/tunnel/tests/tunnel.rs
+++ b/source/daemon/crates/wardnetd-services/src/tunnel/tests/tunnel.rs
@@ -31,7 +31,7 @@ use wardnet_common::speed_test::TunnelSpeedTestResult;
 use wardnet_common::tunnel::BestServerSelector;
 use wardnetd_data::repository::tunnel::TunnelRow;
 use wardnetd_data::repository::tunnel_speed_test::{SpeedTestRow, TunnelSpeedTestRepository};
-use wardnetd_data::repository::{DeviceRepository, TunnelRepository};
+use wardnetd_data::repository::{DeviceRepository, SystemConfigRepository, TunnelRepository};
 
 /// Helper to create an admin auth context for tests.
 pub(super) fn admin_ctx() -> AuthContext {
@@ -641,6 +641,54 @@ impl TunnelSpeedTestRepository for MockSpeedTestRepo {
     }
 }
 
+// -- Mock SystemConfigRepository -------------------------------------------
+
+/// In-memory key-value mock backing the `default_policy` check that
+/// `delete_tunnel` performs before tearing a tunnel down.
+pub(super) struct MockSystemConfigRepo {
+    store: Mutex<std::collections::HashMap<String, String>>,
+}
+
+impl MockSystemConfigRepo {
+    fn new() -> Self {
+        Self {
+            store: Mutex::new(std::collections::HashMap::new()),
+        }
+    }
+}
+
+#[async_trait]
+impl SystemConfigRepository for MockSystemConfigRepo {
+    async fn get(&self, key: &str) -> anyhow::Result<Option<String>> {
+        Ok(self.store.lock().unwrap().get(key).cloned())
+    }
+
+    async fn set(&self, key: &str, value: &str) -> anyhow::Result<()> {
+        self.store
+            .lock()
+            .unwrap()
+            .insert(key.to_owned(), value.to_owned());
+        Ok(())
+    }
+
+    async fn delete(&self, key: &str) -> anyhow::Result<()> {
+        self.store.lock().unwrap().remove(key);
+        Ok(())
+    }
+
+    async fn device_count(&self) -> anyhow::Result<i64> {
+        Ok(0)
+    }
+
+    async fn tunnel_count(&self) -> anyhow::Result<i64> {
+        Ok(0)
+    }
+
+    async fn db_size_bytes(&self) -> anyhow::Result<u64> {
+        Ok(0)
+    }
+}
+
 // -- Mock EventPublisher --------------------------------------------------
 
 /// Records published events for assertion.
@@ -935,6 +983,7 @@ pub(super) struct TestHarness {
     pub(super) svc: Arc<TunnelServiceImpl>,
     pub(super) tunnels: Arc<MockTunnelRepo>,
     pub(super) tunnel_iface: Arc<MockTunnelInterface>,
+    pub(super) system_config: Arc<MockSystemConfigRepo>,
     events: Arc<MockEventPublisher>,
     keys: Arc<MockKeyStore>,
     stats_buffer: Arc<StatsBuffer>,
@@ -950,6 +999,7 @@ pub(super) fn build_harness() -> TestHarness {
     let device_repo: Arc<dyn DeviceRepository> = Arc::new(MockDeviceRepoForTunnel);
     let tunnel_iface = Arc::new(MockTunnelInterface::new());
     let keys = Arc::new(MockKeyStore::new());
+    let system_config = Arc::new(MockSystemConfigRepo::new());
     let events = Arc::new(MockEventPublisher::new());
     let exit_probe = Arc::new(MockTunnelExitProbe::new());
     let latency_prober = Arc::new(MockTunnelLatencyProber::new());
@@ -964,6 +1014,7 @@ pub(super) fn build_harness() -> TestHarness {
     let svc = TunnelServiceImpl::with_key_store(
         repo.clone(),
         device_repo,
+        system_config.clone(),
         tunnel_iface.clone(),
         exit_probe.clone(),
         latency_prober.clone(),
@@ -981,6 +1032,7 @@ pub(super) fn build_harness() -> TestHarness {
         svc: Arc::new(svc),
         tunnels: repo,
         tunnel_iface,
+        system_config,
         events,
         keys,
         stats_buffer,
@@ -996,6 +1048,7 @@ fn build_harness_with_device_repo(device_repo: Arc<dyn DeviceRepository>) -> Tes
     let repo = Arc::new(MockTunnelRepo::new());
     let tunnel_iface = Arc::new(MockTunnelInterface::new());
     let keys = Arc::new(MockKeyStore::new());
+    let system_config = Arc::new(MockSystemConfigRepo::new());
     let events = Arc::new(MockEventPublisher::new());
     let exit_probe = Arc::new(MockTunnelExitProbe::new());
     let latency_prober = Arc::new(MockTunnelLatencyProber::new());
@@ -1010,6 +1063,7 @@ fn build_harness_with_device_repo(device_repo: Arc<dyn DeviceRepository>) -> Tes
     let svc = TunnelServiceImpl::with_key_store(
         repo.clone(),
         device_repo,
+        system_config.clone(),
         tunnel_iface.clone(),
         exit_probe.clone(),
         latency_prober.clone(),
@@ -1027,6 +1081,7 @@ fn build_harness_with_device_repo(device_repo: Arc<dyn DeviceRepository>) -> Tes
         svc: Arc::new(svc),
         tunnels: repo,
         tunnel_iface,
+        system_config,
         events,
         keys,
         stats_buffer,
@@ -1043,6 +1098,7 @@ fn build_harness_with_resolver(server_resolver: Arc<dyn ServerResolver>) -> Test
     let device_repo: Arc<dyn DeviceRepository> = Arc::new(MockDeviceRepoForTunnel);
     let tunnel_iface = Arc::new(MockTunnelInterface::new());
     let keys = Arc::new(MockKeyStore::new());
+    let system_config = Arc::new(MockSystemConfigRepo::new());
     let events = Arc::new(MockEventPublisher::new());
     let exit_probe = Arc::new(MockTunnelExitProbe::new());
     let latency_prober = Arc::new(MockTunnelLatencyProber::new());
@@ -1056,6 +1112,7 @@ fn build_harness_with_resolver(server_resolver: Arc<dyn ServerResolver>) -> Test
     let svc = TunnelServiceImpl::with_key_store(
         repo.clone(),
         device_repo,
+        system_config.clone(),
         tunnel_iface.clone(),
         exit_probe.clone(),
         latency_prober.clone(),
@@ -1073,6 +1130,7 @@ fn build_harness_with_resolver(server_resolver: Arc<dyn ServerResolver>) -> Test
         svc: Arc::new(svc),
         tunnels: repo,
         tunnel_iface,
+        system_config,
         events,
         keys,
         stats_buffer,
@@ -1473,6 +1531,84 @@ async fn delete_tunnel_not_found() {
     let result = auth_context::with_context(admin_ctx(), h.svc.delete_tunnel(Uuid::new_v4())).await;
     assert!(result.is_err());
     assert!(matches!(result.unwrap_err(), AppError::NotFound(_)));
+}
+
+#[tokio::test]
+async fn delete_tunnel_resets_default_policy_pointing_at_it() {
+    // Deleting the tunnel that *is* the global default policy must reset
+    // the policy to "direct" and announce the change — otherwise the
+    // config keeps a dangling tunnel UUID and every `Default`-ruled
+    // device silently degrades to direct on its next resolve.
+    let h = build_harness();
+    let resp = auth_context::with_context(admin_ctx(), h.svc.import_tunnel(sample_request()))
+        .await
+        .unwrap();
+    let id = resp.tunnel.id;
+
+    h.system_config
+        .set_default_policy(&id.to_string())
+        .await
+        .unwrap();
+
+    auth_context::with_context(admin_ctx(), h.svc.delete_tunnel(id))
+        .await
+        .unwrap();
+
+    assert_eq!(
+        h.system_config
+            .get_default_policy()
+            .await
+            .unwrap()
+            .as_deref(),
+        Some("direct"),
+        "default policy must be reset to direct when its tunnel is deleted"
+    );
+    let events = h.events.published_events();
+    assert!(
+        events.iter().any(|e| matches!(
+            e,
+            WardnetEvent::DefaultPolicyChanged { policy, .. } if policy == "direct"
+        )),
+        "deletion of the default-policy tunnel must publish DefaultPolicyChanged: {events:?}"
+    );
+}
+
+#[tokio::test]
+async fn delete_tunnel_leaves_unrelated_default_policy_untouched() {
+    // Deleting a tunnel that is NOT the default policy must not rewrite
+    // the policy or publish a policy-change event.
+    let h = build_harness();
+    let resp = auth_context::with_context(admin_ctx(), h.svc.import_tunnel(sample_request()))
+        .await
+        .unwrap();
+    let id = resp.tunnel.id;
+
+    let other_tunnel = Uuid::new_v4().to_string();
+    h.system_config
+        .set_default_policy(&other_tunnel)
+        .await
+        .unwrap();
+
+    auth_context::with_context(admin_ctx(), h.svc.delete_tunnel(id))
+        .await
+        .unwrap();
+
+    assert_eq!(
+        h.system_config
+            .get_default_policy()
+            .await
+            .unwrap()
+            .as_deref(),
+        Some(other_tunnel.as_str()),
+        "an unrelated default policy must survive tunnel deletion"
+    );
+    let events = h.events.published_events();
+    assert!(
+        !events
+            .iter()
+            .any(|e| matches!(e, WardnetEvent::DefaultPolicyChanged { .. })),
+        "deleting a non-default-policy tunnel must not publish DefaultPolicyChanged: {events:?}"
+    );
 }
 
 #[tokio::test]

--- a/source/daemon/crates/wardnetd-services/src/zone_enforcement/tests/service.rs
+++ b/source/daemon/crates/wardnetd-services/src/zone_enforcement/tests/service.rs
@@ -286,7 +286,7 @@ impl RoutingService for RecordingRouting {
     async fn default_policy(&self) -> Result<String, AppError> {
         unimplemented!()
     }
-    async fn handle_default_policy_changed(&self, _policy: &str) -> Result<(), AppError> {
+    async fn handle_default_policy_changed(&self) -> Result<(), AppError> {
         unimplemented!()
     }
     fn dns_upstream_snapshot(&self) -> Arc<ArcSwap<HashMap<IpAddr, UpstreamId>>> {

--- a/source/daemon/crates/wardnetd-services/src/zone_enforcement/tests/service.rs
+++ b/source/daemon/crates/wardnetd-services/src/zone_enforcement/tests/service.rs
@@ -286,6 +286,9 @@ impl RoutingService for RecordingRouting {
     async fn default_policy(&self) -> Result<String, AppError> {
         unimplemented!()
     }
+    async fn handle_default_policy_changed(&self, _policy: &str) -> Result<(), AppError> {
+        unimplemented!()
+    }
     fn dns_upstream_snapshot(&self) -> Arc<ArcSwap<HashMap<IpAddr, UpstreamId>>> {
         unimplemented!()
     }

--- a/source/daemon/crates/wardnetd/src/routing_listener.rs
+++ b/source/daemon/crates/wardnetd/src/routing_listener.rs
@@ -62,6 +62,23 @@ async fn event_loop(
                     }
                     Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {
                         tracing::warn!(skipped = n, "routing listener: lagged behind event bus: skipped={n}");
+                        // The skipped events may have included a
+                        // `DefaultPolicyChanged`, which has no other
+                        // recovery path (the in-memory policy is only
+                        // written through the handler and
+                        // `set_default_policy`). Resync from the DB so a
+                        // dropped policy event cannot leave the cache
+                        // stale until the next admin change or restart.
+                        if let Err(e) = wardnetd_services::auth_context::with_context(
+                            AuthContext::Admin {
+                                admin_id: uuid::Uuid::nil(),
+                            },
+                            routing.handle_default_policy_changed(),
+                        )
+                        .await
+                        {
+                            tracing::warn!(error = %e, "failed to resync default policy after event lag: {e}");
+                        }
                     }
                     Err(tokio::sync::broadcast::error::RecvError::Closed) => {
                         tracing::info!("routing listener: event bus closed");
@@ -179,16 +196,19 @@ async fn handle_event(event: WardnetEvent, routing: &dyn RoutingService) {
             }
         }
 
-        WardnetEvent::DefaultPolicyChanged { policy, .. } => {
+        // The payload is only a trigger — the handler re-reads the
+        // persisted policy so stale or reordered events cannot regress
+        // the routing state.
+        WardnetEvent::DefaultPolicyChanged { .. } => {
             if let Err(e) = wardnetd_services::auth_context::with_context(
                 AuthContext::Admin {
                     admin_id: uuid::Uuid::nil(),
                 },
-                routing.handle_default_policy_changed(&policy),
+                routing.handle_default_policy_changed(),
             )
             .await
             {
-                tracing::warn!(error = %e, policy, "failed to handle default policy change to {policy}: {e}");
+                tracing::warn!(error = %e, "failed to handle default policy change: {e}");
             }
         }
 

--- a/source/daemon/crates/wardnetd/src/routing_listener.rs
+++ b/source/daemon/crates/wardnetd/src/routing_listener.rs
@@ -179,6 +179,19 @@ async fn handle_event(event: WardnetEvent, routing: &dyn RoutingService) {
             }
         }
 
+        WardnetEvent::DefaultPolicyChanged { policy, .. } => {
+            if let Err(e) = wardnetd_services::auth_context::with_context(
+                AuthContext::Admin {
+                    admin_id: uuid::Uuid::nil(),
+                },
+                routing.handle_default_policy_changed(&policy),
+            )
+            .await
+            {
+                tracing::warn!(error = %e, policy, "failed to handle default policy change to {policy}: {e}");
+            }
+        }
+
         WardnetEvent::TunnelDnsOverrideChanged { tunnel_id, .. } => {
             if let Err(e) = wardnetd_services::auth_context::with_context(
                 AuthContext::Admin {
@@ -224,9 +237,7 @@ async fn handle_event(event: WardnetEvent, routing: &dyn RoutingService) {
         | WardnetEvent::DnsEventInserted { .. }
         // Network Zones (#735) record intent only in Phase 1; the routing
         // listener does not react to zone changes. The CI-2/CI-3 enforcers
-        // (#736/#737) subscribe separately. `DefaultPolicyChanged` is likewise
-        // consumed by the zone enforcer (#736), not here — the routing engine
-        // already re-applies `Default`-ruled devices inside `set_default_policy`.
+        // (#736/#737) subscribe separately.
         | WardnetEvent::NetworkZoneChanged { .. }
         | WardnetEvent::DeviceZoneChanged { .. }
         | WardnetEvent::ZoneExceptionsChanged { .. }
@@ -235,7 +246,6 @@ async fn handle_event(event: WardnetEvent, routing: &dyn RoutingService) {
         | WardnetEvent::NewDeviceQuarantined { .. }
         | WardnetEvent::RuleRequestCreated { .. }
         // Entitlement changes are handled by the dedicated `entitlement_listener`.
-        | WardnetEvent::EntitlementChanged { .. }
-        | WardnetEvent::DefaultPolicyChanged { .. } => {}
+        | WardnetEvent::EntitlementChanged { .. } => {}
     }
 }

--- a/source/daemon/crates/wardnetd/src/tests/routing_listener.rs
+++ b/source/daemon/crates/wardnetd/src/tests/routing_listener.rs
@@ -21,6 +21,13 @@ struct MockRoutingService {
     calls: Mutex<Vec<RoutingCall>>,
     /// When `true`, `handle_route_table_lost` returns an error.
     error_on_route_table_lost: Mutex<bool>,
+    /// Milliseconds `apply_rule_for_device` sleeps before recording. Used
+    /// to park the listener inside a handler so the event bus can
+    /// overflow behind it and force a `Lagged` receive.
+    apply_rule_for_device_delay_ms: std::sync::atomic::AtomicU64,
+    /// When `true`, `handle_default_policy_changed` records the call and
+    /// then returns an error.
+    error_on_default_policy_changed: Mutex<bool>,
 }
 
 /// Describes a single call made to the mock routing service.
@@ -66,6 +73,8 @@ impl MockRoutingService {
         Self {
             calls: Mutex::new(Vec::new()),
             error_on_route_table_lost: Mutex::new(false),
+            apply_rule_for_device_delay_ms: std::sync::atomic::AtomicU64::new(0),
+            error_on_default_policy_changed: Mutex::new(false),
         }
     }
 
@@ -161,6 +170,12 @@ impl RoutingService for MockRoutingService {
         device_id: Uuid,
         target: &RoutingTarget,
     ) -> Result<(), AppError> {
+        let delay = self
+            .apply_rule_for_device_delay_ms
+            .load(std::sync::atomic::Ordering::SeqCst);
+        if delay > 0 {
+            tokio::time::sleep(tokio::time::Duration::from_millis(delay)).await;
+        }
         self.calls
             .lock()
             .unwrap()
@@ -199,6 +214,11 @@ impl RoutingService for MockRoutingService {
             .lock()
             .unwrap()
             .push(RoutingCall::HandleDefaultPolicyChanged);
+        if *self.error_on_default_policy_changed.lock().unwrap() {
+            return Err(AppError::Internal(anyhow::anyhow!(
+                "mock: handle_default_policy_changed forced error"
+            )));
+        }
         Ok(())
     }
 
@@ -778,6 +798,71 @@ async fn default_policy_changed_triggers_handle_default_policy_changed() {
     let calls = routing.take_calls();
     assert_eq!(calls.len(), 1);
     assert_eq!(calls[0], RoutingCall::HandleDefaultPolicyChanged);
+}
+
+/// Park the listener inside a slow `apply_rule_for_device`, then overflow
+/// the small broadcast buffer behind it so the next `recv` returns
+/// `Lagged`. Returns the recorded calls after the listener drains.
+async fn run_lagged_listener(routing: Arc<MockRoutingService>) -> Vec<RoutingCall> {
+    routing
+        .apply_rule_for_device_delay_ms
+        .store(300, std::sync::atomic::Ordering::SeqCst);
+
+    let bus: Arc<dyn EventPublisher> = Arc::new(BroadcastEventBus::new(4));
+    let parent = tracing::info_span!("test");
+    let listener = RoutingListener::start(&bus, routing.clone(), &parent);
+
+    // First event occupies the listener in the delayed handler...
+    bus.publish(WardnetEvent::RoutingRuleChanged {
+        device_id: Uuid::new_v4(),
+        target: RoutingTarget::Direct,
+        previous_target: None,
+        changed_by: RuleCreator::Admin,
+        timestamp: Utc::now(),
+    });
+    tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
+
+    // ...while twice the buffer capacity floods in behind it, evicting
+    // the oldest entries so the listener's next receive lags.
+    for _ in 0..8 {
+        bus.publish(WardnetEvent::TunnelStatsUpdated {
+            tunnel_id: Uuid::new_v4(),
+            status: wardnet_common::tunnel::TunnelStatus::Up,
+            bytes_tx: 0,
+            bytes_rx: 0,
+            last_handshake: None,
+            timestamp: Utc::now(),
+        });
+    }
+
+    tokio::time::sleep(tokio::time::Duration::from_millis(600)).await;
+    listener.shutdown().await;
+    routing.take_calls()
+}
+
+#[tokio::test]
+async fn event_lag_triggers_default_policy_resync() {
+    // A lagged receiver may have dropped a DefaultPolicyChanged, which
+    // has no other recovery path — after catching up, the listener must
+    // resync the routing policy from the DB.
+    let routing = Arc::new(MockRoutingService::new());
+    let calls = run_lagged_listener(routing).await;
+    assert!(
+        calls.contains(&RoutingCall::HandleDefaultPolicyChanged),
+        "event lag must trigger a default-policy resync: {calls:?}"
+    );
+}
+
+#[tokio::test]
+async fn event_lag_resync_error_does_not_panic() {
+    // Even if the resync fails, the listener loop must keep running.
+    let routing = Arc::new(MockRoutingService::new());
+    *routing.error_on_default_policy_changed.lock().unwrap() = true;
+    let calls = run_lagged_listener(routing).await;
+    assert!(
+        calls.contains(&RoutingCall::HandleDefaultPolicyChanged),
+        "the resync must still be attempted on error: {calls:?}"
+    );
 }
 
 #[tokio::test]

--- a/source/daemon/crates/wardnetd/src/tests/routing_listener.rs
+++ b/source/daemon/crates/wardnetd/src/tests/routing_listener.rs
@@ -57,9 +57,7 @@ enum RoutingCall {
     HandleRouteTableLost {
         table: u32,
     },
-    HandleDefaultPolicyChanged {
-        policy: String,
-    },
+    HandleDefaultPolicyChanged,
     RebuildDnsUpstreamSnapshot,
 }
 
@@ -196,13 +194,11 @@ impl RoutingService for MockRoutingService {
         Ok("direct".to_owned())
     }
 
-    async fn handle_default_policy_changed(&self, policy: &str) -> Result<(), AppError> {
+    async fn handle_default_policy_changed(&self) -> Result<(), AppError> {
         self.calls
             .lock()
             .unwrap()
-            .push(RoutingCall::HandleDefaultPolicyChanged {
-                policy: policy.to_owned(),
-            });
+            .push(RoutingCall::HandleDefaultPolicyChanged);
         Ok(())
     }
 
@@ -313,7 +309,7 @@ impl RoutingService for FailingRoutingService {
         Err(AppError::Internal(anyhow::anyhow!("default_policy failed")))
     }
 
-    async fn handle_default_policy_changed(&self, _policy: &str) -> Result<(), AppError> {
+    async fn handle_default_policy_changed(&self) -> Result<(), AppError> {
         Err(AppError::Internal(anyhow::anyhow!(
             "handle_default_policy_changed failed"
         )))
@@ -781,12 +777,7 @@ async fn default_policy_changed_triggers_handle_default_policy_changed() {
 
     let calls = routing.take_calls();
     assert_eq!(calls.len(), 1);
-    assert_eq!(
-        calls[0],
-        RoutingCall::HandleDefaultPolicyChanged {
-            policy: "direct".to_owned(),
-        }
-    );
+    assert_eq!(calls[0], RoutingCall::HandleDefaultPolicyChanged);
 }
 
 #[tokio::test]

--- a/source/daemon/crates/wardnetd/src/tests/routing_listener.rs
+++ b/source/daemon/crates/wardnetd/src/tests/routing_listener.rs
@@ -57,6 +57,9 @@ enum RoutingCall {
     HandleRouteTableLost {
         table: u32,
     },
+    HandleDefaultPolicyChanged {
+        policy: String,
+    },
     RebuildDnsUpstreamSnapshot,
 }
 
@@ -193,6 +196,16 @@ impl RoutingService for MockRoutingService {
         Ok("direct".to_owned())
     }
 
+    async fn handle_default_policy_changed(&self, policy: &str) -> Result<(), AppError> {
+        self.calls
+            .lock()
+            .unwrap()
+            .push(RoutingCall::HandleDefaultPolicyChanged {
+                policy: policy.to_owned(),
+            });
+        Ok(())
+    }
+
     fn dns_upstream_snapshot(
         &self,
     ) -> std::sync::Arc<
@@ -298,6 +311,12 @@ impl RoutingService for FailingRoutingService {
 
     async fn default_policy(&self) -> Result<String, AppError> {
         Err(AppError::Internal(anyhow::anyhow!("default_policy failed")))
+    }
+
+    async fn handle_default_policy_changed(&self, _policy: &str) -> Result<(), AppError> {
+        Err(AppError::Internal(anyhow::anyhow!(
+            "handle_default_policy_changed failed"
+        )))
     }
 
     fn dns_upstream_snapshot(
@@ -738,6 +757,53 @@ async fn tunnel_dns_override_changed_triggers_rebuild_dns_upstream_snapshot() {
     let calls = routing.take_calls();
     assert_eq!(calls.len(), 1);
     assert_eq!(calls[0], RoutingCall::RebuildDnsUpstreamSnapshot);
+}
+
+#[tokio::test]
+async fn default_policy_changed_triggers_handle_default_policy_changed() {
+    // The default policy can be rewritten outside the routing service —
+    // deleting the tunnel it points at resets it to "direct". The
+    // listener must forward the event so the routing engine's in-memory
+    // policy catches up and Default-ruled devices re-resolve immediately.
+    let bus: Arc<dyn EventPublisher> = Arc::new(BroadcastEventBus::new(16));
+    let routing = Arc::new(MockRoutingService::new());
+
+    let parent = tracing::info_span!("test");
+    let listener = RoutingListener::start(&bus, routing.clone(), &parent);
+
+    bus.publish(WardnetEvent::DefaultPolicyChanged {
+        policy: "direct".to_owned(),
+        timestamp: Utc::now(),
+    });
+
+    tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+    listener.shutdown().await;
+
+    let calls = routing.take_calls();
+    assert_eq!(calls.len(), 1);
+    assert_eq!(
+        calls[0],
+        RoutingCall::HandleDefaultPolicyChanged {
+            policy: "direct".to_owned(),
+        }
+    );
+}
+
+#[tokio::test]
+async fn default_policy_changed_error_does_not_panic() {
+    let bus: Arc<dyn EventPublisher> = Arc::new(BroadcastEventBus::new(16));
+    let routing: Arc<dyn RoutingService> = Arc::new(FailingRoutingService);
+
+    let parent = tracing::info_span!("test");
+    let listener = RoutingListener::start(&bus, routing, &parent);
+
+    bus.publish(WardnetEvent::DefaultPolicyChanged {
+        policy: "direct".to_owned(),
+        timestamp: Utc::now(),
+    });
+
+    tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+    listener.shutdown().await;
 }
 
 #[tokio::test]

--- a/source/daemon/crates/wardnetd/src/tests/stubs.rs
+++ b/source/daemon/crates/wardnetd/src/tests/stubs.rs
@@ -517,6 +517,9 @@ impl RoutingService for StubRoutingService {
     async fn default_policy(&self) -> Result<String, AppError> {
         unimplemented!()
     }
+    async fn handle_default_policy_changed(&self, _policy: &str) -> Result<(), AppError> {
+        unimplemented!()
+    }
     fn dns_upstream_snapshot(
         &self,
     ) -> std::sync::Arc<

--- a/source/daemon/crates/wardnetd/src/tests/stubs.rs
+++ b/source/daemon/crates/wardnetd/src/tests/stubs.rs
@@ -517,7 +517,7 @@ impl RoutingService for StubRoutingService {
     async fn default_policy(&self) -> Result<String, AppError> {
         unimplemented!()
     }
-    async fn handle_default_policy_changed(&self, _policy: &str) -> Result<(), AppError> {
+    async fn handle_default_policy_changed(&self) -> Result<(), AppError> {
         unimplemented!()
     }
     fn dns_upstream_snapshot(

--- a/source/daemon/crates/wardnetd/src/tests/tunnel_idle.rs
+++ b/source/daemon/crates/wardnetd/src/tests/tunnel_idle.rs
@@ -238,6 +238,10 @@ impl RoutingService for MockRoutingService {
         Ok("direct".to_owned())
     }
 
+    async fn handle_default_policy_changed(&self, _policy: &str) -> Result<(), AppError> {
+        Ok(())
+    }
+
     fn dns_upstream_snapshot(
         &self,
     ) -> std::sync::Arc<

--- a/source/daemon/crates/wardnetd/src/tests/tunnel_idle.rs
+++ b/source/daemon/crates/wardnetd/src/tests/tunnel_idle.rs
@@ -238,7 +238,7 @@ impl RoutingService for MockRoutingService {
         Ok("direct".to_owned())
     }
 
-    async fn handle_default_policy_changed(&self, _policy: &str) -> Result<(), AppError> {
+    async fn handle_default_policy_changed(&self) -> Result<(), AppError> {
         Ok(())
     }
 


### PR DESCRIPTION
## Problem

`delete_tunnel` switches explicit `Tunnel{id}` device rules to direct, but never checks whether the deleted tunnel is the current global `default_policy`. The config is left pointing at a now-deleted tunnel UUID, and every `Default`-ruled device silently falls back to direct WAN egress on its next resolve (`get_tunnel` → `NotFound` → direct, with only a per-device WARN). In zones that permit direct egress this is a real, unannounced privacy downgrade — the admin still believes the traffic is tunneled.

## Fix

- `TunnelServiceImpl` now takes the `SystemConfigRepository`. In `delete_tunnel`, in the same step that rewrites explicit rules, it checks whether the stored `default_policy` targets the tunnel being deleted — matched by parsed UUID identity via `RoutingTarget::from_default_policy` (the same interpreter the routing engine resolves with), not raw string equality, since `set_default_policy` stores the admin-supplied string verbatim and the UUID parser accepts non-canonical encodings.
- The reset itself is a new `reset_default_policy_from` repository method: a single conditional `UPDATE ... WHERE value = ?` (atomic in the SQLite impl), so a concurrent `set_default_policy` write is never clobbered. `DefaultPolicyChanged` is published only when the reset actually landed.
- The routing listener consumes `DefaultPolicyChanged` via a new `RoutingService::handle_default_policy_changed`, which **re-reads the persisted policy** (source of truth) rather than trusting the event payload — reordered or dropped events therefore always converge on the database state — then syncs the in-memory policy and re-applies `Default`-ruled devices. The listener also runs this resync after an event-bus `Lagged` drop, which previously had no recovery path. The tunnel service can't call the routing service directly (the dependency points routing → tunnel), hence the event path.
- The `Default`-ruled re-apply sweep now lives entirely on this event path: `set_default_policy` persists, updates the in-memory policy (so new resolves and the policy GET are immediately correct), and publishes — both policy writers converge through one mechanism, and the admin call no longer blocks on the kernel walk. The sweep is batched (`find_all` + `find_all_rules` joined in memory) instead of a per-device rule query.
- The zone enforcer keeps consuming the same event unchanged; `switch_tunnel_rules_to_direct` matching is untouched; deleting a tunnel that is *not* the default policy leaves `default_policy` exactly as it was.

## Tests

- `wardnetd-data`: `reset_default_policy_from` is conditional — unset key and mismatched expected value leave the row untouched; a match resets to `"direct"`.
- `wardnetd-services` tunnel: deleting the default-policy tunnel resets the policy and publishes `DefaultPolicyChanged`; a policy stored in non-canonical UUID form (uppercase) is still reset; deleting an unrelated tunnel leaves the policy untouched and publishes nothing.
- `wardnetd-services` routing: the handler re-reads a policy persisted behind the service's back, syncs the in-memory copy, and re-routes `Default`-ruled devices; a redundant trigger with an unchanged policy leaves kernel state untouched; the policy-change re-apply and explicit-target non-interference tests now exercise the event-driven path.
- `wardnetd` listener: `DefaultPolicyChanged` dispatches to the handler; handler errors don't kill the listener loop.
- `cargo fmt`, `cargo clippy --all-targets -- -D warnings`, `cargo test --workspace` all green; new code paths carry dedicated tests, so coverage does not decrease.

Closes #834