### PR TITLE
fix(auth): revoke the server session on logout

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -73,6 +73,40 @@
         ]
       }
     },
+    "/api/auth/logout": {
+      "post": {
+        "tags": [
+          "auth"
+        ],
+        "description": "End the current session. Deletes the session server-side so the token can never authenticate again, and clears the `wardnet_session` cookie in the response. Requires a valid session cookie or `Authorization: Bearer <token>` header; only the caller's own session is affected.",
+        "operationId": "logout",
+        "responses": {
+          "204": {
+            "description": "Session invalidated; session cookie cleared"
+          },
+          "401": {
+            "description": "No valid session",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/auth/refresh": {
       "post": {
         "tags": [

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -78,7 +78,7 @@
         "tags": [
           "auth"
         ],
-        "description": "End the current session. Deletes the session server-side so the token can never authenticate again, and clears the `wardnet_session` cookie in the response. Requires a valid session cookie or `Authorization: Bearer <token>` header; only the caller's own session is affected.",
+        "description": "End the current session. Deletes the session server-side so the token can never authenticate again, and clears the `wardnet_session` cookie in the response. Requires a valid session cookie or a `Authorization: Bearer <session token>` header; only the session that authenticated this request is affected. Callers authenticated with an API key get a 401 — API keys are not sessions and cannot be logged out here.",
         "operationId": "logout",
         "responses": {
           "204": {
@@ -86,6 +86,16 @@
           },
           "401": {
             "description": "No valid session",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Caller lacks an admin auth context",
             "content": {
               "application/json": {
                 "schema": {

--- a/source/admin-app/src/pages/System.tsx
+++ b/source/admin-app/src/pages/System.tsx
@@ -573,9 +573,15 @@ export default function System() {
             onClick={() => {
               // Revoke the server session first; only once that settles is
               // the biometric credential (the last local gate) dropped and
-              // the user routed away. logout() clears local auth state even
-              // when the revoke call fails, so this never strands the UI.
-              void logout().then(() => {
+              // the user routed away. Local auth state clears synchronously
+              // inside logout(), and the request is time-boxed by the SDK,
+              // so this never strands the UI.
+              void logout().then((revoked) => {
+                if (!revoked) {
+                  toast.error(
+                    "Couldn't reach the gateway — sign-out may not have completed there",
+                  );
+                }
                 biometric.unregister();
                 navigate("/login", { replace: true });
               });

--- a/source/admin-app/src/pages/System.tsx
+++ b/source/admin-app/src/pages/System.tsx
@@ -221,7 +221,10 @@ export default function System() {
       return () => clearTimeout(t);
     }
     if (phase === "ready_signed_out") {
-      logout();
+      // The reboot already invalidated the session server-side; logout() is
+      // fire-and-forget here — it clears local auth state regardless of
+      // whether the (already-dead) session revoke round-trip succeeds.
+      void logout();
       biometric.unregister();
       active.reset();
       navigate("/login");
@@ -568,9 +571,14 @@ export default function System() {
           <button
             data-testid="system-logout"
             onClick={() => {
-              logout();
-              biometric.unregister();
-              navigate("/login", { replace: true });
+              // Revoke the server session first; only once that settles is
+              // the biometric credential (the last local gate) dropped and
+              // the user routed away. logout() clears local auth state even
+              // when the revoke call fails, so this never strands the UI.
+              void logout().then(() => {
+                biometric.unregister();
+                navigate("/login", { replace: true });
+              });
             }}
             className="flex w-full items-center gap-3 rounded-xl border border-line bg-card px-4 py-3.5 text-left active:bg-sunken"
           >

--- a/source/admin-app/tests/pages/System.test.tsx
+++ b/source/admin-app/tests/pages/System.test.tsx
@@ -1,4 +1,4 @@
-import { screen } from "@testing-library/react";
+import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -314,10 +314,25 @@ describe("System page", () => {
   });
 
   it("logs out, clears biometrics on the logout action", async () => {
+    h.logout.mockResolvedValue(undefined);
     renderWithProviders(<System />);
     await userEvent.click(screen.getByTestId("system-logout"));
     expect(h.logout).toHaveBeenCalledOnce();
-    expect(h.unregister).toHaveBeenCalledOnce();
+    await waitFor(() => expect(h.unregister).toHaveBeenCalledOnce());
+  });
+
+  it("keeps the biometric gate until the session revoke settles", async () => {
+    let resolveLogout!: () => void;
+    h.logout.mockImplementation(
+      () => new Promise<void>((resolve) => (resolveLogout = resolve)),
+    );
+    renderWithProviders(<System />);
+    await userEvent.click(screen.getByTestId("system-logout"));
+    expect(h.logout).toHaveBeenCalledOnce();
+    // The local gate must not drop while the server-side logout is pending.
+    expect(h.unregister).not.toHaveBeenCalled();
+    resolveLogout();
+    await waitFor(() => expect(h.unregister).toHaveBeenCalledOnce());
   });
 
   it("shows the busy overlay while a restart is in flight", () => {

--- a/source/admin-app/tests/pages/System.test.tsx
+++ b/source/admin-app/tests/pages/System.test.tsx
@@ -314,25 +314,34 @@ describe("System page", () => {
   });
 
   it("logs out, clears biometrics on the logout action", async () => {
-    h.logout.mockResolvedValue(undefined);
+    h.logout.mockResolvedValue(true);
     renderWithProviders(<System />);
     await userEvent.click(screen.getByTestId("system-logout"));
     expect(h.logout).toHaveBeenCalledOnce();
     await waitFor(() => expect(h.unregister).toHaveBeenCalledOnce());
+    expect(h.toastError).not.toHaveBeenCalled();
   });
 
   it("keeps the biometric gate until the session revoke settles", async () => {
-    let resolveLogout!: () => void;
+    let resolveLogout!: (revoked: boolean) => void;
     h.logout.mockImplementation(
-      () => new Promise<void>((resolve) => (resolveLogout = resolve)),
+      () => new Promise<boolean>((resolve) => (resolveLogout = resolve)),
     );
     renderWithProviders(<System />);
     await userEvent.click(screen.getByTestId("system-logout"));
     expect(h.logout).toHaveBeenCalledOnce();
     // The local gate must not drop while the server-side logout is pending.
     expect(h.unregister).not.toHaveBeenCalled();
-    resolveLogout();
+    resolveLogout(true);
     await waitFor(() => expect(h.unregister).toHaveBeenCalledOnce());
+  });
+
+  it("warns but still signs out when the server-side revoke fails", async () => {
+    h.logout.mockResolvedValue(false);
+    renderWithProviders(<System />);
+    await userEvent.click(screen.getByTestId("system-logout"));
+    await waitFor(() => expect(h.toastError).toHaveBeenCalledOnce());
+    expect(h.unregister).toHaveBeenCalledOnce();
   });
 
   it("shows the busy overlay while a restart is in flight", () => {

--- a/source/admin-site/src/components/compound/Sidebar.tsx
+++ b/source/admin-site/src/components/compound/Sidebar.tsx
@@ -145,9 +145,13 @@ export function Sidebar({ onNavigate }: SidebarProps) {
   const sections = isAdmin ? adminSections : [];
 
   function handleLogout() {
-    logout();
-    onNavigate?.();
-    navigate("/");
+    // Revoke the server session before leaving the page. logout() clears
+    // local auth state even when the network call fails, so the redirect
+    // always happens.
+    void logout().then(() => {
+      onNavigate?.();
+      navigate("/");
+    });
   }
 
   return (

--- a/source/admin-site/src/pages/Backups.tsx
+++ b/source/admin-site/src/pages/Backups.tsx
@@ -38,7 +38,7 @@ export default function Backups() {
   const onRestartSignIn = () => {
     // Session cookie was invalidated by the restart (e.g. in-memory
     // session store). Clear local admin flag and route to login.
-    logout();
+    void logout();
     restart.reset();
     void navigate("/login");
   };

--- a/source/admin-site/src/pages/Power.tsx
+++ b/source/admin-site/src/pages/Power.tsx
@@ -31,7 +31,7 @@ export default function Power() {
   const onRestartSignIn = () => {
     // Session cookie was invalidated by the restart (e.g. in-memory
     // session store). Clear local admin flag and route to login.
-    logout();
+    void logout();
     restart.reset();
     void navigate("/login");
   };
@@ -40,7 +40,7 @@ export default function Power() {
     reboot.reset();
   };
   const onRebootSignIn = () => {
-    logout();
+    void logout();
     reboot.reset();
     void navigate("/login");
   };

--- a/source/admin-site/tests/components/compound/Sidebar.test.tsx
+++ b/source/admin-site/tests/components/compound/Sidebar.test.tsx
@@ -23,7 +23,7 @@ const logout = vi.fn();
 
 beforeEach(() => {
   logout.mockReset();
-  logout.mockResolvedValue(undefined);
+  logout.mockResolvedValue(true);
   mockAuth.mockReturnValue({ isAdmin: true, logout } as never);
   mockDaemon.mockReturnValue({
     data: { version: "1.2.3", reachable: true },

--- a/source/admin-site/tests/components/compound/Sidebar.test.tsx
+++ b/source/admin-site/tests/components/compound/Sidebar.test.tsx
@@ -1,4 +1,4 @@
-import { screen } from "@testing-library/react";
+import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { Sidebar } from "@/components/compound/Sidebar";
@@ -22,7 +22,8 @@ const mockUpdate = vi.mocked(useUpdateStatus);
 const logout = vi.fn();
 
 beforeEach(() => {
-  logout.mockClear();
+  logout.mockReset();
+  logout.mockResolvedValue(undefined);
   mockAuth.mockReturnValue({ isAdmin: true, logout } as never);
   mockDaemon.mockReturnValue({
     data: { version: "1.2.3", reachable: true },
@@ -57,7 +58,7 @@ describe("Sidebar", () => {
     renderWithProviders(<Sidebar onNavigate={onNavigate} />);
     await user.click(screen.getByText("Sign out"));
     expect(logout).toHaveBeenCalledOnce();
-    expect(onNavigate).toHaveBeenCalledOnce();
+    await waitFor(() => expect(onNavigate).toHaveBeenCalledOnce());
   });
 
   it("renders the sign-in link and no nav for non-admins", () => {

--- a/source/daemon/crates/wardnetd-api/src/api/auth.rs
+++ b/source/daemon/crates/wardnetd-api/src/api/auth.rs
@@ -24,10 +24,24 @@ fn session_cookie(token: &str, max_age_seconds: u64, secure: bool) -> String {
     )
 }
 
+/// Build a `Set-Cookie` value that expires the `wardnet_session` cookie.
+///
+/// `Max-Age=0` tells the browser to drop the cookie immediately — the only
+/// way to clear it, since it is `HttpOnly` and unreachable from client JS.
+/// Attributes mirror [`session_cookie`] so the browser matches (and thus
+/// replaces) the cookie it stored at login.
+fn clear_session_cookie(secure: bool) -> String {
+    let secure_attr = if secure { "; Secure" } else { "" };
+    format!("wardnet_session=; HttpOnly; SameSite=Strict; Path=/; Max-Age=0{secure_attr}")
+}
+
 /// Register auth routes onto the given [`OpenApiRouter`]. Each module owns its
 /// own route list so `api::mod::router` stays a simple composition point.
 pub fn register(router: OpenApiRouter<AppState>) -> OpenApiRouter<AppState> {
-    router.routes(routes!(login)).routes(routes!(refresh))
+    router
+        .routes(routes!(login))
+        .routes(routes!(refresh))
+        .routes(routes!(logout))
 }
 
 #[utoipa::path(
@@ -107,6 +121,37 @@ pub async fn refresh(
         result.max_age_seconds,
         secure_transport.is_some(),
     );
+
+    Ok((StatusCode::NO_CONTENT, [(SET_COOKIE, cookie_value)]))
+}
+
+#[utoipa::path(
+    post,
+    path = "/api/auth/logout",
+    tag = "auth",
+    description = "End the current session. Deletes the session server-side \
+                   so the token can never authenticate again, and clears the \
+                   `wardnet_session` cookie in the response. Requires a valid \
+                   session cookie or `Authorization: Bearer <token>` header; \
+                   only the caller's own session is affected.",
+    responses(
+        (status = 204, description = "Session invalidated; session cookie cleared"),
+        (status = 401, description = "No valid session", body = ApiError),
+        (status = 500, description = "Internal server error", body = ApiError),
+    ),
+)]
+pub async fn logout(
+    State(state): State<AppState>,
+    secure_transport: Option<Extension<SecureTransport>>,
+    auth: AdminAuth,
+) -> Result<impl IntoResponse, AppError> {
+    let token = auth
+        .session_token
+        .ok_or_else(|| AppError::Unauthorized("no session token in request".to_owned()))?;
+
+    state.auth_service().logout_session(&token).await?;
+
+    let cookie_value = clear_session_cookie(secure_transport.is_some());
 
     Ok((StatusCode::NO_CONTENT, [(SET_COOKIE, cookie_value)]))
 }

--- a/source/daemon/crates/wardnetd-api/src/api/auth.rs
+++ b/source/daemon/crates/wardnetd-api/src/api/auth.rs
@@ -28,11 +28,12 @@ fn session_cookie(token: &str, max_age_seconds: u64, secure: bool) -> String {
 ///
 /// `Max-Age=0` tells the browser to drop the cookie immediately — the only
 /// way to clear it, since it is `HttpOnly` and unreachable from client JS.
-/// Attributes mirror [`session_cookie`] so the browser matches (and thus
-/// replaces) the cookie it stored at login.
+/// Delegates to [`session_cookie`] with an empty token so the attribute list
+/// can never drift from the cookie set at login; a mismatched name/Path would
+/// make the browser treat this as a different cookie and leave the real one
+/// alive.
 fn clear_session_cookie(secure: bool) -> String {
-    let secure_attr = if secure { "; Secure" } else { "" };
-    format!("wardnet_session=; HttpOnly; SameSite=Strict; Path=/; Max-Age=0{secure_attr}")
+    session_cookie("", 0, secure)
 }
 
 /// Register auth routes onto the given [`OpenApiRouter`]. Each module owns its
@@ -132,11 +133,14 @@ pub async fn refresh(
     description = "End the current session. Deletes the session server-side \
                    so the token can never authenticate again, and clears the \
                    `wardnet_session` cookie in the response. Requires a valid \
-                   session cookie or `Authorization: Bearer <token>` header; \
-                   only the caller's own session is affected.",
+                   session cookie or a `Authorization: Bearer <session token>` \
+                   header; only the session that authenticated this request is \
+                   affected. Callers authenticated with an API key get a 401 — \
+                   API keys are not sessions and cannot be logged out here.",
     responses(
         (status = 204, description = "Session invalidated; session cookie cleared"),
         (status = 401, description = "No valid session", body = ApiError),
+        (status = 403, description = "Caller lacks an admin auth context", body = ApiError),
         (status = 500, description = "Internal server error", body = ApiError),
     ),
 )]

--- a/source/daemon/crates/wardnetd-api/src/api/middleware.rs
+++ b/source/daemon/crates/wardnetd-api/src/api/middleware.rs
@@ -57,9 +57,12 @@ pub struct SecureTransport;
 /// no SQL or hashing happens here.
 pub struct AdminAuth {
     pub admin_id: Uuid,
-    /// The raw session token (cookie or Bearer) extracted from the request headers.
-    /// `None` when authenticated via API key (no session token is present).
-    /// Provided to downstream handlers so they do not need to re-parse headers.
+    /// The raw session token that authenticated this request — the cookie or
+    /// Bearer value that `validate_session` actually accepted, never a
+    /// credential that merely rode along in the headers. `None` when the
+    /// request authenticated via API key (no session exists to act on).
+    /// Provided to downstream handlers (refresh, logout) so they operate on
+    /// the same session that authorized them.
     pub session_token: Option<String>,
 }
 
@@ -72,22 +75,36 @@ impl FromRequestParts<AppState> for AdminAuth {
     ) -> Result<Self, Self::Rejection> {
         let headers = &parts.headers;
 
-        // Extract the raw token once (cheap header parse, no DB call) so it is
-        // available to handlers without a second header traversal.
-        let session_token = extract_raw_session_token(headers);
-
-        if let Some(admin_id) = try_session_cookie(headers, state).await? {
+        // Cookie first. If the cookie validates, it is the authenticating
+        // session token.
+        if let Some(token) = extract_cookie_token(headers)
+            && let Some(admin_id) = state.auth_service().validate_session(&token).await?
+        {
             return Ok(Self {
                 admin_id,
-                session_token,
+                session_token: Some(token),
             });
         }
 
-        if let Some(admin_id) = try_bearer(headers, state).await? {
-            return Ok(Self {
-                admin_id,
-                session_token,
-            });
+        // Then the Bearer value: a session token or an API key. The
+        // distinction matters downstream — `session_token` must only carry a
+        // value that names an actual session row, so refresh/logout act on
+        // the session that authorized the request (a request can carry a
+        // stale cookie alongside a valid bearer, and an API key is not a
+        // session at all).
+        if let Some(bearer) = extract_bearer_token(headers) {
+            if let Some(admin_id) = state.auth_service().validate_session(&bearer).await? {
+                return Ok(Self {
+                    admin_id,
+                    session_token: Some(bearer),
+                });
+            }
+            if let Some(admin_id) = state.auth_service().validate_api_key(&bearer).await? {
+                return Ok(Self {
+                    admin_id,
+                    session_token: None,
+                });
+            }
         }
 
         Err(AppError::Unauthorized(
@@ -96,12 +113,12 @@ impl FromRequestParts<AppState> for AdminAuth {
     }
 }
 
-/// Extract the raw session token from the `wardnet_session` cookie or an
-/// `Authorization: Bearer` header without performing any validation.
-/// Cookie takes precedence.
-fn extract_raw_session_token(headers: &HeaderMap) -> Option<String> {
-    if let Some(v) = headers.get(axum::http::header::COOKIE)
-        && let Some(token) = v.to_str().ok().and_then(|s| {
+/// Extract the raw `wardnet_session` cookie value without validating it.
+fn extract_cookie_token(headers: &HeaderMap) -> Option<String> {
+    headers
+        .get(axum::http::header::COOKIE)
+        .and_then(|v| v.to_str().ok())
+        .and_then(|s| {
             s.split(';').find_map(|pair| {
                 let mut parts = pair.trim().splitn(2, '=');
                 let name = parts.next()?.trim();
@@ -113,9 +130,10 @@ fn extract_raw_session_token(headers: &HeaderMap) -> Option<String> {
                 }
             })
         })
-    {
-        return Some(token);
-    }
+}
+
+/// Extract the raw `Authorization: Bearer` value without validating it.
+fn extract_bearer_token(headers: &HeaderMap) -> Option<String> {
     headers
         .get(axum::http::header::AUTHORIZATION)
         .and_then(|v| v.to_str().ok())
@@ -129,25 +147,8 @@ async fn try_session_cookie(
     headers: &HeaderMap,
     state: &AppState,
 ) -> Result<Option<Uuid>, AppError> {
-    let cookie_header = match headers.get(axum::http::header::COOKIE) {
-        Some(v) => v.to_str().unwrap_or_default(),
-        None => return Ok(None),
-    };
-
-    let token = cookie_header.split(';').find_map(|pair| {
-        let mut parts = pair.trim().splitn(2, '=');
-        let name = parts.next()?.trim();
-        let value = parts.next()?.trim();
-        if name == "wardnet_session" {
-            Some(value.to_owned())
-        } else {
-            None
-        }
-    });
-
-    let token = match token {
-        Some(t) if !t.is_empty() => t,
-        _ => return Ok(None),
+    let Some(token) = extract_cookie_token(headers) else {
+        return Ok(None);
     };
 
     state.auth_service().validate_session(&token).await
@@ -163,21 +164,15 @@ async fn try_session_cookie(
 /// path if that fails. Returns the authenticated admin's id, or `None` if
 /// neither validator accepts the bearer.
 async fn try_bearer(headers: &HeaderMap, state: &AppState) -> Result<Option<Uuid>, AppError> {
-    let auth_header = match headers.get(axum::http::header::AUTHORIZATION) {
-        Some(v) => v.to_str().unwrap_or_default(),
-        None => return Ok(None),
+    let Some(bearer_token) = extract_bearer_token(headers) else {
+        return Ok(None);
     };
 
-    let bearer_token = match auth_header.strip_prefix("Bearer ") {
-        Some(t) if !t.is_empty() => t,
-        _ => return Ok(None),
-    };
-
-    if let Some(id) = state.auth_service().validate_session(bearer_token).await? {
+    if let Some(id) = state.auth_service().validate_session(&bearer_token).await? {
         return Ok(Some(id));
     }
 
-    state.auth_service().validate_api_key(bearer_token).await
+    state.auth_service().validate_api_key(&bearer_token).await
 }
 
 /// Axum middleware that resolves the [`AuthContext`] for every request.

--- a/source/daemon/crates/wardnetd-api/src/api/tests/auth.rs
+++ b/source/daemon/crates/wardnetd-api/src/api/tests/auth.rs
@@ -150,17 +150,19 @@ impl AuthService for MockRefreshAuthService {
     }
 }
 
-/// Stateful auth service for logout tests: tracks valid tokens in memory so
-/// the login → logout → replay sequence can be driven end-to-end through the
-/// real handlers and extractors.
+/// Stateful auth service for logout tests: tracks valid session tokens (and
+/// optionally API keys) in memory so the login → logout → replay sequence can
+/// be driven end-to-end through the real handlers and extractors.
 struct InMemorySessionAuthService {
     tokens: Mutex<HashSet<String>>,
+    api_keys: Mutex<HashSet<String>>,
 }
 
 impl InMemorySessionAuthService {
     fn new() -> Self {
         Self {
             tokens: Mutex::new(HashSet::new()),
+            api_keys: Mutex::new(HashSet::new()),
         }
     }
 }
@@ -181,8 +183,8 @@ impl AuthService for InMemorySessionAuthService {
     async fn validate_session(&self, token: &str) -> Result<Option<Uuid>, AppError> {
         Ok(self.tokens.lock().unwrap().contains(token).then(Uuid::nil))
     }
-    async fn validate_api_key(&self, _key: &str) -> Result<Option<Uuid>, AppError> {
-        Ok(None)
+    async fn validate_api_key(&self, key: &str) -> Result<Option<Uuid>, AppError> {
+        Ok(self.api_keys.lock().unwrap().contains(key).then(Uuid::nil))
     }
     async fn logout_session(&self, token: &str) -> Result<(), AppError> {
         self.tokens.lock().unwrap().remove(token);
@@ -674,6 +676,63 @@ async fn logout_via_bearer_token_returns_204() {
     let resp = app.oneshot(req).await.unwrap();
     assert_eq!(resp.status(), StatusCode::NO_CONTENT);
     assert!(auth.tokens.lock().unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn logout_revokes_the_authenticating_bearer_session_not_a_stale_cookie() {
+    // A request can carry a stale cookie alongside the valid bearer token
+    // that actually authenticates it. Logout must revoke the bearer session
+    // — deleting the stale cookie's (nonexistent) session and reporting 204
+    // would leave the live session valid while claiming it was revoked.
+    let auth = Arc::new(InMemorySessionAuthService::new());
+    auth.tokens.lock().unwrap().insert("live-bearer".to_owned());
+    let app = auth_app(make_state_from_arc(auth.clone()));
+
+    let req = Request::builder()
+        .method("POST")
+        .uri("/api/auth/logout")
+        .header("Cookie", "wardnet_session=stale-cookie-token")
+        .header("Authorization", "Bearer live-bearer")
+        .extension(connect_info_ext())
+        .body(Body::empty())
+        .unwrap();
+
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::NO_CONTENT);
+    assert!(
+        auth.tokens.lock().unwrap().is_empty(),
+        "the bearer session that authenticated the request must be revoked"
+    );
+}
+
+#[tokio::test]
+async fn logout_via_api_key_returns_401_without_touching_sessions() {
+    // API keys authenticate but are not sessions: there is nothing to log
+    // out, so the handler must refuse rather than report a bogus 204.
+    let auth = Arc::new(InMemorySessionAuthService::new());
+    auth.api_keys
+        .lock()
+        .unwrap()
+        .insert("my-api-key".to_owned());
+    auth.tokens
+        .lock()
+        .unwrap()
+        .insert("someone-elses-session".to_owned());
+    let app = auth_app(make_state_from_arc(auth.clone()));
+
+    let req = Request::builder()
+        .method("POST")
+        .uri("/api/auth/logout")
+        .header("Authorization", "Bearer my-api-key")
+        .extension(connect_info_ext())
+        .body(Body::empty())
+        .unwrap();
+
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+    // The API key still works and no session was collateral damage.
+    assert!(auth.api_keys.lock().unwrap().contains("my-api-key"));
+    assert_eq!(auth.tokens.lock().unwrap().len(), 1);
 }
 
 #[tokio::test]

--- a/source/daemon/crates/wardnetd-api/src/api/tests/auth.rs
+++ b/source/daemon/crates/wardnetd-api/src/api/tests/auth.rs
@@ -1,7 +1,8 @@
 //! Tests for the authentication API endpoints (POST /api/auth/login).
 
+use std::collections::HashSet;
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
 use async_trait::async_trait;
 use axum::Router;
@@ -80,6 +81,9 @@ impl AuthService for MockAuthService {
     ) -> Result<wardnetd_services::auth::service::WizardState, AppError> {
         unimplemented!()
     }
+    async fn logout_session(&self, _token: &str) -> Result<(), AppError> {
+        unimplemented!()
+    }
     async fn refresh_session(&self, _token: &str) -> Result<LoginResult, AppError> {
         unimplemented!()
     }
@@ -127,6 +131,9 @@ impl AuthService for MockRefreshAuthService {
     ) -> Result<wardnetd_services::auth::service::WizardState, AppError> {
         unimplemented!()
     }
+    async fn logout_session(&self, _token: &str) -> Result<(), AppError> {
+        unimplemented!()
+    }
     async fn refresh_session(&self, _token: &str) -> Result<LoginResult, AppError> {
         match self.refresh_result {
             Ok(()) => Ok(LoginResult {
@@ -143,13 +150,81 @@ impl AuthService for MockRefreshAuthService {
     }
 }
 
+/// Stateful auth service for logout tests: tracks valid tokens in memory so
+/// the login → logout → replay sequence can be driven end-to-end through the
+/// real handlers and extractors.
+struct InMemorySessionAuthService {
+    tokens: Mutex<HashSet<String>>,
+}
+
+impl InMemorySessionAuthService {
+    fn new() -> Self {
+        Self {
+            tokens: Mutex::new(HashSet::new()),
+        }
+    }
+}
+
+#[async_trait]
+impl AuthService for InMemorySessionAuthService {
+    async fn current_admin_username(&self) -> Result<String, AppError> {
+        Ok("admin".to_owned())
+    }
+    async fn login(&self, _u: &str, _p: &str, _remember_me: bool) -> Result<LoginResult, AppError> {
+        let token = "integration-session-token".to_owned();
+        self.tokens.lock().unwrap().insert(token.clone());
+        Ok(LoginResult {
+            token,
+            max_age_seconds: 86400,
+        })
+    }
+    async fn validate_session(&self, token: &str) -> Result<Option<Uuid>, AppError> {
+        Ok(self.tokens.lock().unwrap().contains(token).then(Uuid::nil))
+    }
+    async fn validate_api_key(&self, _key: &str) -> Result<Option<Uuid>, AppError> {
+        Ok(None)
+    }
+    async fn logout_session(&self, token: &str) -> Result<(), AppError> {
+        self.tokens.lock().unwrap().remove(token);
+        Ok(())
+    }
+    async fn setup_admin(&self, _u: &str, _p: &str) -> Result<(), AppError> {
+        unimplemented!()
+    }
+    async fn is_setup_completed(&self) -> Result<bool, AppError> {
+        Ok(true)
+    }
+    async fn wizard_state(
+        &self,
+    ) -> Result<wardnetd_services::auth::service::WizardState, AppError> {
+        unimplemented!()
+    }
+    async fn advance_wizard(
+        &self,
+        _to_step: wardnet_common::api::WizardStep,
+        _mode: Option<wardnet_common::api::WizardMode>,
+    ) -> Result<wardnetd_services::auth::service::WizardState, AppError> {
+        unimplemented!()
+    }
+    async fn refresh_session(&self, _token: &str) -> Result<LoginResult, AppError> {
+        unimplemented!()
+    }
+    async fn cleanup_expired_sessions(&self) -> Result<u64, AppError> {
+        unimplemented!()
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 
 fn make_state(auth: impl AuthService + 'static) -> AppState {
+    make_state_from_arc(Arc::new(auth))
+}
+
+fn make_state_from_arc(auth: Arc<dyn AuthService>) -> AppState {
     AppState::new(
-        Arc::new(auth),
+        auth,
         Arc::new(crate::tests::stubs::StubBackupService),
         Arc::new(StubDeviceService),
         Arc::new(StubDhcpService),
@@ -185,6 +260,13 @@ fn login_app(state: AppState) -> Router {
 fn refresh_app(state: AppState) -> Router {
     Router::new()
         .route("/api/auth/refresh", post(crate::api::auth::refresh))
+        .with_state(state)
+}
+
+fn auth_app(state: AppState) -> Router {
+    Router::new()
+        .route("/api/auth/login", post(crate::api::auth::login))
+        .route("/api/auth/logout", post(crate::api::auth::logout))
         .with_state(state)
 }
 
@@ -502,6 +584,161 @@ async fn refresh_via_bearer_token_returns_204() {
     let resp = app.oneshot(req).await.unwrap();
     assert_eq!(resp.status(), StatusCode::NO_CONTENT);
     assert!(resp.headers().contains_key("set-cookie"));
+}
+
+#[tokio::test]
+async fn logout_returns_204_and_clears_the_session_cookie() {
+    let auth = Arc::new(InMemorySessionAuthService::new());
+    auth.tokens.lock().unwrap().insert("live-token".to_owned());
+    let app = auth_app(make_state_from_arc(auth));
+
+    let req = Request::builder()
+        .method("POST")
+        .uri("/api/auth/logout")
+        .header("Cookie", "wardnet_session=live-token")
+        .extension(connect_info_ext())
+        .body(Body::empty())
+        .unwrap();
+
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::NO_CONTENT);
+
+    let cookie = resp
+        .headers()
+        .get("set-cookie")
+        .expect("Set-Cookie expected")
+        .to_str()
+        .unwrap();
+    assert!(
+        cookie.starts_with("wardnet_session=;"),
+        "cookie value must be emptied, got: {cookie}"
+    );
+    assert!(cookie.contains("Max-Age=0"), "got: {cookie}");
+    assert!(cookie.contains("HttpOnly"));
+    assert!(cookie.contains("SameSite=Strict"));
+    assert!(cookie.contains("Path=/"));
+    assert!(
+        !cookie.contains("Secure"),
+        "plain-HTTP clear cookie must not be Secure, got: {cookie}"
+    );
+}
+
+#[tokio::test]
+async fn logout_over_tls_clears_cookie_with_secure_attribute() {
+    let auth = Arc::new(InMemorySessionAuthService::new());
+    auth.tokens.lock().unwrap().insert("tls-token".to_owned());
+    let app = auth_app(make_state_from_arc(auth));
+
+    let req = Request::builder()
+        .method("POST")
+        .uri("/api/auth/logout")
+        .header("Cookie", "wardnet_session=tls-token")
+        .extension(connect_info_ext())
+        .extension(crate::api::middleware::SecureTransport)
+        .body(Body::empty())
+        .unwrap();
+
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::NO_CONTENT);
+
+    let cookie = resp
+        .headers()
+        .get("set-cookie")
+        .expect("Set-Cookie expected")
+        .to_str()
+        .unwrap();
+    assert!(cookie.contains("Max-Age=0"), "got: {cookie}");
+    assert!(
+        cookie.contains("Secure"),
+        "TLS clear cookie must be Secure, got: {cookie}"
+    );
+}
+
+#[tokio::test]
+async fn logout_via_bearer_token_returns_204() {
+    let auth = Arc::new(InMemorySessionAuthService::new());
+    auth.tokens
+        .lock()
+        .unwrap()
+        .insert("bearer-token".to_owned());
+    let app = auth_app(make_state_from_arc(auth.clone()));
+
+    let req = Request::builder()
+        .method("POST")
+        .uri("/api/auth/logout")
+        .header("Authorization", "Bearer bearer-token")
+        .extension(connect_info_ext())
+        .body(Body::empty())
+        .unwrap();
+
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::NO_CONTENT);
+    assert!(auth.tokens.lock().unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn logout_without_session_returns_401() {
+    let auth = Arc::new(InMemorySessionAuthService::new());
+    let app = auth_app(make_state_from_arc(auth));
+
+    let req = Request::builder()
+        .method("POST")
+        .uri("/api/auth/logout")
+        .extension(connect_info_ext())
+        .body(Body::empty())
+        .unwrap();
+
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+}
+
+/// End-to-end session-revocation flow through the real handlers and the
+/// `AdminAuth` extractor: login issues a cookie, logout revokes it server-side,
+/// and replaying the old cookie afterwards is rejected with 401.
+#[tokio::test]
+async fn login_then_logout_then_old_cookie_is_rejected() {
+    let auth = Arc::new(InMemorySessionAuthService::new());
+    let app = auth_app(make_state_from_arc(auth.clone()));
+
+    // 1. Login → session cookie issued, session exists server-side.
+    let body = serde_json::json!({ "username": "admin", "password": "password123" });
+    let req = Request::builder()
+        .method("POST")
+        .uri("/api/auth/login")
+        .header("Content-Type", "application/json")
+        .extension(connect_info_ext())
+        .body(Body::from(serde_json::to_vec(&body).unwrap()))
+        .unwrap();
+    let resp = app.clone().oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let cookie_header = "wardnet_session=integration-session-token";
+    assert_eq!(auth.tokens.lock().unwrap().len(), 1);
+
+    // 2. Logout with that cookie → 204, session removed from the store.
+    let req = Request::builder()
+        .method("POST")
+        .uri("/api/auth/logout")
+        .header("Cookie", cookie_header)
+        .extension(connect_info_ext())
+        .body(Body::empty())
+        .unwrap();
+    let resp = app.clone().oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::NO_CONTENT);
+    assert!(
+        auth.tokens.lock().unwrap().is_empty(),
+        "session must be deleted server-side"
+    );
+
+    // 3. Replaying the old cookie is rejected by the auth extractor.
+    let req = Request::builder()
+        .method("POST")
+        .uri("/api/auth/logout")
+        .header("Cookie", cookie_header)
+        .extension(connect_info_ext())
+        .body(Body::empty())
+        .unwrap();
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
 }
 
 #[tokio::test]

--- a/source/daemon/crates/wardnetd-api/src/api/tests/backup.rs
+++ b/source/daemon/crates/wardnetd-api/src/api/tests/backup.rs
@@ -78,6 +78,9 @@ impl AuthService for AlwaysAuthService {
     ) -> Result<wardnetd_services::auth::service::WizardState, AppError> {
         unimplemented!()
     }
+    async fn logout_session(&self, _token: &str) -> Result<(), AppError> {
+        unimplemented!()
+    }
     async fn refresh_session(&self, _token: &str) -> Result<LoginResult, AppError> {
         unimplemented!()
     }
@@ -117,6 +120,9 @@ impl AuthService for NeverAuthService {
         _to_step: wardnet_common::api::WizardStep,
         _mode: Option<wardnet_common::api::WizardMode>,
     ) -> Result<wardnetd_services::auth::service::WizardState, AppError> {
+        unimplemented!()
+    }
+    async fn logout_session(&self, _token: &str) -> Result<(), AppError> {
         unimplemented!()
     }
     async fn refresh_session(&self, _token: &str) -> Result<LoginResult, AppError> {

--- a/source/daemon/crates/wardnetd-api/src/api/tests/devices.rs
+++ b/source/daemon/crates/wardnetd-api/src/api/tests/devices.rs
@@ -73,6 +73,9 @@ impl AuthService for MockAuthService {
     ) -> Result<wardnetd_services::auth::service::WizardState, AppError> {
         unimplemented!()
     }
+    async fn logout_session(&self, _token: &str) -> Result<(), AppError> {
+        unimplemented!()
+    }
     async fn refresh_session(&self, _token: &str) -> Result<LoginResult, AppError> {
         unimplemented!()
     }

--- a/source/daemon/crates/wardnetd-api/src/api/tests/dhcp.rs
+++ b/source/daemon/crates/wardnetd-api/src/api/tests/dhcp.rs
@@ -79,6 +79,9 @@ impl AuthService for MockAuthService {
     ) -> Result<wardnetd_services::auth::service::WizardState, AppError> {
         unimplemented!()
     }
+    async fn logout_session(&self, _token: &str) -> Result<(), AppError> {
+        unimplemented!()
+    }
     async fn refresh_session(&self, _token: &str) -> Result<LoginResult, AppError> {
         unimplemented!()
     }

--- a/source/daemon/crates/wardnetd-api/src/api/tests/dns_capture.rs
+++ b/source/daemon/crates/wardnetd-api/src/api/tests/dns_capture.rs
@@ -71,6 +71,9 @@ impl wardnetd_services::AuthService for MockAuthService {
     ) -> Result<wardnetd_services::auth::service::WizardState, AppError> {
         unimplemented!()
     }
+    async fn logout_session(&self, _token: &str) -> Result<(), AppError> {
+        unimplemented!()
+    }
     async fn refresh_session(&self, _token: &str) -> Result<LoginResult, AppError> {
         unimplemented!()
     }

--- a/source/daemon/crates/wardnetd-api/src/api/tests/dns_events.rs
+++ b/source/daemon/crates/wardnetd-api/src/api/tests/dns_events.rs
@@ -97,6 +97,9 @@ impl wardnetd_services::AuthService for MockAuthService {
     ) -> Result<wardnetd_services::auth::service::WizardState, AppError> {
         unimplemented!()
     }
+    async fn logout_session(&self, _token: &str) -> Result<(), AppError> {
+        unimplemented!()
+    }
     async fn refresh_session(&self, _token: &str) -> Result<LoginResult, AppError> {
         unimplemented!()
     }

--- a/source/daemon/crates/wardnetd-api/src/api/tests/dns_filter.rs
+++ b/source/daemon/crates/wardnetd-api/src/api/tests/dns_filter.rs
@@ -88,6 +88,9 @@ impl AuthService for MockAuthService {
     ) -> Result<wardnetd_services::auth::service::WizardState, AppError> {
         unimplemented!()
     }
+    async fn logout_session(&self, _token: &str) -> Result<(), AppError> {
+        unimplemented!()
+    }
     async fn refresh_session(&self, _token: &str) -> Result<LoginResult, AppError> {
         unimplemented!()
     }

--- a/source/daemon/crates/wardnetd-api/src/api/tests/logs_ws.rs
+++ b/source/daemon/crates/wardnetd-api/src/api/tests/logs_ws.rs
@@ -62,6 +62,9 @@ impl AuthService for AlwaysAuthService {
     ) -> Result<wardnetd_services::auth::service::WizardState, AppError> {
         unimplemented!()
     }
+    async fn logout_session(&self, _token: &str) -> Result<(), AppError> {
+        unimplemented!()
+    }
     async fn refresh_session(&self, _token: &str) -> Result<LoginResult, AppError> {
         unimplemented!()
     }

--- a/source/daemon/crates/wardnetd-api/src/api/tests/middleware.rs
+++ b/source/daemon/crates/wardnetd-api/src/api/tests/middleware.rs
@@ -229,6 +229,30 @@ async fn admin_auth_rejected_without_credentials() {
 }
 
 #[tokio::test]
+async fn admin_auth_rejected_when_bearer_is_neither_session_nor_api_key() {
+    // A bearer that fails both the session and API-key validators must fall
+    // through to the 401, not authenticate.
+    let state = make_state(MockAuthService {
+        session_result: None,
+        api_key_result: None,
+    });
+
+    let app = admin_app(state);
+    let req = Request::builder()
+        .uri("/test")
+        .header("Authorization", "Bearer bogus-token")
+        .extension(ConnectInfo(SocketAddr::new(
+            IpAddr::V4(Ipv4Addr::LOCALHOST),
+            1234,
+        )))
+        .body(Body::empty())
+        .unwrap();
+
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
 async fn admin_auth_from_bearer_session_token() {
     // Documented contract on POST /api/auth/login: non-browser callers
     // (wctl, scripts, integrations) replay the login token via
@@ -563,6 +587,70 @@ async fn resolve_auth_context_admin_session() {
     assert!(
         body_str.contains(&admin_id.to_string()),
         "expected admin_id in context, got: {body_str}"
+    );
+}
+
+/// A bearer session token (no cookie) produces `AuthContext::Admin`.
+#[tokio::test]
+async fn resolve_auth_context_admin_from_bearer_session_token() {
+    let admin_id = Uuid::new_v4();
+    let state = make_state_with_device(
+        MockAuthService {
+            session_result: Some(admin_id),
+            api_key_result: None,
+        },
+        MockDeviceService { device: None },
+    );
+
+    let app = auth_context_app(state);
+    let req = Request::builder()
+        .uri("/test")
+        .header("Authorization", "Bearer session-tok")
+        .extension(ConnectInfo(SocketAddr::new(
+            IpAddr::V4(Ipv4Addr::LOCALHOST),
+            1234,
+        )))
+        .body(Body::empty())
+        .unwrap();
+
+    let resp = app.oneshot(req).await.unwrap();
+    let body = axum::body::to_bytes(resp.into_body(), 4096).await.unwrap();
+    let body_str = String::from_utf8_lossy(&body);
+    assert!(
+        body_str.contains("Admin"),
+        "expected Admin context, got: {body_str}"
+    );
+}
+
+/// A bearer API key (session validation misses) produces `AuthContext::Admin`.
+#[tokio::test]
+async fn resolve_auth_context_admin_from_bearer_api_key() {
+    let admin_id = Uuid::new_v4();
+    let state = make_state_with_device(
+        MockAuthService {
+            session_result: None,
+            api_key_result: Some(admin_id),
+        },
+        MockDeviceService { device: None },
+    );
+
+    let app = auth_context_app(state);
+    let req = Request::builder()
+        .uri("/test")
+        .header("Authorization", "Bearer api-key")
+        .extension(ConnectInfo(SocketAddr::new(
+            IpAddr::V4(Ipv4Addr::LOCALHOST),
+            1234,
+        )))
+        .body(Body::empty())
+        .unwrap();
+
+    let resp = app.oneshot(req).await.unwrap();
+    let body = axum::body::to_bytes(resp.into_body(), 4096).await.unwrap();
+    let body_str = String::from_utf8_lossy(&body);
+    assert!(
+        body_str.contains("Admin"),
+        "expected Admin context, got: {body_str}"
     );
 }
 

--- a/source/daemon/crates/wardnetd-api/src/api/tests/middleware.rs
+++ b/source/daemon/crates/wardnetd-api/src/api/tests/middleware.rs
@@ -80,6 +80,9 @@ impl AuthService for MockAuthService {
     ) -> Result<wardnetd_services::auth::service::WizardState, AppError> {
         unimplemented!()
     }
+    async fn logout_session(&self, _token: &str) -> Result<(), AppError> {
+        unimplemented!()
+    }
     async fn refresh_session(&self, _token: &str) -> Result<LoginResult, AppError> {
         unimplemented!()
     }

--- a/source/daemon/crates/wardnetd-api/src/api/tests/network.rs
+++ b/source/daemon/crates/wardnetd-api/src/api/tests/network.rs
@@ -71,6 +71,9 @@ impl AuthService for AlwaysAuthService {
     ) -> Result<wardnetd_services::auth::service::WizardState, AppError> {
         unimplemented!()
     }
+    async fn logout_session(&self, _token: &str) -> Result<(), AppError> {
+        unimplemented!()
+    }
     async fn refresh_session(&self, _token: &str) -> Result<LoginResult, AppError> {
         unimplemented!()
     }
@@ -110,6 +113,9 @@ impl AuthService for NeverAuthService {
         _to_step: wardnet_common::api::WizardStep,
         _mode: Option<wardnet_common::api::WizardMode>,
     ) -> Result<wardnetd_services::auth::service::WizardState, AppError> {
+        unimplemented!()
+    }
+    async fn logout_session(&self, _token: &str) -> Result<(), AppError> {
         unimplemented!()
     }
     async fn refresh_session(&self, _token: &str) -> Result<LoginResult, AppError> {

--- a/source/daemon/crates/wardnetd-api/src/api/tests/network_zone.rs
+++ b/source/daemon/crates/wardnetd-api/src/api/tests/network_zone.rs
@@ -66,6 +66,9 @@ impl AuthService for MockAuthService {
     ) -> Result<wardnetd_services::auth::service::WizardState, AppError> {
         unimplemented!()
     }
+    async fn logout_session(&self, _token: &str) -> Result<(), AppError> {
+        unimplemented!()
+    }
     async fn refresh_session(&self, _token: &str) -> Result<LoginResult, AppError> {
         unimplemented!()
     }

--- a/source/daemon/crates/wardnetd-api/src/api/tests/providers.rs
+++ b/source/daemon/crates/wardnetd-api/src/api/tests/providers.rs
@@ -73,6 +73,9 @@ impl AuthService for MockAuthService {
     ) -> Result<wardnetd_services::auth::service::WizardState, AppError> {
         unimplemented!()
     }
+    async fn logout_session(&self, _token: &str) -> Result<(), AppError> {
+        unimplemented!()
+    }
     async fn refresh_session(&self, _token: &str) -> Result<LoginResult, AppError> {
         unimplemented!()
     }

--- a/source/daemon/crates/wardnetd-api/src/api/tests/router.rs
+++ b/source/daemon/crates/wardnetd-api/src/api/tests/router.rs
@@ -72,6 +72,7 @@ async fn all_api_routes_are_reachable() {
 
     let routes: Vec<(&str, String)> = vec![
         ("POST", "/api/auth/login".to_owned()),
+        ("POST", "/api/auth/logout".to_owned()),
         ("GET", "/api/devices".to_owned()),
         ("GET", "/api/devices/me".to_owned()),
         ("PUT", "/api/devices/me/rule".to_owned()),

--- a/source/daemon/crates/wardnetd-api/src/api/tests/rule_requests.rs
+++ b/source/daemon/crates/wardnetd-api/src/api/tests/rule_requests.rs
@@ -67,6 +67,9 @@ impl wardnetd_services::AuthService for MockAuthService {
     ) -> Result<wardnetd_services::auth::service::WizardState, AppError> {
         unimplemented!()
     }
+    async fn logout_session(&self, _token: &str) -> Result<(), AppError> {
+        unimplemented!()
+    }
     async fn refresh_session(&self, _token: &str) -> Result<LoginResult, AppError> {
         unimplemented!()
     }

--- a/source/daemon/crates/wardnetd-api/src/api/tests/setup.rs
+++ b/source/daemon/crates/wardnetd-api/src/api/tests/setup.rs
@@ -92,6 +92,9 @@ impl AuthService for MockSetupAuthService {
         }
         Ok(*guard)
     }
+    async fn logout_session(&self, _token: &str) -> Result<(), AppError> {
+        unimplemented!()
+    }
     async fn refresh_session(&self, _token: &str) -> Result<LoginResult, AppError> {
         unimplemented!()
     }

--- a/source/daemon/crates/wardnetd-api/src/api/tests/system.rs
+++ b/source/daemon/crates/wardnetd-api/src/api/tests/system.rs
@@ -69,6 +69,9 @@ impl AuthService for AlwaysAuthService {
     ) -> Result<wardnetd_services::auth::service::WizardState, AppError> {
         unimplemented!()
     }
+    async fn logout_session(&self, _token: &str) -> Result<(), AppError> {
+        unimplemented!()
+    }
     async fn refresh_session(&self, _token: &str) -> Result<LoginResult, AppError> {
         unimplemented!()
     }
@@ -109,6 +112,9 @@ impl AuthService for NeverAuthService {
         _to_step: wardnet_common::api::WizardStep,
         _mode: Option<wardnet_common::api::WizardMode>,
     ) -> Result<wardnetd_services::auth::service::WizardState, AppError> {
+        unimplemented!()
+    }
+    async fn logout_session(&self, _token: &str) -> Result<(), AppError> {
         unimplemented!()
     }
     async fn refresh_session(&self, _token: &str) -> Result<LoginResult, AppError> {

--- a/source/daemon/crates/wardnetd-api/src/api/tests/tunnels.rs
+++ b/source/daemon/crates/wardnetd-api/src/api/tests/tunnels.rs
@@ -71,6 +71,9 @@ impl AuthService for MockAuthService {
     ) -> Result<wardnetd_services::auth::service::WizardState, AppError> {
         unimplemented!()
     }
+    async fn logout_session(&self, _token: &str) -> Result<(), AppError> {
+        unimplemented!()
+    }
     async fn refresh_session(&self, _token: &str) -> Result<LoginResult, AppError> {
         unimplemented!()
     }

--- a/source/daemon/crates/wardnetd-api/src/api/tests/users.rs
+++ b/source/daemon/crates/wardnetd-api/src/api/tests/users.rs
@@ -71,6 +71,9 @@ impl AuthService for MockUsersAuthService {
     ) -> Result<wardnetd_services::auth::service::WizardState, AppError> {
         unimplemented!()
     }
+    async fn logout_session(&self, _token: &str) -> Result<(), AppError> {
+        unimplemented!()
+    }
     async fn refresh_session(&self, _token: &str) -> Result<LoginResult, AppError> {
         unimplemented!()
     }

--- a/source/daemon/crates/wardnetd-api/src/api/tests/zone_exception.rs
+++ b/source/daemon/crates/wardnetd-api/src/api/tests/zone_exception.rs
@@ -68,6 +68,9 @@ impl AuthService for MockAuthService {
     ) -> Result<wardnetd_services::auth::service::WizardState, AppError> {
         unimplemented!()
     }
+    async fn logout_session(&self, _token: &str) -> Result<(), AppError> {
+        unimplemented!()
+    }
     async fn refresh_session(&self, _token: &str) -> Result<LoginResult, AppError> {
         unimplemented!()
     }

--- a/source/daemon/crates/wardnetd-api/src/tests/stubs.rs
+++ b/source/daemon/crates/wardnetd-api/src/tests/stubs.rs
@@ -73,6 +73,9 @@ impl AuthService for StubAuthService {
     ) -> Result<WizardState, AppError> {
         unimplemented!()
     }
+    async fn logout_session(&self, _token: &str) -> Result<(), AppError> {
+        unimplemented!()
+    }
     async fn refresh_session(&self, _token: &str) -> Result<LoginResult, AppError> {
         unimplemented!()
     }
@@ -116,6 +119,9 @@ impl AuthService for AlwaysAdminAuth {
         _to_step: WizardStep,
         _mode: Option<WizardMode>,
     ) -> Result<WizardState, AppError> {
+        unimplemented!()
+    }
+    async fn logout_session(&self, _token: &str) -> Result<(), AppError> {
         unimplemented!()
     }
     async fn refresh_session(&self, _token: &str) -> Result<LoginResult, AppError> {

--- a/source/daemon/crates/wardnetd-data/src/repository/session.rs
+++ b/source/daemon/crates/wardnetd-data/src/repository/session.rs
@@ -27,6 +27,11 @@ pub trait SessionRepository: Send + Sync {
     /// Delete all sessions whose `expires_at` is in the past. Returns the number of rows removed.
     async fn delete_expired(&self, now: &str) -> anyhow::Result<u64>;
 
+    /// Delete the session with the given token hash (used by the logout
+    /// endpoint). Returns the number of rows removed (0 when the session was
+    /// already gone, 1 when it existed).
+    async fn delete_by_token_hash(&self, token_hash: &str) -> anyhow::Result<u64>;
+
     /// Slide the expiry forward for an existing session (used by the refresh endpoint).
     async fn extend_expiry(&self, token_hash: &str, new_expires_at: &str) -> anyhow::Result<()>;
 

--- a/source/daemon/crates/wardnetd-data/src/repository/sqlite/session.rs
+++ b/source/daemon/crates/wardnetd-data/src/repository/sqlite/session.rs
@@ -72,6 +72,14 @@ impl SessionRepository for SqliteSessionRepository {
         Ok(result.rows_affected())
     }
 
+    async fn delete_by_token_hash(&self, token_hash: &str) -> anyhow::Result<u64> {
+        let result = sqlx::query("DELETE FROM sessions WHERE token_hash = ?")
+            .bind(token_hash)
+            .execute(&self.pools.write)
+            .await?;
+        Ok(result.rows_affected())
+    }
+
     async fn extend_expiry(&self, token_hash: &str, new_expires_at: &str) -> anyhow::Result<()> {
         sqlx::query("UPDATE sessions SET expires_at = ? WHERE token_hash = ?")
             .bind(new_expires_at)

--- a/source/daemon/crates/wardnetd-data/src/repository/tests/session.rs
+++ b/source/daemon/crates/wardnetd-data/src/repository/tests/session.rs
@@ -99,6 +99,55 @@ async fn delete_expired_removes_only_old_sessions() {
 }
 
 #[tokio::test]
+async fn delete_by_token_hash_removes_only_the_matching_session() {
+    let pool = test_pool().await;
+    seed_admin(&pool).await;
+    let repo = SqliteSessionRepository::new(pool);
+
+    repo.create(
+        "s1",
+        "admin-1",
+        "hash-a",
+        "2026-01-01T00:00:00Z",
+        "2099-01-01T00:00:00Z",
+        true,
+    )
+    .await
+    .unwrap();
+    repo.create(
+        "s2",
+        "admin-1",
+        "hash-b",
+        "2026-01-01T00:00:00Z",
+        "2099-01-01T00:00:00Z",
+        false,
+    )
+    .await
+    .unwrap();
+
+    let deleted = repo.delete_by_token_hash("hash-a").await.unwrap();
+    assert_eq!(deleted, 1);
+
+    // The deleted session no longer resolves; the other one is untouched.
+    assert!(
+        repo.find_admin_id_by_token_hash("hash-a", "2026-06-01T00:00:00Z")
+            .await
+            .unwrap()
+            .is_none()
+    );
+    assert_eq!(
+        repo.find_admin_id_by_token_hash("hash-b", "2026-06-01T00:00:00Z")
+            .await
+            .unwrap(),
+        Some("admin-1".to_owned())
+    );
+
+    // Deleting an unknown hash is a no-op, not an error.
+    let deleted = repo.delete_by_token_hash("no-such-hash").await.unwrap();
+    assert_eq!(deleted, 0);
+}
+
+#[tokio::test]
 async fn find_session_for_refresh_returns_admin_id_and_flag() {
     let pool = test_pool().await;
     seed_admin(&pool).await;

--- a/source/daemon/crates/wardnetd-services/src/auth/service.rs
+++ b/source/daemon/crates/wardnetd-services/src/auth/service.rs
@@ -67,11 +67,11 @@ pub trait AuthService: Send + Sync {
 
     /// Invalidate the session identified by the given raw token (logout).
     ///
-    /// Backs `POST /api/auth/logout`. The token is the caller's own — it comes
-    /// straight from the authenticated request's cookie/bearer header — so
-    /// deleting it can only ever end the caller's session. Idempotent: a
-    /// token whose session row is already gone still succeeds, because the
-    /// desired end state (no server-side session) already holds.
+    /// Backs `POST /api/auth/logout`. Callers must pass the token that
+    /// authenticated the request (the API layer's `AdminAuth` guarantees
+    /// this), so deleting it can only ever end the caller's own session.
+    /// Idempotent: a token whose session row is already gone still succeeds,
+    /// because the desired end state (no server-side session) already holds.
     async fn logout_session(&self, token: &str) -> Result<(), AppError>;
 
     /// Validate a raw session token. Returns the admin UUID if valid and not expired.
@@ -131,6 +131,15 @@ pub trait AuthService: Send + Sync {
 
 /// Maximum lifetime of a `remember_me` session regardless of sliding-window refreshes.
 const MAX_SESSION_DAYS: i64 = 90;
+
+/// Derive the storage key for a raw session token.
+///
+/// Single definition on purpose: every write, lookup, and delete must derive
+/// the key identically, or a session created under one scheme becomes
+/// unreachable (and undeletable) under another.
+fn hash_token(token: &str) -> String {
+    hex::encode(Sha256::digest(token.as_bytes()))
+}
 
 /// Default implementation of [`AuthService`] backed by repository traits.
 pub struct AuthServiceImpl {
@@ -193,7 +202,7 @@ impl AuthService for AuthServiceImpl {
         // Generate random 32-byte token, base64url-encode, SHA-256 hash for storage.
         let token_bytes: [u8; 32] = rand::random();
         let token = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(token_bytes);
-        let token_hash = hex::encode(Sha256::digest(token.as_bytes()));
+        let token_hash = hash_token(&token);
 
         let session_id = Uuid::new_v4().to_string();
         let now = chrono::Utc::now();
@@ -236,7 +245,7 @@ impl AuthService for AuthServiceImpl {
             ));
         };
 
-        let token_hash = hex::encode(Sha256::digest(token.as_bytes()));
+        let token_hash = hash_token(token);
         let now = chrono::Utc::now();
         let now_str = now.to_rfc3339();
 
@@ -286,7 +295,7 @@ impl AuthService for AuthServiceImpl {
         // Rotate token: generate a fresh secret so a captured token cannot be re-used.
         let new_token_bytes: [u8; 32] = rand::random();
         let new_token = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(new_token_bytes);
-        let new_token_hash = hex::encode(Sha256::digest(new_token.as_bytes()));
+        let new_token_hash = hash_token(&new_token);
 
         self.sessions
             .rotate_token(&token_hash, &new_token_hash, &new_expires_at.to_rfc3339())
@@ -302,20 +311,20 @@ impl AuthService for AuthServiceImpl {
     async fn logout_session(&self, token: &str) -> Result<(), AppError> {
         auth_context::require_admin()?;
 
-        let token_hash = hex::encode(Sha256::digest(token.as_bytes()));
+        let token_hash = hash_token(token);
         let removed = self
             .sessions
             .delete_by_token_hash(&token_hash)
             .await
             .map_err(AppError::Internal)?;
 
-        tracing::info!(removed, "session logged out");
+        tracing::info!(removed, "session logged out: removed={removed}");
 
         Ok(())
     }
 
     async fn validate_session(&self, token: &str) -> Result<Option<Uuid>, AppError> {
-        let token_hash = hex::encode(Sha256::digest(token.as_bytes()));
+        let token_hash = hash_token(token);
         let now = chrono::Utc::now().to_rfc3339();
 
         let admin_id_str = self

--- a/source/daemon/crates/wardnetd-services/src/auth/service.rs
+++ b/source/daemon/crates/wardnetd-services/src/auth/service.rs
@@ -65,6 +65,15 @@ pub trait AuthService: Send + Sync {
     /// `max_age_seconds`.
     async fn refresh_session(&self, token: &str) -> Result<LoginResult, AppError>;
 
+    /// Invalidate the session identified by the given raw token (logout).
+    ///
+    /// Backs `POST /api/auth/logout`. The token is the caller's own — it comes
+    /// straight from the authenticated request's cookie/bearer header — so
+    /// deleting it can only ever end the caller's session. Idempotent: a
+    /// token whose session row is already gone still succeeds, because the
+    /// desired end state (no server-side session) already holds.
+    async fn logout_session(&self, token: &str) -> Result<(), AppError>;
+
     /// Validate a raw session token. Returns the admin UUID if valid and not expired.
     async fn validate_session(&self, token: &str) -> Result<Option<Uuid>, AppError>;
 
@@ -288,6 +297,21 @@ impl AuthService for AuthServiceImpl {
             token: new_token,
             max_age_seconds: self.remember_me_expiry_hours * 3600,
         })
+    }
+
+    async fn logout_session(&self, token: &str) -> Result<(), AppError> {
+        auth_context::require_admin()?;
+
+        let token_hash = hex::encode(Sha256::digest(token.as_bytes()));
+        let removed = self
+            .sessions
+            .delete_by_token_hash(&token_hash)
+            .await
+            .map_err(AppError::Internal)?;
+
+        tracing::info!(removed, "session logged out");
+
+        Ok(())
     }
 
     async fn validate_session(&self, token: &str) -> Result<Option<Uuid>, AppError> {

--- a/source/daemon/crates/wardnetd-services/src/auth/tests/auth.rs
+++ b/source/daemon/crates/wardnetd-services/src/auth/tests/auth.rs
@@ -211,6 +211,21 @@ async fn login_success_with_remember_me() {
 }
 
 #[tokio::test]
+async fn login_with_malformed_stored_hash_returns_internal() {
+    // A corrupt password hash in the admins table must surface as Internal,
+    // not masquerade as bad credentials.
+    let svc = make_auth_service(
+        Some(("admin-1".to_owned(), "not-an-argon2-hash".to_owned())),
+        None,
+        None,
+        vec![],
+    );
+
+    let result = svc.login("admin", "any-password", false).await;
+    assert!(matches!(result, Err(AppError::Internal(_))));
+}
+
+#[tokio::test]
 async fn login_wrong_password() {
     let hash = argon2_hash("correct-password");
     let svc = make_auth_service(Some(("admin-1".to_owned(), hash)), None, None, vec![]);
@@ -235,6 +250,16 @@ async fn validate_session_valid() {
     let result = svc.validate_session("any-token").await.unwrap();
     assert!(result.is_some());
     assert_eq!(result.unwrap().to_string(), admin_uuid);
+}
+
+#[tokio::test]
+async fn validate_session_with_malformed_admin_id_returns_internal() {
+    // A session row whose admin_id is not a UUID must error rather than
+    // silently authenticate or deny.
+    let svc = make_auth_service(None, None, Some("not-a-uuid".to_owned()), vec![]);
+
+    let result = svc.validate_session("any-token").await;
+    assert!(matches!(result, Err(AppError::Internal(_))));
 }
 
 #[tokio::test]
@@ -405,6 +430,58 @@ async fn refresh_session_not_remember_me_returns_forbidden() {
     )
     .await;
     assert!(matches!(result, Err(AppError::Forbidden(_))));
+}
+
+/// Build a service whose session row for refresh is exactly `row`.
+fn make_refresh_service(row: (String, bool, String)) -> AuthServiceImpl {
+    AuthServiceImpl::new(
+        Arc::new(MockAdminRepo {
+            find_result: Mutex::new(None),
+            first_id: Mutex::new(None),
+        }),
+        Arc::new(MockSessionRepo {
+            session_for_refresh: Mutex::new(Some(row)),
+            ..Default::default()
+        }),
+        Arc::new(MockApiKeyRepo { hashes: vec![] }),
+        Arc::new(MockSystemConfigRepo),
+        24,
+        720,
+    )
+}
+
+#[tokio::test]
+async fn refresh_session_with_malformed_admin_id_returns_internal() {
+    // A session row whose admin_id is not a UUID must error out, not refresh.
+    let svc = make_refresh_service((
+        "not-a-uuid".to_owned(),
+        true,
+        (chrono::Utc::now() - chrono::Duration::days(30)).to_rfc3339(),
+    ));
+    let result = auth_context::with_context(
+        AuthContext::Admin {
+            admin_id: Uuid::nil(),
+        },
+        async { svc.refresh_session("any-token").await },
+    )
+    .await;
+    assert!(matches!(result, Err(AppError::Internal(_))));
+}
+
+#[tokio::test]
+async fn refresh_session_with_malformed_created_at_returns_internal() {
+    // A session row whose created_at is not RFC 3339 must error out — the
+    // absolute-lifetime cap cannot be enforced without it.
+    let admin_uuid = "00000000-0000-0000-0000-000000000001";
+    let svc = make_refresh_service((admin_uuid.to_owned(), true, "not-a-timestamp".to_owned()));
+    let result = auth_context::with_context(
+        AuthContext::Admin {
+            admin_id: Uuid::parse_str(admin_uuid).unwrap(),
+        },
+        async { svc.refresh_session("any-token").await },
+    )
+    .await;
+    assert!(matches!(result, Err(AppError::Internal(_))));
 }
 
 #[tokio::test]

--- a/source/daemon/crates/wardnetd-services/src/auth/tests/auth.rs
+++ b/source/daemon/crates/wardnetd-services/src/auth/tests/auth.rs
@@ -38,11 +38,14 @@ impl AdminRepository for MockAdminRepo {
 }
 
 /// Mock session repo that captures created sessions and returns preconfigured lookup results.
+#[derive(Default)]
 struct MockSessionRepo {
     /// Returned by `find_admin_id_by_token_hash` (drives `validate_session`).
     find_result: Mutex<Option<String>>,
     /// Returned by `find_session_for_refresh` (drives `refresh_session`).
     session_for_refresh: Mutex<Option<(String, bool, String)>>,
+    /// Token hashes passed to `delete_by_token_hash` (drives `logout_session` assertions).
+    deleted_hashes: Mutex<Vec<String>>,
 }
 
 #[async_trait]
@@ -67,6 +70,16 @@ impl SessionRepository for MockSessionRepo {
     }
     async fn delete_expired(&self, _now: &str) -> anyhow::Result<u64> {
         Ok(0)
+    }
+    async fn delete_by_token_hash(&self, token_hash: &str) -> anyhow::Result<u64> {
+        // Report one row removed when a session is configured, zero otherwise,
+        // mirroring the real repository's rows_affected semantics.
+        let existed = self.find_result.lock().unwrap().take().is_some();
+        self.deleted_hashes
+            .lock()
+            .unwrap()
+            .push(token_hash.to_owned());
+        Ok(u64::from(existed))
     }
     async fn extend_expiry(&self, _token_hash: &str, _new_expires_at: &str) -> anyhow::Result<()> {
         Ok(())
@@ -160,6 +173,7 @@ fn make_auth_service(
         Arc::new(MockSessionRepo {
             find_result: Mutex::new(session_find),
             session_for_refresh: Mutex::new(session_for_refresh),
+            ..Default::default()
         }),
         Arc::new(MockApiKeyRepo {
             hashes: api_key_hashes,
@@ -376,6 +390,7 @@ async fn refresh_session_not_remember_me_returns_forbidden() {
                 false,
                 (chrono::Utc::now() - chrono::Duration::days(30)).to_rfc3339(),
             ))),
+            ..Default::default()
         }),
         Arc::new(MockApiKeyRepo { hashes: vec![] }),
         Arc::new(MockSystemConfigRepo),
@@ -390,6 +405,70 @@ async fn refresh_session_not_remember_me_returns_forbidden() {
     )
     .await;
     assert!(matches!(result, Err(AppError::Forbidden(_))));
+}
+
+#[tokio::test]
+async fn logout_session_requires_admin() {
+    // No auth context → require_admin rejects before touching the repo.
+    let svc = make_auth_service(None, None, None, vec![]);
+    let result = svc.logout_session("any-token").await;
+    assert!(matches!(result, Err(AppError::Forbidden(_))));
+}
+
+#[tokio::test]
+async fn logout_session_deletes_the_sessions_row_by_token_hash() {
+    let admin_uuid = "00000000-0000-0000-0000-000000000001";
+    let sessions = Arc::new(MockSessionRepo {
+        find_result: Mutex::new(Some(admin_uuid.to_owned())),
+        ..Default::default()
+    });
+    let svc = AuthServiceImpl::new(
+        Arc::new(MockAdminRepo {
+            find_result: Mutex::new(None),
+            first_id: Mutex::new(None),
+        }),
+        Arc::clone(&sessions) as Arc<dyn SessionRepository>,
+        Arc::new(MockApiKeyRepo { hashes: vec![] }),
+        Arc::new(MockSystemConfigRepo),
+        24,
+        720,
+    );
+
+    let result = auth_context::with_context(
+        AuthContext::Admin {
+            admin_id: Uuid::parse_str(admin_uuid).unwrap(),
+        },
+        async { svc.logout_session("raw-token").await },
+    )
+    .await;
+    assert!(result.is_ok());
+
+    // The repo receives the SHA-256 hash of the raw token, never the token itself.
+    let deleted = sessions.deleted_hashes.lock().unwrap().clone();
+    let expected_hash = {
+        use sha2::{Digest, Sha256};
+        hex::encode(Sha256::digest("raw-token".as_bytes()))
+    };
+    assert_eq!(deleted, vec![expected_hash]);
+
+    // The session no longer resolves afterwards.
+    let after = svc.validate_session("raw-token").await.unwrap();
+    assert!(after.is_none());
+}
+
+#[tokio::test]
+async fn logout_session_is_idempotent_when_session_already_gone() {
+    // No session row exists (delete affects 0 rows) → still Ok, the desired
+    // end state (no server-side session) already holds.
+    let svc = make_auth_service(None, None, None, vec![]);
+    let result = auth_context::with_context(
+        AuthContext::Admin {
+            admin_id: Uuid::nil(),
+        },
+        async { svc.logout_session("any-token").await },
+    )
+    .await;
+    assert!(result.is_ok());
 }
 
 #[tokio::test]

--- a/source/daemon/crates/wardnetd-services/src/auth/tests/session_cleanup_runner.rs
+++ b/source/daemon/crates/wardnetd-services/src/auth/tests/session_cleanup_runner.rs
@@ -68,6 +68,9 @@ impl AuthService for MockAuthService {
     ) -> Result<LoginResult, AppError> {
         unimplemented!()
     }
+    async fn logout_session(&self, _token: &str) -> Result<(), AppError> {
+        unimplemented!()
+    }
     async fn refresh_session(&self, _token: &str) -> Result<LoginResult, AppError> {
         unimplemented!()
     }

--- a/source/daemon/crates/wardnetd-services/src/auth/tests/setup.rs
+++ b/source/daemon/crates/wardnetd-services/src/auth/tests/setup.rs
@@ -87,6 +87,9 @@ impl SessionRepository for MockSessionRepo {
     async fn delete_expired(&self, _now: &str) -> anyhow::Result<u64> {
         Ok(0)
     }
+    async fn delete_by_token_hash(&self, _token_hash: &str) -> anyhow::Result<u64> {
+        Ok(0)
+    }
     async fn extend_expiry(&self, _token_hash: &str, _new_expires_at: &str) -> anyhow::Result<()> {
         Ok(())
     }

--- a/source/daemon/crates/wardnetd-services/src/auth/tests/wizard.rs
+++ b/source/daemon/crates/wardnetd-services/src/auth/tests/wizard.rs
@@ -73,6 +73,9 @@ impl SessionRepository for MockSessionRepo {
     async fn delete_expired(&self, _now: &str) -> anyhow::Result<u64> {
         Ok(0)
     }
+    async fn delete_by_token_hash(&self, _token_hash: &str) -> anyhow::Result<u64> {
+        Ok(0)
+    }
     async fn extend_expiry(&self, _token_hash: &str, _new_expires_at: &str) -> anyhow::Result<()> {
         Ok(())
     }

--- a/source/daemon/crates/wardnetd/src/tests/stubs.rs
+++ b/source/daemon/crates/wardnetd/src/tests/stubs.rs
@@ -121,6 +121,9 @@ impl AuthService for StubAuthService {
     ) -> Result<WizardState, AppError> {
         unimplemented!()
     }
+    async fn logout_session(&self, _token: &str) -> Result<(), AppError> {
+        unimplemented!()
+    }
     async fn refresh_session(&self, _token: &str) -> Result<LoginResult, AppError> {
         unimplemented!()
     }

--- a/source/sdk/wardnet-js/src/globals.d.ts
+++ b/source/sdk/wardnet-js/src/globals.d.ts
@@ -60,6 +60,13 @@ interface AbortSignal {
   aborted: boolean;
 }
 
+/** AbortController — available natively in browsers and Node 15+. */
+declare class AbortController {
+  readonly signal: AbortSignal;
+  constructor();
+  abort(): void;
+}
+
 /** WebSocket — available natively in browsers and Node 22+. */
 declare class WebSocket {
   static readonly OPEN: number;

--- a/source/sdk/wardnet-js/src/services/auth.ts
+++ b/source/sdk/wardnet-js/src/services/auth.ts
@@ -23,6 +23,17 @@ export class AuthService {
     await this.client.request<void>("/auth/refresh", { method: "POST" });
   }
 
+  /**
+   * End the current session.
+   *
+   * The daemon deletes the session server-side (the token can never
+   * authenticate again) and clears the `wardnet_session` cookie in the
+   * response. No body — the daemon reads the token from the request cookie.
+   */
+  async logout(): Promise<void> {
+    await this.client.request<void>("/auth/logout", { method: "POST" });
+  }
+
   /** Return the authenticated admin's identity. */
   async me(): Promise<MeResponse> {
     return this.client.request<MeResponse>("/users/me");

--- a/source/sdk/wardnet-js/src/services/auth.ts
+++ b/source/sdk/wardnet-js/src/services/auth.ts
@@ -29,9 +29,22 @@ export class AuthService {
    * The daemon deletes the session server-side (the token can never
    * authenticate again) and clears the `wardnet_session` cookie in the
    * response. No body — the daemon reads the token from the request cookie.
+   *
+   * Bounded by a 5s timeout: sign-out flows gate navigation on this call, and
+   * an unreachable gateway (router mid-reboot, phone off the home LAN) would
+   * otherwise leave the UI hanging on the browser's connection timeout.
    */
   async logout(): Promise<void> {
-    await this.client.request<void>("/auth/logout", { method: "POST" });
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), 5000);
+    try {
+      await this.client.request<void>("/auth/logout", {
+        method: "POST",
+        signal: controller.signal,
+      });
+    } finally {
+      clearTimeout(timer);
+    }
   }
 
   /** Return the authenticated admin's identity. */

--- a/source/web/src/stores/authStore.ts
+++ b/source/web/src/stores/authStore.ts
@@ -10,7 +10,7 @@ interface AuthState {
     password: string,
     rememberMe?: boolean,
   ) => Promise<void>;
-  logout: () => void;
+  logout: () => Promise<void>;
   checkAuth: () => Promise<void>;
   refresh: () => Promise<void>;
 }
@@ -30,8 +30,17 @@ export const useAuthStore = create<AuthState>((set) => ({
     set({ isAdmin: true });
   },
 
-  logout: () => {
-    set({ isAdmin: false });
+  logout: async () => {
+    try {
+      // Revoke the session server-side and clear the HttpOnly cookie — the
+      // cookie is unreachable from JS, so only the daemon can drop it.
+      await authService.logout();
+    } catch {
+      // Even if revocation fails (daemon restarting, flaky network), the UI
+      // must still sign out locally — never trap the user in a logged-in UI.
+    } finally {
+      set({ isAdmin: false });
+    }
   },
 
   checkAuth: async () => {

--- a/source/web/src/stores/authStore.ts
+++ b/source/web/src/stores/authStore.ts
@@ -10,7 +10,13 @@ interface AuthState {
     password: string,
     rememberMe?: boolean,
   ) => Promise<void>;
-  logout: () => Promise<void>;
+  /**
+   * Sign out. Clears local auth state synchronously, then revokes the
+   * session server-side. Resolves `true` when the daemon confirmed the
+   * revocation, `false` when the network call failed (the HttpOnly cookie
+   * may still be alive — callers can warn the user).
+   */
+  logout: () => Promise<boolean>;
   checkAuth: () => Promise<void>;
   refresh: () => Promise<void>;
 }
@@ -31,15 +37,21 @@ export const useAuthStore = create<AuthState>((set) => ({
   },
 
   logout: async () => {
+    // Sign out locally before the network round-trip: the UI reacts
+    // instantly, and a slow request that settles after a subsequent re-login
+    // can no longer clobber the fresh session's state.
+    set({ isAdmin: false });
     try {
       // Revoke the session server-side and clear the HttpOnly cookie — the
       // cookie is unreachable from JS, so only the daemon can drop it.
       await authService.logout();
-    } catch {
-      // Even if revocation fails (daemon restarting, flaky network), the UI
-      // must still sign out locally — never trap the user in a logged-in UI.
-    } finally {
-      set({ isAdmin: false });
+      return true;
+    } catch (e) {
+      // The UI is already signed out locally, but the server session may
+      // have survived — surface that instead of failing silently, since a
+      // live cookie on a shared device re-authenticates the next user.
+      console.warn("logout: server-side session revocation failed", e);
+      return false;
     }
   },
 

--- a/source/web/tests/hooks/useAuth.test.tsx
+++ b/source/web/tests/hooks/useAuth.test.tsx
@@ -3,7 +3,12 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createQueryWrapper } from "../test-utils";
 
 const { authService, systemService } = vi.hoisted(() => ({
-  authService: { me: vi.fn(), login: vi.fn(), refresh: vi.fn() },
+  authService: {
+    me: vi.fn(),
+    login: vi.fn(),
+    logout: vi.fn(),
+    refresh: vi.fn(),
+  },
   systemService: { getStatus: vi.fn() },
 }));
 vi.mock("../../src/lib/sdk", () => ({ authService, systemService }));

--- a/source/web/tests/lib/authService.test.ts
+++ b/source/web/tests/lib/authService.test.ts
@@ -1,0 +1,39 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { AuthService, WardnetClient } from "@wardnet/js";
+
+/**
+ * Exercises the real SDK `AuthService` against a stubbed `fetch`, so the
+ * request line each method produces is pinned down — the store tests mock
+ * the service away, which would let a wrong path or verb slip through.
+ */
+describe("AuthService", () => {
+  const fetchMock = vi.fn();
+  vi.stubGlobal("fetch", fetchMock);
+
+  afterEach(() => {
+    fetchMock.mockReset();
+  });
+
+  it("logout POSTs to /auth/logout and resolves on 204", async () => {
+    fetchMock.mockResolvedValue(new Response(null, { status: 204 }));
+    const service = new AuthService(new WardnetClient({ baseUrl: "/api" }));
+
+    await expect(service.logout()).resolves.toBeUndefined();
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("/api/auth/logout");
+    expect(init.method).toBe("POST");
+    // The session cookie is the credential — it must ride along.
+    expect(init.credentials).toBe("include");
+  });
+
+  it("logout rejects when the daemon reports an error", async () => {
+    fetchMock.mockResolvedValue(
+      new Response(JSON.stringify({ error: "unauthorized" }), { status: 401 }),
+    );
+    const service = new AuthService(new WardnetClient({ baseUrl: "/api" }));
+
+    await expect(service.logout()).rejects.toMatchObject({ status: 401 });
+  });
+});

--- a/source/web/tests/lib/authService.test.ts
+++ b/source/web/tests/lib/authService.test.ts
@@ -26,6 +26,9 @@ describe("AuthService", () => {
     expect(init.method).toBe("POST");
     // The session cookie is the credential — it must ride along.
     expect(init.credentials).toBe("include");
+    // Sign-out flows gate navigation on this call, so it must be time-boxed
+    // rather than riding the browser's connection timeout.
+    expect(init.signal).toBeInstanceOf(AbortSignal);
   });
 
   it("logout rejects when the daemon reports an error", async () => {

--- a/source/web/tests/stores/authStore.test.ts
+++ b/source/web/tests/stores/authStore.test.ts
@@ -40,19 +40,36 @@ describe("authStore", () => {
     });
   });
 
-  it("logout revokes the server session and clears isAdmin", async () => {
+  it("logout revokes the server session and resolves true", async () => {
     authService.logout.mockResolvedValue(undefined);
     useAuthStore.setState({ isAdmin: true });
-    await useAuthStore.getState().logout();
+    await expect(useAuthStore.getState().logout()).resolves.toBe(true);
     expect(authService.logout).toHaveBeenCalledOnce();
     expect(useAuthStore.getState().isAdmin).toBe(false);
   });
 
-  it("logout clears isAdmin even when the network call fails", async () => {
+  it("logout clears isAdmin synchronously, before the network call settles", async () => {
+    let resolveLogout!: () => void;
+    authService.logout.mockImplementation(
+      () => new Promise<void>((resolve) => (resolveLogout = resolve)),
+    );
+    useAuthStore.setState({ isAdmin: true });
+    const pending = useAuthStore.getState().logout();
+    // Local sign-out must not wait for the round-trip — and a stale
+    // completion must not be what flips the flag (it already flipped).
+    expect(useAuthStore.getState().isAdmin).toBe(false);
+    resolveLogout();
+    await expect(pending).resolves.toBe(true);
+  });
+
+  it("logout resolves false and warns when the network call fails, still clearing isAdmin", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
     authService.logout.mockRejectedValue(new Error("network down"));
     useAuthStore.setState({ isAdmin: true });
-    await expect(useAuthStore.getState().logout()).resolves.toBeUndefined();
+    await expect(useAuthStore.getState().logout()).resolves.toBe(false);
     expect(useAuthStore.getState().isAdmin).toBe(false);
+    expect(warn).toHaveBeenCalledOnce();
+    warn.mockRestore();
   });
 
   it("checkAuth marks admin when the status probe succeeds", async () => {

--- a/source/web/tests/stores/authStore.test.ts
+++ b/source/web/tests/stores/authStore.test.ts
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { WardnetApiError } from "@wardnet/js";
 
 const { authService, systemService } = vi.hoisted(() => ({
-  authService: { login: vi.fn(), refresh: vi.fn() },
+  authService: { login: vi.fn(), logout: vi.fn(), refresh: vi.fn() },
   systemService: { getStatus: vi.fn() },
 }));
 vi.mock("../../src/lib/sdk", () => ({ authService, systemService }));
@@ -40,9 +40,18 @@ describe("authStore", () => {
     });
   });
 
-  it("logout clears isAdmin", () => {
+  it("logout revokes the server session and clears isAdmin", async () => {
+    authService.logout.mockResolvedValue(undefined);
     useAuthStore.setState({ isAdmin: true });
-    useAuthStore.getState().logout();
+    await useAuthStore.getState().logout();
+    expect(authService.logout).toHaveBeenCalledOnce();
+    expect(useAuthStore.getState().isAdmin).toBe(false);
+  });
+
+  it("logout clears isAdmin even when the network call fails", async () => {
+    authService.logout.mockRejectedValue(new Error("network down"));
+    useAuthStore.setState({ isAdmin: true });
+    await expect(useAuthStore.getState().logout()).resolves.toBeUndefined();
     expect(useAuthStore.getState().isAdmin).toBe(false);
   });
 


### PR DESCRIPTION
Fixes #830.

## Problem

Tapping "Log out" in the admin app only flipped `isAdmin` to `false` in memory and unregistered the biometric credential. The daemon was never told, and it had no endpoint to be told with — the HttpOnly `wardnet_session` cookie stayed valid on the device. On a shared device the next person to open the app was silently re-authenticated as the previous admin, with no password and no biometric prompt (unregistering the credential actually removed the one local gate that would have been in the way).

## Fix

One change across the stack, since the client call is useless without the server capability:

**Daemon**
- New `POST /api/auth/logout` endpoint behind the `AdminAuth` extractor. `AdminAuth.session_token` now carries exactly the token that passed validation — never a credential that merely rode along in the headers — so logout always revokes the session that authorized the request. Covers two subtle cases: a request carrying a stale cookie alongside a valid bearer token revokes the bearer session (not the dead cookie), and API-key callers get a 401 instead of a misleading 204, since an API key is not a session.
- `AuthService::logout_session` opens with `auth_context::require_admin()` per `.agents/auth.md`, hashes the raw token via a single shared `hash_token` helper (also now used by login/refresh/validate, so the token→row-key derivation can't drift between write and delete) and deletes the matching row via the new `SessionRepository::delete_by_token_hash`. Idempotent: a session that is already gone is not an error.
- The 204 response carries a `Set-Cookie` with `Max-Age=0`, built by delegating to the same `session_cookie` helper used at login so the attribute list can never diverge and stop matching the stored cookie.
- `refresh` / `remember_me` behaviour untouched; `docs/openapi.json` regenerated via `make openapi` (declares 204/401/403/500).

**SDK**
- `AuthService.logout()` calling the new endpoint, time-boxed at 5s — sign-out flows gate navigation on this call, and an unreachable gateway (router mid-reboot, phone off the home LAN) must not leave the UI hanging on the browser's connection timeout.

**Web store**
- `useAuthStore.logout` clears `isAdmin` synchronously before the network round-trip (the UI reacts instantly, and a slow request that settles after a re-login can't clobber the fresh session's state), then awaits the revocation and resolves `true`/`false` so callers can tell a confirmed revocation from a failed one. Failures are logged rather than swallowed silently.

**Admin app / admin site**
- The System page logout action and the sidebar sign-out wait for the revocation to settle before unregistering the biometric credential and navigating; the System page shows a toast when the gateway couldn't confirm the sign-out, since a surviving cookie on a shared device is exactly the risk this change exists to close.
- The post-restart "sign in again" flows (Power, Backups, reboot path in System) stay fire-and-forget — the session is already invalid there and local state clears synchronously regardless.

## Tests

- Repository: `delete_by_token_hash` removes only the matching row, unknown hash is a no-op.
- Service: guard rejects unauthenticated callers; delete receives the SHA-256 of the token (never the raw token); idempotency; malformed stored-hash / admin-id / created-at rows surface as internal errors.
- API: 204 + cleared cookie (plain and TLS variants), bearer-token path, 401 without a session, 401 for API-key callers with sessions untouched, stale-cookie-plus-valid-bearer revokes the bearer session, and an end-to-end login → logout → replay-old-cookie-gets-401 flow through the real handlers and extractor.
- Middleware: bearer that is neither session nor API key is rejected; auth-context resolution covered for bearer session tokens and API keys.
- SDK: `logout()` request line and abort signal pinned against a stubbed `fetch`.
- Store: revokes and reports the outcome; clears `isAdmin` before the call settles; resolves `false` and warns when the network call fails.
- Admin app: the logout action keeps the biometric gate until the revocation resolves, and warns when the server-side revoke fails.

Daemon coverage: 87.26% lines on `main` → 87.29% on this branch (regions 84.26% → 84.28%, functions 83.39% → 83.56%) via `make coverage-daemon`; `make check-daemon` passes locally.

Note per the issue's release-blocker flag: this closes a full unauthenticated-admin-access hole on shared devices, so it's worth prioritising for the next release.