### PR TITLE
fix(security): resolve the two remaining RustSec advisories flagged by Scorecard

### DIFF
--- a/.github/scripts/audit-ignore-staleness.py
+++ b/.github/scripts/audit-ignore-staleness.py
@@ -26,7 +26,12 @@ from pathlib import Path
 
 DAEMON = Path(__file__).resolve().parents[2] / "source" / "daemon"
 AUDIT_TOML = DAEMON / ".cargo" / "audit.toml"
-OSV_TOML = DAEMON / "osv-scanner.toml"
+# osv-scanner resolves its config per lockfile directory, so the fuzz
+# workspace carries its own copy of the ignores relevant to fuzz/Cargo.lock.
+OSV_TOMLS = [
+    (DAEMON / "osv-scanner.toml", "osv-scanner.toml"),
+    (DAEMON / "fuzz" / "osv-scanner.toml", "fuzz/osv-scanner.toml"),
+]
 # Every Cargo.lock osv-scanner walks; a crate lingering in any of them keeps
 # the advisory reachable, so union them for the presence check.
 LOCKFILES = [DAEMON / "Cargo.lock", DAEMON / "fuzz" / "Cargo.lock"]
@@ -39,11 +44,12 @@ def ignored_ids() -> dict[str, list[str]]:
         cfg = tomllib.loads(AUDIT_TOML.read_text())
         for adv in cfg.get("advisories", {}).get("ignore", []):
             ids.setdefault(adv, []).append(".cargo/audit.toml")
-    if OSV_TOML.exists():
-        cfg = tomllib.loads(OSV_TOML.read_text())
-        for entry in cfg.get("IgnoredVulns", []):
-            if "id" in entry:
-                ids.setdefault(entry["id"], []).append("osv-scanner.toml")
+    for path, label in OSV_TOMLS:
+        if path.exists():
+            cfg = tomllib.loads(path.read_text())
+            for entry in cfg.get("IgnoredVulns", []):
+                if "id" in entry:
+                    ids.setdefault(entry["id"], []).append(label)
     return ids
 
 

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -8,6 +8,7 @@ on:
       - "source/daemon/**/Cargo.lock"
       - "source/daemon/.cargo/audit.toml"
       - "source/daemon/osv-scanner.toml"
+      - "source/daemon/fuzz/osv-scanner.toml"
       - ".github/scripts/audit-ignore-staleness.py"
   pull_request:
     branches: [main]
@@ -16,6 +17,7 @@ on:
       - "source/daemon/**/Cargo.lock"
       - "source/daemon/.cargo/audit.toml"
       - "source/daemon/osv-scanner.toml"
+      - "source/daemon/fuzz/osv-scanner.toml"
       - ".github/scripts/audit-ignore-staleness.py"
   schedule:
     # Run daily at 06:00 UTC to catch newly disclosed advisories

--- a/source/daemon/.cargo/audit.toml
+++ b/source/daemon/.cargo/audit.toml
@@ -2,10 +2,6 @@
 # https://github.com/rustsec/rustsec/tree/main/cargo-audit
 
 [advisories]
-# RUSTSEC-2023-0071: rsa timing sidechannel (Marvin Attack)
-# Transitive via sqlx-mysql. We compile sqlx with SQLite only, so the
-# vulnerable rsa path isn't linked into wardnetd. No upstream fix.
-#
 # RUSTSEC-2024-0436: paste crate unmaintained
 # Compile-time proc-macro pulled in via netlink-packet-core (used by
 # rtnetlink for kernel policy routing). Not a CVE — the author stopped
@@ -38,12 +34,12 @@
 # reachable. No 0.25.x backport. Re-evaluate when dhcproto upgrades.
 #
 # RUSTSEC-2026-0173: proc-macro-error2 unmaintained.
-# Compile-time proc-macro pulled in via i18n-embed-fl (through age) and
-# tabled_derive (through wctl's tabled). Not a CVE — the author stopped
-# publishing updates. Zero runtime footprint. Blocked on age →
-# i18n-embed-fl migrating off proc-macro-error2 (the tabled/wctl path is
-# removable but not sufficient alone). Tracked in wardnet/wardnet#758;
-# remove this entry when `cargo tree -i proc-macro-error2` returns nothing.
+# Compile-time proc-macro pulled in via i18n-embed-fl (through age).
+# Not a CVE — the author stopped publishing updates. Zero runtime
+# footprint. Blocked on age → i18n-embed-fl migrating off
+# proc-macro-error2 (even latest i18n-embed-fl 0.10 still depends on
+# it). Tracked in wardnet/wardnet#758; remove this entry when
+# `cargo tree -i proc-macro-error2` returns nothing.
 #
 # RUSTSEC-2026-0186: memmap2 unchecked pointer offset.
 # Transitive via pyroscope (continuous-profiling client) and
@@ -52,7 +48,6 @@
 # in-bounds offsets, so the unchecked path isn't reachable in our usage.
 # No fixed release yet. Re-evaluate when pyroscope bumps memmap2.
 ignore = [
-    "RUSTSEC-2023-0071",
     "RUSTSEC-2024-0436",
     "RUSTSEC-2026-0097",
     "RUSTSEC-2026-0118",

--- a/source/daemon/Cargo.lock
+++ b/source/daemon/Cargo.lock
@@ -40,19 +40,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
  "cfg-if",
- "cipher 0.4.4",
+ "cipher",
  "cpufeatures 0.2.17",
-]
-
-[[package]]
-name = "aes"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1fc76eaeac4c9164506c466d4ffdd8ec9d0c5bf57ee97177c4d8eceb3a0e138"
-dependencies = [
- "cipher 0.5.1",
- "cpubits",
- "cpufeatures 0.3.0",
 ]
 
 [[package]]
@@ -62,21 +51,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
 dependencies = [
  "aead",
- "aes 0.8.4",
- "cipher 0.4.4",
+ "aes",
+ "cipher",
  "ctr",
  "ghash",
  "subtle",
-]
-
-[[package]]
-name = "aes-keywrap"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10b6f24a1f796bc46415a1d0d18dc0a8203ccba088acf5def3291c4f61225522"
-dependencies = [
- "aes 0.9.1",
- "byteorder",
 ]
 
 [[package]]
@@ -231,12 +210,6 @@ dependencies = [
  "cpufeatures 0.2.17",
  "password-hash",
 ]
-
-[[package]]
-name = "arrayref"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
 
 [[package]]
 name = "arrayvec"
@@ -557,12 +530,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "binstring"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0669d5a35b64fdb5ab7fb19cae13148b6b5cbdf4b8247faf54ece47f699c8cef"
-
-[[package]]
 name = "bit-vec"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -593,17 +560,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
 dependencies = [
  "digest 0.10.7",
-]
-
-[[package]]
-name = "blake2b_simd"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b79834656f71332577234b50bfc009996f7449e0c056884e6a02492ded0ca2f3"
-dependencies = [
- "arrayref",
- "arrayvec",
- "constant_time_eq",
 ]
 
 [[package]]
@@ -694,7 +650,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
 dependencies = [
  "cfg-if",
- "cipher 0.4.4",
+ "cipher",
  "cpufeatures 0.2.17",
 ]
 
@@ -717,7 +673,7 @@ checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
 dependencies = [
  "aead",
  "chacha20 0.9.1",
- "cipher 0.4.4",
+ "cipher",
  "poly1305",
  "zeroize",
 ]
@@ -743,18 +699,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
  "crypto-common 0.1.7",
- "inout 0.1.4",
+ "inout",
  "zeroize",
-]
-
-[[package]]
-name = "cipher"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e34d8227fe1ba289043aeb13792056ff80fd6de1a9f49137a5f499de8e8c78ea"
-dependencies = [
- "crypto-common 0.2.1",
- "inout 0.2.2",
 ]
 
 [[package]]
@@ -824,17 +770,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
 
 [[package]]
-name = "coarsetime"
-version = "0.1.37"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e58eb270476aa4fc7843849f8a35063e8743b4dbcdf6dd0f8ea0886980c204c2"
-dependencies = [
- "libc",
- "wasix",
- "wasm-bindgen",
-]
-
-[[package]]
 name = "colorchoice"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -870,12 +805,6 @@ name = "const-oid"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
-
-[[package]]
-name = "constant_time_eq"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 
 [[package]]
 name = "cookie"
@@ -940,12 +869,6 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
-
-[[package]]
-name = "cpubits"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15b85f9c39137c3a891689859392b1bd49812121d0d61c9caf00d46ed5ce06ae"
 
 [[package]]
 name = "cpufeatures"
@@ -1069,9 +992,7 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
 dependencies = [
- "getrandom 0.4.2",
  "hybrid-array",
- "rand_core 0.10.0",
 ]
 
 [[package]]
@@ -1086,7 +1007,7 @@ version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
 dependencies = [
- "cipher 0.4.4",
+ "cipher",
 ]
 
 [[package]]
@@ -1186,16 +1107,6 @@ checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
  "const-oid 0.9.6",
  "pem-rfc7468",
- "zeroize",
-]
-
-[[package]]
-name = "der"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71fd89660b2dc699704064e59e9dba0147b903e85319429e131620d022be411b"
-dependencies = [
- "const-oid 0.10.2",
  "zeroize",
 ]
 
@@ -1318,12 +1229,12 @@ version = "0.16.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
 dependencies = [
- "der 0.7.10",
+ "der",
  "digest 0.10.7",
  "elliptic-curve",
  "rfc6979",
- "signature 2.2.0",
- "spki 0.7.3",
+ "signature",
+ "spki",
 ]
 
 [[package]]
@@ -1343,18 +1254,8 @@ version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
 dependencies = [
- "pkcs8 0.10.2",
- "signature 2.2.0",
-]
-
-[[package]]
-name = "ed25519-compact"
-version = "2.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c24599140dc39d7a81e4476e7573d41bbc18e07c803900298e522a5fbcfbfb6"
-dependencies = [
- "ct-codecs",
- "getrandom 0.4.2",
+ "pkcs8",
+ "signature",
 ]
 
 [[package]]
@@ -1394,7 +1295,7 @@ dependencies = [
  "group",
  "hkdf 0.12.4",
  "pem-rfc7468",
- "pkcs8 0.10.2",
+ "pkcs8",
  "rand_core 0.6.4",
  "sec1",
  "subtle",
@@ -1443,7 +1344,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2073,30 +1974,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hmac-sha1-compact"
-version = "1.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0b3ba31f6dc772cc8221ce81dbbbd64fa1e668255a6737d95eeace59b5a8823"
-
-[[package]]
-name = "hmac-sha256"
-version = "1.1.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec9d92d097f4749b64e8cc33d924d9f40a2d4eb91402b458014b781f5733d60f"
-dependencies = [
- "digest 0.10.7",
-]
-
-[[package]]
-name = "hmac-sha512"
-version = "1.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "019ece39bbefc17f13f677a690328cb978dbf6790e141a3c24e66372cb38588b"
-dependencies = [
- "digest 0.10.7",
-]
-
-[[package]]
 name = "http"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2147,7 +2024,6 @@ version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8655f91cd07f2b9d0c24137bd650fe69617773435ee5ec83022377777ce65ef1"
 dependencies = [
- "ctutils",
  "typenum",
 ]
 
@@ -2459,15 +2335,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "inout"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4250ce6452e92010fdf7268ccc5d14faa80bb12fc741938534c58f16804e03c7"
-dependencies = [
- "hybrid-array",
-]
-
-[[package]]
 name = "instant-acme"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2668,63 +2535,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "jwt-simple"
-version = "0.12.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3991f54af4b009bb6efe01aa5a4fcce9ca52f3de7a104a3f6b6e2ad36c852c48"
-dependencies = [
- "anyhow",
- "binstring",
- "blake2b_simd",
- "coarsetime",
- "ct-codecs",
- "ed25519-compact",
- "hmac-sha1-compact",
- "hmac-sha256",
- "hmac-sha512",
- "k256",
- "p256",
- "p384",
- "rand 0.8.5",
- "serde",
- "serde_json",
- "superboring",
- "thiserror 2.0.18",
- "zeroize",
-]
-
-[[package]]
-name = "k256"
-version = "0.13.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6e3919bbaa2945715f0bb6d3934a173d1e9a59ac23767fbaaef277265a7411b"
-dependencies = [
- "cfg-if",
- "ecdsa",
- "elliptic-curve",
- "once_cell",
- "sha2 0.10.9",
- "signature 2.2.0",
-]
-
-[[package]]
-name = "keccak"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e24a010dd405bd7ed803e5253182815b41bf2e6a80cc3bfc066658e03a198aa"
-dependencies = [
- "cfg-if",
- "cpufeatures 0.3.0",
-]
-
-[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
-dependencies = [
- "spin 0.9.8",
-]
 
 [[package]]
 name = "leb128fmt"
@@ -2771,12 +2585,6 @@ dependencies = [
  "cfg-if",
  "windows-link",
 ]
-
-[[package]]
-name = "libm"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
@@ -2999,33 +2807,6 @@ dependencies = [
  "log",
  "wasi",
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "ml-dsa"
-version = "0.1.0-rc.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "163f15320f3fba11760c373af52d7f69d638482c2c350d877fb06513b1c3137c"
-dependencies = [
- "const-oid 0.10.2",
- "crypto-common 0.2.1",
- "ctutils",
- "hybrid-array",
- "module-lattice",
- "pkcs8 0.11.0",
- "sha3",
- "signature 3.0.0",
-]
-
-[[package]]
-name = "module-lattice"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c61b87c9683ab7cb1c6871d261ad5479b6b10ceb52c4352aaca3b5d35a8febe"
-dependencies = [
- "ctutils",
- "hybrid-array",
- "num-traits",
 ]
 
 [[package]]
@@ -3287,7 +3068,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3298,22 +3079,6 @@ checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
 dependencies = [
  "num-integer",
  "num-traits",
-]
-
-[[package]]
-name = "num-bigint-dig"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e661dda6640fad38e827a6d4a310ff4763082116fe217f279885c97f511bb0b7"
-dependencies = [
- "lazy_static",
- "libm",
- "num-integer",
- "num-iter",
- "num-traits",
- "rand 0.8.5",
- "smallvec",
- "zeroize",
 ]
 
 [[package]]
@@ -3332,24 +3097,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-iter"
-version = "0.1.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
-dependencies = [
- "autocfg",
- "num-integer",
- "num-traits",
-]
-
-[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
- "libm",
 ]
 
 [[package]]
@@ -3578,18 +3331,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "p384"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe42f1670a52a47d448f14b6a5c61dd78fce51856e68edaa38f7ae3a46b8d6b6"
-dependencies = [
- "ecdsa",
- "elliptic-curve",
- "primeorder",
- "sha2 0.10.9",
-]
-
-[[package]]
 name = "papergrid"
 version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3769,34 +3510,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
-name = "pkcs1"
-version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
-dependencies = [
- "der 0.7.10",
- "pkcs8 0.10.2",
- "spki 0.7.3",
-]
-
-[[package]]
 name = "pkcs8"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
 dependencies = [
- "der 0.7.10",
- "spki 0.7.3",
-]
-
-[[package]]
-name = "pkcs8"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "451913da69c775a56034ea8d9003d27ee8948e12443eae7c038ba100a4f21cb7"
-dependencies = [
- "der 0.8.0",
- "spki 0.8.0",
+ "der",
+ "spki",
 ]
 
 [[package]]
@@ -4451,27 +4171,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rsa"
-version = "0.9.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
-dependencies = [
- "const-oid 0.9.6",
- "digest 0.10.7",
- "num-bigint-dig",
- "num-integer",
- "num-traits",
- "pkcs1",
- "pkcs8 0.10.2",
- "rand_core 0.6.4",
- "sha2 0.10.9",
- "signature 2.2.0",
- "spki 0.7.3",
- "subtle",
- "zeroize",
-]
-
-[[package]]
 name = "rtnetlink"
 version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4611,7 +4310,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4670,7 +4369,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4718,7 +4417,7 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97a22f5af31f73a954c10289c93e8a50cc23d971e80ee446f1f6f7137a088213"
 dependencies = [
- "cipher 0.4.4",
+ "cipher",
 ]
 
 [[package]]
@@ -4772,9 +4471,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
 dependencies = [
  "base16ct",
- "der 0.7.10",
+ "der",
  "generic-array",
- "pkcs8 0.10.2",
+ "pkcs8",
  "subtle",
  "zeroize",
 ]
@@ -4969,16 +4668,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sha3"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be176f1a57ce4e3d31c1a166222d9768de5954f811601fb7ca06fc8203905ce1"
-dependencies = [
- "digest 0.11.2",
- "keccak",
-]
-
-[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5011,16 +4700,6 @@ checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "digest 0.10.7",
  "rand_core 0.6.4",
-]
-
-[[package]]
-name = "signature"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d567dcbaf0049cb8ac2608a76cd95ff9e4412e1899d389ee400918ca7537f5"
-dependencies = [
- "digest 0.11.2",
- "rand_core 0.10.0",
 ]
 
 [[package]]
@@ -5112,17 +4791,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
 dependencies = [
  "base64ct",
- "der 0.7.10",
-]
-
-[[package]]
-name = "spki"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d9efca8738c78ee9484207732f728b1ef517bbb1833d6fc0879ca898a522f6f"
-dependencies = [
- "base64ct",
- "der 0.8.0",
+ "der",
 ]
 
 [[package]]
@@ -5334,22 +5003,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
-name = "superboring"
-version = "0.1.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efc6310a69b44420f3bf53d518077615b7d466cc57df7a80e404e7feb8c510f7"
-dependencies = [
- "aes-gcm",
- "aes-keywrap",
- "getrandom 0.2.17",
- "hmac-sha256",
- "hmac-sha512",
- "ml-dsa",
- "rand 0.8.5",
- "rsa",
-]
-
-[[package]]
 name = "surge-ping"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5511,7 +5164,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6472,15 +6125,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasix"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae86f02046da16a333a9129d31451423e1657737ecdafed4193838a5f54c5cfe"
-dependencies = [
- "wasi",
-]
-
-[[package]]
 name = "wasm-bindgen"
 version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6606,13 +6250,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2175ef28a9a693fa88f322d88484f702a340da864a449a2b6b2a1fe26db712f3"
 dependencies = [
  "aes-gcm",
- "base64ct",
  "ece-native",
  "hkdf 0.12.4",
  "http",
- "jwt-simple",
  "p256",
- "serde",
  "sha2 0.10.9",
 ]
 
@@ -6697,7 +6338,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/source/daemon/Cargo.lock
+++ b/source/daemon/Cargo.lock
@@ -587,12 +587,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
-name = "bytecount"
-version = "0.6.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
-
-[[package]]
 name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3331,17 +3325,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "papergrid"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0984e668274d34691bc2b262ef0d115de5fa9973bcdee7ae32213f93099153e"
-dependencies = [
- "bytecount",
- "fnv",
- "unicode-width",
-]
-
-[[package]]
 name = "parking"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5114,30 +5097,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tabled"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5dc662e6da844ad6e428ad16b57967c9d33c82e16bb1c258326c0c078605dff"
-dependencies = [
- "papergrid",
- "tabled_derive",
- "testing_table",
-]
-
-[[package]]
-name = "tabled_derive"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ea5d1b13ca6cff1f9231ffd62f15eefd72543dab5e468735f1a456728a02846"
-dependencies = [
- "heck",
- "proc-macro-error2",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "tagptr"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5165,15 +5124,6 @@ dependencies = [
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "testing_table"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f8daae29995a24f65619e19d8d31dea5b389f3d853d8bf297bbf607cd0014cc"
-dependencies = [
- "unicode-width",
 ]
 
 [[package]]
@@ -5711,12 +5661,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
 
 [[package]]
-name = "unicode-width"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
-
-[[package]]
 name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6239,7 +6183,6 @@ dependencies = [
  "reqwest 0.12.28",
  "serde",
  "serde_json",
- "tabled",
  "tokio",
 ]
 

--- a/source/daemon/Cargo.toml
+++ b/source/daemon/Cargo.toml
@@ -120,12 +120,14 @@ ed25519-dalek = { version = "2", default-features = false, features = ["std"] }
 # free function + base-point constant, so no `static_secrets` feature is needed;
 # clamping is applied to match `wg genkey`.
 x25519-dalek = { version = "3", default-features = false }
-# https://crates.io/crates/web-push-native — HTTP-agnostic Web Push: VAPID JWT
-# (ES256) + RFC8291/RFC8188 payload encryption via RustCrypto, no OpenSSL/isahc.
-# Returns request headers + encrypted body; we POST with the workspace `reqwest`.
-# Re-exports `jwt_simple` (VAPID ES256 keygen/sign) and `p256` (subscription key
-# parsing), so no separate p256/jwt dependency is needed.
-web-push-native = "0.4"
+# https://crates.io/crates/web-push-native — HTTP-agnostic Web Push: RFC 8291 /
+# RFC 8188 payload encryption via RustCrypto, no OpenSSL/isahc. Returns request
+# headers + encrypted body; we POST with the workspace `reqwest`. The default
+# `vapid` feature stays OFF: it drags in jwt-simple → superboring → `rsa`
+# (RUSTSEC-2023-0071, Marvin timing sidechannel) just to mint a two-claim ES256
+# token, so push/sender.rs signs the VAPID JWT directly with the re-exported
+# `p256` instead.
+web-push-native = { version = "0.4", default-features = false }
 # https://crates.io/crates/http — name the `http::Request` web-push-native emits
 # so we can marshal it onto the reqwest client. Same version reqwest 0.12 uses.
 http = "1"

--- a/source/daemon/Cargo.toml
+++ b/source/daemon/Cargo.toml
@@ -138,8 +138,6 @@ mime_guess = "2"
 clap = { version = "4", features = ["derive"] }
 # https://crates.io/crates/reqwest
 reqwest = { version = "0.12", default-features = false, features = ["json", "cookies", "rustls-tls", "stream"] }
-# https://crates.io/crates/tabled
-tabled = "0.21"
 # https://crates.io/crates/async-trait
 async-trait = "0.1"
 # https://crates.io/crates/wireguard-control

--- a/source/daemon/crates/wardnetd-services/src/push/sender.rs
+++ b/source/daemon/crates/wardnetd-services/src/push/sender.rs
@@ -1,20 +1,27 @@
 //! Web Push delivery: VAPID signing + RFC 8291 payload encryption + HTTP POST.
 //!
 //! This is the cryptographic edge of the push subsystem and the focus of the
-//! security review. All key material and encryption is delegated to
-//! [`web_push_native`] (`RustCrypto`: `p256` / `aes-gcm` / `hkdf`); this module
-//! only marshals a stored subscription into a builder call and classifies the
-//! push service's HTTP response.
+//! security review. Payload encryption is delegated to [`web_push_native`]
+//! (`RustCrypto`: `p256` / `aes-gcm` / `hkdf`); the RFC 8292 VAPID token is
+//! signed here with the re-exported `p256` directly, because web-push-native's
+//! `vapid` feature would pull the whole jwt-simple stack (and with it the
+//! `rsa` crate, RUSTSEC-2023-0071) for a JWT with three claims. Beyond that,
+//! this module only marshals a stored subscription into a builder call and
+//! classifies the push service's HTTP response.
 //!
 //! The [`WebPushSender`] trait is the seam the [`PushService`](super) tests and
 //! the mock daemon substitute — the real [`ReqwestWebPushSender`] performs
 //! network I/O, so unit tests never touch it.
 
+use std::time::{SystemTime, UNIX_EPOCH};
+
 use async_trait::async_trait;
 use base64::Engine;
 use base64::engine::general_purpose::{URL_SAFE, URL_SAFE_NO_PAD};
-use web_push_native::jwt_simple::algorithms::{ECDSAP256PublicKeyLike, ES256KeyPair};
 use web_push_native::p256::PublicKey;
+use web_push_native::p256::ecdsa::signature::Signer;
+use web_push_native::p256::ecdsa::{Signature, SigningKey};
+use web_push_native::p256::elliptic_curve::rand_core::OsRng;
 use web_push_native::{Auth, WebPushBuilder};
 
 /// Decode a base64url value, accepting both unpadded and padded input —
@@ -25,10 +32,10 @@ fn decode_b64url(value: &str) -> Result<Vec<u8>, base64::DecodeError> {
         .or_else(|_| URL_SAFE.decode(value))
 }
 
-/// The daemon's VAPID key pair. Wraps [`ES256KeyPair`] so the rest of the
-/// service never depends on the JWT crate directly.
+/// The daemon's VAPID key pair. Wraps a P-256 [`SigningKey`] so the rest of
+/// the service never depends on the ECDSA crates directly.
 pub struct VapidKey {
-    key_pair: ES256KeyPair,
+    signing_key: SigningKey,
 }
 
 impl VapidKey {
@@ -36,40 +43,83 @@ impl VapidKey {
     #[must_use]
     pub fn generate() -> Self {
         Self {
-            key_pair: ES256KeyPair::generate(),
+            signing_key: SigningKey::random(&mut OsRng),
         }
     }
 
     /// Reconstruct a key pair from the raw bytes produced by [`Self::to_bytes`].
     pub fn from_bytes(raw: &[u8]) -> Result<Self, anyhow::Error> {
-        // The raw P-256 private scalar is 32 bytes; `ES256KeyPair::from_bytes`
-        // *panics* on a shorter slice, so reject a corrupt/truncated stored
-        // secret here instead of crashing the daemon.
+        // The raw P-256 private scalar is 32 bytes; keep the explicit length
+        // check so a corrupt/truncated stored secret yields a diagnosable
+        // error instead of a generic decode failure.
         if raw.len() != 32 {
             anyhow::bail!("VAPID key must be 32 bytes, got {}", raw.len());
         }
-        let key_pair = ES256KeyPair::from_bytes(raw)
+        let signing_key = SigningKey::from_slice(raw)
             .map_err(|e| anyhow::anyhow!("invalid stored VAPID key: {e}"))?;
-        Ok(Self { key_pair })
+        Ok(Self { signing_key })
     }
 
     /// Serialize the private key for storage in the [`SecretStore`](crate::secret_store::SecretStore).
     #[must_use]
     pub fn to_bytes(&self) -> Vec<u8> {
-        self.key_pair.to_bytes()
+        self.signing_key.to_bytes().to_vec()
     }
 
     /// The uncompressed SEC1 public point, base64url-unpadded — the value a
     /// browser passes as `applicationServerKey` to `PushManager.subscribe`.
     #[must_use]
     pub fn public_key_base64url(&self) -> String {
-        let uncompressed = self
-            .key_pair
-            .public_key()
-            .public_key()
-            .to_bytes_uncompressed();
-        base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(uncompressed)
+        let uncompressed = self.signing_key.verifying_key().to_encoded_point(false);
+        URL_SAFE_NO_PAD.encode(uncompressed.as_bytes())
     }
+}
+
+/// How long a minted VAPID token stays valid. Matches the 12-hour TTL
+/// [`WebPushBuilder`] puts on the request itself.
+const VAPID_TOKEN_LIFETIME_SECS: u64 = 12 * 60 * 60;
+
+/// Build the RFC 8292 `Authorization` header value: `vapid t=<jwt>, k=<pub>`.
+///
+/// The token is a plain ES256 JWS over the three claims push services
+/// validate — `aud` (endpoint origin), `exp`, and `sub` (our contact
+/// address). P-256 JWS signatures are the fixed-size `r || s` form, so the
+/// signature bytes go into the token as-is.
+fn vapid_authorization(
+    endpoint: &http::Uri,
+    contact: &str,
+    vapid: &VapidKey,
+) -> Result<String, anyhow::Error> {
+    let scheme = endpoint
+        .scheme_str()
+        .ok_or_else(|| anyhow::anyhow!("push endpoint has no scheme"))?;
+    let host = endpoint
+        .host()
+        .ok_or_else(|| anyhow::anyhow!("push endpoint has no host"))?;
+    let audience = format!("{scheme}://{host}");
+
+    let expiry = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_err(|e| anyhow::anyhow!("system clock is before the Unix epoch: {e}"))?
+        .as_secs()
+        + VAPID_TOKEN_LIFETIME_SECS;
+
+    let header = URL_SAFE_NO_PAD.encode(br#"{"typ":"JWT","alg":"ES256"}"#);
+    let claims = serde_json::json!({
+        "aud": audience,
+        "exp": expiry,
+        "sub": contact,
+    });
+    let claims = URL_SAFE_NO_PAD.encode(serde_json::to_vec(&claims)?);
+
+    let signing_input = format!("{header}.{claims}");
+    let signature: Signature = vapid.signing_key.sign(signing_input.as_bytes());
+    let signature = URL_SAFE_NO_PAD.encode(signature.to_bytes());
+
+    Ok(format!(
+        "vapid t={signing_input}.{signature}, k={}",
+        vapid.public_key_base64url()
+    ))
 }
 
 /// A single delivery target — one stored subscription's addressing + keys.
@@ -146,10 +196,16 @@ impl ReqwestWebPushSender {
         }
         let ua_auth = Auth::clone_from_slice(&auth);
 
-        let request = WebPushBuilder::new(endpoint, ua_public, ua_auth)
-            .with_vapid(&vapid.key_pair, &self.contact)
+        let authorization = vapid_authorization(&endpoint, &self.contact, vapid)?;
+        let mut request = WebPushBuilder::new(endpoint, ua_public, ua_auth)
             .build(payload)
             .map_err(|e| anyhow::anyhow!("web push encryption failed: {e}"))?;
+        request.headers_mut().insert(
+            http::header::AUTHORIZATION,
+            authorization
+                .try_into()
+                .map_err(|e| anyhow::anyhow!("bad VAPID header value: {e}"))?,
+        );
         Ok(request)
     }
 }

--- a/source/daemon/crates/wardnetd-services/src/push/tests.rs
+++ b/source/daemon/crates/wardnetd-services/src/push/tests.rs
@@ -1148,6 +1148,74 @@ fn build_request_sets_web_push_headers() {
 }
 
 #[test]
+fn build_request_vapid_token_verifies_against_advertised_key() {
+    // The Authorization header must carry an ES256 JWS a push service can
+    // actually validate: signature over `header.claims` with the key
+    // advertised in `k=`, and the claims RFC 8292 requires.
+    use web_push_native::p256::ecdsa::signature::Verifier;
+    use web_push_native::p256::ecdsa::{Signature, VerifyingKey};
+
+    let vapid = VapidKey::generate();
+    let subscriber = VapidKey::generate();
+    let p256dh = subscriber.public_key_base64url();
+    let auth = URL_SAFE_NO_PAD.encode([7u8; 16]);
+
+    let sender = ReqwestWebPushSender::new(reqwest::Client::new(), "mailto:a@b.c".to_owned());
+    let request = sender
+        .build_request(
+            &vapid,
+            &PushTarget {
+                endpoint: "https://push.example.com/xyz",
+                p256dh: &p256dh,
+                auth: &auth,
+            },
+            b"{}".to_vec(),
+        )
+        .expect("valid subscription should build");
+
+    let header = request
+        .headers()
+        .get(http::header::AUTHORIZATION)
+        .unwrap()
+        .to_str()
+        .unwrap();
+    let (token, advertised_key) = header
+        .strip_prefix("vapid t=")
+        .and_then(|rest| rest.split_once(", k="))
+        .expect("header must be `vapid t=<jwt>, k=<pub>`");
+    assert_eq!(advertised_key, vapid.public_key_base64url());
+
+    let [jose, claims, signature] = token.split('.').collect::<Vec<_>>()[..] else {
+        panic!("token must have three segments, got {token}");
+    };
+    let verifying_key =
+        VerifyingKey::from_sec1_bytes(&URL_SAFE_NO_PAD.decode(advertised_key).unwrap()).unwrap();
+    let signature = Signature::from_slice(&URL_SAFE_NO_PAD.decode(signature).unwrap()).unwrap();
+    verifying_key
+        .verify(format!("{jose}.{claims}").as_bytes(), &signature)
+        .expect("token signature must verify against the advertised key");
+
+    let jose: serde_json::Value =
+        serde_json::from_slice(&URL_SAFE_NO_PAD.decode(jose).unwrap()).unwrap();
+    assert_eq!(jose["alg"], "ES256");
+
+    let claims: serde_json::Value =
+        serde_json::from_slice(&URL_SAFE_NO_PAD.decode(claims).unwrap()).unwrap();
+    assert_eq!(claims["aud"], "https://push.example.com");
+    assert_eq!(claims["sub"], "mailto:a@b.c");
+    let exp = claims["exp"].as_u64().expect("exp must be numeric");
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_secs();
+    assert!(exp > now, "token must not be born expired");
+    assert!(
+        exp <= now + 24 * 60 * 60,
+        "push services reject exp more than 24h out"
+    );
+}
+
+#[test]
 fn build_request_rejects_wrong_length_auth() {
     let vapid = VapidKey::generate();
     let subscriber = VapidKey::generate();

--- a/source/daemon/crates/wctl/Cargo.toml
+++ b/source/daemon/crates/wctl/Cargo.toml
@@ -20,7 +20,5 @@ serde.workspace = true
 serde_json.workspace = true
 # https://crates.io/crates/tokio
 tokio.workspace = true
-# https://crates.io/crates/tabled
-tabled.workspace = true
 # https://crates.io/crates/anyhow
 anyhow.workspace = true

--- a/source/daemon/fuzz/Cargo.lock
+++ b/source/daemon/fuzz/Cargo.lock
@@ -25,19 +25,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
  "cfg-if",
- "cipher 0.4.4",
+ "cipher",
  "cpufeatures 0.2.17",
-]
-
-[[package]]
-name = "aes"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1fc76eaeac4c9164506c466d4ffdd8ec9d0c5bf57ee97177c4d8eceb3a0e138"
-dependencies = [
- "cipher 0.5.2",
- "cpubits",
- "cpufeatures 0.3.0",
 ]
 
 [[package]]
@@ -47,21 +36,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
 dependencies = [
  "aead",
- "aes 0.8.4",
- "cipher 0.4.4",
+ "aes",
+ "cipher",
  "ctr",
  "ghash",
  "subtle",
-]
-
-[[package]]
-name = "aes-keywrap"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10b6f24a1f796bc46415a1d0d18dc0a8203ccba088acf5def3291c4f61225522"
-dependencies = [
- "aes 0.9.1",
- "byteorder",
 ]
 
 [[package]]
@@ -163,18 +142,6 @@ dependencies = [
  "cpufeatures 0.2.17",
  "password-hash",
 ]
-
-[[package]]
-name = "arrayref"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
-
-[[package]]
-name = "arrayvec"
-version = "0.7.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
 
 [[package]]
 name = "asn1-rs"
@@ -378,12 +345,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d86b93f97252c47b41663388e6d155714a9d0c398b99f1005cbc5f978b29f445"
 
 [[package]]
-name = "binstring"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0669d5a35b64fdb5ab7fb19cae13148b6b5cbdf4b8247faf54ece47f699c8cef"
-
-[[package]]
 name = "bit-vec"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -408,17 +369,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
 dependencies = [
  "digest 0.10.7",
-]
-
-[[package]]
-name = "blake2b_simd"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b79834656f71332577234b50bfc009996f7449e0c056884e6a02492ded0ca2f3"
-dependencies = [
- "arrayref",
- "arrayvec",
- "constant_time_eq",
 ]
 
 [[package]]
@@ -488,7 +438,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
 dependencies = [
  "cfg-if",
- "cipher 0.4.4",
+ "cipher",
  "cpufeatures 0.2.17",
 ]
 
@@ -511,7 +461,7 @@ checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
 dependencies = [
  "aead",
  "chacha20 0.9.1",
- "cipher 0.4.4",
+ "cipher",
  "poly1305",
  "zeroize",
 ]
@@ -537,18 +487,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
  "crypto-common 0.1.7",
- "inout 0.1.4",
+ "inout",
  "zeroize",
-]
-
-[[package]]
-name = "cipher"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8cf2a2c93cd704877c0858356ed03480ff301ee950b43f1cbe4573b088bfa6c"
-dependencies = [
- "crypto-common 0.2.2",
- "inout 0.2.2",
 ]
 
 [[package]]
@@ -565,17 +505,6 @@ name = "cmov"
 version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
-
-[[package]]
-name = "coarsetime"
-version = "0.1.37"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e58eb270476aa4fc7843849f8a35063e8743b4dbcdf6dd0f8ea0886980c204c2"
-dependencies = [
- "libc",
- "wasix",
- "wasm-bindgen",
-]
 
 [[package]]
 name = "combine"
@@ -607,12 +536,6 @@ name = "const-oid"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
-
-[[package]]
-name = "constant_time_eq"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 
 [[package]]
 name = "cookie"
@@ -667,12 +590,6 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
-
-[[package]]
-name = "cpubits"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15b85f9c39137c3a891689859392b1bd49812121d0d61c9caf00d46ed5ce06ae"
 
 [[package]]
 name = "cpufeatures"
@@ -778,16 +695,8 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
 dependencies = [
- "getrandom 0.4.2",
  "hybrid-array",
- "rand_core 0.10.1",
 ]
-
-[[package]]
-name = "ct-codecs"
-version = "1.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49fb0c6640b4507ebd99ff67677009e381ba5eee1d14df78de4a3d16eb123c39"
 
 [[package]]
 name = "ctr"
@@ -795,7 +704,7 @@ version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
 dependencies = [
- "cipher 0.4.4",
+ "cipher",
 ]
 
 [[package]]
@@ -862,16 +771,6 @@ checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
  "const-oid 0.9.6",
  "pem-rfc7468",
- "zeroize",
-]
-
-[[package]]
-name = "der"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a69dedd701da44b0536442edf09c81a64b0ab97a7a4a5e3d1971f00027cbc63d"
-dependencies = [
- "const-oid 0.10.2",
  "zeroize",
 ]
 
@@ -970,12 +869,12 @@ version = "0.16.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
 dependencies = [
- "der 0.7.10",
+ "der",
  "digest 0.10.7",
  "elliptic-curve",
  "rfc6979",
- "signature 2.2.0",
- "spki 0.7.3",
+ "signature",
+ "spki",
 ]
 
 [[package]]
@@ -995,18 +894,8 @@ version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
 dependencies = [
- "pkcs8 0.10.2",
- "signature 2.2.0",
-]
-
-[[package]]
-name = "ed25519-compact"
-version = "2.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c24599140dc39d7a81e4476e7573d41bbc18e07c803900298e522a5fbcfbfb6"
-dependencies = [
- "ct-codecs",
- "getrandom 0.4.2",
+ "pkcs8",
+ "signature",
 ]
 
 [[package]]
@@ -1046,7 +935,7 @@ dependencies = [
  "group",
  "hkdf 0.12.4",
  "pem-rfc7468",
- "pkcs8 0.10.2",
+ "pkcs8",
  "rand_core 0.6.4",
  "sec1",
  "subtle",
@@ -1388,13 +1277,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "r-efi 6.0.0",
  "rand_core 0.10.1",
  "wasip2",
  "wasip3",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -1543,30 +1430,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hmac-sha1-compact"
-version = "1.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0b3ba31f6dc772cc8221ce81dbbbd64fa1e668255a6737d95eeace59b5a8823"
-
-[[package]]
-name = "hmac-sha256"
-version = "1.1.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec9d92d097f4749b64e8cc33d924d9f40a2d4eb91402b458014b781f5733d60f"
-dependencies = [
- "digest 0.10.7",
-]
-
-[[package]]
-name = "hmac-sha512"
-version = "1.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "019ece39bbefc17f13f677a690328cb978dbf6790e141a3c24e66372cb38588b"
-dependencies = [
- "digest 0.10.7",
-]
-
-[[package]]
 name = "http"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1617,7 +1480,6 @@ version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
 dependencies = [
- "ctutils",
  "typenum",
 ]
 
@@ -1905,15 +1767,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "inout"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4250ce6452e92010fdf7268ccc5d14faa80bb12fc741938534c58f16804e03c7"
-dependencies = [
- "hybrid-array",
-]
-
-[[package]]
 name = "instant-acme"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2053,63 +1906,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "jwt-simple"
-version = "0.12.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f45048cd18221c81d27dd4621d51df25b33f11b68655d79f67a9f9d3eb48fecc"
-dependencies = [
- "anyhow",
- "binstring",
- "blake2b_simd",
- "coarsetime",
- "ct-codecs",
- "ed25519-compact",
- "hmac-sha1-compact",
- "hmac-sha256",
- "hmac-sha512",
- "k256",
- "p256",
- "p384",
- "rand 0.8.6",
- "serde",
- "serde_json",
- "superboring",
- "thiserror 2.0.18",
- "zeroize",
-]
-
-[[package]]
-name = "k256"
-version = "0.13.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6e3919bbaa2945715f0bb6d3934a173d1e9a59ac23767fbaaef277265a7411b"
-dependencies = [
- "cfg-if",
- "ecdsa",
- "elliptic-curve",
- "once_cell",
- "sha2 0.10.9",
- "signature 2.2.0",
-]
-
-[[package]]
-name = "keccak"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e24a010dd405bd7ed803e5253182815b41bf2e6a80cc3bfc066658e03a198aa"
-dependencies = [
- "cfg-if",
- "cpufeatures 0.3.0",
-]
-
-[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
-dependencies = [
- "spin",
-]
 
 [[package]]
 name = "leb128fmt"
@@ -2132,12 +1932,6 @@ dependencies = [
  "arbitrary",
  "cc",
 ]
-
-[[package]]
-name = "libm"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libsqlite3-sys"
@@ -2260,33 +2054,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ml-dsa"
-version = "0.1.0-rc.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "163f15320f3fba11760c373af52d7f69d638482c2c350d877fb06513b1c3137c"
-dependencies = [
- "const-oid 0.10.2",
- "crypto-common 0.2.2",
- "ctutils",
- "hybrid-array",
- "module-lattice",
- "pkcs8 0.11.0",
- "sha3",
- "signature 3.0.0",
-]
-
-[[package]]
-name = "module-lattice"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c61b87c9683ab7cb1c6871d261ad5479b6b10ceb52c4352aaca3b5d35a8febe"
-dependencies = [
- "ctutils",
- "hybrid-array",
- "num-traits",
-]
-
-[[package]]
 name = "multer"
 version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2342,22 +2109,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-bigint-dig"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e661dda6640fad38e827a6d4a310ff4763082116fe217f279885c97f511bb0b7"
-dependencies = [
- "lazy_static",
- "libm",
- "num-integer",
- "num-iter",
- "num-traits",
- "rand 0.8.6",
- "smallvec",
- "zeroize",
-]
-
-[[package]]
 name = "num-conv"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2373,23 +2124,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-iter"
-version = "0.1.46"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c92800bd69a1eac91786bcfe9da64a897eb72911b8dc3095decbd07429e8048b"
-dependencies = [
- "num-integer",
- "num-traits",
-]
-
-[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
- "libm",
 ]
 
 [[package]]
@@ -2485,18 +2225,6 @@ name = "p256"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
-dependencies = [
- "ecdsa",
- "elliptic-curve",
- "primeorder",
- "sha2 0.10.9",
-]
-
-[[package]]
-name = "p384"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe42f1670a52a47d448f14b6a5c61dd78fce51856e68edaa38f7ae3a46b8d6b6"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
@@ -2648,34 +2376,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
-name = "pkcs1"
-version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
-dependencies = [
- "der 0.7.10",
- "pkcs8 0.10.2",
- "spki 0.7.3",
-]
-
-[[package]]
 name = "pkcs8"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
 dependencies = [
- "der 0.7.10",
- "spki 0.7.3",
-]
-
-[[package]]
-name = "pkcs8"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "451913da69c775a56034ea8d9003d27ee8948e12443eae7c038ba100a4f21cb7"
-dependencies = [
- "der 0.8.1",
- "spki 0.8.0",
+ "der",
+ "spki",
 ]
 
 [[package]]
@@ -3076,27 +2783,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rsa"
-version = "0.9.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
-dependencies = [
- "const-oid 0.9.6",
- "digest 0.10.7",
- "num-bigint-dig",
- "num-integer",
- "num-traits",
- "pkcs1",
- "pkcs8 0.10.2",
- "rand_core 0.6.4",
- "sha2 0.10.9",
- "signature 2.2.0",
- "spki 0.7.3",
- "subtle",
- "zeroize",
-]
-
-[[package]]
 name = "rust-embed"
 version = "8.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3267,7 +2953,7 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97a22f5af31f73a954c10289c93e8a50cc23d971e80ee446f1f6f7137a088213"
 dependencies = [
- "cipher 0.4.4",
+ "cipher",
 ]
 
 [[package]]
@@ -3312,9 +2998,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
 dependencies = [
  "base16ct",
- "der 0.7.10",
+ "der",
  "generic-array",
- "pkcs8 0.10.2",
+ "pkcs8",
  "subtle",
  "zeroize",
 ]
@@ -3496,16 +3182,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sha3"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be176f1a57ce4e3d31c1a166222d9768de5954f811601fb7ca06fc8203905ce1"
-dependencies = [
- "digest 0.11.3",
- "keccak",
-]
-
-[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3538,16 +3214,6 @@ checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "digest 0.10.7",
  "rand_core 0.6.4",
-]
-
-[[package]]
-name = "signature"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d567dcbaf0049cb8ac2608a76cd95ff9e4412e1899d389ee400918ca7537f5"
-dependencies = [
- "digest 0.11.3",
- "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -3619,17 +3285,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
 dependencies = [
  "base64ct",
- "der 0.7.10",
-]
-
-[[package]]
-name = "spki"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d9efca8738c78ee9484207732f728b1ef517bbb1833d6fc0879ca898a522f6f"
-dependencies = [
- "base64ct",
- "der 0.8.1",
+ "der",
 ]
 
 [[package]]
@@ -3839,22 +3495,6 @@ name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
-
-[[package]]
-name = "superboring"
-version = "0.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ad752f6ecf1cde1cd92cff4400137c5d92d376f78bb901d2807a35dba5872a7"
-dependencies = [
- "aes-gcm",
- "aes-keywrap",
- "getrandom 0.2.17",
- "hmac-sha256",
- "hmac-sha512",
- "ml-dsa",
- "rand 0.8.6",
- "rsa",
-]
 
 [[package]]
 name = "syn"
@@ -4593,15 +4233,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasix"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae86f02046da16a333a9129d31451423e1657737ecdafed4193838a5f54c5cfe"
-dependencies = [
- "wasi",
-]
-
-[[package]]
 name = "wasm-bindgen"
 version = "0.2.123"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4710,13 +4341,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2175ef28a9a693fa88f322d88484f702a340da864a449a2b6b2a1fe26db712f3"
 dependencies = [
  "aes-gcm",
- "base64ct",
  "ece-native",
  "hkdf 0.12.4",
  "http",
- "jwt-simple",
  "p256",
- "serde",
  "sha2 0.10.9",
 ]
 

--- a/source/daemon/fuzz/osv-scanner.toml
+++ b/source/daemon/fuzz/osv-scanner.toml
@@ -1,0 +1,22 @@
+# osv-scanner config for the fuzz workspace's own lockfile.
+#
+# osv-scanner (and OpenSSF Scorecard's Vulnerabilities check, which runs
+# it) resolves config per lockfile *directory* — the parent
+# source/daemon/osv-scanner.toml does NOT apply to fuzz/Cargo.lock. The
+# fuzz targets link the production crates via path deps, so any advisory
+# that is transitively unavoidable in the daemon workspace shows up here
+# too and needs its ignore duplicated. Keep the reasoning in sync with
+# ../osv-scanner.toml.
+#
+# Format: https://google.github.io/osv-scanner/configuration/
+
+[[IgnoredVulns]]
+id = "RUSTSEC-2026-0173"
+reason = """
+proc-macro-error2 unmaintained. Compile-time proc-macro pulled in via
+i18n-embed-fl (through wardnetd-services' age dependency). Not a CVE —
+the author stopped publishing updates. Zero runtime footprint. Blocked
+on age → i18n-embed-fl migrating off proc-macro-error2. Tracked in
+wardnet/wardnet#758; remove this entry when `cargo tree -i
+proc-macro-error2` returns nothing.
+"""

--- a/source/daemon/osv-scanner.toml
+++ b/source/daemon/osv-scanner.toml
@@ -7,13 +7,6 @@
 # Format: https://google.github.io/osv-scanner/configuration/
 
 [[IgnoredVulns]]
-id = "RUSTSEC-2023-0071"
-reason = """
-rsa timing sidechannel (Marvin Attack). Transitive via sqlx-mysql, which
-we don't link — sqlx is compiled with SQLite only. No upstream fix.
-"""
-
-[[IgnoredVulns]]
 id = "RUSTSEC-2024-0436"
 reason = """
 paste crate unmaintained. Compile-time proc-macro pulled in via
@@ -59,12 +52,12 @@ Re-evaluate when dhcproto upgrades.
 id = "RUSTSEC-2026-0173"
 reason = """
 proc-macro-error2 unmaintained. Compile-time proc-macro pulled in via
-i18n-embed-fl (through age) and tabled_derive (through wctl's tabled).
-Not a CVE — the author stopped publishing updates. Zero runtime
-footprint. Blocked on age → i18n-embed-fl migrating off
-proc-macro-error2 (the tabled/wctl path is removable but not
-sufficient alone). Tracked in wardnet/wardnet#758; remove this entry
-when `cargo tree -i proc-macro-error2` returns nothing.
+i18n-embed-fl (through age). Not a CVE — the author stopped publishing
+updates. Zero runtime footprint. Blocked on age → i18n-embed-fl
+migrating off proc-macro-error2 (even latest i18n-embed-fl 0.10 still
+depends on it). Tracked in wardnet/wardnet#758; remove this entry (and
+the copy in fuzz/osv-scanner.toml) when `cargo tree -i
+proc-macro-error2` returns nothing.
 """
 
 [[IgnoredVulns]]


### PR DESCRIPTION
Scorecard's Vulnerabilities check was still reporting RUSTSEC-2023-0071 (`rsa`, Marvin timing sidechannel) and RUSTSEC-2026-0173 (`proc-macro-error2`, unmaintained) even though both were triaged in `osv-scanner.toml`. Root cause: osv-scanner resolves its config **per lockfile directory**, and both crates also sit in `fuzz/Cargo.lock`, which had no config next to it — so the fuzz workspace kept both advisories alive. The other five triaged advisories only touch the main lockfile, which is why they never showed up.

Rather than just duplicating the ignores, this fixes what can actually be fixed:

**RUSTSEC-2023-0071 — fixed, not suppressed.** The only `rsa` path was web-push-native's default `vapid` feature, which pulls jwt-simple → superboring → `rsa` purely to mint the RFC 8292 VAPID token. We never use RSA — VAPID is ECDSA P-256. web-push-native is now built without default features and the push sender signs the `Authorization: vapid t=…, k=…` header itself with the `p256` the crate already re-exports. Claims (`aud`/`exp`/`sub`), 12h token lifetime, header shape and the stored 32-byte key format are all unchanged, so existing VAPID keys and subscriptions keep working. This evicts `rsa` and the whole jwt-simple tree (~35 crates) from both lockfiles, and the old ignore entries are deleted. A new test decodes the minted token and verifies the ES256 signature against the advertised key.

**RUSTSEC-2026-0173 — narrowed to the one unavoidable path.** Dropped `tabled` from wctl (declared but never used), which removes the `tabled_derive` path. The remaining path is `age → i18n-embed-fl`, which still has no upstream fix (even i18n-embed-fl 0.10 depends on proc-macro-error2; tracked in #758). That triaged ignore is now duplicated into a new `fuzz/osv-scanner.toml` so it finally covers the fuzz lockfile; the staleness watchdog reads the new file and the security workflow triggers on it.

Verification:
- `cargo check --workspace --all-targets`, `cargo clippy -p wardnetd-services -p wctl --all-targets` clean
- `cargo test -p wardnetd-services`: 1253 passed (includes the new VAPID token verification test)
- `audit-ignore-staleness.py` against a fresh advisory-db: 6 active, 0 stale, 0 unresolved
- `rsa`, `jwt-simple`, `superboring`, `tabled` absent from both lockfiles