### PR TITLE
ci: enable cubit performance tracking (advisory)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -176,3 +176,19 @@ jobs:
       packages: read
     uses: ./.github/workflows/tests-e2e.yml
     secrets: inherit
+
+  cubit:
+    name: Cubit
+    needs: preflight
+    # Record the performance baseline on main so the next PR has something to
+    # compare against. Advisory; never blocks. No bot-skip (a push to main is a
+    # trusted event with a full token, like the coverage leaf). pull-requests
+    # is granted only to match the shared reusable workflow's ceiling — the
+    # record path posts no comment.
+    if: >
+      needs.preflight.outputs.daemon == 'true' ||
+      needs.preflight.outputs.ci == 'true'
+    permissions:
+      contents: write
+      pull-requests: write
+    uses: ./.github/workflows/cubit.yml

--- a/.github/workflows/cubit.yml
+++ b/.github/workflows/cubit.yml
@@ -1,0 +1,44 @@
+name: Cubit
+
+# Reusable leaf for performance-regression tracking via cubit
+# (github.com/wardnet/cubit). Called from pr.yml (compare + sticky PR comment)
+# and ci.yml (record the baseline on main). Mirrors how the `bulwark` coverage
+# leaf is wired.
+#
+# Advisory ONLY: cubit never fails the build, and this leaf is deliberately left
+# out of pr.yml's `all-checks-passed` aggregator so it can't gate a merge. The
+# PR comment and trend dashboard inform a human go/no-go.
+#
+# NOTE: this leaf does not run any benchmarks yet — it is wired ahead of the
+# benchmarks so the workflow already exists on `main` when the benchmarks PR
+# opens (and thus reliably runs on it). Until then, cubit finds no criterion
+# output and posts a short "no benchmark data" note; the benchmarks PR adds the
+# `cargo bench` step that produces real data.
+
+on:
+  workflow_call:
+
+# Workflow-level stays read-only; the job below elevates to the writes it needs,
+# which the caller (pr.yml / ci.yml cubit job) must grant to the same ceiling.
+permissions:
+  contents: read
+
+jobs:
+  cubit:
+    name: cubit
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: write # push the cubit-state baseline branch (record, on main)
+      pull-requests: write # post/update the sticky performance comment (compare, on PRs)
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+
+      - uses: wardnet/cubit@v0.0.1
+        with:
+          criterion-dir: source/daemon/target/criterion

--- a/.github/workflows/cubit.yml
+++ b/.github/workflows/cubit.yml
@@ -39,6 +39,9 @@ jobs:
 
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
-      - uses: wardnet/cubit@v0.0.1
+      # Moving major tag: cubit advances `v0` on each 0.x release, so fixes flow
+      # here without a wardnet bump (same pattern as bulwark's @v1). Pin to an
+      # exact version once cubit reaches 1.0.
+      - uses: wardnet/cubit@v0
         with:
           criterion-dir: source/daemon/target/criterion

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -182,6 +182,27 @@ jobs:
     uses: ./.github/workflows/tests-e2e.yml
     secrets: inherit
 
+  cubit:
+    name: Cubit
+    needs: preflight
+    # Advisory performance-regression tracking (compare + PR comment). Gated on
+    # the same `daemon || ci` filter as build-daemon. Skip bot-authored PRs:
+    # same-repo bot branches (Dependabot etc.) get a read-only token, so the PR
+    # comment can't be posted — matching the coverage leaf's bot skip. Gate on
+    # the PR author, not github.actor, so a re-run doesn't flip it.
+    #
+    # Deliberately NOT listed in `all-checks-passed` below: cubit is a light
+    # gate and must never block a merge.
+    if: >
+      github.event.pull_request.user.type != 'Bot' && (
+        needs.preflight.outputs.daemon == 'true' ||
+        needs.preflight.outputs.ci == 'true'
+      )
+    permissions:
+      contents: write # cubit pushes/reads the cubit-state baseline branch
+      pull-requests: write # cubit posts the sticky performance comment
+    uses: ./.github/workflows/cubit.yml
+
   # Aggregator for branch protection. Lists every other job as a
   # dependency, runs unconditionally (if: always()), and passes iff
   # each dependency either succeeded or was legitimately skipped via


### PR DESCRIPTION
## Summary

Enable [cubit](https://github.com/wardnet/cubit) performance-regression tracking
in CI, mirroring how the `bulwark` coverage leaf is wired. This is the **first**
of two PRs: it lands the workflow on `main` so the follow-up **benchmarks** PR
reliably triggers it.

## What this does

- **`.github/workflows/cubit.yml`** (new, reusable) — calls `wardnet/cubit@v0.0.1`
  against `source/daemon/target/criterion`. cubit auto-detects mode from the
  event: **compare + sticky PR comment** on `pull_request`, **record the baseline**
  (push to the `cubit-state` branch) on push to `main`.
- **`pr.yml` / `ci.yml`** — add a `cubit` leaf gated on `daemon || ci` (same
  filter as `build-daemon`), skipping bot-authored PRs (a same-repo bot branch
  gets a read-only token and can't post the comment — matching the coverage leaf).
- Scoped permissions: `contents: write` (the `cubit-state` branch) +
  `pull-requests: write` (the comment); harden-runner audit; pinned actions.

## Advisory, never blocks

cubit is a **light gate**: the action never exits non-zero, and this leaf is
deliberately **left out of `all-checks-passed`**, so it can't gate a merge. The
PR comment + trend dashboard inform a human go/no-go.

## No benchmarks yet — by design

There are no daemon benches in-tree yet, so this PR runs no `cargo bench`. cubit
finds no criterion output and posts a short "no benchmark data" note (green).
The point is to get the workflow onto `main` first. The **next PR** adds the
`DnsCache` criterion benches plus the `cargo bench` step, at which point cubit
posts the first real comparison and — on merge — records the baseline.

## Verification

- All three workflow files parse; `cubit` confirmed absent from the
  `all-checks-passed` aggregator.
- cubit `v0.0.1` is released and was verified end-to-end (install, version,
  self-update) in its own repo.

## Merge Commit Message

ci: enable cubit performance tracking (advisory)

Wire wardnet/cubit@v0.0.1 into CI, mirroring the bulwark coverage leaf: a reusable cubit.yml (compare + PR comment on pull_request, record the baseline on push to main), added to pr.yml/ci.yml as a `daemon || ci`-gated leaf that skips bot PRs. Advisory only — never fails the build, excluded from all-checks-passed. No benchmarks run yet; this lands the workflow on main ahead of the benchmarks PR.
