### PR TITLE
fix(daemon): make device IP lookup deterministic and clear IP on departure

### DIFF
--- a/source/daemon/crates/wardnetd-api/src/api/devices.rs
+++ b/source/daemon/crates/wardnetd-api/src/api/devices.rs
@@ -234,10 +234,10 @@ pub async fn get_device(
     let device = state.discovery_service().get_device_by_id(uuid).await?;
     let rule = state
         .device_service()
-        .get_device_for_ip(&device.last_ip)
+        .get_rule_for_device(&device.id.to_string())
         .await
         .ok()
-        .and_then(|r| r.current_rule);
+        .flatten();
     let dhcp_map = build_dhcp_status_map(&state).await?;
     let device = enrich_device(device, &dhcp_map, rule.clone());
     Ok(Json(DeviceDetailResponse {
@@ -309,10 +309,10 @@ pub async fn update_device(
     // Fetch current rule for the response.
     let rule = state
         .device_service()
-        .get_device_for_ip(&device.last_ip)
+        .get_rule_for_device(&device_id_str)
         .await
         .ok()
-        .and_then(|r| r.current_rule);
+        .flatten();
 
     let dhcp_map = build_dhcp_status_map(&state).await?;
     let device = enrich_device(device, &dhcp_map, rule.clone());
@@ -355,10 +355,10 @@ pub async fn assign_device_zone(
     let device = state.discovery_service().get_device_by_id(uuid).await?;
     let rule = state
         .device_service()
-        .get_device_for_ip(&device.last_ip)
+        .get_rule_for_device(&device.id.to_string())
         .await
         .ok()
-        .and_then(|r| r.current_rule);
+        .flatten();
     let dhcp_map = build_dhcp_status_map(&state).await?;
     let device = enrich_device(device, &dhcp_map, rule.clone());
     Ok(Json(DeviceDetailResponse {

--- a/source/daemon/crates/wardnetd-api/src/api/tests/devices.rs
+++ b/source/daemon/crates/wardnetd-api/src/api/tests/devices.rs
@@ -268,6 +268,13 @@ impl DeviceService for MockDeviceService {
         Ok(self.current_rules.clone())
     }
 
+    async fn get_rule_for_device(
+        &self,
+        _device_id: &str,
+    ) -> Result<Option<RoutingTarget>, AppError> {
+        Ok(self.rule.clone())
+    }
+
     async fn update_admin_locked(&self, _id: &str, _locked: bool) -> Result<(), AppError> {
         Ok(())
     }
@@ -610,6 +617,10 @@ fn device_router(state: AppState) -> Router {
         .route(
             "/api/devices/{id}",
             get(crate::api::devices::get_device).put(crate::api::devices::update_device),
+        )
+        .route(
+            "/api/devices/{id}/zone",
+            put(crate::api::devices::assign_device_zone),
         )
         .with_state(state)
 }
@@ -1003,6 +1014,32 @@ async fn get_device_by_id_invalid_uuid() {
 // ---------------------------------------------------------------------------
 // PUT /api/devices/:id (admin, update)
 // ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn assign_device_zone_success() {
+    let device = sample_device();
+    let state = build_state_with_dhcp(
+        MockDeviceService::found(device.clone(), Some(RoutingTarget::Direct)),
+        MockDiscoveryService {
+            devices: vec![device],
+        },
+        MockDhcpService::empty(),
+    );
+    let app = device_router(state);
+
+    // The handler resolves the device's current rule by device ID (not by its
+    // last_ip, which is cleared on departure — issue #831), so the response
+    // still carries the correct rule for the reassigned device.
+    let (status, json) = put_json(
+        app,
+        "/api/devices/00000000-0000-0000-0000-000000000001/zone",
+        r#"{"zone_id":"00000000-0000-0000-0000-000000000201"}"#,
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(json["device"]["mac"], "aa:bb:cc:dd:ee:01");
+    assert_eq!(json["current_rule"]["type"], "direct");
+}
 
 #[tokio::test]
 async fn update_device_success() {

--- a/source/daemon/crates/wardnetd-api/src/api/tests/dns_capture.rs
+++ b/source/daemon/crates/wardnetd-api/src/api/tests/dns_capture.rs
@@ -150,6 +150,12 @@ impl DeviceService for MockDnsDeviceService {
     ) -> Result<std::collections::HashMap<Uuid, RoutingTarget>, AppError> {
         unimplemented!()
     }
+    async fn get_rule_for_device(
+        &self,
+        _device_id: &str,
+    ) -> Result<Option<RoutingTarget>, AppError> {
+        unimplemented!()
+    }
     async fn update_admin_locked(&self, _id: &str, _locked: bool) -> Result<(), AppError> {
         unimplemented!()
     }

--- a/source/daemon/crates/wardnetd-api/src/api/tests/dns_events.rs
+++ b/source/daemon/crates/wardnetd-api/src/api/tests/dns_events.rs
@@ -202,6 +202,12 @@ impl DeviceService for MockDnsEventsDeviceService {
     ) -> Result<std::collections::HashMap<Uuid, RoutingTarget>, AppError> {
         unimplemented!()
     }
+    async fn get_rule_for_device(
+        &self,
+        _device_id: &str,
+    ) -> Result<Option<RoutingTarget>, AppError> {
+        unimplemented!()
+    }
     async fn update_admin_locked(&self, _id: &str, _locked: bool) -> Result<(), AppError> {
         unimplemented!()
     }

--- a/source/daemon/crates/wardnetd-api/src/api/tests/middleware.rs
+++ b/source/daemon/crates/wardnetd-api/src/api/tests/middleware.rs
@@ -445,6 +445,12 @@ impl DeviceService for MockDeviceService {
     ) -> Result<std::collections::HashMap<Uuid, RoutingTarget>, AppError> {
         unimplemented!()
     }
+    async fn get_rule_for_device(
+        &self,
+        _device_id: &str,
+    ) -> Result<Option<RoutingTarget>, AppError> {
+        unimplemented!()
+    }
     async fn update_admin_locked(&self, _id: &str, _locked: bool) -> Result<(), AppError> {
         unimplemented!()
     }

--- a/source/daemon/crates/wardnetd-api/src/tests/stubs.rs
+++ b/source/daemon/crates/wardnetd-api/src/tests/stubs.rs
@@ -162,6 +162,12 @@ impl DeviceService for StubDeviceService {
     ) -> Result<std::collections::HashMap<Uuid, RoutingTarget>, AppError> {
         unimplemented!()
     }
+    async fn get_rule_for_device(
+        &self,
+        _device_id: &str,
+    ) -> Result<Option<RoutingTarget>, AppError> {
+        unimplemented!()
+    }
     async fn update_admin_locked(&self, _id: &str, _locked: bool) -> Result<(), AppError> {
         unimplemented!()
     }

--- a/source/daemon/crates/wardnetd-data/src/repository/device.rs
+++ b/source/daemon/crates/wardnetd-data/src/repository/device.rs
@@ -58,6 +58,15 @@ pub trait DeviceRepository: Send + Sync {
         mode: DeviceConnectionMode,
     ) -> anyhow::Result<()>;
 
+    /// Clear a device's `last_ip`, leaving the row otherwise intact.
+    ///
+    /// Called when a device is marked gone so its (now stale) row can no longer
+    /// collide with a live device's address in [`find_by_ip`](Self::find_by_ip)
+    /// once DHCP recycles the departed device's IP. The address is emptied
+    /// rather than the row deleted — device history is retained; the row is just
+    /// no longer resolvable by IP until the device is observed again.
+    async fn clear_last_ip(&self, id: &str) -> anyhow::Result<()>;
+
     /// Batch update `last_seen` timestamps. Each tuple is (`device_id`, `last_seen_iso`).
     async fn update_last_seen_batch(&self, updates: &[(String, String)]) -> anyhow::Result<()>;
 

--- a/source/daemon/crates/wardnetd-data/src/repository/sqlite/device.rs
+++ b/source/daemon/crates/wardnetd-data/src/repository/sqlite/device.rs
@@ -94,7 +94,15 @@ const SELECT_COLS: &str = "id, mac, name, hostname, manufacturer, device_type, f
 #[async_trait]
 impl DeviceRepository for SqliteDeviceRepository {
     async fn find_by_ip(&self, ip: &str) -> anyhow::Result<Option<Device>> {
-        let query = format!("SELECT {SELECT_COLS} FROM devices WHERE last_ip = ?");
+        // `last_ip` is not unique: departed devices keep their row, so DHCP
+        // recycling an address to a new device leaves two rows sharing an IP.
+        // Order by `last_seen DESC` so the lookup always resolves to the most
+        // recently seen (live) device rather than an arbitrary rowid-ordered
+        // (stale) one — the IP-keyed self-service auth path relies on this to
+        // identify the caller's own device.
+        let query = format!(
+            "SELECT {SELECT_COLS} FROM devices WHERE last_ip = ? ORDER BY last_seen DESC LIMIT 1"
+        );
         let row = sqlx::query_as::<_, DeviceRow>(sqlx::AssertSqlSafe(query))
             .bind(ip)
             .fetch_optional(&self.pools.read)
@@ -168,6 +176,19 @@ impl DeviceRepository for SqliteDeviceRepository {
         .bind(id)
         .execute(&self.pools.write)
         .await?;
+        Ok(())
+    }
+
+    async fn clear_last_ip(&self, id: &str) -> anyhow::Result<()> {
+        // Empty the address rather than deleting the row: the device history is
+        // still wanted, but a departed row must never again match a live
+        // request's source IP in `find_by_ip`. Empty string is the established
+        // "no known address" sentinel (see discovery `restore_devices`); the
+        // NOT NULL column forbids a true NULL.
+        sqlx::query("UPDATE devices SET last_ip = '' WHERE id = ?")
+            .bind(id)
+            .execute(&self.pools.write)
+            .await?;
         Ok(())
     }
 

--- a/source/daemon/crates/wardnetd-data/src/repository/sqlite/device.rs
+++ b/source/daemon/crates/wardnetd-data/src/repository/sqlite/device.rs
@@ -94,6 +94,15 @@ const SELECT_COLS: &str = "id, mac, name, hostname, manufacturer, device_type, f
 #[async_trait]
 impl DeviceRepository for SqliteDeviceRepository {
     async fn find_by_ip(&self, ip: &str) -> anyhow::Result<Option<Device>> {
+        // Empty string is the "no known address" sentinel written to departed
+        // devices (see `clear_last_ip` / discovery `restore_devices`), not a
+        // real address. Never match on it: every departed device shares it, so
+        // an empty lookup would otherwise resolve to an arbitrary departed row
+        // (mirrors the `is_empty` guard in `DeviceIpSnapshot`).
+        if ip.is_empty() {
+            return Ok(None);
+        }
+
         // `last_ip` is not unique: departed devices keep their row, so DHCP
         // recycling an address to a new device leaves two rows sharing an IP.
         // Order by `last_seen DESC` so the lookup always resolves to the most

--- a/source/daemon/crates/wardnetd-data/src/repository/tests/device.rs
+++ b/source/daemon/crates/wardnetd-data/src/repository/tests/device.rs
@@ -24,7 +24,16 @@ fn sample_device_row(id: &str, mac: &str, ip: &str) -> DeviceRow {
 }
 
 async fn insert_device(pool: &sqlx::SqlitePool, id: &str, mac: &str, ip: &str) {
-    let now = "2026-03-07T00:00:00Z";
+    insert_device_seen_at(pool, id, mac, ip, "2026-03-07T00:00:00Z").await;
+}
+
+async fn insert_device_seen_at(
+    pool: &sqlx::SqlitePool,
+    id: &str,
+    mac: &str,
+    ip: &str,
+    last_seen: &str,
+) {
     sqlx::query(
         "INSERT INTO devices (id, mac, last_ip, device_type, first_seen, last_seen, zone_id) \
          VALUES (?, ?, ?, 'unknown', ?, ?, '00000000-0000-0000-0000-000000000201')",
@@ -32,8 +41,8 @@ async fn insert_device(pool: &sqlx::SqlitePool, id: &str, mac: &str, ip: &str) {
     .bind(id)
     .bind(mac)
     .bind(ip)
-    .bind(now)
-    .bind(now)
+    .bind("2026-03-07T00:00:00Z")
+    .bind(last_seen)
     .execute(pool)
     .await
     .unwrap();
@@ -60,6 +69,63 @@ async fn find_by_ip_not_found() {
 
     let result = repo.find_by_ip("10.0.0.99").await.unwrap();
     assert!(result.is_none());
+}
+
+// Regression for issue #831: `last_ip` is not unique (departed devices keep
+// their row), so DHCP recycling an address leaves two rows sharing it. The
+// lookup must resolve to the most recently seen (live) device, not an arbitrary
+// rowid-ordered (stale) one — the IP-keyed self-service auth path depends on it.
+#[tokio::test]
+async fn find_by_ip_returns_most_recently_seen_on_collision() {
+    let pool = test_pool().await;
+    // DEV1 is the older, departed occupant of the address; DEV2 is the live
+    // device DHCP later handed the same IP to. DEV1 is inserted first so it wins
+    // the rowid ordering that the un-ordered query used to return.
+    insert_device_seen_at(
+        &pool,
+        DEV1,
+        "aa:bb:cc:dd:ee:01",
+        "192.168.1.10",
+        "2026-03-07T00:00:00Z",
+    )
+    .await;
+    insert_device_seen_at(
+        &pool,
+        DEV2,
+        "aa:bb:cc:dd:ee:02",
+        "192.168.1.10",
+        "2026-03-08T00:00:00Z",
+    )
+    .await;
+    let repo = SqliteDeviceRepository::new(pool);
+
+    let device = repo.find_by_ip("192.168.1.10").await.unwrap().unwrap();
+    assert_eq!(
+        device.id.to_string(),
+        DEV2,
+        "collision must resolve to the more recently seen device"
+    );
+}
+
+// Regression for issue #831: clearing a departed device's `last_ip` must make
+// its row unresolvable by that IP so it can never again be returned for a live
+// device's source address.
+#[tokio::test]
+async fn clear_last_ip_removes_row_from_ip_lookup() {
+    let pool = test_pool().await;
+    insert_device(&pool, DEV1, "aa:bb:cc:dd:ee:01", "192.168.1.10").await;
+    let repo = SqliteDeviceRepository::new(pool);
+
+    // Precondition: the device resolves by its IP.
+    assert!(repo.find_by_ip("192.168.1.10").await.unwrap().is_some());
+
+    repo.clear_last_ip(DEV1).await.unwrap();
+
+    // The row still exists but no longer carries the address...
+    let device = repo.find_by_id(DEV1).await.unwrap().unwrap();
+    assert_eq!(device.last_ip, "");
+    // ...so a lookup for that IP no longer returns the departed device.
+    assert!(repo.find_by_ip("192.168.1.10").await.unwrap().is_none());
 }
 
 #[tokio::test]

--- a/source/daemon/crates/wardnetd-data/src/repository/tests/device.rs
+++ b/source/daemon/crates/wardnetd-data/src/repository/tests/device.rs
@@ -128,6 +128,23 @@ async fn clear_last_ip_removes_row_from_ip_lookup() {
     assert!(repo.find_by_ip("192.168.1.10").await.unwrap().is_none());
 }
 
+// Regression for issue #831: empty string is the "no known address" sentinel
+// written to departed devices, not a real address. Every departed device shares
+// it, so an empty lookup must never match — otherwise it would resolve to an
+// arbitrary departed row (and, via `get_device_for_ip(&device.last_ip)`, surface
+// another device's routing rule).
+#[tokio::test]
+async fn find_by_ip_empty_returns_none() {
+    let pool = test_pool().await;
+    // Two departed devices, both with their address cleared to the empty
+    // sentinel and distinct last_seen timestamps.
+    insert_device_seen_at(&pool, DEV1, "aa:bb:cc:dd:ee:01", "", "2026-03-07T00:00:00Z").await;
+    insert_device_seen_at(&pool, DEV2, "aa:bb:cc:dd:ee:02", "", "2026-03-08T00:00:00Z").await;
+    let repo = SqliteDeviceRepository::new(pool);
+
+    assert!(repo.find_by_ip("").await.unwrap().is_none());
+}
+
 #[tokio::test]
 async fn find_by_id_found() {
     let pool = test_pool().await;

--- a/source/daemon/crates/wardnetd-services/src/device/discovery.rs
+++ b/source/daemon/crates/wardnetd-services/src/device/discovery.rs
@@ -335,6 +335,38 @@ impl DeviceDiscoveryServiceImpl {
             .clone()
     }
 
+    /// Clear a departed device's stored `last_ip` so its row can no longer be
+    /// resolved by a live device's source IP in `find_by_ip` (the IP-keyed
+    /// self-service auth path) once DHCP recycles the departed address.
+    ///
+    /// Taken under the per-mac lock and gated on the device still being `gone`:
+    /// a device that reappears in the same instant as the departure sweep has
+    /// already had the live IP written to its row by its own observation, so we
+    /// must not clobber that back to empty. Holding the same lock the
+    /// observation path holds serialises the two; the re-check closes the window
+    /// between the sweep flipping `gone` and this acquiring the lock.
+    async fn clear_departed_ip(&self, device_id: Uuid, mac: &str) {
+        let mac_lock = self.lock_for_mac(mac).await;
+        let _guard = mac_lock.lock_owned().await;
+
+        let still_gone = {
+            let state = self.state.read().await;
+            state.get(mac).is_none_or(|entry| entry.gone)
+        };
+        if !still_gone {
+            return;
+        }
+
+        if let Err(e) = self.devices.clear_last_ip(&device_id.to_string()).await {
+            tracing::warn!(
+                error = %e,
+                device_id = %device_id,
+                mac = %mac,
+                "device discovery: failed to clear departed device's last_ip"
+            );
+        }
+    }
+
     /// Handle a device not found in the in-memory map.
     ///
     /// Checks the database for a previous record, and either reappears the device
@@ -832,6 +864,7 @@ impl DeviceDiscoveryService for DeviceDiscoveryServiceImpl {
         let ids: Vec<Uuid> = departed.iter().map(|(id, _, _)| *id).collect();
 
         for (device_id, mac, last_ip) in departed {
+            self.clear_departed_ip(device_id, &mac).await;
             self.publish_device_gone(device_id, mac, last_ip);
         }
 
@@ -1125,6 +1158,7 @@ impl DeviceDiscoveryService for DeviceDiscoveryServiceImpl {
 
         match gone {
             Some((id, mac, last_ip)) => {
+                self.clear_departed_ip(id, &mac).await;
                 self.publish_device_gone(id, mac, last_ip);
                 Ok(Some(id))
             }

--- a/source/daemon/crates/wardnetd-services/src/device/discovery.rs
+++ b/source/daemon/crates/wardnetd-services/src/device/discovery.rs
@@ -349,15 +349,14 @@ impl DeviceDiscoveryServiceImpl {
         let mac_lock = self.lock_for_mac(mac).await;
         let _guard = mac_lock.lock_owned().await;
 
+        // Skip the clear if the device reappeared between the sweep flipping
+        // `gone` and this acquiring the lock — its observation has already
+        // written the live IP under this same lock, which we must not clobber.
         let still_gone = {
             let state = self.state.read().await;
             state.get(mac).is_none_or(|entry| entry.gone)
         };
-        if !still_gone {
-            return;
-        }
-
-        if let Err(e) = self.devices.clear_last_ip(&device_id.to_string()).await {
+        if still_gone && let Err(e) = self.devices.clear_last_ip(&device_id.to_string()).await {
             tracing::warn!(
                 error = %e,
                 device_id = %device_id,

--- a/source/daemon/crates/wardnetd-services/src/device/service.rs
+++ b/source/daemon/crates/wardnetd-services/src/device/service.rs
@@ -58,6 +58,16 @@ pub trait DeviceService: Send + Sync {
     /// Requires admin privileges via the [`AuthContext`].
     async fn current_rules(&self) -> Result<HashMap<Uuid, RoutingTarget>, AppError>;
 
+    /// Return the current routing target for a single device by its ID, if it
+    /// has one.
+    ///
+    /// Resolves the rule directly from the device ID rather than round-tripping
+    /// through the device's `last_ip` — a departed device's `last_ip` is cleared,
+    /// so an IP-keyed lookup would either miss the rule or resolve to a
+    /// different device. Requires admin privileges via the [`AuthContext`].
+    async fn get_rule_for_device(&self, device_id: &str)
+    -> Result<Option<RoutingTarget>, AppError>;
+
     /// Update the `admin_locked` flag for a device.
     ///
     /// Requires admin privileges via the [`AuthContext`].
@@ -382,6 +392,21 @@ impl DeviceService for DeviceServiceImpl {
             .map_err(AppError::Internal)?;
 
         Ok(rules.into_iter().map(|r| (r.device_id, r.target)).collect())
+    }
+
+    async fn get_rule_for_device(
+        &self,
+        device_id: &str,
+    ) -> Result<Option<RoutingTarget>, AppError> {
+        auth_context::require_admin()?;
+
+        let rule = self
+            .devices
+            .find_rule_for_device(device_id)
+            .await
+            .map_err(AppError::Internal)?;
+
+        Ok(rule.map(|r| r.target))
     }
 
     async fn update_admin_locked(&self, device_id: &str, locked: bool) -> Result<(), AppError> {

--- a/source/daemon/crates/wardnetd-services/src/device/tests/device.rs
+++ b/source/daemon/crates/wardnetd-services/src/device/tests/device.rs
@@ -42,6 +42,9 @@ impl DeviceRepository for MockDeviceRepo {
     async fn insert(&self, _device: &DeviceRow) -> anyhow::Result<()> {
         Ok(())
     }
+    async fn clear_last_ip(&self, _id: &str) -> anyhow::Result<()> {
+        Ok(())
+    }
     async fn update_last_seen_and_ip(
         &self,
         _id: &str,
@@ -798,6 +801,9 @@ async fn update_dns_capture_settings_returns_404_for_unknown() {
             Ok(vec![])
         }
         async fn insert(&self, _device: &DeviceRow) -> anyhow::Result<()> {
+            Ok(())
+        }
+        async fn clear_last_ip(&self, _id: &str) -> anyhow::Result<()> {
             Ok(())
         }
         async fn update_last_seen_and_ip(

--- a/source/daemon/crates/wardnetd-services/src/device/tests/device.rs
+++ b/source/daemon/crates/wardnetd-services/src/device/tests/device.rs
@@ -704,6 +704,40 @@ async fn current_rules_anonymous_forbidden() {
     assert!(result.is_err());
 }
 
+// -- Tests: get_rule_for_device ------------------------------------------
+
+#[tokio::test]
+async fn get_rule_for_device_returns_target() {
+    let svc = make_svc(false, Some(sample_rule()));
+
+    let rule = auth_context::with_context(admin_ctx(), svc.get_rule_for_device("dev-id"))
+        .await
+        .unwrap();
+
+    assert_eq!(rule, Some(RoutingTarget::Direct));
+}
+
+#[tokio::test]
+async fn get_rule_for_device_none_when_no_rule() {
+    let svc = make_svc(false, None);
+
+    let rule = auth_context::with_context(admin_ctx(), svc.get_rule_for_device("dev-id"))
+        .await
+        .unwrap();
+
+    assert_eq!(rule, None);
+}
+
+#[tokio::test]
+async fn get_rule_for_device_anonymous_forbidden() {
+    let svc = make_svc(false, Some(sample_rule()));
+
+    let result =
+        auth_context::with_context(AuthContext::Anonymous, svc.get_rule_for_device("dev-id")).await;
+
+    assert!(result.is_err());
+}
+
 // -- Tests: get_dns_capture_settings -------------------------------------
 
 #[tokio::test]

--- a/source/daemon/crates/wardnetd-services/src/device/tests/discovery.rs
+++ b/source/daemon/crates/wardnetd-services/src/device/tests/discovery.rs
@@ -52,6 +52,9 @@ struct MockDeviceRepo {
     batch_updates: Mutex<Vec<(String, String)>>,
     hostname_updates: Mutex<Vec<(String, String)>>,
     name_type_updates: Mutex<Vec<(String, Option<String>, String)>>,
+    /// When set, `clear_last_ip` returns an error, exercising the departure
+    /// sweep's failure-tolerant path.
+    fail_clear_last_ip: std::sync::atomic::AtomicBool,
 }
 
 impl MockDeviceRepo {
@@ -72,6 +75,7 @@ impl MockDeviceRepo {
             batch_updates: Mutex::new(Vec::new()),
             hostname_updates: Mutex::new(Vec::new()),
             name_type_updates: Mutex::new(Vec::new()),
+            fail_clear_last_ip: std::sync::atomic::AtomicBool::new(false),
         }
     }
 }
@@ -152,6 +156,32 @@ impl DeviceRepository for MockDeviceRepo {
             last_seen.to_owned(),
             mode,
         ));
+
+        // Mirror the SQLite repo so an observation's IP write is reflected in
+        // subsequent lookups (e.g. a reappearance restoring an IP the departure
+        // sweep had cleared).
+        let mut devices = self.devices.lock().unwrap();
+        if let Some(d) = devices.iter_mut().find(|d| d.id.to_string() == id) {
+            d.last_ip = ip.to_owned();
+            d.connection_mode = mode;
+            if let Ok(ts) = last_seen.parse() {
+                d.last_seen = ts;
+            }
+        }
+        Ok(())
+    }
+
+    async fn clear_last_ip(&self, id: &str) -> anyhow::Result<()> {
+        if self
+            .fail_clear_last_ip
+            .load(std::sync::atomic::Ordering::SeqCst)
+        {
+            anyhow::bail!("simulated clear_last_ip failure");
+        }
+        let mut devices = self.devices.lock().unwrap();
+        if let Some(d) = devices.iter_mut().find(|d| d.id.to_string() == id) {
+            d.last_ip = String::new();
+        }
         Ok(())
     }
 
@@ -940,6 +970,91 @@ async fn scan_departures_emits_device_gone() {
             mac, last_ip, ..
         } if mac == "aa:bb:cc:dd:ee:01" && last_ip == "192.168.1.10"
     ));
+}
+
+// Regression for issue #831: when the sweep marks a device gone it must clear
+// the device's stored `last_ip`, so a departed device's row can no longer be
+// resolved by a live device's source IP in `find_by_ip` once DHCP recycles the
+// address.
+#[tokio::test]
+async fn scan_departures_clears_departed_last_ip() {
+    let h = build_harness();
+    let obs = sample_observation("aa:bb:cc:dd:ee:01", "192.168.1.10");
+    h.svc.process_observation(&obs).await.unwrap();
+
+    // Precondition: the freshly discovered device resolves by its IP.
+    assert!(h.repo.find_by_ip("192.168.1.10").await.unwrap().is_some());
+
+    // Force the departure sweep.
+    tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+    let departed = h.svc.scan_departures(0).await.unwrap();
+    assert_eq!(departed.len(), 1);
+
+    // The departed device's IP is cleared: its row no longer resolves by that
+    // address, closing the collision window against a device DHCP later hands
+    // the same IP.
+    assert!(
+        h.repo.find_by_ip("192.168.1.10").await.unwrap().is_none(),
+        "departed device must no longer be resolvable by its old IP"
+    );
+    let device = h
+        .repo
+        .find_by_id(&departed[0].to_string())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(device.last_ip, "");
+}
+
+// A failure clearing the departed device's IP must not abort the sweep: the
+// device is still reported departed (so downstream listeners run) and the
+// failure is logged rather than propagated.
+#[tokio::test]
+async fn scan_departures_tolerates_clear_last_ip_failure() {
+    let h = build_harness();
+    let obs = sample_observation("aa:bb:cc:dd:ee:01", "192.168.1.10");
+    h.svc.process_observation(&obs).await.unwrap();
+    h.repo
+        .fail_clear_last_ip
+        .store(true, std::sync::atomic::Ordering::SeqCst);
+
+    tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+    let departed = h.svc.scan_departures(0).await.unwrap();
+    assert_eq!(departed.len(), 1);
+
+    // The clear failed, so the IP is left in place — but the sweep still
+    // completed and emitted the departure event.
+    let events = h.events.published_events();
+    assert!(
+        events
+            .iter()
+            .any(|e| matches!(e, WardnetEvent::DeviceGone { .. }))
+    );
+}
+
+// Regression for issue #831: a device that reconnects in the same instant as
+// the departure sweep must keep the live IP its observation just wrote — the
+// sweep's IP clear must not clobber it back to empty.
+#[tokio::test]
+async fn scan_departures_does_not_clear_ip_of_reconnected_device() {
+    let h = build_harness();
+    let obs = sample_observation("aa:bb:cc:dd:ee:01", "192.168.1.10");
+    h.svc.process_observation(&obs).await.unwrap();
+
+    // Depart, then immediately reconnect at the same address before asserting.
+    tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+    h.svc.scan_departures(0).await.unwrap();
+    let result = h.svc.process_observation(&obs).await.unwrap();
+    assert!(
+        matches!(result, ObservationResult::Reappeared(_)),
+        "expected Reappeared, got {result:?}"
+    );
+
+    // The reconnect re-established the address; it must still be resolvable.
+    assert!(
+        h.repo.find_by_ip("192.168.1.10").await.unwrap().is_some(),
+        "reconnected device must remain resolvable by its IP"
+    );
 }
 
 #[tokio::test]

--- a/source/daemon/crates/wardnetd-services/src/device/tests/discovery.rs
+++ b/source/daemon/crates/wardnetd-services/src/device/tests/discovery.rs
@@ -1057,6 +1057,33 @@ async fn scan_departures_does_not_clear_ip_of_reconnected_device() {
     );
 }
 
+// Regression for issue #831: the WireGuard handshake-staleness departure path
+// (`mark_peer_gone`) must clear `last_ip` too, mirroring the timeout sweep, so a
+// stale remote peer's row can't collide with a live device's source IP.
+#[tokio::test]
+async fn mark_peer_gone_clears_departed_last_ip() {
+    let h = build_harness();
+    let obs = sample_observation("aa:bb:cc:dd:ee:01", "192.168.1.10");
+    h.svc.process_observation(&obs).await.unwrap();
+    let device_id = h.repo.find_by_ip("192.168.1.10").await.unwrap().unwrap().id;
+
+    // A zero timeout marks the peer gone once its last_seen has elapsed.
+    tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+    let gone = h
+        .svc
+        .mark_peer_gone(device_id, std::time::Duration::from_secs(0))
+        .await
+        .unwrap();
+    assert_eq!(gone, Some(device_id));
+
+    // The departed peer's IP is cleared, closing the same collision window the
+    // timeout sweep does.
+    assert!(
+        h.repo.find_by_ip("192.168.1.10").await.unwrap().is_none(),
+        "gone peer must no longer be resolvable by its old IP"
+    );
+}
+
 #[tokio::test]
 async fn scan_departures_ignores_recent() {
     let h = build_harness();

--- a/source/daemon/crates/wardnetd-services/src/device/tests/ip_snapshot.rs
+++ b/source/daemon/crates/wardnetd-services/src/device/tests/ip_snapshot.rs
@@ -54,6 +54,9 @@ impl DeviceRepository for MockDeviceRepo {
     async fn insert(&self, _device: &DeviceRow) -> anyhow::Result<()> {
         unimplemented!("not exercised by DeviceIpSnapshot")
     }
+    async fn clear_last_ip(&self, _id: &str) -> anyhow::Result<()> {
+        unimplemented!("not exercised by DeviceIpSnapshot")
+    }
     async fn update_last_seen_and_ip(
         &self,
         _id: &str,

--- a/source/daemon/crates/wardnetd-services/src/dhcp/tests/dhcp.rs
+++ b/source/daemon/crates/wardnetd-services/src/dhcp/tests/dhcp.rs
@@ -404,6 +404,9 @@ impl DeviceRepository for MockDeviceRepository {
     async fn insert(&self, _device: &DeviceRow) -> anyhow::Result<()> {
         unimplemented!()
     }
+    async fn clear_last_ip(&self, _id: &str) -> anyhow::Result<()> {
+        unimplemented!()
+    }
     async fn update_last_seen_and_ip(
         &self,
         _id: &str,

--- a/source/daemon/crates/wardnetd-services/src/dns/tests/capture_runner.rs
+++ b/source/daemon/crates/wardnetd-services/src/dns/tests/capture_runner.rs
@@ -59,6 +59,12 @@ impl DeviceService for MockDeviceService {
     async fn current_rules(&self) -> Result<HashMap<uuid::Uuid, RoutingTarget>, AppError> {
         unimplemented!()
     }
+    async fn get_rule_for_device(
+        &self,
+        _device_id: &str,
+    ) -> Result<Option<RoutingTarget>, AppError> {
+        unimplemented!()
+    }
     async fn update_admin_locked(&self, _device_id: &str, _locked: bool) -> Result<(), AppError> {
         unimplemented!()
     }

--- a/source/daemon/crates/wardnetd-services/src/dns_filter/tests/service.rs
+++ b/source/daemon/crates/wardnetd-services/src/dns_filter/tests/service.rs
@@ -132,6 +132,9 @@ impl DeviceRepository for MemoryDeviceRepository {
     async fn insert(&self, _row: &DeviceRow) -> anyhow::Result<()> {
         unimplemented!()
     }
+    async fn clear_last_ip(&self, _id: &str) -> anyhow::Result<()> {
+        unimplemented!()
+    }
     async fn update_last_seen_and_ip(
         &self,
         _id: &str,

--- a/source/daemon/crates/wardnetd-services/src/inbound_wg/tests/service.rs
+++ b/source/daemon/crates/wardnetd-services/src/inbound_wg/tests/service.rs
@@ -103,6 +103,12 @@ impl DeviceService for MockDeviceService {
     ) -> Result<HashMap<Uuid, wardnet_common::routing::RoutingTarget>, AppError> {
         unimplemented!("not exercised by inbound-wg tests")
     }
+    async fn get_rule_for_device(
+        &self,
+        _device_id: &str,
+    ) -> Result<Option<wardnet_common::routing::RoutingTarget>, AppError> {
+        unimplemented!("not exercised by inbound-wg tests")
+    }
     async fn update_admin_locked(&self, _device_id: &str, _locked: bool) -> Result<(), AppError> {
         unimplemented!("not exercised by inbound-wg tests")
     }

--- a/source/daemon/crates/wardnetd-services/src/private_dns/tests/service.rs
+++ b/source/daemon/crates/wardnetd-services/src/private_dns/tests/service.rs
@@ -187,6 +187,12 @@ impl DeviceService for MockDeviceService {
     ) -> Result<HashMap<Uuid, wardnet_common::routing::RoutingTarget>, AppError> {
         unimplemented!("not exercised by private-dns tests")
     }
+    async fn get_rule_for_device(
+        &self,
+        _device_id: &str,
+    ) -> Result<Option<wardnet_common::routing::RoutingTarget>, AppError> {
+        unimplemented!("not exercised by private-dns tests")
+    }
     async fn update_admin_locked(&self, _device_id: &str, _locked: bool) -> Result<(), AppError> {
         unimplemented!("not exercised by private-dns tests")
     }

--- a/source/daemon/crates/wardnetd-services/src/routing/tests/routing.rs
+++ b/source/daemon/crates/wardnetd-services/src/routing/tests/routing.rs
@@ -74,6 +74,10 @@ impl DeviceRepository for MockDeviceRepo {
         Ok(())
     }
 
+    async fn clear_last_ip(&self, _id: &str) -> anyhow::Result<()> {
+        Ok(())
+    }
+
     async fn update_last_seen_and_ip(
         &self,
         _id: &str,

--- a/source/daemon/crates/wardnetd-services/src/rule_request/tests/service.rs
+++ b/source/daemon/crates/wardnetd-services/src/rule_request/tests/service.rs
@@ -158,6 +158,12 @@ impl DeviceService for MockDeviceService {
     async fn current_rules(&self) -> Result<HashMap<Uuid, RoutingTarget>, AppError> {
         unimplemented!()
     }
+    async fn get_rule_for_device(
+        &self,
+        _device_id: &str,
+    ) -> Result<Option<RoutingTarget>, AppError> {
+        unimplemented!()
+    }
     async fn update_admin_locked(&self, _id: &str, _locked: bool) -> Result<(), AppError> {
         unimplemented!()
     }

--- a/source/daemon/crates/wardnetd-services/src/tunnel/tests/tunnel.rs
+++ b/source/daemon/crates/wardnetd-services/src/tunnel/tests/tunnel.rs
@@ -756,6 +756,9 @@ impl DeviceRepository for MockDeviceRepoForTunnel {
     ) -> anyhow::Result<()> {
         Ok(())
     }
+    async fn clear_last_ip(&self, _id: &str) -> anyhow::Result<()> {
+        Ok(())
+    }
     async fn update_last_seen_and_ip(
         &self,
         _id: &str,
@@ -850,6 +853,9 @@ impl DeviceRepository for MockDeviceRepoWithSwitchedDevices {
         &self,
         _d: &wardnetd_data::repository::device::DeviceRow,
     ) -> anyhow::Result<()> {
+        Ok(())
+    }
+    async fn clear_last_ip(&self, _id: &str) -> anyhow::Result<()> {
         Ok(())
     }
     async fn update_last_seen_and_ip(

--- a/source/daemon/crates/wardnetd/src/tests/device_snapshot_listener.rs
+++ b/source/daemon/crates/wardnetd/src/tests/device_snapshot_listener.rs
@@ -68,6 +68,9 @@ impl DeviceRepository for MockDeviceRepo {
     async fn insert(&self, _device: &DeviceRow) -> anyhow::Result<()> {
         unimplemented!("not exercised by DeviceSnapshotListener")
     }
+    async fn clear_last_ip(&self, _id: &str) -> anyhow::Result<()> {
+        unimplemented!("not exercised by DeviceSnapshotListener")
+    }
     async fn update_last_seen_and_ip(
         &self,
         _id: &str,

--- a/source/daemon/crates/wardnetd/src/tests/stubs.rs
+++ b/source/daemon/crates/wardnetd/src/tests/stubs.rs
@@ -168,6 +168,12 @@ impl DeviceService for StubDeviceService {
     ) -> Result<std::collections::HashMap<Uuid, RoutingTarget>, AppError> {
         unimplemented!()
     }
+    async fn get_rule_for_device(
+        &self,
+        _device_id: &str,
+    ) -> Result<Option<RoutingTarget>, AppError> {
+        unimplemented!()
+    }
     async fn update_admin_locked(&self, _id: &str, _locked: bool) -> Result<(), AppError> {
         unimplemented!()
     }


### PR DESCRIPTION
## Problem

`find_by_ip` selected a device by `last_ip` with no `ORDER BY`/`LIMIT`, and `last_ip` is not unique. Departed devices are never removed from the `devices` table (`scan_departures` only flips an in-memory `gone` flag and publishes `DeviceGone`), so when DHCP later recycles a departed device's IP onto a different device, two rows end up sharing the same `last_ip`, and the lookup returns an arbitrary — effectively rowid-ordered, i.e. the oldest/stale — row.

The IP-keyed self-service auth path (`GET /api/devices/me`, `PUT /api/devices/me/rule`) resolves the caller's identity through this same lookup, so under ordinary DHCP churn a device's owner could end up viewing and mutating a stale, departed device's routing rule and DNS-capture settings instead of their own. Both callers that build identity from IP (the auth middleware's `get_device_for_ip` and `DeviceServiceImpl`) go through `find_by_ip`, so fixing the repository method fixes both.

## Fix

Two complementary changes, both needed to close the hole:

1. **Deterministic lookup** — `find_by_ip` now runs `... WHERE last_ip = ? ORDER BY last_seen DESC LIMIT 1`, so a collision always resolves to the most recently seen (live) device.
2. **Clear stale state on departure** — a new `clear_last_ip` repository method empties a device's `last_ip` (kept as the existing empty-string "no known address" sentinel; the column is `NOT NULL`). It is called whenever a device is marked gone — both the timeout sweep (`scan_departures`) and the WireGuard handshake-staleness path (`mark_peer_gone`) — so a departed row can never again match a live request's source IP.

The clear is taken under the existing per-MAC lock and gated on the device still being `gone`, so a device that reconnects in the same instant as the sweep keeps the live IP its own observation just wrote rather than having it clobbered back to empty.

No schema change: a unique constraint on `last_ip` is deliberately avoided — legitimate stale rows for offline devices are expected to exist.

## Tests

- `find_by_ip` resolves an IP collision to the more recently seen device.
- `clear_last_ip` removes a row from IP lookup while leaving the row intact.
- The departure sweep clears a departed device's `last_ip`.
- A device reconnecting alongside the sweep keeps its IP.
- A failure clearing the IP does not abort the sweep.

The touched files sit at 92%/94% line coverage, above the project average, so overall coverage does not decrease.

Closes #831