### PR TITLE
test(dns): DnsCache criterion benches, run through cubit

### DIFF
--- a/.github/workflows/cubit.yml
+++ b/.github/workflows/cubit.yml
@@ -9,11 +9,12 @@ name: Cubit
 # out of pr.yml's `all-checks-passed` aggregator so it can't gate a merge. The
 # PR comment and trend dashboard inform a human go/no-go.
 #
-# NOTE: this leaf does not run any benchmarks yet — it is wired ahead of the
-# benchmarks so the workflow already exists on `main` when the benchmarks PR
-# opens (and thus reliably runs on it). Until then, cubit finds no criterion
-# output and posts a short "no benchmark data" note; the benchmarks PR adds the
-# `cargo bench` step that produces real data.
+# Runs the daemon micro-benchmarks (criterion) and hands their output to cubit.
+# The bench step is `continue-on-error` so a bench that fails to build stays
+# visible in the UI without failing the job — cubit then posts its "no data"
+# fallback. Short criterion windows keep CI fast; the numbers are noisy on shared
+# runners by design (the trend dashboard's variance band is how a human reads
+# them).
 
 on:
   workflow_call:
@@ -27,7 +28,7 @@ jobs:
   cubit:
     name: cubit
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 30
     permissions:
       contents: write # push the cubit-state baseline branch (record, on main)
       pull-requests: write # post/update the sticky performance comment (compare, on PRs)
@@ -38,6 +39,16 @@ jobs:
           egress-policy: audit
 
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+
+      - uses: ./.github/actions/setup-rust
+
+      - name: Run daemon micro-benchmarks
+        # continue-on-error: a bench that fails to compile shows as failed in the
+        # UI but does not fail this advisory job — cubit falls back to a "no data"
+        # comment. Short criterion windows keep the leaf fast.
+        continue-on-error: true
+        working-directory: source/daemon
+        run: cargo bench -p wardnetd-services --bench dns_components -- --warm-up-time 1 --measurement-time 2
 
       # Moving major tag: cubit advances `v0` on each 0.x release, so fixes flow
       # here without a wardnet bump (same pattern as bulwark's @v1). Pin to an

--- a/source/daemon/Cargo.lock
+++ b/source/daemon/Cargo.lock
@@ -120,6 +120,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloca"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5a7d05ea6aea7e9e64d25b9156ba2fee3fdd659e34e41063cd2fc7cd020d7f4"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -133,6 +142,12 @@ checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "anstream"
@@ -599,6 +614,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "cc"
 version = "1.2.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -684,6 +705,33 @@ dependencies = [
  "serde",
  "wasm-bindgen",
  "windows-link",
+]
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
 ]
 
 [[package]]
@@ -907,6 +955,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "criterion"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "950046b2aa2492f9a536f5f4f9a3de7b9e2476e575e05bd6c333371add4d98f3"
+dependencies = [
+ "alloca",
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "itertools",
+ "num-traits",
+ "oorandom",
+ "page_size",
+ "regex",
+ "serde",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8d80a2f4f5b554395e47b5d8305bc3d27813bacb73493eb1001e8f76dae29ea"
+dependencies = [
+ "cast",
+ "itertools",
+]
+
+[[package]]
 name = "critical-section"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -956,6 +1037,12 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-bigint"
@@ -1768,6 +1855,17 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
+]
+
+[[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
 ]
 
 [[package]]
@@ -3212,6 +3310,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
 name = "opaque-debug"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3322,6 +3426,16 @@ dependencies = [
  "elliptic-curve",
  "primeorder",
  "sha2 0.10.9",
+]
+
+[[package]]
+name = "page_size"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30d5b2194ed13191c1999ae0704b7839fb18384fa22e49b57eeaa97d79ce40da"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]
@@ -5218,6 +5332,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "tinyvec"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6006,6 +6130,7 @@ dependencies = [
  "axum",
  "base64 0.22.1",
  "chrono",
+ "criterion",
  "cron",
  "ed25519-dalek",
  "flate2",

--- a/source/daemon/Cargo.toml
+++ b/source/daemon/Cargo.toml
@@ -184,6 +184,14 @@ tokio-stream = { version = "0.1", features = ["sync"] }
 # https://crates.io/crates/cron
 cron = "0.16"
 
+# https://crates.io/crates/criterion — benchmark harness (dev-only). We disable
+# default features (plotters/gnuplot/rayon) and keep only cargo_bench_support:
+# criterion still writes target/criterion/**/estimates.json, which the `cubit`
+# tool ingests, without pulling the plotting stack into the dev build.
+criterion = { version = "0.8", default-features = false, features = [
+    "cargo_bench_support",
+] }
+
 # https://crates.io/crates/hickory-proto
 hickory-proto = { version = "0.26", features = ["dnssec-ring"] }
 # https://crates.io/crates/hickory-resolver

--- a/source/daemon/crates/wardnetd-services/Cargo.toml
+++ b/source/daemon/crates/wardnetd-services/Cargo.toml
@@ -113,3 +113,12 @@ minisign.workspace = true
 tempfile.workspace = true
 # https://crates.io/crates/wiremock — mock bridge + mock Cloudflare HTTP servers for DDNS provider tests
 wiremock.workspace = true
+# https://crates.io/crates/criterion — micro-benchmark harness for the DNS component benches (see benches/)
+criterion.workspace = true
+
+# Micro-benchmarks for the hot DNS components (cache, and later authoritative
+# view + filter). `harness = false` hands the binary's main() to criterion.
+# Output lands in target/criterion/**/estimates.json for the `cubit` tool.
+[[bench]]
+name = "dns_components"
+harness = false

--- a/source/daemon/crates/wardnetd-services/benches/dns_components.rs
+++ b/source/daemon/crates/wardnetd-services/benches/dns_components.rs
@@ -1,0 +1,80 @@
+//! Micro-benchmarks for the hot DNS components.
+//!
+//! These isolate individual pieces of the resolution pipeline so a change's
+//! cost shows up as its own line in the `cubit` trend dashboard, rather than
+//! being averaged into an end-to-end number. criterion writes the timings to
+//! `target/criterion/**/estimates.json`, which `cubit` ingests.
+//!
+//! Run: `cargo bench -p wardnetd-services --bench dns_components`
+
+use std::hint::black_box;
+
+use criterion::{Criterion, criterion_group, criterion_main};
+use hickory_proto::op::{Message, OpCode};
+use hickory_proto::rr::RecordType;
+use wardnet_common::dns::UpstreamId;
+use wardnetd_services::dns::DnsCache;
+
+fn response() -> Message {
+    Message::response(0, OpCode::Query)
+}
+
+/// `DnsCache` lookup + insert — the per-query cache path. Hit and miss are
+/// benched separately because they exercise different branches (the miss path
+/// also evicts the absent-and-expired key).
+fn bench_cache(c: &mut Criterion) {
+    let mut group = c.benchmark_group("dns_cache");
+
+    group.bench_function("get_hit", |b| {
+        let mut cache = DnsCache::new(1024);
+        cache.insert(
+            UpstreamId::Default,
+            "example.com",
+            RecordType::A,
+            response(),
+            300,
+            0,
+            86400,
+        );
+        b.iter(|| {
+            black_box(cache.get(UpstreamId::Default, black_box("example.com"), RecordType::A));
+        });
+    });
+
+    group.bench_function("get_miss", |b| {
+        // `get` takes `&self` (hit/miss counters + TTL aging use interior
+        // mutability), so this cache needs no `mut` — only `insert` does.
+        let cache = DnsCache::new(1024);
+        b.iter(|| {
+            black_box(cache.get(
+                UpstreamId::Default,
+                black_box("absent.example.com"),
+                RecordType::A,
+            ));
+        });
+    });
+
+    group.bench_function("insert", |b| {
+        b.iter_batched(
+            || DnsCache::new(1024),
+            |mut cache| {
+                cache.insert(
+                    UpstreamId::Default,
+                    black_box("example.com"),
+                    RecordType::A,
+                    response(),
+                    300,
+                    0,
+                    86400,
+                );
+                cache
+            },
+            criterion::BatchSize::SmallInput,
+        );
+    });
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_cache);
+criterion_main!(benches);


### PR DESCRIPTION
## Summary

Add the first daemon micro-benchmarks (`DnsCache`) and run them through cubit,
producing the **first real performance comparison**. Follows the cubit
enablement PR (#972).

## What

- **criterion 0.8.2** dev-dependency (default features off — no plotters/gnuplot/rayon
  — keeping only `cargo_bench_support`; criterion still writes the
  `estimates.json` cubit ingests).
- **`wardnetd-services` `dns_components` bench** — `DnsCache` `get_hit` / `get_miss`
  / `insert` (`harness = false`).
- **`cubit.yml`** — add `setup-rust` + `cargo bench -p wardnetd-services --bench
  dns_components -- --warm-up-time 1 --measurement-time 2`, with
  `continue-on-error` so a bench build failure stays visible without failing the
  advisory job.

## Behavior

- **On this PR:** cubit runs the bench and compares against `latest:main` (no
  baseline yet) → posts an "all new" comparison comment (with the logo).
- **On merge to main:** the `ci.yml` cubit leaf records the baseline → future
  PRs diff against it.

## Verification

- Compiles + clippy clean against the current `main` (criterion 0.8.2); bench
  runs (~95 / 28 / 1200 ns).
- cubit ingests criterion 0.8's `estimates.json` (shape unchanged:
  `median.point_estimate` + CI) and renders the comparison — verified locally.

## Merge Commit Message

test(dns): DnsCache criterion micro-benchmarks, run through cubit

Add criterion 0.8.2 + a DnsCache get/insert micro-bench, and wire the daemon bench run into the cubit CI leaf. cubit posts the first real comparison on the PR and records the baseline on merge.

https://claude.ai/code/session_016pTq6aVBJvTtXmwTgKw2Yh