### PR TITLE
fix(db): bound WAL and add checkpoint + ANALYZE to daily maintenance

### DIFF
--- a/source/daemon/crates/wardnetd-data/src/db.rs
+++ b/source/daemon/crates/wardnetd-data/src/db.rs
@@ -204,7 +204,10 @@ pub async fn init_db_pools_from_connection_string(conn: &str) -> anyhow::Result<
                 // the sidecar back down instead of letting it grow unbounded.
                 // Set on every connection because `journal_size_limit` is a
                 // per-connection setting in SQLite.
-                .pragma("journal_size_limit", WAL_JOURNAL_SIZE_LIMIT_BYTES.to_string())
+                .pragma(
+                    "journal_size_limit",
+                    WAL_JOURNAL_SIZE_LIMIT_BYTES.to_string(),
+                )
         };
 
         // Writer first — migrations run on it and they must complete

--- a/source/daemon/crates/wardnetd-data/src/db.rs
+++ b/source/daemon/crates/wardnetd-data/src/db.rs
@@ -22,6 +22,19 @@ const BUSY_TIMEOUT: Duration = Duration::from_secs(30);
 /// VACUUM kicks in for a legacy `auto_vacuum=NONE` database. ~25k pages
 /// at the default 4 KiB page size is ~100 MiB of reclaimable space.
 const VACUUM_FREELIST_THRESHOLD_PAGES: i64 = 25_000;
+/// Cap the on-disk `-wal` sidecar so a burst of writes (e.g. the daily
+/// DNS query-log retention `DELETE`) can't leave the WAL parked at a
+/// multi-hundred-MiB high-water mark forever. `SQLite`'s automatic
+/// checkpoints are always `PASSIVE` — they let WAL space be *reused* but
+/// never *shrink the file*; without this limit the WAL only grows to its
+/// historical peak and stays there, slowing every subsequent operation.
+/// With the limit set, the checkpointer truncates the file back down to
+/// this size once its frames have been folded into the main database.
+/// 64 MiB is comfortably above the largest single transaction yet small
+/// enough for the Raspberry-Pi-class targets this runs on. The daily
+/// [`MaintenanceRepository::wal_checkpoint_truncate`] resets it the rest
+/// of the way to ~0.
+const WAL_JOURNAL_SIZE_LIMIT_BYTES: i64 = 64 * 1024 * 1024;
 const MEMORY_CONNECTION_STRING: &str = ":memory:";
 /// File-name suffix for the sentinel a backup restore drops next to the
 /// database. Its presence on startup means the `<db>` file was just
@@ -187,6 +200,11 @@ pub async fn init_db_pools_from_connection_string(conn: &str) -> anyhow::Result<
                 .auto_vacuum(SqliteAutoVacuum::Incremental)
                 .busy_timeout(BUSY_TIMEOUT)
                 .foreign_keys(true)
+                // Bound the on-disk WAL so a passive auto-checkpoint truncates
+                // the sidecar back down instead of letting it grow unbounded.
+                // Set on every connection because `journal_size_limit` is a
+                // per-connection setting in SQLite.
+                .pragma("journal_size_limit", WAL_JOURNAL_SIZE_LIMIT_BYTES.to_string())
         };
 
         // Writer first — migrations run on it and they must complete

--- a/source/daemon/crates/wardnetd-data/src/repository/maintenance.rs
+++ b/source/daemon/crates/wardnetd-data/src/repository/maintenance.rs
@@ -1,15 +1,13 @@
 //! Database-wide maintenance operations that don't belong to any
 //! domain repository.
 //!
-//! Driven daily by [`crate::db::DbPools`]'s owner, the
-//! [`DbMaintenanceRunner`]: reclaim freed pages
+//! Driven daily by the `DbMaintenanceRunner` background task (in the
+//! `wardnetd-services` crate): reclaim freed pages
 //! ([`incremental_vacuum`](MaintenanceRepository::incremental_vacuum)),
 //! shrink the WAL sidecar back to ~0
 //! ([`wal_checkpoint_truncate`](MaintenanceRepository::wal_checkpoint_truncate)),
 //! and refresh the query planner's statistics
 //! ([`optimize`](MaintenanceRepository::optimize)).
-//!
-//! [`DbMaintenanceRunner`]: https://docs.rs/wardnetd-services
 
 use async_trait::async_trait;
 
@@ -54,9 +52,11 @@ pub trait MaintenanceRepository: Send + Sync {
     /// indefinitely. This is that periodic truncation — run daily so the
     /// sidecar returns to ~0 instead of dragging every read and write.
     ///
-    /// Runs against the writer connection. A [`WalCheckpointOutcome::busy`]
-    /// result is not an error — it means a reader held a snapshot and the
-    /// file was left in place for the next tick to retry.
+    /// Runs against the writer connection under a short busy timeout so a
+    /// TRUNCATE stuck behind a long-lived reader can't monopolise the
+    /// writer. A [`WalCheckpointOutcome::busy`] result is not an error — it
+    /// means a reader held a snapshot and the file was left in place for
+    /// the next tick to retry.
     async fn wal_checkpoint_truncate(&self) -> anyhow::Result<WalCheckpointOutcome>;
 
     /// Refresh the query planner's statistics via `PRAGMA optimize`.

--- a/source/daemon/crates/wardnetd-data/src/repository/maintenance.rs
+++ b/source/daemon/crates/wardnetd-data/src/repository/maintenance.rs
@@ -1,12 +1,34 @@
 //! Database-wide maintenance operations that don't belong to any
 //! domain repository.
 //!
-//! Today there's exactly one — [`incremental_vacuum`](MaintenanceRepository::incremental_vacuum)
-//! — driven by the DNS query-log cleanup runner after a bulk DELETE.
-//! Future operations of the same shape (e.g. `PRAGMA wal_checkpoint`,
-//! `ANALYZE`) belong here.
+//! Driven daily by [`crate::db::DbPools`]'s owner, the
+//! [`DbMaintenanceRunner`]: reclaim freed pages
+//! ([`incremental_vacuum`](MaintenanceRepository::incremental_vacuum)),
+//! shrink the WAL sidecar back to ~0
+//! ([`wal_checkpoint_truncate`](MaintenanceRepository::wal_checkpoint_truncate)),
+//! and refresh the query planner's statistics
+//! ([`optimize`](MaintenanceRepository::optimize)).
+//!
+//! [`DbMaintenanceRunner`]: https://docs.rs/wardnetd-services
 
 use async_trait::async_trait;
+
+/// Result of a `PRAGMA wal_checkpoint(TRUNCATE)`.
+///
+/// Mirrors the single row `SQLite` returns: `(busy, log, checkpointed)`.
+/// A [`busy`](Self::busy) checkpoint means a concurrent reader still held
+/// a snapshot of some WAL frames, so the file could **not** be truncated
+/// this pass; the next daily tick retries.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct WalCheckpointOutcome {
+    /// `true` when `SQLite` reported `busy = 1` — a reader blocked the
+    /// checkpoint from completing and the WAL was left in place.
+    pub busy: bool,
+    /// Total number of frames in the WAL at checkpoint time.
+    pub wal_frames: i64,
+    /// Number of frames successfully moved into the main database.
+    pub checkpointed_frames: i64,
+}
 
 /// Cross-cutting database maintenance.
 #[async_trait]
@@ -22,6 +44,31 @@ pub trait MaintenanceRepository: Send + Sync {
     /// return doesn't imply failure (it can mean the freelist was
     /// already empty, or the file is on `auto_vacuum=NONE`).
     async fn incremental_vacuum(&self) -> anyhow::Result<u64>;
+
+    /// Fold the WAL into the main database and truncate the `-wal`
+    /// sidecar back to zero bytes via `PRAGMA wal_checkpoint(TRUNCATE)`.
+    ///
+    /// `SQLite`'s automatic checkpoints are always `PASSIVE`: they mark WAL
+    /// space reusable but never shrink the file on disk, so without a
+    /// periodic explicit truncation the WAL parks at its high-water mark
+    /// indefinitely. This is that periodic truncation — run daily so the
+    /// sidecar returns to ~0 instead of dragging every read and write.
+    ///
+    /// Runs against the writer connection. A [`WalCheckpointOutcome::busy`]
+    /// result is not an error — it means a reader held a snapshot and the
+    /// file was left in place for the next tick to retry.
+    async fn wal_checkpoint_truncate(&self) -> anyhow::Result<WalCheckpointOutcome>;
+
+    /// Refresh the query planner's statistics via `PRAGMA optimize`.
+    ///
+    /// `PRAGMA optimize` runs `ANALYZE` only on the tables whose row
+    /// counts have shifted enough since the last run to matter, so it is
+    /// cheap to call routinely — unlike a bare `ANALYZE`, which rescans
+    /// every table. Bounded by `PRAGMA analysis_limit` so a single index
+    /// scan can't monopolise the writer on a large table. Without this the
+    /// planner works from stale `sqlite_stat1` data and can pick bad
+    /// indexes as tables like `dns_query_log` grow.
+    async fn optimize(&self) -> anyhow::Result<()>;
 
     /// Cheap connectivity probe — runs `SELECT 1` against the read pool and
     /// returns `Ok(())` if the database answered. Used by the health

--- a/source/daemon/crates/wardnetd-data/src/repository/mod.rs
+++ b/source/daemon/crates/wardnetd-data/src/repository/mod.rs
@@ -37,7 +37,7 @@ pub use dns_local::{
     ZoneUpdate,
 };
 pub use inbound_wg::{InboundWgPeerRepository, InboundWgPeerRow};
-pub use maintenance::MaintenanceRepository;
+pub use maintenance::{MaintenanceRepository, WalCheckpointOutcome};
 pub use network_zone::NetworkZoneRepository;
 pub use notification::{NewNotification, NotificationRepository, StoredNotification};
 pub use private_dns::{PrivateDnsGrantRepository, PrivateDnsGrantRow};

--- a/source/daemon/crates/wardnetd-data/src/repository/sqlite/maintenance.rs
+++ b/source/daemon/crates/wardnetd-data/src/repository/sqlite/maintenance.rs
@@ -4,7 +4,7 @@ use async_trait::async_trait;
 use sqlx::SqlitePool;
 
 use crate::db::DbPools;
-use crate::repository::maintenance::MaintenanceRepository;
+use crate::repository::maintenance::{MaintenanceRepository, WalCheckpointOutcome};
 
 /// How many pages a single `PRAGMA incremental_vacuum(N)` call is
 /// allowed to reclaim. Tuned for a Raspberry Pi: ~8 MiB at the `SQLite`
@@ -13,6 +13,13 @@ use crate::repository::maintenance::MaintenanceRepository;
 /// `busy_timeout`. The cleanup tick fires daily; unreclaimed pages
 /// stay on the freelist and get picked up by the next call.
 const INCREMENTAL_VACUUM_PAGES: u32 = 2_000;
+
+/// Upper bound on how many rows-per-index `PRAGMA optimize` samples
+/// before it stops, per `SQLite`'s own recommendation for keeping the
+/// analysis cheap on large tables. Without a limit, `ANALYZE` on a table
+/// like `dns_query_log` can scan the whole index and hold the writer for
+/// seconds; 400 gives the planner good-enough estimates in milliseconds.
+const ANALYSIS_LIMIT: u32 = 400;
 
 pub struct SqliteMaintenanceRepository {
     pools: DbPools,
@@ -52,6 +59,40 @@ impl MaintenanceRepository for SqliteMaintenanceRepository {
             .await
             .unwrap_or(before);
         Ok(u64::try_from((before - after).max(0)).unwrap_or(0))
+    }
+
+    async fn wal_checkpoint_truncate(&self) -> anyhow::Result<WalCheckpointOutcome> {
+        // `PRAGMA wal_checkpoint(TRUNCATE)` returns exactly one row:
+        // `(busy, log, checkpointed)`. `busy = 1` means a reader still
+        // held a snapshot of some WAL frames, so the file could not be
+        // truncated this pass — reported, not raised, so the daily runner
+        // simply retries on the next tick. Runs on the writer connection:
+        // a checkpoint coordinates with the same lock the writer holds,
+        // and TRUNCATE must not race a second writer.
+        let (busy, wal_frames, checkpointed_frames): (i64, i64, i64) =
+            sqlx::query_as("PRAGMA wal_checkpoint(TRUNCATE)")
+                .fetch_one(&self.pools.write)
+                .await?;
+        Ok(WalCheckpointOutcome {
+            busy: busy != 0,
+            wal_frames,
+            checkpointed_frames,
+        })
+    }
+
+    async fn optimize(&self) -> anyhow::Result<()> {
+        // Bound the work first (see `ANALYSIS_LIMIT`), then let
+        // `PRAGMA optimize` decide which tables actually need `ANALYZE`.
+        // Both run on the writer since `optimize` may write `sqlite_stat1`.
+        sqlx::query(sqlx::AssertSqlSafe(format!(
+            "PRAGMA analysis_limit = {ANALYSIS_LIMIT}"
+        )))
+        .execute(&self.pools.write)
+        .await?;
+        sqlx::query("PRAGMA optimize")
+            .execute(&self.pools.write)
+            .await?;
+        Ok(())
     }
 
     async fn ping(&self) -> anyhow::Result<()> {

--- a/source/daemon/crates/wardnetd-data/src/repository/sqlite/maintenance.rs
+++ b/source/daemon/crates/wardnetd-data/src/repository/sqlite/maintenance.rs
@@ -21,6 +21,15 @@ const INCREMENTAL_VACUUM_PAGES: u32 = 2_000;
 /// seconds; 400 gives the planner good-enough estimates in milliseconds.
 const ANALYSIS_LIMIT: u32 = 400;
 
+/// Busy timeout (ms) the daily `wal_checkpoint(TRUNCATE)` runs under. A
+/// TRUNCATE checkpoint waits for readers to release their WAL snapshots,
+/// and the pool-wide `busy_timeout` is 30 s — far too long to let a
+/// daily maintenance tick monopolise the single writer connection while a
+/// long-lived reader is active. Bound the checkpoint's own wait to 1 s so
+/// it either truncates promptly or reports `busy` and lets the next daily
+/// tick retry; `journal_size_limit` keeps the file capped meanwhile.
+const CHECKPOINT_BUSY_TIMEOUT_MS: u32 = 1_000;
+
 pub struct SqliteMaintenanceRepository {
     pools: DbPools,
 }
@@ -69,10 +78,34 @@ impl MaintenanceRepository for SqliteMaintenanceRepository {
         // simply retries on the next tick. Runs on the writer connection:
         // a checkpoint coordinates with the same lock the writer holds,
         // and TRUNCATE must not race a second writer.
-        let (busy, wal_frames, checkpointed_frames): (i64, i64, i64) =
-            sqlx::query_as("PRAGMA wal_checkpoint(TRUNCATE)")
-                .fetch_one(&self.pools.write)
-                .await?;
+        //
+        // Acquire a single connection and drop its busy timeout for the
+        // duration of the checkpoint so a TRUNCATE stuck behind a
+        // long-lived reader can't monopolise the writer for the pool-wide
+        // 30 s. The connection is checked out (writer pool is size 1) so no
+        // other writer contends while we override the timeout, and we
+        // restore the previous value before returning it to the pool.
+        let mut conn = self.pools.write.acquire().await?;
+        let prev_busy_ms: i64 = sqlx::query_scalar("PRAGMA busy_timeout")
+            .fetch_one(&mut *conn)
+            .await?;
+        sqlx::query(sqlx::AssertSqlSafe(format!(
+            "PRAGMA busy_timeout = {CHECKPOINT_BUSY_TIMEOUT_MS}"
+        )))
+        .execute(&mut *conn)
+        .await?;
+        let result = sqlx::query_as::<_, (i64, i64, i64)>("PRAGMA wal_checkpoint(TRUNCATE)")
+            .fetch_one(&mut *conn)
+            .await;
+        // Restore the pool-wide busy timeout before this connection is
+        // reused for normal writes — best-effort, and always attempted even
+        // when the checkpoint itself errored.
+        let _ = sqlx::query(sqlx::AssertSqlSafe(format!(
+            "PRAGMA busy_timeout = {prev_busy_ms}"
+        )))
+        .execute(&mut *conn)
+        .await;
+        let (busy, wal_frames, checkpointed_frames) = result?;
         Ok(WalCheckpointOutcome {
             busy: busy != 0,
             wal_frames,
@@ -83,15 +116,18 @@ impl MaintenanceRepository for SqliteMaintenanceRepository {
     async fn optimize(&self) -> anyhow::Result<()> {
         // Bound the work first (see `ANALYSIS_LIMIT`), then let
         // `PRAGMA optimize` decide which tables actually need `ANALYZE`.
-        // Both run on the writer since `optimize` may write `sqlite_stat1`.
+        // Both statements must run on the *same* connection because
+        // `analysis_limit` is a per-connection setting — acquire one
+        // explicitly rather than issuing two independent pool acquisitions
+        // that could land on different connections. Runs on the writer
+        // since `optimize` may write `sqlite_stat1`.
+        let mut conn = self.pools.write.acquire().await?;
         sqlx::query(sqlx::AssertSqlSafe(format!(
             "PRAGMA analysis_limit = {ANALYSIS_LIMIT}"
         )))
-        .execute(&self.pools.write)
+        .execute(&mut *conn)
         .await?;
-        sqlx::query("PRAGMA optimize")
-            .execute(&self.pools.write)
-            .await?;
+        sqlx::query("PRAGMA optimize").execute(&mut *conn).await?;
         Ok(())
     }
 

--- a/source/daemon/crates/wardnetd-data/src/repository/sqlite/tests/maintenance.rs
+++ b/source/daemon/crates/wardnetd-data/src/repository/sqlite/tests/maintenance.rs
@@ -90,6 +90,102 @@ async fn incremental_vacuum_reduces_freelist() {
     let _ = std::fs::remove_file(path.with_extension("db-shm"));
 }
 
+/// After writes have grown the `-wal` sidecar, `wal_checkpoint_truncate`
+/// truncates it back toward zero.
+///
+/// This is the exact behaviour the field bug lacked: `SQLite`'s automatic
+/// checkpoints are `PASSIVE`, which backfill frames into the main database
+/// but leave the `-wal` file parked at its high-water mark on disk. The
+/// explicit `TRUNCATE` checkpoint is what shrinks the file, so the
+/// assertion that matters is `wal_after < wal_before`.
+#[tokio::test]
+async fn wal_checkpoint_truncate_shrinks_wal_file() {
+    let (pool, path) = make_incremental_pool().await;
+    let wal = path.with_extension("db-wal");
+
+    // Generate enough WAL frames to grow the sidecar well past the point a
+    // passive auto-checkpoint leaves it (it never truncates the file).
+    sqlx::query("CREATE TABLE _wal_scratch (data TEXT NOT NULL)")
+        .execute(&pool)
+        .await
+        .unwrap();
+    let payload = "y".repeat(500);
+    for _ in 0..2_000 {
+        sqlx::query("INSERT INTO _wal_scratch (data) VALUES (?)")
+            .bind(&payload)
+            .execute(&pool)
+            .await
+            .unwrap();
+    }
+
+    let wal_before = std::fs::metadata(&wal).map_or(0, |m| m.len());
+    assert!(
+        wal_before > 64 * 1024,
+        "expected a non-trivial -wal after inserts, got {wal_before} bytes"
+    );
+
+    let repo = SqliteMaintenanceRepository::new(pool.clone());
+    let outcome = repo.wal_checkpoint_truncate().await.unwrap();
+    assert!(
+        !outcome.busy,
+        "checkpoint should complete with no competing reader"
+    );
+
+    let wal_after = std::fs::metadata(&wal).map_or(0, |m| m.len());
+    assert!(
+        wal_after < wal_before,
+        "TRUNCATE checkpoint should shrink the -wal: before={wal_before}, after={wal_after}"
+    );
+
+    pool.close().await;
+    let _ = std::fs::remove_file(&path);
+    let _ = std::fs::remove_file(&wal);
+    let _ = std::fs::remove_file(path.with_extension("db-shm"));
+}
+
+/// `optimize` runs `PRAGMA analysis_limit` + `PRAGMA optimize` and refreshes
+/// planner statistics without error on a live database.
+#[tokio::test]
+async fn optimize_runs_and_populates_stat_table() {
+    let (pool, path) = make_incremental_pool().await;
+
+    // A table with an index gives `PRAGMA optimize` something to analyze.
+    sqlx::query("CREATE TABLE _opt_scratch (id INTEGER PRIMARY KEY, k TEXT NOT NULL)")
+        .execute(&pool)
+        .await
+        .unwrap();
+    sqlx::query("CREATE INDEX _opt_scratch_k ON _opt_scratch (k)")
+        .execute(&pool)
+        .await
+        .unwrap();
+    for i in 0..500 {
+        sqlx::query("INSERT INTO _opt_scratch (k) VALUES (?)")
+            .bind(format!("key-{i}"))
+            .execute(&pool)
+            .await
+            .unwrap();
+    }
+
+    let repo = SqliteMaintenanceRepository::new(pool.clone());
+    repo.optimize().await.expect("optimize should succeed");
+
+    // `PRAGMA optimize` should have run `ANALYZE`, creating `sqlite_stat1`.
+    let stat_tables: i64 =
+        sqlx::query_scalar("SELECT COUNT(*) FROM sqlite_master WHERE name = 'sqlite_stat1'")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+    assert_eq!(
+        stat_tables, 1,
+        "optimize should have created sqlite_stat1 via ANALYZE"
+    );
+
+    pool.close().await;
+    let _ = std::fs::remove_file(&path);
+    let _ = std::fs::remove_file(path.with_extension("db-wal"));
+    let _ = std::fs::remove_file(path.with_extension("db-shm"));
+}
+
 /// `ping` runs `SELECT 1` against the read pool and returns `Ok` while the
 /// database is live — the health monitor's `database` probe (issue #214).
 #[tokio::test]

--- a/source/daemon/crates/wardnetd-data/src/tests/db.rs
+++ b/source/daemon/crates/wardnetd-data/src/tests/db.rs
@@ -208,6 +208,38 @@ async fn init_db_pools_with_file_path_creates_migrates_and_runs_the_restore_guar
 }
 
 #[tokio::test]
+async fn file_pools_cap_the_wal_journal_size_limit() {
+    // Regression for the 530 MiB WAL bloat: every file-backed connection
+    // must open with `journal_size_limit` set so a passive auto-checkpoint
+    // truncates the sidecar back down instead of letting it grow unbounded.
+    // A limit of 0 (SQLite's default) means "never truncate" — the bug.
+    let dir = std::env::temp_dir();
+    let db = dir.join(format!("wardnet-wal-limit-{}.db", Uuid::new_v4()));
+
+    let pools = init_db_pools_from_connection_string(db.to_str().unwrap())
+        .await
+        .expect("file-based pool creation should succeed");
+
+    for pool in [&pools.write, &pools.read] {
+        let limit: i64 = sqlx::query_scalar("PRAGMA journal_size_limit")
+            .fetch_one(pool)
+            .await
+            .expect("journal_size_limit query should succeed");
+        assert_eq!(
+            limit,
+            64 * 1024 * 1024,
+            "every file connection must cap the WAL at 64 MiB, got {limit}"
+        );
+    }
+
+    pools.write.close().await;
+    pools.read.close().await;
+    for s in ["", "-wal", "-shm"] {
+        let _ = tokio::fs::remove_file(sidecar(&db, s)).await;
+    }
+}
+
+#[tokio::test]
 async fn discard_stale_wal_tolerates_unremovable_sidecar_and_marker() {
     // The guard must never panic on filesystem errors. Make both the
     // `-wal` sidecar and the marker directories so `remove_file` fails

--- a/source/daemon/crates/wardnetd-data/src/tests/db.rs
+++ b/source/daemon/crates/wardnetd-data/src/tests/db.rs
@@ -212,7 +212,8 @@ async fn file_pools_cap_the_wal_journal_size_limit() {
     // Regression for the 530 MiB WAL bloat: every file-backed connection
     // must open with `journal_size_limit` set so a passive auto-checkpoint
     // truncates the sidecar back down instead of letting it grow unbounded.
-    // A limit of 0 (SQLite's default) means "never truncate" — the bug.
+    // SQLite's default is -1 (no limit) — the bug — so an unset connection
+    // lets the WAL grow without bound; here we assert the explicit cap.
     let dir = std::env::temp_dir();
     let db = dir.join(format!("wardnet-wal-limit-{}.db", Uuid::new_v4()));
 

--- a/source/daemon/crates/wardnetd-services/src/db_maintenance_runner.rs
+++ b/source/daemon/crates/wardnetd-services/src/db_maintenance_runner.rs
@@ -1,10 +1,22 @@
 //! Daily database-maintenance runner.
 //!
-//! Calls [`MaintenanceService::run_incremental_vacuum`] once per calendar day
-//! to return freed `SQLite` pages to the filesystem. Fires independently of
-//! any domain-level feature flag so it benefits **all** retention-driven
-//! tables (DNS query log, future event logs, audit trails), not just the ones
-//! whose per-feature runner happens to be active.
+//! Runs three maintenance operations once per calendar day, in order:
+//!
+//! 1. [`MaintenanceService::run_incremental_vacuum`] — return freed
+//!    `SQLite` pages to the filesystem.
+//! 2. [`MaintenanceService::run_wal_checkpoint`] — truncate the WAL
+//!    sidecar back to ~0. Automatic checkpoints are always `PASSIVE` and
+//!    never shrink the `-wal` file, so without this it parks at its
+//!    high-water mark (observed at 530 MiB in the field) and drags every
+//!    read and write.
+//! 3. [`MaintenanceService::run_optimize`] — refresh the query planner's
+//!    statistics (`ANALYZE` via `PRAGMA optimize`) so it keeps picking
+//!    good indexes as tables grow.
+//!
+//! Fires independently of any domain-level feature flag so it benefits
+//! **all** retention-driven tables (DNS query log, future event logs,
+//! audit trails), not just the ones whose per-feature runner happens to be
+//! active.
 //!
 //! Like every background component, it calls the auth-gated service under an
 //! admin [`crate::auth_context`] rather than holding a repository directly.
@@ -102,11 +114,26 @@ async fn runner_loop(
                 let today_now = today();
                 if today_now != last_vacuum_day {
                     last_vacuum_day = today_now;
-                    run_vacuum(maintenance.as_ref(), &admin_ctx).await;
+                    run_daily_maintenance(maintenance.as_ref(), &admin_ctx).await;
                 }
             }
         }
     }
+}
+
+/// Run the full daily maintenance sequence: vacuum, WAL checkpoint,
+/// optimize. Each step is independent — a failure in one is logged and
+/// the next still runs, so a busy checkpoint never skips the planner
+/// refresh. The order matters: vacuum first moves freed pages onto the
+/// freelist (writing WAL frames), then the checkpoint folds them in and
+/// truncates the sidecar, then optimize refreshes statistics.
+pub(crate) async fn run_daily_maintenance(
+    maintenance: &dyn MaintenanceService,
+    admin_ctx: &AuthContext,
+) {
+    run_vacuum(maintenance, admin_ctx).await;
+    run_checkpoint(maintenance, admin_ctx).await;
+    run_optimize(maintenance, admin_ctx).await;
 }
 
 pub(crate) async fn run_vacuum(maintenance: &dyn MaintenanceService, admin_ctx: &AuthContext) {
@@ -122,6 +149,42 @@ pub(crate) async fn run_vacuum(maintenance: &dyn MaintenanceService, admin_ctx: 
         Ok(_) => {}
         Err(e) => {
             tracing::warn!(error = %e, "incremental vacuum failed: {e}");
+        }
+    }
+}
+
+pub(crate) async fn run_checkpoint(maintenance: &dyn MaintenanceService, admin_ctx: &AuthContext) {
+    match auth_context::with_context(admin_ctx.clone(), maintenance.run_wal_checkpoint()).await {
+        Ok(outcome) if outcome.busy => {
+            // A reader held a snapshot, so the WAL couldn't be truncated
+            // this pass. Not an error — the next daily tick retries.
+            tracing::info!(
+                wal_frames = outcome.wal_frames,
+                checkpointed_frames = outcome.checkpointed_frames,
+                "WAL checkpoint could not truncate (reader active); will retry next tick"
+            );
+        }
+        Ok(outcome) => {
+            tracing::info!(
+                wal_frames = outcome.wal_frames,
+                checkpointed_frames = outcome.checkpointed_frames,
+                "WAL checkpoint truncated sidecar: checkpointed_frames={checkpointed_frames}",
+                checkpointed_frames = outcome.checkpointed_frames,
+            );
+        }
+        Err(e) => {
+            tracing::warn!(error = %e, "WAL checkpoint failed: {e}");
+        }
+    }
+}
+
+pub(crate) async fn run_optimize(maintenance: &dyn MaintenanceService, admin_ctx: &AuthContext) {
+    match auth_context::with_context(admin_ctx.clone(), maintenance.run_optimize()).await {
+        Ok(()) => {
+            tracing::debug!("database optimize (ANALYZE via PRAGMA optimize) complete");
+        }
+        Err(e) => {
+            tracing::warn!(error = %e, "database optimize failed: {e}");
         }
     }
 }

--- a/source/daemon/crates/wardnetd-services/src/db_maintenance_runner.rs
+++ b/source/daemon/crates/wardnetd-services/src/db_maintenance_runner.rs
@@ -181,7 +181,9 @@ pub(crate) async fn run_checkpoint(maintenance: &dyn MaintenanceService, admin_c
 pub(crate) async fn run_optimize(maintenance: &dyn MaintenanceService, admin_ctx: &AuthContext) {
     match auth_context::with_context(admin_ctx.clone(), maintenance.run_optimize()).await {
         Ok(()) => {
-            tracing::debug!("database optimize (ANALYZE via PRAGMA optimize) complete");
+            // Logged at info! to match the vacuum and checkpoint steps so
+            // the full daily maintenance cycle is visible at one log level.
+            tracing::info!("database optimize (ANALYZE via PRAGMA optimize) complete");
         }
         Err(e) => {
             tracing::warn!(error = %e, "database optimize failed: {e}");

--- a/source/daemon/crates/wardnetd-services/src/maintenance.rs
+++ b/source/daemon/crates/wardnetd-services/src/maintenance.rs
@@ -13,7 +13,7 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 
-use wardnetd_data::repository::MaintenanceRepository;
+use wardnetd_data::repository::{MaintenanceRepository, WalCheckpointOutcome};
 
 use crate::auth_context;
 use crate::error::AppError;
@@ -26,6 +26,14 @@ pub trait MaintenanceService: Send + Sync {
     /// Release free database pages back to the filesystem in a single
     /// bounded step. Returns the number of pages reclaimed (best-effort).
     async fn run_incremental_vacuum(&self) -> Result<u64, AppError>;
+
+    /// Truncate the WAL sidecar back to ~0 via
+    /// `PRAGMA wal_checkpoint(TRUNCATE)`. Returns the checkpoint outcome so
+    /// the caller can log a [`WalCheckpointOutcome::busy`] result.
+    async fn run_wal_checkpoint(&self) -> Result<WalCheckpointOutcome, AppError>;
+
+    /// Refresh the query planner's statistics via `PRAGMA optimize`.
+    async fn run_optimize(&self) -> Result<(), AppError>;
 }
 
 pub struct MaintenanceServiceImpl {
@@ -47,5 +55,18 @@ impl MaintenanceService for MaintenanceServiceImpl {
             .incremental_vacuum()
             .await
             .map_err(AppError::Internal)
+    }
+
+    async fn run_wal_checkpoint(&self) -> Result<WalCheckpointOutcome, AppError> {
+        auth_context::require_admin()?;
+        self.repo
+            .wal_checkpoint_truncate()
+            .await
+            .map_err(AppError::Internal)
+    }
+
+    async fn run_optimize(&self) -> Result<(), AppError> {
+        auth_context::require_admin()?;
+        self.repo.optimize().await.map_err(AppError::Internal)
     }
 }

--- a/source/daemon/crates/wardnetd-services/src/tests/db_maintenance_runner.rs
+++ b/source/daemon/crates/wardnetd-services/src/tests/db_maintenance_runner.rs
@@ -6,7 +6,9 @@ use async_trait::async_trait;
 use uuid::Uuid;
 use wardnet_common::auth::AuthContext;
 
-use crate::db_maintenance_runner::{DbMaintenanceRunner, run_daily_maintenance, run_vacuum};
+use crate::db_maintenance_runner::{
+    DbMaintenanceRunner, run_checkpoint, run_daily_maintenance, run_vacuum,
+};
 use crate::error::AppError;
 use crate::maintenance::MaintenanceService;
 use wardnetd_data::repository::WalCheckpointOutcome;
@@ -15,6 +17,9 @@ use wardnetd_data::repository::WalCheckpointOutcome;
 
 struct MockMaintenance {
     result: anyhow::Result<u64>,
+    /// When the service is `ok`, whether the checkpoint reports `busy`
+    /// (a reader blocked the truncation) rather than a clean truncate.
+    checkpoint_busy: bool,
     /// Calls to `run_incremental_vacuum`.
     calls: Mutex<u32>,
     /// Calls to `run_wal_checkpoint`.
@@ -27,6 +32,19 @@ impl MockMaintenance {
     fn ok(reclaimed: u64) -> Arc<Self> {
         Arc::new(Self {
             result: Ok(reclaimed),
+            checkpoint_busy: false,
+            calls: Mutex::new(0),
+            checkpoint_calls: Mutex::new(0),
+            optimize_calls: Mutex::new(0),
+        })
+    }
+
+    /// Like [`ok`](Self::ok) but the checkpoint reports `busy` so the
+    /// runner's reader-active log branch is exercised.
+    fn ok_busy_checkpoint() -> Arc<Self> {
+        Arc::new(Self {
+            result: Ok(0),
+            checkpoint_busy: true,
             calls: Mutex::new(0),
             checkpoint_calls: Mutex::new(0),
             optimize_calls: Mutex::new(0),
@@ -36,6 +54,7 @@ impl MockMaintenance {
     fn err() -> Arc<Self> {
         Arc::new(Self {
             result: Err(anyhow::anyhow!("synthetic vacuum error")),
+            checkpoint_busy: false,
             calls: Mutex::new(0),
             checkpoint_calls: Mutex::new(0),
             optimize_calls: Mutex::new(0),
@@ -69,7 +88,7 @@ impl MaintenanceService for MockMaintenance {
         *self.checkpoint_calls.lock().unwrap() += 1;
         match &self.result {
             Ok(_) => Ok(WalCheckpointOutcome {
-                busy: false,
+                busy: self.checkpoint_busy,
                 wal_frames: 0,
                 checkpointed_frames: 0,
             }),
@@ -136,6 +155,23 @@ async fn run_daily_maintenance_continues_past_errors() {
     assert_eq!(repo.call_count(), 1);
     assert_eq!(repo.checkpoint_count(), 1);
     assert_eq!(repo.optimize_count(), 1);
+}
+
+/// A busy checkpoint (reader held a snapshot) takes the reader-active log
+/// branch without panicking and still counts as a call.
+#[tokio::test]
+async fn run_checkpoint_handles_busy_outcome() {
+    let repo = MockMaintenance::ok_busy_checkpoint();
+    run_checkpoint(repo.as_ref(), &admin_ctx()).await; // must not panic
+    assert_eq!(repo.checkpoint_count(), 1);
+}
+
+/// A checkpoint error is logged and swallowed, not propagated.
+#[tokio::test]
+async fn run_checkpoint_warns_and_does_not_panic_on_error() {
+    let repo = MockMaintenance::err();
+    run_checkpoint(repo.as_ref(), &admin_ctx()).await; // must not panic
+    assert_eq!(repo.checkpoint_count(), 1);
 }
 
 // ── Runner integration tests ──────────────────────────────────────────────────

--- a/source/daemon/crates/wardnetd-services/src/tests/db_maintenance_runner.rs
+++ b/source/daemon/crates/wardnetd-services/src/tests/db_maintenance_runner.rs
@@ -6,15 +6,21 @@ use async_trait::async_trait;
 use uuid::Uuid;
 use wardnet_common::auth::AuthContext;
 
-use crate::db_maintenance_runner::{DbMaintenanceRunner, run_vacuum};
+use crate::db_maintenance_runner::{DbMaintenanceRunner, run_daily_maintenance, run_vacuum};
 use crate::error::AppError;
 use crate::maintenance::MaintenanceService;
+use wardnetd_data::repository::WalCheckpointOutcome;
 
 // ── Mock maintenance service ──────────────────────────────────────────────────
 
 struct MockMaintenance {
     result: anyhow::Result<u64>,
+    /// Calls to `run_incremental_vacuum`.
     calls: Mutex<u32>,
+    /// Calls to `run_wal_checkpoint`.
+    checkpoint_calls: Mutex<u32>,
+    /// Calls to `run_optimize`.
+    optimize_calls: Mutex<u32>,
 }
 
 impl MockMaintenance {
@@ -22,6 +28,8 @@ impl MockMaintenance {
         Arc::new(Self {
             result: Ok(reclaimed),
             calls: Mutex::new(0),
+            checkpoint_calls: Mutex::new(0),
+            optimize_calls: Mutex::new(0),
         })
     }
 
@@ -29,11 +37,21 @@ impl MockMaintenance {
         Arc::new(Self {
             result: Err(anyhow::anyhow!("synthetic vacuum error")),
             calls: Mutex::new(0),
+            checkpoint_calls: Mutex::new(0),
+            optimize_calls: Mutex::new(0),
         })
     }
 
     fn call_count(&self) -> u32 {
         *self.calls.lock().unwrap()
+    }
+
+    fn checkpoint_count(&self) -> u32 {
+        *self.checkpoint_calls.lock().unwrap()
+    }
+
+    fn optimize_count(&self) -> u32 {
+        *self.optimize_calls.lock().unwrap()
     }
 }
 
@@ -43,6 +61,26 @@ impl MaintenanceService for MockMaintenance {
         *self.calls.lock().unwrap() += 1;
         match &self.result {
             Ok(n) => Ok(*n),
+            Err(e) => Err(AppError::Internal(anyhow::anyhow!("{e}"))),
+        }
+    }
+
+    async fn run_wal_checkpoint(&self) -> Result<WalCheckpointOutcome, AppError> {
+        *self.checkpoint_calls.lock().unwrap() += 1;
+        match &self.result {
+            Ok(_) => Ok(WalCheckpointOutcome {
+                busy: false,
+                wal_frames: 0,
+                checkpointed_frames: 0,
+            }),
+            Err(e) => Err(AppError::Internal(anyhow::anyhow!("{e}"))),
+        }
+    }
+
+    async fn run_optimize(&self) -> Result<(), AppError> {
+        *self.optimize_calls.lock().unwrap() += 1;
+        match &self.result {
+            Ok(_) => Ok(()),
             Err(e) => Err(AppError::Internal(anyhow::anyhow!("{e}"))),
         }
     }
@@ -75,6 +113,29 @@ async fn run_vacuum_warns_and_does_not_panic_on_error() {
     let repo = MockMaintenance::err();
     run_vacuum(repo.as_ref(), &admin_ctx()).await; // must not panic
     assert_eq!(repo.call_count(), 1);
+}
+
+// ── run_daily_maintenance — vacuum + checkpoint + optimize ───────────────────
+
+/// The daily sequence must fire all three operations exactly once.
+#[tokio::test]
+async fn run_daily_maintenance_runs_vacuum_checkpoint_and_optimize() {
+    let repo = MockMaintenance::ok(3);
+    run_daily_maintenance(repo.as_ref(), &admin_ctx()).await;
+    assert_eq!(repo.call_count(), 1, "vacuum should fire once");
+    assert_eq!(repo.checkpoint_count(), 1, "checkpoint should fire once");
+    assert_eq!(repo.optimize_count(), 1, "optimize should fire once");
+}
+
+/// A failure in one step must not stop the others: all three still fire
+/// even when every call returns an error.
+#[tokio::test]
+async fn run_daily_maintenance_continues_past_errors() {
+    let repo = MockMaintenance::err();
+    run_daily_maintenance(repo.as_ref(), &admin_ctx()).await; // must not panic
+    assert_eq!(repo.call_count(), 1);
+    assert_eq!(repo.checkpoint_count(), 1);
+    assert_eq!(repo.optimize_count(), 1);
 }
 
 // ── Runner integration tests ──────────────────────────────────────────────────
@@ -113,6 +174,16 @@ async fn runner_fires_vacuum_on_day_rollover() {
         repo.call_count() >= 1,
         "expected vacuum to fire on day rollover, call_count={}",
         repo.call_count()
+    );
+    assert!(
+        repo.checkpoint_count() >= 1,
+        "expected WAL checkpoint to fire on day rollover, checkpoint_count={}",
+        repo.checkpoint_count()
+    );
+    assert!(
+        repo.optimize_count() >= 1,
+        "expected optimize to fire on day rollover, optimize_count={}",
+        repo.optimize_count()
     );
 }
 

--- a/source/daemon/crates/wardnetd-services/src/tests/health_checks.rs
+++ b/source/daemon/crates/wardnetd-services/src/tests/health_checks.rs
@@ -343,6 +343,14 @@ impl wardnetd_data::repository::MaintenanceRepository for MockMaintenanceRepo {
     async fn incremental_vacuum(&self) -> anyhow::Result<u64> {
         unimplemented!()
     }
+    async fn wal_checkpoint_truncate(
+        &self,
+    ) -> anyhow::Result<wardnetd_data::repository::WalCheckpointOutcome> {
+        unimplemented!()
+    }
+    async fn optimize(&self) -> anyhow::Result<()> {
+        unimplemented!()
+    }
     async fn ping(&self) -> anyhow::Result<()> {
         if self.fail {
             Err(anyhow::anyhow!("simulated db failure"))

--- a/source/daemon/crates/wardnetd-services/src/tests/maintenance.rs
+++ b/source/daemon/crates/wardnetd-services/src/tests/maintenance.rs
@@ -1,0 +1,133 @@
+//! Tests for [`MaintenanceServiceImpl`] — the auth-gated wrapper over the
+//! [`MaintenanceRepository`]. Covers the admin gate and the pass-through of
+//! each operation's success and error to the repository.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use uuid::Uuid;
+use wardnet_common::auth::AuthContext;
+use wardnetd_data::repository::{MaintenanceRepository, WalCheckpointOutcome};
+
+use crate::auth_context;
+use crate::error::AppError;
+use crate::maintenance::{MaintenanceService, MaintenanceServiceImpl};
+
+/// Mock repository whose every operation succeeds or fails on demand.
+struct MockRepo {
+    fail: bool,
+}
+
+#[async_trait]
+impl MaintenanceRepository for MockRepo {
+    async fn incremental_vacuum(&self) -> anyhow::Result<u64> {
+        if self.fail {
+            anyhow::bail!("synthetic vacuum error")
+        }
+        Ok(7)
+    }
+
+    async fn wal_checkpoint_truncate(&self) -> anyhow::Result<WalCheckpointOutcome> {
+        if self.fail {
+            anyhow::bail!("synthetic checkpoint error")
+        }
+        Ok(WalCheckpointOutcome {
+            busy: false,
+            wal_frames: 12,
+            checkpointed_frames: 12,
+        })
+    }
+
+    async fn optimize(&self) -> anyhow::Result<()> {
+        if self.fail {
+            anyhow::bail!("synthetic optimize error")
+        }
+        Ok(())
+    }
+
+    async fn ping(&self) -> anyhow::Result<()> {
+        Ok(())
+    }
+}
+
+fn service(fail: bool) -> MaintenanceServiceImpl {
+    MaintenanceServiceImpl::new(Arc::new(MockRepo { fail }))
+}
+
+fn admin_ctx() -> AuthContext {
+    AuthContext::Admin {
+        admin_id: Uuid::nil(),
+    }
+}
+
+// ── run_wal_checkpoint ───────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn run_wal_checkpoint_returns_outcome_for_admin() {
+    let svc = service(false);
+    let outcome = auth_context::with_context(admin_ctx(), svc.run_wal_checkpoint())
+        .await
+        .expect("admin checkpoint should succeed");
+    assert!(!outcome.busy);
+    assert_eq!(outcome.checkpointed_frames, 12);
+}
+
+#[tokio::test]
+async fn run_wal_checkpoint_maps_repo_error_to_internal() {
+    let svc = service(true);
+    let err = auth_context::with_context(admin_ctx(), svc.run_wal_checkpoint())
+        .await
+        .expect_err("repo failure should surface");
+    assert!(matches!(err, AppError::Internal(_)));
+}
+
+#[tokio::test]
+async fn run_wal_checkpoint_forbidden_without_admin() {
+    let svc = service(false);
+    // No auth context set → require_admin() must reject before touching the repo.
+    let err = svc
+        .run_wal_checkpoint()
+        .await
+        .expect_err("non-admin must be forbidden");
+    assert!(matches!(err, AppError::Forbidden(_)));
+}
+
+// ── run_optimize ─────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn run_optimize_succeeds_for_admin() {
+    let svc = service(false);
+    auth_context::with_context(admin_ctx(), svc.run_optimize())
+        .await
+        .expect("admin optimize should succeed");
+}
+
+#[tokio::test]
+async fn run_optimize_maps_repo_error_to_internal() {
+    let svc = service(true);
+    let err = auth_context::with_context(admin_ctx(), svc.run_optimize())
+        .await
+        .expect_err("repo failure should surface");
+    assert!(matches!(err, AppError::Internal(_)));
+}
+
+#[tokio::test]
+async fn run_optimize_forbidden_without_admin() {
+    let svc = service(false);
+    let err = svc
+        .run_optimize()
+        .await
+        .expect_err("non-admin must be forbidden");
+    assert!(matches!(err, AppError::Forbidden(_)));
+}
+
+// ── run_incremental_vacuum (pre-existing method, exercised for completeness) ──
+
+#[tokio::test]
+async fn run_incremental_vacuum_returns_reclaimed_for_admin() {
+    let svc = service(false);
+    let reclaimed = auth_context::with_context(admin_ctx(), svc.run_incremental_vacuum())
+        .await
+        .expect("admin vacuum should succeed");
+    assert_eq!(reclaimed, 7);
+}

--- a/source/daemon/crates/wardnetd-services/src/tests/mod.rs
+++ b/source/daemon/crates/wardnetd-services/src/tests/mod.rs
@@ -6,6 +6,7 @@ mod health;
 mod health_checks;
 mod init;
 mod jobs;
+mod maintenance;
 mod request_context;
 mod subnet;
 mod version;


### PR DESCRIPTION
The daemon opens SQLite in WAL mode but nothing ever truncates the WAL.
SQLite's automatic checkpoints are always PASSIVE: they backfill frames
into the main database but never shrink the -wal file on disk. With no
journal_size_limit and no periodic wal_checkpoint(TRUNCATE), the WAL
parks at its historical high-water mark forever — observed at 530 MiB in
the field, dragging every read and write. The daily DNS query-log
retention DELETE (a large single-transaction write) is what drives it up
there while the reader pool holds snapshots that stall the passive reset.

Fixes, layered:

- Set `PRAGMA journal_size_limit = 64 MiB` on every file-backed
  connection so a passive checkpoint truncates the sidecar back down
  instead of growing unbounded. This is the always-on guard that stops
  the WAL from ever parking at hundreds of MiB again.

- Add `wal_checkpoint_truncate()` to MaintenanceRepository and run it in
  the daily DbMaintenanceRunner, resetting the sidecar to ~0. A busy
  checkpoint (reader active) is reported, not raised, and retried next
  tick.

- Add `optimize()` (PRAGMA optimize, bounded by analysis_limit=400) to
  refresh the query planner's statistics — the ANALYZE the planner needs
  as tables like dns_query_log grow. Run daily alongside the checkpoint.

The daily runner now performs vacuum -> checkpoint -> optimize; each step
is independent so a failure in one still runs the others.