### PR TITLE
perf(dns): hot-path optimizations from #967 (findings 2, 4, 5, 6, 7)

### DIFF
--- a/source/daemon/crates/wardnetd-services/benches/dns_components.rs
+++ b/source/daemon/crates/wardnetd-services/benches/dns_components.rs
@@ -34,8 +34,17 @@ use wardnetd_services::dns::filter_parser::parse_line;
 use wardnetd_services::dns::{DnsCache, row_to_event};
 use wardnetd_services::dns_filter::{DnsFilter, DnsFilterInputs, RuntimeDnsFilterProfile};
 
-fn response() -> Message {
-    Message::response(0, OpCode::Query)
+/// A one-answer A response as the wire bytes the cache now stores — a
+/// realistic hit payload, so the get-hit bench reflects the buffer copy +
+/// TTL-aging walk over an actual record rather than an empty message.
+fn response_wire() -> Vec<u8> {
+    let mut resp = Message::response(0, OpCode::Query);
+    resp.add_answer(Record::from_rdata(
+        Name::from_str_relaxed("example.com.").expect("answer name"),
+        300,
+        RData::A(A(Ipv4Addr::new(93, 184, 216, 34))),
+    ));
+    resp.to_bytes().expect("encode response")
 }
 
 /// `DnsCache` lookup + insert — the per-query cache path. Hit and miss are
@@ -50,13 +59,18 @@ fn bench_cache(c: &mut Criterion) {
             UpstreamId::Default,
             "example.com",
             RecordType::A,
-            response(),
+            response_wire(),
             300,
             0,
             86400,
         );
         b.iter(|| {
-            black_box(cache.get(UpstreamId::Default, black_box("example.com"), RecordType::A));
+            black_box(cache.get(
+                UpstreamId::Default,
+                black_box("example.com"),
+                RecordType::A,
+                0,
+            ));
         });
     });
 
@@ -69,6 +83,7 @@ fn bench_cache(c: &mut Criterion) {
                 UpstreamId::Default,
                 black_box("absent.example.com"),
                 RecordType::A,
+                0,
             ));
         });
     });
@@ -81,7 +96,7 @@ fn bench_cache(c: &mut Criterion) {
                     UpstreamId::Default,
                     black_box("example.com"),
                     RecordType::A,
-                    response(),
+                    response_wire(),
                     300,
                     0,
                     86400,
@@ -115,7 +130,7 @@ fn bench_cache_concurrent(c: &mut Criterion) {
                     UpstreamId::Default,
                     "example.com",
                     RecordType::A,
-                    response(),
+                    response_wire(),
                     300,
                     0,
                     86400,
@@ -136,6 +151,7 @@ fn bench_cache_concurrent(c: &mut Criterion) {
                                         UpstreamId::Default,
                                         black_box("example.com"),
                                         RecordType::A,
+                                        0,
                                     ));
                                 }
                             })
@@ -279,7 +295,9 @@ fn bench_filter(c: &mut Criterion) {
 
     let build_10k = || {
         DnsFilter::build(DnsFilterInputs {
-            blocked_domains: (0..10_000).map(|i| format!("blocked{i}.example.com")).collect(),
+            blocked_domains: (0..10_000)
+                .map(|i| format!("blocked{i}.example.com"))
+                .collect(),
             allowlist: vec![],
             custom_rules: vec![],
         })
@@ -291,11 +309,7 @@ fn bench_filter(c: &mut Criterion) {
     group.bench_function("check_uncanonical", |b| {
         let filter = build_10k();
         b.iter(|| {
-            black_box(filter.check(
-                black_box("Allowed.Example.Org."),
-                RecordType::A,
-                client,
-            ));
+            black_box(filter.check(black_box("Allowed.Example.Org."), RecordType::A, client));
         });
     });
 

--- a/source/daemon/crates/wardnetd-services/benches/dns_components.rs
+++ b/source/daemon/crates/wardnetd-services/benches/dns_components.rs
@@ -28,9 +28,10 @@ use uuid::Uuid;
 use wardnet_common::dns::{
     ConditionalForwardingRule, CustomDnsRecord, DnsRecordSource, DnsRecordType, UpstreamId,
 };
-use wardnetd_services::dns::DnsCache;
+use wardnetd_data::repository::QueryLogRow;
 use wardnetd_services::dns::authoritative::AuthoritativeView;
 use wardnetd_services::dns::filter_parser::parse_line;
+use wardnetd_services::dns::{DnsCache, row_to_event};
 use wardnetd_services::dns_filter::{DnsFilter, DnsFilterInputs, RuntimeDnsFilterProfile};
 
 fn response() -> Message {
@@ -354,6 +355,34 @@ fn bench_message(c: &mut Criterion) {
     group.finish();
 }
 
+/// `row_to_event` — the WS-event projection `DnsLogSink::record` builds per
+/// query (~6 string clones). It's pure waste when no live-log viewer is
+/// connected (the normal state); `record` now skips it when there are no
+/// subscribers, so this tracks the cost that gating elides.
+fn bench_log_sink(c: &mut Criterion) {
+    let mut group = c.benchmark_group("dns_log_sink");
+
+    let row = QueryLogRow {
+        timestamp: "2026-05-05T00:00:00Z".to_owned(),
+        client_ip: "10.0.0.1".to_owned(),
+        domain: "metrics.analytics-node.example".to_owned(),
+        query_type: "A".to_owned(),
+        result: "forwarded".to_owned(),
+        upstream: Some("1.1.1.1:53".to_owned()),
+        latency_ms: 1.0,
+        device_id: None,
+        protocol: "udp".to_owned(),
+    };
+
+    group.bench_function("row_to_event", |b| {
+        b.iter(|| {
+            black_box(row_to_event(black_box(&row)));
+        });
+    });
+
+    group.finish();
+}
+
 criterion_group!(
     benches,
     bench_cache,
@@ -361,5 +390,6 @@ criterion_group!(
     bench_authoritative,
     bench_filter,
     bench_message,
+    bench_log_sink,
 );
 criterion_main!(benches);

--- a/source/daemon/crates/wardnetd-services/benches/dns_components.rs
+++ b/source/daemon/crates/wardnetd-services/benches/dns_components.rs
@@ -17,6 +17,7 @@ use std::sync::{Arc, Barrier, RwLock};
 use std::thread;
 use std::time::Instant;
 
+use arc_swap::ArcSwap;
 use chrono::Utc;
 use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
 use hickory_proto::op::{Message, OpCode, Query};
@@ -30,7 +31,7 @@ use wardnet_common::dns::{
 use wardnetd_services::dns::DnsCache;
 use wardnetd_services::dns::authoritative::AuthoritativeView;
 use wardnetd_services::dns::filter_parser::parse_line;
-use wardnetd_services::dns_filter::{DnsFilter, DnsFilterInputs};
+use wardnetd_services::dns_filter::{DnsFilter, DnsFilterInputs, RuntimeDnsFilterProfile};
 
 fn response() -> Message {
     Message::response(0, OpCode::Query)
@@ -274,6 +275,42 @@ fn bench_filter(c: &mut Criterion) {
             });
         });
     }
+
+    let build_10k = || {
+        DnsFilter::build(DnsFilterInputs {
+            blocked_domains: (0..10_000).map(|i| format!("blocked{i}.example.com")).collect(),
+            allowlist: vec![],
+            custom_rules: vec![],
+        })
+    };
+
+    // Owned normalize path: a mixed-case, trailing-dot name (the one shape
+    // `check` still has to allocate and lowercase, vs the borrow it takes for
+    // the canonical names the pipeline normally hands down).
+    group.bench_function("check_uncanonical", |b| {
+        let filter = build_10k();
+        b.iter(|| {
+            black_box(filter.check(
+                black_box("Allowed.Example.Org."),
+                RecordType::A,
+                client,
+            ));
+        });
+    });
+
+    // The real profile path: `RuntimeDnsFilterProfile::check` fans one query
+    // across each source, loading every one through its `ArcSwap` and
+    // aggregating outcomes — the cost a query actually pays when a profile
+    // stacks several blocklists, not `DnsFilter::check` in isolation.
+    group.bench_function("profile_check_pass", |b| {
+        let filters: Vec<Arc<ArcSwap<DnsFilter>>> = (0..4)
+            .map(|_| Arc::new(ArcSwap::from_pointee(build_10k())))
+            .collect();
+        let profile = RuntimeDnsFilterProfile::new(Uuid::nil(), "bench".to_string(), filters);
+        b.iter(|| {
+            black_box(profile.check(black_box("allowed.example.org"), RecordType::A, client));
+        });
+    });
 
     group.finish();
 }

--- a/source/daemon/crates/wardnetd-services/src/dns/cache.rs
+++ b/source/daemon/crates/wardnetd-services/src/dns/cache.rs
@@ -2,7 +2,6 @@ use std::collections::{HashMap, VecDeque};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{Duration, Instant};
 
-use hickory_proto::op::Message;
 use hickory_proto::rr::RecordType;
 
 use wardnet_common::dns::UpstreamId;
@@ -11,6 +10,19 @@ use crate::dns_filter::filter::normalize_owned;
 
 type CacheKey = (UpstreamId, String, RecordType);
 
+/// DNS wire-format record type for EDNS `OPT`. Its "TTL" field is actually
+/// extended-rcode + version + flags, not a real TTL, so the aging walk must
+/// leave it untouched.
+const RR_TYPE_OPT: u16 = 41;
+
+/// Fixed-size portion of a resource record following its NAME: TYPE(2) +
+/// CLASS(2) + TTL(4) + RDLENGTH(2).
+const RR_FIXED_LEN: usize = 10;
+
+/// Byte offset of the TTL field within a record's fixed portion (past TYPE and
+/// CLASS).
+const RR_TTL_OFFSET: usize = 4;
+
 /// Once the eviction queue holds this many slots for an empty-ish cache it
 /// gets compacted regardless of the live-entry count, so a small cache can't
 /// keep a long tail of stale slots alive.
@@ -18,7 +30,11 @@ const ORDER_COMPACT_FLOOR: usize = 64;
 
 /// A cached DNS response with TTL-aware expiration.
 struct CachedEntry {
-    response: Message,
+    /// The full response in wire format, exactly as sent to the first client
+    /// that populated it (transaction id included but irrelevant — the read
+    /// path overwrites it). Serving a hit is a buffer copy + txid patch +
+    /// in-place TTL aging, with no per-hit `Message` clone or re-encode.
+    wire: Vec<u8>,
     inserted_at: Instant,
     ttl: Duration,
     /// Matches this entry to its slot in `insertion_order`; an overwrite
@@ -84,16 +100,24 @@ impl DnsCache {
         }
     }
 
-    /// Look up a cached response keyed by upstream pool. Returns `None`
-    /// if not found or expired. Expired entries are left for the eviction
-    /// machinery to reclaim so lookups stay shared-access.
+    /// Look up a cached response keyed by upstream pool, returning it as a
+    /// send-ready wire buffer stamped with the caller's transaction `id`.
+    /// Returns `None` if not found or expired. Expired entries are left for
+    /// the eviction machinery to reclaim so lookups stay shared-access.
     ///
-    /// The returned message's record TTLs are aged down by the entry's
-    /// time in cache and capped at the entry's remaining lifetime, so a
-    /// client hitting near the end of the entry's lifetime can't
-    /// over-cache the records downstream — neither past their original
-    /// TTL nor past the admin's `ttl_max` clamp.
-    pub fn get(&self, upstream: UpstreamId, domain: &str, rtype: RecordType) -> Option<Message> {
+    /// The returned buffer's record TTLs are aged down by the entry's time in
+    /// cache and capped at the entry's remaining lifetime, so a client hitting
+    /// near the end of the entry's lifetime can't over-cache the records
+    /// downstream — neither past their original TTL nor past the admin's
+    /// `ttl_max` clamp. Aging happens in place on the wire bytes; no `Message`
+    /// is parsed, cloned, or re-encoded on the hit path.
+    pub fn get(
+        &self,
+        upstream: UpstreamId,
+        domain: &str,
+        rtype: RecordType,
+        id: u16,
+    ) -> Option<Vec<u8>> {
         let key = (upstream, canonical_domain(domain), rtype);
 
         let Some(entry) = self.entries.get(&key) else {
@@ -108,20 +132,27 @@ impl DnsCache {
         }
 
         self.hits.fetch_add(1, Ordering::Relaxed);
-        let mut response = entry.response.clone();
+        let mut wire = entry.wire.clone();
+        // Stamp the querying client's transaction id over the cached one — the
+        // only header field a hit needs to change (2 bytes, big-endian).
+        if wire.len() >= 2 {
+            wire[..2].copy_from_slice(&id.to_be_bytes());
+        }
         // Whole seconds for both, so a fresh hit (sub-second age) doesn't
         // round the remaining lifetime down below the original TTL.
         let elapsed = age.as_secs();
-        age_record_ttls(
-            &mut response,
+        age_wire_ttls(
+            &mut wire,
             elapsed,
             entry.ttl.as_secs().saturating_sub(elapsed),
         );
-        Some(response)
+        Some(wire)
     }
 
-    /// Insert a response into the cache with the given TTL, keyed by the
-    /// upstream pool that produced it.
+    /// Insert a response — as its wire-format bytes, exactly as sent — into
+    /// the cache with the given TTL, keyed by the upstream pool that produced
+    /// it. The send paths already hold these bytes (the built response or the
+    /// raw upstream datagram), so caching costs no extra encode.
     ///
     /// The TTL is clamped between `ttl_min` and `ttl_max` seconds.
     #[allow(clippy::too_many_arguments)]
@@ -130,7 +161,7 @@ impl DnsCache {
         upstream: UpstreamId,
         domain: &str,
         rtype: RecordType,
-        response: Message,
+        wire: Vec<u8>,
         ttl_secs: u32,
         ttl_min: u32,
         ttl_max: u32,
@@ -159,7 +190,7 @@ impl DnsCache {
         self.entries.insert(
             key,
             CachedEntry {
-                response,
+                wire,
                 inserted_at: Instant::now(),
                 ttl: Duration::from_secs(u64::from(ttl)),
                 seq,
@@ -298,27 +329,89 @@ impl DnsCache {
     }
 }
 
-/// Age a cached response's record TTLs by its time in cache, and cap them
-/// at the entry's remaining lifetime so the admin's `ttl_max` clamp bounds
-/// what downstream resolvers cache, not just how long this cache keeps the
-/// entry. Nonzero TTLs floor at 1 so a still-valid entry never serves a
-/// wrapped TTL; a TTL of 0 is an upstream do-not-cache signal and is left
-/// alone. All three record sections are aged — the forwarding paths cache
-/// the full upstream message, which can carry glue records in additionals
-/// (OPT never appears there; hickory parses it into `Message::edns`).
-fn age_record_ttls(response: &mut Message, elapsed_secs: u64, remaining_secs: u64) {
+/// Age every resource record's TTL in a wire-format response by its time in
+/// cache, capping at the entry's remaining lifetime so the admin's `ttl_max`
+/// clamp bounds what downstream resolvers cache, not just how long this cache
+/// keeps the entry. Nonzero TTLs floor at 1 so a still-valid entry never
+/// serves a wrapped TTL; a TTL of 0 is an upstream do-not-cache signal and is
+/// left alone.
+///
+/// Walks the header counts and question section to reach the records, then
+/// each record's NAME (following the length/pointer encoding) to reach its
+/// TTL field. `OPT` records are skipped — their "TTL" field is EDNS metadata,
+/// not a real TTL. The walk is fully bounds-checked: a buffer that doesn't
+/// parse cleanly (never expected — we cached bytes we ourselves sent) simply
+/// stops aging where it fell off, rather than panicking on the hot path.
+fn age_wire_ttls(buf: &mut [u8], elapsed_secs: u64, remaining_secs: u64) {
     let elapsed = u32::try_from(elapsed_secs).unwrap_or(u32::MAX);
     let remaining = u32::try_from(remaining_secs).unwrap_or(u32::MAX);
-    for record in response
-        .answers
-        .iter_mut()
-        .chain(response.authorities.iter_mut())
-        .chain(response.additionals.iter_mut())
-    {
-        if record.ttl == 0 {
-            continue;
+    let _ = age_wire_ttls_inner(buf, elapsed, remaining);
+}
+
+/// Fallible core of [`age_wire_ttls`]; returns `None` the moment an offset
+/// would run past the buffer, leaving the remainder untouched.
+fn age_wire_ttls_inner(buf: &mut [u8], elapsed: u32, remaining: u32) -> Option<()> {
+    // Header is 12 bytes: id(2) flags(2) qdcount(2) then the three record
+    // section counts — answer(2), authority(2), additional(2). All three
+    // sections carry real records to age, so sum them into one record count.
+    let question_count = u16::from_be_bytes([*buf.get(4)?, *buf.get(5)?]);
+    let record_count = u32::from(u16::from_be_bytes([*buf.get(6)?, *buf.get(7)?]))
+        + u32::from(u16::from_be_bytes([*buf.get(8)?, *buf.get(9)?]))
+        + u32::from(u16::from_be_bytes([*buf.get(10)?, *buf.get(11)?]));
+
+    let mut pos = 12;
+    for _ in 0..question_count {
+        pos = skip_name(buf, pos)?;
+        pos = pos.checked_add(4)?; // QTYPE(2) + QCLASS(2)
+    }
+
+    for _ in 0..record_count {
+        pos = skip_name(buf, pos)?;
+        let rtype = u16::from_be_bytes([*buf.get(pos)?, *buf.get(pos + 1)?]);
+        let ttl_at = pos.checked_add(RR_TTL_OFFSET)?;
+        let rdlen_at = pos.checked_add(8)?;
+        let rdlength = usize::from(u16::from_be_bytes([
+            *buf.get(rdlen_at)?,
+            *buf.get(rdlen_at + 1)?,
+        ]));
+
+        // OPT carries EDNS state in its TTL slot — never a real TTL.
+        if rtype != RR_TYPE_OPT {
+            let ttl = u32::from_be_bytes([
+                *buf.get(ttl_at)?,
+                *buf.get(ttl_at + 1)?,
+                *buf.get(ttl_at + 2)?,
+                *buf.get(ttl_at + 3)?,
+            ]);
+            if ttl != 0 {
+                let aged = ttl.saturating_sub(elapsed).min(remaining).max(1);
+                buf.get_mut(ttl_at..ttl_at + 4)?
+                    .copy_from_slice(&aged.to_be_bytes());
+            }
         }
-        record.ttl = record.ttl.saturating_sub(elapsed).min(remaining).max(1);
+
+        pos = pos.checked_add(RR_FIXED_LEN)?.checked_add(rdlength)?;
+    }
+    Some(())
+}
+
+/// Advance past a DNS NAME starting at `pos`, returning the offset of the byte
+/// after it. A name is a run of length-prefixed labels ending in a zero byte,
+/// or a 2-byte compression pointer (top two bits set) that terminates it. The
+/// reserved `0x40`/`0x80` length forms are treated as malformed.
+fn skip_name(buf: &[u8], mut pos: usize) -> Option<usize> {
+    loop {
+        let len = *buf.get(pos)?;
+        match len & 0xC0 {
+            0x00 => {
+                if len == 0 {
+                    return Some(pos + 1);
+                }
+                pos = pos.checked_add(1 + usize::from(len))?;
+            }
+            0xC0 => return pos.checked_add(2),
+            _ => return None,
+        }
     }
 }
 

--- a/source/daemon/crates/wardnetd-services/src/dns/cache.rs
+++ b/source/daemon/crates/wardnetd-services/src/dns/cache.rs
@@ -7,7 +7,7 @@ use hickory_proto::rr::RecordType;
 
 use wardnet_common::dns::UpstreamId;
 
-use crate::dns_filter::filter::normalize;
+use crate::dns_filter::filter::normalize_owned;
 
 type CacheKey = (UpstreamId, String, RecordType);
 
@@ -325,7 +325,8 @@ fn age_record_ttls(response: &mut Message, elapsed_secs: u64, remaining_secs: u6
 /// Canonical cache-key form of a domain: lowercase, no trailing dot. The
 /// server inserts wire-format FQDNs ("foo.com.") while eviction callers pass
 /// bare names ("foo.com"); both must map to the same key. Delegates to the
-/// filter's normalizer so every DNS path agrees on canonical form.
+/// filter's owned normalizer so every DNS path agrees on canonical form —
+/// the key is always owned, so the single-pass `normalize_owned` fits here.
 fn canonical_domain(domain: &str) -> String {
-    normalize(domain)
+    normalize_owned(domain)
 }

--- a/source/daemon/crates/wardnetd-services/src/dns/log_sink.rs
+++ b/source/daemon/crates/wardnetd-services/src/dns/log_sink.rs
@@ -146,7 +146,12 @@ impl DnsLogSink {
         if let Some(ref inst) = self.stat_instruments {
             record_dns_stats(inst, &row);
         }
-        let event = row_to_event(&row);
+        // Build the broadcast event only when a live-stream viewer is
+        // connected. With none — the normal state — `send` would fail and
+        // discard it anyway, so `row_to_event`'s handful of string clones
+        // would be pure waste on every query. Computed here, before `row` is
+        // moved into the persist send below.
+        let event = (self.stream_tx.receiver_count() > 0).then(|| row_to_event(&row));
         // Forward to capture runner only when a device is identified.
         // Avoid cloning when the channel is already known-full — check
         // capacity first to skip the heap allocation on a saturated buffer.
@@ -164,8 +169,12 @@ impl DnsLogSink {
         if let Err(mpsc::error::TrySendError::Full(_)) = self.persist_tx.try_send(row) {
             self.dropped_entries.fetch_add(1, Ordering::Relaxed);
         }
-        // Closed/no-subscriber broadcast errors are normal and ignored.
-        let _ = self.stream_tx.send(event);
+        // Closed/no-subscriber broadcast errors are normal and ignored. A
+        // subscriber that raced in after the `receiver_count` check above just
+        // misses this one event — live-stream is best-effort.
+        if let Some(event) = event {
+            let _ = self.stream_tx.send(event);
+        }
     }
 
     /// Subscribe to the live-stream broadcast.

--- a/source/daemon/crates/wardnetd-services/src/dns/tests/cache.rs
+++ b/source/daemon/crates/wardnetd-services/src/dns/tests/cache.rs
@@ -4,6 +4,7 @@ use std::time::Duration;
 use hickory_proto::op::{Message, OpCode};
 use hickory_proto::rr::rdata::{A, SOA};
 use hickory_proto::rr::{Name, RData, Record, RecordType};
+use hickory_proto::serialize::binary::{BinDecodable, BinEncodable};
 use uuid::Uuid;
 use wardnet_common::dns::UpstreamId;
 
@@ -24,16 +25,43 @@ fn make_answer_response(domain: &str, ttl: u32) -> Message {
     resp
 }
 
+/// Encode a response to the wire bytes the cache now stores.
+fn wire(msg: &Message) -> Vec<u8> {
+    msg.to_bytes().expect("encode response to wire")
+}
+
+/// Look a response up and decode the returned wire buffer back into a
+/// `Message`, so the TTL/section assertions below can inspect it. Uses a
+/// fixed transaction id — the tests that care assert on it explicitly.
+fn get_msg(
+    cache: &DnsCache,
+    upstream: UpstreamId,
+    domain: &str,
+    rtype: RecordType,
+) -> Option<Message> {
+    cache
+        .get(upstream, domain, rtype, 0)
+        .map(|b| Message::from_bytes(&b).expect("decode cached wire response"))
+}
+
 const DEFAULT: UpstreamId = UpstreamId::Default;
 
 #[test]
 fn insert_and_get() {
     let mut cache = DnsCache::new(100);
     let resp = make_response();
-    cache.insert(DEFAULT, "example.com", RecordType::A, resp, 300, 0, 86400);
+    cache.insert(
+        DEFAULT,
+        "example.com",
+        RecordType::A,
+        wire(&resp),
+        300,
+        0,
+        86400,
+    );
     assert_eq!(cache.len(), 1);
-    assert!(cache.get(DEFAULT, "example.com", RecordType::A).is_some());
-    assert!(cache.get(DEFAULT, "other.com", RecordType::A).is_none());
+    assert!(get_msg(&cache, DEFAULT, "example.com", RecordType::A).is_some());
+    assert!(get_msg(&cache, DEFAULT, "other.com", RecordType::A).is_none());
 }
 
 #[test]
@@ -43,12 +71,12 @@ fn case_insensitive() {
         DEFAULT,
         "Example.COM",
         RecordType::A,
-        make_response(),
+        wire(&make_response()),
         300,
         0,
         86400,
     );
-    assert!(cache.get(DEFAULT, "example.com", RecordType::A).is_some());
+    assert!(get_msg(&cache, DEFAULT, "example.com", RecordType::A).is_some());
 }
 
 #[test]
@@ -61,13 +89,13 @@ fn trailing_dot_normalized_across_insert_get_and_invalidate() {
         DEFAULT,
         "example.com.",
         RecordType::A,
-        make_response(),
+        wire(&make_response()),
         300,
         0,
         86400,
     );
     assert!(
-        cache.get(DEFAULT, "example.com", RecordType::A).is_some(),
+        get_msg(&cache, DEFAULT, "example.com", RecordType::A).is_some(),
         "bare-name lookup must hit the FQDN-inserted entry"
     );
     assert_eq!(
@@ -85,7 +113,7 @@ fn zero_ttl_not_cached() {
         DEFAULT,
         "example.com",
         RecordType::A,
-        make_response(),
+        wire(&make_response()),
         0,
         0,
         86400,
@@ -100,7 +128,7 @@ fn flush_clears_all() {
         DEFAULT,
         "a.com",
         RecordType::A,
-        make_response(),
+        wire(&make_response()),
         300,
         0,
         86400,
@@ -109,7 +137,7 @@ fn flush_clears_all() {
         DEFAULT,
         "b.com",
         RecordType::A,
-        make_response(),
+        wire(&make_response()),
         300,
         0,
         86400,
@@ -125,7 +153,7 @@ fn evicts_when_at_capacity() {
         DEFAULT,
         "a.com",
         RecordType::A,
-        make_response(),
+        wire(&make_response()),
         300,
         0,
         86400,
@@ -134,7 +162,7 @@ fn evicts_when_at_capacity() {
         DEFAULT,
         "b.com",
         RecordType::A,
-        make_response(),
+        wire(&make_response()),
         300,
         0,
         86400,
@@ -143,14 +171,14 @@ fn evicts_when_at_capacity() {
         DEFAULT,
         "c.com",
         RecordType::A,
-        make_response(),
+        wire(&make_response()),
         300,
         0,
         86400,
     );
     assert_eq!(cache.len(), 2);
     // Oldest (a.com) should have been evicted.
-    assert!(cache.get(DEFAULT, "a.com", RecordType::A).is_none());
+    assert!(get_msg(&cache, DEFAULT, "a.com", RecordType::A).is_none());
 }
 
 #[test]
@@ -160,13 +188,13 @@ fn hit_rate_tracking() {
         DEFAULT,
         "a.com",
         RecordType::A,
-        make_response(),
+        wire(&make_response()),
         300,
         0,
         86400,
     );
-    cache.get(DEFAULT, "a.com", RecordType::A); // hit
-    cache.get(DEFAULT, "b.com", RecordType::A); // miss
+    let _ = get_msg(&cache, DEFAULT, "a.com", RecordType::A); // hit
+    let _ = get_msg(&cache, DEFAULT, "b.com", RecordType::A); // miss
     assert_eq!(cache.hits(), 1);
     assert_eq!(cache.misses(), 1);
     assert!((cache.hit_rate() - 0.5).abs() < f64::EPSILON);
@@ -180,7 +208,7 @@ fn ttl_min_clamp() {
         DEFAULT,
         "a.com",
         RecordType::A,
-        make_response(),
+        wire(&make_response()),
         5,
         60,
         86400,
@@ -195,7 +223,7 @@ fn different_record_types_cached_separately() {
         DEFAULT,
         "a.com",
         RecordType::A,
-        make_response(),
+        wire(&make_response()),
         300,
         0,
         86400,
@@ -204,14 +232,14 @@ fn different_record_types_cached_separately() {
         DEFAULT,
         "a.com",
         RecordType::AAAA,
-        make_response(),
+        wire(&make_response()),
         300,
         0,
         86400,
     );
     assert_eq!(cache.len(), 2);
-    assert!(cache.get(DEFAULT, "a.com", RecordType::A).is_some());
-    assert!(cache.get(DEFAULT, "a.com", RecordType::AAAA).is_some());
+    assert!(get_msg(&cache, DEFAULT, "a.com", RecordType::A).is_some());
+    assert!(get_msg(&cache, DEFAULT, "a.com", RecordType::AAAA).is_some());
 }
 
 #[test]
@@ -232,7 +260,15 @@ fn hit_ages_answer_and_authority_ttls() {
         300,
         RData::SOA(soa),
     ));
-    cache.insert(DEFAULT, "example.com", RecordType::A, resp, 300, 0, 86400);
+    cache.insert(
+        DEFAULT,
+        "example.com",
+        RecordType::A,
+        wire(&resp),
+        300,
+        0,
+        86400,
+    );
     cache.backdate(
         DEFAULT,
         "example.com",
@@ -240,8 +276,7 @@ fn hit_ages_answer_and_authority_ttls() {
         Duration::from_mins(2),
     );
 
-    let hit = cache
-        .get(DEFAULT, "example.com", RecordType::A)
+    let hit = get_msg(&cache, DEFAULT, "example.com", RecordType::A)
         .expect("entry is still within its 300s lifetime");
     assert_eq!(
         hit.answers[0].ttl, 180,
@@ -260,14 +295,12 @@ fn fresh_hit_serves_ttl_no_larger_than_inserted() {
         DEFAULT,
         "example.com",
         RecordType::A,
-        make_answer_response("example.com.", 300),
+        wire(&make_answer_response("example.com.", 300)),
         300,
         0,
         86400,
     );
-    let hit = cache
-        .get(DEFAULT, "example.com", RecordType::A)
-        .expect("hit");
+    let hit = get_msg(&cache, DEFAULT, "example.com", RecordType::A).expect("hit");
     assert!(hit.answers[0].ttl <= 300);
     assert!(hit.answers[0].ttl >= 1);
 }
@@ -281,7 +314,7 @@ fn aged_ttl_floors_at_one_and_never_wraps() {
         DEFAULT,
         "example.com",
         RecordType::A,
-        make_answer_response("example.com.", 30),
+        wire(&make_answer_response("example.com.", 30)),
         30,
         300,
         86400,
@@ -293,8 +326,7 @@ fn aged_ttl_floors_at_one_and_never_wraps() {
         Duration::from_mins(2),
     );
 
-    let hit = cache
-        .get(DEFAULT, "example.com", RecordType::A)
+    let hit = get_msg(&cache, DEFAULT, "example.com", RecordType::A)
         .expect("entry is still within its clamped 300s lifetime");
     assert_eq!(
         hit.answers[0].ttl, 1,
@@ -309,7 +341,7 @@ fn expired_entry_is_not_served() {
         DEFAULT,
         "example.com",
         RecordType::A,
-        make_answer_response("example.com.", 300),
+        wire(&make_answer_response("example.com.", 300)),
         300,
         0,
         86400,
@@ -321,7 +353,7 @@ fn expired_entry_is_not_served() {
         Duration::from_mins(5),
     );
 
-    assert!(cache.get(DEFAULT, "example.com", RecordType::A).is_none());
+    assert!(get_msg(&cache, DEFAULT, "example.com", RecordType::A).is_none());
     assert_eq!(cache.misses(), 1);
 
     // A fresh insert for the same key overwrites the expired entry and
@@ -330,13 +362,13 @@ fn expired_entry_is_not_served() {
         DEFAULT,
         "example.com",
         RecordType::A,
-        make_answer_response("example.com.", 300),
+        wire(&make_answer_response("example.com.", 300)),
         300,
         0,
         86400,
     );
     assert_eq!(cache.len(), 1);
-    assert!(cache.get(DEFAULT, "example.com", RecordType::A).is_some());
+    assert!(get_msg(&cache, DEFAULT, "example.com", RecordType::A).is_some());
 }
 
 #[test]
@@ -349,7 +381,7 @@ fn sweep_reclaims_expired_entries_before_evicting_live_ones() {
         DEFAULT,
         "keep.com",
         RecordType::A,
-        make_response(),
+        wire(&make_response()),
         300,
         0,
         86400,
@@ -359,7 +391,7 @@ fn sweep_reclaims_expired_entries_before_evicting_live_ones() {
             DEFAULT,
             domain,
             RecordType::A,
-            make_response(),
+            wire(&make_response()),
             30,
             0,
             86400,
@@ -372,17 +404,17 @@ fn sweep_reclaims_expired_entries_before_evicting_live_ones() {
         DEFAULT,
         "new.com",
         RecordType::A,
-        make_response(),
+        wire(&make_response()),
         300,
         0,
         86400,
     );
 
     assert!(
-        cache.get(DEFAULT, "keep.com", RecordType::A).is_some(),
+        get_msg(&cache, DEFAULT, "keep.com", RecordType::A).is_some(),
         "the oldest live entry must survive while expired entries exist"
     );
-    assert!(cache.get(DEFAULT, "new.com", RecordType::A).is_some());
+    assert!(get_msg(&cache, DEFAULT, "new.com", RecordType::A).is_some());
     assert_eq!(
         cache.len(),
         2,
@@ -400,7 +432,7 @@ fn served_ttl_capped_by_remaining_entry_lifetime() {
         DEFAULT,
         "example.com",
         RecordType::A,
-        make_answer_response("example.com.", 86400),
+        wire(&make_answer_response("example.com.", 86400)),
         86400,
         0,
         300,
@@ -412,8 +444,7 @@ fn served_ttl_capped_by_remaining_entry_lifetime() {
         Duration::from_secs(100),
     );
 
-    let hit = cache
-        .get(DEFAULT, "example.com", RecordType::A)
+    let hit = get_msg(&cache, DEFAULT, "example.com", RecordType::A)
         .expect("entry is still within its clamped 300s lifetime");
     assert_eq!(
         hit.answers[0].ttl, 200,
@@ -432,11 +463,17 @@ fn zero_ttl_record_is_not_inflated() {
         0,
         RData::A(A(Ipv4Addr::new(192, 0, 2, 2))),
     ));
-    cache.insert(DEFAULT, "example.com", RecordType::A, resp, 300, 0, 86400);
+    cache.insert(
+        DEFAULT,
+        "example.com",
+        RecordType::A,
+        wire(&resp),
+        300,
+        0,
+        86400,
+    );
 
-    let hit = cache
-        .get(DEFAULT, "example.com", RecordType::A)
-        .expect("hit");
+    let hit = get_msg(&cache, DEFAULT, "example.com", RecordType::A).expect("hit");
     assert_eq!(hit.authorities[0].ttl, 0, "TTL 0 must be preserved");
     assert_eq!(hit.answers[0].ttl, 300);
 }
@@ -452,7 +489,15 @@ fn hit_ages_additional_record_ttls() {
         300,
         RData::A(A(Ipv4Addr::new(192, 0, 2, 3))),
     ));
-    cache.insert(DEFAULT, "example.com", RecordType::A, resp, 300, 0, 86400);
+    cache.insert(
+        DEFAULT,
+        "example.com",
+        RecordType::A,
+        wire(&resp),
+        300,
+        0,
+        86400,
+    );
     cache.backdate(
         DEFAULT,
         "example.com",
@@ -460,9 +505,7 @@ fn hit_ages_additional_record_ttls() {
         Duration::from_mins(2),
     );
 
-    let hit = cache
-        .get(DEFAULT, "example.com", RecordType::A)
-        .expect("hit");
+    let hit = get_msg(&cache, DEFAULT, "example.com", RecordType::A).expect("hit");
     assert_eq!(
         hit.additionals[0].ttl, 180,
         "additional-section TTLs must shrink by time spent in cache"
@@ -476,7 +519,7 @@ fn overwritten_entry_survives_its_stale_queue_slot() {
         DEFAULT,
         "a.com",
         RecordType::A,
-        make_response(),
+        wire(&make_response()),
         300,
         0,
         86400,
@@ -485,7 +528,7 @@ fn overwritten_entry_survives_its_stale_queue_slot() {
         DEFAULT,
         "b.com",
         RecordType::A,
-        make_response(),
+        wire(&make_response()),
         300,
         0,
         86400,
@@ -496,7 +539,7 @@ fn overwritten_entry_survives_its_stale_queue_slot() {
         DEFAULT,
         "a.com",
         RecordType::A,
-        make_response(),
+        wire(&make_response()),
         300,
         0,
         86400,
@@ -505,7 +548,7 @@ fn overwritten_entry_survives_its_stale_queue_slot() {
         DEFAULT,
         "c.com",
         RecordType::A,
-        make_response(),
+        wire(&make_response()),
         300,
         0,
         86400,
@@ -513,11 +556,11 @@ fn overwritten_entry_survives_its_stale_queue_slot() {
 
     assert_eq!(cache.len(), 2);
     assert!(
-        cache.get(DEFAULT, "a.com", RecordType::A).is_some(),
+        get_msg(&cache, DEFAULT, "a.com", RecordType::A).is_some(),
         "re-inserted entry must not be evicted through its stale slot"
     );
-    assert!(cache.get(DEFAULT, "b.com", RecordType::A).is_none());
-    assert!(cache.get(DEFAULT, "c.com", RecordType::A).is_some());
+    assert!(get_msg(&cache, DEFAULT, "b.com", RecordType::A).is_none());
+    assert!(get_msg(&cache, DEFAULT, "c.com", RecordType::A).is_some());
 }
 
 #[test]
@@ -527,7 +570,7 @@ fn eviction_skips_slots_of_invalidated_entries() {
         DEFAULT,
         "a.com",
         RecordType::A,
-        make_response(),
+        wire(&make_response()),
         300,
         0,
         86400,
@@ -536,7 +579,7 @@ fn eviction_skips_slots_of_invalidated_entries() {
         DEFAULT,
         "b.com",
         RecordType::A,
-        make_response(),
+        wire(&make_response()),
         300,
         0,
         86400,
@@ -546,7 +589,7 @@ fn eviction_skips_slots_of_invalidated_entries() {
         DEFAULT,
         "c.com",
         RecordType::A,
-        make_response(),
+        wire(&make_response()),
         300,
         0,
         86400,
@@ -555,7 +598,7 @@ fn eviction_skips_slots_of_invalidated_entries() {
         DEFAULT,
         "d.com",
         RecordType::A,
-        make_response(),
+        wire(&make_response()),
         300,
         0,
         86400,
@@ -563,11 +606,11 @@ fn eviction_skips_slots_of_invalidated_entries() {
 
     assert_eq!(cache.len(), 2);
     assert!(
-        cache.get(DEFAULT, "b.com", RecordType::A).is_none(),
+        get_msg(&cache, DEFAULT, "b.com", RecordType::A).is_none(),
         "b.com is the oldest live entry once a.com's slot is stale"
     );
-    assert!(cache.get(DEFAULT, "c.com", RecordType::A).is_some());
-    assert!(cache.get(DEFAULT, "d.com", RecordType::A).is_some());
+    assert!(get_msg(&cache, DEFAULT, "c.com", RecordType::A).is_some());
+    assert!(get_msg(&cache, DEFAULT, "d.com", RecordType::A).is_some());
 }
 
 #[test]
@@ -583,7 +626,7 @@ fn insert_at_capacity_keeps_eviction_work_bounded() {
             DEFAULT,
             &domain,
             RecordType::A,
-            make_response(),
+            wire(&make_response()),
             300,
             0,
             86400,
@@ -604,7 +647,7 @@ fn repeated_overwrites_compact_stale_queue_slots() {
             DEFAULT,
             "example.com",
             RecordType::A,
-            make_response(),
+            wire(&make_response()),
             300,
             0,
             86400,
@@ -625,7 +668,7 @@ fn upstream_id_separates_cache_entries() {
         UpstreamId::Default,
         "example.com",
         RecordType::A,
-        make_response(),
+        wire(&make_response()),
         300,
         0,
         86400,
@@ -634,20 +677,95 @@ fn upstream_id_separates_cache_entries() {
         UpstreamId::Tunnel(tunnel_id),
         "example.com",
         RecordType::A,
-        make_response(),
+        wire(&make_response()),
         300,
         0,
         86400,
     );
     assert_eq!(cache.len(), 2);
+    assert!(get_msg(&cache, UpstreamId::Default, "example.com", RecordType::A).is_some());
     assert!(
-        cache
-            .get(UpstreamId::Default, "example.com", RecordType::A)
-            .is_some()
+        get_msg(
+            &cache,
+            UpstreamId::Tunnel(tunnel_id),
+            "example.com",
+            RecordType::A
+        )
+        .is_some()
     );
-    assert!(
-        cache
-            .get(UpstreamId::Tunnel(tunnel_id), "example.com", RecordType::A)
-            .is_some()
+}
+
+#[test]
+fn hit_stamps_the_querying_transaction_id() {
+    let mut cache = DnsCache::new(100);
+    cache.insert(
+        DEFAULT,
+        "example.com",
+        RecordType::A,
+        wire(&make_answer_response("example.com.", 300)),
+        300,
+        0,
+        86400,
+    );
+    // Every client that hits this entry supplies its own transaction id; the
+    // hit must carry it, not the id baked into the cached bytes.
+    let bytes = cache
+        .get(DEFAULT, "example.com", RecordType::A, 0xBEEF)
+        .expect("hit");
+    assert_eq!(
+        &bytes[..2],
+        &0xBEEF_u16.to_be_bytes(),
+        "the first two wire bytes are the client's txid"
+    );
+    assert_eq!(
+        Message::from_bytes(&bytes).expect("decode").metadata.id,
+        0xBEEF
+    );
+}
+
+#[test]
+fn hit_ages_records_but_leaves_the_edns_opt_untouched() {
+    use hickory_proto::op::Edns;
+    // The tunnel/conditional paths cache the raw upstream datagram, which
+    // routinely carries an EDNS OPT record in the additional section. Its
+    // "TTL" slot is really extended-rcode + version + flags, so the aging
+    // walk must skip it (RR type 41) or it corrupts EDNS.
+    let mut cache = DnsCache::new(100);
+    let mut resp = make_answer_response("example.com.", 300);
+    let mut edns = Edns::new();
+    // Version 1 puts a nonzero byte in the OPT record's "TTL" slot, so a walk
+    // that failed to skip type-41 records would actually corrupt it (a
+    // version-0 slot is all-zero and the `ttl != 0` guard would spare it
+    // anyway, testing nothing).
+    edns.set_version(1);
+    edns.set_max_payload(4096);
+    resp.set_edns(edns);
+    cache.insert(
+        DEFAULT,
+        "example.com",
+        RecordType::A,
+        wire(&resp),
+        300,
+        0,
+        86400,
+    );
+    cache.backdate(
+        DEFAULT,
+        "example.com",
+        RecordType::A,
+        Duration::from_mins(2),
+    );
+
+    let hit = get_msg(&cache, DEFAULT, "example.com", RecordType::A).expect("hit");
+    assert_eq!(hit.answers[0].ttl, 180, "the real answer TTL still ages");
+    assert_eq!(
+        hit.version(),
+        1,
+        "the OPT version byte (in the TTL slot) must be left untouched"
+    );
+    assert_eq!(
+        hit.max_payload(),
+        4096,
+        "the OPT record must survive intact"
     );
 }

--- a/source/daemon/crates/wardnetd-services/src/dns_filter/filter.rs
+++ b/source/daemon/crates/wardnetd-services/src/dns_filter/filter.rs
@@ -9,6 +9,7 @@
 //! runner swaps just that one filter via `ArcSwap`, and every profile holding
 //! an `Arc<ArcSwap<DnsFilter>>` to it transparently sees the new state.
 
+use std::borrow::Cow;
 use std::collections::HashSet;
 use std::net::IpAddr;
 
@@ -88,12 +89,12 @@ impl DnsFilter {
         let mut blocked_domains: HashSet<String> = inputs
             .blocked_domains
             .into_iter()
-            .map(|d| normalize(&d))
+            .map(|d| normalize_owned(&d))
             .collect();
         let mut allowed_domains: HashSet<String> = inputs
             .allowlist
             .into_iter()
-            .map(|d| normalize(&d))
+            .map(|d| normalize_owned(&d))
             .collect();
         let mut complex = Vec::new();
 
@@ -259,6 +260,40 @@ fn matches_subdomain(domain: &str, set: &HashSet<String>) -> bool {
     false
 }
 
-pub(crate) fn normalize(s: &str) -> String {
+/// Canonical form of a domain: lowercase, no trailing dot.
+///
+/// Borrows when the input is already canonical — the common case on the
+/// query hot path, where the pipeline hands down a name it has already
+/// lowercased and dot-trimmed, so a query crossing several filter sources
+/// no longer allocates a fresh copy per source. Only a name that actually
+/// needs case folding pays for an owned `String`.
+///
+/// Callers that must own the result (a map key, a cache key) should use
+/// [`normalize_owned`] instead: `normalize(s).into_owned()` scans to decide
+/// whether it can borrow and *then* copies, two passes over the string, which
+/// is pure overhead when the answer is always "own it".
+pub(crate) fn normalize(s: &str) -> Cow<'_, str> {
+    let trimmed = s.trim_end_matches('.');
+    // Scan once to the first byte that needs folding. None → the input is
+    // already canonical and we hand it back borrowed. Some(i) → copy the
+    // bytes and lowercase only from `i` on; the prefix is already lowercase,
+    // so it needs no second pass. ASCII bytes are always char boundaries,
+    // so `i` is a valid split point.
+    match trimmed.bytes().position(|b| b.is_ascii_uppercase()) {
+        None => Cow::Borrowed(trimmed),
+        Some(i) => {
+            let mut owned = trimmed.to_owned();
+            owned[i..].make_ascii_lowercase();
+            Cow::Owned(owned)
+        }
+    }
+}
+
+/// Owned canonical form, in a single fused allocate-and-lowercase pass. For
+/// callers that always need to own the result — building the filter's domain
+/// sets, the cache's key — where borrowing can't help and the [`normalize`]
+/// Cow's scan-then-copy would only add a redundant pass. Produces the exact
+/// same string as `normalize(s).into_owned()`.
+pub(crate) fn normalize_owned(s: &str) -> String {
     s.trim_end_matches('.').to_ascii_lowercase()
 }

--- a/source/daemon/crates/wardnetd/src/dns/pipeline.rs
+++ b/source/daemon/crates/wardnetd/src/dns/pipeline.rs
@@ -929,11 +929,27 @@ async fn forward_via_default_resolver(
     pass_result: &str,
     upstream_id: UpstreamId,
 ) -> anyhow::Result<()> {
-    let resolver_guard = resolver.read().await;
-    let lookup: Result<Lookup, _> = resolver_guard.lookup(domain, rtype).await;
+    // Clone the Arc-backed resolver out and drop the read guard before the
+    // upstream round-trip. tokio's RwLock is write-preferring, so holding the
+    // guard across `.lookup().await` lets an `update_config` resolver rebuild
+    // (the queued writer) block every new query until the slowest in-flight
+    // lookup returns — a single config edit could otherwise stall DNS for all
+    // clients for as long as the upstream timeout.
+    let resolver = resolver.read().await.clone();
+    let lookup: Result<Lookup, _> = resolver.lookup(domain, rtype).await;
 
-    let cfg = config.read().await;
-    let upstream = upstream_label(&cfg.upstream_servers);
+    // Snapshot the config fields we need, then drop the guard, so the response
+    // and cache work below doesn't hold the config lock across its awaits
+    // either.
+    let (upstream, rebinding_protection, ttl_min, ttl_max) = {
+        let cfg = config.read().await;
+        (
+            upstream_label(&cfg.upstream_servers),
+            cfg.rebinding_protection,
+            cfg.cache_ttl_min_secs,
+            cfg.cache_ttl_max_secs,
+        )
+    };
 
     match lookup {
         Ok(lookup) => {
@@ -951,9 +967,9 @@ async fn forward_via_default_resolver(
                 pass_result,
                 upstream_id,
                 upstream,
-                cfg.rebinding_protection,
-                cfg.cache_ttl_min_secs,
-                cfg.cache_ttl_max_secs,
+                rebinding_protection,
+                ttl_min,
+                ttl_max,
                 lookup.answers(),
             )
             .await?;
@@ -979,8 +995,8 @@ async fn forward_via_default_resolver(
                 upstream,
                 nx_domain,
                 e.into_soa(),
-                cfg.cache_ttl_min_secs,
-                cfg.cache_ttl_max_secs,
+                ttl_min,
+                ttl_max,
             )
             .await?;
         }

--- a/source/daemon/crates/wardnetd/src/dns/pipeline.rs
+++ b/source/daemon/crates/wardnetd/src/dns/pipeline.rs
@@ -621,11 +621,11 @@ impl QueryPipeline {
         //    versa).
         let cached = {
             let cache_guard = self.cache.read().await;
-            cache_guard.get(upstream_id, &domain, rtype)
+            cache_guard.get(upstream_id, &domain, rtype, id)
         };
-        if let Some(mut response) = cached {
-            response.metadata.id = id;
-            let bytes = response.to_bytes()?;
+        if let Some(bytes) = cached {
+            // The cache already stamped our transaction id and aged the TTLs;
+            // the buffer is send-ready with no per-hit clone or re-encode.
             reply.send_to(&bytes, src).await?;
             tracing::trace!(%domain, ?rtype, ?upstream_id, "cache hit");
             record_query(
@@ -1088,12 +1088,13 @@ async fn send_resolved(
     socket.send_to(&bytes, src).await?;
 
     if min_ttl < u32::MAX && min_ttl > 0 {
+        // Cache the exact bytes we just sent — no separate encode.
         let mut cache_guard = cache.write().await;
         cache_guard.insert(
             upstream_id,
             domain,
             rtype,
-            response,
+            bytes,
             min_ttl,
             cache_ttl_min_secs,
             cache_ttl_max_secs,
@@ -1356,11 +1357,13 @@ async fn forward_via_tunnel(
         if raw_ttl > 0 {
             let cfg = config.read().await;
             let mut cache_guard = cache.write().await;
+            // Cache the raw upstream datagram we relayed, not a re-encode of
+            // the parsed message.
             cache_guard.insert(
                 upstream_id,
                 domain,
                 rtype,
-                parsed,
+                buf.clone(),
                 raw_ttl,
                 cfg.cache_ttl_min_secs,
                 cfg.cache_ttl_max_secs,
@@ -1439,7 +1442,7 @@ async fn send_negative(
     request: &Message,
     nx_domain: bool,
     authority: Option<hickory_proto::rr::Record>,
-) -> anyhow::Result<Message> {
+) -> anyhow::Result<Vec<u8>> {
     let mut response = Message::response(id, OpCode::Query);
     response.metadata.recursion_desired = true;
     response.metadata.recursion_available = true;
@@ -1454,7 +1457,9 @@ async fn send_negative(
     }
     let bytes = response.to_bytes()?;
     socket.send_to(&bytes, src).await?;
-    Ok(response)
+    // Returns the wire bytes (not the `Message`) so the negative-cache path can
+    // store exactly what was sent without re-encoding.
+    Ok(bytes)
 }
 
 /// Shared negative-answer responder for the recursive and forwarding paths:
@@ -1511,7 +1516,7 @@ async fn relay_negative(
         (None, 0)
     };
 
-    let response = send_negative(socket, src, id, request, nx_domain, authority).await?;
+    let bytes = send_negative(socket, src, id, request, nx_domain, authority).await?;
 
     if negative_ttl > 0 {
         let mut cache_guard = cache.write().await;
@@ -1519,7 +1524,7 @@ async fn relay_negative(
             upstream_id,
             domain,
             rtype,
-            response,
+            bytes,
             negative_ttl,
             cache_ttl_min_secs,
             cache_ttl_max_secs,
@@ -1846,11 +1851,12 @@ async fn forward_via_conditional(
         if raw_ttl > 0 {
             let cfg = config.read().await;
             let mut cache_guard = cache.write().await;
+            // Cache the raw upstream datagram we relayed, not a re-encode.
             cache_guard.insert(
                 upstream_id,
                 domain,
                 rtype,
-                parsed,
+                buf.clone(),
                 raw_ttl,
                 cfg.cache_ttl_min_secs,
                 cfg.cache_ttl_max_secs,

--- a/source/daemon/crates/wardnetd/src/dns/rate_limit.rs
+++ b/source/daemon/crates/wardnetd/src/dns/rate_limit.rs
@@ -10,16 +10,27 @@
 //! every roaming device into one bucket.
 
 use std::collections::HashMap;
-use std::hash::Hash;
+use std::hash::{BuildHasher, Hash, RandomState};
 use std::net::IpAddr;
 use std::sync::Mutex;
 use std::sync::atomic::{AtomicU32, Ordering};
 use std::time::Instant;
 
-/// Upper bound on tracked client buckets. A key-spoofing flood would
-/// otherwise grow the map without limit; once full we drop idle (full)
-/// buckets before admitting a new client.
+/// Number of independent bucket shards. A query locks only its key's shard,
+/// so unrelated clients no longer serialize against one global lock, and the
+/// at-capacity purge scans a single shard instead of the whole map — which
+/// matters precisely in the spoofed-source flood the limiter exists to shed,
+/// where a global purge under one lock would stall every query at once.
+const SHARDS: usize = 16;
+
+/// Upper bound on tracked client buckets across all shards. A key-spoofing
+/// flood would otherwise grow the maps without limit; once a shard is full we
+/// drop idle (full) buckets in that shard before admitting a new client.
 const MAX_TRACKED_CLIENTS: usize = 65_536;
+
+/// Per-shard bucket ceiling. Keys hash uniformly across shards, so the global
+/// cap is `SHARDS * MAX_TRACKED_PER_SHARD` == [`MAX_TRACKED_CLIENTS`].
+const MAX_TRACKED_PER_SHARD: usize = MAX_TRACKED_CLIENTS / SHARDS;
 
 struct Bucket {
     tokens: f64,
@@ -30,16 +41,24 @@ struct Bucket {
 /// grant token for `DoT`). The active rate is held in an atomic so the hot
 /// path (`check`) needs no config lock; it's refreshed via
 /// [`set_rate`](Self::set_rate) on config change.
+///
+/// Buckets are split across [`SHARDS`] independently-locked maps so a query
+/// contends only with others whose key hashes to the same shard, and the
+/// capacity purge is bounded to one shard's worth of keys.
 pub(crate) struct RateLimiter<K = IpAddr> {
     rate: AtomicU32,
-    buckets: Mutex<HashMap<K, Bucket>>,
+    shards: [Mutex<HashMap<K, Bucket>>; SHARDS],
+    /// Per-instance randomised hasher for shard selection, so a spoofed-source
+    /// flood can't deterministically pile every key onto one shard.
+    shard_hasher: RandomState,
 }
 
 impl<K: Eq + Hash> RateLimiter<K> {
     pub(crate) fn new(rate: u32) -> Self {
         Self {
             rate: AtomicU32::new(rate),
-            buckets: Mutex::new(HashMap::new()),
+            shards: std::array::from_fn(|_| Mutex::new(HashMap::new())),
+            shard_hasher: RandomState::new(),
         }
     }
 
@@ -61,9 +80,15 @@ impl<K: Eq + Hash> RateLimiter<K> {
             return true;
         }
         let rate = f64::from(rate);
-        let mut map = self.buckets.lock().expect("rate-limiter mutex poisoned");
+        // Reduce in u64 first; the result is < SHARDS, so the cast can't
+        // truncate.
+        let shard = usize::try_from(self.shard_hasher.hash_one(&key) % SHARDS as u64)
+            .expect("shard index < SHARDS fits usize");
+        let mut map = self.shards[shard]
+            .lock()
+            .expect("rate-limiter mutex poisoned");
 
-        if !map.contains_key(&key) && map.len() >= MAX_TRACKED_CLIENTS {
+        if !map.contains_key(&key) && map.len() >= MAX_TRACKED_PER_SHARD {
             map.retain(|_, b| {
                 let refilled = (b.tokens
                     + now.saturating_duration_since(b.last).as_secs_f64() * rate)

--- a/source/daemon/crates/wardnetd/src/dns/tests/rate_limit.rs
+++ b/source/daemon/crates/wardnetd/src/dns/tests/rate_limit.rs
@@ -52,3 +52,19 @@ fn refills_over_time() {
     let later = t + Duration::from_secs(1);
     assert!(rl.check_at(IP, 3, later));
 }
+
+#[test]
+fn distinct_keys_get_independent_buckets_across_shards() {
+    // With buckets sharded by key hash, distinct clients must still each get
+    // their own bucket — a query must never consume a token from a different
+    // client that happened to hash to the same shard.
+    let rl = RateLimiter::new(0);
+    let t = Instant::now();
+    for i in 0..1000u32 {
+        let ip = std::net::IpAddr::V4(std::net::Ipv4Addr::from(0x0A00_0100 + i));
+        // Capacity 2: this client's own burst, independent of every other.
+        assert!(rl.check_at(ip, 2, t), "client {i} first query");
+        assert!(rl.check_at(ip, 2, t), "client {i} second query");
+        assert!(!rl.check_at(ip, 2, t), "client {i} third query denied");
+    }
+}

--- a/source/daemon/crates/wardnetd/src/dns/tests/server.rs
+++ b/source/daemon/crates/wardnetd/src/dns/tests/server.rs
@@ -1668,6 +1668,7 @@ async fn spawn_invalidator_for_test(
 /// `Pass` answer keyed on `Default`.
 async fn seed_cache(cache: &Arc<RwLock<wardnetd_services::dns::cache::DnsCache>>) {
     use hickory_proto::op::{Message, OpCode};
+    use hickory_proto::serialize::binary::BinEncodable;
     let mut answer = Message::response(0, OpCode::Query);
     answer.metadata.recursion_desired = true;
     answer.metadata.recursion_available = true;
@@ -1675,7 +1676,7 @@ async fn seed_cache(cache: &Arc<RwLock<wardnetd_services::dns::cache::DnsCache>>
         UpstreamId::Default,
         "seed.example.",
         RecordType::A,
-        answer,
+        answer.to_bytes().expect("encode seed response"),
         60,
         1,
         60,
@@ -2671,7 +2672,7 @@ async fn recursor_nodata_relays_noerror_not_servfail() {
         cache
             .write()
             .await
-            .get(UpstreamId::Default, "foo.com", RecordType::A)
+            .get(UpstreamId::Default, "foo.com", RecordType::A, 0)
             .is_some(),
         "negative response must be cached so repeats don't re-resolve"
     );
@@ -2718,7 +2719,7 @@ async fn recursor_negative_with_zero_minimum_is_not_cached_or_raised() {
         cache
             .write()
             .await
-            .get(UpstreamId::Default, "foo.com", RecordType::A)
+            .get(UpstreamId::Default, "foo.com", RecordType::A, 0)
             .is_none(),
         "a zone-forbidden negative must not be cached"
     );


### PR DESCRIPTION
Works through the measurable hot-path items in #967. Each fix is its own commit with its own before/after numbers; rebased onto #981 so the filter micro-benches and the `dns_resolution` macro bench are available to measure against.

Findings #1 and #3 already landed earlier; #8/#9 are design decisions left for their own change.

## Finding #5 — filter re-normalizes the domain per source

`DnsFilter::check` called `normalize(domain)` (trim dot + lowercase), allocating a fresh `String` per filter source even though the pipeline already hands it a canonical name. Split into `normalize` → `Cow<str>` (borrows on the canonical hot path; allocates only when a byte actually needs folding) and `normalize_owned` → `String` (single fused pass for callers that must own — the filter sets and the cache key; routing those through `Cow` + `into_owned` measurably regressed the always-owned cache path).

| bench | Δ |
|---|---|
| `dns_filter/check_pass/10000` (canonical miss, hot path) | ~7% faster |
| `dns_filter/check_block/10000` (canonical hit) | ~9% faster |
| `dns_filter/profile_check_pass` (real `RuntimeDnsFilterProfile`, 4 sources) | ~9% faster |

## Finding #2 — every cache hit deep-clones the `Message` and re-encodes it

Hits cloned the stored `Message` (every record + name) and re-serialized with `to_bytes()`, when the only difference between two hits is the 2-byte transaction id. Now the cache stores **wire bytes** (the send paths already hold them — the built response, or the raw upstream datagram on the tunnel/conditional paths), and a hit is: clone the buffer, stamp the client's txid, and age the record TTLs **in place** with a bounds-checked wire walk (skips OPT/type-41, whose "TTL" slot is EDNS metadata). Same downstream-TTL semantics as before; entries also shrink (wire form < parsed `Message`).

| bench | Δ |
|---|---|
| `dns_resolution/cache_hit` (full pipeline) | **1.66 µs → 1.11 µs (~33% faster)** |

## Finding #4 — resolver guard held across the upstream round-trip

`forward_via_default_resolver` held `resolver.read().await` across `.lookup().await`. tokio's `RwLock` is write-preferring, so an `update_config` resolver rebuild would block every new query behind the slowest in-flight lookup — a config edit could stall DNS for all clients for the upstream timeout. Clone the `Arc`-backed resolver out and drop the guard before awaiting; the config guard (held across the response/cache awaits) gets the same treatment. Recursor path is the same shape but `Recursor` isn't `Clone` and recursive mode is opt-in — left for a follow-up. Lock-hold-time isn't a micro-bench number; validated by the existing forward-path tests staying green.

## Finding #6 — log sink builds the WS event with zero subscribers

`DnsLogSink::record` ran `row_to_event` (several string clones) and broadcast it on every query; with no live-log viewer (the normal state) the send fails and the event is discarded. Gate it on `stream_tx.receiver_count() > 0`. New `dns_log_sink/row_to_event` bench tracks the per-query cost now elided.

## Finding #7 — rate limiter: global mutex with an O(64k) purge under it

Every query took one `Mutex<HashMap>`, and at `MAX_TRACKED_CLIENTS` (a spoofed-source flood) the full-map `retain` ran under that lock, stalling all queries exactly when the limiter should shed load. Sharded into 16 independently-locked maps by a per-instance randomised key hash: a query contends only within its shard, and the purge scans 1/16 of the keyspace. Per-key behaviour is unchanged. Contention relief only shows multi-threaded (not in the single-thread micro-benches); a unit test covers the property sharding must preserve — distinct keys stay independent.

## Notes

- Local micro-numbers are noisy on a shared runner; cubit's paired same-runner comparison in CI is the authoritative signal (the `dns_resolution/cache_hit` and `dns_filter/*` lines pair head vs base directly).
- `cargo test -p wardnetd-services` (423 dns tests) and `-p wardnetd` (128 dns tests) green; `cargo clippy --all-targets` clean on both crates.

Closes #967