### PR TITLE
test(dns): macro resolution bench + expand DNS micro benches

### DIFF
--- a/.github/workflows/cubit.yml
+++ b/.github/workflows/cubit.yml
@@ -65,8 +65,8 @@ jobs:
           bench-command: >-
             cargo bench --manifest-path source/daemon/Cargo.toml
             -p wardnetd-services --bench dns_components
-            -- --warm-up-time 1 --measurement-time 2 || true ;
+            -- --warm-up-time 3 --measurement-time 5 || true ;
             cargo bench --manifest-path source/daemon/Cargo.toml
             -p wardnetd --bench dns_resolution --features bench-internals
-            -- --warm-up-time 1 --measurement-time 2 || true
+            -- --warm-up-time 3 --measurement-time 5 || true
           paired: "true"

--- a/.github/workflows/cubit.yml
+++ b/.github/workflows/cubit.yml
@@ -56,8 +56,17 @@ jobs:
       - uses: wardnet/cubit@v0
         with:
           criterion-dir: source/daemon/target/criterion
+          # Two bench targets, both writing to source/daemon/target/criterion
+          # (which cubit ingests): the wardnetd-services micro benches, and the
+          # wardnetd macro resolution bench (needs the bench-internals feature —
+          # a dev-only seam, never compiled into a production build). Each trails
+          # `|| true` so a bench build failure leaves cubit to post its "no data"
+          # fallback rather than failing this advisory job.
           bench-command: >-
             cargo bench --manifest-path source/daemon/Cargo.toml
             -p wardnetd-services --bench dns_components
+            -- --warm-up-time 1 --measurement-time 2 || true ;
+            cargo bench --manifest-path source/daemon/Cargo.toml
+            -p wardnetd --bench dns_resolution --features bench-internals
             -- --warm-up-time 1 --measurement-time 2 || true
           paired: "true"

--- a/source/daemon/Cargo.lock
+++ b/source/daemon/Cargo.lock
@@ -5998,6 +5998,7 @@ dependencies = [
  "axum-server",
  "chrono",
  "clap",
+ "criterion",
  "cron",
  "dhcproto",
  "futures",

--- a/source/daemon/crates/wardnetd-services/benches/dns_components.rs
+++ b/source/daemon/crates/wardnetd-services/benches/dns_components.rs
@@ -5,15 +5,32 @@
 //! being averaged into an end-to-end number. criterion writes the timings to
 //! `target/criterion/**/estimates.json`, which `cubit` ingests.
 //!
+//! Coverage: the `DnsCache` hot path (single-threaded and under a concurrency
+//! sweep), the `AuthoritativeView` lookups, the DNS filter (rule parsing +
+//! matching), and hickory `Message` parse/encode.
+//!
 //! Run: `cargo bench -p wardnetd-services --bench dns_components`
 
 use std::hint::black_box;
+use std::net::{IpAddr, Ipv4Addr};
+use std::sync::{Arc, Barrier, RwLock};
+use std::thread;
+use std::time::Instant;
 
-use criterion::{Criterion, criterion_group, criterion_main};
-use hickory_proto::op::{Message, OpCode};
-use hickory_proto::rr::RecordType;
-use wardnet_common::dns::UpstreamId;
+use chrono::Utc;
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
+use hickory_proto::op::{Message, OpCode, Query};
+use hickory_proto::rr::rdata::A;
+use hickory_proto::rr::{Name, RData, Record, RecordType};
+use hickory_proto::serialize::binary::{BinDecodable, BinEncodable};
+use uuid::Uuid;
+use wardnet_common::dns::{
+    ConditionalForwardingRule, CustomDnsRecord, DnsRecordSource, DnsRecordType, UpstreamId,
+};
 use wardnetd_services::dns::DnsCache;
+use wardnetd_services::dns::authoritative::AuthoritativeView;
+use wardnetd_services::dns::filter_parser::parse_line;
+use wardnetd_services::dns_filter::{DnsFilter, DnsFilterInputs};
 
 fn response() -> Message {
     Message::response(0, OpCode::Query)
@@ -76,5 +93,236 @@ fn bench_cache(c: &mut Criterion) {
     group.finish();
 }
 
-criterion_group!(benches, bench_cache);
+/// Concurrency sweep on `DnsCache::get` — the daemon shares one cache behind a
+/// read lock across every per-query task, so a change that makes the hit path
+/// contend (e.g. a lock added around the atomic counters) shows up here.
+///
+/// `get` takes `&self`, so a `std::sync::RwLock` read guard models the shared
+/// hot path faithfully. Each of the N threads runs `iters` lookups; a
+/// [`Barrier`] releases them together and only the parallel region is timed.
+/// The per-measurement thread spawn/join is amortized across `iters`.
+fn bench_cache_concurrent(c: &mut Criterion) {
+    let mut group = c.benchmark_group("dns_cache");
+
+    for threads in [1usize, 4, 8, 16] {
+        group.bench_function(
+            BenchmarkId::new("get_hit", format!("threads={threads}")),
+            |b| {
+                let mut cache = DnsCache::new(1024);
+                cache.insert(
+                    UpstreamId::Default,
+                    "example.com",
+                    RecordType::A,
+                    response(),
+                    300,
+                    0,
+                    86400,
+                );
+                let cache = Arc::new(RwLock::new(cache));
+
+                b.iter_custom(|iters| {
+                    let barrier = Arc::new(Barrier::new(threads + 1));
+                    let handles: Vec<_> = (0..threads)
+                        .map(|_| {
+                            let cache = Arc::clone(&cache);
+                            let barrier = Arc::clone(&barrier);
+                            thread::spawn(move || {
+                                barrier.wait();
+                                for _ in 0..iters {
+                                    let guard = cache.read().expect("cache read lock");
+                                    black_box(guard.get(
+                                        UpstreamId::Default,
+                                        black_box("example.com"),
+                                        RecordType::A,
+                                    ));
+                                }
+                            })
+                        })
+                        .collect();
+
+                    barrier.wait();
+                    let start = Instant::now();
+                    for h in handles {
+                        h.join().expect("worker thread");
+                    }
+                    start.elapsed()
+                });
+            },
+        );
+    }
+
+    group.finish();
+}
+
+/// Build `n` distinct enabled A records under `zone`, named `host{i}.{zone}`.
+fn a_records(zone: &str, n: usize) -> Vec<CustomDnsRecord> {
+    (0..n)
+        .map(|i| CustomDnsRecord {
+            id: Uuid::new_v4(),
+            zone_id: None,
+            domain: format!("host{i}.{zone}"),
+            record_type: DnsRecordType::A,
+            value: format!("10.0.{}.{}", i / 256, i % 256),
+            ttl: 120,
+            enabled: true,
+            source: DnsRecordSource::Manual,
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+        })
+        .collect()
+}
+
+/// `AuthoritativeView` lookups — the pre-cache local-record path taken on every
+/// query. Swept over view sizes so a change from O(1) hashing to anything
+/// worse is visible as the size grows.
+fn bench_authoritative(c: &mut Criterion) {
+    let mut group = c.benchmark_group("authoritative");
+
+    for size in [10usize, 100, 1000] {
+        let mut records = a_records("zone.lan", size);
+        // One CNAME so `lookup_cname` has something to find.
+        records.push(CustomDnsRecord {
+            id: Uuid::new_v4(),
+            zone_id: None,
+            domain: "alias.zone.lan".into(),
+            record_type: DnsRecordType::Cname,
+            value: "host0.zone.lan".into(),
+            ttl: 120,
+            enabled: true,
+            source: DnsRecordSource::Manual,
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+        });
+        let rules: Vec<ConditionalForwardingRule> = (0..size)
+            .map(|i| ConditionalForwardingRule {
+                id: Uuid::new_v4(),
+                domain: format!("corp{i}.example"),
+                upstream: "10.1.2.3:53".into(),
+                enabled: true,
+                created_at: Utc::now(),
+            })
+            .collect();
+        let view = AuthoritativeView::build(&[], records, rules);
+
+        group.bench_with_input(BenchmarkId::new("lookup_hit", size), &size, |b, _| {
+            b.iter(|| {
+                black_box(view.lookup(black_box("host0.zone.lan"), DnsRecordType::A));
+            });
+        });
+        group.bench_with_input(BenchmarkId::new("lookup_miss", size), &size, |b, _| {
+            b.iter(|| {
+                black_box(view.lookup(black_box("absent.zone.lan"), DnsRecordType::A));
+            });
+        });
+        group.bench_with_input(BenchmarkId::new("lookup_cname", size), &size, |b, _| {
+            b.iter(|| {
+                black_box(view.lookup_cname(black_box("alias.zone.lan")));
+            });
+        });
+        group.bench_with_input(
+            BenchmarkId::new("match_forwarding_rule", size),
+            &size,
+            |b, _| {
+                // A subdomain of the last (longest to reach) rule, so the
+                // suffix scan does real work.
+                let needle = format!("svc.corp{}.example", size.saturating_sub(1));
+                b.iter(|| {
+                    black_box(view.match_forwarding_rule(black_box(&needle)));
+                });
+            },
+        );
+    }
+
+    group.finish();
+}
+
+/// DNS filter: rule-text parsing throughput and query matching against an
+/// N-rule set. Both are on the blocklist-compile / hot paths.
+fn bench_filter(c: &mut Criterion) {
+    let mut group = c.benchmark_group("dns_filter");
+
+    // `parse_line` — called once per rule when a blocklist/custom-rules source
+    // is compiled. Benched on a representative adblock-syntax domain rule.
+    group.bench_function("parse_line", |b| {
+        b.iter(|| {
+            black_box(parse_line(black_box("||ads.example.com^")).ok());
+        });
+    });
+
+    let client = IpAddr::V4(Ipv4Addr::new(192, 168, 1, 50));
+    for size in [100usize, 1000, 10_000] {
+        let blocked: Vec<String> = (0..size)
+            .map(|i| format!("blocked{i}.example.com"))
+            .collect();
+        let filter = DnsFilter::build(DnsFilterInputs {
+            blocked_domains: blocked,
+            allowlist: vec![],
+            custom_rules: vec![],
+        });
+
+        // Hit: a name in the block set (worst case — the full match runs).
+        group.bench_with_input(BenchmarkId::new("check_block", size), &size, |b, _| {
+            let needle = format!("blocked{}.example.com", size / 2);
+            b.iter(|| {
+                black_box(filter.check(black_box(&needle), RecordType::A, client));
+            });
+        });
+        // Miss: a name absent from every set (the common pass-through case).
+        group.bench_with_input(BenchmarkId::new("check_pass", size), &size, |b, _| {
+            b.iter(|| {
+                black_box(filter.check(black_box("allowed.example.org"), RecordType::A, client));
+            });
+        });
+    }
+
+    group.finish();
+}
+
+/// hickory `Message` decode/encode — the wire (de)serialization every query and
+/// response pays once. `from_bytes` is the first thing `handle` does; `to_vec`
+/// is the last thing every response path does.
+fn bench_message(c: &mut Criterion) {
+    let mut group = c.benchmark_group("dns_message");
+
+    let mut query = Message::query();
+    query.metadata.id = 0x1234;
+    query.metadata.recursion_desired = true;
+    query.add_queries(vec![Query::query(
+        Name::from_str_relaxed("www.example.com.").expect("name"),
+        RecordType::A,
+    )]);
+    let query_bytes = query.to_bytes().expect("encode query");
+
+    let mut resp = Message::response(0x1234, OpCode::Query);
+    resp.metadata.recursion_desired = true;
+    resp.metadata.recursion_available = true;
+    resp.add_queries(query.queries.clone());
+    resp.add_answer(Record::from_rdata(
+        Name::from_str_relaxed("www.example.com.").expect("name"),
+        60,
+        RData::A(A(Ipv4Addr::new(93, 184, 216, 34))),
+    ));
+
+    group.bench_function("parse_query", |b| {
+        b.iter(|| {
+            black_box(Message::from_bytes(black_box(&query_bytes)).expect("parse"));
+        });
+    });
+    group.bench_function("encode_response", |b| {
+        b.iter(|| {
+            black_box(resp.to_bytes().expect("encode"));
+        });
+    });
+
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_cache,
+    bench_cache_concurrent,
+    bench_authoritative,
+    bench_filter,
+    bench_message,
+);
 criterion_main!(benches);

--- a/source/daemon/crates/wardnetd/Cargo.toml
+++ b/source/daemon/crates/wardnetd/Cargo.toml
@@ -9,6 +9,18 @@ publish.workspace = true
 [lints]
 workspace = true
 
+[features]
+# Widens the visibility of the DNS query-path construction helpers and the
+# in-process stubs (see `dns::bench_support`) so the criterion harness in
+# `benches/dns_resolution.rs` can stand a `QueryPipeline` up without a real
+# socket, upstream, or database. Adds visibility ONLY — it changes no
+# production code path.
+#
+# NEVER enable this in production builds. It exists solely for benches; the
+# stubs it exposes answer canned data and skip every admin/repository code
+# path. Mirrors the `fuzz-internals` seam in `wardnetd-services`.
+bench-internals = []
+
 [dependencies]
 # Internal
 wardnet-common.workspace = true
@@ -116,3 +128,16 @@ sd-notify.workspace = true
 tokio = { workspace = true, features = ["test-util"] }
 # https://crates.io/crates/tempfile
 tempfile.workspace = true
+# https://crates.io/crates/criterion — macro-benchmark harness for the DNS
+# resolution pipeline (see benches/); needs the `bench-internals` feature.
+criterion.workspace = true
+
+# End-to-end macro-benchmarks for the DNS resolution pipeline: one line per
+# resolution branch (cache-hit, cache-miss→upstream, filter block/rewrite,
+# authoritative). `harness = false` hands the binary's main() to criterion;
+# output lands in target/criterion/**/estimates.json for the `cubit` tool.
+# Gated on `bench-internals` so a plain `cargo build` never pulls in the seam.
+[[bench]]
+name = "dns_resolution"
+harness = false
+required-features = ["bench-internals"]

--- a/source/daemon/crates/wardnetd/benches/dns_resolution.rs
+++ b/source/daemon/crates/wardnetd/benches/dns_resolution.rs
@@ -1,0 +1,152 @@
+//! End-to-end macro-benchmarks for the DNS resolution pipeline (#911's
+//! `QueryPipeline`).
+//!
+//! Each benchmark drives `QueryPipeline::handle` down exactly one resolution
+//! branch, so a regression shows up as its own line in the `cubit` trend
+//! dashboard rather than being averaged into a single end-to-end number:
+//!
+//! * `cache_hit`     — answered from the response cache; no upstream touched.
+//! * `cache_miss`    — a fresh domain forwarded to an in-process stub upstream.
+//! * `blocked`       — filter verdict `Block` → NXDOMAIN, before cache/upstream.
+//! * `rewrite`       — filter verdict `Rewrite` → synthetic A, before upstream.
+//! * `authoritative` — answered from the local authoritative view.
+//!
+//! The seam lives in `wardnetd::dns::bench_support`, compiled only under the
+//! `bench-internals` feature (hence the `required-features` on the `[[bench]]`).
+//!
+//! Run: `cargo bench -p wardnetd --bench dns_resolution --features bench-internals`
+
+use std::hint::black_box;
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+use std::sync::Arc;
+
+use criterion::{Criterion, criterion_group, criterion_main};
+use hickory_proto::rr::RecordType;
+use tokio::runtime::Runtime;
+use tokio::sync::mpsc::Receiver;
+use wardnet_common::dns::FilterAction;
+use wardnetd::dns::bench_support::{
+    BenchPipeline, a_record, build_bench_pipeline, query_bytes, spawn_stub_upstream,
+};
+use wardnetd::dns::pipeline::{ClientIdentity, TransportProtocol};
+use wardnetd::dns::reply_capture::ReplyCapture;
+use wardnetd_services::dns::server::DnsSocket;
+
+/// Transport-level peer address every bench query arrives from.
+const SRC: SocketAddr = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 5353);
+
+fn client() -> ClientIdentity {
+    ClientIdentity::Ip(SRC.ip())
+}
+
+/// A multi-thread tokio runtime — the daemon resolves on a multi-thread
+/// runtime, and the forwarding branch's loopback round-trip needs the reactor
+/// to make progress on the stub-upstream task concurrently with `handle`.
+fn runtime() -> Runtime {
+    tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .expect("build multi-thread runtime")
+}
+
+/// Stand up a bench pipeline whose upstream is a fresh in-process stub.
+fn setup(rt: &Runtime) -> BenchPipeline {
+    rt.block_on(async {
+        let upstream = spawn_stub_upstream().await;
+        build_bench_pipeline(upstream)
+    })
+}
+
+/// One reusable capture socket + its drain. The pipeline sends at most one
+/// frame per query into a capacity-1 channel, so draining after every `handle`
+/// keeps the single slot free for the next iteration (a fresh channel per
+/// iteration would only add allocation noise).
+fn reply_pair() -> (Arc<dyn DnsSocket>, Receiver<Vec<u8>>) {
+    let (capture, rx) = ReplyCapture::channel();
+    (Arc::new(capture), rx)
+}
+
+/// Resolve one query and drain its captured reply — the timed unit of work.
+fn drive(
+    rt: &Runtime,
+    bench: &BenchPipeline,
+    reply: &Arc<dyn DnsSocket>,
+    rx: &mut Receiver<Vec<u8>>,
+    packet: &[u8],
+) {
+    rt.block_on(async {
+        bench
+            .pipeline()
+            .handle(packet, SRC, reply, client(), TransportProtocol::Udp)
+            .await
+            .expect("pipeline handle");
+    });
+    black_box(rx.try_recv().ok());
+}
+
+fn bench_resolution(c: &mut Criterion) {
+    let rt = runtime();
+    let mut group = c.benchmark_group("dns_resolution");
+
+    // cache_hit: warm the cache once, then every iteration is served from it —
+    // the stub upstream exists but is never touched again.
+    group.bench_function("cache_hit", |b| {
+        let bench = setup(&rt);
+        let (reply, mut rx) = reply_pair();
+        let packet = query_bytes(0x0001, "cache.bench.example.", RecordType::A);
+        drive(&rt, &bench, &reply, &mut rx, &packet); // warm
+        b.iter(|| drive(&rt, &bench, &reply, &mut rx, &packet));
+    });
+
+    // cache_miss: a fresh domain every iteration forces a miss → forward to the
+    // stub upstream, whose TTL-60 answer is written back to the cache. The
+    // unique-domain scheme (a monotonic counter) keeps it a miss without a
+    // cache flush; the per-iteration `format!` + encode is dwarfed by the
+    // loopback round-trip, and the bounded cache (10k default) evicts FIFO.
+    group.bench_function("cache_miss", |b| {
+        let bench = setup(&rt);
+        let (reply, mut rx) = reply_pair();
+        let mut n: u64 = 0;
+        b.iter(|| {
+            n += 1;
+            let packet = query_bytes(0x0002, &format!("m{n}.bench.example."), RecordType::A);
+            drive(&rt, &bench, &reply, &mut rx, &packet);
+        });
+    });
+
+    // blocked: filter returns Block → NXDOMAIN, short-circuiting before the
+    // cache and upstream.
+    group.bench_function("blocked", |b| {
+        let bench = setup(&rt);
+        bench.set_filter_action(FilterAction::Block);
+        let (reply, mut rx) = reply_pair();
+        let packet = query_bytes(0x0003, "blocked.bench.example.", RecordType::A);
+        b.iter(|| drive(&rt, &bench, &reply, &mut rx, &packet));
+    });
+
+    // rewrite: filter returns Rewrite → a synthetic A answer, before upstream.
+    group.bench_function("rewrite", |b| {
+        let bench = setup(&rt);
+        bench.set_filter_action(FilterAction::Rewrite {
+            ip: IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)),
+        });
+        let (reply, mut rx) = reply_pair();
+        let packet = query_bytes(0x0004, "rewrite.bench.example.", RecordType::A);
+        b.iter(|| drive(&rt, &bench, &reply, &mut rx, &packet));
+    });
+
+    // authoritative: the name lives in the local authoritative view, answered
+    // before the cache and filter.
+    group.bench_function("authoritative", |b| {
+        let bench = setup(&rt);
+        bench.set_authoritative_records(vec![a_record("auth.bench.lan", "10.0.0.5")]);
+        let (reply, mut rx) = reply_pair();
+        let packet = query_bytes(0x0005, "auth.bench.lan.", RecordType::A);
+        b.iter(|| drive(&rt, &bench, &reply, &mut rx, &packet));
+    });
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_resolution);
+criterion_main!(benches);

--- a/source/daemon/crates/wardnetd/src/dns/bench_support.rs
+++ b/source/daemon/crates/wardnetd/src/dns/bench_support.rs
@@ -1,0 +1,491 @@
+//! Feature-gated bench seam for the DNS resolution pipeline.
+//!
+//! Compiled only under `cfg(test)` or the `bench-internals` feature — NEVER in
+//! a production build. It exposes just enough of the crate-private query path
+//! for `benches/dns_resolution.rs` to stand a [`QueryPipeline`] up and drive it
+//! directly: an in-process UDP stub upstream, a settable filter, empty routing
+//! and device snapshots, a no-op tunnel repository, and helpers to populate the
+//! authoritative view and encode a query packet.
+//!
+//! Nothing here touches a real socket beyond the loopback stub, an upstream
+//! resolver aimed at that stub, or a database — the goal is to isolate the
+//! resolve core's own cost. Mirrors the `fuzz-internals` seam in
+//! `wardnetd-services`: it ADDS visibility only, and changes no production code
+//! path when the feature is off.
+
+use std::collections::HashMap;
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+use std::sync::Arc;
+
+use arc_swap::ArcSwap;
+use async_trait::async_trait;
+use chrono::Utc;
+use hickory_proto::op::{Message, OpCode};
+use hickory_proto::rr::rdata::A;
+use hickory_proto::rr::{Name, RData, Record, RecordType};
+use hickory_proto::serialize::binary::{BinDecodable, BinEncodable};
+use tokio::net::UdpSocket;
+use tokio::sync::RwLock;
+use uuid::Uuid;
+use wardnet_common::dns::{
+    CustomDnsRecord, DnsConfig, DnsProtocol, DnsRecordSource, DnsRecordType, FilterAction,
+    UpstreamDns,
+};
+use wardnet_common::tunnel::{Tunnel, TunnelConfig};
+use wardnetd_data::repository::TunnelRepository;
+use wardnetd_data::repository::tunnel::TunnelRow;
+use wardnetd_services::dns::authoritative::AuthoritativeView;
+use wardnetd_services::dns::cache::DnsCache;
+use wardnetd_services::dns_filter::service::CheckOutcome;
+
+use crate::dns::pipeline::QueryPipeline;
+use crate::dns::rate_limit::RateLimiter;
+use crate::dns::server::build_forwarding_resolver;
+
+/// A `DnsFilterService` whose hot-path verdict is settable and read lock-free.
+///
+/// Only [`check`](wardnetd_services::DnsFilterService::check) is exercised by
+/// the bench; every admin/repository method is `unimplemented!()` — the bench
+/// never calls them. The action lives in an [`ArcSwap`] so flipping it between
+/// resolution branches never introduces lock contention on the concurrent hot
+/// path.
+pub struct BenchFilter {
+    action: ArcSwap<FilterAction>,
+}
+
+impl BenchFilter {
+    /// A filter that starts by passing every query.
+    #[must_use]
+    pub fn passing() -> Self {
+        Self {
+            action: ArcSwap::from_pointee(FilterAction::Pass),
+        }
+    }
+
+    /// Swap the verdict every subsequent `check` returns.
+    pub fn set(&self, action: FilterAction) {
+        self.action.store(Arc::new(action));
+    }
+}
+
+#[async_trait]
+impl wardnetd_services::DnsFilterService for BenchFilter {
+    async fn check(&self, _domain: &str, _qtype: RecordType, _client: IpAddr) -> CheckOutcome {
+        CheckOutcome {
+            action: **self.action.load(),
+            would_have_blocked: false,
+        }
+    }
+    async fn rebuild_all(&self) -> Result<(), wardnetd_services::error::AppError> {
+        Ok(())
+    }
+    async fn list_profiles(
+        &self,
+    ) -> Result<wardnet_common::api::ListProfilesResponse, wardnetd_services::error::AppError> {
+        unimplemented!()
+    }
+    async fn get_profile(
+        &self,
+        _id: Uuid,
+    ) -> Result<wardnet_common::api::GetProfileResponse, wardnetd_services::error::AppError> {
+        unimplemented!()
+    }
+    async fn create_profile(
+        &self,
+        _r: wardnet_common::api::CreateProfileRequest,
+    ) -> Result<wardnet_common::api::CreateProfileResponse, wardnetd_services::error::AppError>
+    {
+        unimplemented!()
+    }
+    async fn update_profile(
+        &self,
+        _id: Uuid,
+        _r: wardnet_common::api::UpdateProfileRequest,
+    ) -> Result<wardnet_common::api::UpdateProfileResponse, wardnetd_services::error::AppError>
+    {
+        unimplemented!()
+    }
+    async fn delete_profile(
+        &self,
+        _id: Uuid,
+    ) -> Result<wardnet_common::api::DeleteProfileResponse, wardnetd_services::error::AppError>
+    {
+        unimplemented!()
+    }
+    async fn list_blocklists(
+        &self,
+        _profile_id: Uuid,
+    ) -> Result<wardnet_common::api::ListBlocklistsResponse, wardnetd_services::error::AppError>
+    {
+        unimplemented!()
+    }
+    async fn create_blocklist(
+        &self,
+        _profile_id: Uuid,
+        _r: wardnet_common::api::CreateBlocklistRequest,
+    ) -> Result<wardnet_common::api::CreateBlocklistResponse, wardnetd_services::error::AppError>
+    {
+        unimplemented!()
+    }
+    async fn update_blocklist(
+        &self,
+        _profile_id: Uuid,
+        _id: Uuid,
+        _r: wardnet_common::api::UpdateBlocklistRequest,
+    ) -> Result<wardnet_common::api::UpdateBlocklistResponse, wardnetd_services::error::AppError>
+    {
+        unimplemented!()
+    }
+    async fn delete_blocklist(
+        &self,
+        _profile_id: Uuid,
+        _id: Uuid,
+    ) -> Result<wardnet_common::api::DeleteBlocklistResponse, wardnetd_services::error::AppError>
+    {
+        unimplemented!()
+    }
+    async fn refresh_blocklist(
+        &self,
+        _profile_id: Uuid,
+        _id: Uuid,
+    ) -> Result<wardnet_common::jobs::JobDispatchedResponse, wardnetd_services::error::AppError>
+    {
+        unimplemented!()
+    }
+    async fn list_allowlist(
+        &self,
+        _profile_id: Uuid,
+    ) -> Result<wardnet_common::api::ListAllowlistResponse, wardnetd_services::error::AppError>
+    {
+        unimplemented!()
+    }
+    async fn create_allowlist_entry(
+        &self,
+        _profile_id: Uuid,
+        _r: wardnet_common::api::CreateAllowlistRequest,
+    ) -> Result<wardnet_common::api::CreateAllowlistResponse, wardnetd_services::error::AppError>
+    {
+        unimplemented!()
+    }
+    async fn delete_allowlist_entry(
+        &self,
+        _profile_id: Uuid,
+        _id: Uuid,
+    ) -> Result<wardnet_common::api::DeleteAllowlistResponse, wardnetd_services::error::AppError>
+    {
+        unimplemented!()
+    }
+    async fn list_custom_rules(
+        &self,
+        _profile_id: Uuid,
+    ) -> Result<wardnet_common::api::ListFilterRulesResponse, wardnetd_services::error::AppError>
+    {
+        unimplemented!()
+    }
+    async fn create_custom_rule(
+        &self,
+        _profile_id: Uuid,
+        _r: wardnet_common::api::CreateFilterRuleRequest,
+    ) -> Result<wardnet_common::api::CreateFilterRuleResponse, wardnetd_services::error::AppError>
+    {
+        unimplemented!()
+    }
+    async fn update_custom_rule(
+        &self,
+        _profile_id: Uuid,
+        _id: Uuid,
+        _r: wardnet_common::api::UpdateFilterRuleRequest,
+    ) -> Result<wardnet_common::api::UpdateFilterRuleResponse, wardnetd_services::error::AppError>
+    {
+        unimplemented!()
+    }
+    async fn delete_custom_rule(
+        &self,
+        _profile_id: Uuid,
+        _id: Uuid,
+    ) -> Result<wardnet_common::api::DeleteFilterRuleResponse, wardnetd_services::error::AppError>
+    {
+        unimplemented!()
+    }
+    async fn list_device_settings(
+        &self,
+        _params: wardnet_common::api::ListDeviceFilterSettingsParams,
+    ) -> Result<
+        wardnet_common::api::ListDeviceFilterSettingsResponse,
+        wardnetd_services::error::AppError,
+    > {
+        unimplemented!()
+    }
+    async fn get_device_settings(
+        &self,
+        _device_id: Uuid,
+    ) -> Result<
+        wardnet_common::api::GetDeviceFilterSettingsResponse,
+        wardnetd_services::error::AppError,
+    > {
+        unimplemented!()
+    }
+    async fn update_device_settings(
+        &self,
+        _device_id: Uuid,
+        _r: wardnet_common::api::UpdateDeviceFilterSettingsRequest,
+    ) -> Result<
+        wardnet_common::api::UpdateDeviceFilterSettingsResponse,
+        wardnetd_services::error::AppError,
+    > {
+        unimplemented!()
+    }
+    async fn get_filter_config(
+        &self,
+    ) -> Result<wardnet_common::api::DnsFilterConfigResponse, wardnetd_services::error::AppError>
+    {
+        unimplemented!()
+    }
+    async fn update_filter_config(
+        &self,
+        _r: wardnet_common::api::UpdateDnsFilterConfigRequest,
+    ) -> Result<wardnet_common::api::DnsFilterConfigResponse, wardnetd_services::error::AppError>
+    {
+        unimplemented!()
+    }
+    async fn rebuild_blocklist_filter(
+        &self,
+        _id: Uuid,
+    ) -> Result<(), wardnetd_services::error::AppError> {
+        Ok(())
+    }
+    async fn rebuild_profile(&self, _id: Uuid) -> Result<(), wardnetd_services::error::AppError> {
+        Ok(())
+    }
+    async fn rebuild_device(&self, _id: Uuid) -> Result<(), wardnetd_services::error::AppError> {
+        Ok(())
+    }
+    async fn rebuild_default_context(&self) -> Result<(), wardnetd_services::error::AppError> {
+        Ok(())
+    }
+    async fn handle_device_ip_changed(
+        &self,
+        _device_id: Uuid,
+        _old_ip: &str,
+        _new_ip: &str,
+    ) -> Result<(), wardnetd_services::error::AppError> {
+        Ok(())
+    }
+}
+
+/// No-op `TunnelRepository`: knows no tunnels, so the tunnel-forward path is
+/// never taken. Present only to satisfy `QueryPipeline::new`.
+fn stub_tunnel_repo() -> Arc<dyn TunnelRepository> {
+    struct Stub;
+    #[async_trait]
+    impl TunnelRepository for Stub {
+        async fn find_all(&self) -> anyhow::Result<Vec<Tunnel>> {
+            Ok(vec![])
+        }
+        async fn find_by_id(&self, _id: &str) -> anyhow::Result<Option<Tunnel>> {
+            Ok(None)
+        }
+        async fn find_config_by_id(&self, _id: &str) -> anyhow::Result<Option<TunnelConfig>> {
+            Ok(None)
+        }
+        async fn insert(&self, _row: &TunnelRow) -> anyhow::Result<()> {
+            Ok(())
+        }
+        async fn update_status(&self, _id: &str, _status: &str) -> anyhow::Result<()> {
+            Ok(())
+        }
+        async fn update_dns_override(&self, _id: &str, _value: bool) -> anyhow::Result<()> {
+            Ok(())
+        }
+        async fn update_stats(
+            &self,
+            _id: &str,
+            _bytes_tx: i64,
+            _bytes_rx: i64,
+            _last_handshake: Option<&str>,
+        ) -> anyhow::Result<()> {
+            Ok(())
+        }
+        async fn delete(&self, _id: &str) -> anyhow::Result<()> {
+            Ok(())
+        }
+        async fn next_interface_index(&self) -> anyhow::Result<i64> {
+            Ok(0)
+        }
+        async fn count(&self) -> anyhow::Result<i64> {
+            Ok(0)
+        }
+        async fn update_endpoint(
+            &self,
+            _id: &str,
+            _endpoint: &str,
+            _peer_config_json: &str,
+            _server_name: &str,
+            _resolved_at: &str,
+        ) -> anyhow::Result<()> {
+            Ok(())
+        }
+        async fn count_active(&self) -> anyhow::Result<i64> {
+            Ok(0)
+        }
+    }
+    Arc::new(Stub)
+}
+
+/// The single A record `spawn_stub_upstream` answers with (`example.com`'s
+/// historical address); public, so DNS-rebinding protection never trips.
+const STUB_ANSWER_IP: Ipv4Addr = Ipv4Addr::new(93, 184, 216, 34);
+
+/// Spawn a loopback UDP responder that answers every A question with
+/// [`STUB_ANSWER_IP`] at TTL 60 (so the answer is cacheable), and echoes an
+/// empty NOERROR for anything else. Returns the bound address; the task
+/// self-terminates when the runtime is dropped.
+///
+/// This is the bench's stand-in for a real upstream — an in-process socket,
+/// so the "forward to upstream" branch measures the pipeline plus a loopback
+/// round-trip rather than the internet.
+pub async fn spawn_stub_upstream() -> SocketAddr {
+    let socket = UdpSocket::bind("127.0.0.1:0")
+        .await
+        .expect("stub upstream bind");
+    let addr = socket.local_addr().expect("stub upstream local_addr");
+    tokio::spawn(async move {
+        let mut buf = vec![0u8; 4096];
+        loop {
+            let Ok((n, peer)) = socket.recv_from(&mut buf).await else {
+                break;
+            };
+            let Ok(request) = Message::from_bytes(&buf[..n]) else {
+                continue;
+            };
+            let mut response = Message::response(request.metadata.id, OpCode::Query);
+            response.metadata.recursion_desired = true;
+            response.metadata.recursion_available = true;
+            response.add_queries(request.queries.clone());
+            for q in &request.queries {
+                if q.query_type() == RecordType::A {
+                    response.add_answer(Record::from_rdata(
+                        q.name().clone(),
+                        60,
+                        RData::A(A(STUB_ANSWER_IP)),
+                    ));
+                }
+            }
+            if let Ok(bytes) = response.to_bytes() {
+                let _ = socket.send_to(&bytes, peer).await;
+            }
+        }
+    });
+    addr
+}
+
+/// Wire-encode a one-question query, ready to hand to
+/// [`QueryPipeline::handle`](crate::dns::pipeline::QueryPipeline::handle).
+#[must_use]
+pub fn query_bytes(id: u16, name: &str, rtype: RecordType) -> Vec<u8> {
+    use hickory_proto::op::Query;
+
+    let mut msg = Message::query();
+    msg.metadata.id = id;
+    msg.metadata.recursion_desired = true;
+    msg.add_queries(vec![Query::query(
+        Name::from_str_relaxed(name).expect("query name"),
+        rtype,
+    )]);
+    msg.to_bytes().expect("encode query")
+}
+
+/// A single enabled manual A record for `domain` → `ip`, for seeding the
+/// authoritative view.
+#[must_use]
+pub fn a_record(domain: &str, ip: &str) -> CustomDnsRecord {
+    CustomDnsRecord {
+        id: Uuid::new_v4(),
+        zone_id: None,
+        domain: domain.to_ascii_lowercase(),
+        record_type: DnsRecordType::A,
+        value: ip.into(),
+        ttl: 120,
+        enabled: true,
+        source: DnsRecordSource::Manual,
+        created_at: Utc::now(),
+        updated_at: Utc::now(),
+    }
+}
+
+/// A `DnsConfig` whose sole upstream is the stub at `addr` (plaintext UDP),
+/// with rate limiting disabled and every other field at its default.
+#[must_use]
+pub fn config_with_upstream(addr: SocketAddr) -> DnsConfig {
+    DnsConfig {
+        upstream_servers: vec![UpstreamDns {
+            name: "bench-stub".into(),
+            address: addr.ip().to_string(),
+            protocol: DnsProtocol::Udp,
+            port: Some(addr.port()),
+            tls_server_name: None,
+        }],
+        rate_limit_per_second: 0,
+        ..DnsConfig::default()
+    }
+}
+
+/// A `QueryPipeline` wired for benchmarking, plus the handles a bench needs to
+/// steer it down a specific branch.
+pub struct BenchPipeline {
+    pipeline: Arc<QueryPipeline>,
+    filter: Arc<BenchFilter>,
+}
+
+impl BenchPipeline {
+    /// The pipeline under test. Call
+    /// [`handle`](crate::dns::pipeline::QueryPipeline::handle) on it.
+    #[must_use]
+    pub fn pipeline(&self) -> &Arc<QueryPipeline> {
+        &self.pipeline
+    }
+
+    /// Set the verdict the filter returns for every subsequent query — used
+    /// to steer into the block and rewrite branches.
+    pub fn set_filter_action(&self, action: FilterAction) {
+        self.filter.set(action);
+    }
+
+    /// Swap in an authoritative view built from `records`, so a query for one
+    /// of those names is answered authoritatively (before cache and filter).
+    pub fn set_authoritative_records(&self, records: Vec<CustomDnsRecord>) {
+        self.pipeline
+            .authoritative_view
+            .store(Arc::new(AuthoritativeView::build(&[], records, vec![])));
+    }
+}
+
+/// Build a benchmark pipeline whose upstream is the stub at `upstream`. The
+/// routing and device snapshots start empty, the tunnel repository is a no-op,
+/// and the rate limiter is disabled — so `handle` measures the resolve core
+/// itself rather than admission control or per-client bookkeeping.
+#[must_use]
+pub fn build_bench_pipeline(upstream: SocketAddr) -> BenchPipeline {
+    let cfg = config_with_upstream(upstream);
+    let resolver = Arc::new(RwLock::new(build_forwarding_resolver(&cfg)));
+    let rate_limiter = Arc::new(RateLimiter::new(0));
+    let cache = Arc::new(RwLock::new(DnsCache::new(cfg.cache_size as usize)));
+    let filter = Arc::new(BenchFilter::passing());
+
+    let pipeline = QueryPipeline::new(
+        Arc::new(RwLock::new(cfg)),
+        resolver,
+        Arc::new(RwLock::new(None)),
+        rate_limiter,
+        cache,
+        Arc::clone(&filter) as Arc<dyn wardnetd_services::DnsFilterService>,
+        Arc::new(ArcSwap::from_pointee(HashMap::new())),
+        Arc::new(ArcSwap::from_pointee(HashMap::new())),
+        stub_tunnel_repo(),
+    );
+
+    BenchPipeline {
+        pipeline: Arc::new(pipeline),
+        filter,
+    }
+}

--- a/source/daemon/crates/wardnetd/src/dns/bench_support.rs
+++ b/source/daemon/crates/wardnetd/src/dns/bench_support.rs
@@ -1,7 +1,9 @@
 //! Feature-gated bench seam for the DNS resolution pipeline.
 //!
-//! Compiled only under `cfg(test)` or the `bench-internals` feature — NEVER in
-//! a production build. It exposes just enough of the crate-private query path
+//! Compiled only under the `bench-internals` feature — NEVER in a production
+//! build, and deliberately NOT under a plain `cfg(test)` (no test uses it), so
+//! its bench-only stubs stay out of the coverage build. It exposes just enough
+//! of the crate-private query path
 //! for `benches/dns_resolution.rs` to stand a [`QueryPipeline`] up and drive it
 //! directly: an in-process UDP stub upstream, a settable filter, empty routing
 //! and device snapshots, a no-op tunnel repository, and helpers to populate the

--- a/source/daemon/crates/wardnetd/src/dns/mod.rs
+++ b/source/daemon/crates/wardnetd/src/dns/mod.rs
@@ -6,12 +6,16 @@ pub mod server;
 mod rate_limit;
 
 // The bench seam (issue: DNS pipeline criterion benches). Compiled only under
-// `cfg(test)` or the `bench-internals` feature — never in a production build.
+// the `bench-internals` feature — never in a production build, and NOT under a
+// plain `cfg(test)` either: nothing in the test suite uses it (only the bench
+// target does), so gating it on the feature alone keeps its bench-only stubs
+// out of the coverage build (which runs with `cfg(test)` but without the
+// feature) rather than counting as ~190 permanently-uncovered lines.
 // It re-exposes the crate-private query-path construction helpers and a set of
 // in-process stubs so `benches/dns_resolution.rs` can drive `QueryPipeline`
 // directly. Adds visibility only; production paths are untouched when the
 // feature is off.
-#[cfg(any(test, feature = "bench-internals"))]
+#[cfg(feature = "bench-internals")]
 pub mod bench_support;
 
 #[cfg(test)]

--- a/source/daemon/crates/wardnetd/src/dns/mod.rs
+++ b/source/daemon/crates/wardnetd/src/dns/mod.rs
@@ -5,5 +5,14 @@ pub mod server;
 
 mod rate_limit;
 
+// The bench seam (issue: DNS pipeline criterion benches). Compiled only under
+// `cfg(test)` or the `bench-internals` feature — never in a production build.
+// It re-exposes the crate-private query-path construction helpers and a set of
+// in-process stubs so `benches/dns_resolution.rs` can drive `QueryPipeline`
+// directly. Adds visibility only; production paths are untouched when the
+// feature is off.
+#[cfg(any(test, feature = "bench-internals"))]
+pub mod bench_support;
+
 #[cfg(test)]
 mod tests;


### PR DESCRIPTION
## Summary

Add a **macro benchmark** for the full DNS resolution pipeline and broaden the
**micro** coverage, then wire both into the cubit leaf so they're tracked and
compared per PR (paired, same-runner).

## Macro bench (new)

`wardnetd/benches/dns_resolution.rs` drives `QueryPipeline::handle` down each
resolution branch, one criterion line each:

- `cache_hit` — served from the response cache; upstream never touched
- `cache_miss` — fresh domain → forwarded to an in-process stub upstream
- `blocked` — filter `Block` → NXDOMAIN
- `rewrite` — filter `Rewrite` → synthetic A
- `authoritative` — answered from the local authoritative view

Harness: a dev-only **`bench-internals`** feature (mirrors wardnetd-services'
`fuzz-internals`) gates `dns::bench_support` — an in-process stub upstream, a
settable filter, a no-op tunnel repo, and `build_bench_pipeline` which stands a
**real** `QueryPipeline` up with the existing `ReplyCapture` socket. It's
**strictly additive**: no production code path changes when the feature is off,
and `[[bench]]` carries `required-features = ["bench-internals"]` so a plain
`cargo build` never pulls in the seam.

## Micro benches (expanded)

`wardnetd-services/benches/dns_components.rs` gains: `AuthoritativeView`
lookup/cname/forwarding-rule (size sweep), DNS filter parse + match, hickory
`Message` parse/encode, and a **`DnsCache::get` concurrency sweep** (`iter_custom`
+ `Barrier`, threads = [1, 4, 8, 16]).

## CI

The cubit `bench-command` now runs both targets (macro needs
`--features bench-internals`); both write to `source/daemon/target/criterion`,
which cubit ingests. Note: this adds a full `wardnetd` bench compile to the leaf,
and paired runs it for head + base — heavier per-PR CI time (advisory, cached
across runs via Swatinem; leaf gated on daemon||ci).

## Verification (Linux, rust 1.96)

- Builds with and without `bench-internals`; clippy-clean; rustfmt-clean.
- Macro group runs: cache_miss ~192µs, blocked ~1.5µs, rewrite ~2µs,
  authoritative ~1.9µs. Micro benches compile.