### PR TITLE
fix(devices): enforce auth guards across discovery and DNS capture

### DIFF
--- a/source/daemon/crates/wardnetd-api/src/api/dns_events.rs
+++ b/source/daemon/crates/wardnetd-api/src/api/dns_events.rs
@@ -68,104 +68,124 @@ pub async fn stream_dns_events(
 
     let (tx, rx) = mpsc::channel::<Result<Event, Infallible>>(64);
 
-    // Clone state + ids for the spawned task.
-    let state_clone = state.clone();
+    // The spawned task runs detached, so it does not inherit this request's
+    // task-local `AuthContext`. Capture it here and re-establish it around the
+    // task so the self-service guard on `fetch_pending_dns_events` sees the same
+    // device/admin identity the request authenticated as.
+    let auth_ctx = wardnetd_services::auth_context::try_current()
+        .unwrap_or(wardnet_common::auth::AuthContext::Anonymous);
 
-    tokio::spawn(async move {
-        // Subscribe to the event bus BEFORE the flush phase so that any
-        // DnsEventInserted emitted while we are paging through pending rows
-        // is buffered in the broadcast receiver rather than lost.
-        let mut event_rx = state_clone.event_publisher().subscribe();
-
-        // --- Flush phase: replay all pending rows not yet acked ----
-        let mut last_flushed_id = cursor;
-        loop {
-            let batch = match state_clone
-                .device_service()
-                .fetch_pending_dns_events(&device_id, last_flushed_id, 200)
-                .await
-            {
-                Ok(b) => b,
-                Err(e) => {
-                    tracing::warn!(error = %e, "failed to fetch pending DNS events; closing stream");
-                    return;
-                }
-            };
-
-            if batch.is_empty() {
-                break;
-            }
-
-            let max_id = batch.last().expect("non-empty batch has last element").id;
-            for item in &batch {
-                let data = match serde_json::to_string(item) {
-                    Ok(s) => s,
-                    Err(e) => {
-                        tracing::warn!(error = %e, "failed to serialize DNS event item");
-                        continue;
-                    }
-                };
-                let event = Event::default().id(item.id.to_string()).data(data);
-                if tx.send(Ok(event)).await.is_err() {
-                    return; // Client disconnected.
-                }
-            }
-
-            last_flushed_id = max_id;
-
-            if batch.len() < 200 {
-                break; // Reached the end of pending rows.
-            }
-        }
-
-        // --- Live phase: forward events from the broadcast bus ----
-        loop {
-            match event_rx.recv().await {
-                Ok(WardnetEvent::DnsEventInserted {
-                    device_id: ev_id,
-                    row_id,
-                    domain,
-                    status,
-                    captured_at,
-                    ..
-                }) if ev_id == device_uuid && row_id > last_flushed_id => {
-                    let item = DnsEventItem {
-                        id: row_id,
-                        domain,
-                        status,
-                        captured_at,
-                    };
-                    let data = match serde_json::to_string(&item) {
-                        Ok(s) => s,
-                        Err(e) => {
-                            tracing::warn!(error = %e, "failed to serialize live DNS event item");
-                            continue;
-                        }
-                    };
-                    let event = Event::default().id(row_id.to_string()).data(data);
-                    if tx.send(Ok(event)).await.is_err() {
-                        return; // Client disconnected.
-                    }
-                    last_flushed_id = row_id;
-                }
-                Ok(_) => {} // Event not for this device or already seen.
-                Err(tokio::sync::broadcast::error::RecvError::Lagged(_)) => {
-                    // Broadcast buffer overflowed. Close stream; client
-                    // reconnects and the flush phase re-delivers missing rows.
-                    tracing::debug!(
-                        device_id = %device_uuid,
-                        "DNS events broadcast lagged; closing stream to trigger client reconnect"
-                    );
-                    break;
-                }
-                Err(tokio::sync::broadcast::error::RecvError::Closed) => break,
-            }
-        }
-    });
+    tokio::spawn(wardnetd_services::auth_context::with_context(
+        auth_ctx,
+        pump_dns_events(state.clone(), device_uuid, device_id, cursor, tx),
+    ));
 
     Ok(Sse::new(ReceiverStream::new(rx))
         .keep_alive(KeepAlive::default())
         .into_response())
+}
+
+/// Drive one DNS-events SSE connection: replay pending rows (flush phase), then
+/// forward live `DnsEventInserted` events until the client disconnects or the
+/// bus closes. Runs detached under the caller's `AuthContext`, re-established by
+/// [`stream_dns_events`] so the self-service guard on `fetch_pending_dns_events`
+/// sees the request's identity.
+async fn pump_dns_events(
+    state: AppState,
+    device_uuid: Uuid,
+    device_id: String,
+    cursor: i64,
+    tx: mpsc::Sender<Result<Event, Infallible>>,
+) {
+    // Subscribe to the event bus BEFORE the flush phase so that any
+    // DnsEventInserted emitted while we are paging through pending rows is
+    // buffered in the broadcast receiver rather than lost.
+    let mut event_rx = state.event_publisher().subscribe();
+
+    // --- Flush phase: replay all pending rows not yet acked ----
+    let mut last_flushed_id = cursor;
+    loop {
+        let batch = match state
+            .device_service()
+            .fetch_pending_dns_events(&device_id, last_flushed_id, 200)
+            .await
+        {
+            Ok(b) => b,
+            Err(e) => {
+                tracing::warn!(error = %e, "failed to fetch pending DNS events; closing stream");
+                return;
+            }
+        };
+
+        if batch.is_empty() {
+            break;
+        }
+
+        let max_id = batch.last().expect("non-empty batch has last element").id;
+        for item in &batch {
+            let data = match serde_json::to_string(item) {
+                Ok(s) => s,
+                Err(e) => {
+                    tracing::warn!(error = %e, "failed to serialize DNS event item");
+                    continue;
+                }
+            };
+            let event = Event::default().id(item.id.to_string()).data(data);
+            if tx.send(Ok(event)).await.is_err() {
+                return; // Client disconnected.
+            }
+        }
+
+        last_flushed_id = max_id;
+
+        if batch.len() < 200 {
+            break; // Reached the end of pending rows.
+        }
+    }
+
+    // --- Live phase: forward events from the broadcast bus ----
+    loop {
+        match event_rx.recv().await {
+            Ok(WardnetEvent::DnsEventInserted {
+                device_id: ev_id,
+                row_id,
+                domain,
+                status,
+                captured_at,
+                ..
+            }) if ev_id == device_uuid && row_id > last_flushed_id => {
+                let item = DnsEventItem {
+                    id: row_id,
+                    domain,
+                    status,
+                    captured_at,
+                };
+                let data = match serde_json::to_string(&item) {
+                    Ok(s) => s,
+                    Err(e) => {
+                        tracing::warn!(error = %e, "failed to serialize live DNS event item");
+                        continue;
+                    }
+                };
+                let event = Event::default().id(row_id.to_string()).data(data);
+                if tx.send(Ok(event)).await.is_err() {
+                    return; // Client disconnected.
+                }
+                last_flushed_id = row_id;
+            }
+            Ok(_) => {} // Event not for this device or already seen.
+            Err(tokio::sync::broadcast::error::RecvError::Lagged(_)) => {
+                // Broadcast buffer overflowed. Close stream; client reconnects
+                // and the flush phase re-delivers missing rows.
+                tracing::debug!(
+                    device_id = %device_uuid,
+                    "DNS events broadcast lagged; closing stream to trigger client reconnect"
+                );
+                break;
+            }
+            Err(tokio::sync::broadcast::error::RecvError::Closed) => break,
+        }
+    }
 }
 
 #[utoipa::path(

--- a/source/daemon/crates/wardnetd-api/src/api/tests/devices.rs
+++ b/source/daemon/crates/wardnetd-api/src/api/tests/devices.rs
@@ -308,13 +308,6 @@ impl DeviceService for MockDeviceService {
     ) -> Result<Vec<wardnet_common::api::DnsEventItem>, AppError> {
         unimplemented!()
     }
-    async fn mark_dns_events_synced(
-        &self,
-        _device_id: &str,
-        _up_to_id: i64,
-    ) -> Result<(), AppError> {
-        unimplemented!()
-    }
     async fn ack_dns_events(&self, _device_id: &str, _up_to_id: i64) -> Result<(), AppError> {
         unimplemented!()
     }

--- a/source/daemon/crates/wardnetd-api/src/api/tests/dns_capture.rs
+++ b/source/daemon/crates/wardnetd-api/src/api/tests/dns_capture.rs
@@ -201,13 +201,6 @@ impl DeviceService for MockDnsDeviceService {
     ) -> Result<Vec<wardnet_common::api::DnsEventItem>, AppError> {
         unimplemented!()
     }
-    async fn mark_dns_events_synced(
-        &self,
-        _device_id: &str,
-        _up_to_id: i64,
-    ) -> Result<(), AppError> {
-        unimplemented!()
-    }
     async fn ack_dns_events(&self, _device_id: &str, _up_to_id: i64) -> Result<(), AppError> {
         unimplemented!()
     }

--- a/source/daemon/crates/wardnetd-api/src/api/tests/dns_events.rs
+++ b/source/daemon/crates/wardnetd-api/src/api/tests/dns_events.rs
@@ -14,6 +14,7 @@ use uuid::Uuid;
 use wardnet_common::api::{
     DeviceMeResponse, DnsCaptureSettingsResponse, DnsEventItem, SetMyRuleResponse,
 };
+use wardnet_common::auth::AuthContext;
 use wardnet_common::device::{Device, DeviceType};
 use wardnet_common::routing::RoutingTarget;
 
@@ -136,6 +137,10 @@ struct MockDnsEventsDeviceService {
     pending: Vec<DnsEventItem>,
     /// When `true`, `fetch_pending_dns_events` returns an error.
     fetch_error: bool,
+    /// Records the `AuthContext` observed inside `fetch_pending_dns_events`, so
+    /// a test can assert the SSE handler propagated the request's identity into
+    /// the detached flush task.
+    observed_ctx: Arc<std::sync::Mutex<Option<AuthContext>>>,
 }
 
 impl MockDnsEventsDeviceService {
@@ -144,6 +149,7 @@ impl MockDnsEventsDeviceService {
             device: Some(sample_device()),
             pending,
             fetch_error: false,
+            observed_ctx: Arc::new(std::sync::Mutex::new(None)),
         }
     }
 
@@ -152,6 +158,7 @@ impl MockDnsEventsDeviceService {
             device: None,
             pending: vec![],
             fetch_error: false,
+            observed_ctx: Arc::new(std::sync::Mutex::new(None)),
         }
     }
 
@@ -160,7 +167,13 @@ impl MockDnsEventsDeviceService {
             device: Some(sample_device()),
             pending: vec![],
             fetch_error: true,
+            observed_ctx: Arc::new(std::sync::Mutex::new(None)),
         }
+    }
+
+    /// Handle to the slot recording the context seen by the flush task.
+    fn ctx_recorder(&self) -> Arc<std::sync::Mutex<Option<AuthContext>>> {
+        self.observed_ctx.clone()
     }
 }
 
@@ -239,6 +252,7 @@ impl DeviceService for MockDnsEventsDeviceService {
         _after_id: i64,
         _limit: i64,
     ) -> Result<Vec<DnsEventItem>, AppError> {
+        *self.observed_ctx.lock().unwrap() = wardnetd_services::auth_context::try_current();
         if self.fetch_error {
             return Err(AppError::Internal(anyhow::anyhow!("db error")));
         }
@@ -458,6 +472,53 @@ async fn stream_emits_flush_event_from_mock() {
     assert!(
         body.contains("id: 7"),
         "expected SSE event id: 7, got: {body}"
+    );
+}
+
+#[tokio::test]
+async fn stream_propagates_request_auth_context_to_flush_task() {
+    let pending = vec![DnsEventItem {
+        id: 9,
+        domain: "captured.example".to_owned(),
+        status: "allowed".to_owned(),
+        captured_at: "2026-06-12T00:00:00Z".to_owned(),
+    }];
+    let svc = MockDnsEventsDeviceService::with_device(pending);
+    let recorder = svc.ctx_recorder();
+    let app = dns_events_router(build_state(svc));
+
+    let admin_ctx = AuthContext::Admin {
+        admin_id: Uuid::parse_str("00000000-0000-0000-0000-0000000000aa").unwrap(),
+    };
+
+    // Drive the request inside an admin context. The flush task is spawned
+    // detached, so it does NOT inherit this task-local — the only way the mock
+    // observes the admin context is if the handler captured it and re-wrapped
+    // the task in `with_context`. Dropping that wrap would leave the flush task
+    // context-less and fail this assertion.
+    let resp = wardnetd_services::auth_context::with_context(
+        admin_ctx,
+        app.oneshot(
+            Request::builder()
+                .uri("/api/devices/me/dns-events/stream")
+                .extension(client_connect_info())
+                .body(Body::empty())
+                .unwrap(),
+        ),
+    )
+    .await
+    .unwrap();
+
+    // Reading the body drives the flush phase to completion, so the mock's
+    // fetch call (and its context capture) has run by the time we assert.
+    let _ = axum::body::to_bytes(resp.into_body(), 4096)
+        .await
+        .unwrap_or_default();
+
+    let observed = recorder.lock().unwrap().clone();
+    assert!(
+        matches!(observed, Some(AuthContext::Admin { .. })),
+        "flush task must run under the request's admin context, got: {observed:?}"
     );
 }
 

--- a/source/daemon/crates/wardnetd-api/src/api/tests/dns_events.rs
+++ b/source/daemon/crates/wardnetd-api/src/api/tests/dns_events.rs
@@ -244,13 +244,6 @@ impl DeviceService for MockDnsEventsDeviceService {
         }
         Ok(self.pending.clone())
     }
-    async fn mark_dns_events_synced(
-        &self,
-        _device_id: &str,
-        _up_to_id: i64,
-    ) -> Result<(), AppError> {
-        Ok(())
-    }
     async fn ack_dns_events(&self, _device_id: &str, _up_to_id: i64) -> Result<(), AppError> {
         Ok(())
     }

--- a/source/daemon/crates/wardnetd-api/src/api/tests/middleware.rs
+++ b/source/daemon/crates/wardnetd-api/src/api/tests/middleware.rs
@@ -484,13 +484,6 @@ impl DeviceService for MockDeviceService {
     ) -> Result<Vec<wardnet_common::api::DnsEventItem>, AppError> {
         unimplemented!()
     }
-    async fn mark_dns_events_synced(
-        &self,
-        _device_id: &str,
-        _up_to_id: i64,
-    ) -> Result<(), AppError> {
-        unimplemented!()
-    }
     async fn ack_dns_events(&self, _device_id: &str, _up_to_id: i64) -> Result<(), AppError> {
         unimplemented!()
     }

--- a/source/daemon/crates/wardnetd-api/src/tests/stubs.rs
+++ b/source/daemon/crates/wardnetd-api/src/tests/stubs.rs
@@ -201,13 +201,6 @@ impl DeviceService for StubDeviceService {
     ) -> Result<Vec<wardnet_common::api::DnsEventItem>, AppError> {
         Ok(vec![])
     }
-    async fn mark_dns_events_synced(
-        &self,
-        _device_id: &str,
-        _up_to_id: i64,
-    ) -> Result<(), AppError> {
-        Ok(())
-    }
     async fn ack_dns_events(&self, _device_id: &str, _up_to_id: i64) -> Result<(), AppError> {
         Ok(())
     }

--- a/source/daemon/crates/wardnetd-data/src/repository/dns_events.rs
+++ b/source/daemon/crates/wardnetd-data/src/repository/dns_events.rs
@@ -53,10 +53,6 @@ pub trait DnsEventsRepository: Send + Sync {
         limit: i64,
     ) -> anyhow::Result<Vec<DnsEventRow>>;
 
-    /// Mark all rows with `id <= up_to_id` for `device_id` as synced.
-    /// Returns the number of rows updated.
-    async fn mark_synced_up_to(&self, device_id: &str, up_to_id: i64) -> anyhow::Result<u64>;
-
     /// Delete all rows with `id <= up_to_id` for `device_id`.
     /// Returns the number of rows deleted.
     async fn delete_up_to(&self, device_id: &str, up_to_id: i64) -> anyhow::Result<u64>;

--- a/source/daemon/crates/wardnetd-data/src/repository/sqlite/dns_events.rs
+++ b/source/daemon/crates/wardnetd-data/src/repository/sqlite/dns_events.rs
@@ -148,18 +148,6 @@ impl DnsEventsRepository for SqliteDnsEventsRepository {
             .collect())
     }
 
-    async fn mark_synced_up_to(&self, device_id: &str, up_to_id: i64) -> anyhow::Result<u64> {
-        let result = sqlx::query(
-            "UPDATE dns_events SET sync_state = 'synced' \
-             WHERE device_id = ? AND id <= ? AND sync_state = 'pending'",
-        )
-        .bind(device_id)
-        .bind(up_to_id)
-        .execute(&self.pools.write)
-        .await?;
-        Ok(result.rows_affected())
-    }
-
     async fn delete_up_to(&self, device_id: &str, up_to_id: i64) -> anyhow::Result<u64> {
         let result = sqlx::query("DELETE FROM dns_events WHERE device_id = ? AND id <= ?")
             .bind(device_id)

--- a/source/daemon/crates/wardnetd-data/src/repository/tests/dns_events.rs
+++ b/source/daemon/crates/wardnetd-data/src/repository/tests/dns_events.rs
@@ -222,7 +222,7 @@ async fn fetch_pending_respects_after_id_cursor() {
 }
 
 #[tokio::test]
-async fn fetch_pending_empty_after_mark_synced() {
+async fn fetch_pending_empty_after_delete_up_to() {
     let pool = test_pool().await;
     insert_device(&pool, DEV1, "aa:bb:cc:dd:ee:01", "192.168.1.10").await;
     let repo = SqliteDnsEventsRepository::new(pool);
@@ -235,11 +235,11 @@ async fn fetch_pending_empty_after_mark_synced() {
         .await
         .unwrap();
 
-    let affected = repo.mark_synced_up_to(DEV1, id).await.unwrap();
-    assert_eq!(affected, 2, "both rows should be marked synced");
+    let deleted = repo.delete_up_to(DEV1, id).await.unwrap();
+    assert_eq!(deleted, 2, "both rows should be deleted on ack");
 
     let rows = repo.fetch_pending(DEV1, 0, 100).await.unwrap();
-    assert!(rows.is_empty(), "no pending rows after mark_synced_up_to");
+    assert!(rows.is_empty(), "no pending rows after delete_up_to");
 }
 
 #[tokio::test]
@@ -265,7 +265,7 @@ async fn delete_up_to_scoped_to_device() {
 }
 
 #[tokio::test]
-async fn mark_synced_up_to_returns_affected_count() {
+async fn delete_up_to_returns_affected_count() {
     let pool = test_pool().await;
     insert_device(&pool, DEV1, "aa:bb:cc:dd:ee:01", "192.168.1.10").await;
     let repo = SqliteDnsEventsRepository::new(pool);
@@ -281,10 +281,10 @@ async fn mark_synced_up_to_returns_affected_count() {
         .await
         .unwrap();
 
-    let affected = repo.mark_synced_up_to(DEV1, id3).await.unwrap();
-    assert_eq!(affected, 3, "all 3 rows should be marked synced");
+    let deleted = repo.delete_up_to(DEV1, id3).await.unwrap();
+    assert_eq!(deleted, 3, "all 3 rows should be deleted");
 
-    // Calling again is idempotent — no rows remain with sync_state='pending'.
-    let affected2 = repo.mark_synced_up_to(DEV1, id3).await.unwrap();
-    assert_eq!(affected2, 0, "second call should affect 0 rows");
+    // Calling again is idempotent — the rows are already gone.
+    let deleted2 = repo.delete_up_to(DEV1, id3).await.unwrap();
+    assert_eq!(deleted2, 0, "second call should delete 0 rows");
 }

--- a/source/daemon/crates/wardnetd-services/src/device/discovery.rs
+++ b/source/daemon/crates/wardnetd-services/src/device/discovery.rs
@@ -620,6 +620,8 @@ enum ObsAction {
 #[async_trait]
 impl DeviceDiscoveryService for DeviceDiscoveryServiceImpl {
     async fn restore_devices(&self) -> Result<(), AppError> {
+        auth_context::require_admin()?;
+
         // Fold the configured zone subnets into the trusted set before we start
         // processing observations, so a device inside a zone subnet isn't dropped
         // in the window between startup and the first zone-change event.
@@ -712,6 +714,8 @@ impl DeviceDiscoveryService for DeviceDiscoveryServiceImpl {
         &self,
         obs: &ObservedDevice,
     ) -> Result<ObservationResult, AppError> {
+        auth_context::require_admin()?;
+
         // Filter out observations from IPs outside every trusted subnet (the LAN
         // `/24` plus any configured Network-Zone subnet). When the Pi is the
         // gateway, return traffic from the internet arrives with the router's MAC
@@ -824,6 +828,8 @@ impl DeviceDiscoveryService for DeviceDiscoveryServiceImpl {
     }
 
     async fn flush_last_seen(&self) -> Result<u64, AppError> {
+        auth_context::require_admin()?;
+
         let updates: Vec<(String, String)> = {
             let state = self.state.read().await;
             let now = chrono::Utc::now().to_rfc3339();
@@ -846,6 +852,8 @@ impl DeviceDiscoveryService for DeviceDiscoveryServiceImpl {
     }
 
     async fn scan_departures(&self, timeout_secs: u64) -> Result<Vec<Uuid>, AppError> {
+        auth_context::require_admin()?;
+
         let timeout = std::time::Duration::from_secs(timeout_secs);
 
         let departed: Vec<(Uuid, String, String)> = {
@@ -871,6 +879,8 @@ impl DeviceDiscoveryService for DeviceDiscoveryServiceImpl {
     }
 
     async fn resolve_hostname(&self, mac: &str, ip: &str) -> Result<(), AppError> {
+        auth_context::require_admin()?;
+
         // The MAC may belong to a device the registry hasn't seen yet (e.g.
         // a lease event arriving before packet capture observes the device).
         // Treat that as a no-op rather than an error; the next observation

--- a/source/daemon/crates/wardnetd-services/src/device/service.rs
+++ b/source/daemon/crates/wardnetd-services/src/device/service.rs
@@ -105,9 +105,9 @@ pub trait DeviceService: Send + Sync {
         enabled: bool,
     ) -> Result<DnsCaptureSettingsResponse, AppError>;
 
-    /// Return pending (unsynced) DNS events for the device with `id > after_id`,
-    /// oldest first, up to `limit` rows. No auth check — caller resolves device
-    /// by IP.
+    /// Return pending DNS events for the device with `id > after_id`, oldest
+    /// first, up to `limit` rows. Self-service: the caller must be the device
+    /// itself (matched by IP/MAC) or an admin.
     async fn fetch_pending_dns_events(
         &self,
         device_id: &str,
@@ -115,19 +115,17 @@ pub trait DeviceService: Send + Sync {
         limit: i64,
     ) -> Result<Vec<DnsEventItem>, AppError>;
 
-    /// Mark all DNS events with `id <= up_to_id` as synced for the device.
-    async fn mark_dns_events_synced(&self, device_id: &str, up_to_id: i64) -> Result<(), AppError>;
-
     /// Delete all DNS events with `id <= up_to_id` for the device (called on
-    /// client ack).
+    /// client ack). Self-service: the caller must be the device itself (matched
+    /// by IP/MAC) or an admin.
     async fn ack_dns_events(&self, device_id: &str, up_to_id: i64) -> Result<(), AppError>;
 
     /// Return all device IDs that currently have DNS capture enabled.
-    /// For internal use by background tasks — no auth check.
+    /// Requires admin privileges via the [`AuthContext`].
     async fn list_capture_enabled_device_ids(&self) -> Result<Vec<String>, AppError>;
 
     /// Return the DNS capture settings for a device by ID, or `None` if the
-    /// device does not exist. For internal use by background tasks — no auth check.
+    /// device does not exist. Requires admin privileges via the [`AuthContext`].
     async fn get_device_capture_settings(
         &self,
         device_id: &str,
@@ -410,10 +408,7 @@ impl DeviceService for DeviceServiceImpl {
     }
 
     async fn update_admin_locked(&self, device_id: &str, locked: bool) -> Result<(), AppError> {
-        let ctx = auth_context::try_current().unwrap_or(AuthContext::Anonymous);
-        if !ctx.is_admin() {
-            return Err(AppError::Forbidden("admin privileges required".to_owned()));
-        }
+        auth_context::require_admin()?;
 
         self.devices
             .update_admin_locked(device_id, locked)
@@ -435,10 +430,7 @@ impl DeviceService for DeviceServiceImpl {
         &self,
         device_id: &str,
     ) -> Result<DnsCaptureSettingsResponse, AppError> {
-        let ctx = auth_context::try_current().unwrap_or(AuthContext::Anonymous);
-        if !ctx.is_admin() {
-            return Err(AppError::Forbidden("admin privileges required".to_owned()));
-        }
+        auth_context::require_admin()?;
 
         let device = self
             .devices
@@ -469,10 +461,7 @@ impl DeviceService for DeviceServiceImpl {
         cap_count: Option<i64>,
         cap_days: Option<i64>,
     ) -> Result<(), AppError> {
-        let ctx = auth_context::try_current().unwrap_or(AuthContext::Anonymous);
-        if !ctx.is_admin() {
-            return Err(AppError::Forbidden("admin privileges required".to_owned()));
-        }
+        auth_context::require_admin()?;
 
         let found = self
             .devices
@@ -567,6 +556,20 @@ impl DeviceService for DeviceServiceImpl {
         after_id: i64,
         limit: i64,
     ) -> Result<Vec<DnsEventItem>, AppError> {
+        // Self-service (category c, `.agents/auth.md`): the DNS-events stream is
+        // reached by the device itself (resolved by source IP) or an admin.
+        // Match the current context against the device's MAC before returning
+        // its captured events. Capture is independent of the routing
+        // admin-lock, so pass `false`.
+        let device = self
+            .devices
+            .find_by_id(device_id)
+            .await
+            .map_err(AppError::Internal)?
+            .ok_or_else(|| AppError::NotFound("device not found".to_owned()))?;
+        let ctx = auth_context::try_current().unwrap_or(AuthContext::Anonymous);
+        Self::check_device_mutation_auth(&ctx, &device.mac, false)?;
+
         let rows = self
             .dns_events
             .fetch_pending(device_id, after_id, limit)
@@ -583,15 +586,21 @@ impl DeviceService for DeviceServiceImpl {
             .collect())
     }
 
-    async fn mark_dns_events_synced(&self, device_id: &str, up_to_id: i64) -> Result<(), AppError> {
-        self.dns_events
-            .mark_synced_up_to(device_id, up_to_id)
-            .await
-            .map_err(AppError::Internal)?;
-        Ok(())
-    }
-
     async fn ack_dns_events(&self, device_id: &str, up_to_id: i64) -> Result<(), AppError> {
+        // Self-service (category c, `.agents/auth.md`): the ack route is reached
+        // by the device itself (resolved by source IP) or an admin. Match the
+        // current context against the device's MAC before deleting its captured
+        // events. Capture is independent of the routing admin-lock, so pass
+        // `false`.
+        let device = self
+            .devices
+            .find_by_id(device_id)
+            .await
+            .map_err(AppError::Internal)?
+            .ok_or_else(|| AppError::NotFound("device not found".to_owned()))?;
+        let ctx = auth_context::try_current().unwrap_or(AuthContext::Anonymous);
+        Self::check_device_mutation_auth(&ctx, &device.mac, false)?;
+
         self.dns_events
             .delete_up_to(device_id, up_to_id)
             .await
@@ -600,6 +609,8 @@ impl DeviceService for DeviceServiceImpl {
     }
 
     async fn list_capture_enabled_device_ids(&self) -> Result<Vec<String>, AppError> {
+        auth_context::require_admin()?;
+
         self.devices
             .find_all_capture_enabled_ids()
             .await
@@ -610,6 +621,8 @@ impl DeviceService for DeviceServiceImpl {
         &self,
         device_id: &str,
     ) -> Result<Option<(bool, i64, i64)>, AppError> {
+        auth_context::require_admin()?;
+
         match self
             .devices
             .find_by_id(device_id)

--- a/source/daemon/crates/wardnetd-services/src/device/tests/device.rs
+++ b/source/daemon/crates/wardnetd-services/src/device/tests/device.rs
@@ -1181,7 +1181,40 @@ fn svc_with_device() -> DeviceServiceImpl {
     )
 }
 
+/// Build a service whose repo resolves every id to `None` (no such device).
+fn svc_without_device() -> DeviceServiceImpl {
+    DeviceServiceImpl::new(
+        Arc::new(MockDeviceRepo {
+            device: None,
+            rule: None,
+            all_rules: vec![],
+        }),
+        Arc::new(RowsDnsEventsRepo { rows: vec![] }),
+        Arc::new(MockNetworkZoneRepo),
+        Arc::new(MockSystemConfigRepo),
+        Arc::new(MockEventPublisher),
+    )
+}
+
 const SAMPLE_ID: &str = "00000000-0000-0000-0000-000000000001";
+
+#[tokio::test]
+async fn fetch_pending_dns_events_not_found_for_unknown_device() {
+    let svc = svc_without_device();
+    // Even an admin gets NotFound when the device row is gone: the guard
+    // resolves the device first to know whose events it would return.
+    let result =
+        auth_context::with_context(admin_ctx(), svc.fetch_pending_dns_events(SAMPLE_ID, 0, 100))
+            .await;
+    assert!(matches!(result, Err(crate::error::AppError::NotFound(_))));
+}
+
+#[tokio::test]
+async fn ack_dns_events_not_found_for_unknown_device() {
+    let svc = svc_without_device();
+    let result = auth_context::with_context(admin_ctx(), svc.ack_dns_events(SAMPLE_ID, 42)).await;
+    assert!(matches!(result, Err(crate::error::AppError::NotFound(_))));
+}
 
 #[tokio::test]
 async fn fetch_pending_dns_events_rejects_anonymous() {

--- a/source/daemon/crates/wardnetd-services/src/device/tests/device.rs
+++ b/source/daemon/crates/wardnetd-services/src/device/tests/device.rs
@@ -164,9 +164,6 @@ impl DnsEventsRepository for MockDnsEventsRepo {
     ) -> anyhow::Result<Vec<wardnetd_data::repository::DnsEventRow>> {
         Ok(vec![])
     }
-    async fn mark_synced_up_to(&self, _device_id: &str, _up_to_id: i64) -> anyhow::Result<u64> {
-        Ok(0)
-    }
     async fn delete_up_to(&self, _device_id: &str, _up_to_id: i64) -> anyhow::Result<u64> {
         Ok(0)
     }
@@ -1022,9 +1019,6 @@ impl DnsEventsRepository for RowsDnsEventsRepo {
     ) -> anyhow::Result<Vec<DnsEventRow>> {
         Ok(self.rows.clone())
     }
-    async fn mark_synced_up_to(&self, _device_id: &str, _up_to_id: i64) -> anyhow::Result<u64> {
-        Ok(0)
-    }
     async fn delete_up_to(&self, _device_id: &str, _up_to_id: i64) -> anyhow::Result<u64> {
         Ok(1)
     }
@@ -1117,8 +1111,7 @@ async fn list_capture_enabled_device_ids_delegates_to_repo() {
         Arc::new(MockSystemConfigRepo),
         Arc::new(MockEventPublisher),
     );
-    let ids = svc
-        .list_capture_enabled_device_ids()
+    let ids = auth_context::with_context(admin_ctx(), svc.list_capture_enabled_device_ids())
         .await
         .expect("should succeed");
     assert!(ids.is_empty()); // MockDeviceRepo returns empty list
@@ -1140,8 +1133,7 @@ async fn get_device_capture_settings_returns_settings_when_device_found() {
         Arc::new(MockSystemConfigRepo),
         Arc::new(MockEventPublisher),
     );
-    let result = svc
-        .get_device_capture_settings("any-id")
+    let result = auth_context::with_context(admin_ctx(), svc.get_device_capture_settings("any-id"))
         .await
         .expect("should succeed");
     let (enabled, c, d) = result.expect("device should be found");
@@ -1163,9 +1155,112 @@ async fn get_device_capture_settings_returns_none_for_unknown_device() {
         Arc::new(MockSystemConfigRepo),
         Arc::new(MockEventPublisher),
     );
-    let result = svc
-        .get_device_capture_settings("unknown-id")
-        .await
-        .expect("should succeed");
+    let result =
+        auth_context::with_context(admin_ctx(), svc.get_device_capture_settings("unknown-id"))
+            .await
+            .expect("should succeed");
     assert!(result.is_none());
+}
+
+// ---------------------------------------------------------------------------
+// Auth guards on the DNS-events / capture methods
+// ---------------------------------------------------------------------------
+
+/// Build a service whose repo resolves any id to [`sample_device`].
+fn svc_with_device() -> DeviceServiceImpl {
+    DeviceServiceImpl::new(
+        Arc::new(MockDeviceRepo {
+            device: Some(sample_device(false)),
+            rule: None,
+            all_rules: vec![],
+        }),
+        Arc::new(RowsDnsEventsRepo { rows: vec![] }),
+        Arc::new(MockNetworkZoneRepo),
+        Arc::new(MockSystemConfigRepo),
+        Arc::new(MockEventPublisher),
+    )
+}
+
+const SAMPLE_ID: &str = "00000000-0000-0000-0000-000000000001";
+
+#[tokio::test]
+async fn fetch_pending_dns_events_rejects_anonymous() {
+    let svc = svc_with_device();
+    let result = auth_context::with_context(
+        AuthContext::Anonymous,
+        svc.fetch_pending_dns_events(SAMPLE_ID, 0, 100),
+    )
+    .await;
+    assert!(matches!(result, Err(crate::error::AppError::Forbidden(_))));
+}
+
+#[tokio::test]
+async fn fetch_pending_dns_events_rejects_other_device() {
+    let svc = svc_with_device();
+    // A device caller whose MAC does not match the target device.
+    let result = auth_context::with_context(
+        device_ctx("00:00:00:00:00:99"),
+        svc.fetch_pending_dns_events(SAMPLE_ID, 0, 100),
+    )
+    .await;
+    assert!(matches!(result, Err(crate::error::AppError::Forbidden(_))));
+}
+
+#[tokio::test]
+async fn fetch_pending_dns_events_accepts_owning_device() {
+    let svc = svc_with_device();
+    // The self-service caller matched by its own MAC succeeds.
+    let result = auth_context::with_context(
+        device_ctx("AA:BB:CC:DD:EE:01"),
+        svc.fetch_pending_dns_events(SAMPLE_ID, 0, 100),
+    )
+    .await;
+    assert!(
+        result.is_ok(),
+        "owning device should be allowed: {result:?}"
+    );
+}
+
+#[tokio::test]
+async fn ack_dns_events_rejects_anonymous() {
+    let svc = svc_with_device();
+    let result =
+        auth_context::with_context(AuthContext::Anonymous, svc.ack_dns_events(SAMPLE_ID, 42)).await;
+    assert!(matches!(result, Err(crate::error::AppError::Forbidden(_))));
+}
+
+#[tokio::test]
+async fn ack_dns_events_accepts_owning_device() {
+    let svc = svc_with_device();
+    let result = auth_context::with_context(
+        device_ctx("AA:BB:CC:DD:EE:01"),
+        svc.ack_dns_events(SAMPLE_ID, 42),
+    )
+    .await;
+    assert!(
+        result.is_ok(),
+        "owning device should be allowed: {result:?}"
+    );
+}
+
+#[tokio::test]
+async fn list_capture_enabled_device_ids_rejects_anonymous() {
+    let svc = svc_with_device();
+    let result = auth_context::with_context(
+        AuthContext::Anonymous,
+        svc.list_capture_enabled_device_ids(),
+    )
+    .await;
+    assert!(matches!(result, Err(crate::error::AppError::Forbidden(_))));
+}
+
+#[tokio::test]
+async fn get_device_capture_settings_rejects_anonymous() {
+    let svc = svc_with_device();
+    let result = auth_context::with_context(
+        AuthContext::Anonymous,
+        svc.get_device_capture_settings(SAMPLE_ID),
+    )
+    .await;
+    assert!(matches!(result, Err(crate::error::AppError::Forbidden(_))));
 }

--- a/source/daemon/crates/wardnetd-services/src/device/tests/discovery.rs
+++ b/source/daemon/crates/wardnetd-services/src/device/tests/discovery.rs
@@ -650,6 +650,35 @@ struct TestHarness {
     system_config: Arc<MockSystemConfig>,
 }
 
+/// Thin wrappers that run the admin-guarded discovery methods under an admin
+/// [`AuthContext`], mirroring how the background `device_detector` tasks wrap
+/// every call. Tests that specifically exercise the auth guard call `svc`
+/// directly with the context they want.
+impl TestHarness {
+    async fn restore_devices(&self) -> Result<(), AppError> {
+        auth_context::with_context(admin_ctx(), self.svc.restore_devices()).await
+    }
+
+    async fn process_observation(
+        &self,
+        obs: &ObservedDevice,
+    ) -> Result<ObservationResult, AppError> {
+        auth_context::with_context(admin_ctx(), self.svc.process_observation(obs)).await
+    }
+
+    async fn flush_last_seen(&self) -> Result<u64, AppError> {
+        auth_context::with_context(admin_ctx(), self.svc.flush_last_seen()).await
+    }
+
+    async fn scan_departures(&self, timeout_secs: u64) -> Result<Vec<Uuid>, AppError> {
+        auth_context::with_context(admin_ctx(), self.svc.scan_departures(timeout_secs)).await
+    }
+
+    async fn resolve_hostname(&self, mac: &str, ip: &str) -> Result<(), AppError> {
+        auth_context::with_context(admin_ctx(), self.svc.resolve_hostname(mac, ip)).await
+    }
+}
+
 fn build_harness() -> TestHarness {
     build_harness_with_devices(Vec::new())
 }
@@ -755,7 +784,7 @@ async fn process_observation_accepts_zone_subnet_ip() {
     h.svc.rebuild_trusted_subnets().await.unwrap();
 
     let obs = sample_observation("aa:bb:cc:dd:ee:10", "10.0.100.50");
-    let result = h.svc.process_observation(&obs).await.unwrap();
+    let result = h.process_observation(&obs).await.unwrap();
 
     assert!(
         !matches!(result, ObservationResult::Ignored),
@@ -778,7 +807,7 @@ async fn process_observation_ignores_wan_ip_outside_all_subnets() {
     h.svc.rebuild_trusted_subnets().await.unwrap();
 
     let obs = sample_observation("aa:bb:cc:dd:ee:11", "8.8.8.8");
-    let result = h.svc.process_observation(&obs).await.unwrap();
+    let result = h.process_observation(&obs).await.unwrap();
 
     assert!(
         matches!(result, ObservationResult::Ignored),
@@ -800,7 +829,7 @@ async fn rebuild_trusted_subnets_picks_up_new_zone_subnet() {
     h.svc.rebuild_trusted_subnets().await.unwrap();
 
     let obs = sample_observation("aa:bb:cc:dd:ee:12", "10.0.100.50");
-    let before = h.svc.process_observation(&obs).await.unwrap();
+    let before = h.process_observation(&obs).await.unwrap();
     assert!(
         matches!(before, ObservationResult::Ignored),
         "expected the zone-subnet IP to be ignored before the subnet is configured, got {before:?}"
@@ -810,7 +839,7 @@ async fn rebuild_trusted_subnets_picks_up_new_zone_subnet() {
     zones.set_zones(vec![zone_with_subnet("10.0.100.0/24")]);
     h.svc.rebuild_trusted_subnets().await.unwrap();
 
-    let after = h.svc.process_observation(&obs).await.unwrap();
+    let after = h.process_observation(&obs).await.unwrap();
     assert!(
         !matches!(after, ObservationResult::Ignored),
         "expected the observation to be processed after the zone subnet is added, got {after:?}"
@@ -822,7 +851,7 @@ async fn process_observation_new_device() {
     let h = build_harness();
     let obs = sample_observation("aa:bb:cc:dd:ee:01", "192.168.1.10");
 
-    let result = h.svc.process_observation(&obs).await.unwrap();
+    let result = h.process_observation(&obs).await.unwrap();
     assert!(
         matches!(result, ObservationResult::NewDevice { .. }),
         "expected NewDevice, got {result:?}"
@@ -851,13 +880,13 @@ async fn process_observation_known_device_same_ip() {
     let obs = sample_observation("aa:bb:cc:dd:ee:01", "192.168.1.10");
 
     // First observation registers the device.
-    h.svc.process_observation(&obs).await.unwrap();
+    h.process_observation(&obs).await.unwrap();
 
     // Clear events from the first observation.
     h.events.events.lock().unwrap().clear();
 
     // Second observation with same MAC and IP.
-    let result = h.svc.process_observation(&obs).await.unwrap();
+    let result = h.process_observation(&obs).await.unwrap();
     assert!(
         matches!(result, ObservationResult::Seen(_)),
         "expected Seen, got {result:?}"
@@ -872,14 +901,14 @@ async fn process_observation_known_device_same_ip() {
 async fn process_observation_known_device_different_ip() {
     let h = build_harness();
     let obs1 = sample_observation("aa:bb:cc:dd:ee:01", "192.168.1.10");
-    h.svc.process_observation(&obs1).await.unwrap();
+    h.process_observation(&obs1).await.unwrap();
 
     // Clear events.
     h.events.events.lock().unwrap().clear();
 
     // Second observation with same MAC but different IP.
     let obs2 = sample_observation("aa:bb:cc:dd:ee:01", "192.168.1.20");
-    let result = h.svc.process_observation(&obs2).await.unwrap();
+    let result = h.process_observation(&obs2).await.unwrap();
     assert!(
         matches!(
             &result,
@@ -910,19 +939,19 @@ async fn process_observation_gone_device_returns() {
     let obs = sample_observation("aa:bb:cc:dd:ee:01", "192.168.1.10");
 
     // Register device.
-    h.svc.process_observation(&obs).await.unwrap();
+    h.process_observation(&obs).await.unwrap();
 
     // Mark it as departed (use a tiny timeout so it departs immediately).
     // We need to wait a small amount of time for the Instant to advance.
     tokio::time::sleep(std::time::Duration::from_millis(10)).await;
-    let departed = h.svc.scan_departures(0).await.unwrap();
+    let departed = h.scan_departures(0).await.unwrap();
     assert_eq!(departed.len(), 1);
 
     // Clear events.
     h.events.events.lock().unwrap().clear();
 
     // Device reappears.
-    let result = h.svc.process_observation(&obs).await.unwrap();
+    let result = h.process_observation(&obs).await.unwrap();
     assert!(
         matches!(result, ObservationResult::Reappeared(_)),
         "expected Reappeared, got {result:?}"
@@ -938,9 +967,9 @@ async fn process_observation_gone_device_returns() {
 async fn flush_last_seen_updates_batch() {
     let h = build_harness();
     let obs = sample_observation("aa:bb:cc:dd:ee:01", "192.168.1.10");
-    h.svc.process_observation(&obs).await.unwrap();
+    h.process_observation(&obs).await.unwrap();
 
-    let count = h.svc.flush_last_seen().await.unwrap();
+    let count = h.flush_last_seen().await.unwrap();
     assert_eq!(count, 1);
 
     let batch = h.repo.batch_updates.lock().unwrap();
@@ -951,14 +980,14 @@ async fn flush_last_seen_updates_batch() {
 async fn scan_departures_emits_device_gone() {
     let h = build_harness();
     let obs = sample_observation("aa:bb:cc:dd:ee:01", "192.168.1.10");
-    h.svc.process_observation(&obs).await.unwrap();
+    h.process_observation(&obs).await.unwrap();
 
     // Clear events from registration.
     h.events.events.lock().unwrap().clear();
 
     // Wait briefly and scan with a zero timeout to force departure.
     tokio::time::sleep(std::time::Duration::from_millis(10)).await;
-    let departed = h.svc.scan_departures(0).await.unwrap();
+    let departed = h.scan_departures(0).await.unwrap();
     assert_eq!(departed.len(), 1);
 
     // Verify DeviceGone event was emitted.
@@ -980,14 +1009,14 @@ async fn scan_departures_emits_device_gone() {
 async fn scan_departures_clears_departed_last_ip() {
     let h = build_harness();
     let obs = sample_observation("aa:bb:cc:dd:ee:01", "192.168.1.10");
-    h.svc.process_observation(&obs).await.unwrap();
+    h.process_observation(&obs).await.unwrap();
 
     // Precondition: the freshly discovered device resolves by its IP.
     assert!(h.repo.find_by_ip("192.168.1.10").await.unwrap().is_some());
 
     // Force the departure sweep.
     tokio::time::sleep(std::time::Duration::from_millis(10)).await;
-    let departed = h.svc.scan_departures(0).await.unwrap();
+    let departed = h.scan_departures(0).await.unwrap();
     assert_eq!(departed.len(), 1);
 
     // The departed device's IP is cleared: its row no longer resolves by that
@@ -1013,13 +1042,13 @@ async fn scan_departures_clears_departed_last_ip() {
 async fn scan_departures_tolerates_clear_last_ip_failure() {
     let h = build_harness();
     let obs = sample_observation("aa:bb:cc:dd:ee:01", "192.168.1.10");
-    h.svc.process_observation(&obs).await.unwrap();
+    h.process_observation(&obs).await.unwrap();
     h.repo
         .fail_clear_last_ip
         .store(true, std::sync::atomic::Ordering::SeqCst);
 
     tokio::time::sleep(std::time::Duration::from_millis(10)).await;
-    let departed = h.svc.scan_departures(0).await.unwrap();
+    let departed = h.scan_departures(0).await.unwrap();
     assert_eq!(departed.len(), 1);
 
     // The clear failed, so the IP is left in place — but the sweep still
@@ -1039,12 +1068,12 @@ async fn scan_departures_tolerates_clear_last_ip_failure() {
 async fn scan_departures_does_not_clear_ip_of_reconnected_device() {
     let h = build_harness();
     let obs = sample_observation("aa:bb:cc:dd:ee:01", "192.168.1.10");
-    h.svc.process_observation(&obs).await.unwrap();
+    h.process_observation(&obs).await.unwrap();
 
     // Depart, then immediately reconnect at the same address before asserting.
     tokio::time::sleep(std::time::Duration::from_millis(10)).await;
-    h.svc.scan_departures(0).await.unwrap();
-    let result = h.svc.process_observation(&obs).await.unwrap();
+    h.scan_departures(0).await.unwrap();
+    let result = h.process_observation(&obs).await.unwrap();
     assert!(
         matches!(result, ObservationResult::Reappeared(_)),
         "expected Reappeared, got {result:?}"
@@ -1064,7 +1093,7 @@ async fn scan_departures_does_not_clear_ip_of_reconnected_device() {
 async fn mark_peer_gone_clears_departed_last_ip() {
     let h = build_harness();
     let obs = sample_observation("aa:bb:cc:dd:ee:01", "192.168.1.10");
-    h.svc.process_observation(&obs).await.unwrap();
+    h.process_observation(&obs).await.unwrap();
     let device_id = h.repo.find_by_ip("192.168.1.10").await.unwrap().unwrap().id;
 
     // A zero timeout marks the peer gone once its last_seen has elapsed.
@@ -1088,13 +1117,13 @@ async fn mark_peer_gone_clears_departed_last_ip() {
 async fn scan_departures_ignores_recent() {
     let h = build_harness();
     let obs = sample_observation("aa:bb:cc:dd:ee:01", "192.168.1.10");
-    h.svc.process_observation(&obs).await.unwrap();
+    h.process_observation(&obs).await.unwrap();
 
     // Clear events.
     h.events.events.lock().unwrap().clear();
 
     // Scan with a very large timeout -- device should not be departed.
-    let departed = h.svc.scan_departures(3600).await.unwrap();
+    let departed = h.scan_departures(3600).await.unwrap();
     assert!(departed.is_empty());
 
     // No events emitted.
@@ -1313,8 +1342,7 @@ async fn resolve_hostname_falls_back_to_reverse_dns() {
     mappings.insert("192.168.1.10".to_owned(), "myphone.local".to_owned());
     let h = build_harness_with_resolver(vec![device], mappings);
 
-    h.svc
-        .resolve_hostname("aa:bb:cc:dd:ee:01", "192.168.1.10")
+    h.resolve_hostname("aa:bb:cc:dd:ee:01", "192.168.1.10")
         .await
         .unwrap();
 
@@ -1334,8 +1362,7 @@ async fn resolve_hostname_no_result_does_not_update_db() {
     // Empty resolver and no DHCP lease: nothing to write.
     let h = build_harness_with_resolver(vec![device], HashMap::new());
 
-    h.svc
-        .resolve_hostname("aa:bb:cc:dd:ee:01", "192.168.1.10")
+    h.resolve_hostname("aa:bb:cc:dd:ee:01", "192.168.1.10")
         .await
         .unwrap();
 
@@ -1367,8 +1394,7 @@ async fn resolve_hostname_prefers_dhcp_over_reverse_dns() {
     )]);
     let h = build_harness_with_resolver_and_dhcp(vec![device], mappings, dhcp);
 
-    h.svc
-        .resolve_hostname("aa:bb:cc:dd:ee:01", "192.168.1.10")
+    h.resolve_hostname("aa:bb:cc:dd:ee:01", "192.168.1.10")
         .await
         .unwrap();
 
@@ -1392,8 +1418,7 @@ async fn resolve_hostname_falls_back_when_dhcp_value_empty() {
     let dhcp = MockDhcpRepository::with_lease_hostnames(vec![("aa:bb:cc:dd:ee:01", Some("   "))]);
     let h = build_harness_with_resolver_and_dhcp(vec![device], mappings, dhcp);
 
-    h.svc
-        .resolve_hostname("aa:bb:cc:dd:ee:01", "192.168.1.10")
+    h.resolve_hostname("aa:bb:cc:dd:ee:01", "192.168.1.10")
         .await
         .unwrap();
 
@@ -1416,8 +1441,7 @@ async fn resolve_hostname_falls_back_when_no_active_lease() {
     let h =
         build_harness_with_resolver_and_dhcp(vec![device], mappings, MockDhcpRepository::empty());
 
-    h.svc
-        .resolve_hostname("aa:bb:cc:dd:ee:01", "192.168.1.10")
+    h.resolve_hostname("aa:bb:cc:dd:ee:01", "192.168.1.10")
         .await
         .unwrap();
 
@@ -1433,8 +1457,7 @@ async fn resolve_hostname_no_op_when_device_not_registered() {
     let dhcp = MockDhcpRepository::with_lease_hostnames(vec![("aa:bb:cc:dd:ee:99", Some("ghost"))]);
     let h = build_harness_with_resolver_and_dhcp(vec![], HashMap::new(), dhcp);
 
-    h.svc
-        .resolve_hostname("aa:bb:cc:dd:ee:99", "192.168.1.99")
+    h.resolve_hostname("aa:bb:cc:dd:ee:99", "192.168.1.99")
         .await
         .unwrap();
 
@@ -1464,8 +1487,7 @@ async fn resolve_hostname_tolerates_mixed_case_caller() {
     let h = build_harness_with_resolver_and_dhcp(vec![device], HashMap::new(), dhcp);
 
     // Caller uses uppercase; both lookups must still hit.
-    h.svc
-        .resolve_hostname("AA:BB:CC:DD:EE:01", "192.168.1.10")
+    h.resolve_hostname("AA:BB:CC:DD:EE:01", "192.168.1.10")
         .await
         .unwrap();
 
@@ -1484,12 +1506,12 @@ async fn restore_devices_populates_in_memory_state() {
     );
     let h = build_harness_with_devices(vec![device]);
 
-    h.svc.restore_devices().await.unwrap();
+    h.restore_devices().await.unwrap();
 
     // After restore, processing the same MAC should not create a new device
     // because restore marks devices as gone; re-observing should reappear them.
     let obs = sample_observation("aa:bb:cc:dd:ee:01", "192.168.1.10");
-    let result = h.svc.process_observation(&obs).await.unwrap();
+    let result = h.process_observation(&obs).await.unwrap();
     assert!(
         matches!(result, ObservationResult::Reappeared(_)),
         "expected Reappeared after restore, got {result:?}"
@@ -1505,7 +1527,7 @@ async fn restore_devices_empty_repo() {
     let h = build_harness();
 
     // Restore with no devices should succeed.
-    h.svc.restore_devices().await.unwrap();
+    h.restore_devices().await.unwrap();
 }
 
 #[tokio::test]
@@ -1564,14 +1586,14 @@ async fn get_device_by_id_success() {
 async fn flush_last_seen_with_gone_devices_skips_them() {
     let h = build_harness();
     let obs = sample_observation("aa:bb:cc:dd:ee:01", "192.168.1.10");
-    h.svc.process_observation(&obs).await.unwrap();
+    h.process_observation(&obs).await.unwrap();
 
     // Mark device as departed.
     tokio::time::sleep(std::time::Duration::from_millis(10)).await;
-    h.svc.scan_departures(0).await.unwrap();
+    h.scan_departures(0).await.unwrap();
 
     // Flush should skip gone devices.
-    let count = h.svc.flush_last_seen().await.unwrap();
+    let count = h.flush_last_seen().await.unwrap();
     assert_eq!(count, 0, "gone devices should not be flushed");
 }
 
@@ -1588,7 +1610,7 @@ async fn process_observation_reappear_from_db_not_memory() {
     // Do NOT call restore_devices, so the in-memory map is empty.
     // Observing should find the device in the DB and reappear it.
     let obs = sample_observation("aa:bb:cc:dd:ee:01", "192.168.1.20");
-    let result = h.svc.process_observation(&obs).await.unwrap();
+    let result = h.process_observation(&obs).await.unwrap();
     assert!(
         matches!(result, ObservationResult::Reappeared(_)),
         "expected Reappeared from DB, got {result:?}"
@@ -1611,7 +1633,7 @@ async fn quarantine_on_new_device_publishes_event() {
     h.system_config.set_quarantine(true);
 
     let obs = sample_observation("aa:bb:cc:dd:ee:01", "192.168.1.10");
-    let result = h.svc.process_observation(&obs).await.unwrap();
+    let result = h.process_observation(&obs).await.unwrap();
     assert!(matches!(result, ObservationResult::NewDevice { .. }));
 
     let events = h.events.published_events();
@@ -1636,7 +1658,7 @@ async fn quarantine_off_new_device_publishes_no_quarantine_event() {
     // Toggle left at its default (off).
 
     let obs = sample_observation("aa:bb:cc:dd:ee:01", "192.168.1.10");
-    h.svc.process_observation(&obs).await.unwrap();
+    h.process_observation(&obs).await.unwrap();
 
     let events = h.events.published_events();
     assert!(
@@ -1661,7 +1683,7 @@ async fn quarantine_on_reappearing_device_is_not_requarantined() {
     h.system_config.set_quarantine(true);
 
     let obs = sample_observation("aa:bb:cc:dd:ee:01", "192.168.1.10");
-    let result = h.svc.process_observation(&obs).await.unwrap();
+    let result = h.process_observation(&obs).await.unwrap();
     assert!(
         matches!(result, ObservationResult::Reappeared(_)),
         "expected Reappeared, got {result:?}"
@@ -1693,7 +1715,7 @@ async fn process_peer_observation_reappears_gone_device_as_remote() {
     let h = build_harness_with_devices(vec![device]);
 
     // Restore marks every device gone in the in-memory map.
-    h.svc.restore_devices().await.unwrap();
+    h.restore_devices().await.unwrap();
     h.events.events.lock().unwrap().clear();
 
     // Peer IPs live in the inbound-WG subnet, outside the LAN subnet — the
@@ -1868,7 +1890,7 @@ async fn observation_claiming_our_own_lan_ip_is_ignored() {
     let h = build_harness();
     let obs = sample_observation("aa:bb:cc:dd:ee:02", OWN_LAN_IP);
 
-    let result = h.svc.process_observation(&obs).await.unwrap();
+    let result = h.process_observation(&obs).await.unwrap();
 
     assert!(
         matches!(result, ObservationResult::Ignored),
@@ -1891,13 +1913,11 @@ async fn observation_claiming_our_own_lan_ip_is_ignored() {
 async fn known_device_flapping_onto_our_own_lan_ip_is_ignored() {
     let h = build_harness();
     let mac = "aa:bb:cc:dd:ee:03";
-    h.svc
-        .process_observation(&sample_observation(mac, "192.168.1.40"))
+    h.process_observation(&sample_observation(mac, "192.168.1.40"))
         .await
         .unwrap();
 
     let result = h
-        .svc
         .process_observation(&sample_observation(mac, OWN_LAN_IP))
         .await
         .unwrap();
@@ -1927,15 +1947,13 @@ async fn mac_flapping_across_many_ips_stops_being_trusted() {
 
     // Establish the device, then flap it across distinct addresses.
     for ip in ["192.168.1.4", "192.168.1.22", "192.168.1.59"] {
-        h.svc
-            .process_observation(&sample_observation(mac, ip))
+        h.process_observation(&sample_observation(mac, ip))
             .await
             .unwrap();
     }
 
     // One address too many, inside the window: the MAC is now untrustworthy.
     let result = h
-        .svc
         .process_observation(&sample_observation(mac, "192.168.1.77"))
         .await
         .unwrap();
@@ -1958,13 +1976,11 @@ async fn mac_flapping_across_many_ips_stops_being_trusted() {
 async fn a_device_changing_ip_normally_is_still_trusted() {
     let h = build_harness();
     let mac = "aa:bb:cc:dd:ee:05";
-    h.svc
-        .process_observation(&sample_observation(mac, "192.168.1.50"))
+    h.process_observation(&sample_observation(mac, "192.168.1.50"))
         .await
         .unwrap();
 
     let result = h
-        .svc
         .process_observation(&sample_observation(mac, "192.168.1.51"))
         .await
         .unwrap();
@@ -1987,13 +2003,11 @@ async fn own_ip_claims_count_toward_the_flap_threshold() {
 
     // The recorded #886 trace: .4, .22, <own IP>, .59 from one MAC.
     for ip in ["192.168.1.4", "192.168.1.22", OWN_LAN_IP] {
-        h.svc
-            .process_observation(&sample_observation(mac, ip))
+        h.process_observation(&sample_observation(mac, ip))
             .await
             .unwrap();
     }
     let result = h
-        .svc
         .process_observation(&sample_observation(mac, "192.168.1.59"))
         .await
         .unwrap();
@@ -2026,8 +2040,7 @@ async fn flap_ignored_observations_still_count_as_presence() {
         "192.168.1.63",
         "192.168.1.64",
     ] {
-        h.svc
-            .process_observation(&sample_observation(mac, ip))
+        h.process_observation(&sample_observation(mac, ip))
             .await
             .unwrap();
     }
@@ -2037,13 +2050,12 @@ async fn flap_ignored_observations_still_count_as_presence() {
     // presence.
     tokio::time::sleep(std::time::Duration::from_millis(1200)).await;
     let result = h
-        .svc
         .process_observation(&sample_observation(mac, "192.168.1.64"))
         .await
         .unwrap();
     assert!(matches!(result, ObservationResult::Ignored));
 
-    let departed = h.svc.scan_departures(1).await.unwrap();
+    let departed = h.scan_departures(1).await.unwrap();
     assert!(
         departed.is_empty(),
         "a flapping-but-present MAC must not be marked gone (#886): {departed:?}"
@@ -2063,7 +2075,7 @@ async fn restore_devices_repairs_a_row_claiming_our_own_ip() {
     );
     let h = build_harness_with_devices(vec![poisoned]);
 
-    h.svc.restore_devices().await.unwrap();
+    h.restore_devices().await.unwrap();
 
     let updates = h.repo.last_seen_updates.lock().unwrap();
     assert!(
@@ -2071,5 +2083,60 @@ async fn restore_devices_repairs_a_row_claiming_our_own_ip() {
             .iter()
             .any(|(id, ip, _, _)| id == "0a0a0a0a-0000-0000-0000-000000000001" && ip.is_empty()),
         "the poisoned row's last_ip must be cleared at startup (#886): {updates:?}"
+    );
+}
+
+// -- Auth guards ----------------------------------------------------------
+
+/// Every admin-guarded background method rejects an anonymous caller with
+/// `Forbidden` rather than silently doing its work. These run outside the HTTP
+/// middleware, so a bug that let them execute unguarded would have no other
+/// backstop.
+#[tokio::test]
+async fn guarded_methods_reject_anonymous_caller() {
+    let h = build_harness();
+    let obs = sample_observation("aa:bb:cc:dd:ee:01", "192.168.1.10");
+
+    let anon = AuthContext::Anonymous;
+    assert!(matches!(
+        auth_context::with_context(anon.clone(), h.svc.restore_devices()).await,
+        Err(AppError::Forbidden(_))
+    ));
+    assert!(matches!(
+        auth_context::with_context(anon.clone(), h.svc.process_observation(&obs)).await,
+        Err(AppError::Forbidden(_))
+    ));
+    assert!(matches!(
+        auth_context::with_context(anon.clone(), h.svc.flush_last_seen()).await,
+        Err(AppError::Forbidden(_))
+    ));
+    assert!(matches!(
+        auth_context::with_context(anon.clone(), h.svc.scan_departures(0)).await,
+        Err(AppError::Forbidden(_))
+    ));
+    assert!(matches!(
+        auth_context::with_context(
+            anon,
+            h.svc.resolve_hostname("aa:bb:cc:dd:ee:01", "192.168.1.10")
+        )
+        .await,
+        Err(AppError::Forbidden(_))
+    ));
+}
+
+/// The nil-admin context the `device_detector` background tasks establish
+/// reaches the service and is accepted, so the guard does not break the runner.
+#[tokio::test]
+async fn process_observation_accepts_nil_admin_context() {
+    let h = build_harness();
+    let obs = sample_observation("aa:bb:cc:dd:ee:01", "192.168.1.10");
+
+    let nil_admin = AuthContext::Admin {
+        admin_id: Uuid::nil(),
+    };
+    let result = auth_context::with_context(nil_admin, h.svc.process_observation(&obs)).await;
+    assert!(
+        matches!(result, Ok(ObservationResult::NewDevice { .. })),
+        "nil-admin observation should register the device: {result:?}"
     );
 }

--- a/source/daemon/crates/wardnetd-services/src/dns/capture_runner.rs
+++ b/source/daemon/crates/wardnetd-services/src/dns/capture_runner.rs
@@ -19,9 +19,11 @@ use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
 use tracing::Instrument;
 use uuid::Uuid;
+use wardnet_common::auth::AuthContext;
 use wardnet_common::event::WardnetEvent;
 use wardnetd_data::repository::{DnsEventsRepository, QueryLogRow};
 
+use crate::auth_context;
 use crate::device::DeviceService;
 use crate::event::EventPublisher;
 
@@ -85,6 +87,27 @@ impl DnsCaptureRunner {
     }
 }
 
+/// Load the capture-enabled device-id set from the DB under the runner's admin
+/// context. Returns `None` (and logs) on error so the caller can decide whether
+/// to start empty or keep its existing cache.
+async fn load_enabled_ids(
+    device_service: &dyn DeviceService,
+    admin_ctx: &AuthContext,
+) -> Option<HashSet<String>> {
+    match auth_context::with_context(
+        admin_ctx.clone(),
+        device_service.list_capture_enabled_device_ids(),
+    )
+    .await
+    {
+        Ok(ids) => Some(ids.into_iter().collect()),
+        Err(e) => {
+            tracing::error!(error = %e, "failed to load capture-enabled device IDs: {e}");
+            None
+        }
+    }
+}
+
 async fn runner_loop(
     mut capture_rx: mpsc::Receiver<QueryLogRow>,
     device_service: Arc<dyn DeviceService>,
@@ -93,15 +116,17 @@ async fn runner_loop(
     prune_interval: Duration,
     cancel: CancellationToken,
 ) {
-    // Populate the hot-path cache from DB on startup.
-    let mut enabled: HashSet<String> = match device_service.list_capture_enabled_device_ids().await
-    {
-        Ok(ids) => ids.into_iter().collect(),
-        Err(e) => {
-            tracing::error!(error = %e, "failed to load capture-enabled device IDs: {e}");
-            HashSet::new()
-        }
+    // This runner lives outside the HTTP middleware, so it establishes its own
+    // system/admin context (`Uuid::nil()`) around every service call, per
+    // `.agents/auth.md`.
+    let admin_ctx = AuthContext::Admin {
+        admin_id: Uuid::nil(),
     };
+
+    // Populate the hot-path cache from DB on startup.
+    let mut enabled = load_enabled_ids(device_service.as_ref(), &admin_ctx)
+        .await
+        .unwrap_or_default();
     tracing::info!(
         count = enabled.len(),
         "DNS capture runner started: count={count}",
@@ -173,12 +198,10 @@ async fn runner_loop(
                         // Events in the skipped window may include
                         // DeviceCaptureSettingsChanged — reload from DB so the
                         // in-memory cache is not permanently stale.
-                        match device_service.list_capture_enabled_device_ids().await {
-                            Ok(ids) => enabled = ids.into_iter().collect(),
-                            Err(e) => tracing::error!(
-                                error = %e,
-                                "failed to re-sync capture-enabled IDs after lag: {e}"
-                            ),
+                        if let Some(ids) =
+                            load_enabled_ids(device_service.as_ref(), &admin_ctx).await
+                        {
+                            enabled = ids;
                         }
                     }
                     Err(tokio::sync::broadcast::error::RecvError::Closed) => {
@@ -188,13 +211,17 @@ async fn runner_loop(
                 }
             }
             _ = prune_ticker.tick() => {
-                run_prune(device_service.as_ref(), dns_events_repo.as_ref()).await;
+                run_prune(device_service.as_ref(), dns_events_repo.as_ref(), &admin_ctx).await;
             }
         }
     }
 }
 
-async fn run_prune(device_service: &dyn DeviceService, dns_events_repo: &dyn DnsEventsRepository) {
+async fn run_prune(
+    device_service: &dyn DeviceService,
+    dns_events_repo: &dyn DnsEventsRepository,
+    admin_ctx: &AuthContext,
+) {
     // Fetch all devices that have stored events.
     let ids_with_data = match dns_events_repo.find_device_ids_with_data().await {
         Ok(ids) => ids,
@@ -205,7 +232,12 @@ async fn run_prune(device_service: &dyn DeviceService, dns_events_repo: &dyn Dns
     };
 
     for device_id in &ids_with_data {
-        match device_service.get_device_capture_settings(device_id).await {
+        match auth_context::with_context(
+            admin_ctx.clone(),
+            device_service.get_device_capture_settings(device_id),
+        )
+        .await
+        {
             Ok(Some((true, cap_count, cap_days))) => {
                 if let Err(e) = dns_events_repo
                     .prune_for_device(device_id, cap_count, cap_days)

--- a/source/daemon/crates/wardnetd-services/src/dns/capture_runner.rs
+++ b/source/daemon/crates/wardnetd-services/src/dns/capture_runner.rs
@@ -89,10 +89,13 @@ impl DnsCaptureRunner {
 
 /// Load the capture-enabled device-id set from the DB under the runner's admin
 /// context. Returns `None` (and logs) on error so the caller can decide whether
-/// to start empty or keep its existing cache.
+/// to start empty or keep its existing cache. `phase` names the call site so a
+/// startup load failure stays distinguishable from a post-lag re-sync failure
+/// in the logs.
 async fn load_enabled_ids(
     device_service: &dyn DeviceService,
     admin_ctx: &AuthContext,
+    phase: &str,
 ) -> Option<HashSet<String>> {
     match auth_context::with_context(
         admin_ctx.clone(),
@@ -102,7 +105,7 @@ async fn load_enabled_ids(
     {
         Ok(ids) => Some(ids.into_iter().collect()),
         Err(e) => {
-            tracing::error!(error = %e, "failed to load capture-enabled device IDs: {e}");
+            tracing::error!(error = %e, "failed to load capture-enabled device IDs {phase}: {e}");
             None
         }
     }
@@ -124,7 +127,7 @@ async fn runner_loop(
     };
 
     // Populate the hot-path cache from DB on startup.
-    let mut enabled = load_enabled_ids(device_service.as_ref(), &admin_ctx)
+    let mut enabled = load_enabled_ids(device_service.as_ref(), &admin_ctx, "on startup")
         .await
         .unwrap_or_default();
     tracing::info!(
@@ -199,7 +202,8 @@ async fn runner_loop(
                         // DeviceCaptureSettingsChanged — reload from DB so the
                         // in-memory cache is not permanently stale.
                         if let Some(ids) =
-                            load_enabled_ids(device_service.as_ref(), &admin_ctx).await
+                            load_enabled_ids(device_service.as_ref(), &admin_ctx, "after event-bus lag")
+                                .await
                         {
                             enabled = ids;
                         }

--- a/source/daemon/crates/wardnetd-services/src/dns/tests/capture_runner.rs
+++ b/source/daemon/crates/wardnetd-services/src/dns/tests/capture_runner.rs
@@ -16,6 +16,7 @@ use wardnet_common::routing::RoutingTarget;
 use wardnetd_data::repository::QueryLogRow;
 use wardnetd_data::repository::dns_events::{DnsCaptureStats, DnsEventsRepository};
 
+use crate::auth_context;
 use crate::device::DeviceService;
 use crate::dns::DnsCaptureRunner;
 use crate::error::AppError;
@@ -98,23 +99,24 @@ impl DeviceService for MockDeviceService {
     ) -> Result<Vec<DnsEventItem>, AppError> {
         unimplemented!()
     }
-    async fn mark_dns_events_synced(
-        &self,
-        _device_id: &str,
-        _up_to_id: i64,
-    ) -> Result<(), AppError> {
-        unimplemented!()
-    }
     async fn ack_dns_events(&self, _device_id: &str, _up_to_id: i64) -> Result<(), AppError> {
         unimplemented!()
     }
     async fn list_capture_enabled_device_ids(&self) -> Result<Vec<String>, AppError> {
+        // Regression: the runner runs outside the HTTP middleware and must
+        // establish an admin context before calling the service (issue #839).
+        auth_context::require_admin().expect(
+            "DnsCaptureRunner must call list_capture_enabled_device_ids under admin context",
+        );
         Ok(self.enabled_ids.clone())
     }
     async fn get_device_capture_settings(
         &self,
         _device_id: &str,
     ) -> Result<Option<(bool, i64, i64)>, AppError> {
+        // Regression: the prune path must also carry an admin context (#839).
+        auth_context::require_admin()
+            .expect("DnsCaptureRunner must call get_device_capture_settings under admin context");
         if self.error_on_settings {
             return Err(AppError::Internal(anyhow::anyhow!("db error")));
         }
@@ -188,9 +190,6 @@ impl DnsEventsRepository for RecordingDnsEventsRepo {
     ) -> anyhow::Result<Vec<wardnetd_data::repository::DnsEventRow>> {
         Ok(vec![])
     }
-    async fn mark_synced_up_to(&self, _device_id: &str, _up_to_id: i64) -> anyhow::Result<u64> {
-        Ok(0)
-    }
     async fn delete_up_to(&self, _device_id: &str, _up_to_id: i64) -> anyhow::Result<u64> {
         Ok(0)
     }
@@ -253,9 +252,6 @@ impl DnsEventsRepository for PruningDnsEventsRepo {
         _limit: i64,
     ) -> anyhow::Result<Vec<wardnetd_data::repository::DnsEventRow>> {
         Ok(vec![])
-    }
-    async fn mark_synced_up_to(&self, _device_id: &str, _up_to_id: i64) -> anyhow::Result<u64> {
-        Ok(0)
     }
     async fn delete_up_to(&self, _device_id: &str, _up_to_id: i64) -> anyhow::Result<u64> {
         Ok(0)

--- a/source/daemon/crates/wardnetd-services/src/dns/tests/capture_runner.rs
+++ b/source/daemon/crates/wardnetd-services/src/dns/tests/capture_runner.rs
@@ -31,6 +31,9 @@ struct MockDeviceService {
     device: Option<Device>,
     /// When `true`, `get_device_capture_settings` returns an error.
     error_on_settings: bool,
+    /// When `true`, `list_capture_enabled_device_ids` returns an error,
+    /// exercising the runner's start-empty-on-load-failure path.
+    error_on_list: bool,
 }
 
 #[async_trait]
@@ -108,6 +111,9 @@ impl DeviceService for MockDeviceService {
         auth_context::require_admin().expect(
             "DnsCaptureRunner must call list_capture_enabled_device_ids under admin context",
         );
+        if self.error_on_list {
+            return Err(AppError::Internal(anyhow::anyhow!("db error")));
+        }
         Ok(self.enabled_ids.clone())
     }
     async fn get_device_capture_settings(
@@ -331,6 +337,7 @@ async fn rows_with_enabled_device_are_inserted() {
         enabled_ids: vec![DEV1.to_owned()],
         device: Some(sample_device(true)),
         error_on_settings: false,
+        error_on_list: false,
     });
     let dns_repo = RecordingDnsEventsRepo::new();
     let dns_repo_dyn: Arc<dyn DnsEventsRepository> =
@@ -359,12 +366,52 @@ async fn rows_with_enabled_device_are_inserted() {
 }
 
 #[tokio::test]
+async fn start_load_failure_begins_with_empty_cache() {
+    let (tx, rx) = mpsc::channel(16);
+    // The startup load of capture-enabled IDs errors, so the runner logs and
+    // begins with an empty cache — a row for an otherwise-enabled device is
+    // therefore dropped rather than captured.
+    let device_service: Arc<dyn DeviceService> = Arc::new(MockDeviceService {
+        enabled_ids: vec![DEV1.to_owned()],
+        device: Some(sample_device(true)),
+        error_on_settings: false,
+        error_on_list: true,
+    });
+    let dns_repo = RecordingDnsEventsRepo::new();
+    let dns_repo_dyn: Arc<dyn DnsEventsRepository> =
+        Arc::clone(&dns_repo) as Arc<dyn DnsEventsRepository>;
+    let events: Arc<dyn EventPublisher> = TestEventBus::new();
+
+    let runner = DnsCaptureRunner::start(
+        rx,
+        device_service,
+        dns_repo_dyn,
+        Arc::clone(&events),
+        &tracing::Span::current(),
+    );
+
+    tx.send(sample_row(Some(DEV1), "example.com"))
+        .await
+        .unwrap();
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    runner.shutdown().await;
+
+    let inserts = dns_repo.recorded_inserts().await;
+    assert!(
+        inserts.is_empty(),
+        "a startup load failure must start the cache empty, dropping the row: {inserts:?}"
+    );
+}
+
+#[tokio::test]
 async fn rows_without_device_id_are_skipped() {
     let (tx, rx) = mpsc::channel(16);
     let device_service: Arc<dyn DeviceService> = Arc::new(MockDeviceService {
         enabled_ids: vec![DEV1.to_owned()],
         device: None,
         error_on_settings: false,
+        error_on_list: false,
     });
     let dns_repo = RecordingDnsEventsRepo::new();
     let dns_repo_dyn: Arc<dyn DnsEventsRepository> =
@@ -397,6 +444,7 @@ async fn rows_for_non_enabled_device_are_skipped() {
         enabled_ids: vec![],
         device: Some(sample_device(false)),
         error_on_settings: false,
+        error_on_list: false,
     });
     let dns_repo = RecordingDnsEventsRepo::new();
     let dns_repo_dyn: Arc<dyn DnsEventsRepository> =
@@ -430,6 +478,7 @@ async fn settings_changed_event_enables_device() {
         enabled_ids: vec![],
         device: None,
         error_on_settings: false,
+        error_on_list: false,
     });
     let dns_repo = RecordingDnsEventsRepo::new();
     let dns_repo_dyn: Arc<dyn DnsEventsRepository> =
@@ -479,6 +528,7 @@ async fn settings_changed_event_disables_device() {
         enabled_ids: vec![DEV1.to_owned()],
         device: Some(sample_device(true)),
         error_on_settings: false,
+        error_on_list: false,
     });
     let dns_repo = RecordingDnsEventsRepo::new();
     let dns_repo_dyn: Arc<dyn DnsEventsRepository> =
@@ -528,6 +578,7 @@ async fn shutdown_completes() {
         enabled_ids: vec![],
         device: None,
         error_on_settings: false,
+        error_on_list: false,
     });
     let dns_repo: Arc<dyn DnsEventsRepository> = RecordingDnsEventsRepo::new();
     let events: Arc<dyn EventPublisher> = TestEventBus::new();
@@ -551,6 +602,7 @@ async fn channel_closed_exits_runner() {
         enabled_ids: vec![],
         device: None,
         error_on_settings: false,
+        error_on_list: false,
     });
     let dns_repo: Arc<dyn DnsEventsRepository> = RecordingDnsEventsRepo::new();
     let events: Arc<dyn EventPublisher> = TestEventBus::new();
@@ -576,6 +628,7 @@ async fn prune_loop_calls_prune_for_enabled_device() {
         enabled_ids: vec![DEV1.to_owned()],
         device: Some(sample_device(true)),
         error_on_settings: false,
+        error_on_list: false,
     });
     let dns_repo = PruningDnsEventsRepo::new(&[DEV1]);
     let dns_repo_dyn: Arc<dyn DnsEventsRepository> =
@@ -609,6 +662,7 @@ async fn prune_loop_deletes_data_for_disabled_device() {
         enabled_ids: vec![],
         device: Some(sample_device(false)),
         error_on_settings: false,
+        error_on_list: false,
     });
     let dns_repo = PruningDnsEventsRepo::new(&[DEV1]);
     let dns_repo_dyn: Arc<dyn DnsEventsRepository> =
@@ -642,6 +696,7 @@ async fn prune_loop_deletes_data_for_unknown_device() {
         enabled_ids: vec![],
         device: None, // device has been deleted from the DB
         error_on_settings: false,
+        error_on_list: false,
     });
     let dns_repo = PruningDnsEventsRepo::new(&[DEV1]);
     let dns_repo_dyn: Arc<dyn DnsEventsRepository> =
@@ -677,6 +732,7 @@ async fn prune_loop_warns_on_device_settings_error() {
         enabled_ids: vec![],
         device: None,
         error_on_settings: true,
+        error_on_list: false,
     });
     let dns_repo = PruningDnsEventsRepo::new(&[DEV1]);
     let dns_repo_dyn: Arc<dyn DnsEventsRepository> =

--- a/source/daemon/crates/wardnetd-services/src/inbound_wg/tests/service.rs
+++ b/source/daemon/crates/wardnetd-services/src/inbound_wg/tests/service.rs
@@ -142,13 +142,6 @@ impl DeviceService for MockDeviceService {
     ) -> Result<Vec<wardnet_common::api::DnsEventItem>, AppError> {
         unimplemented!("not exercised by inbound-wg tests")
     }
-    async fn mark_dns_events_synced(
-        &self,
-        _device_id: &str,
-        _up_to_id: i64,
-    ) -> Result<(), AppError> {
-        unimplemented!("not exercised by inbound-wg tests")
-    }
     async fn ack_dns_events(&self, _device_id: &str, _up_to_id: i64) -> Result<(), AppError> {
         unimplemented!("not exercised by inbound-wg tests")
     }

--- a/source/daemon/crates/wardnetd-services/src/private_dns/tests/service.rs
+++ b/source/daemon/crates/wardnetd-services/src/private_dns/tests/service.rs
@@ -226,13 +226,6 @@ impl DeviceService for MockDeviceService {
     ) -> Result<Vec<wardnet_common::api::DnsEventItem>, AppError> {
         unimplemented!("not exercised by private-dns tests")
     }
-    async fn mark_dns_events_synced(
-        &self,
-        _device_id: &str,
-        _up_to_id: i64,
-    ) -> Result<(), AppError> {
-        unimplemented!("not exercised by private-dns tests")
-    }
     async fn ack_dns_events(&self, _device_id: &str, _up_to_id: i64) -> Result<(), AppError> {
         unimplemented!("not exercised by private-dns tests")
     }

--- a/source/daemon/crates/wardnetd-services/src/rule_request/tests/service.rs
+++ b/source/daemon/crates/wardnetd-services/src/rule_request/tests/service.rs
@@ -197,13 +197,6 @@ impl DeviceService for MockDeviceService {
     ) -> Result<Vec<wardnet_common::api::DnsEventItem>, AppError> {
         unimplemented!()
     }
-    async fn mark_dns_events_synced(
-        &self,
-        _device_id: &str,
-        _up_to_id: i64,
-    ) -> Result<(), AppError> {
-        unimplemented!()
-    }
     async fn ack_dns_events(&self, _device_id: &str, _up_to_id: i64) -> Result<(), AppError> {
         unimplemented!()
     }

--- a/source/daemon/crates/wardnetd/src/device_detector.rs
+++ b/source/daemon/crates/wardnetd/src/device_detector.rs
@@ -5,7 +5,9 @@ use tokio::sync::{broadcast, mpsc};
 use tokio::time::interval;
 use tokio_util::sync::CancellationToken;
 use tracing::Instrument;
+use uuid::Uuid;
 
+use wardnet_common::auth::AuthContext;
 use wardnet_common::config::DetectionConfig;
 use wardnet_common::event::WardnetEvent;
 use wardnetd_data::repository::SystemConfigRepository;
@@ -14,6 +16,16 @@ use wardnetd_services::event::EventPublisher;
 use wardnetd_services::{DeviceDiscoveryService, ObservationResult};
 
 use crate::garp_learning;
+
+/// Auth context every device-detector background call establishes before
+/// reaching the discovery service. These tasks run outside the HTTP middleware,
+/// so no `AuthContext` is set by default; `Uuid::nil()` marks the work as
+/// system-initiated in audit logs (see `.agents/auth.md`).
+fn system_ctx() -> AuthContext {
+    AuthContext::Admin {
+        admin_id: Uuid::nil(),
+    }
+}
 
 /// Background device detection orchestrator.
 ///
@@ -172,7 +184,12 @@ async fn processor_task(
                     );
                 }
 
-                match discovery.process_observation(&obs).await {
+                match wardnetd_services::auth_context::with_context(
+                    system_ctx(),
+                    discovery.process_observation(&obs),
+                )
+                .await
+                {
                     Ok(ObservationResult::NewDevice { device_id, .. }) => {
                         tracing::info!(mac = %obs.mac, ip = %obs.ip, "device detected: mac={mac}, ip={ip}", mac = obs.mac, ip = obs.ip);
 
@@ -185,8 +202,11 @@ async fn processor_task(
                         let resolve_span = tracing::Span::current();
                         tokio::spawn(
                             async move {
-                                if let Err(e) =
-                                    discovery_clone.resolve_hostname(&mac, &ip).await
+                                if let Err(e) = wardnetd_services::auth_context::with_context(
+                                    system_ctx(),
+                                    discovery_clone.resolve_hostname(&mac, &ip),
+                                )
+                                .await
                                 {
                                     tracing::warn!(
                                         device_id = %device_id,
@@ -240,7 +260,12 @@ async fn flush_task(
             _ = tick.tick() => {}
         }
 
-        match discovery.flush_last_seen().await {
+        match wardnetd_services::auth_context::with_context(
+            system_ctx(),
+            discovery.flush_last_seen(),
+        )
+        .await
+        {
             Ok(count) => {
                 tracing::debug!(count, "flushed last_seen timestamps: count={count}");
             }
@@ -266,7 +291,12 @@ async fn departure_task(
             _ = tick.tick() => {}
         }
 
-        match discovery.scan_departures(timeout_secs).await {
+        match wardnetd_services::auth_context::with_context(
+            system_ctx(),
+            discovery.scan_departures(timeout_secs),
+        )
+        .await
+        {
             Ok(departed) => {
                 tracing::info!(
                     count = departed.len(),
@@ -326,7 +356,12 @@ async fn hostname_listener_task(
                         WardnetEvent::DhcpLeaseAssigned { mac, ip, hostname: Some(h), .. }
                         | WardnetEvent::DhcpLeaseRenewed { mac, ip, hostname: Some(h), .. },
                     ) if !h.trim().is_empty() => {
-                        if let Err(e) = discovery.resolve_hostname(&mac, &ip).await {
+                        if let Err(e) = wardnetd_services::auth_context::with_context(
+                            system_ctx(),
+                            discovery.resolve_hostname(&mac, &ip),
+                        )
+                        .await
+                        {
                             tracing::warn!(
                                 %mac,
                                 error = %e,
@@ -372,7 +407,12 @@ async fn zone_subnet_listener_task(
             result = event_rx.recv() => {
                 match result {
                     Ok(WardnetEvent::NetworkZoneChanged { .. }) => {
-                        if let Err(e) = discovery.rebuild_trusted_subnets().await {
+                        if let Err(e) = wardnetd_services::auth_context::with_context(
+                            system_ctx(),
+                            discovery.rebuild_trusted_subnets(),
+                        )
+                        .await
+                        {
                             tracing::warn!(
                                 error = %e,
                                 "device discovery: failed to rebuild trusted subnets after zone change: {e}"
@@ -393,7 +433,12 @@ async fn zone_subnet_listener_task(
                             "zone-subnet listener lagged behind event bus, skipped {n} events; \
                              forcing a trusted-subnet rebuild"
                         );
-                        if let Err(e) = discovery.rebuild_trusted_subnets().await {
+                        if let Err(e) = wardnetd_services::auth_context::with_context(
+                            system_ctx(),
+                            discovery.rebuild_trusted_subnets(),
+                        )
+                        .await
+                        {
                             tracing::warn!(
                                 error = %e,
                                 "device discovery: failed to rebuild trusted subnets after lag: {e}"

--- a/source/daemon/crates/wardnetd/src/main.rs
+++ b/source/daemon/crates/wardnetd/src/main.rs
@@ -406,11 +406,14 @@ async fn run(
         .restore_tunnels()
         .await
         .map_err(|e| anyhow::anyhow!("{e}"))?;
-    services
-        .discovery
-        .restore_devices()
-        .await
-        .map_err(|e| anyhow::anyhow!("{e}"))?;
+    auth_context::with_context(
+        AuthContext::Admin {
+            admin_id: uuid::Uuid::nil(),
+        },
+        services.discovery.restore_devices(),
+    )
+    .await
+    .map_err(|e| anyhow::anyhow!("{e}"))?;
 
     // Capture the root span so background tasks can create child spans that
     // inherit the `wardnetd{version=...}` context.

--- a/source/daemon/crates/wardnetd/src/tests/device_detector.rs
+++ b/source/daemon/crates/wardnetd/src/tests/device_detector.rs
@@ -104,6 +104,15 @@ impl PacketCapture for SingleObservationCapture {
 // Mock: DeviceDiscoveryService
 // ---------------------------------------------------------------------------
 
+/// Assert the calling background task established an admin context before
+/// reaching the discovery service. A missing `with_context` wrap in
+/// `device_detector.rs` would surface here as a panic instead of a silent
+/// `Forbidden` (issue #839).
+fn expect_admin_context() {
+    wardnetd_services::auth_context::require_admin()
+        .expect("device_detector must call the discovery service under an admin context");
+}
+
 /// Mock discovery service that records calls and returns configurable results.
 struct MockDiscovery {
     /// Number of times `process_observation` was called.
@@ -163,6 +172,7 @@ impl DeviceDiscoveryService for MockDiscovery {
     }
 
     async fn rebuild_trusted_subnets(&self) -> Result<(), AppError> {
+        expect_admin_context();
         Ok(())
     }
 
@@ -170,6 +180,7 @@ impl DeviceDiscoveryService for MockDiscovery {
         &self,
         _obs: &ObservedDevice,
     ) -> Result<ObservationResult, AppError> {
+        expect_admin_context();
         self.process_count.fetch_add(1, Ordering::SeqCst);
         match self.observation_result {
             ObservationResultFactory::NewDevice => Ok(ObservationResult::NewDevice {
@@ -190,16 +201,19 @@ impl DeviceDiscoveryService for MockDiscovery {
     }
 
     async fn flush_last_seen(&self) -> Result<u64, AppError> {
+        expect_admin_context();
         self.flush_count.fetch_add(1, Ordering::SeqCst);
         Ok(0)
     }
 
     async fn scan_departures(&self, _timeout_secs: u64) -> Result<Vec<Uuid>, AppError> {
+        expect_admin_context();
         self.departure_count.fetch_add(1, Ordering::SeqCst);
         Ok(vec![])
     }
 
     async fn resolve_hostname(&self, _mac: &str, _ip: &str) -> Result<(), AppError> {
+        expect_admin_context();
         self.resolve_count.fetch_add(1, Ordering::SeqCst);
         Ok(())
     }

--- a/source/daemon/crates/wardnetd/src/tests/device_detector.rs
+++ b/source/daemon/crates/wardnetd/src/tests/device_detector.rs
@@ -123,6 +123,8 @@ struct MockDiscovery {
     departure_count: Arc<AtomicUsize>,
     /// Number of times `resolve_hostname` was called.
     resolve_count: Arc<AtomicUsize>,
+    /// Number of times `rebuild_trusted_subnets` was called.
+    rebuild_count: Arc<AtomicUsize>,
     /// Result to return from `process_observation`.
     observation_result: ObservationResultFactory,
 }
@@ -143,6 +145,7 @@ impl MockDiscovery {
             flush_count: Arc::new(AtomicUsize::new(0)),
             departure_count: Arc::new(AtomicUsize::new(0)),
             resolve_count: Arc::new(AtomicUsize::new(0)),
+            rebuild_count: Arc::new(AtomicUsize::new(0)),
             observation_result: factory,
         }
     }
@@ -173,6 +176,7 @@ impl DeviceDiscoveryService for MockDiscovery {
 
     async fn rebuild_trusted_subnets(&self) -> Result<(), AppError> {
         expect_admin_context();
+        self.rebuild_count.fetch_add(1, Ordering::SeqCst);
         Ok(())
     }
 
@@ -331,6 +335,39 @@ async fn start_and_shutdown() {
     );
 
     // Shutdown should complete without hanging or panicking.
+    detector.shutdown().await;
+}
+
+#[tokio::test]
+async fn zone_change_triggers_trusted_subnet_rebuild() {
+    let discovery = Arc::new(MockDiscovery::new(ObservationResultFactory::Seen));
+    let capture: Arc<dyn PacketCapture> = Arc::new(MockCapture::new(Arc::new(AtomicUsize::new(0))));
+    let rebuild_count = discovery.rebuild_count.clone();
+
+    // Keep the bus alive so we can publish into the zone-subnet listener; a
+    // temporary would drop its sender and close the listener immediately.
+    let events = test_events();
+    let detector = DeviceDetector::start(
+        capture,
+        discovery as Arc<dyn DeviceDiscoveryService>,
+        stub_system_config(),
+        &events,
+        &fast_config(),
+        "eth0".to_owned(),
+        &test_span(),
+    );
+
+    events.publish(WardnetEvent::NetworkZoneChanged {
+        zone_id: Uuid::new_v4(),
+        timestamp: chrono::Utc::now(),
+    });
+
+    tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+    assert!(
+        rebuild_count.load(Ordering::SeqCst) >= 1,
+        "NetworkZoneChanged should trigger a trusted-subnet rebuild under an admin context"
+    );
+
     detector.shutdown().await;
 }
 

--- a/source/daemon/crates/wardnetd/src/tests/stubs.rs
+++ b/source/daemon/crates/wardnetd/src/tests/stubs.rs
@@ -207,13 +207,6 @@ impl DeviceService for StubDeviceService {
     ) -> Result<Vec<wardnet_common::api::DnsEventItem>, AppError> {
         unimplemented!()
     }
-    async fn mark_dns_events_synced(
-        &self,
-        _device_id: &str,
-        _up_to_id: i64,
-    ) -> Result<(), AppError> {
-        unimplemented!()
-    }
     async fn ack_dns_events(&self, _device_id: &str, _up_to_id: i64) -> Result<(), AppError> {
         unimplemented!()
     }


### PR DESCRIPTION
## Summary

Several device-subsystem service methods skipped the mandatory `AuthContext` guard that every service method is supposed to run as its first operation, and their background callers never established an admin identity. None of these had a live exploit path today (handler-level IP checks contained the exposure), but the guard rule exists for defense-in-depth precisely so a handler bug isn't the only thing standing between an unauthenticated caller and the service. This closes the gaps atomically — each guard lands together with the `with_context` wrap on its caller so the runners don't start returning `Forbidden` — and removes a dead sync path found along the way.

Closes #839

## Changes

**Discovery guard + wrap**
- `restore_devices`, `process_observation`, `flush_last_seen`, `scan_departures`, `resolve_hostname` now call `auth_context::require_admin()?` first.
- `device_detector.rs` wraps every discovery call, and `main.rs` wraps the startup restore, in `auth_context::with_context(AuthContext::Admin { admin_id: Uuid::nil() }, …)` — matching the existing routing / DHCP / zone-enforcement / DNS runners.

**DNS-events / capture guard + wrap**
- `fetch_pending_dns_events` and `ack_dns_events` (self-service by source IP) get the device-or-admin check via `check_device_mutation_auth`, the same pattern `set_my_capture_enabled` uses. The detached SSE task re-establishes the request's `AuthContext` so the guard sees the caller's identity.
- `list_capture_enabled_device_ids` and `get_device_capture_settings` (background-only) require admin, and the `DnsCaptureRunner` call sites are wrapped.

**Duplication cleanup**
- `update_admin_locked`, `get_dns_capture_settings`, `update_dns_capture_settings` now call `require_admin()` instead of re-implementing the `try_current()/is_admin()` check inline.

**Dead code**
- Removed `DeviceService::mark_dns_events_synced` and `DnsEventsRepository::mark_synced_up_to` (trait, SQLite impl, and all test doubles). The sync protocol settled on delete-on-ack via `ack_dns_events`; the mark-then-sync path had no production callers.

## Tests
- Each newly-guarded method rejects `AuthContext::Anonymous` and accepts the appropriate context (admin, or the owning device for the self-service methods).
- The `device_detector` and `DnsCaptureRunner` mocks assert an admin context reaches the service, so a missing `with_context` wrap surfaces as a test failure rather than a silent `Forbidden`.
- Repurposed the two `mark_synced_up_to` repo tests onto `delete_up_to` to keep coverage on the live ack path.
- `make check-daemon` passes (fmt, clippy `-D warnings`, full workspace tests).