### PR TITLE
ci(cubit): publish PR dashboards to the perf-reports Pages hub

### DIFF
--- a/.github/workflows/cubit.yml
+++ b/.github/workflows/cubit.yml
@@ -21,6 +21,14 @@ name: Cubit
 
 on:
   workflow_call:
+    secrets:
+      PERF_REPORTS_TOKEN:
+        description: >-
+          Fine-grained token with contents write on wardnet/perf-reports, the
+          central Pages hub PR dashboards are published to. Optional: the
+          record path (ci.yml) never publishes, and a compare run without it
+          falls back to linking the report artifact from the PR comment.
+        required: false
 
 # Workflow-level stays read-only; the job below elevates to the writes it needs,
 # which the caller (pr.yml / ci.yml cubit job) must grant to the same ceiling.
@@ -70,3 +78,11 @@ jobs:
             -p wardnetd --bench dns_resolution --features bench-internals
             -- --warm-up-time 3 --measurement-time 5 || true
           paired: "true"
+          # Publish each PR's dashboard to the org's central Pages hub so the
+          # sticky comment links a clickable page
+          # (https://wardnet.github.io/perf-reports/wardnet/pr-<n>/) instead of
+          # an artifact zip. Best-effort inside the action: a missing token
+          # (fork PRs get no secrets) or a failed push falls back to linking
+          # the artifact download.
+          pages-repo: wardnet/perf-reports
+          pages-token: ${{ secrets.PERF_REPORTS_TOKEN }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -202,6 +202,10 @@ jobs:
       contents: write # cubit pushes/reads the cubit-state baseline branch
       pull-requests: write # cubit posts the sticky performance comment
     uses: ./.github/workflows/cubit.yml
+    # PERF_REPORTS_TOKEN (org secret) — lets cubit publish the PR's dashboard
+    # to the wardnet/perf-reports Pages hub. ci.yml's record path never
+    # publishes, so only this caller passes secrets.
+    secrets: inherit
 
   # Aggregator for branch protection. Lists every other job as a
   # dependency, runs unconditionally (if: always()), and passes iff


### PR DESCRIPTION
Wires the cubit leaf to the new [wardnet/perf-reports](https://github.com/wardnet/perf-reports) Pages hub, so the sticky performance comment on each PR links a clickable dashboard page — `https://wardnet.github.io/perf-reports/wardnet/pr-<n>/` — instead of only the report artifact zip.

## Changes

- **`.github/workflows/cubit.yml`**: declare the optional `PERF_REPORTS_TOKEN` secret on the `workflow_call` trigger and pass `pages-repo: wardnet/perf-reports` + `pages-token` to the cubit action.
- **`.github/workflows/pr.yml`**: `secrets: inherit` on the cubit job so the org secret reaches the reusable workflow.
- `ci.yml` is untouched — the record path on main never publishes a dashboard, which is also why the secret is declared `required: false`.

## Behavior

Publishing is best-effort inside the action and the leaf stays advisory: fork PRs (no secrets) and any failed push to the hub fall back to linking the artifact download from the comment; nothing new can fail the job or gate a merge.

## Merge ordering

Needs cubit `v0.0.4` released first (advancing the `v0` moving tag) so the pinned `wardnet/cubit@v0` picks up the new `pages-repo` / `pages-token` inputs. Merging earlier is harmless — a composite action only warns on unknown inputs — but the comment keeps linking the artifact until `v0` catches up.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KSfzG1jqR2VyRaBKxG19DX)_