### PR TITLE
fix(ci): grant contents:write to dependabot auto-merge + harden batch loop

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -50,13 +50,13 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4
+        uses: github/codeql-action/init@7188fc363630916deb702c7fdcf4e481b751f97a # v4
         with:
           languages: ${{ matrix.language }}
           build-mode: none
           config-file: .github/codeql/codeql-config.yml
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4
+        uses: github/codeql-action/analyze@7188fc363630916deb702c7fdcf4e481b751f97a # v4
         with:
           category: "/language:${{ matrix.language }}"

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -125,7 +125,24 @@ jobs:
             fi
 
             echo "   → merging (squash)"
-            if ! gh pr merge "$number" --repo "$REPO" --squash --delete-branch; then
+            if out=$(gh pr merge "$number" --repo "$REPO" --squash --delete-branch 2>&1); then
+              echo "   → merged"
+              continue
+            fi
+            # The merge was rejected. Classify: some reasons are
+            # expected and benign for a daily batch and must NOT fail
+            # the job; anything else is a genuine problem.
+            echo "$out" | sed 's/^/     /'
+            if echo "$out" | grep -qiE 'merge conflict|not mergeable'; then
+              # MERGEABLE at list time can go stale by merge time.
+              # Dependabot rebases conflicted PRs; a later run merges it.
+              echo "   → skip: merge conflict — Dependabot will rebase; picked up next run"
+            elif echo "$out" | grep -qi "without .workflows. permission"; then
+              # The default GITHUB_TOKEN cannot merge PRs that touch
+              # .github/workflows/** — there is no permissions: key that
+              # grants the `workflow` scope. These need a human/PAT merge.
+              echo "   → skip: touches a workflow file; GITHUB_TOKEN can't merge these — merge manually"
+            else
               echo "   → FAILED to merge #${number}; continuing with the rest"
               failed=1
             fi

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -26,7 +26,7 @@ on:
   workflow_dispatch:     # allow manual triggering for debugging
 
 permissions:
-  contents: read
+  contents: write        # required to squash-merge PRs and delete their branches
   pull-requests: write
 
 jobs:
@@ -60,10 +60,17 @@ jobs:
           count=$(jq 'length' prs.json)
           echo "Found ${count} open Dependabot PR(s)."
 
+          # Track per-PR merge failures so one bad PR doesn't abort the
+          # whole batch (the loop runs under `set -e`). We surface a red
+          # X at the end if any eligible merge failed.
+          failed=0
+
           # Extract "from X.Y.Z to A.B.C" out of the title, classify
           # the bump via semver comparison, merge if patch/minor and
           # the PR is ready.
-          jq -c '.[]' prs.json | while read -r pr; do
+          # Fed via process substitution (not a pipe) so the loop runs
+          # in this shell and `failed` survives past `done`.
+          while read -r pr; do
             number=$(echo "$pr" | jq -r '.number')
             title=$(echo "$pr" | jq -r '.title')
             mergeable=$(echo "$pr" | jq -r '.mergeable')
@@ -118,5 +125,14 @@ jobs:
             fi
 
             echo "   → merging (squash)"
-            gh pr merge "$number" --repo "$REPO" --squash --delete-branch
-          done
+            if ! gh pr merge "$number" --repo "$REPO" --squash --delete-branch; then
+              echo "   → FAILED to merge #${number}; continuing with the rest"
+              failed=1
+            fi
+          done < <(jq -c '.[]' prs.json)
+
+          if [[ "$failed" -ne 0 ]]; then
+            echo ""
+            echo "One or more eligible PRs failed to merge — see log above."
+            exit 1
+          fi


### PR DESCRIPTION
## Problem

The **Dependabot auto-merge** workflow ([run 29725159900](https://github.com/wardnet/wardnet/actions/runs/29725159900/job/88296440466)) failed and merged nothing:

```
── PR #1001: bump vite from 8.1.3 to 8.1.5
   → merging (squash)
GraphQL: Resource not accessible by integration (mergePullRequest)
##[error]Process completed with exit code 1.
```

## Fixes

### 1. Permissions (the actual failure)
The job granted `contents: read`. Squash-merging a PR (and `--delete-branch`) writes to the repo, so the `GITHUB_TOKEN` needs **`contents: write`**. With read-only contents, `mergePullRequest` is rejected as "not accessible by integration."

### 2. Batch-loop resilience
The merge ran as the last command under `set -euo pipefail`, so the **first** failed merge aborted the step and skipped every remaining eligible PR. Now: each merge is guarded, the loop is fed via process substitution (`done < <(jq ...)`) so the failure flag survives the subshell, and the job `exit 1`s at the end only if something genuinely broke.

### 3. Classify benign merge failures (follow-up commit)
After 1 & 2, a re-dispatch merged 10 PRs but still went red on two **structural, non-bug** failures. These are now logged skips that do not fail the job:
- **`Pull Request has merge conflicts`** — a PR listed `MERGEABLE` can go stale by merge time; Dependabot rebases it and a later run merges it.
- **`... without 'workflows' permission`** — the default `GITHUB_TOKEN` cannot merge PRs that touch `.github/workflows/**`, and no `permissions:` key grants that scope. These need a human/PAT merge.

Any *other* merge error still sets `failed=1` and fails the job.

## Validation
- `yaml.safe_load` parses the workflow.
- `bash -n` on the extracted `run:` script passes.
- Live dispatch from this branch merged 10/16 open Dependabot PRs; remaining are conflicts, workflow-file bumps, a major bump, and unparseable digest/build-metadata titles (all correctly skipped).

## Merge Commit Message

fix(ci): grant contents:write to dependabot auto-merge, harden the batch loop, and treat merge-conflict / workflow-scope failures as benign skips

---

### 4. Repair CodeQL version mismatch on `main` (follow-up commit)

The first dispatch merged **#991** (`codeql-action/analyze` → 4.37.1) but the workflow-scope block stopped **#989** (`codeql-action/init` → 4.37.1). That left `codeql.yml` on `main` mismatched — `init@4.36.3` + `analyze@4.37.1` — so CodeQL fails on *every* PR and push to main:

```
##[error]Loaded a configuration file for version '4.36.3', but running version '4.37.1'
```

This PR's red CodeQL checks were caused by that broken `main`, not by the auto-merge changes. This commit aligns both steps on the 4.37.1 SHA, unblocking `main` in one human merge. **Supersedes #989** (which can be closed).
