### PR TITLE
ci: scope workflow write permissions to jobs, not top level

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -25,15 +25,19 @@ on:
     - cron: "0 1 * * *"  # 01:00 UTC daily
   workflow_dispatch:     # allow manual triggering for debugging
 
+# Minimal top-level default; the write scopes are granted only to the
+# job that actually needs them (see below).
 permissions:
-  contents: write        # required to squash-merge PRs and delete their branches
-  pull-requests: write
+  contents: read
 
 jobs:
   auto-merge:
     name: Auto-merge Dependabot patch/minor PRs
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    permissions:
+      contents: write        # required to squash-merge PRs and delete their branches
+      pull-requests: write
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0

--- a/.github/workflows/fuzzing-maintenance.yml
+++ b/.github/workflows/fuzzing-maintenance.yml
@@ -15,15 +15,19 @@ on:
     - cron: "0 3 * * 0"
   workflow_dispatch:
 
+# Top-level read-only; `issues: write` is granted per-job to the CFLite
+# runs that can file a crash issue, keeping the token least-privilege.
 permissions:
   contents: read
-  issues: write
 
 jobs:
   coverage:
     name: Coverage report
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    permissions:
+      contents: read
+      issues: write  # CFLite run_fuzzers files a GitHub Issue on a new crash
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
@@ -54,6 +58,9 @@ jobs:
     name: Prune corpus
     needs: coverage
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write  # CFLite run_fuzzers files a GitHub Issue on a new crash
     # fuzz-seconds (20) + CFLite build + setup.
     timeout-minutes: 40
     steps:

--- a/.github/workflows/fuzzing-scheduled.yml
+++ b/.github/workflows/fuzzing-scheduled.yml
@@ -27,16 +27,20 @@ on:
     - cron: "0 */12 * * *"
   workflow_dispatch:
 
+# Top-level read-only; `issues: write` is scoped to the job below so the
+# token stays least-privilege (keeps Scorecard off the top-level write).
 permissions:
   contents: read
-  # `issues: write` lets CFLite file a GitHub Issue when a fuzzer
-  # reports a new crash. Nothing else on this repo writes.
-  issues: write
 
 jobs:
   batch:
     name: Batch fuzz (600s)
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      # `issues: write` lets CFLite file a GitHub Issue when a fuzzer
+      # reports a new crash. Nothing else on this repo writes.
+      issues: write
     # fuzz-seconds (10) + CFLite build + setup. Caps a hung target
     # before it eats a runner for GitHub's 6h default.
     timeout-minutes: 30


### PR DESCRIPTION
## Summary

OpenSSF Scorecard's **Token-Permissions** check was scoring **0 (high severity)**. The root cause was three workflows declaring `write` permission scopes at the *top level* of the workflow, which grants the broad token to every job in the run — the pattern Scorecard penalizes hardest.

This PR moves each `write` scope down to the specific job that needs it and leaves the top-level default read-only.

## Changes

| Workflow | Before (top-level) | After |
|----------|--------------------|-------|
| `dependabot-auto-merge.yml` | `contents: write` + `pull-requests: write` | top-level `contents: read`; writes scoped to the `auto-merge` job |
| `fuzzing-maintenance.yml` | `issues: write` | top-level `contents: read`; `issues: write` scoped to `coverage` + `prune` jobs |
| `fuzzing-scheduled.yml` | `issues: write` | top-level `contents: read`; `issues: write` scoped to the `batch` job |

After this change, **no workflow in the repo has a top-level write permission**. The remaining job-level writes flagged by Scorecard (release `contents: write`, CodeQL `security-events: write`, GHCR `packages: write`, etc.) are already the best-practice, least-privilege state the check wants and are unavoidable for those jobs.

## Behavior impact

None. The same jobs receive the same permissions — just declared at the job level instead of workflow-wide. All three files validate as YAML.

## Merge Commit Message

ci: scope workflow write permissions to jobs, not top level

https://claude.ai/code/session_01KxNhoqVxXTUewBsmCFUVZB