### PR TITLE
fix(dns): enforce auth guards on DnsService and DnsFilterService methods

### DIFF
--- a/source/daemon/crates/wardnetd-services/src/dns/service.rs
+++ b/source/daemon/crates/wardnetd-services/src/dns/service.rs
@@ -450,6 +450,7 @@ impl DnsService for DnsServiceImpl {
     }
 
     async fn get_dns_config(&self) -> Result<DnsConfig, AppError> {
+        auth_context::require_admin()?;
         self.load_config().await
     }
 

--- a/source/daemon/crates/wardnetd-services/src/dns/tests/service.rs
+++ b/source/daemon/crates/wardnetd-services/src/dns/tests/service.rs
@@ -12,6 +12,7 @@ use wardnet_common::dns::ForwarderSelectionMode::{self, Failover, Fastest, Singl
 use super::admin;
 use crate::dns::service::{DnsService, DnsServiceImpl, resolve_forwarder_selection};
 use crate::error::AppError;
+use wardnet_common::auth::AuthContext;
 use wardnetd_data::repository::{
     DnsRepository, QueryLogFilter, QueryLogRow, SystemConfigRepository,
 };
@@ -245,4 +246,21 @@ async fn single_mode_with_unlisted_server_is_rejected() {
     .await
     .unwrap_err();
     assert!(matches!(err, AppError::BadRequest(_)));
+}
+
+#[tokio::test]
+async fn get_dns_config_rejects_anonymous_caller() {
+    let svc = service();
+    let err = crate::auth_context::with_context(AuthContext::Anonymous, svc.get_dns_config())
+        .await
+        .unwrap_err();
+    assert!(matches!(err, AppError::Forbidden(_)));
+}
+
+#[tokio::test]
+async fn get_dns_config_allows_admin_caller() {
+    let svc = service();
+    crate::auth_context::with_context(admin(), svc.get_dns_config())
+        .await
+        .expect("admin caller can read the DNS config");
 }

--- a/source/daemon/crates/wardnetd-services/src/dns_filter/service.rs
+++ b/source/daemon/crates/wardnetd-services/src/dns_filter/service.rs
@@ -759,6 +759,7 @@ impl DnsFilterService for DnsFilterServiceImpl {
     }
 
     async fn rebuild_all(&self) -> Result<(), AppError> {
+        auth_context::require_admin()?;
         self.refresh_config().await?;
 
         // Wipe everything; rebuild from scratch.
@@ -1373,6 +1374,7 @@ impl DnsFilterService for DnsFilterServiceImpl {
     }
 
     async fn rebuild_blocklist_filter(&self, blocklist_id: Uuid) -> Result<(), AppError> {
+        auth_context::require_admin()?;
         self.rebuild_blocklist_inner(blocklist_id).await?;
         // After a blocklist swap, the profile's filter list still references
         // the same Arc, so no profile rebuild needed; but the source filter
@@ -1390,6 +1392,7 @@ impl DnsFilterService for DnsFilterServiceImpl {
     }
 
     async fn rebuild_profile(&self, profile_id: Uuid) -> Result<(), AppError> {
+        auth_context::require_admin()?;
         // Re-fetch this profile's blocklists to make sure all per-source
         // filters exist before we re-stitch.
         let blocklists = self
@@ -1423,10 +1426,12 @@ impl DnsFilterService for DnsFilterServiceImpl {
     }
 
     async fn rebuild_device(&self, device_id: Uuid) -> Result<(), AppError> {
+        auth_context::require_admin()?;
         self.rebuild_device_inner(device_id).await
     }
 
     async fn rebuild_default_context(&self) -> Result<(), AppError> {
+        auth_context::require_admin()?;
         self.refresh_config().await?;
         self.rebuild_default_context_inner().await
     }
@@ -1437,6 +1442,7 @@ impl DnsFilterService for DnsFilterServiceImpl {
         old_ip: &str,
         new_ip: &str,
     ) -> Result<(), AppError> {
+        auth_context::require_admin()?;
         let mut by_ip = self.contexts.write().await;
         let entry = old_ip
             .parse::<IpAddr>()

--- a/source/daemon/crates/wardnetd-services/src/dns_filter/tests/service.rs
+++ b/source/daemon/crates/wardnetd-services/src/dns_filter/tests/service.rs
@@ -1842,3 +1842,44 @@ async fn check_for_device_falls_back_to_the_default_context_for_unknown_devices(
         "unknown device + unknown IP resolve through the default context"
     );
 }
+
+/// The rebuild/handle methods run only from `DnsFilterRunner` inside an
+/// admin context, but each still guards its entry so a caller that forgets to
+/// establish one is rejected rather than silently mutating filter state.
+#[tokio::test]
+async fn rebuild_methods_reject_non_admin_caller() {
+    async fn anon<F: Future>(fut: F) -> F::Output {
+        auth_context::with_context(AuthContext::Anonymous, fut).await
+    }
+
+    let h = build().await;
+    let id = Uuid::new_v4();
+    let ip_changed = h
+        .service
+        .handle_device_ip_changed(id, "10.0.0.1", "10.0.0.2");
+
+    assert!(matches!(
+        anon(h.service.rebuild_all()).await,
+        Err(AppError::Forbidden(_))
+    ));
+    assert!(matches!(
+        anon(h.service.rebuild_blocklist_filter(id)).await,
+        Err(AppError::Forbidden(_))
+    ));
+    assert!(matches!(
+        anon(h.service.rebuild_profile(id)).await,
+        Err(AppError::Forbidden(_))
+    ));
+    assert!(matches!(
+        anon(h.service.rebuild_device(id)).await,
+        Err(AppError::Forbidden(_))
+    ));
+    assert!(matches!(
+        anon(h.service.rebuild_default_context()).await,
+        Err(AppError::Forbidden(_))
+    ));
+    assert!(matches!(
+        anon(ip_changed).await,
+        Err(AppError::Forbidden(_))
+    ));
+}


### PR DESCRIPTION
## Summary

`.agents/auth.md` requires every service trait method to validate the caller as its first operation (`auth_context::require_admin()?;` / `require_authenticated()?;`), as a defense-in-depth layer: even if a handler bug exposes a service method, the guard inside the service rejects unauthorized calls. A cluster of methods skipped it with neither a guard nor a documented exception. Nothing leaks today (current callers are admin-gated or context-wrapped), but the tripwire was missing.

## Changes

**`DnsService::get_dns_config` — add the guard.** It was the only method in a 15-method impl without `require_admin()?`. Added it as the first line, matching every sibling and the identically shaped `DhcpService::get_dhcp_config`. No caller regresses:
- `dns/runner.rs`, `dns/query_log_runner.rs`, `health/checks.rs` already wrap the call in `auth_context::with_context(admin_ctx, ...)`.
- The sole HTTP caller (`wardnetd-api/src/api/dns.rs`) is `AdminAuth`-gated.

**`DnsFilterService` mutating methods — add the guard.** `rebuild_all`, `rebuild_blocklist_filter`, `rebuild_profile`, `rebuild_device`, `rebuild_default_context`, and `handle_device_ip_changed` all return `Result` and are invoked only from `DnsFilterRunner`, which already runs them inside `auth_context::with_context(Admin)`. `require_admin()?` therefore passes on the live path while rejecting any future call site that forgets to establish an admin context — real runtime protection instead of a comment. No non-test HTTP route reaches these methods.

**`DnsFilterService::check` — stays unguarded, documented.** It's the per-query DNS hot path: it returns `CheckOutcome` (not `Result`, so `?` can't apply), runs with no auth context, and has no HTTP surface. It keeps its explanatory note.

## Tests

- `get_dns_config` under `AuthContext::Anonymous` → `Err(Forbidden)`, and under an admin context → `Ok`.
- The six mutating `DnsFilterService` methods reject a non-admin caller with `Forbidden`.

## Verification

- `cargo test -p wardnetd-services --lib` — 1364 passed, 0 failed
- `cargo clippy -p wardnetd-services --lib --tests` — clean
- `cargo fmt --check` — clean

Closes #840