### PR TITLE
feat(private-dns): daemon API, signed iOS profile, and JS SDK

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -15185,6 +15185,710 @@
         }
       }
     },
+    "/api/private-dns": {
+      "put": {
+        "tags": [
+          "private-dns"
+        ],
+        "description": "Enable or disable Private DNS. Enabling is Premium-gated and requires the hard prerequisites — the wardnet DNS provider, an issued TLS certificate, and an active entitlement — returning 409 when any is missing (reverse-tunnel readiness is informational and never blocks). On enable the daemon seeds the split-horizon wildcard record and starts the `:853` listener; on disable it removes the record and stops it. Returns the full status. Admin only.",
+        "operationId": "set_enabled",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SetPrivateDnsEnabledRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Private DNS state applied",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PrivateDnsStatusResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthenticated - session cookie or API key missing/invalid",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "description": "Standard API error response.",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "detail": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "error": {
+                      "type": "string"
+                    },
+                    "request_id": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "description": "Request ID for correlation with server logs."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden - caller is not an admin",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "description": "Standard API error response.",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "detail": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "error": {
+                      "type": "string"
+                    },
+                    "request_id": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "description": "Request ID for correlation with server logs."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflicting concurrent operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "description": "Standard API error response.",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "detail": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "error": {
+                      "type": "string"
+                    },
+                    "request_id": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "description": "Request ID for correlation with server logs."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "description": "Standard API error response.",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "detail": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "error": {
+                      "type": "string"
+                    },
+                    "request_id": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "description": "Request ID for correlation with server logs."
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/private-dns/grants": {
+      "post": {
+        "tags": [
+          "private-dns"
+        ],
+        "description": "Grant a managed device encrypted-DNS access: mint its secret hostname (a high-entropy label under the wardnet wildcard, never in CT logs). Requires the feature to be enabled; returns 409 if the device already holds a grant or the feature is disabled, and 404 if the device is unknown. The response carries the full minted hostname. Admin only.",
+        "operationId": "create_grant",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreatePrivateDnsGrantRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Device granted",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PrivateDnsGrantSummary"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthenticated - session cookie or API key missing/invalid",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "description": "Standard API error response.",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "detail": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "error": {
+                      "type": "string"
+                    },
+                    "request_id": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "description": "Request ID for correlation with server logs."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden - caller is not an admin",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "description": "Standard API error response.",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "detail": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "error": {
+                      "type": "string"
+                    },
+                    "request_id": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "description": "Request ID for correlation with server logs."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Resource not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "description": "Standard API error response.",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "detail": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "error": {
+                      "type": "string"
+                    },
+                    "request_id": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "description": "Request ID for correlation with server logs."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflicting concurrent operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "description": "Standard API error response.",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "detail": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "error": {
+                      "type": "string"
+                    },
+                    "request_id": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "description": "Request ID for correlation with server logs."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "description": "Standard API error response.",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "detail": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "error": {
+                      "type": "string"
+                    },
+                    "request_id": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "description": "Request ID for correlation with server logs."
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/private-dns/grants/{device_id}": {
+      "delete": {
+        "tags": [
+          "private-dns"
+        ],
+        "description": "Revoke a device's encrypted-DNS grant by device id: delete its hostname and immediately cut off any established `DoT` session (the token is otherwise only checked at handshake). Returns 404 if the device has no grant. Admin only.",
+        "operationId": "delete_grant",
+        "parameters": [
+          {
+            "name": "device_id",
+            "in": "path",
+            "description": "Device ID",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Grant revoked"
+          },
+          "401": {
+            "description": "Unauthenticated - session cookie or API key missing/invalid",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "description": "Standard API error response.",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "detail": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "error": {
+                      "type": "string"
+                    },
+                    "request_id": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "description": "Request ID for correlation with server logs."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden - caller is not an admin",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "description": "Standard API error response.",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "detail": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "error": {
+                      "type": "string"
+                    },
+                    "request_id": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "description": "Request ID for correlation with server logs."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Resource not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "description": "Standard API error response.",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "detail": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "error": {
+                      "type": "string"
+                    },
+                    "request_id": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "description": "Request ID for correlation with server logs."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "description": "Standard API error response.",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "detail": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "error": {
+                      "type": "string"
+                    },
+                    "request_id": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "description": "Request ID for correlation with server logs."
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/private-dns/me": {
+      "get": {
+        "tags": [
+          "private-dns"
+        ],
+        "description": "The caller device's own Private DNS state, identified by source IP (like `GET /api/devices/me`): whether the feature is enabled, whether this device is granted, and its full hostname when granted. Backs the user PWA. No authentication required — the daemon trusts the source IP of the incoming TCP connection.",
+        "operationId": "get_me",
+        "responses": {
+          "200": {
+            "description": "This device's Private DNS state",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PrivateDnsMeResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {}
+        ]
+      }
+    },
+    "/api/private-dns/me/profile": {
+      "get": {
+        "tags": [
+          "private-dns"
+        ],
+        "description": "The signed iOS configuration profile (`.mobileconfig`) for the caller device, identified by source IP. Served as `application/x-apple-aspen-config` at a plain, navigable URL so Safari's install flow triggers on a real navigation. Returns 404 when this device isn't granted or the feature is disabled. No authentication required.",
+        "operationId": "get_me_profile",
+        "responses": {
+          "200": {
+            "description": "Signed configuration profile",
+            "content": {
+              "application/x-apple-aspen-config": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "integer",
+                    "format": "int32",
+                    "minimum": 0
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "No profile for this device",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {}
+        ]
+      }
+    },
+    "/api/private-dns/status": {
+      "get": {
+        "tags": [
+          "private-dns"
+        ],
+        "description": "Report Private DNS state for the admin UI: whether it is enabled, the wardnet domain grants live under, the enable prerequisites (wardnet provider, issued certificate, active entitlement, plus the informational reverse-tunnel readiness), and every per-device grant with its full minted hostname. Admin only.",
+        "operationId": "get_status",
+        "responses": {
+          "200": {
+            "description": "Current Private DNS status",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PrivateDnsStatusResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthenticated - session cookie or API key missing/invalid",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "description": "Standard API error response.",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "detail": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "error": {
+                      "type": "string"
+                    },
+                    "request_id": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "description": "Request ID for correlation with server logs."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden - caller is not an admin",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "description": "Standard API error response.",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "detail": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "error": {
+                      "type": "string"
+                    },
+                    "request_id": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "description": "Request ID for correlation with server logs."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "description": "Standard API error response.",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "detail": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "error": {
+                      "type": "string"
+                    },
+                    "request_id": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "description": "Request ID for correlation with server logs."
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/providers": {
       "get": {
         "tags": [
@@ -21861,6 +22565,20 @@
           }
         }
       },
+      "CreatePrivateDnsGrantRequest": {
+        "type": "object",
+        "description": "Request body for `POST /api/private-dns/grants`.",
+        "required": [
+          "device_id"
+        ],
+        "properties": {
+          "device_id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "The device to grant encrypted-DNS access. Must already exist and must\nnot already hold a grant."
+          }
+        }
+      },
       "CreateProfileRequest": {
         "type": "object",
         "description": "Request body for POST /api/dns/filter/profiles.",
@@ -24818,6 +25536,119 @@
           }
         }
       },
+      "PrivateDnsGrantSummary": {
+        "type": "object",
+        "description": "One per-device grant, carrying the full minted hostname the phone dials.",
+        "required": [
+          "id",
+          "device_id",
+          "hostname",
+          "created_at"
+        ],
+        "properties": {
+          "created_at": {
+            "type": "string",
+            "description": "RFC 3339 creation timestamp."
+          },
+          "device_id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "hostname": {
+            "type": "string",
+            "description": "The device's secret hostname (`<token>.<domain>`) — entered into\nAndroid Private DNS and carried as the `ServerName` in the iOS profile."
+          },
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          }
+        }
+      },
+      "PrivateDnsMeResponse": {
+        "type": "object",
+        "description": "Response for `GET /api/private-dns/me` — the device-keyed self-service view\n(identified by source IP, like `GET /api/devices/me`).",
+        "required": [
+          "enabled",
+          "granted"
+        ],
+        "properties": {
+          "enabled": {
+            "type": "boolean",
+            "description": "Whether Private DNS is enabled on the box at all."
+          },
+          "granted": {
+            "type": "boolean",
+            "description": "Whether *this* device holds a grant."
+          },
+          "hostname": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "This device's full hostname, present only when granted and the wardnet\ndomain is known; `null` otherwise."
+          }
+        }
+      },
+      "PrivateDnsPrerequisites": {
+        "type": "object",
+        "description": "Enable prerequisites for Private DNS, surfaced to the admin UI so it can\nexplain *why* the toggle is blocked.\n\nThe first three are **hard gates** — [`PrivateDnsStatusResponse::enabled`]\ncannot be turned on unless all are `true`. `relay_connected` is\n**informational**: the LAN (split-horizon) path works without the reverse\ntunnel; only roaming needs it, so a disconnected relay never blocks enable.",
+        "required": [
+          "wardnet_provider",
+          "certificate",
+          "entitled",
+          "relay_connected"
+        ],
+        "properties": {
+          "certificate": {
+            "type": "boolean",
+            "description": "An issued TLS certificate is live (the `DoT` listener derives its config\nfrom it)."
+          },
+          "entitled": {
+            "type": "boolean",
+            "description": "The box currently holds an active Premium entitlement."
+          },
+          "relay_connected": {
+            "type": "boolean",
+            "description": "The reverse tunnel to the regional edge is up. Informational only —\nroaming queries need it, LAN queries do not."
+          },
+          "wardnet_provider": {
+            "type": "boolean",
+            "description": "The box is on the wardnet DDNS provider (so grants get a wildcard-SAN\nhostname)."
+          }
+        }
+      },
+      "PrivateDnsStatusResponse": {
+        "type": "object",
+        "description": "Response for `GET /api/private-dns/status` and `PUT /api/private-dns`.",
+        "required": [
+          "enabled",
+          "prerequisites",
+          "grants"
+        ],
+        "properties": {
+          "domain": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "The wardnet FQDN grants live under (`<token>.<domain>`), when the\nprovider is configured; `null` otherwise."
+          },
+          "enabled": {
+            "type": "boolean",
+            "description": "Whether the feature (and therefore the `:853` listener) is enabled."
+          },
+          "grants": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PrivateDnsGrantSummary"
+            },
+            "description": "Every grant, oldest first."
+          },
+          "prerequisites": {
+            "$ref": "#/components/schemas/PrivateDnsPrerequisites"
+          }
+        }
+      },
       "Proto": {
         "type": "string",
         "description": "Transport protocol a [`PortSpec`] applies to.",
@@ -25407,6 +26238,18 @@
           },
           "target": {
             "$ref": "#/components/schemas/RoutingTarget"
+          }
+        }
+      },
+      "SetPrivateDnsEnabledRequest": {
+        "type": "object",
+        "description": "Request body for `PUT /api/private-dns`.",
+        "required": [
+          "enabled"
+        ],
+        "properties": {
+          "enabled": {
+            "type": "boolean"
           }
         }
       },
@@ -27322,6 +28165,10 @@
     {
       "name": "inbound-wg",
       "description": "Inbound WireGuard remote-access server and peers"
+    },
+    {
+      "name": "private-dns",
+      "description": "Private DNS: per-device encrypted DNS (DoT) grants and the signed iOS profile"
     },
     {
       "name": "providers",

--- a/source/.changeset/private-dns-sdk.md
+++ b/source/.changeset/private-dns-sdk.md
@@ -1,0 +1,5 @@
+---
+"@wardnet/js": minor
+---
+
+Add a `PrivateDnsService` for the encrypted-DNS (Private DNS) feature: read status and enable prerequisites, enable/disable, grant and revoke devices, the device-keyed `me` state, and a `profileUrl()` for the signed iOS `.mobileconfig`.

--- a/source/daemon/Cargo.lock
+++ b/source/daemon/Cargo.lock
@@ -814,6 +814,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
 
 [[package]]
+name = "cms"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b77c319abfd5219629c45c34c89ba945ed3c5e49fcde9d16b6c3885f118a730"
+dependencies = [
+ "const-oid 0.9.6",
+ "der",
+ "spki",
+ "x509-cert",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1189,6 +1201,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
  "const-oid 0.9.6",
+ "der_derive",
+ "flagset",
  "pem-rfc7468",
  "zeroize",
 ]
@@ -1205,6 +1219,17 @@ dependencies = [
  "num-bigint",
  "num-traits",
  "rusticata-macros",
+]
+
+[[package]]
+name = "der_derive"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8034092389675178f570469e6c3b0465d3d30b4505c294a6550db47f3c17ad18"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1427,7 +1452,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1522,6 +1547,12 @@ dependencies = [
  "libc",
  "winapi",
 ]
+
+[[package]]
+name = "flagset"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7ac824320a75a52197e8f2d787f6a38b6718bb6897a35142d749af3c0e8f4fe"
 
 [[package]]
 name = "flate2"
@@ -3232,7 +3263,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4473,7 +4504,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4532,7 +4563,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4798,6 +4829,12 @@ dependencies = [
  "cpufeatures 0.3.0",
  "digest 0.11.2",
 ]
+
+[[package]]
+name = "sha1_smol"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbfa15b3dddfee50a0fff136974b3e1bde555604ba463834a7eb7deb6417705d"
 
 [[package]]
 name = "sha2"
@@ -5301,10 +5338,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5422,6 +5459,27 @@ name = "tinyvec_macros"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "tls_codec"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de2e01245e2bb89d6f05801c564fa27624dbd7b1846859876c7dad82e90bf6b"
+dependencies = [
+ "tls_codec_derive",
+ "zeroize",
+]
+
+[[package]]
+name = "tls_codec_derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d2e76690929402faae40aebdda620a2c0e25dd6d3b9afe48867dfd95991f4bd"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "tokio"
@@ -5950,6 +6008,7 @@ dependencies = [
  "getrandom 0.4.2",
  "js-sys",
  "serde_core",
+ "sha1_smol",
  "wasm-bindgen",
 ]
 
@@ -6172,6 +6231,7 @@ dependencies = [
  "clap",
  "ipnetwork 0.21.1",
  "rand 0.10.2",
+ "rcgen",
  "reqwest 0.12.28",
  "serde",
  "serde_json",
@@ -6198,8 +6258,11 @@ dependencies = [
  "axum",
  "base64 0.22.1",
  "chrono",
+ "cms",
+ "const-oid 0.9.6",
  "criterion",
  "cron",
+ "der",
  "ed25519-dalek",
  "flate2",
  "futures",
@@ -6210,6 +6273,7 @@ dependencies = [
  "ipnetwork 0.21.1",
  "minisign",
  "minisign-verify",
+ "p256",
  "rand 0.10.2",
  "rcgen",
  "regex",
@@ -6218,6 +6282,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.11.0",
+ "spki",
  "sqlx",
  "sysinfo",
  "tar",
@@ -6235,6 +6300,7 @@ dependencies = [
  "web-push-native",
  "wiremock",
  "x25519-dalek 3.0.0",
+ "x509-cert",
  "x509-parser",
 ]
 
@@ -6475,7 +6541,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6936,6 +7002,18 @@ checksum = "e7e8131a03190127fb2263afc72b322ecadae46b6ff8c6f399ff5d02f5559af6"
 dependencies = [
  "curve25519-dalek 5.0.0",
  "rand_core 0.10.0",
+]
+
+[[package]]
+name = "x509-cert"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1301e935010a701ae5f8655edc0ad17c44bad3ac5ce8c39185f75453b720ae94"
+dependencies = [
+ "const-oid 0.9.6",
+ "der",
+ "spki",
+ "tls_codec",
 ]
 
 [[package]]

--- a/source/daemon/Cargo.toml
+++ b/source/daemon/Cargo.toml
@@ -53,7 +53,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 
 # https://crates.io/crates/uuid
-uuid = { version = "1", features = ["v4", "serde"] }
+uuid = { version = "1", features = ["v4", "v5", "serde"] }
 # https://crates.io/crates/chrono
 chrono = { version = "0.4", features = ["serde"] }
 
@@ -259,6 +259,29 @@ rcgen = "0.14.8"
 # https://crates.io/crates/x509-parser — parse `not_after` from the issued
 # chain to schedule renewal.
 x509-parser = "0.18"
+# https://crates.io/crates/cms — CMS SignedData types that wrap the iOS
+# `.mobileconfig` so Apple shows "Verified" (issue #914). Pure-Rust RustCrypto
+# stack (der/spki/x509-cert), no OpenSSL. The `builder` feature is deliberately
+# OFF: it drags in `rsa` (RUSTSEC-2023-0071, Marvin timing sidechannel) for RSA
+# signing we never do, so the SignedData is assembled from the base types and
+# signed with `p256` directly — the same reason the web-push `vapid` feature is
+# disabled above.
+cms = { version = "0.2.3", default-features = false, features = ["std", "alloc"] }
+# https://crates.io/crates/x509-cert — parse the issued chain into the DER
+# certificate + issuer/serial the CMS signer embeds.
+x509-cert = { version = "0.2", features = ["pem"] }
+# https://crates.io/crates/p256 — sign the CMS SignerInfo with the leaf's
+# ECDSA P-256 key (rcgen generates a P-256 leaf), matching the cert's algorithm.
+p256 = { version = "0.13", features = ["ecdsa", "pem", "pkcs8"] }
+# https://crates.io/crates/der — encode the `.mobileconfig` bytes as the CMS
+# encapsulated content (OctetString → Any).
+der = { version = "0.7", features = ["oid"] }
+# https://crates.io/crates/const-oid — the id-data / SHA-256 OIDs the CMS
+# structure references.
+const-oid = "0.9"
+# https://crates.io/crates/spki — the SHA-256 AlgorithmIdentifier for the CMS
+# digest algorithms set.
+spki = "0.7"
 # https://crates.io/crates/rustls — install the aws-lc-rs crypto provider as the
 # process default for :443 TLS (both ring + aws-lc-rs are in the tree, so rustls
 # 0.23 can't auto-pick).

--- a/source/daemon/crates/wardnet-common/src/api.rs
+++ b/source/daemon/crates/wardnet-common/src/api.rs
@@ -358,6 +358,83 @@ pub struct SetInboundWgPeerEnabledRequest {
     pub enabled: bool,
 }
 
+// -- Private DNS (encrypted DNS at home + roaming, issue #914) -------------
+
+/// Enable prerequisites for Private DNS, surfaced to the admin UI so it can
+/// explain *why* the toggle is blocked.
+///
+/// The first three are **hard gates** — [`PrivateDnsStatusResponse::enabled`]
+/// cannot be turned on unless all are `true`. `relay_connected` is
+/// **informational**: the LAN (split-horizon) path works without the reverse
+/// tunnel; only roaming needs it, so a disconnected relay never blocks enable.
+#[allow(clippy::struct_excessive_bools)] // four independent prerequisite flags, not a state machine
+#[derive(Debug, Clone, Serialize, Deserialize, utoipa::ToSchema)]
+pub struct PrivateDnsPrerequisites {
+    /// The box is on the wardnet DDNS provider (so grants get a wildcard-SAN
+    /// hostname).
+    pub wardnet_provider: bool,
+    /// An issued TLS certificate is live (the `DoT` listener derives its config
+    /// from it).
+    pub certificate: bool,
+    /// The box currently holds an active Premium entitlement.
+    pub entitled: bool,
+    /// The reverse tunnel to the regional edge is up. Informational only —
+    /// roaming queries need it, LAN queries do not.
+    pub relay_connected: bool,
+}
+
+/// One per-device grant, carrying the full minted hostname the phone dials.
+#[derive(Debug, Clone, Serialize, Deserialize, utoipa::ToSchema)]
+pub struct PrivateDnsGrantSummary {
+    pub id: Uuid,
+    pub device_id: Uuid,
+    /// The device's secret hostname (`<token>.<domain>`) — entered into
+    /// Android Private DNS and carried as the `ServerName` in the iOS profile.
+    pub hostname: String,
+    /// RFC 3339 creation timestamp.
+    pub created_at: String,
+}
+
+/// Response for `GET /api/private-dns/status` and `PUT /api/private-dns`.
+#[derive(Debug, Clone, Serialize, Deserialize, utoipa::ToSchema)]
+pub struct PrivateDnsStatusResponse {
+    /// Whether the feature (and therefore the `:853` listener) is enabled.
+    pub enabled: bool,
+    /// The wardnet FQDN grants live under (`<token>.<domain>`), when the
+    /// provider is configured; `null` otherwise.
+    pub domain: Option<String>,
+    pub prerequisites: PrivateDnsPrerequisites,
+    /// Every grant, oldest first.
+    pub grants: Vec<PrivateDnsGrantSummary>,
+}
+
+/// Request body for `PUT /api/private-dns`.
+#[derive(Debug, Clone, Serialize, Deserialize, utoipa::ToSchema)]
+pub struct SetPrivateDnsEnabledRequest {
+    pub enabled: bool,
+}
+
+/// Request body for `POST /api/private-dns/grants`.
+#[derive(Debug, Clone, Serialize, Deserialize, utoipa::ToSchema)]
+pub struct CreatePrivateDnsGrantRequest {
+    /// The device to grant encrypted-DNS access. Must already exist and must
+    /// not already hold a grant.
+    pub device_id: Uuid,
+}
+
+/// Response for `GET /api/private-dns/me` — the device-keyed self-service view
+/// (identified by source IP, like `GET /api/devices/me`).
+#[derive(Debug, Clone, Serialize, Deserialize, utoipa::ToSchema)]
+pub struct PrivateDnsMeResponse {
+    /// Whether Private DNS is enabled on the box at all.
+    pub enabled: bool,
+    /// Whether *this* device holds a grant.
+    pub granted: bool,
+    /// This device's full hostname, present only when granted and the wardnet
+    /// domain is known; `null` otherwise.
+    pub hostname: Option<String>,
+}
+
 /// Response for `GET /api/tunnels/{id}/devices`.
 ///
 /// The devices currently routed through the given tunnel — i.e. those

--- a/source/daemon/crates/wardnetd-api/src/api/mod.rs
+++ b/source/daemon/crates/wardnetd-api/src/api/mod.rs
@@ -17,6 +17,7 @@ pub mod logs_ws;
 pub mod middleware;
 pub mod network;
 pub mod network_zone;
+pub mod private_dns;
 pub mod providers;
 pub mod push;
 pub mod responses;
@@ -120,6 +121,7 @@ pub(crate) fn build_openapi_router() -> OpenApiRouter<AppState> {
     r = dns_events::register(r);
     r = tunnels::register(r);
     r = inbound_wg::register(r);
+    r = private_dns::register(r);
     r = providers::register(r);
     r = dhcp::register(r);
     r = dns::register(r);

--- a/source/daemon/crates/wardnetd-api/src/api/private_dns.rs
+++ b/source/daemon/crates/wardnetd-api/src/api/private_dns.rs
@@ -1,0 +1,340 @@
+use axum::Json;
+use axum::body::Body;
+use axum::extract::{Path, State};
+use axum::http::{StatusCode, header};
+use axum::response::IntoResponse;
+use utoipa_axum::router::OpenApiRouter;
+use utoipa_axum::routes;
+use uuid::Uuid;
+use wardnet_common::api::{
+    ApiError, CreatePrivateDnsGrantRequest, PrivateDnsGrantSummary, PrivateDnsMeResponse,
+    PrivateDnsPrerequisites, PrivateDnsStatusResponse, SetPrivateDnsEnabledRequest,
+};
+use wardnet_common::auth::AuthContext;
+
+use crate::api::middleware::{AdminAuth, ClientIp};
+use crate::api::responses::{AuthErrors, Conflict, NotFound};
+use crate::state::AppState;
+use wardnetd_services::auth_context;
+use wardnetd_services::ddns::DdnsStatus;
+use wardnetd_services::error::AppError;
+use wardnetd_services::private_dns::cert_ready;
+use wardnetd_services::private_dns::profile::MOBILECONFIG_CONTENT_TYPE;
+
+/// Register Private DNS routes onto the given [`OpenApiRouter`].
+pub fn register(router: OpenApiRouter<AppState>) -> OpenApiRouter<AppState> {
+    router
+        .routes(routes!(get_status))
+        .routes(routes!(set_enabled))
+        .routes(routes!(create_grant))
+        .routes(routes!(delete_grant))
+        .routes(routes!(get_me))
+        .routes(routes!(get_me_profile))
+}
+
+const TAG: &str = "private-dns";
+
+/// An internal admin context for the device-keyed endpoints: their handler has
+/// already authenticated the caller by source IP, then reaches the admin-gated
+/// Private DNS service to read that one device's state (mirrors how
+/// `GET /api/devices/me` enriches itself from admin-only services).
+fn system_admin() -> AuthContext {
+    AuthContext::Admin {
+        admin_id: Uuid::nil(),
+    }
+}
+
+/// `<token>.<domain>`, or the bare token when the domain isn't known (a grant
+/// only exists while the feature is enabled, which requires the domain, so the
+/// fallback is defensive).
+fn hostname(token: &str, domain: Option<&str>) -> String {
+    match domain {
+        Some(domain) => format!("{token}.{domain}"),
+        None => token.to_owned(),
+    }
+}
+
+/// The wardnet domain grants live under, derived from a DDNS status: the FQDN
+/// when on the wardnet provider, else `None`. Kept here so the API layer reads
+/// DDNS once and derives both the domain and the `wardnet_provider` flag from
+/// the same snapshot (the service's `status()` would round-trip DDNS again).
+fn wardnet_domain(ddns: &DdnsStatus) -> Option<String> {
+    if ddns.provider.as_deref() == Some("wardnet") {
+        ddns.fqdn.clone()
+    } else {
+        None
+    }
+}
+
+/// Assemble the admin status view: enabled state, enable prerequisites (pulled
+/// from DDNS / TLS / entitlement), and every grant with its full hostname.
+async fn build_status(state: &AppState) -> Result<PrivateDnsStatusResponse, AppError> {
+    // One DDNS read feeds both `domain` and `wardnet_provider`; `is_enabled()`
+    // is a bare config read, so a transient DDNS hiccup can't flap the flag.
+    let enabled = state.private_dns_service().is_enabled().await?;
+    let ddns = state.ddns_service().status().await?;
+
+    let domain = wardnet_domain(&ddns);
+    let wardnet_provider = domain.is_some();
+    let certificate = cert_ready(&state.tls_service().status().await?);
+    let entitled = state.is_entitled();
+    // Informational readiness signal for roaming: on the wardnet provider, not
+    // suspended, and publishing a public IP (so the wildcard CNAME resolves to
+    // the regional edge). Not a live probe of the reverse tunnel, and never a
+    // gate — the LAN path works regardless.
+    let relay_connected = wardnet_provider && !ddns.suspended && ddns.last_public_ip.is_some();
+
+    let grants = state
+        .private_dns_service()
+        .list_grants()
+        .await?
+        .into_iter()
+        .map(|g| PrivateDnsGrantSummary {
+            id: g.id,
+            device_id: g.device_id,
+            hostname: hostname(&g.token, domain.as_deref()),
+            created_at: g.created_at,
+        })
+        .collect();
+
+    Ok(PrivateDnsStatusResponse {
+        enabled,
+        domain,
+        prerequisites: PrivateDnsPrerequisites {
+            wardnet_provider,
+            certificate,
+            entitled,
+            relay_connected,
+        },
+        grants,
+    })
+}
+
+#[utoipa::path(
+    get,
+    path = "/api/private-dns/status",
+    tag = TAG,
+    description = "Report Private DNS state for the admin UI: whether it is enabled, the \
+                   wardnet domain grants live under, the enable prerequisites \
+                   (wardnet provider, issued certificate, active entitlement, plus the \
+                   informational reverse-tunnel readiness), and every per-device grant with \
+                   its full minted hostname. Admin only.",
+    responses(
+        (status = 200, description = "Current Private DNS status", body = PrivateDnsStatusResponse),
+        AuthErrors,
+    ),
+)]
+pub async fn get_status(
+    State(state): State<AppState>,
+    _auth: AdminAuth,
+) -> Result<Json<PrivateDnsStatusResponse>, AppError> {
+    Ok(Json(build_status(&state).await?))
+}
+
+#[utoipa::path(
+    put,
+    path = "/api/private-dns",
+    tag = TAG,
+    description = "Enable or disable Private DNS. Enabling is Premium-gated and requires the \
+                   hard prerequisites — the wardnet DNS provider, an issued TLS certificate, \
+                   and an active entitlement — returning 409 when any is missing \
+                   (reverse-tunnel readiness is informational and never blocks). On enable the \
+                   daemon seeds the split-horizon wildcard record and starts the `:853` \
+                   listener; on disable it removes the record and stops it. Returns the full \
+                   status. Admin only.",
+    request_body = SetPrivateDnsEnabledRequest,
+    responses(
+        (status = 200, description = "Private DNS state applied", body = PrivateDnsStatusResponse),
+        AuthErrors,
+        Conflict,
+    ),
+)]
+pub async fn set_enabled(
+    State(state): State<AppState>,
+    _auth: AdminAuth,
+    Json(body): Json<SetPrivateDnsEnabledRequest>,
+) -> Result<Json<PrivateDnsStatusResponse>, AppError> {
+    state
+        .private_dns_service()
+        .set_enabled(body.enabled)
+        .await?;
+    Ok(Json(build_status(&state).await?))
+}
+
+#[utoipa::path(
+    post,
+    path = "/api/private-dns/grants",
+    tag = TAG,
+    description = "Grant a managed device encrypted-DNS access: mint its secret hostname \
+                   (a high-entropy label under the wardnet wildcard, never in CT logs). \
+                   Requires the feature to be enabled; returns 409 if the device already \
+                   holds a grant or the feature is disabled, and 404 if the device is \
+                   unknown. The response carries the full minted hostname. Admin only.",
+    request_body = CreatePrivateDnsGrantRequest,
+    responses(
+        (status = 201, description = "Device granted", body = PrivateDnsGrantSummary),
+        AuthErrors,
+        Conflict,
+        NotFound,
+    ),
+)]
+pub async fn create_grant(
+    State(state): State<AppState>,
+    _auth: AdminAuth,
+    Json(body): Json<CreatePrivateDnsGrantRequest>,
+) -> Result<(StatusCode, Json<PrivateDnsGrantSummary>), AppError> {
+    let grant = state
+        .private_dns_service()
+        .grant_device(body.device_id)
+        .await?;
+    // Domain is known here (granting requires the feature enabled, which
+    // requires the wardnet provider), but read it back rather than assume —
+    // via DDNS directly, matching how `build_status` resolves it.
+    let domain = wardnet_domain(&state.ddns_service().status().await?);
+    let summary = PrivateDnsGrantSummary {
+        id: grant.id,
+        device_id: grant.device_id,
+        hostname: hostname(&grant.token, domain.as_deref()),
+        created_at: grant.created_at,
+    };
+    Ok((StatusCode::CREATED, Json(summary)))
+}
+
+#[utoipa::path(
+    delete,
+    path = "/api/private-dns/grants/{device_id}",
+    tag = TAG,
+    description = "Revoke a device's encrypted-DNS grant by device id: delete its hostname \
+                   and immediately cut off any established `DoT` session (the token is \
+                   otherwise only checked at handshake). Returns 404 if the device has no \
+                   grant. Admin only.",
+    params(("device_id" = Uuid, Path, description = "Device ID")),
+    responses(
+        (status = 204, description = "Grant revoked"),
+        AuthErrors,
+        NotFound,
+    ),
+)]
+pub async fn delete_grant(
+    State(state): State<AppState>,
+    _auth: AdminAuth,
+    Path(device_id): Path<Uuid>,
+) -> Result<StatusCode, AppError> {
+    let Some(grant) = state.private_dns_service().device_grant(device_id).await? else {
+        return Err(AppError::NotFound(format!(
+            "device {device_id} has no Private DNS grant"
+        )));
+    };
+    state.private_dns_service().revoke_grant(grant.id).await?;
+    Ok(StatusCode::NO_CONTENT)
+}
+
+#[utoipa::path(
+    get,
+    path = "/api/private-dns/me",
+    tag = TAG,
+    description = "The caller device's own Private DNS state, identified by source IP (like \
+                   `GET /api/devices/me`): whether the feature is enabled, whether this device \
+                   is granted, and its full hostname when granted. Backs the user PWA. No \
+                   authentication required — the daemon trusts the source IP of the incoming \
+                   TCP connection.",
+    responses(
+        (status = 200, description = "This device's Private DNS state", body = PrivateDnsMeResponse),
+        (status = 500, description = "Internal server error", body = ApiError),
+    ),
+    security(()),
+)]
+pub async fn get_me(
+    State(state): State<AppState>,
+    ClientIp(ip): ClientIp,
+) -> Result<Json<PrivateDnsMeResponse>, AppError> {
+    // Bare config read — no DDNS round-trip, so a transient DDNS error can't
+    // 500 the user PWA when this device has no grant to resolve a hostname for.
+    let enabled =
+        auth_context::with_context(system_admin(), state.private_dns_service().is_enabled())
+            .await?;
+
+    // Resolve the caller device by source IP (self-service, like /devices/me).
+    let device = state
+        .device_service()
+        .get_device_for_ip(&ip.to_string())
+        .await?
+        .device;
+
+    let grant = match &device {
+        Some(device) => {
+            auth_context::with_context(
+                system_admin(),
+                state.private_dns_service().device_grant(device.id),
+            )
+            .await?
+        }
+        None => None,
+    };
+
+    // A hostname is only meaningful when the feature is on *and* the device is
+    // granted — matching `/me/profile`, which 404s while disabled. Resolve the
+    // domain lazily then, degrading to no hostname on a DDNS hiccup rather than
+    // failing the whole call.
+    let hostname = match (enabled, &grant) {
+        (true, Some(grant)) => {
+            let domain = auth_context::with_context(system_admin(), state.ddns_service().status())
+                .await
+                .ok()
+                .and_then(|ddns| wardnet_domain(&ddns));
+            domain.map(|domain| hostname(&grant.token, Some(&domain)))
+        }
+        _ => None,
+    };
+
+    Ok(Json(PrivateDnsMeResponse {
+        enabled,
+        granted: grant.is_some(),
+        hostname,
+    }))
+}
+
+#[utoipa::path(
+    get,
+    path = "/api/private-dns/me/profile",
+    tag = TAG,
+    description = "The signed iOS configuration profile (`.mobileconfig`) for the caller \
+                   device, identified by source IP. Served as \
+                   `application/x-apple-aspen-config` at a plain, navigable URL so Safari's \
+                   install flow triggers on a real navigation. Returns 404 when this device \
+                   isn't granted or the feature is disabled. No authentication required.",
+    responses(
+        (status = 200, description = "Signed configuration profile", content_type = "application/x-apple-aspen-config", body = Vec<u8>),
+        (status = 404, description = "No profile for this device", body = ApiError),
+        (status = 500, description = "Internal server error", body = ApiError),
+    ),
+    security(()),
+)]
+pub async fn get_me_profile(
+    State(state): State<AppState>,
+    ClientIp(ip): ClientIp,
+) -> Result<impl IntoResponse, AppError> {
+    let Some(device) = state
+        .device_service()
+        .get_device_for_ip(&ip.to_string())
+        .await?
+        .device
+    else {
+        return Err(AppError::NotFound("no profile for this device".to_owned()));
+    };
+
+    let profile = auth_context::with_context(
+        system_admin(),
+        state.private_dns_service().device_profile(device.id),
+    )
+    .await?;
+
+    let Some(profile) = profile else {
+        return Err(AppError::NotFound("no profile for this device".to_owned()));
+    };
+
+    Ok((
+        [(header::CONTENT_TYPE, MOBILECONFIG_CONTENT_TYPE)],
+        Body::from(profile),
+    ))
+}

--- a/source/daemon/crates/wardnetd-api/src/api/tests/mod.rs
+++ b/source/daemon/crates/wardnetd-api/src/api/tests/mod.rs
@@ -19,6 +19,7 @@ mod network;
 mod network_zone;
 mod openapi;
 mod panic_isolation;
+mod private_dns;
 mod providers;
 mod push;
 mod request_context;

--- a/source/daemon/crates/wardnetd-api/src/api/tests/private_dns.rs
+++ b/source/daemon/crates/wardnetd-api/src/api/tests/private_dns.rs
@@ -1,0 +1,646 @@
+//! Tests for the Private DNS API (`/api/private-dns/*`) — issue #914. Drives
+//! the real handlers through an axum router with a canned `PrivateDnsService`,
+//! asserting status codes, the status/prerequisite envelope, the 409 enable
+//! gate, and the device-keyed `me` surface (including the signed-profile
+//! content type).
+
+use std::net::SocketAddr;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+use async_trait::async_trait;
+use axum::Router;
+use axum::body::Body;
+use axum::extract::ConnectInfo;
+use axum::http::{Request, StatusCode};
+use axum::routing::{get, post, put};
+use chrono::Utc;
+use tower::ServiceExt;
+use uuid::Uuid;
+use wardnet_common::api::{DeviceMeResponse, PrivateDnsMeResponse, PrivateDnsStatusResponse};
+use wardnet_common::device::{Device, DeviceConnectionMode, DeviceType};
+
+use crate::state::AppState;
+use crate::tests::stubs::{
+    AlwaysAdminAuth, StubBackupService, StubDdnsService, StubDhcpServer, StubDhcpService,
+    StubDiscoveryService, StubDnsFilterService, StubDnsLocalService, StubDnsServer, StubDnsService,
+    StubEventPublisher, StubLogService, StubNetworkZoneService, StubProviderService,
+    StubRoutingService, StubRuleRequestService, StubStatsService, StubSystemService,
+    StubTunnelService, StubUpdateService, StubZoneExceptionService,
+};
+use wardnetd_services::entitlement::Entitlement;
+use wardnetd_services::error::AppError;
+use wardnetd_services::private_dns::{PrivateDnsGrant, PrivateDnsService, PrivateDnsStatus};
+use wardnetd_services::{DeviceService, LogService, TlsService, TlsStatus};
+
+// The API layer derives the grant domain from the DDNS status, so this must
+// match `StubDdnsService`'s wardnet fqdn (the single source of truth).
+const DOMAIN: &str = "test.my.wardnet.services";
+// The device the source IP resolves to in the device-keyed tests.
+const ME_DEVICE: Uuid = Uuid::from_u128(0x1111_2222_3333_4444_5555_6666_7777_8888);
+
+// ── Canned PrivateDnsService ─────────────────────────────────────────────────
+
+/// Configurable to drive every documented path without a per-test struct.
+#[derive(Default)]
+struct MockPrivateDns {
+    enabled: AtomicBool,
+    /// The single grant `list_grants` / `device_grant` return (its `device_id`
+    /// gates the device-keyed lookups).
+    grant: Option<PrivateDnsGrant>,
+    /// When set, `set_enabled(true)` rejects with 409 (a missing hard prereq).
+    enable_conflicts: bool,
+    /// Bytes `device_profile` returns for the granted device (`None` → 404).
+    profile: Option<Vec<u8>>,
+}
+
+fn sample_grant() -> PrivateDnsGrant {
+    PrivateDnsGrant {
+        id: Uuid::from_u128(0xabcd),
+        device_id: ME_DEVICE,
+        token: "abcdefghijklmnop".to_owned(),
+        created_at: "2026-07-20T00:00:00Z".to_owned(),
+    }
+}
+
+#[async_trait]
+impl PrivateDnsService for MockPrivateDns {
+    async fn status(&self) -> Result<PrivateDnsStatus, AppError> {
+        Ok(PrivateDnsStatus {
+            enabled: self.enabled.load(Ordering::Relaxed),
+            domain: Some(DOMAIN.to_owned()),
+        })
+    }
+    async fn is_enabled(&self) -> Result<bool, AppError> {
+        Ok(self.enabled.load(Ordering::Relaxed))
+    }
+    async fn set_enabled(&self, enabled: bool) -> Result<PrivateDnsStatus, AppError> {
+        if enabled && self.enable_conflicts {
+            return Err(AppError::Conflict(
+                "Private DNS requires the wardnet DNS provider".to_owned(),
+            ));
+        }
+        self.enabled.store(enabled, Ordering::Relaxed);
+        Ok(PrivateDnsStatus {
+            enabled,
+            domain: Some(DOMAIN.to_owned()),
+        })
+    }
+    async fn grant_device(&self, device_id: Uuid) -> Result<PrivateDnsGrant, AppError> {
+        Ok(PrivateDnsGrant {
+            device_id,
+            ..sample_grant()
+        })
+    }
+    async fn revoke_grant(&self, _grant_id: Uuid) -> Result<(), AppError> {
+        Ok(())
+    }
+    async fn list_grants(&self) -> Result<Vec<PrivateDnsGrant>, AppError> {
+        Ok(self.grant.clone().into_iter().collect())
+    }
+    async fn device_grant(&self, device_id: Uuid) -> Result<Option<PrivateDnsGrant>, AppError> {
+        Ok(self.grant.clone().filter(|g| g.device_id == device_id))
+    }
+    async fn device_profile(&self, _device_id: Uuid) -> Result<Option<Vec<u8>>, AppError> {
+        Ok(self.profile.clone())
+    }
+    async fn resolve_token(&self, _token: &str) -> Result<Option<PrivateDnsGrant>, AppError> {
+        Ok(None)
+    }
+    async fn reconcile(&self) -> Result<(), AppError> {
+        Ok(())
+    }
+}
+
+// ── TLS stub whose `status` resolves (the shared one panics) ─────────────────
+
+struct IssuedTls;
+
+#[async_trait]
+impl TlsService for IssuedTls {
+    async fn ensure_certificate(&self) -> Result<TlsStatus, AppError> {
+        unimplemented!()
+    }
+    async fn status(&self) -> Result<TlsStatus, AppError> {
+        Ok(TlsStatus::UpToDate {
+            domain: DOMAIN.to_owned(),
+            not_after: Utc::now(),
+        })
+    }
+    async fn mark_provisioning_started(&self) -> Result<(), AppError> {
+        unimplemented!()
+    }
+    async fn provisioning_status(
+        &self,
+    ) -> Result<wardnet_common::api::TlsStatusResponse, AppError> {
+        unimplemented!()
+    }
+    async fn teardown(&self) -> Result<(), AppError> {
+        unimplemented!()
+    }
+}
+
+// ── DeviceService whose source-IP lookup resolves to `ME_DEVICE` ─────────────
+
+struct MeDeviceService {
+    /// When false, the source IP resolves to no device (unknown caller).
+    known: bool,
+}
+
+fn me_device() -> Device {
+    Device {
+        id: ME_DEVICE,
+        mac: "aa:bb:cc:dd:ee:ff".to_owned(),
+        name: Some("phone".to_owned()),
+        hostname: None,
+        manufacturer: None,
+        device_type: DeviceType::Unknown,
+        first_seen: Utc::now(),
+        last_seen: Utc::now(),
+        last_ip: "192.168.1.10".to_owned(),
+        admin_locked: false,
+        zone_id: Uuid::nil(),
+        dns_capture_enabled: false,
+        dns_capture_cap_count: 0,
+        dns_capture_cap_days: 0,
+        connection_mode: DeviceConnectionMode::Lan,
+    }
+}
+
+#[async_trait]
+impl DeviceService for MeDeviceService {
+    async fn get_device_for_ip(&self, _ip: &str) -> Result<DeviceMeResponse, AppError> {
+        Ok(DeviceMeResponse {
+            device: self.known.then(me_device),
+            current_rule: None,
+            admin_locked: false,
+            available_tunnels: vec![],
+            zone: None,
+        })
+    }
+    async fn get_device(&self, _id: &str) -> Result<Option<Device>, AppError> {
+        unimplemented!()
+    }
+    async fn clear_remote_connection_mode(&self, _id: &str) -> Result<(), AppError> {
+        unimplemented!()
+    }
+    async fn set_rule_for_ip(
+        &self,
+        _ip: &str,
+        _t: wardnet_common::routing::RoutingTarget,
+    ) -> Result<wardnet_common::api::SetMyRuleResponse, AppError> {
+        unimplemented!()
+    }
+    async fn set_rule(
+        &self,
+        _id: &str,
+        _t: wardnet_common::routing::RoutingTarget,
+    ) -> Result<(), AppError> {
+        unimplemented!()
+    }
+    async fn current_rules(
+        &self,
+    ) -> Result<std::collections::HashMap<Uuid, wardnet_common::routing::RoutingTarget>, AppError>
+    {
+        unimplemented!()
+    }
+    async fn get_rule_for_device(
+        &self,
+        _id: &str,
+    ) -> Result<Option<wardnet_common::routing::RoutingTarget>, AppError> {
+        unimplemented!()
+    }
+    async fn update_admin_locked(&self, _id: &str, _locked: bool) -> Result<(), AppError> {
+        unimplemented!()
+    }
+    async fn get_dns_capture_settings(
+        &self,
+        _id: &str,
+    ) -> Result<wardnet_common::api::DnsCaptureSettingsResponse, AppError> {
+        unimplemented!()
+    }
+    async fn update_dns_capture_settings(
+        &self,
+        _id: &str,
+        _enabled: Option<bool>,
+        _cap_count: Option<i64>,
+        _cap_days: Option<i64>,
+    ) -> Result<(), AppError> {
+        unimplemented!()
+    }
+    async fn set_my_capture_enabled(
+        &self,
+        _ip: &str,
+        _enabled: bool,
+    ) -> Result<wardnet_common::api::DnsCaptureSettingsResponse, AppError> {
+        unimplemented!()
+    }
+    async fn fetch_pending_dns_events(
+        &self,
+        _id: &str,
+        _after_id: i64,
+        _limit: i64,
+    ) -> Result<Vec<wardnet_common::api::DnsEventItem>, AppError> {
+        unimplemented!()
+    }
+    async fn ack_dns_events(&self, _id: &str, _up_to_id: i64) -> Result<(), AppError> {
+        unimplemented!()
+    }
+    async fn list_capture_enabled_device_ids(&self) -> Result<Vec<String>, AppError> {
+        unimplemented!()
+    }
+    async fn get_device_capture_settings(
+        &self,
+        _id: &str,
+    ) -> Result<Option<(bool, i64, i64)>, AppError> {
+        unimplemented!()
+    }
+}
+
+// ── Harness ──────────────────────────────────────────────────────────────────
+
+fn make_state(private_dns: MockPrivateDns, device: MeDeviceService) -> AppState {
+    AppState::new(
+        Arc::new(AlwaysAdminAuth),
+        Arc::new(StubBackupService),
+        Arc::new(device),
+        Arc::new(StubDhcpService),
+        Arc::new(StubDnsService),
+        Arc::new(StubDnsFilterService),
+        Arc::new(StubDnsLocalService),
+        Arc::new(StubDdnsService),
+        Arc::new(IssuedTls),
+        Arc::new(StubDiscoveryService),
+        Arc::new(StubLogService) as Arc<dyn LogService>,
+        Arc::new(StubProviderService),
+        Arc::new(StubRoutingService),
+        Arc::new(StubNetworkZoneService),
+        Arc::new(StubSystemService),
+        Arc::new(StubTunnelService),
+        Arc::new(StubUpdateService),
+        Arc::new(StubDhcpServer),
+        Arc::new(StubDnsServer),
+        Arc::new(StubEventPublisher),
+        crate::tests::stubs::StubJobService::new_arc(),
+        Arc::new(StubStatsService),
+        Arc::new(StubRuleRequestService),
+        Arc::new(StubZoneExceptionService),
+    )
+    .with_private_dns_service(Arc::new(private_dns))
+    .with_entitlement({
+        // A subscribed box, so the `entitled` prerequisite reads true.
+        let entitlement = Entitlement::shared();
+        entitlement.set_premium(true);
+        entitlement
+    })
+}
+
+fn app(state: AppState) -> Router {
+    Router::new()
+        .route(
+            "/api/private-dns/status",
+            get(crate::api::private_dns::get_status),
+        )
+        .route(
+            "/api/private-dns",
+            put(crate::api::private_dns::set_enabled),
+        )
+        .route(
+            "/api/private-dns/grants",
+            post(crate::api::private_dns::create_grant),
+        )
+        .route(
+            "/api/private-dns/grants/{device_id}",
+            axum::routing::delete(crate::api::private_dns::delete_grant),
+        )
+        .route("/api/private-dns/me", get(crate::api::private_dns::get_me))
+        .route(
+            "/api/private-dns/me/profile",
+            get(crate::api::private_dns::get_me_profile),
+        )
+        .with_state(state)
+}
+
+fn connect_info() -> ConnectInfo<SocketAddr> {
+    ConnectInfo("192.168.1.10:44321".parse().unwrap())
+}
+
+fn admin_request(method: &str, uri: &str, body: Option<serde_json::Value>) -> Request<Body> {
+    let mut builder = Request::builder()
+        .method(method)
+        .uri(uri)
+        .header("Cookie", "wardnet_session=test");
+    let body = match body {
+        Some(value) => {
+            builder = builder.header("Content-Type", "application/json");
+            Body::from(serde_json::to_vec(&value).unwrap())
+        }
+        None => Body::empty(),
+    };
+    let mut req = builder.body(body).unwrap();
+    req.extensions_mut().insert(connect_info());
+    req
+}
+
+fn anon_get(uri: &str) -> Request<Body> {
+    let mut req = Request::builder()
+        .method("GET")
+        .uri(uri)
+        .body(Body::empty())
+        .unwrap();
+    req.extensions_mut().insert(connect_info());
+    req
+}
+
+// ── Admin endpoints ──────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn status_reports_enabled_prereqs_and_grants() {
+    let state = make_state(
+        MockPrivateDns {
+            enabled: AtomicBool::new(true),
+            grant: Some(sample_grant()),
+            ..Default::default()
+        },
+        MeDeviceService { known: true },
+    );
+    let resp = app(state)
+        .oneshot(admin_request("GET", "/api/private-dns/status", None))
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = axum::body::to_bytes(resp.into_body(), 8192).await.unwrap();
+    let json: PrivateDnsStatusResponse = serde_json::from_slice(&body).unwrap();
+    assert!(json.enabled);
+    assert_eq!(json.domain.as_deref(), Some(DOMAIN));
+    // Prereqs are derived from the stub DDNS (wardnet) + issued TLS + entitled.
+    assert!(json.prerequisites.wardnet_provider);
+    assert!(json.prerequisites.certificate);
+    assert!(json.prerequisites.entitled);
+    assert_eq!(json.grants.len(), 1);
+    // The grant carries the full minted hostname, not the bare token.
+    assert_eq!(
+        json.grants[0].hostname,
+        format!("abcdefghijklmnop.{DOMAIN}")
+    );
+}
+
+#[tokio::test]
+async fn set_enabled_returns_full_status() {
+    let state = make_state(MockPrivateDns::default(), MeDeviceService { known: true });
+    let resp = app(state)
+        .oneshot(admin_request(
+            "PUT",
+            "/api/private-dns",
+            Some(serde_json::json!({ "enabled": true })),
+        ))
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = axum::body::to_bytes(resp.into_body(), 8192).await.unwrap();
+    let json: PrivateDnsStatusResponse = serde_json::from_slice(&body).unwrap();
+    assert!(json.enabled);
+}
+
+#[tokio::test]
+async fn set_enabled_conflicts_when_prereq_missing() {
+    let state = make_state(
+        MockPrivateDns {
+            enable_conflicts: true,
+            ..Default::default()
+        },
+        MeDeviceService { known: true },
+    );
+    let resp = app(state)
+        .oneshot(admin_request(
+            "PUT",
+            "/api/private-dns",
+            Some(serde_json::json!({ "enabled": true })),
+        ))
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::CONFLICT);
+}
+
+#[tokio::test]
+async fn create_grant_returns_201_with_hostname() {
+    let state = make_state(
+        MockPrivateDns {
+            enabled: AtomicBool::new(true),
+            ..Default::default()
+        },
+        MeDeviceService { known: true },
+    );
+    let resp = app(state)
+        .oneshot(admin_request(
+            "POST",
+            "/api/private-dns/grants",
+            Some(serde_json::json!({ "device_id": ME_DEVICE })),
+        ))
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::CREATED);
+    let body = axum::body::to_bytes(resp.into_body(), 8192).await.unwrap();
+    let json: wardnet_common::api::PrivateDnsGrantSummary = serde_json::from_slice(&body).unwrap();
+    assert_eq!(json.device_id, ME_DEVICE);
+    assert!(json.hostname.ends_with(&format!(".{DOMAIN}")));
+}
+
+#[tokio::test]
+async fn delete_grant_returns_204_when_present() {
+    let state = make_state(
+        MockPrivateDns {
+            enabled: AtomicBool::new(true),
+            grant: Some(sample_grant()),
+            ..Default::default()
+        },
+        MeDeviceService { known: true },
+    );
+    let resp = app(state)
+        .oneshot(admin_request(
+            "DELETE",
+            &format!("/api/private-dns/grants/{ME_DEVICE}"),
+            None,
+        ))
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::NO_CONTENT);
+}
+
+#[tokio::test]
+async fn delete_grant_returns_404_when_absent() {
+    let state = make_state(
+        MockPrivateDns {
+            enabled: AtomicBool::new(true),
+            grant: None,
+            ..Default::default()
+        },
+        MeDeviceService { known: true },
+    );
+    let resp = app(state)
+        .oneshot(admin_request(
+            "DELETE",
+            &format!("/api/private-dns/grants/{}", Uuid::new_v4()),
+            None,
+        ))
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn admin_endpoints_reject_unauthenticated() {
+    let cases: [(&str, &str, Option<serde_json::Value>); 4] = [
+        ("GET", "/api/private-dns/status", None),
+        (
+            "PUT",
+            "/api/private-dns",
+            Some(serde_json::json!({ "enabled": true })),
+        ),
+        (
+            "POST",
+            "/api/private-dns/grants",
+            Some(serde_json::json!({ "device_id": ME_DEVICE })),
+        ),
+        (
+            "DELETE",
+            "/api/private-dns/grants/00000000-0000-0000-0000-000000000000",
+            None,
+        ),
+    ];
+    for (method, uri, body) in cases {
+        let state = make_state(MockPrivateDns::default(), MeDeviceService { known: true });
+        let mut builder = Request::builder().method(method).uri(uri);
+        let req_body = match body {
+            Some(value) => {
+                builder = builder.header("Content-Type", "application/json");
+                Body::from(serde_json::to_vec(&value).unwrap())
+            }
+            None => Body::empty(),
+        };
+        let mut req = builder.body(req_body).unwrap();
+        req.extensions_mut().insert(connect_info());
+        let resp = app(state).oneshot(req).await.unwrap();
+        assert_eq!(
+            resp.status(),
+            StatusCode::UNAUTHORIZED,
+            "{method} {uri} must reject an unauthenticated caller"
+        );
+    }
+}
+
+// ── Device-keyed surface (unauthenticated, by source IP) ─────────────────────
+
+#[tokio::test]
+async fn me_reports_this_devices_grant() {
+    let state = make_state(
+        MockPrivateDns {
+            enabled: AtomicBool::new(true),
+            grant: Some(sample_grant()),
+            ..Default::default()
+        },
+        MeDeviceService { known: true },
+    );
+    let resp = app(state)
+        .oneshot(anon_get("/api/private-dns/me"))
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = axum::body::to_bytes(resp.into_body(), 8192).await.unwrap();
+    let json: PrivateDnsMeResponse = serde_json::from_slice(&body).unwrap();
+    assert!(json.enabled);
+    assert!(json.granted);
+    assert_eq!(
+        json.hostname.as_deref(),
+        Some(&*format!("abcdefghijklmnop.{DOMAIN}"))
+    );
+}
+
+#[tokio::test]
+async fn me_reports_ungranted_device() {
+    let state = make_state(
+        MockPrivateDns {
+            enabled: AtomicBool::new(true),
+            grant: None,
+            ..Default::default()
+        },
+        MeDeviceService { known: true },
+    );
+    let resp = app(state)
+        .oneshot(anon_get("/api/private-dns/me"))
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = axum::body::to_bytes(resp.into_body(), 8192).await.unwrap();
+    let json: PrivateDnsMeResponse = serde_json::from_slice(&body).unwrap();
+    assert!(!json.granted);
+    assert!(json.hostname.is_none());
+}
+
+#[tokio::test]
+async fn me_hides_hostname_while_disabled() {
+    // A retained grant surfaces as `granted`, but the hostname is withheld
+    // while the feature is off — it wouldn't resolve, matching /me/profile's 404.
+    let state = make_state(
+        MockPrivateDns {
+            enabled: AtomicBool::new(false),
+            grant: Some(sample_grant()),
+            ..Default::default()
+        },
+        MeDeviceService { known: true },
+    );
+    let resp = app(state)
+        .oneshot(anon_get("/api/private-dns/me"))
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = axum::body::to_bytes(resp.into_body(), 8192).await.unwrap();
+    let json: PrivateDnsMeResponse = serde_json::from_slice(&body).unwrap();
+    assert!(!json.enabled);
+    assert!(json.granted);
+    assert!(json.hostname.is_none());
+}
+
+#[tokio::test]
+async fn me_profile_serves_signed_bytes_with_apple_content_type() {
+    let state = make_state(
+        MockPrivateDns {
+            enabled: AtomicBool::new(true),
+            grant: Some(sample_grant()),
+            profile: Some(b"\x30\x82fake-cms".to_vec()),
+            ..Default::default()
+        },
+        MeDeviceService { known: true },
+    );
+    let resp = app(state)
+        .oneshot(anon_get("/api/private-dns/me/profile"))
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    assert_eq!(
+        resp.headers()
+            .get(axum::http::header::CONTENT_TYPE)
+            .unwrap(),
+        "application/x-apple-aspen-config"
+    );
+    let body = axum::body::to_bytes(resp.into_body(), 8192).await.unwrap();
+    assert_eq!(&body[..], b"\x30\x82fake-cms");
+}
+
+#[tokio::test]
+async fn me_profile_404_when_not_granted() {
+    let state = make_state(
+        MockPrivateDns {
+            enabled: AtomicBool::new(true),
+            grant: None,
+            profile: None,
+            ..Default::default()
+        },
+        MeDeviceService { known: true },
+    );
+    let resp = app(state)
+        .oneshot(anon_get("/api/private-dns/me/profile"))
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+}

--- a/source/daemon/crates/wardnetd-api/src/openapi.rs
+++ b/source/daemon/crates/wardnetd-api/src/openapi.rs
@@ -62,6 +62,7 @@ use wardnetd_services::version::RELEASE_VERSION;
         (name = "rule-requests", description = "Device-initiated firewall rule requests and admin decisions"),
         (name = "tunnels", description = "WireGuard tunnel lifecycle"),
         (name = "inbound-wg", description = "Inbound WireGuard remote-access server and peers"),
+        (name = "private-dns", description = "Private DNS: per-device encrypted DNS (DoT) grants and the signed iOS profile"),
         (name = "providers", description = "VPN provider integration"),
         (name = "dhcp", description = "DHCP server configuration, leases, and reservations"),
         (name = "dns", description = "DNS resolver, ad-blocking, filters"),

--- a/source/daemon/crates/wardnetd-api/src/state.rs
+++ b/source/daemon/crates/wardnetd-api/src/state.rs
@@ -4,6 +4,7 @@ use wardnetd_services::dhcp::server::DhcpServer;
 use wardnetd_services::dns::server::DnsServer;
 use wardnetd_services::entitlement::Entitlement;
 use wardnetd_services::event::EventPublisher;
+use wardnetd_services::private_dns::PrivateDnsService;
 use wardnetd_services::tls::runner::TlsRetryNudge;
 use wardnetd_services::{
     AuthService, BackupService, DdnsService, DeviceDiscoveryService, DeviceService, DhcpService,
@@ -41,6 +42,7 @@ struct Inner {
     system_service: Arc<dyn SystemService>,
     tunnel_service: Arc<dyn TunnelService>,
     inbound_wg_service: Arc<dyn InboundWgService>,
+    private_dns_service: Arc<dyn PrivateDnsService>,
     update_service: Arc<dyn UpdateService>,
     dhcp_server: Arc<dyn DhcpServer>,
     dns_server: Arc<dyn DnsServer>,
@@ -125,6 +127,9 @@ impl AppState {
                 // service via `with_inbound_wg_service`.
                 inbound_wg_service: Arc::new(NoopInboundWgService),
                 // Defaults to a no-op; production and the mock inject the live
+                // service via `with_private_dns_service`.
+                private_dns_service: Arc::new(NoopPrivateDnsService),
+                // Defaults to a no-op; production and the mock inject the live
                 // service via `with_push_service`.
                 push_service: Arc::new(NoopPushService),
                 // Defaults to an empty monitor (initial snapshot is UP with no
@@ -150,6 +155,20 @@ impl AppState {
         Arc::get_mut(&mut self.inner)
             .expect("with_inbound_wg_service must be called before AppState is cloned")
             .inbound_wg_service = inbound_wg_service;
+        self
+    }
+
+    /// Inject the live [`PrivateDnsService`] (issues #912/#914). Defaults to a
+    /// no-op in [`Self::new`]; production and the mock wire the real one. Must
+    /// be called before the state is cloned or shared.
+    #[must_use]
+    pub fn with_private_dns_service(
+        mut self,
+        private_dns_service: Arc<dyn PrivateDnsService>,
+    ) -> Self {
+        Arc::get_mut(&mut self.inner)
+            .expect("with_private_dns_service must be called before AppState is cloned")
+            .private_dns_service = private_dns_service;
         self
     }
 
@@ -341,6 +360,13 @@ impl AppState {
         self.inner.inbound_wg_service.as_ref()
     }
 
+    /// Access the Private DNS service (per-device encrypted-DNS grants + the
+    /// signed iOS profile — issues #912/#914).
+    #[must_use]
+    pub fn private_dns_service(&self) -> &dyn PrivateDnsService {
+        self.inner.private_dns_service.as_ref()
+    }
+
     /// Access the auto-update service.
     #[must_use]
     pub fn update_service(&self) -> &dyn UpdateService {
@@ -479,6 +505,71 @@ impl InboundWgService for NoopInboundWgService {
     ) -> Result<Vec<wardnetd_services::InboundWgMonitorPeer>, wardnetd_services::error::AppError>
     {
         Ok(Vec::new())
+    }
+    async fn reconcile(&self) -> Result<(), wardnetd_services::error::AppError> {
+        Ok(())
+    }
+}
+
+/// No-op [`PrivateDnsService`] used as the [`AppState::new`] default before the
+/// live service is injected via [`AppState::with_private_dns_service`]
+/// (issues #912/#914). Reads that would otherwise error return empty; the rest
+/// report "not configured".
+struct NoopPrivateDnsService;
+
+#[async_trait::async_trait]
+impl PrivateDnsService for NoopPrivateDnsService {
+    async fn status(
+        &self,
+    ) -> Result<wardnetd_services::private_dns::PrivateDnsStatus, wardnetd_services::error::AppError>
+    {
+        Err(wardnetd_services::error::AppError::Internal(
+            anyhow::anyhow!("private-dns service not configured"),
+        ))
+    }
+    async fn is_enabled(&self) -> Result<bool, wardnetd_services::error::AppError> {
+        Ok(false)
+    }
+    async fn set_enabled(
+        &self,
+        _enabled: bool,
+    ) -> Result<wardnetd_services::private_dns::PrivateDnsStatus, wardnetd_services::error::AppError>
+    {
+        Err(wardnetd_services::error::AppError::Internal(
+            anyhow::anyhow!("private-dns service not configured"),
+        ))
+    }
+    async fn grant_device(
+        &self,
+        _device_id: uuid::Uuid,
+    ) -> Result<wardnetd_services::private_dns::PrivateDnsGrant, wardnetd_services::error::AppError>
+    {
+        Err(wardnetd_services::error::AppError::Internal(
+            anyhow::anyhow!("private-dns service not configured"),
+        ))
+    }
+    async fn revoke_grant(
+        &self,
+        _grant_id: uuid::Uuid,
+    ) -> Result<(), wardnetd_services::error::AppError> {
+        Ok(())
+    }
+    async fn list_grants(
+        &self,
+    ) -> Result<
+        Vec<wardnetd_services::private_dns::PrivateDnsGrant>,
+        wardnetd_services::error::AppError,
+    > {
+        Ok(Vec::new())
+    }
+    async fn resolve_token(
+        &self,
+        _token: &str,
+    ) -> Result<
+        Option<wardnetd_services::private_dns::PrivateDnsGrant>,
+        wardnetd_services::error::AppError,
+    > {
+        Ok(None)
     }
     async fn reconcile(&self) -> Result<(), wardnetd_services::error::AppError> {
         Ok(())

--- a/source/daemon/crates/wardnetd-mock/Cargo.toml
+++ b/source/daemon/crates/wardnetd-mock/Cargo.toml
@@ -36,6 +36,8 @@ clap.workspace = true
 ipnetwork.workspace = true
 # https://crates.io/crates/rand
 rand.workspace = true
+# https://crates.io/crates/rcgen — self-signed cert for the mock's signed Private DNS profile
+rcgen.workspace = true
 # https://crates.io/crates/reqwest
 reqwest.workspace = true
 # https://crates.io/crates/serde

--- a/source/daemon/crates/wardnetd-mock/src/backends/mod.rs
+++ b/source/daemon/crates/wardnetd-mock/src/backends/mod.rs
@@ -19,6 +19,7 @@ pub mod noop_latency_prober;
 pub mod noop_network_inspector;
 pub mod noop_network_probe;
 pub mod noop_power_ops;
+pub mod noop_private_dns;
 pub mod noop_remote_access;
 pub mod noop_routing;
 pub mod noop_throughput_tester;

--- a/source/daemon/crates/wardnetd-mock/src/backends/noop_private_dns.rs
+++ b/source/daemon/crates/wardnetd-mock/src/backends/noop_private_dns.rs
@@ -1,0 +1,181 @@
+//! In-memory Private DNS service for the mock (issues #912/#914).
+//!
+//! The real [`PrivateDnsServiceImpl`](wardnetd_services::private_dns) is wired
+//! to the live DDNS/TLS services and secret store; in the mock those are the
+//! offline stand-ins (`noop_remote_access`), so — exactly as the mock swaps in
+//! `MockDdnsService`/`MockTlsService` — it swaps in this stateful fake. It backs
+//! the full admin flow (enable, grant, revoke) against in-memory state and signs
+//! a real `.mobileconfig` with a one-off self-signed cert so the profile
+//! download works offline.
+
+use std::sync::Mutex;
+
+use async_trait::async_trait;
+use chrono::Utc;
+use rand::RngExt;
+use uuid::Uuid;
+use wardnetd_services::error::AppError;
+use wardnetd_services::private_dns::profile;
+use wardnetd_services::private_dns::{PrivateDnsGrant, PrivateDnsService, PrivateDnsStatus};
+
+/// The demo wardnet domain grants live under — matches the mock's demo DDNS
+/// host (`noop_remote_access::configure_demo`) so the UI reads coherently.
+const DEMO_DOMAIN: &str = "home1.demo.wardnet.services";
+
+/// RFC 4648 base-32 alphabet, lowercased — mirrors the real token minting.
+const BASE32_ALPHABET: &[u8; 32] = b"abcdefghijklmnopqrstuvwxyz234567";
+
+struct Inner {
+    enabled: bool,
+    grants: Vec<PrivateDnsGrant>,
+}
+
+/// Stateful in-memory [`PrivateDnsService`]. Provisioned and enabled out of the
+/// box (the mock always stands in for a fully subscribed box).
+pub struct MockPrivateDnsService {
+    inner: Mutex<Inner>,
+    /// A one-off self-signed P-256 cert/key, standing in for the box's live
+    /// Let's Encrypt pair so `device_profile` can produce a signed profile.
+    cert_pem: Vec<u8>,
+    key_pem: Vec<u8>,
+}
+
+impl Default for MockPrivateDnsService {
+    fn default() -> Self {
+        let key_pair = rcgen::KeyPair::generate().expect("mock: generate profile keypair");
+        let cert = rcgen::CertificateParams::new(vec![format!("*.{DEMO_DOMAIN}")])
+            .expect("mock: cert params")
+            .self_signed(&key_pair)
+            .expect("mock: self-sign profile cert");
+        Self {
+            inner: Mutex::new(Inner {
+                enabled: true,
+                grants: Vec::new(),
+            }),
+            cert_pem: cert.pem().into_bytes(),
+            key_pem: key_pair.serialize_pem().into_bytes(),
+        }
+    }
+}
+
+impl MockPrivateDnsService {
+    fn mint_token() -> String {
+        let mut rng = rand::rng();
+        (0..16)
+            .map(|_| char::from(BASE32_ALPHABET[rng.random_range(0..32)]))
+            .collect()
+    }
+
+    fn hostname(token: &str) -> String {
+        format!("{token}.{DEMO_DOMAIN}")
+    }
+}
+
+#[async_trait]
+impl PrivateDnsService for MockPrivateDnsService {
+    async fn status(&self) -> Result<PrivateDnsStatus, AppError> {
+        Ok(PrivateDnsStatus {
+            enabled: self.inner.lock().unwrap().enabled,
+            domain: Some(DEMO_DOMAIN.to_owned()),
+        })
+    }
+
+    async fn is_enabled(&self) -> Result<bool, AppError> {
+        Ok(self.inner.lock().unwrap().enabled)
+    }
+
+    async fn set_enabled(&self, enabled: bool) -> Result<PrivateDnsStatus, AppError> {
+        self.inner.lock().unwrap().enabled = enabled;
+        Ok(PrivateDnsStatus {
+            enabled,
+            domain: Some(DEMO_DOMAIN.to_owned()),
+        })
+    }
+
+    async fn grant_device(&self, device_id: Uuid) -> Result<PrivateDnsGrant, AppError> {
+        let mut inner = self.inner.lock().unwrap();
+        if !inner.enabled {
+            return Err(AppError::Conflict("Private DNS is disabled".to_owned()));
+        }
+        if inner.grants.iter().any(|g| g.device_id == device_id) {
+            return Err(AppError::Conflict(
+                "device already has a Private DNS grant".to_owned(),
+            ));
+        }
+        let grant = PrivateDnsGrant {
+            id: Uuid::new_v4(),
+            device_id,
+            token: Self::mint_token(),
+            created_at: Utc::now().format("%Y-%m-%dT%H:%M:%SZ").to_string(),
+        };
+        inner.grants.push(grant.clone());
+        Ok(grant)
+    }
+
+    async fn revoke_grant(&self, grant_id: Uuid) -> Result<(), AppError> {
+        let mut inner = self.inner.lock().unwrap();
+        let before = inner.grants.len();
+        inner.grants.retain(|g| g.id != grant_id);
+        if inner.grants.len() == before {
+            return Err(AppError::NotFound(format!("grant {grant_id} not found")));
+        }
+        Ok(())
+    }
+
+    async fn list_grants(&self) -> Result<Vec<PrivateDnsGrant>, AppError> {
+        Ok(self.inner.lock().unwrap().grants.clone())
+    }
+
+    async fn device_grant(&self, device_id: Uuid) -> Result<Option<PrivateDnsGrant>, AppError> {
+        Ok(self
+            .inner
+            .lock()
+            .unwrap()
+            .grants
+            .iter()
+            .find(|g| g.device_id == device_id)
+            .cloned())
+    }
+
+    async fn device_profile(&self, device_id: Uuid) -> Result<Option<Vec<u8>>, AppError> {
+        let (enabled, grant) = {
+            let inner = self.inner.lock().unwrap();
+            (
+                inner.enabled,
+                inner
+                    .grants
+                    .iter()
+                    .find(|g| g.device_id == device_id)
+                    .cloned(),
+            )
+        };
+        if !enabled {
+            return Ok(None);
+        }
+        let Some(grant) = grant else {
+            return Ok(None);
+        };
+        let signed = profile::build_signed_profile(
+            &Self::hostname(&grant.token),
+            &self.cert_pem,
+            &self.key_pem,
+        )
+        .map_err(|e| AppError::Internal(anyhow::anyhow!(e)))?;
+        Ok(Some(signed))
+    }
+
+    async fn resolve_token(&self, token: &str) -> Result<Option<PrivateDnsGrant>, AppError> {
+        Ok(self
+            .inner
+            .lock()
+            .unwrap()
+            .grants
+            .iter()
+            .find(|g| g.token == token)
+            .cloned())
+    }
+
+    async fn reconcile(&self) -> Result<(), AppError> {
+        Ok(())
+    }
+}

--- a/source/daemon/crates/wardnetd-mock/src/main.rs
+++ b/source/daemon/crates/wardnetd-mock/src/main.rs
@@ -31,6 +31,7 @@ use wardnetd_mock::backends::noop_latency_prober::NoopLatencyProber;
 use wardnetd_mock::backends::noop_network_inspector::NoopNetworkInspector;
 use wardnetd_mock::backends::noop_network_probe::NoopNetworkProbe;
 use wardnetd_mock::backends::noop_power_ops::NoopSystemPowerOps;
+use wardnetd_mock::backends::noop_private_dns::MockPrivateDnsService;
 use wardnetd_mock::backends::noop_remote_access::{
     MockDdnsService, MockRemoteAccessState, MockTlsService,
 };
@@ -401,6 +402,9 @@ async fn run(
     )
     .with_push_service(services.push.clone())
     .with_inbound_wg_service(services.inbound_wg.clone())
+    // Private DNS reaches the live DDNS/TLS/secret store, which the mock stands
+    // in for offline; swap in the stateful in-memory fake, mirroring DDNS/TLS.
+    .with_private_dns_service(Arc::new(MockPrivateDnsService::default()))
     .with_entitlement(services.entitlement.clone())
     .with_health_monitor(health_monitor);
 

--- a/source/daemon/crates/wardnetd-services/Cargo.toml
+++ b/source/daemon/crates/wardnetd-services/Cargo.toml
@@ -99,6 +99,18 @@ instant-acme.workspace = true
 rcgen.workspace = true
 # https://crates.io/crates/x509-parser — parse cert `not_after` for renewal scheduling
 x509-parser.workspace = true
+# https://crates.io/crates/cms — CMS SignedData for the signed iOS `.mobileconfig` (#914)
+cms.workspace = true
+# https://crates.io/crates/x509-cert — parse the leaf chain for the CMS signer + certificates set
+x509-cert.workspace = true
+# https://crates.io/crates/p256 — sign the CMS SignerInfo with the leaf's ECDSA P-256 key
+p256.workspace = true
+# https://crates.io/crates/der — encode the profile bytes as the CMS encapsulated content
+der.workspace = true
+# https://crates.io/crates/const-oid — id-data / SHA-256 OIDs for the CMS structure
+const-oid.workspace = true
+# https://crates.io/crates/spki — SHA-256 / ECDSA AlgorithmIdentifiers for the CMS structure
+spki.workspace = true
 # https://crates.io/crates/web-push-native — Web Push encryption + VAPID signing
 web-push-native.workspace = true
 # https://crates.io/crates/http — name the http::Request web-push-native returns

--- a/source/daemon/crates/wardnetd-services/src/lib.rs
+++ b/source/daemon/crates/wardnetd-services/src/lib.rs
@@ -691,6 +691,7 @@ fn create_services(
         dns_local_service.clone(),
         entitlement.clone(),
         event_publisher.clone(),
+        backends.secret_store.clone(),
         lan_ip,
     ));
 

--- a/source/daemon/crates/wardnetd-services/src/private_dns/mod.rs
+++ b/source/daemon/crates/wardnetd-services/src/private_dns/mod.rs
@@ -26,6 +26,7 @@
 //! the LAN resolve their secret hostname straight to the Pi and reach the
 //! local `:853` listener without hairpinning.
 
+pub mod profile;
 pub mod runner;
 
 #[cfg(test)]
@@ -52,6 +53,7 @@ use crate::dns_local::DnsLocalService;
 use crate::entitlement::Entitlement;
 use crate::error::AppError;
 use crate::event::EventPublisher;
+use crate::secret_store::SecretStore;
 use crate::tls::{TlsService, TlsStatus};
 
 /// TTL (seconds) for the split-horizon wildcard system record. Mirrors the
@@ -176,6 +178,24 @@ pub trait PrivateDnsService: Send + Sync {
     /// Every grant, oldest first.
     async fn list_grants(&self) -> Result<Vec<PrivateDnsGrant>, AppError>;
 
+    /// This device's grant, or `None` if it has none. Backs the device-keyed
+    /// `GET /api/private-dns/me` surface, whose handler has already resolved
+    /// the device by source IP and calls this under an internal admin context.
+    /// A default `Ok(None)` keeps test doubles that predate it compiling.
+    async fn device_grant(&self, device_id: Uuid) -> Result<Option<PrivateDnsGrant>, AppError> {
+        let _ = device_id;
+        Ok(None)
+    }
+
+    /// The signed `.mobileconfig` for this device, or `None` when the device
+    /// isn't granted, the feature is disabled, or the wardnet domain / cert
+    /// isn't available yet (all of which surface as a 404). Backs the
+    /// device-keyed `GET /api/private-dns/me/profile`. Defaults to `Ok(None)`.
+    async fn device_profile(&self, device_id: Uuid) -> Result<Option<Vec<u8>>, AppError> {
+        let _ = device_id;
+        Ok(None)
+    }
+
     /// Resolve a `DoT` SNI token label to its grant, or `None` for an unknown
     /// token (the listener closes those connections). Pure lookup — the
     /// listener decides policy.
@@ -201,6 +221,9 @@ pub struct PrivateDnsServiceImpl {
     dns_local: Arc<dyn DnsLocalService>,
     entitlement: Arc<Entitlement>,
     events: Arc<dyn EventPublisher>,
+    /// Source of the live Let's Encrypt cert/key used to CMS-sign the iOS
+    /// `.mobileconfig` (issue #914). Reached only from `device_profile`.
+    secrets: Arc<dyn SecretStore>,
     /// The Pi's LAN-interface IPv4 — the value of the wildcard record.
     lan_ip: Ipv4Addr,
 }
@@ -217,6 +240,7 @@ impl PrivateDnsServiceImpl {
         dns_local: Arc<dyn DnsLocalService>,
         entitlement: Arc<Entitlement>,
         events: Arc<dyn EventPublisher>,
+        secrets: Arc<dyn SecretStore>,
         lan_ip: Ipv4Addr,
     ) -> Self {
         Self {
@@ -228,8 +252,19 @@ impl PrivateDnsServiceImpl {
             dns_local,
             entitlement,
             events,
+            secrets,
             lan_ip,
         }
+    }
+
+    /// This device's grant row mapped to a [`PrivateDnsGrant`], or `None`.
+    async fn grant_for_device(&self, device_id: Uuid) -> Result<Option<PrivateDnsGrant>, AppError> {
+        let row = self
+            .grants
+            .find_by_device_id(&device_id.to_string())
+            .await
+            .map_err(AppError::Internal)?;
+        row.as_ref().map(PrivateDnsGrant::from_row).transpose()
     }
 
     fn require_entitled(&self) -> Result<(), AppError> {
@@ -495,6 +530,39 @@ impl PrivateDnsService for PrivateDnsServiceImpl {
         auth_context::require_admin()?;
         let rows = self.grants.find_all().await.map_err(AppError::Internal)?;
         rows.iter().map(PrivateDnsGrant::from_row).collect()
+    }
+
+    async fn device_grant(&self, device_id: Uuid) -> Result<Option<PrivateDnsGrant>, AppError> {
+        auth_context::require_admin()?;
+        self.grant_for_device(device_id).await
+    }
+
+    async fn device_profile(&self, device_id: Uuid) -> Result<Option<Vec<u8>>, AppError> {
+        auth_context::require_admin()?;
+
+        // Every miss here is a legitimate 404, not an error: an ungranted or
+        // disabled device simply has no profile, and a box without the wardnet
+        // domain / issued cert can't mint one yet.
+        if !self.enabled().await? {
+            return Ok(None);
+        }
+        let Some(domain) = self.wardnet_domain().await? else {
+            return Ok(None);
+        };
+        let Some(grant) = self.grant_for_device(device_id).await? else {
+            return Ok(None);
+        };
+        let Some((chain_pem, key_pem)) = crate::tls::load_stored_cert(self.secrets.as_ref())
+            .await
+            .map_err(AppError::Internal)?
+        else {
+            return Ok(None);
+        };
+
+        let hostname = format!("{}.{}", grant.token, domain);
+        let signed = profile::build_signed_profile(&hostname, &chain_pem, &key_pem)
+            .map_err(|e| AppError::Internal(anyhow::anyhow!(e)))?;
+        Ok(Some(signed))
     }
 
     async fn resolve_token(&self, token: &str) -> Result<Option<PrivateDnsGrant>, AppError> {

--- a/source/daemon/crates/wardnetd-services/src/private_dns/profile.rs
+++ b/source/daemon/crates/wardnetd-services/src/private_dns/profile.rs
@@ -1,0 +1,307 @@
+//! Signed iOS configuration-profile (`.mobileconfig`) generation (issue #914).
+//!
+//! iOS has no programmatic Private-DNS API, so a granted device installs an
+//! encrypted-DNS **configuration profile**: a `com.apple.dnsSettings.managed`
+//! payload carrying `DNSProtocol=TLS` and the device's secret `ServerName`.
+//! `ServerAddresses` is deliberately omitted — the hostname is a DDNS name that
+//! split-horizon resolves to the Pi on the LAN and to the regional edge while
+//! roaming, so pinning an address would break one of those paths. No
+//! `OnDemandRules` either: iOS already auto-exempts captive-portal probing for
+//! managed DNS, and an always-on rule would strand the phone behind hotel
+//! logins.
+//!
+//! The profile is **CMS-signed with the box's live Let's Encrypt leaf** so iOS
+//! renders it green ("Verified") instead of the scary "Not Signed" banner. The
+//! signature is a standard PKCS#7 / RFC 5652 `SignedData` over the plist, with
+//! the leaf (and its issuing intermediate) embedded so the phone can build a
+//! path to the ISRG root already in its trust store.
+//!
+//! Identifiers are **`UUIDv5`**, derived from the hostname: re-downloading the
+//! profile yields byte-identical identifiers, so iOS *replaces* the existing
+//! profile in place rather than stacking a second copy.
+
+use const_oid::ObjectIdentifier;
+use der::asn1::{OctetString, SetOfVec};
+use der::{Any, Encode, Tag};
+use p256::ecdsa::signature::Signer;
+use p256::ecdsa::{DerSignature, SigningKey};
+use p256::pkcs8::DecodePrivateKey;
+use sha2::{Digest, Sha256};
+use spki::AlgorithmIdentifierOwned;
+use uuid::Uuid;
+use x509_cert::Certificate;
+use x509_cert::attr::Attribute;
+
+use cms::cert::{CertificateChoices, IssuerAndSerialNumber};
+use cms::content_info::{CmsVersion, ContentInfo};
+use cms::signed_data::{
+    CertificateSet, EncapsulatedContentInfo, SignedData, SignerIdentifier, SignerInfo, SignerInfos,
+};
+
+/// Apple's content type for a downloadable configuration profile. Safari keys
+/// its install flow off this exact string, so the endpoint must serve it
+/// verbatim.
+pub const MOBILECONFIG_CONTENT_TYPE: &str = "application/x-apple-aspen-config";
+
+/// Reverse-DNS prefix for the profile's payload identifiers. Combined with the
+/// per-device hostname it yields a stable, collision-free identity per grant.
+const PAYLOAD_ID_PREFIX: &str = "services.wardnet.private-dns";
+
+/// User-facing name shown in iOS Settings › General › VPN & Device Management.
+const DISPLAY_NAME: &str = "wardnet Private DNS";
+
+/// Fixed namespace for the `UUIDv5` payload identifiers. A private, arbitrary
+/// constant — its only job is to keep the derived UUIDs stable across
+/// re-downloads and disjoint from any other `UUIDv5` space.
+const PROFILE_UUID_NAMESPACE: Uuid = Uuid::from_u128(0x9f2c_6d1a_4b83_5e70_a1c4_8f6b_2d09_e357);
+
+/// id-data (`1.2.840.113549.1.7.1`) — the CMS encapsulated content type for an
+/// opaque octet payload (the plist).
+const ID_DATA: ObjectIdentifier = ObjectIdentifier::new_unwrap("1.2.840.113549.1.7.1");
+
+/// id-signedData (`1.2.840.113549.1.7.2`) — the outer `ContentInfo` type.
+const ID_SIGNED_DATA: ObjectIdentifier = ObjectIdentifier::new_unwrap("1.2.840.113549.1.7.2");
+
+/// id-sha256 (`2.16.840.1.101.3.4.2.1`) — the digest algorithm for the
+/// `SignedData` and the signer's `messageDigest` attribute.
+const ID_SHA256: ObjectIdentifier = ObjectIdentifier::new_unwrap("2.16.840.1.101.3.4.2.1");
+
+/// ecdsa-with-SHA256 (`1.2.840.10045.4.3.2`) — the leaf's signature algorithm.
+const ID_ECDSA_SHA256: ObjectIdentifier = ObjectIdentifier::new_unwrap("1.2.840.10045.4.3.2");
+
+/// id-contentType (`1.2.840.113549.1.9.3`) — the signed attribute that pins the
+/// wrapped content type (RFC 5652 §11.1).
+const ID_CONTENT_TYPE: ObjectIdentifier = ObjectIdentifier::new_unwrap("1.2.840.113549.1.9.3");
+
+/// id-messageDigest (`1.2.840.113549.1.9.4`) — the signed attribute carrying the
+/// content digest (RFC 5652 §11.2).
+const ID_MESSAGE_DIGEST: ObjectIdentifier = ObjectIdentifier::new_unwrap("1.2.840.113549.1.9.4");
+
+/// Something went wrong producing the signed profile. All variants are
+/// operator-facing (missing/garbled cert material, a signer that can't sign);
+/// none are reachable through user input.
+#[derive(Debug, thiserror::Error)]
+pub enum ProfileError {
+    /// The stored certificate chain was empty or not valid PEM.
+    #[error("could not parse the certificate chain: {0}")]
+    Certificate(String),
+    /// The stored private key was not a PKCS#8 P-256 key.
+    #[error("could not parse the signing key: {0}")]
+    Key(String),
+    /// Assembling or DER-encoding the CMS `SignedData` failed.
+    #[error("could not build the CMS signature: {0}")]
+    Cms(String),
+}
+
+/// Render the (unsigned) `.mobileconfig` plist for `hostname`.
+///
+/// Pure and deterministic — the same hostname always yields byte-identical
+/// output (identifiers included), which is what lets a re-download replace the
+/// installed profile instead of stacking a duplicate.
+#[must_use]
+pub fn build_plist(hostname: &str) -> String {
+    let escaped = xml_escape(hostname);
+    let top_uuid = payload_uuid("config", hostname);
+    let dns_uuid = payload_uuid("dns", hostname);
+    let top_id = format!("{PAYLOAD_ID_PREFIX}.{hostname}");
+    let dns_id = format!("{top_id}.dns");
+    let top_id = xml_escape(&top_id);
+    let dns_id = xml_escape(&dns_id);
+
+    // Hand-rolled rather than via a plist crate: the schema is tiny and fixed,
+    // and a literal template keeps the golden-file test honest about the exact
+    // bytes iOS receives.
+    format!(
+        r#"<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>PayloadContent</key>
+	<array>
+		<dict>
+			<key>DNSSettings</key>
+			<dict>
+				<key>DNSProtocol</key>
+				<string>TLS</string>
+				<key>ServerName</key>
+				<string>{escaped}</string>
+			</dict>
+			<key>PayloadDisplayName</key>
+			<string>{DISPLAY_NAME}</string>
+			<key>PayloadIdentifier</key>
+			<string>{dns_id}</string>
+			<key>PayloadType</key>
+			<string>com.apple.dnsSettings.managed</string>
+			<key>PayloadUUID</key>
+			<string>{dns_uuid}</string>
+			<key>PayloadVersion</key>
+			<integer>1</integer>
+		</dict>
+	</array>
+	<key>PayloadDisplayName</key>
+	<string>{DISPLAY_NAME}</string>
+	<key>PayloadIdentifier</key>
+	<string>{top_id}</string>
+	<key>PayloadRemovalDisallowed</key>
+	<false/>
+	<key>PayloadType</key>
+	<string>Configuration</string>
+	<key>PayloadUUID</key>
+	<string>{top_uuid}</string>
+	<key>PayloadVersion</key>
+	<integer>1</integer>
+</dict>
+</plist>
+"#
+    )
+}
+
+/// Build the signed `.mobileconfig` for `hostname`: render the plist, then wrap
+/// it in a CMS `SignedData` under the box's live cert/key.
+///
+/// `cert_chain_pem` is the leaf-first Let's Encrypt chain and `key_pem` the
+/// leaf's PKCS#8 private key — exactly the pair
+/// [`crate::tls::load_stored_cert`] returns.
+pub fn build_signed_profile(
+    hostname: &str,
+    cert_chain_pem: &[u8],
+    key_pem: &[u8],
+) -> Result<Vec<u8>, ProfileError> {
+    let plist = build_plist(hostname);
+    sign(plist.as_bytes(), cert_chain_pem, key_pem)
+}
+
+/// CMS-sign `payload` with the leaf of `cert_chain_pem` (and embed the full
+/// chain), producing a DER `ContentInfo` of type `signedData` with the payload
+/// attached.
+pub fn sign(
+    payload: &[u8],
+    cert_chain_pem: &[u8],
+    key_pem: &[u8],
+) -> Result<Vec<u8>, ProfileError> {
+    let certs = Certificate::load_pem_chain(cert_chain_pem)
+        .map_err(|e| ProfileError::Certificate(e.to_string()))?;
+    let leaf = certs
+        .first()
+        .ok_or_else(|| ProfileError::Certificate("empty chain".to_owned()))?;
+
+    let key_pem = std::str::from_utf8(key_pem)
+        .map_err(|e| ProfileError::Key(format!("key PEM is not UTF-8: {e}")))?;
+    let signing_key =
+        SigningKey::from_pkcs8_pem(key_pem).map_err(|e| ProfileError::Key(e.to_string()))?;
+
+    // Attach the plist as the encapsulated content (id-data OCTET STRING).
+    let econtent = Any::new(Tag::OctetString, payload).map_err(cms_err)?;
+    let encap = EncapsulatedContentInfo {
+        econtent_type: ID_DATA,
+        econtent: Some(econtent),
+    };
+
+    let sha256 = AlgorithmIdentifierOwned {
+        oid: ID_SHA256,
+        parameters: None,
+    };
+
+    // Signed attributes: contentType (must equal the eContentType) and
+    // messageDigest = SHA-256 of the eContent *value* octets (RFC 5652 §5.4).
+    let content_type_attr = attribute(
+        ID_CONTENT_TYPE,
+        Any::encode_from(&ID_DATA).map_err(cms_err)?,
+    )?;
+    let digest = Sha256::digest(payload);
+    let message_digest_attr = attribute(
+        ID_MESSAGE_DIGEST,
+        Any::new(Tag::OctetString, digest.as_slice()).map_err(cms_err)?,
+    )?;
+    let signed_attrs: SetOfVec<Attribute> =
+        SetOfVec::try_from(vec![content_type_attr, message_digest_attr]).map_err(cms_err)?;
+
+    // Sign the DER of the attributes as a universal SET (0x31) — distinct from
+    // the [0] IMPLICIT tag they carry on the wire inside the SignerInfo.
+    let tbs = signed_attrs.to_der().map_err(cms_err)?;
+    let signature: DerSignature = signing_key.sign(&tbs);
+    let signature = OctetString::new(signature.to_bytes()).map_err(cms_err)?;
+
+    // The signer is identified by the leaf's issuer + serial; the leaf's key
+    // signs, so its algorithm (ECDSA-P256-SHA256) is what iOS verifies against.
+    let signer_info = SignerInfo {
+        version: CmsVersion::V1,
+        sid: SignerIdentifier::IssuerAndSerialNumber(IssuerAndSerialNumber {
+            issuer: leaf.tbs_certificate.issuer.clone(),
+            serial_number: leaf.tbs_certificate.serial_number.clone(),
+        }),
+        digest_alg: sha256.clone(),
+        signed_attrs: Some(signed_attrs),
+        signature_algorithm: AlgorithmIdentifierOwned {
+            oid: ID_ECDSA_SHA256,
+            parameters: None,
+        },
+        signature,
+        unsigned_attrs: None,
+    };
+
+    // Embed the leaf (+ issuing intermediate) so iOS can build a path to the
+    // ISRG root already in its trust store.
+    let certificate_set = CertificateSet::try_from(
+        certs
+            .into_iter()
+            .map(CertificateChoices::Certificate)
+            .collect::<Vec<_>>(),
+    )
+    .map_err(cms_err)?;
+
+    let signed_data = SignedData {
+        version: CmsVersion::V1,
+        digest_algorithms: SetOfVec::try_from(vec![sha256]).map_err(cms_err)?,
+        encap_content_info: encap,
+        certificates: Some(certificate_set),
+        crls: None,
+        signer_infos: SignerInfos(SetOfVec::try_from(vec![signer_info]).map_err(cms_err)?),
+    };
+
+    let content_info = ContentInfo {
+        content_type: ID_SIGNED_DATA,
+        content: Any::encode_from(&signed_data).map_err(cms_err)?,
+    };
+    content_info.to_der().map_err(cms_err)
+}
+
+/// Wrap a single-valued CMS attribute (`oid` → `{ value }`).
+fn attribute(oid: ObjectIdentifier, value: Any) -> Result<Attribute, ProfileError> {
+    Ok(Attribute {
+        oid,
+        values: SetOfVec::try_from(vec![value]).map_err(cms_err)?,
+    })
+}
+
+/// Map any DER error from CMS assembly onto [`ProfileError::Cms`].
+fn cms_err(e: der::Error) -> ProfileError {
+    ProfileError::Cms(e.to_string())
+}
+
+/// Derive a stable `UUIDv5` for `role` (`config` / `dns`) under `hostname`, so
+/// re-downloads replace rather than stack the installed profile.
+fn payload_uuid(role: &str, hostname: &str) -> Uuid {
+    Uuid::new_v5(
+        &PROFILE_UUID_NAMESPACE,
+        format!("{role}:{hostname}").as_bytes(),
+    )
+}
+
+/// Escape the five XML metacharacters. The interpolated values (hostname,
+/// identifiers) are daemon-minted and never contain them today, but a mangled
+/// grant must never be able to break out of a `<string>` element.
+fn xml_escape(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for c in s.chars() {
+        match c {
+            '&' => out.push_str("&amp;"),
+            '<' => out.push_str("&lt;"),
+            '>' => out.push_str("&gt;"),
+            '"' => out.push_str("&quot;"),
+            '\'' => out.push_str("&apos;"),
+            _ => out.push(c),
+        }
+    }
+    out
+}

--- a/source/daemon/crates/wardnetd-services/src/private_dns/tests/mod.rs
+++ b/source/daemon/crates/wardnetd-services/src/private_dns/tests/mod.rs
@@ -1,2 +1,3 @@
+mod profile;
 mod runner;
 mod service;

--- a/source/daemon/crates/wardnetd-services/src/private_dns/tests/profile.golden.mobileconfig
+++ b/source/daemon/crates/wardnetd-services/src/private_dns/tests/profile.golden.mobileconfig
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>PayloadContent</key>
+	<array>
+		<dict>
+			<key>DNSSettings</key>
+			<dict>
+				<key>DNSProtocol</key>
+				<string>TLS</string>
+				<key>ServerName</key>
+				<string>abcdefghijklmnop.casa.my.wardnet.services</string>
+			</dict>
+			<key>PayloadDisplayName</key>
+			<string>wardnet Private DNS</string>
+			<key>PayloadIdentifier</key>
+			<string>services.wardnet.private-dns.abcdefghijklmnop.casa.my.wardnet.services.dns</string>
+			<key>PayloadType</key>
+			<string>com.apple.dnsSettings.managed</string>
+			<key>PayloadUUID</key>
+			<string>5010f8b2-ac7e-567f-bb57-15ebbdab74e1</string>
+			<key>PayloadVersion</key>
+			<integer>1</integer>
+		</dict>
+	</array>
+	<key>PayloadDisplayName</key>
+	<string>wardnet Private DNS</string>
+	<key>PayloadIdentifier</key>
+	<string>services.wardnet.private-dns.abcdefghijklmnop.casa.my.wardnet.services</string>
+	<key>PayloadRemovalDisallowed</key>
+	<false/>
+	<key>PayloadType</key>
+	<string>Configuration</string>
+	<key>PayloadUUID</key>
+	<string>154b1e78-8c24-57c5-8bfa-42ec1df2d5fd</string>
+	<key>PayloadVersion</key>
+	<integer>1</integer>
+</dict>
+</plist>

--- a/source/daemon/crates/wardnetd-services/src/private_dns/tests/profile.rs
+++ b/source/daemon/crates/wardnetd-services/src/private_dns/tests/profile.rs
@@ -1,0 +1,141 @@
+//! Tests for the signed `.mobileconfig` generator (issue #914).
+
+use cms::content_info::ContentInfo;
+use cms::signed_data::SignedData;
+use const_oid::ObjectIdentifier;
+use der::asn1::OctetString;
+use der::{Decode, Encode};
+use p256::ecdsa::signature::Verifier;
+use p256::ecdsa::{DerSignature, SigningKey, VerifyingKey};
+use p256::pkcs8::DecodePrivateKey;
+
+use crate::private_dns::profile::{build_plist, build_signed_profile, sign};
+
+/// id-signedData (`1.2.840.113549.1.7.2`).
+const ID_SIGNED_DATA: ObjectIdentifier = ObjectIdentifier::new_unwrap("1.2.840.113549.1.7.2");
+
+const GOLDEN_HOST: &str = "abcdefghijklmnop.casa.my.wardnet.services";
+
+/// A self-signed P-256 leaf + PKCS#8 key, standing in for the box's live
+/// Let's Encrypt pair (rcgen defaults to P-256, matching the real leaf).
+fn self_signed_pem() -> (Vec<u8>, Vec<u8>) {
+    let key_pair = rcgen::KeyPair::generate().expect("keypair");
+    let params = rcgen::CertificateParams::new(vec![GOLDEN_HOST.to_owned()]).expect("cert params");
+    let cert = params.self_signed(&key_pair).expect("self-sign");
+    (
+        cert.pem().into_bytes(),
+        key_pair.serialize_pem().into_bytes(),
+    )
+}
+
+/// The value of the first `<key>PayloadUUID</key>` in a plist (the payload's).
+fn extract_first_uuid(plist: &str) -> &str {
+    let marker = "<key>PayloadUUID</key>";
+    let after = &plist[plist.find(marker).expect("PayloadUUID key") + marker.len()..];
+    let open = after.find("<string>").expect("uuid open") + "<string>".len();
+    let close = after.find("</string>").expect("uuid close");
+    &after[open..close]
+}
+
+#[test]
+fn plist_matches_golden() {
+    let golden = include_str!("profile.golden.mobileconfig");
+    assert_eq!(build_plist(GOLDEN_HOST), golden);
+}
+
+#[test]
+fn plist_omits_addresses_and_ondemand() {
+    // DDNS-friendly bootstrap: never pin an address, and let iOS handle
+    // captive portals rather than an always-on OnDemand rule.
+    let plist = build_plist(GOLDEN_HOST);
+    assert!(plist.contains("<key>DNSProtocol</key>"));
+    assert!(plist.contains("<string>TLS</string>"));
+    assert!(plist.contains(&format!("<string>{GOLDEN_HOST}</string>")));
+    assert!(!plist.contains("ServerAddresses"));
+    assert!(!plist.contains("OnDemandRules"));
+}
+
+#[test]
+fn identifiers_are_stable_across_rebuilds() {
+    // Byte-identical output for the same host is what lets a re-download
+    // replace the installed profile instead of stacking a duplicate.
+    assert_eq!(build_plist(GOLDEN_HOST), build_plist(GOLDEN_HOST));
+}
+
+#[test]
+fn identifiers_differ_between_hosts() {
+    let a = build_plist("aaaa1111bbbb2222.casa.my.wardnet.services");
+    let b = build_plist("cccc3333dddd4444.casa.my.wardnet.services");
+    assert_ne!(a, b);
+    // The UUIDs specifically must differ (not just the ServerName), or iOS
+    // would treat two devices' profiles as the same installed payload.
+    let uuid_a = extract_first_uuid(&a);
+    let uuid_b = extract_first_uuid(&b);
+    assert_ne!(uuid_a, uuid_b);
+}
+
+#[test]
+fn xml_metacharacters_are_escaped() {
+    // A hostname can't contain these today, but a mangled grant must never
+    // break out of the <string> element.
+    let plist = build_plist("a&b<c>d\"e'f.example.test");
+    assert!(plist.contains("a&amp;b&lt;c&gt;d&quot;e&apos;f.example.test"));
+    // No raw metacharacter leaked into the interpolated value.
+    assert!(!plist.contains("a&b<c>d"));
+}
+
+#[test]
+fn signed_profile_is_valid_cms_signeddata() {
+    let (chain, key) = self_signed_pem();
+    let signed = build_signed_profile(GOLDEN_HOST, &chain, &key).expect("sign");
+
+    let ci = ContentInfo::from_der(&signed).expect("parse ContentInfo");
+    assert_eq!(ci.content_type, ID_SIGNED_DATA);
+
+    let sd = SignedData::from_der(&ci.content.to_der().unwrap()).expect("parse SignedData");
+
+    // The leaf is embedded so iOS can build the path to the ISRG root.
+    let certs = sd.certificates.as_ref().expect("certificates present");
+    assert_eq!(certs.0.len(), 1);
+
+    // Exactly one signer, over the attached plist.
+    assert_eq!(sd.signer_infos.0.len(), 1);
+    let plist = build_plist(GOLDEN_HOST);
+    let econtent = sd
+        .encap_content_info
+        .econtent
+        .as_ref()
+        .expect("attached content");
+    let octets = OctetString::from_der(&econtent.to_der().unwrap()).unwrap();
+    assert_eq!(octets.as_bytes(), plist.as_bytes());
+}
+
+#[test]
+fn signed_profile_signature_verifies() {
+    let key_pair = rcgen::KeyPair::generate().unwrap();
+    let params = rcgen::CertificateParams::new(vec![GOLDEN_HOST.to_owned()]).unwrap();
+    let cert = params.self_signed(&key_pair).unwrap();
+    let chain = cert.pem().into_bytes();
+    let key = key_pair.serialize_pem().into_bytes();
+
+    let der = sign(b"hello profile", &chain, &key).expect("sign");
+    let ci = ContentInfo::from_der(&der).unwrap();
+    let sd = SignedData::from_der(&ci.content.to_der().unwrap()).unwrap();
+    let info = sd.signer_infos.0.iter().next().unwrap();
+
+    // Re-encode the signed attributes as the SET they are signed over
+    // (RFC 5652 §5.4) and verify with the leaf's public key.
+    let tbs = info
+        .signed_attrs
+        .as_ref()
+        .expect("signed attrs")
+        .to_der()
+        .unwrap();
+    let sig = DerSignature::try_from(info.signature.as_bytes()).unwrap();
+    let verifying_key = VerifyingKey::from(
+        &SigningKey::from_pkcs8_pem(std::str::from_utf8(&key).unwrap()).unwrap(),
+    );
+    verifying_key
+        .verify(&tbs, &sig)
+        .expect("signature verifies");
+}

--- a/source/daemon/crates/wardnetd-services/src/private_dns/tests/service.rs
+++ b/source/daemon/crates/wardnetd-services/src/private_dns/tests/service.rs
@@ -18,6 +18,7 @@ use crate::entitlement::Entitlement;
 use crate::error::AppError;
 use crate::event::{BroadcastEventBus, EventPublisher};
 use crate::private_dns::{PrivateDnsService, PrivateDnsServiceImpl, encode_base32, mint_token};
+use crate::secret_store::SecretStore;
 use crate::tls::{TlsService, TlsStatus};
 use wardnetd_data::repository::private_dns::{
     DeviceAlreadyGrantedPrivateDnsError, PrivateDnsGrantRepository, PrivateDnsGrantRow,
@@ -29,6 +30,43 @@ const DOMAIN: &str = "casa.my.wardnet.services";
 fn admin_ctx() -> AuthContext {
     AuthContext::Admin {
         admin_id: Uuid::new_v4(),
+    }
+}
+
+// -- In-memory SecretStore ------------------------------------------------
+//
+// Backs the cert/key `device_profile` signs with. Empty by default (no cert
+// issued); the profile happy-path test seeds a self-signed pair.
+#[derive(Default)]
+struct MockSecretStore {
+    store: Mutex<HashMap<String, Vec<u8>>>,
+}
+
+#[async_trait]
+impl SecretStore for MockSecretStore {
+    async fn put(&self, path: &str, value: &[u8]) -> anyhow::Result<()> {
+        self.store
+            .lock()
+            .unwrap()
+            .insert(path.to_owned(), value.to_vec());
+        Ok(())
+    }
+    async fn get(&self, path: &str) -> anyhow::Result<Option<Vec<u8>>> {
+        Ok(self.store.lock().unwrap().get(path).cloned())
+    }
+    async fn delete(&self, path: &str) -> anyhow::Result<()> {
+        self.store.lock().unwrap().remove(path);
+        Ok(())
+    }
+    async fn list(&self, prefix: &str) -> anyhow::Result<Vec<String>> {
+        Ok(self
+            .store
+            .lock()
+            .unwrap()
+            .keys()
+            .filter(|k| k.starts_with(prefix))
+            .cloned()
+            .collect())
     }
 }
 
@@ -509,6 +547,7 @@ struct Harness {
     dns_local: Arc<MockDnsLocalService>,
     entitlement: Arc<Entitlement>,
     events: Arc<BroadcastEventBus>,
+    secrets: Arc<MockSecretStore>,
     service: PrivateDnsServiceImpl,
 }
 
@@ -524,6 +563,7 @@ fn harness() -> Harness {
     let entitlement = Entitlement::shared();
     entitlement.set_premium(true);
     let events = Arc::new(BroadcastEventBus::new(16));
+    let secrets = Arc::new(MockSecretStore::default());
 
     let service = PrivateDnsServiceImpl::new(
         grants.clone(),
@@ -534,6 +574,7 @@ fn harness() -> Harness {
         dns_local.clone(),
         entitlement.clone(),
         events.clone(),
+        secrets.clone(),
         Ipv4Addr::new(192, 168, 1, 1),
     );
     Harness {
@@ -545,6 +586,7 @@ fn harness() -> Harness {
         dns_local,
         entitlement,
         events,
+        secrets,
         service,
     }
 }
@@ -815,6 +857,91 @@ async fn list_grants_returns_all_rows() {
         .await
         .expect("list");
     assert_eq!(grants.len(), 2);
+}
+
+// -- Device-keyed surface (`/me`, `/me/profile`) ---------------------------
+
+#[tokio::test]
+async fn device_grant_returns_only_this_devices_grant() {
+    let h = harness();
+    enable(&h).await;
+    let a = h.devices.add_device();
+    let b = h.devices.add_device();
+    auth_context::with_context(admin_ctx(), h.service.grant_device(a))
+        .await
+        .expect("grant a");
+
+    let for_a = auth_context::with_context(admin_ctx(), h.service.device_grant(a))
+        .await
+        .expect("device_grant a");
+    assert_eq!(for_a.map(|g| g.device_id), Some(a));
+
+    let for_b = auth_context::with_context(admin_ctx(), h.service.device_grant(b))
+        .await
+        .expect("device_grant b");
+    assert!(for_b.is_none(), "ungranted device has no grant");
+}
+
+#[tokio::test]
+async fn device_profile_is_none_when_disabled_or_ungranted() {
+    let h = harness();
+    let device_id = h.devices.add_device();
+
+    // Feature disabled → no profile.
+    let none = auth_context::with_context(admin_ctx(), h.service.device_profile(device_id))
+        .await
+        .expect("device_profile");
+    assert!(none.is_none());
+
+    // Enabled but this device isn't granted → still none.
+    enable(&h).await;
+    let none = auth_context::with_context(admin_ctx(), h.service.device_profile(device_id))
+        .await
+        .expect("device_profile");
+    assert!(none.is_none());
+}
+
+#[tokio::test]
+async fn device_profile_signs_when_granted_and_cert_present() {
+    let h = harness();
+    enable(&h).await;
+    let device_id = h.devices.add_device();
+    let grant = auth_context::with_context(admin_ctx(), h.service.grant_device(device_id))
+        .await
+        .expect("grant");
+
+    // Seed a self-signed cert/key at the same secret-store keys the TLS layer
+    // uses, so `device_profile` has material to sign with.
+    let key_pair = rcgen::KeyPair::generate().unwrap();
+    let cert = rcgen::CertificateParams::new(vec![format!("{}.{DOMAIN}", grant.token)])
+        .unwrap()
+        .self_signed(&key_pair)
+        .unwrap();
+    h.secrets
+        .put(crate::tls::SECRET_CERT_CHAIN, cert.pem().as_bytes())
+        .await
+        .unwrap();
+    h.secrets
+        .put(
+            crate::tls::SECRET_CERT_KEY,
+            key_pair.serialize_pem().as_bytes(),
+        )
+        .await
+        .unwrap();
+
+    let profile = auth_context::with_context(admin_ctx(), h.service.device_profile(device_id))
+        .await
+        .expect("device_profile")
+        .expect("a granted device with a cert gets a signed profile");
+    // The signed profile embeds the plist verbatim, so the device's hostname
+    // appears in the bytes.
+    let hostname = format!("{}.{DOMAIN}", grant.token);
+    assert!(
+        profile
+            .windows(hostname.len())
+            .any(|w| w == hostname.as_bytes()),
+        "signed profile must carry the device hostname"
+    );
 }
 
 // -- Reconcile -------------------------------------------------------------

--- a/source/daemon/crates/wardnetd/src/main.rs
+++ b/source/daemon/crates/wardnetd/src/main.rs
@@ -962,6 +962,7 @@ async fn run(
     )
     .with_push_service(services.push.clone())
     .with_inbound_wg_service(services.inbound_wg.clone())
+    .with_private_dns_service(services.private_dns.clone())
     .with_health_monitor(health_monitor.clone())
     // Inject the live entitlement handle (the same one the DDNS cloud clients
     // flip) so the serving layer can gate the premium app surfaces while

--- a/source/sdk/wardnet-js/src/index.ts
+++ b/source/sdk/wardnet-js/src/index.ts
@@ -21,6 +21,7 @@ export { DhcpService } from "./services/dhcp.js";
 export { JobsService } from "./services/jobs.js";
 export { RuleRequestService } from "./services/rule-requests.js";
 export { InboundWgService } from "./services/inbound-wg.js";
+export { PrivateDnsService } from "./services/private-dns.js";
 export { PushService } from "./services/push.js";
 export { LogService } from "./services/logs.js";
 export type { LogEntry, LogFilter, LogStreamCallbacks } from "./services/logs.js";
@@ -243,6 +244,16 @@ export type {
   ListInboundWgPeersResponse,
   SetInboundWgPeerEnabledRequest,
 } from "./types/inbound-wg.js";
+
+// Types — Private DNS (encrypted DNS at home + roaming)
+export type {
+  PrivateDnsPrerequisites,
+  PrivateDnsGrantSummary,
+  PrivateDnsStatusResponse,
+  SetPrivateDnsEnabledRequest,
+  CreatePrivateDnsGrantRequest,
+  PrivateDnsMeResponse,
+} from "./types/private-dns.js";
 
 // Types — backup
 export type {

--- a/source/sdk/wardnet-js/src/services/private-dns.ts
+++ b/source/sdk/wardnet-js/src/services/private-dns.ts
@@ -1,0 +1,69 @@
+import type { WardnetClient } from "../client.js";
+import type {
+  CreatePrivateDnsGrantRequest,
+  PrivateDnsGrantSummary,
+  PrivateDnsMeResponse,
+  PrivateDnsStatusResponse,
+  SetPrivateDnsEnabledRequest,
+} from "../types/private-dns.js";
+
+/**
+ * Private DNS — encrypted DNS at home and while roaming (issues #910/#914).
+ *
+ * The admin methods manage the feature and per-device grants. The `me` methods
+ * are device-keyed (identified by the caller's source IP, like `devices/me`)
+ * and back the user PWA.
+ */
+export class PrivateDnsService {
+  constructor(private readonly client: WardnetClient) {}
+
+  /** Read enabled state, enable prerequisites, and every grant. Admin only. */
+  async getStatus(): Promise<PrivateDnsStatusResponse> {
+    return this.client.request<PrivateDnsStatusResponse>("/private-dns/status");
+  }
+
+  /**
+   * Enable or disable Private DNS. Enabling is Premium-gated and rejects with
+   * 409 when a hard prerequisite is missing. Returns the full status.
+   */
+  async setEnabled(enabled: boolean): Promise<PrivateDnsStatusResponse> {
+    const body: SetPrivateDnsEnabledRequest = { enabled };
+    return this.client.request<PrivateDnsStatusResponse>("/private-dns", {
+      method: "PUT",
+      body: JSON.stringify(body),
+    });
+  }
+
+  /**
+   * Grant a managed device encrypted-DNS access. The response carries the full
+   * minted hostname. Admin only.
+   */
+  async grantDevice(deviceId: string): Promise<PrivateDnsGrantSummary> {
+    const body: CreatePrivateDnsGrantRequest = { device_id: deviceId };
+    return this.client.request<PrivateDnsGrantSummary>("/private-dns/grants", {
+      method: "POST",
+      body: JSON.stringify(body),
+    });
+  }
+
+  /** Revoke a device's grant by device id. Admin only. */
+  async revokeDevice(deviceId: string): Promise<void> {
+    await this.client.request<void>(`/private-dns/grants/${deviceId}`, {
+      method: "DELETE",
+    });
+  }
+
+  /** This device's own Private DNS state, identified by source IP. */
+  async me(): Promise<PrivateDnsMeResponse> {
+    return this.client.request<PrivateDnsMeResponse>("/private-dns/me");
+  }
+
+  /**
+   * The URL of this device's signed iOS profile (`.mobileconfig`). Returns a
+   * plain URL rather than fetching: Safari's install flow triggers on a real
+   * navigation, so this is meant to be used as a link `href` or QR target.
+   */
+  profileUrl(): string {
+    return `${this.client.baseUrl}/private-dns/me/profile`;
+  }
+}

--- a/source/sdk/wardnet-js/src/types/private-dns.ts
+++ b/source/sdk/wardnet-js/src/types/private-dns.ts
@@ -1,0 +1,75 @@
+/**
+ * Private DNS — encrypted DNS at home and while roaming (issues #910/#914).
+ *
+ * An admin grants a managed device a secret hostname; the phone points Android
+ * Private DNS (DoT) or an iOS configuration profile at it and resolves through
+ * the box everywhere. Admin operations manage the feature and grants; the
+ * device-keyed `me` surface (identified by source IP, like `devices/me`) backs
+ * the user PWA.
+ */
+
+/**
+ * Enable prerequisites, surfaced so the admin UI can explain a blocked toggle.
+ *
+ * The first three are hard gates — enabling requires all `true`.
+ * `relay_connected` is informational (the LAN path works without the reverse
+ * tunnel; only roaming needs it), so it never blocks enable.
+ */
+export interface PrivateDnsPrerequisites {
+  /** The box is on the wardnet DDNS provider. */
+  wardnet_provider: boolean;
+  /** An issued TLS certificate is live. */
+  certificate: boolean;
+  /** The box holds an active Premium entitlement. */
+  entitled: boolean;
+  /** The reverse tunnel to the regional edge is up. Informational only. */
+  relay_connected: boolean;
+}
+
+/** One per-device grant, with the full minted hostname the phone dials. */
+export interface PrivateDnsGrantSummary {
+  id: string;
+  device_id: string;
+  /**
+   * The device's secret hostname (`<token>.<domain>`) — entered into Android
+   * Private DNS and carried as the `ServerName` in the iOS profile.
+   */
+  hostname: string;
+  /** RFC 3339 creation timestamp. */
+  created_at: string;
+}
+
+/** Response for `GET /api/private-dns/status` and `PUT /api/private-dns`. */
+export interface PrivateDnsStatusResponse {
+  /** Whether the feature (and therefore the `:853` listener) is enabled. */
+  enabled: boolean;
+  /** The wardnet FQDN grants live under, or `null` when not on the provider. */
+  domain: string | null;
+  prerequisites: PrivateDnsPrerequisites;
+  /** Every grant, oldest first. */
+  grants: PrivateDnsGrantSummary[];
+}
+
+/** Request body for `PUT /api/private-dns`. */
+export interface SetPrivateDnsEnabledRequest {
+  enabled: boolean;
+}
+
+/** Request body for `POST /api/private-dns/grants`. */
+export interface CreatePrivateDnsGrantRequest {
+  /** The device to grant encrypted-DNS access. */
+  device_id: string;
+}
+
+/**
+ * Response for `GET /api/private-dns/me` — the device-keyed self-service view
+ * (identified by source IP, like `devices/me`).
+ */
+export interface PrivateDnsMeResponse {
+  /** Whether Private DNS is enabled on the box at all. */
+  enabled: boolean;
+  /** Whether this device holds a grant. */
+  granted: boolean;
+  /** This device's full hostname when granted; `null` otherwise. */
+  hostname: string | null;
+}

--- a/source/web/src/lib/sdk.ts
+++ b/source/web/src/lib/sdk.ts
@@ -24,6 +24,7 @@ import {
   ZoneExceptionsService,
   PushService,
   InboundWgService,
+  PrivateDnsService,
 } from "@wardnet/js";
 
 /** Shared SDK client instance. All services use this single client. */
@@ -56,3 +57,4 @@ export const networkZonesService = new NetworkZonesService(client);
 export const zoneExceptionsService = new ZoneExceptionsService(client);
 export const pushService = new PushService(client);
 export const inboundWgService = new InboundWgService(client);
+export const privateDnsService = new PrivateDnsService(client);


### PR DESCRIPTION
Part of #910. Builds on the grants + DoT listener service layer (#912): adds the admin/user API contract, the signed iOS configuration profile, and the JS SDK.

## Daemon API (`wardnetd-api`)

- `GET /api/private-dns/status` (admin) — enabled state, the wardnet domain grants live under, the enable prerequisites (`wardnet_provider`, `certificate`, `entitled`, plus the informational `relay_connected`), and every grant with its full minted hostname.
- `PUT /api/private-dns` (admin) — enable/disable. Enabling is Premium-gated and returns **409** when a hard prerequisite is missing; `relay_connected` is informational and never blocks it.
- `POST /api/private-dns/grants` / `DELETE /api/private-dns/grants/{device_id}` (admin) — the grant response carries the full minted hostname.
- `GET /api/private-dns/me` — device-keyed (by source IP, like `/api/devices/me`): enabled/granted state + this device's hostname.
- `GET /api/private-dns/me/profile` — device-keyed; serves the signed `.mobileconfig` as `application/x-apple-aspen-config` at a plain, navigable URL (Safari's install flow needs a real navigation). Returns **404** when not granted or the feature is disabled.

DTOs live in `wardnet-common`; `PrivateDnsService` is injected into `AppState` and wired in the daemon; the OpenAPI spec is regenerated.

## Signed profile generator (`wardnetd-services/private_dns/profile.rs`)

- Payload `com.apple.dnsSettings.managed`, `DNSProtocol=TLS`, `ServerName` set, `ServerAddresses` omitted (DDNS-friendly bootstrap), no `OnDemandRules` (iOS auto-exempts captive portals), and stable UUIDv5 identifiers so re-downloading replaces rather than stacks the profile.
- **CMS-signed with the box's live Let's Encrypt leaf** (ECDSA P-256 / SHA-256, chain embedded) so iOS shows *Verified*.
- Golden-file, XML-escaping, UUID-stability, and end-to-end signature-verification tests.

## Mock

Stateful in-memory `PrivateDnsService` so every endpoint works offline, including a self-signed `.mobileconfig` download.

## SDK (`@wardnet/js`)

`types/private-dns.ts` + `services/private-dns.ts` (`getStatus` / `setEnabled` / grant management / `me`, plus `profileUrl()` returning a URL rather than a fetch), registered and exported; changeset included.

## Testing

`cargo test`, `cargo clippy -D warnings`, and `cargo fmt --check` all pass for the affected crates; SDK type-check passes. New coverage: profile generation + signature, service device-keyed methods, and the full API surface (status/enable/grants/me/profile, auth, and 404/409 paths).

Closes #914