### PR TITLE
perf(dns-filter): stream blocklist domains + exempt bulk load from slow-query alert

### DIFF
--- a/source/daemon/Cargo.lock
+++ b/source/daemon/Cargo.lock
@@ -6150,6 +6150,7 @@ dependencies = [
  "argon2",
  "async-trait",
  "chrono",
+ "futures",
  "libc",
  "serde",
  "serde_json",

--- a/source/daemon/crates/wardnetd-data/Cargo.toml
+++ b/source/daemon/crates/wardnetd-data/Cargo.toml
@@ -36,6 +36,10 @@ anyhow.workspace = true
 toml.workspace = true
 # https://crates.io/crates/async-trait
 async-trait.workspace = true
+# https://crates.io/crates/futures — streaming the blocklist-domain load row
+# by row (`BoxStream`) so a ~2.2M-domain feed never materialises as an
+# intermediate `Vec` before the filter set is built.
+futures.workspace = true
 # https://crates.io/crates/libc — statvfs(3) for the startup-VACUUM disk-space guard
 libc.workspace = true
 

--- a/source/daemon/crates/wardnetd-data/src/db.rs
+++ b/source/daemon/crates/wardnetd-data/src/db.rs
@@ -1,6 +1,7 @@
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
+use sqlx::ConnectOptions;
 use sqlx::SqlitePool;
 use sqlx::sqlite::{
     SqliteAutoVacuum, SqliteConnectOptions, SqliteJournalMode, SqlitePoolOptions, SqliteSynchronous,
@@ -9,6 +10,11 @@ use uuid::Uuid;
 
 /// Reader pool size — bounded so a runaway read can't exhaust file descriptors.
 const READ_MAX_CONNECTIONS: u32 = 5;
+/// Bulk-read pool size. This pool serves only the known-bulk blocklist
+/// domain load, which the rebuild path runs one blocklist at a time, so a
+/// tiny pool suffices. It is kept separate from `read` so its disabled
+/// slow-statement logging can never mask a genuinely slow normal `SELECT`.
+const BULK_READ_MAX_CONNECTIONS: u32 = 2;
 /// Writer pool is always a single connection — `SQLite` only allows one writer
 /// at a time, and serialising at the pool level produces async-aware
 /// backpressure instead of busy-spin waits inside `SQLite`.
@@ -121,16 +127,24 @@ pub struct DbPools {
     /// Single-connection pool for `INSERT`/`UPDATE`/`DELETE` and
     /// transactions. Also the pool that owns migrations.
     pub write: SqlitePool,
+    /// Dedicated pool for *known-bulk* reads whose row count is inherently
+    /// huge — currently just the blocklist-domain stream (a threat-intel
+    /// feed is ~2.2M domains). Its connections have statement logging
+    /// disabled so the load's multi-second runtime doesn't trip the 1 s
+    /// `slow_statements` alert that guards the `read` pool. Points at the
+    /// same database as `read`; it differs only in log settings and size.
+    pub bulk_read: SqlitePool,
 }
 
 impl DbPools {
-    /// Wrap a single pool as both reader and writer. Used by tests and
-    /// the in-memory shared-cache path where splitting would create two
+    /// Wrap a single pool as reader, writer and bulk-reader. Used by tests
+    /// and the in-memory shared-cache path where splitting would create two
     /// unrelated in-memory databases.
     #[must_use]
     pub fn single(pool: SqlitePool) -> Self {
         Self {
             read: pool.clone(),
+            bulk_read: pool.clone(),
             write: pool,
         }
     }
@@ -225,7 +239,22 @@ pub async fn init_db_pools_from_connection_string(conn: &str) -> anyhow::Result<
             .connect_with(make_options())
             .await?;
 
-        DbPools { read, write }
+        // Bulk-read pool: same database, but with statement logging turned
+        // off. The blocklist-domain load streams millions of rows and
+        // routinely exceeds the 1 s slow-statement threshold on Pi-class
+        // hardware — expected, not a regression. Isolating it here keeps the
+        // 1 s alert honest for every normal `SELECT` on `read` while
+        // silencing the predictable boot/import noise.
+        let bulk_read = SqlitePoolOptions::new()
+            .max_connections(BULK_READ_MAX_CONNECTIONS)
+            .connect_with(make_options().disable_statement_logging())
+            .await?;
+
+        DbPools {
+            read,
+            write,
+            bulk_read,
+        }
     };
 
     sqlx::migrate!("./migrations").run(&pools.write).await?;

--- a/source/daemon/crates/wardnetd-data/src/repository/dns_filter.rs
+++ b/source/daemon/crates/wardnetd-data/src/repository/dns_filter.rs
@@ -156,7 +156,25 @@ pub trait DnsFilterRepository: Send + Sync {
 
     /// Load the domain list backing one blocklist. Empty when the blocklist
     /// has not yet been downloaded or has been disabled.
+    ///
+    /// Materialises every row into a `Vec` up front; prefer
+    /// [`Self::stream_blocklist_domains`] on the hot rebuild path where a
+    /// multi-million-row feed would otherwise double peak memory.
     async fn load_blocklist_domains(&self, blocklist_id: Uuid) -> anyhow::Result<Vec<String>>;
+
+    /// Stream the domain list backing one blocklist row by row.
+    ///
+    /// The active generation of a threat-intel feed is ~2.2M domains.
+    /// Returning them as a `Vec` and *then* folding them into the filter's
+    /// `HashSet` holds two full copies at once; streaming lets the caller
+    /// insert each domain and drop it, keeping peak memory to a single set.
+    /// The stream borrows the bulk-read pool, whose statement logging is
+    /// disabled, so this inherently slow load never trips the slow-statement
+    /// alert.
+    fn stream_blocklist_domains(
+        &self,
+        blocklist_id: Uuid,
+    ) -> futures::stream::BoxStream<'_, anyhow::Result<String>>;
 
     // ── Per-device settings ─────────────────────────────────────────────
 

--- a/source/daemon/crates/wardnetd-data/src/repository/sqlite/dns_filter.rs
+++ b/source/daemon/crates/wardnetd-data/src/repository/sqlite/dns_filter.rs
@@ -2,6 +2,7 @@
 
 use async_trait::async_trait;
 use chrono::{NaiveDateTime, TimeZone, Utc};
+use futures::stream::{BoxStream, StreamExt, TryStreamExt};
 use sqlx::SqlitePool;
 use uuid::Uuid;
 
@@ -16,6 +17,16 @@ use crate::repository::dns_filter::{
 
 const TS_FMT: &str = "%Y-%m-%dT%H:%M:%SZ";
 const KEY_DNS_FILTERING_ENABLED: &str = "dns_filtering_enabled";
+
+/// Domains backing one blocklist's *active* generation. Shared by the
+/// streaming loader (`stream_blocklist_domains`) and the collecting one
+/// (`load_blocklist_domains`) so the two can never drift apart while still
+/// running on different pools.
+const BLOCKLIST_DOMAINS_QUERY: &str = "SELECT bd.domain \
+     FROM dns_filter_blocked_domains bd \
+     JOIN dns_filter_blocklists bl \
+       ON bd.blocklist_id = bl.id AND bd.generation = bl.active_generation \
+     WHERE bl.id = ?";
 
 fn now_iso() -> String {
     Utc::now().format(TS_FMT).to_string()
@@ -801,18 +812,31 @@ impl DnsFilterRepository for SqliteDnsFilterRepository {
         })
     }
 
-    async fn load_blocklist_domains(&self, blocklist_id: Uuid) -> anyhow::Result<Vec<String>> {
+    fn stream_blocklist_domains(
+        &self,
+        blocklist_id: Uuid,
+    ) -> BoxStream<'_, anyhow::Result<String>> {
         let id = blocklist_id.to_string();
-        let domains: Vec<String> = sqlx::query_scalar(
-            "SELECT bd.domain \
-             FROM dns_filter_blocked_domains bd \
-             JOIN dns_filter_blocklists bl \
-               ON bd.blocklist_id = bl.id AND bd.generation = bl.active_generation \
-             WHERE bl.id = ?",
-        )
-        .bind(&id)
-        .fetch_all(&self.pools.read)
-        .await?;
+        sqlx::query_scalar::<_, String>(BLOCKLIST_DOMAINS_QUERY)
+            .bind(id)
+            // Bulk-read pool: statement logging is disabled there, so this
+            // inherently slow multi-million-row load never trips the 1 s
+            // slow-statement alert that guards the normal `read` pool.
+            .fetch(&self.pools.bulk_read)
+            .map_err(anyhow::Error::from)
+            .boxed()
+    }
+
+    async fn load_blocklist_domains(&self, blocklist_id: Uuid) -> anyhow::Result<Vec<String>> {
+        // Deliberately the normal `read` pool, NOT `bulk_read`: this
+        // convenience collector has no built-in row-count ceiling, so any
+        // caller must keep the 1 s slow-statement alert. The streaming
+        // `stream_blocklist_domains` is the one exempted path.
+        let id = blocklist_id.to_string();
+        let domains: Vec<String> = sqlx::query_scalar::<_, String>(BLOCKLIST_DOMAINS_QUERY)
+            .bind(id)
+            .fetch_all(&self.pools.read)
+            .await?;
         Ok(domains)
     }
 

--- a/source/daemon/crates/wardnetd-data/src/repository/tests/dns_filter.rs
+++ b/source/daemon/crates/wardnetd-data/src/repository/tests/dns_filter.rs
@@ -660,7 +660,14 @@ async fn on_disk_pools(acquire_timeout: std::time::Duration) -> (crate::db::DbPo
 
     sqlx::migrate!("./migrations").run(&write).await.unwrap();
 
-    (crate::db::DbPools { read, write }, path_str)
+    (
+        crate::db::DbPools {
+            bulk_read: read.clone(),
+            read,
+            write,
+        },
+        path_str,
+    )
 }
 
 /// Regression guard: importing a large blocklist must not hold the daemon's

--- a/source/daemon/crates/wardnetd-services/src/dns_filter/filter.rs
+++ b/source/daemon/crates/wardnetd-services/src/dns_filter/filter.rs
@@ -260,6 +260,42 @@ fn matches_subdomain(domain: &str, set: &HashSet<String>) -> bool {
     false
 }
 
+/// Incrementally assembles the blocked-domain set of a *pure blocklist*
+/// [`DnsFilter`] — one with no allowlist and no custom rules, which is
+/// exactly what a single blocklist compiles to.
+///
+/// The blocklist rebuild path streams its domains straight from the
+/// database (a threat-intel feed is ~2.2M rows). Feeding them through this
+/// builder inserts each one into the final [`HashSet`] and drops it, so the
+/// set is the only large allocation that ever exists — no intermediate
+/// `Vec` doubling peak memory. Normalisation matches [`DnsFilter::build`].
+#[derive(Debug, Default)]
+pub struct BlocklistFilterBuilder {
+    blocked_domains: HashSet<String>,
+}
+
+impl BlocklistFilterBuilder {
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Normalise and insert one blocked domain.
+    pub fn insert(&mut self, domain: &str) {
+        self.blocked_domains.insert(normalize_owned(domain));
+    }
+
+    /// Finish, yielding a filter whose only rules are the accumulated
+    /// blocked domains.
+    #[must_use]
+    pub fn finish(self) -> DnsFilter {
+        DnsFilter {
+            blocked_domains: self.blocked_domains,
+            ..DnsFilter::default()
+        }
+    }
+}
+
 /// Canonical form of a domain: lowercase, no trailing dot.
 ///
 /// Borrows when the input is already canonical — the common case on the

--- a/source/daemon/crates/wardnetd-services/src/dns_filter/mod.rs
+++ b/source/daemon/crates/wardnetd-services/src/dns_filter/mod.rs
@@ -18,7 +18,7 @@ pub mod service;
 
 pub use blocklist_downloader::{BlocklistFetcher, HttpBlocklistFetcher};
 pub use device_context::DeviceFilterContext;
-pub use filter::{DnsFilter, DnsFilterInputs, FilterStats};
+pub use filter::{BlocklistFilterBuilder, DnsFilter, DnsFilterInputs, FilterStats};
 pub use filter_profile::RuntimeDnsFilterProfile;
 pub use runner::DnsFilterRunner;
 pub use service::{DnsFilterService, DnsFilterServiceImpl};

--- a/source/daemon/crates/wardnetd-services/src/dns_filter/service.rs
+++ b/source/daemon/crates/wardnetd-services/src/dns_filter/service.rs
@@ -19,6 +19,7 @@ use std::sync::Arc;
 use arc_swap::ArcSwap;
 use async_trait::async_trait;
 use chrono::Utc;
+use futures::TryStreamExt;
 use hickory_proto::rr::RecordType;
 use std::sync::atomic::{AtomicBool, Ordering};
 
@@ -50,7 +51,7 @@ use wardnetd_data::repository::{
 use crate::auth_context;
 use crate::dns_filter::blocklist_downloader::{self, BlocklistFetcher};
 use crate::dns_filter::device_context::DeviceFilterContext;
-use crate::dns_filter::filter::{DnsFilter, DnsFilterInputs};
+use crate::dns_filter::filter::{BlocklistFilterBuilder, DnsFilter, DnsFilterInputs};
 use crate::dns_filter::filter_profile::RuntimeDnsFilterProfile;
 use crate::error::AppError;
 use crate::event::EventPublisher;
@@ -455,22 +456,22 @@ impl DnsFilterServiceImpl {
             return Ok(());
         };
 
-        let inputs = if bl.enabled {
-            let domains = self
-                .repo
-                .load_blocklist_domains(blocklist_id)
-                .await
-                .map_err(AppError::Internal)?;
-            DnsFilterInputs {
-                blocked_domains: domains,
-                allowlist: Vec::new(),
-                custom_rules: Vec::new(),
+        let new_filter = if bl.enabled {
+            // Stream the domains straight into the filter set. A threat-intel
+            // feed is ~2.2M rows; collecting them into a `Vec` first and then
+            // folding that into the set would hold two full copies at once.
+            // A blocklist compiles to a pure blocked-domain filter (no
+            // allowlist, no custom rules), so `BlocklistFilterBuilder` is all
+            // we need here.
+            let mut builder = BlocklistFilterBuilder::new();
+            let mut domains = self.repo.stream_blocklist_domains(blocklist_id);
+            while let Some(domain) = domains.try_next().await.map_err(AppError::Internal)? {
+                builder.insert(&domain);
             }
+            builder.finish()
         } else {
-            DnsFilterInputs::default()
+            DnsFilter::empty()
         };
-
-        let new_filter = DnsFilter::build(inputs);
         let mut filters = self.blocklist_filters.write().await;
         if let Some(slot) = filters.get(&blocklist_id) {
             slot.store(Arc::new(new_filter));

--- a/source/daemon/crates/wardnetd-services/src/dns_filter/tests/filter.rs
+++ b/source/daemon/crates/wardnetd-services/src/dns_filter/tests/filter.rs
@@ -7,7 +7,9 @@ use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 use hickory_proto::rr::RecordType;
 use wardnet_common::dns::FilterAction;
 
-use crate::dns_filter::filter::{DnsFilter, DnsFilterInputs, MatchKind, MatchOutcome};
+use crate::dns_filter::filter::{
+    BlocklistFilterBuilder, DnsFilter, DnsFilterInputs, MatchKind, MatchOutcome,
+};
 
 fn localhost_v4() -> IpAddr {
     IpAddr::V4(Ipv4Addr::LOCALHOST)
@@ -447,4 +449,82 @@ fn match_kind_blocks_classification() {
     assert!(MatchKind::ImportantBlock.blocks());
     assert!(!MatchKind::Allow.blocks());
     assert!(!MatchKind::ImportantAllow.blocks());
+}
+
+// ---------- Streaming blocklist builder ----------
+
+/// The blocklist rebuild path builds its filter with [`BlocklistFilterBuilder`]
+/// (streaming rows straight into the set) instead of [`DnsFilter::build`]. The
+/// two must be indistinguishable: same normalisation, same de-duplication, same
+/// hot-path verdicts, and — since a blocklist has no allowlist or custom rules —
+/// a pure blocked-domain filter. This guards against the two paths drifting.
+#[test]
+fn blocklist_filter_builder_matches_build() {
+    // Mixed case + a trailing dot + a duplicate that only collapses after
+    // normalisation — exactly the cases the normaliser has to fold.
+    let raw = vec![
+        "ADS.Example.com".to_owned(),
+        "tracker.test.".to_owned(),
+        "Dup.test".to_owned(),
+        "dup.test".to_owned(),
+    ];
+
+    // Path A: the legacy Vec -> DnsFilterInputs -> build route.
+    let via_build = DnsFilter::build(DnsFilterInputs {
+        blocked_domains: raw.clone(),
+        ..DnsFilterInputs::default()
+    });
+
+    // Path B: the streaming builder used by `rebuild_blocklist_inner`.
+    let mut builder = BlocklistFilterBuilder::new();
+    for domain in &raw {
+        builder.insert(domain);
+    }
+    let via_builder = builder.finish();
+
+    // Identical, de-duplicated, normalised set (the two `dup.test` collapse).
+    assert_eq!(via_builder.stats().blocked_count, 3);
+    assert_eq!(
+        via_build.stats().blocked_count,
+        via_builder.stats().blocked_count,
+    );
+    // A blocklist is a *pure* blocked-domain filter.
+    assert_eq!(via_builder.stats().allowed_count, 0);
+    assert_eq!(via_builder.stats().complex_count, 0);
+    assert!(!via_builder.is_empty());
+
+    // Identical hot-path verdicts, including query-side normalisation and
+    // subdomain matching.
+    for (query, expect_blocked) in [
+        ("ads.example.com", true),
+        ("ADS.EXAMPLE.COM", true),
+        ("sub.ads.example.com", true),
+        ("tracker.test", true),
+        ("dup.test", true),
+        ("allowed.test", false),
+    ] {
+        let from_builder = via_builder.check_action(query, RecordType::A, localhost_v4());
+        assert_eq!(
+            from_builder,
+            via_build.check_action(query, RecordType::A, localhost_v4()),
+            "verdict diverged between build paths for {query}",
+        );
+        assert_eq!(
+            from_builder == FilterAction::Block,
+            expect_blocked,
+            "unexpected verdict for {query}",
+        );
+    }
+}
+
+/// An empty stream (a downloaded-but-empty or not-yet-populated blocklist)
+/// yields the same empty filter the old `build(default)` path produced.
+#[test]
+fn blocklist_filter_builder_empty_is_empty() {
+    let filter = BlocklistFilterBuilder::new().finish();
+    assert!(filter.is_empty());
+    assert_eq!(
+        filter.check_action("example.com", RecordType::A, localhost_v4()),
+        FilterAction::Pass,
+    );
 }

--- a/source/daemon/crates/wardnetd-services/src/dns_filter/tests/service.rs
+++ b/source/daemon/crates/wardnetd-services/src/dns_filter/tests/service.rs
@@ -1378,20 +1378,40 @@ async fn rebuild_blocklist_filter_loads_domains() {
             .await
             .unwrap();
 
+        // Compose the profile first with an empty blocklist, so the default
+        // context already holds this blocklist's `Arc<ArcSwap<DnsFilter>>`.
+        h.service.rebuild_all().await.unwrap();
+
+        // Now populate the blocklist and rebuild ONLY the per-source filter.
+        // The single rebuild must land in the live runtime cache through the
+        // shared `ArcSwap` without a full profile recompose.
         h.repo
             .replace_blocklist_domains(bl.blocklist.id, &["x.test".to_owned(), "y.test".to_owned()])
             .await
             .unwrap();
-
-        // Rebuild the per-source filter — should pull the freshly-replaced
-        // domains into the runtime cache. Verified indirectly via the
-        // hot-path `check`.
         h.service
             .rebuild_blocklist_filter(bl.blocklist.id)
             .await
             .unwrap();
     })
     .await;
+
+    // A random IP falls through to the default (Ad Blocking) context, which
+    // now composes the freshly-rebuilt blocklist filter. Both replaced
+    // domains must block via the hot path — the streaming rebuild actually
+    // populated the set.
+    let ip = "10.77.77.77".parse::<IpAddr>().unwrap();
+    for domain in ["x.test", "y.test"] {
+        let outcome = h.service.check(domain, RecordType::A, ip).await;
+        assert_eq!(
+            outcome.action,
+            FilterAction::Block,
+            "expected {domain} to be blocked after single-blocklist rebuild",
+        );
+    }
+    // A domain that was never in the list still passes.
+    let outcome = h.service.check("allowed.test", RecordType::A, ip).await;
+    assert_eq!(outcome.action, FilterAction::Pass);
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Problem

The daemon logged a `slow statement` alert on every boot and blocklist refresh:

```
slow statement: execution time exceeded alert threshold
  [db.statement=SELECT bd.domain FROM dns_filter_blocked_domains bd JOIN dns_filter_blocklists bl ...
   · elapsed=3.13s · rows_returned=2202025 · slow_threshold=1s]
```

This is the **cache-build path** (`rebuild_blocklist_inner` → `load_blocklist_domains`), not a hot query. It runs on boot bootstrap and after each list import/refresh — never per DNS lookup. The query plan is already optimal (covering index `idx_dns_filter_blocked_domains_blocklist_gen_domain`, index-only scan); the 3s is inherent to materialising ~2.2M domain rows for a threat-intel feed.

Two problems fell out of that:
1. A predictable, expected bulk load fires the 1s slow-statement alert as if it were a regression — noise.
2. The load materialised the full `Vec<String>` (2.2M) and *then* folded it into the filter's `HashSet`, holding two full copies at peak (~100 MB on Pi-class hardware).

## Changes

**1. Threshold exception — dedicated `bulk_read` pool**
- New `bulk_read` pool in `DbPools`, same database/options as `read` but with `disable_statement_logging()`. The blocklist stream runs on it, so its inherently-slow runtime no longer trips the 1s alert — while every normal `SELECT` on the `read` pool keeps the alert intact.
- `load_blocklist_domains` deliberately stays on the `read` pool (it has no built-in row-count ceiling, so any future caller must keep the alert). The streaming method is the only exempted path; the two share a single SQL constant so they can't drift.

**2. Stream into the set — halved peak memory**
- New `stream_blocklist_domains(...) -> BoxStream<'_, Result<String>>` on the repo, consumed by a new `BlocklistFilterBuilder` that normalises and inserts each domain straight into the final `HashSet`. The intermediate `Vec` is gone, cutting peak memory for this load from ~2 copies to ~1. A blocklist compiles to a pure blocked-domain filter (no allowlist / custom rules), so the builder is all this path needs.

## Not addressed (intentional)

Streaming holds the `bulk_read` connection across the fetch+normalise loop, where the old `fetch_all` released it before the build. This is an inherent trade-off of avoiding the intermediate copy — the data has to live either in the DB cursor or in a buffer, not neither — and its blast radius is contained by the dedicated pool (it never competes with the DNS hot path or admin reads, and rebuilds are serialised).

## Tests

- `blocklist_filter_builder_matches_build` — asserts the streaming builder produces a filter identical to the legacy `DnsFilter::build` (same normalisation of mixed-case/trailing-dot, same dedup, same subdomain verdicts, pure blocked-domain filter).
- `blocklist_filter_builder_empty_is_empty` — empty stream ⇒ empty filter.
- Strengthened `rebuild_blocklist_filter_loads_domains` — previously only asserted `rebuild` returned `Ok` (its "verified via check" comment was stale); now asserts the streamed set actually blocks both domains via the hot-path `check`, proving the single rebuild propagates through the shared `ArcSwap`.

Verified: `cargo clippy -p wardnetd-data -p wardnetd-services --tests` clean; data-crate `dns_filter` 28 passed; service-crate `dns_filter` 118 passed.