### PR TITLE
Route SDK calls through their transport abstraction and complete the public type surface

### DIFF
--- a/.agents/technical-stack.md
+++ b/.agents/technical-stack.md
@@ -16,7 +16,8 @@
 - `wardnetd-mock` — local dev binary: full API with no-op network backends, on-disk or in-memory SQLite, real file-backed secret store under `/tmp/wardnet-mock/secrets`
 
 ## SDK (`@wardnet/js`)
-- TypeScript 5.9, zero runtime dependencies
+- TypeScript 5.9, zero required runtime dependencies
+- Logging ships a zero-dependency console adapter by default; `consola` is an **optional** peer dependency — consumers that want richer output enable it via `setAdapter(createConsolaAdapter())` from the `@wardnet/js/consola` subpath
 - Uses native `fetch` (works in browser and Node 18+)
 - No DOM types — minimal `globals.d.ts` for cross-environment support
 - Linked via Yarn `portal:` protocol from all app surfaces (`"@wardnet/js": "portal:../sdk/wardnet-js"`)

--- a/source/end2end-tests/daemon/tests/helpers.ts
+++ b/source/end2end-tests/daemon/tests/helpers.ts
@@ -55,6 +55,11 @@ export const MALWARE_PHISHING_PROFILE_ID = "00000000-0000-0000-0000-000000000102
  * to every subsequent request. Node's fetch has no cookie jar, so the
  * session cookie the daemon sets is invisible to follow-up calls;
  * `Authorization: Bearer <token>` is the documented non-browser path.
+ *
+ * The token is attached via the `buildHeaders` seam rather than a
+ * `request` override so it also covers the endpoints that bypass
+ * `request` — `BackupService.export`/`previewImport`, which post raw
+ * octet-stream / multipart bodies through `authorizedFetch`.
  */
 export class AuthedClient extends WardnetClient {
   constructor(
@@ -64,11 +69,11 @@ export class AuthedClient extends WardnetClient {
     super({ baseUrl });
   }
 
-  override async request<T>(path: string, init?: RequestInit): Promise<T> {
-    const headers = new Headers(init?.headers);
-    headers.set("Content-Type", "application/json");
-    headers.set("Authorization", `Bearer ${this.token}`);
-    return super.request<T>(path, { ...init, headers });
+  protected override buildHeaders(init?: RequestInit): Record<string, string> {
+    return {
+      ...super.buildHeaders(init),
+      Authorization: `Bearer ${this.token}`,
+    };
   }
 }
 

--- a/source/end2end-tests/daemon/yarn.lock
+++ b/source/end2end-tests/daemon/yarn.lock
@@ -329,8 +329,11 @@ __metadata:
 "@wardnet/js@portal:../../sdk/wardnet-js::locator=%40wardnet%2Fend2end-daemon%40workspace%3A.":
   version: 0.0.0-use.local
   resolution: "@wardnet/js@portal:../../sdk/wardnet-js::locator=%40wardnet%2Fend2end-daemon%40workspace%3A."
-  dependencies:
-    consola: "npm:^3.4.2"
+  peerDependencies:
+    consola: ^3.4.2
+  peerDependenciesMeta:
+    consola:
+      optional: true
   languageName: node
   linkType: soft
 
@@ -359,13 +362,6 @@ __metadata:
   version: 3.0.0
   resolution: "chownr@npm:3.0.0"
   checksum: 10c0/43925b87700f7e3893296c8e9c56cc58f926411cce3a6e5898136daaf08f08b9a8eb76d37d3267e707d0dcc17aed2e2ebdf5848c0c3ce95cf910a919935c1b10
-  languageName: node
-  linkType: hard
-
-"consola@npm:^3.4.2":
-  version: 3.4.2
-  resolution: "consola@npm:3.4.2"
-  checksum: 10c0/7cebe57ecf646ba74b300bcce23bff43034ed6fbec9f7e39c27cee1dc00df8a21cd336b466ad32e304ea70fba04ec9e890c200270de9a526ce021ba8a7e4c11a
   languageName: node
   linkType: hard
 

--- a/source/sdk/wardnet-js/package.json
+++ b/source/sdk/wardnet-js/package.json
@@ -10,6 +10,10 @@
     ".": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
+    },
+    "./consola": {
+      "types": "./dist/consola.d.ts",
+      "import": "./dist/consola.js"
     }
   },
   "files": [
@@ -25,12 +29,18 @@
     "format:check": "prettier --check src/"
   },
   "devDependencies": {
+    "consola": "^3.4.2",
     "prettier": "3.9.4",
     "tsup": "8.5.1",
     "typescript": "6.0.3"
   },
-  "packageManager": "yarn@4.17.0",
-  "dependencies": {
+  "peerDependencies": {
     "consola": "^3.4.2"
-  }
+  },
+  "peerDependenciesMeta": {
+    "consola": {
+      "optional": true
+    }
+  },
+  "packageManager": "yarn@4.17.0"
 }

--- a/source/sdk/wardnet-js/src/client.ts
+++ b/source/sdk/wardnet-js/src/client.ts
@@ -37,13 +37,47 @@ export class WardnetClient {
     this.baseUrl = options?.baseUrl ?? "/api";
   }
 
+  /**
+   * Build the header set for an outgoing request.
+   *
+   * This is the single seam a subclass overrides to attach cross-cutting
+   * headers — most commonly `Authorization`. Every network call in the SDK
+   * routes its header construction through here: the JSON path in `request`,
+   * and the raw octet-stream / multipart calls in `BackupService` (which use
+   * {@link authorizedFetch} directly because they don't fit the JSON-in /
+   * JSON-out shape). Because the seam is shared, an override applies to all
+   * of them uniformly instead of silently missing the endpoints that bypass
+   * `request`.
+   */
+  protected buildHeaders(init?: RequestInit): Record<string, string> {
+    return { ...init?.headers };
+  }
+
+  /**
+   * Perform a `fetch` against the daemon API with the client's shared
+   * transport policy applied: base-URL prefixing, `credentials: "include"`
+   * (so the browser session cookie rides along), and headers routed through
+   * {@link buildHeaders} so subclass auth overrides take effect.
+   *
+   * Callers own the request and response body shapes. `request` uses this
+   * for the JSON path; `BackupService` calls it directly for its
+   * octet-stream (`export`) and multipart (`previewImport`) endpoints.
+   */
+  async authorizedFetch(path: string, init?: RequestInit): Promise<Response> {
+    return fetch(`${this.baseUrl}${path}`, {
+      credentials: "include",
+      ...init,
+      headers: this.buildHeaders(init),
+    });
+  }
+
   /** Send a typed HTTP request to the daemon API.
    *
    * Returns `undefined` (cast to `T`) on `204 No Content` so callers
    * with `Promise<void>` can route through the same path as JSON-
    * returning calls — important because subclasses (e.g. `AuthedClient`
-   * in the e2e harness) override `request` to attach an
-   * `Authorization` header. Bypassing `request` means bypassing
+   * in the e2e harness) override `buildHeaders` to attach an
+   * `Authorization` header. Bypassing the client means bypassing
    * those overrides; routing through it keeps the auth path uniform.
    */
   async request<T>(path: string, init?: RequestInit): Promise<T> {
@@ -61,11 +95,11 @@ export class WardnetClient {
       }
     }
 
-    const res = await fetch(`${this.baseUrl}${path}`, {
-      headers: { "Content-Type": "application/json" },
-      credentials: "include",
-      ...init,
-    });
+    const headers: Record<string, string> = {
+      "Content-Type": "application/json",
+      ...init?.headers,
+    };
+    const res = await this.authorizedFetch(path, { ...init, headers });
 
     if (!res.ok) {
       const requestId = res.headers.get("X-Request-Id") ?? undefined;

--- a/source/sdk/wardnet-js/src/client.ts
+++ b/source/sdk/wardnet-js/src/client.ts
@@ -18,11 +18,9 @@ export interface WardnetClientOptions {
 function toHeaderRecord(headers: RequestInit["headers"]): Record<string, string> {
   if (headers == null) return {};
   if (headers instanceof Headers || Array.isArray(headers)) {
-    const record: Record<string, string> = {};
-    new Headers(headers).forEach((value, name) => {
-      record[name] = value;
-    });
-    return record;
+    // `Object.fromEntries` copies each header as an own property (no computed
+    // writes, so no prototype-pollution surface).
+    return Object.fromEntries(new Headers(headers).entries());
   }
   return { ...headers };
 }

--- a/source/sdk/wardnet-js/src/client.ts
+++ b/source/sdk/wardnet-js/src/client.ts
@@ -7,6 +7,26 @@ export interface WardnetClientOptions {
   baseUrl?: string;
 }
 
+/**
+ * Coerce any accepted `headers` value into a plain record so it can be merged
+ * with a spread. A plain object (the SDK's own call sites, and the type it
+ * advertises) is spread directly — no `Headers` is allocated on the request
+ * hot path. A `Headers` instance or `[name, value][]` (which a browser
+ * consumer may hand in) is enumerated via the platform `Headers`, which would
+ * otherwise spread to `{}` and silently drop every header.
+ */
+function toHeaderRecord(headers: RequestInit["headers"]): Record<string, string> {
+  if (headers == null) return {};
+  if (headers instanceof Headers || Array.isArray(headers)) {
+    const record: Record<string, string> = {};
+    new Headers(headers).forEach((value, name) => {
+      record[name] = value;
+    });
+    return record;
+  }
+  return { ...headers };
+}
+
 /** Error thrown when an API request fails. */
 export class WardnetApiError extends Error {
   /** Server-generated request ID for correlating with server logs. */
@@ -50,7 +70,7 @@ export class WardnetClient {
    * `request`.
    */
   protected buildHeaders(init?: RequestInit): Record<string, string> {
-    return { ...init?.headers };
+    return toHeaderRecord(init?.headers);
   }
 
   /**
@@ -97,7 +117,7 @@ export class WardnetClient {
 
     const headers: Record<string, string> = {
       "Content-Type": "application/json",
-      ...init?.headers,
+      ...toHeaderRecord(init?.headers),
     };
     const res = await this.authorizedFetch(path, { ...init, headers });
 

--- a/source/sdk/wardnet-js/src/consola.ts
+++ b/source/sdk/wardnet-js/src/consola.ts
@@ -35,7 +35,19 @@ export function createConsolaAdapter(instance?: ConsolaInstance): LogAdapter {
 
   return {
     log(level: EmittedLevel, tag: string, args: unknown[]) {
-      const write = withTag(tag)[level] as (...a: unknown[]) => void;
+      const scoped = withTag(tag);
+      // Explicit dispatch rather than `scoped[level]` — avoids a computed
+      // member access. The cast normalizes consola's overloaded log signature
+      // to a plain rest-parameter form so `args` can be spread through.
+      const write = (
+        level === "error"
+          ? scoped.error
+          : level === "warn"
+            ? scoped.warn
+            : level === "info"
+              ? scoped.info
+              : scoped.debug
+      ) as (...a: unknown[]) => void;
       write(...args);
     },
   };

--- a/source/sdk/wardnet-js/src/consola.ts
+++ b/source/sdk/wardnet-js/src/consola.ts
@@ -1,0 +1,42 @@
+import { createConsola, type ConsolaInstance } from "consola";
+import type { EmittedLevel, LogAdapter } from "./logger.js";
+
+/**
+ * `consola`-backed log adapter, exposed from the `@wardnet/js/consola`
+ * subpath so importing the SDK's main entry never pulls `consola` in.
+ * `consola` is declared as an optional peer dependency; only consumers that
+ * enable this adapter need it installed.
+ *
+ * Wire it up once at app startup:
+ *
+ * ```ts
+ * import { setAdapter } from "@wardnet/js";
+ * import { createConsolaAdapter } from "@wardnet/js/consola";
+ *
+ * setAdapter(createConsolaAdapter());
+ * ```
+ *
+ * The SDK owns level filtering, so the underlying instance runs at consola's
+ * most verbose level and forwards every record it is handed. Pass a
+ * pre-configured `instance` to share reporters/formatting with the host app.
+ */
+export function createConsolaAdapter(instance?: ConsolaInstance): LogAdapter {
+  const root = instance ?? createConsola({ level: 5 });
+  const scoped = new Map<string, ConsolaInstance>();
+
+  const withTag = (tag: string): ConsolaInstance => {
+    let s = scoped.get(tag);
+    if (s === undefined) {
+      s = root.withTag(tag);
+      scoped.set(tag, s);
+    }
+    return s;
+  };
+
+  return {
+    log(level: EmittedLevel, tag: string, args: unknown[]) {
+      const write = withTag(tag)[level] as (...a: unknown[]) => void;
+      write(...args);
+    },
+  };
+}

--- a/source/sdk/wardnet-js/src/globals.d.ts
+++ b/source/sdk/wardnet-js/src/globals.d.ts
@@ -10,6 +10,19 @@ declare function fetch(input: string | URL, init?: RequestInit): Promise<Respons
 declare function setTimeout(callback: () => void, ms: number): ReturnType<typeof setTimeout>;
 declare function clearTimeout(id: ReturnType<typeof setTimeout>): void;
 
+/**
+ * Console — available in both browsers and Node. Only the methods the
+ * default log adapter writes through are declared; consumers wanting richer
+ * output swap the sink via `setAdapter` (e.g. the `@wardnet/js/consola`
+ * adapter) rather than relying on more of this surface.
+ */
+declare const console: {
+  error(...args: unknown[]): void;
+  warn(...args: unknown[]): void;
+  info(...args: unknown[]): void;
+  debug(...args: unknown[]): void;
+};
+
 interface RequestInit {
   method?: string;
   headers?: Record<string, string>;

--- a/source/sdk/wardnet-js/src/globals.d.ts
+++ b/source/sdk/wardnet-js/src/globals.d.ts
@@ -25,7 +25,11 @@ declare const console: {
 
 interface RequestInit {
   method?: string;
-  headers?: Record<string, string>;
+  // Mirrors what the platform `fetch` accepts. The SDK's own call sites pass a
+  // plain object; the wider union keeps consumers who hand in a `Headers`
+  // instance or entries array (valid in the browser) from being silently
+  // dropped — `WardnetClient` normalizes all three forms.
+  headers?: Record<string, string> | Headers | string[][];
   body?: string | Blob | FormData | null;
   credentials?: "include" | "omit" | "same-origin";
   signal?: AbortSignal;
@@ -67,7 +71,17 @@ declare class FormData {
 interface Headers {
   get(name: string): string | null;
   has(name: string): boolean;
+  forEach(callback: (value: string, name: string) => void): void;
 }
+
+/**
+ * `Headers` constructor — available natively in browsers and Node 18+. The
+ * SDK uses it only to normalize a caller-supplied `Headers`/entries value into
+ * a plain record; it accepts the same inputs as the platform constructor.
+ */
+declare const Headers: {
+  new (init?: Record<string, string> | Headers | string[][]): Headers;
+};
 
 interface AbortSignal {
   aborted: boolean;

--- a/source/sdk/wardnet-js/src/globals.d.ts
+++ b/source/sdk/wardnet-js/src/globals.d.ts
@@ -72,6 +72,7 @@ interface Headers {
   get(name: string): string | null;
   has(name: string): boolean;
   forEach(callback: (value: string, name: string) => void): void;
+  entries(): IterableIterator<[string, string]>;
 }
 
 /**

--- a/source/sdk/wardnet-js/src/index.ts
+++ b/source/sdk/wardnet-js/src/index.ts
@@ -1,6 +1,6 @@
 // Logging
-export { createLogger, setLevel } from "./logger.js";
-export type { Logger, LogLevel } from "./logger.js";
+export { createLogger, setLevel, setAdapter, consoleAdapter } from "./logger.js";
+export type { Logger, LogLevel, EmittedLevel, LogAdapter } from "./logger.js";
 
 // Client
 export { WardnetClient, WardnetApiError } from "./client.js";

--- a/source/sdk/wardnet-js/src/index.ts
+++ b/source/sdk/wardnet-js/src/index.ts
@@ -93,6 +93,8 @@ export type { LoginRequest, LoginResponse, MeResponse } from "./types/auth.js";
 export type {
   LastShutdownState,
   LastShutdownStatus,
+  SystemDiagnostic,
+  RecentErrorsResponse,
   SetDefaultPolicyRequest,
   SetDefaultPolicyResponse,
   SystemStatusResponse,
@@ -168,6 +170,8 @@ export type {
   TunnelTestResponse,
   TunnelSpeedTestResult,
   TunnelSpeedTestHistoryResponse,
+  UpdateTunnelDnsOverrideRequest,
+  UpdateTunnelDnsOverrideResponse,
   ListProvidersResponse,
   ValidateCredentialsRequest,
   ValidateCredentialsResponse,

--- a/source/sdk/wardnet-js/src/logger.ts
+++ b/source/sdk/wardnet-js/src/logger.ts
@@ -1,6 +1,7 @@
-import { createConsola } from "consola";
-
 export type LogLevel = "silent" | "error" | "warn" | "info" | "debug";
+
+/** The levels that actually reach an adapter (`silent` filters everything out). */
+export type EmittedLevel = Exclude<LogLevel, "silent">;
 
 const NUMERIC: Record<LogLevel, number> = {
   silent: -1,
@@ -10,8 +11,47 @@ const NUMERIC: Record<LogLevel, number> = {
   debug: 5,
 };
 
-// consola instance at max level — we own all level filtering.
-const _root = createConsola({ level: 5 });
+/**
+ * Output sink for log records. The SDK owns level filtering; an adapter only
+ * has to write records it is handed. This is the seam that keeps the package
+ * dependency-free by default: the built-in {@link consoleAdapter} needs
+ * nothing, and richer sinks (e.g. the `consola` adapter under
+ * `@wardnet/js/consola`) are opt-in via {@link setAdapter}.
+ */
+export interface LogAdapter {
+  log(level: EmittedLevel, tag: string, args: unknown[]): void;
+}
+
+const CONSOLE_METHOD: Record<EmittedLevel, (...args: unknown[]) => void> = {
+  error: (...args) => console.error(...args),
+  warn: (...args) => console.warn(...args),
+  info: (...args) => console.info(...args),
+  debug: (...args) => console.debug(...args),
+};
+
+/**
+ * Zero-dependency default adapter. Writes to the matching `console` method,
+ * prefixing the record with its `[tag]` so scoped loggers stay
+ * distinguishable in plain terminal or DevTools output.
+ */
+export const consoleAdapter: LogAdapter = {
+  log(level, tag, args) {
+    // eslint-disable-next-line security/detect-object-injection -- level is an EmittedLevel union member indexing a fixed Record, never external input
+    CONSOLE_METHOD[level](`[${tag}]`, ...args);
+  },
+};
+
+let _adapter: LogAdapter = consoleAdapter;
+
+/**
+ * Swap the output sink used by every logger, current and future. Apps that
+ * bundle `consola` call this once at startup with the adapter from
+ * `@wardnet/js/consola`; leaving it unset keeps the zero-dependency
+ * {@link consoleAdapter}.
+ */
+export function setAdapter(adapter: LogAdapter): void {
+  _adapter = adapter;
+}
 
 const _overrides = new Map<string, LogLevel>();
 const _resolved = new Map<string, LogLevel>();
@@ -53,28 +93,20 @@ export interface Logger {
 }
 
 export function createLogger(tag: string): Logger {
-  const scoped = _root.withTag(tag);
-  // eslint-disable-next-line security/detect-object-injection -- keys are LogLevel union members indexing a Record<LogLevel, number>, never external input
-  const enabled = (level: LogLevel) => NUMERIC[resolveLevel(tag)] >= NUMERIC[level];
-  // Cast to satisfy TypeScript's strict spread-into-rest rules while keeping
-  // our public interface typed as unknown[].
-  type AnyArgs = [unknown, ...unknown[]];
+  const enabled = (level: EmittedLevel) => NUMERIC[resolveLevel(tag)] >= NUMERIC[level];
+  const emit =
+    (level: EmittedLevel) =>
+    (...args: unknown[]) => {
+      if (enabled(level)) _adapter.log(level, tag, args);
+    };
   return {
     get tag() {
       return tag;
     },
-    error: (...args) => {
-      if (enabled("error")) scoped.error(...(args as AnyArgs));
-    },
-    warn: (...args) => {
-      if (enabled("warn")) scoped.warn(...(args as AnyArgs));
-    },
-    info: (...args) => {
-      if (enabled("info")) scoped.info(...(args as AnyArgs));
-    },
-    debug: (...args) => {
-      if (enabled("debug")) scoped.debug(...(args as AnyArgs));
-    },
+    error: emit("error"),
+    warn: emit("warn"),
+    info: emit("info"),
+    debug: emit("debug"),
   };
 }
 

--- a/source/sdk/wardnet-js/src/logger.ts
+++ b/source/sdk/wardnet-js/src/logger.ts
@@ -93,6 +93,7 @@ export interface Logger {
 }
 
 export function createLogger(tag: string): Logger {
+  // eslint-disable-next-line security/detect-object-injection -- keys are LogLevel union members indexing a Record<LogLevel, number>, never external input
   const enabled = (level: EmittedLevel) => NUMERIC[resolveLevel(tag)] >= NUMERIC[level];
   const emit =
     (level: EmittedLevel) =>

--- a/source/sdk/wardnet-js/src/services/backup.ts
+++ b/source/sdk/wardnet-js/src/services/backup.ts
@@ -17,8 +17,11 @@ import type {
  * just plumbs the request through the shared `WardnetClient`
  * (credentials include cookies by default).
  *
- * Two methods bypass `WardnetClient.request` because they don't fit
- * the JSON-in / JSON-out shape:
+ * Two methods don't fit the JSON-in / JSON-out shape of
+ * `WardnetClient.request`, so they call `WardnetClient.authorizedFetch`
+ * directly instead. That still routes header construction through the
+ * client, so a subclass's `buildHeaders` override (e.g. bearer auth) is
+ * applied to these endpoints too:
  *
  * - `export` returns `application/octet-stream` (the encrypted
  *   bundle bytes). Using `Blob` keeps the SDK free of a Node-vs-browser
@@ -44,10 +47,9 @@ export class BackupService {
    * The Blob's MIME type is `application/octet-stream`.
    */
   async export(body: ExportBackupRequest): Promise<Blob> {
-    const res = await fetch(`${this.client.baseUrl}/backup/export`, {
+    const res = await this.client.authorizedFetch("/backup/export", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      credentials: "include",
       body: JSON.stringify(body),
     });
     if (!res.ok) {
@@ -69,11 +71,10 @@ export class BackupService {
     form.append("bundle", bundle, "bundle.wardnet.age");
     form.append("passphrase", passphrase);
 
-    const res = await fetch(`${this.client.baseUrl}/backup/import/preview`, {
+    const res = await this.client.authorizedFetch("/backup/import/preview", {
       method: "POST",
       // NB: no Content-Type header — the platform sets it with the
       // multipart boundary when the body is a FormData.
-      credentials: "include",
       body: form,
     });
     if (!res.ok) {

--- a/source/sdk/wardnet-js/src/services/system.ts
+++ b/source/sdk/wardnet-js/src/services/system.ts
@@ -1,5 +1,6 @@
 import { type WardnetClient } from "../client.js";
 import type {
+  RecentErrorsResponse,
   SetDefaultPolicyRequest,
   SetDefaultPolicyResponse,
   SystemStatusResponse,
@@ -12,6 +13,15 @@ export class SystemService {
   /** Get system status including version, uptime, and counts (admin only). */
   async getStatus(): Promise<SystemStatusResponse> {
     return this.client.request<SystemStatusResponse>("/system/status");
+  }
+
+  /**
+   * Recent warnings and errors from the daemon's in-memory notifier ring
+   * buffer (admin only). Powers the dashboard's "recent issues" panel;
+   * currently returns at most the last 15 entries, newest first.
+   */
+  async getRecentErrors(): Promise<RecentErrorsResponse> {
+    return this.client.request<RecentErrorsResponse>("/system/errors");
   }
 
   /**

--- a/source/sdk/wardnet-js/src/types/system.ts
+++ b/source/sdk/wardnet-js/src/types/system.ts
@@ -55,3 +55,31 @@ export interface SetDefaultPolicyRequest {
 export interface SetDefaultPolicyResponse {
   policy: string;
 }
+
+/**
+ * A structured, admin-facing problem report raised by a daemon component,
+ * paired with a plain-language message and a remediation hint. Mirrors the
+ * daemon's `ApiDiagnostic`.
+ */
+export interface SystemDiagnostic {
+  /** ISO 8601 timestamp of when the underlying condition occurred. */
+  timestamp: string;
+  /** Stable machine-readable class identifier, e.g. `tunnel_start_failed`. */
+  code: string;
+  /** One of `error`, `warning`, `info`. */
+  severity: string;
+  /** The subsystem that raised it. */
+  component: string;
+  /** Plain-language description of what happened. */
+  message: string;
+  /** What the admin can do about it. */
+  hint: string;
+}
+
+/**
+ * Response for GET /api/system/errors — the most recent admin-facing
+ * diagnostics from the daemon (currently the last 15 entries).
+ */
+export interface RecentErrorsResponse {
+  errors: SystemDiagnostic[];
+}

--- a/source/sdk/wardnet-js/tsup.config.ts
+++ b/source/sdk/wardnet-js/tsup.config.ts
@@ -1,10 +1,13 @@
 import { defineConfig } from "tsup";
 
 export default defineConfig({
-  entry: ["src/index.ts"],
+  // `consola` is a separate entry so the main bundle stays dependency-free;
+  // it's an optional peer, pulled in only by consumers importing this subpath.
+  entry: ["src/index.ts", "src/consola.ts"],
   format: ["esm"],
   target: "es2020",
   dts: true,
   sourcemap: true,
   clean: true,
+  external: ["consola"],
 });

--- a/source/web/package.json
+++ b/source/web/package.json
@@ -29,6 +29,7 @@
   "dependencies": {
     "@wardnet/ui": "^0.3.0",
     "clsx": "2.1.1",
+    "consola": "^3.4.2",
     "cronstrue": "3.24.0",
     "qrcode": "1.5.4",
     "tailwind-merge": "3.6.0"

--- a/source/web/src/hooks/useSystemStatus.ts
+++ b/source/web/src/hooks/useSystemStatus.ts
@@ -1,5 +1,6 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { systemService, client } from "../lib/sdk";
+import type { RecentErrorsResponse } from "@wardnet/js";
+import { systemService } from "../lib/sdk";
 
 export function useSystemStatus() {
   return useQuery({
@@ -26,34 +27,12 @@ export function useAcknowledgeShutdown() {
   });
 }
 
-/**
- * A structured, admin-facing problem report. Raised by a daemon component and
- * paired with a plain-language message and a remediation hint — see the
- * daemon's `diagnostics` module. Replaces the old raw warning/error log line.
- */
-interface SystemDiagnostic {
-  timestamp: string;
-  /** Stable class identifier, e.g. `tunnel_start_failed`. */
-  code: string;
-  /** One of `error`, `warning`, `info`. */
-  severity: string;
-  /** The subsystem that raised it. */
-  component: string;
-  message: string;
-  /** What the admin can do about it. */
-  hint: string;
-}
-
-interface RecentErrorsResponse {
-  errors: SystemDiagnostic[];
-}
-
 export function useRecentErrors() {
   return useQuery<RecentErrorsResponse>({
     queryKey: ["system", "errors"],
-    queryFn: () => client.request<RecentErrorsResponse>("/system/errors"),
+    queryFn: () => systemService.getRecentErrors(),
     refetchInterval: 15_000,
   });
 }
 
-export type { SystemDiagnostic };
+export type { SystemDiagnostic } from "@wardnet/js";

--- a/source/web/src/lib/logger.ts
+++ b/source/web/src/lib/logger.ts
@@ -1,4 +1,11 @@
-import { createLogger } from "@wardnet/js";
+import { createLogger, setAdapter } from "@wardnet/js";
+import { createConsolaAdapter } from "@wardnet/js/consola";
+
+// Route SDK + UI logging through consola for rich, tagged output. The SDK
+// declares no hard dependency on consola (it defaults to a zero-dependency
+// console adapter); the web apps bundle consola and opt in here, so every
+// surface that imports `@wardnet/web` shares one configured adapter.
+setAdapter(createConsolaAdapter());
 
 export { createLogger, setLevel } from "@wardnet/js";
 export type { Logger, LogLevel } from "@wardnet/js";

--- a/source/web/src/lib/utils.ts
+++ b/source/web/src/lib/utils.ts
@@ -101,9 +101,16 @@ export function suggestHostnameForMac(
 
 /** Format bytes into a human-readable string (e.g. "1.2 GB"). */
 export function formatBytes(bytes: number): string {
-  if (bytes === 0) return "0 B";
+  // Non-positive input has no magnitude: `Math.log(0)` is `-Infinity` and
+  // `Math.log(<0)` is `NaN`, either of which would produce a garbage index.
+  if (bytes <= 0) return "0 B";
   const units = ["B", "KB", "MB", "GB", "TB"];
-  const i = Math.floor(Math.log(bytes) / Math.log(1024));
+  // Clamp to the largest known unit so values past 1 PB still render as
+  // "N TB" rather than indexing past the array and printing "undefined".
+  const i = Math.min(
+    Math.floor(Math.log(bytes) / Math.log(1024)),
+    units.length - 1,
+  );
   const value = bytes / Math.pow(1024, i);
   // eslint-disable-next-line security/detect-object-injection -- i is a numeric magnitude index into a local const unit array; no attacker-controlled key
   return `${value.toFixed(i === 0 ? 0 : 1)} ${units[i]}`;

--- a/source/web/src/lib/utils.ts
+++ b/source/web/src/lib/utils.ts
@@ -105,12 +105,11 @@ export function formatBytes(bytes: number): string {
   // `Math.log(<0)` is `NaN`, either of which would produce a garbage index.
   if (bytes <= 0) return "0 B";
   const units = ["B", "KB", "MB", "GB", "TB"];
-  // Clamp to the largest known unit so values past 1 PB still render as
-  // "N TB" rather than indexing past the array and printing "undefined".
-  const i = Math.min(
-    Math.floor(Math.log(bytes) / Math.log(1024)),
-    units.length - 1,
-  );
+  // Clamp both ends: values in (0, 1) give a negative magnitude and values
+  // past 1 PB give one beyond the last unit — either would index off the
+  // array and print "undefined". Keep i within [0, units.length - 1].
+  const magnitude = Math.floor(Math.log(bytes) / Math.log(1024));
+  const i = Math.min(Math.max(magnitude, 0), units.length - 1);
   const value = bytes / Math.pow(1024, i);
   // eslint-disable-next-line security/detect-object-injection -- i is a numeric magnitude index into a local const unit array; no attacker-controlled key
   return `${value.toFixed(i === 0 ? 0 : 1)} ${units[i]}`;

--- a/source/web/tests/hooks/useSystemStatus.test.tsx
+++ b/source/web/tests/hooks/useSystemStatus.test.tsx
@@ -4,7 +4,11 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createQueryWrapper } from "../test-utils";
 
 const { systemService, client } = vi.hoisted(() => ({
-  systemService: { getStatus: vi.fn(), acknowledgeShutdown: vi.fn() },
+  systemService: {
+    getStatus: vi.fn(),
+    acknowledgeShutdown: vi.fn(),
+    getRecentErrors: vi.fn(),
+  },
   client: { request: vi.fn() },
 }));
 vi.mock("../../src/lib/sdk", () => ({ systemService, client }));
@@ -38,12 +42,13 @@ describe("useSystemStatus", () => {
     expect(systemService.acknowledgeShutdown).toHaveBeenCalledOnce();
   });
 
-  it("fetches recent errors from the raw client endpoint", async () => {
-    client.request.mockResolvedValue({ errors: [] });
+  it("fetches recent errors through SystemService", async () => {
+    systemService.getRecentErrors.mockResolvedValue({ errors: [] });
     const { result } = renderHook(() => useRecentErrors(), {
       wrapper: createQueryWrapper(),
     });
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
-    expect(client.request).toHaveBeenCalledWith("/system/errors");
+    expect(systemService.getRecentErrors).toHaveBeenCalledOnce();
+    expect(client.request).not.toHaveBeenCalled();
   });
 });

--- a/source/web/tests/lib/utils.test.ts
+++ b/source/web/tests/lib/utils.test.ts
@@ -124,6 +124,12 @@ describe("formatBytes", () => {
     expect(formatBytes(1024 ** 5)).toBe("1024.0 TB");
     expect(formatBytes(5 * 1024 ** 5)).toBe("5120.0 TB");
   });
+  // A positive value below 1 byte gives a negative magnitude; without the
+  // lower clamp the index went to -1 and printed "undefined".
+  it("clamps positive sub-byte input to the B unit", () => {
+    expect(formatBytes(0.5)).toBe("1 B");
+    expect(formatBytes(0.001)).toBe("0 B");
+  });
 });
 
 describe("formatMbps / formatMs", () => {

--- a/source/web/tests/lib/utils.test.ts
+++ b/source/web/tests/lib/utils.test.ts
@@ -111,6 +111,19 @@ describe("formatBytes", () => {
     expect(formatBytes(1024 * 1024)).toBe("1.0 MB");
     expect(formatBytes(1.5 * 1024 * 1024 * 1024)).toBe("1.5 GB");
   });
+  // Math.log is -Infinity / NaN for these; without a guard they produced
+  // "NaN undefined" and an out-of-range unit index.
+  it("returns 0 B for non-positive input", () => {
+    expect(formatBytes(-1)).toBe("0 B");
+    expect(formatBytes(-1024)).toBe("0 B");
+  });
+  // Past the last known unit, clamp to TB instead of indexing off the array
+  // and printing "undefined".
+  it("clamps values beyond the largest unit to TB", () => {
+    expect(formatBytes(1024 ** 4)).toBe("1.0 TB");
+    expect(formatBytes(1024 ** 5)).toBe("1024.0 TB");
+    expect(formatBytes(5 * 1024 ** 5)).toBe("5120.0 TB");
+  });
 });
 
 describe("formatMbps / formatMs", () => {

--- a/source/web/tests/sdk/transport.test.ts
+++ b/source/web/tests/sdk/transport.test.ts
@@ -1,0 +1,143 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  BackupService,
+  SystemService,
+  WardnetClient,
+  type SystemDiagnostic,
+  type RecentErrorsResponse,
+  type UpdateTunnelDnsOverrideRequest,
+  type UpdateTunnelDnsOverrideResponse,
+} from "@wardnet/js";
+
+/**
+ * Client that attaches a marker header through the `buildHeaders` seam — the
+ * same override point the e2e `AuthedClient` uses for bearer auth. Every SDK
+ * transport path (JSON `request`, plus backup's raw octet-stream/multipart
+ * calls) must route through this seam, or a consumer's auth silently drops
+ * for exactly the endpoints that bypass `request`.
+ */
+class HeaderStampedClient extends WardnetClient {
+  protected override buildHeaders(init?: RequestInit): Record<string, string> {
+    return { ...super.buildHeaders(init), "X-Test-Auth": "Bearer test-token" };
+  }
+}
+
+/** Minimal `Response` stand-in covering only what the SDK reads. */
+function fakeResponse(init: {
+  ok?: boolean;
+  status?: number;
+  json?: unknown;
+  blob?: Blob;
+}): Response {
+  return {
+    ok: init.ok ?? true,
+    status: init.status ?? 200,
+    statusText: "OK",
+    headers: new Headers(),
+    json: async () => init.json,
+    blob: async () => init.blob ?? new Blob([]),
+  } as unknown as Response;
+}
+
+function lastFetchHeaders(mock: ReturnType<typeof vi.fn>): Headers {
+  const init = mock.mock.calls.at(-1)?.[1] as RequestInit | undefined;
+  return new Headers(init?.headers);
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("WardnetClient transport seam", () => {
+  it("routes BackupService.export through buildHeaders (auth header preserved)", async () => {
+    const fetchMock = vi.fn(async () =>
+      fakeResponse({ blob: new Blob(["bundle-bytes"]) }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const backup = new BackupService(
+      new HeaderStampedClient({ baseUrl: "/api" }),
+    );
+    const blob = await backup.export({ passphrase: "correct horse battery" });
+
+    expect(blob).toBeInstanceOf(Blob);
+    const [url] = fetchMock.mock.calls[0];
+    expect(url).toBe("/api/backup/export");
+    const headers = lastFetchHeaders(fetchMock);
+    expect(headers.get("X-Test-Auth")).toBe("Bearer test-token");
+    // JSON body still declares its content type.
+    expect(headers.get("Content-Type")).toBe("application/json");
+  });
+
+  it("routes BackupService.previewImport through buildHeaders without forcing a content type", async () => {
+    const fetchMock = vi.fn(async () =>
+      fakeResponse({
+        json: {
+          manifest: {},
+          compatible: true,
+          files_to_replace: [],
+          preview_token: "tok-123",
+        },
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const backup = new BackupService(
+      new HeaderStampedClient({ baseUrl: "/api" }),
+    );
+    const preview = await backup.previewImport(
+      new Blob(["bundle"]),
+      "correct horse battery",
+    );
+
+    expect(preview.preview_token).toBe("tok-123");
+    const [url] = fetchMock.mock.calls[0];
+    expect(url).toBe("/api/backup/import/preview");
+    const headers = lastFetchHeaders(fetchMock);
+    expect(headers.get("X-Test-Auth")).toBe("Bearer test-token");
+    // Must stay unset so the platform can inject the multipart boundary.
+    expect(headers.get("Content-Type")).toBeNull();
+  });
+});
+
+describe("SystemService.getRecentErrors", () => {
+  it("GETs /system/errors and returns the typed payload", async () => {
+    const payload: RecentErrorsResponse = {
+      errors: [
+        {
+          timestamp: "2026-07-12T00:00:00Z",
+          code: "dns_upstream_timeout",
+          severity: "error",
+          component: "dns",
+          message: "upstream timeout",
+          hint: "check the configured upstream resolvers",
+        },
+      ],
+    };
+    const fetchMock = vi.fn(async () => fakeResponse({ json: payload }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const system = new SystemService(new WardnetClient({ baseUrl: "/api" }));
+    const result = await system.getRecentErrors();
+
+    const [url] = fetchMock.mock.calls[0];
+    expect(url).toBe("/api/system/errors");
+    const first: SystemDiagnostic = result.errors[0];
+    expect(first.message).toBe("upstream timeout");
+  });
+});
+
+// Compile-time guard: these DTOs must remain importable from the package
+// entry. If the re-exports in the SDK's index.ts regress, this file stops
+// compiling and `tsc --noEmit` (and the test run) fails.
+describe("public type surface", () => {
+  it("exposes the tunnel DNS-override DTOs", () => {
+    const req: UpdateTunnelDnsOverrideRequest = { override_default_dns: true };
+    // Reference the response type at the type level only — it wraps a Tunnel,
+    // whose full shape we don't need to reconstruct here.
+    const readTunnel = (res: UpdateTunnelDnsOverrideResponse): unknown =>
+      res.tunnel;
+    expect(req.override_default_dns).toBe(true);
+    expect(typeof readTunnel).toBe("function");
+  });
+});

--- a/source/web/tests/sdk/transport.test.ts
+++ b/source/web/tests/sdk/transport.test.ts
@@ -51,7 +51,7 @@ afterEach(() => {
 
 describe("WardnetClient transport seam", () => {
   it("routes BackupService.export through buildHeaders (auth header preserved)", async () => {
-    const fetchMock = vi.fn(async () =>
+    const fetchMock = vi.fn(async (_input: string, _init?: RequestInit) =>
       fakeResponse({ blob: new Blob(["bundle-bytes"]) }),
     );
     vi.stubGlobal("fetch", fetchMock);
@@ -71,7 +71,7 @@ describe("WardnetClient transport seam", () => {
   });
 
   it("routes BackupService.previewImport through buildHeaders without forcing a content type", async () => {
-    const fetchMock = vi.fn(async () =>
+    const fetchMock = vi.fn(async (_input: string, _init?: RequestInit) =>
       fakeResponse({
         json: {
           manifest: {},
@@ -115,7 +115,9 @@ describe("SystemService.getRecentErrors", () => {
         },
       ],
     };
-    const fetchMock = vi.fn(async () => fakeResponse({ json: payload }));
+    const fetchMock = vi.fn(async (_input: string, _init?: RequestInit) =>
+      fakeResponse({ json: payload }),
+    );
     vi.stubGlobal("fetch", fetchMock);
 
     const system = new SystemService(new WardnetClient({ baseUrl: "/api" }));
@@ -130,7 +132,9 @@ describe("SystemService.getRecentErrors", () => {
 
 describe("header normalization", () => {
   it("preserves headers passed as a Headers instance", async () => {
-    const fetchMock = vi.fn(async () => fakeResponse({ json: {} }));
+    const fetchMock = vi.fn(async (_input: string, _init?: RequestInit) =>
+      fakeResponse({ json: {} }),
+    );
     vi.stubGlobal("fetch", fetchMock);
 
     const client = new WardnetClient({ baseUrl: "/api" });
@@ -145,7 +149,9 @@ describe("header normalization", () => {
   });
 
   it("preserves headers passed as an entries array", async () => {
-    const fetchMock = vi.fn(async () => fakeResponse({ json: {} }));
+    const fetchMock = vi.fn(async (_input: string, _init?: RequestInit) =>
+      fakeResponse({ json: {} }),
+    );
     vi.stubGlobal("fetch", fetchMock);
 
     const client = new WardnetClient({ baseUrl: "/api" });

--- a/source/web/tests/sdk/transport.test.ts
+++ b/source/web/tests/sdk/transport.test.ts
@@ -40,7 +40,8 @@ function fakeResponse(init: {
 }
 
 function lastFetchHeaders(mock: ReturnType<typeof vi.fn>): Headers {
-  const init = mock.mock.calls.at(-1)?.[1] as RequestInit | undefined;
+  const calls = mock.mock.calls;
+  const init = calls[calls.length - 1]?.[1] as RequestInit | undefined;
   return new Headers(init?.headers);
 }
 
@@ -124,6 +125,34 @@ describe("SystemService.getRecentErrors", () => {
     expect(url).toBe("/api/system/errors");
     const first: SystemDiagnostic = result.errors[0];
     expect(first.message).toBe("upstream timeout");
+  });
+});
+
+describe("header normalization", () => {
+  it("preserves headers passed as a Headers instance", async () => {
+    const fetchMock = vi.fn(async () => fakeResponse({ json: {} }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const client = new WardnetClient({ baseUrl: "/api" });
+    await client.request("/thing", {
+      headers: new Headers({ "X-Custom": "yes" }),
+    });
+
+    const headers = lastFetchHeaders(fetchMock);
+    expect(headers.get("X-Custom")).toBe("yes");
+    // The JSON default is still applied on top of the caller's headers.
+    expect(headers.get("Content-Type")).toBe("application/json");
+  });
+
+  it("preserves headers passed as an entries array", async () => {
+    const fetchMock = vi.fn(async () => fakeResponse({ json: {} }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const client = new WardnetClient({ baseUrl: "/api" });
+    await client.request("/thing", { headers: [["X-Custom", "yes"]] });
+
+    const headers = lastFetchHeaders(fetchMock);
+    expect(headers.get("X-Custom")).toBe("yes");
   });
 });
 

--- a/source/web/tests/sdk/transport.test.ts
+++ b/source/web/tests/sdk/transport.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi, type Mock } from "vitest";
 import {
   BackupService,
   SystemService,
@@ -8,6 +8,13 @@ import {
   type UpdateTunnelDnsOverrideRequest,
   type UpdateTunnelDnsOverrideResponse,
 } from "@wardnet/js";
+
+/**
+ * `fetch` call signature. Typing the mocks with it (rather than adding unused
+ * parameters to their implementations) makes `mock.calls` a `[url, init?]`
+ * tuple so the assertions below can read the outgoing URL and headers.
+ */
+type FetchFn = (url: string, init?: RequestInit) => Promise<Response>;
 
 /**
  * Client that attaches a marker header through the `buildHeaders` seam — the
@@ -39,9 +46,9 @@ function fakeResponse(init: {
   } as unknown as Response;
 }
 
-function lastFetchHeaders(mock: ReturnType<typeof vi.fn>): Headers {
+function lastFetchHeaders(mock: Mock<FetchFn>): Headers {
   const calls = mock.mock.calls;
-  const init = calls[calls.length - 1]?.[1] as RequestInit | undefined;
+  const init = calls[calls.length - 1]?.[1];
   return new Headers(init?.headers);
 }
 
@@ -51,7 +58,7 @@ afterEach(() => {
 
 describe("WardnetClient transport seam", () => {
   it("routes BackupService.export through buildHeaders (auth header preserved)", async () => {
-    const fetchMock = vi.fn(async (_input: string, _init?: RequestInit) =>
+    const fetchMock = vi.fn<FetchFn>(async () =>
       fakeResponse({ blob: new Blob(["bundle-bytes"]) }),
     );
     vi.stubGlobal("fetch", fetchMock);
@@ -71,7 +78,7 @@ describe("WardnetClient transport seam", () => {
   });
 
   it("routes BackupService.previewImport through buildHeaders without forcing a content type", async () => {
-    const fetchMock = vi.fn(async (_input: string, _init?: RequestInit) =>
+    const fetchMock = vi.fn<FetchFn>(async () =>
       fakeResponse({
         json: {
           manifest: {},
@@ -115,7 +122,7 @@ describe("SystemService.getRecentErrors", () => {
         },
       ],
     };
-    const fetchMock = vi.fn(async (_input: string, _init?: RequestInit) =>
+    const fetchMock = vi.fn<FetchFn>(async () =>
       fakeResponse({ json: payload }),
     );
     vi.stubGlobal("fetch", fetchMock);
@@ -132,9 +139,7 @@ describe("SystemService.getRecentErrors", () => {
 
 describe("header normalization", () => {
   it("preserves headers passed as a Headers instance", async () => {
-    const fetchMock = vi.fn(async (_input: string, _init?: RequestInit) =>
-      fakeResponse({ json: {} }),
-    );
+    const fetchMock = vi.fn<FetchFn>(async () => fakeResponse({ json: {} }));
     vi.stubGlobal("fetch", fetchMock);
 
     const client = new WardnetClient({ baseUrl: "/api" });
@@ -149,9 +154,7 @@ describe("header normalization", () => {
   });
 
   it("preserves headers passed as an entries array", async () => {
-    const fetchMock = vi.fn(async (_input: string, _init?: RequestInit) =>
-      fakeResponse({ json: {} }),
-    );
+    const fetchMock = vi.fn<FetchFn>(async () => fakeResponse({ json: {} }));
     vi.stubGlobal("fetch", fetchMock);
 
     const client = new WardnetClient({ baseUrl: "/api" });

--- a/source/yarn.lock
+++ b/source/yarn.lock
@@ -5557,6 +5557,11 @@ __metadata:
     prettier: "npm:3.9.4"
     tsup: "npm:8.5.1"
     typescript: "npm:6.0.3"
+  peerDependencies:
+    consola: ^3.4.2
+  peerDependenciesMeta:
+    consola:
+      optional: true
   languageName: unknown
   linkType: soft
 
@@ -5703,6 +5708,7 @@ __metadata:
     "@wardnet/js": "workspace:*"
     "@wardnet/ui": "npm:^0.3.0"
     clsx: "npm:2.1.1"
+    consola: "npm:^3.4.2"
     cronstrue: "npm:3.24.0"
     eslint: "npm:10.7.0"
     eslint-config-prettier: "npm:10.1.8"


### PR DESCRIPTION
Closes #857.

`@wardnet/js` had a few calls and types that skipped the one abstraction meant to own them. These are the same class of defect, so they're fixed together.

## Transport seam (backup auth)
`BackupService.export()` and `previewImport()` issued raw `fetch()` calls straight past `WardnetClient`, so any `Authorization` header a consumer applied by subclassing the client was silently dropped for exactly those two endpoints — the documented non-browser/bearer-token path.

Header construction now lives in one place on `WardnetClient`:
- `buildHeaders()` — a protected seam a subclass overrides to attach cross-cutting headers. It normalizes a `Headers` instance or entries array into a plain record (the common plain-object path still spreads directly, so no `Headers` is allocated on the request hot path).
- `authorizedFetch()` — a shared fetch (base-URL prefixing, `credentials: "include"`, headers via `buildHeaders`) that both `request()` and the two multipart/octet-stream backup calls route through.

The e2e `AuthedClient` moves from a `request()` override to the `buildHeaders()` seam, so its bearer token now also covers the backup endpoints.

## System diagnostics
Added `SystemService.getRecentErrors()`, backed by `SystemDiagnostic` / `RecentErrorsResponse` in the SDK's `types` module (mirroring the daemon's `/system/errors` `ApiDiagnostic` DTO). The web `useRecentErrors` hook now calls it instead of a raw `client.request()` with a locally redeclared response shape, and re-exports `SystemDiagnostic` from the SDK.

## Tunnel DTO exports
`UpdateTunnelDnsOverrideRequest` / `UpdateTunnelDnsOverrideResponse` — the contract of the public `TunnelService.setDnsOverride()` — were the only DTOs on an exported method missing from the entry point. They're exported now.

## consola → optional peer dependency
`package.json` declared a hard runtime dependency on `consola`, contradicting the SDK's "zero runtime dependencies" position. Instead of dropping consola's tagged output, the log sink is now pluggable:
- A zero-dependency console adapter is the default; `setAdapter()` swaps it.
- A consola-backed adapter lives behind the `@wardnet/js/consola` subpath, so importing the package entry never pulls consola in. `consola` becomes an optional `peerDependency`.
- The web apps bundle consola and opt in once, in the shared logger, keeping the richer output.

`technical-stack.md` now states the real footprint: zero *required* runtime dependencies, consola optional.

## formatBytes bounds
`formatBytes` printed `"NaN undefined"` for `bytes <= 0`, `"... undefined"` past 1 PB, and (after the first pass) `"N undefined"` for positive inputs below 1 byte. The unit index is now clamped on both ends and non-positive input returns `"0 B"`.

## Testing
- New web-side suite asserts the auth header reaches both backup fetches, that headers supplied as a `Headers` instance or entries array survive, that `getRecentErrors()` hits `/system/errors`, and a compile-time guard on the tunnel DTO exports.
- `formatBytes` boundary tests (non-positive, sub-byte, 1 PB overflow) alongside the existing in-range cases.
- SDK `tsc --noEmit` and `tsup` build pass, including the new `./consola` entry with consola externalized.