### PR TITLE
feat(private-dns): relay :853 DoT through the reverse tunnel

### DIFF
--- a/source/daemon/crates/wardnetd-services/src/cloud/tests/tunneller.rs
+++ b/source/daemon/crates/wardnetd-services/src/cloud/tests/tunneller.rs
@@ -21,7 +21,8 @@ use axum::response::Response;
 use axum::routing::{get, post};
 use base64::Engine as _;
 use serde_json::json;
-use tokio::net::UdpSocket;
+use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _};
+use tokio::net::{TcpListener, UdpSocket};
 use tokio::sync::mpsc;
 use tokio::time::timeout;
 use tokio_tungstenite::tungstenite::Message;
@@ -30,10 +31,10 @@ use wardnetd_data::secret_store::SecretStore;
 
 use crate::cloud::TenantsClient;
 use crate::cloud::tunneller::{
-    self, FRAME_CLOSE, FRAME_CONNECT, FRAME_DATA, FRAME_PING, FRAME_PONG, Frame,
+    self, FRAME_CLOSE, FRAME_CONNECT, FRAME_DATA, FRAME_PING, FRAME_PONG, FRAME_READY, Frame,
 };
 use crate::cloud::tunneller_runner::{
-    Backoff, Conn, TunnelerConnector, TunnelerRunner, handle_frame,
+    Backoff, Conn, TunnelerConnector, TunnelerRunner, connect_dot_relay, handle_frame,
 };
 use crate::ddns::region::RegionEndpoint;
 
@@ -65,6 +66,14 @@ fn encode_close_and_pong_have_fixed_shape() {
 }
 
 #[test]
+fn encode_ready_has_fixed_shape() {
+    // FRAME_READY is [type, conn_id:u32be] — the TCP path's "local connect ok".
+    assert_eq!(tunneller::encode_ready(9), vec![FRAME_READY, 0, 0, 0, 9]);
+    // It only ever flows daemon→node, so it must not decode as an inbound frame.
+    assert_eq!(tunneller::decode(&tunneller::encode_ready(9)), None);
+}
+
+#[test]
 fn decode_connect_reads_dest_port() {
     // [FRAME_CONNECT, conn_id=9, dest_port=0x0050 (80)]
     let bytes = [FRAME_CONNECT, 0, 0, 0, 9, 0x00, 0x50];
@@ -91,8 +100,8 @@ fn decode_ping_requires_zero_conn_id() {
 fn decode_rejects_short_unknown_and_unused_frames() {
     // Too short (< 5 bytes).
     assert_eq!(tunneller::decode(&[FRAME_DATA, 0, 0]), None);
-    // FRAME_READY (0x02) is the TCP path's signal, unused for UDP → ignored.
-    assert_eq!(tunneller::decode(&[0x02, 0, 0, 0, 1]), None);
+    // FRAME_READY (0x02) is daemon→node only, never a valid inbound frame → ignored.
+    assert_eq!(tunneller::decode(&[FRAME_READY, 0, 0, 0, 1]), None);
     // A CONNECT truncated before its dest_port.
     assert_eq!(tunneller::decode(&[FRAME_CONNECT, 0, 0, 0, 1]), None);
 }
@@ -260,6 +269,38 @@ fn connector_with_config(port: u16) -> (Arc<TunnelerConnector>, Arc<MockSystemCo
     (connector, system_config)
 }
 
+/// Build a connector with the two feature gates set explicitly, so a test can drive
+/// the per-frame gating (WG-only / private-DNS-only / both off). The gateway/secret
+/// fields are unused placeholders — only the config flags are exercised.
+fn connector_with_gates(wg: bool, private_dns: bool) -> Arc<TunnelerConnector> {
+    let system_config = Arc::new(MockSystemConfig::with(&[
+        ("inbound_wg_enabled", if wg { "true" } else { "false" }),
+        (
+            "private_dns_enabled",
+            if private_dns { "true" } else { "false" },
+        ),
+        ("inbound_wg_listen_port", "9000"),
+        ("ddns_region", "test"),
+    ]));
+    let secrets = Arc::new(MockSecretStore::default());
+    let tenants = Arc::new(TenantsClient::new(
+        reqwest::Client::new(),
+        "http://unused".to_owned(),
+    ));
+    let catalog = vec![RegionEndpoint {
+        slug: "test".to_owned(),
+        gateway_base_url: "http://unused".to_owned(),
+        health_url: String::new(),
+    }];
+    Arc::new(TunnelerConnector::new(
+        system_config,
+        secrets,
+        tenants,
+        crate::entitlement::Entitlement::shared(),
+        catalog,
+    ))
+}
+
 /// A relay opener that succeeds with a throwaway loopback socket (no reader task,
 /// no real target) — stands in for `open_relay` when a test only cares about the
 /// bookkeeping around it.
@@ -270,6 +311,13 @@ async fn fake_open_ok(
 ) -> std::io::Result<Conn> {
     let socket = UdpSocket::bind(("127.0.0.1", 0)).await?;
     Ok(Conn::new_for_test(Arc::new(socket)))
+}
+
+/// A TCP relay opener that succeeds with a throwaway write channel — stands in for
+/// `open_tcp_relay` when a test only cares about the bookkeeping around it.
+async fn fake_open_tcp_ok(_conn_id: u32, _out_tx: mpsc::Sender<Message>) -> std::io::Result<Conn> {
+    let (tx, _rx) = mpsc::channel::<Vec<u8>>(8);
+    Ok(Conn::new_tcp_for_test(tx))
 }
 
 /// Decode a single binary frame off the out-channel, asserting it is a `FRAME_CLOSE`
@@ -304,6 +352,7 @@ async fn open_relay_failure_sends_close() {
         &out_tx,
         &mut conns,
         &open,
+        &fake_open_tcp_ok,
     )
     .await;
 
@@ -320,7 +369,7 @@ async fn ninth_concurrent_conn_is_rejected_at_cap() {
     let (out_tx, mut out_rx) = mpsc::channel::<Message>(256);
     let mut conns = HashMap::new();
 
-    // The first MAX_CONNS (8) flows are accepted with no FRAME_CLOSE.
+    // The first MAX_UDP_CONNS (8) flows are accepted with no FRAME_CLOSE.
     for conn_id in 1..=8u32 {
         handle_frame(
             &connect_frame(conn_id, 51_820),
@@ -329,6 +378,7 @@ async fn ninth_concurrent_conn_is_rejected_at_cap() {
             &out_tx,
             &mut conns,
             &fake_open_ok,
+            &fake_open_tcp_ok,
         )
         .await;
     }
@@ -346,6 +396,7 @@ async fn ninth_concurrent_conn_is_rejected_at_cap() {
         &out_tx,
         &mut conns,
         &fake_open_ok,
+        &fake_open_tcp_ok,
     )
     .await;
     assert_eq!(conns.len(), 8, "9th conn_id rejected - cap holds");
@@ -381,6 +432,7 @@ async fn connect_rereads_listen_port_per_flow() {
         &out_tx,
         &mut conns,
         &open,
+        &fake_open_tcp_ok,
     )
     .await;
     // Admin changes the listen port live between flows.
@@ -393,6 +445,7 @@ async fn connect_rereads_listen_port_per_flow() {
         &out_tx,
         &mut conns,
         &open,
+        &fake_open_tcp_ok,
     )
     .await;
 
@@ -401,6 +454,291 @@ async fn connect_rereads_listen_port_per_flow() {
         vec![1111, 2222],
         "each new flow re-reads the live inbound_wg_listen_port"
     );
+}
+
+// ── Unit: per-frame gating (issue #913) ───────────────────────────────────────────
+
+/// Drive a single CONNECT through `handle_frame` and report whether it was accepted
+/// (recorded in `conns`) or rejected with a `FRAME_CLOSE` — using no-op fake openers,
+/// so only the gate + dispatch decision is exercised.
+async fn connect_outcome(connector: &Arc<TunnelerConnector>, dest_port: u16) -> (usize, bool) {
+    let (out_tx, mut out_rx) = mpsc::channel::<Message>(256);
+    let mut conns = HashMap::new();
+    handle_frame(
+        &connect_frame(1, dest_port),
+        connector,
+        9000,
+        &out_tx,
+        &mut conns,
+        &fake_open_ok,
+        &fake_open_tcp_ok,
+    )
+    .await;
+    let closed = out_rx.try_recv().is_ok();
+    (conns.len(), closed)
+}
+
+#[tokio::test]
+async fn wg_only_gate_relays_wireguard_and_rejects_dot() {
+    let connector = connector_with_gates(true, false);
+
+    // A WireGuard flow (advisory dest_port) is accepted.
+    let (accepted, closed) = connect_outcome(&connector, 51_820).await;
+    assert_eq!(
+        (accepted, closed),
+        (1, false),
+        "WG flow accepted when WG on"
+    );
+
+    // A DoT flow is rejected with FRAME_CLOSE while Private DNS is off.
+    let (accepted, closed) = connect_outcome(&connector, 853).await;
+    assert_eq!(
+        (accepted, closed),
+        (0, true),
+        "DoT flow closed when DNS off"
+    );
+}
+
+#[tokio::test]
+async fn private_dns_only_gate_relays_dot_and_rejects_wireguard() {
+    let connector = connector_with_gates(false, true);
+
+    // A DoT flow is accepted.
+    let (accepted, closed) = connect_outcome(&connector, 853).await;
+    assert_eq!(
+        (accepted, closed),
+        (1, false),
+        "DoT flow accepted when DNS on"
+    );
+
+    // A WireGuard flow is rejected with FRAME_CLOSE while inbound-WG is off.
+    let (accepted, closed) = connect_outcome(&connector, 51_820).await;
+    assert_eq!((accepted, closed), (0, true), "WG flow closed when WG off");
+}
+
+#[tokio::test]
+async fn both_gates_off_rejects_every_flow() {
+    // With neither feature enabled the outer loop would not even dial, but should a
+    // frame still arrive mid-teardown, every flow is closed regardless of transport.
+    let connector = connector_with_gates(false, false);
+
+    let (accepted, closed) = connect_outcome(&connector, 51_820).await;
+    assert_eq!(
+        (accepted, closed),
+        (0, true),
+        "WG flow closed when both off"
+    );
+    let (accepted, closed) = connect_outcome(&connector, 853).await;
+    assert_eq!(
+        (accepted, closed),
+        (0, true),
+        "DoT flow closed when both off"
+    );
+}
+
+#[tokio::test]
+async fn https_connect_is_deferred_and_closed() {
+    // dest_port 443 has no local target yet (#816): always closed, regardless of
+    // which feature is enabled.
+    let connector = connector_with_gates(true, true);
+    let (accepted, closed) = connect_outcome(&connector, 443).await;
+    assert_eq!(
+        (accepted, closed),
+        (0, true),
+        "HTTPS (443) closed - deferred"
+    );
+}
+
+// ── Unit: split caps are independent (issue #913) ─────────────────────────────────
+
+#[tokio::test]
+async fn udp_and_tcp_caps_are_enforced_independently() {
+    let connector = connector_with_gates(true, true);
+    let (out_tx, mut out_rx) = mpsc::channel::<Message>(256);
+    let mut conns = HashMap::new();
+
+    // Fill the TCP (DoT) budget to MAX_TCP_CONNS = 16.
+    for conn_id in 1..=16u32 {
+        handle_frame(
+            &connect_frame(conn_id, 853),
+            &connector,
+            9000,
+            &out_tx,
+            &mut conns,
+            &fake_open_ok,
+            &fake_open_tcp_ok,
+        )
+        .await;
+    }
+    assert_eq!(conns.len(), 16, "16 DoT flows accepted");
+    assert!(
+        out_rx.try_recv().is_err(),
+        "no FRAME_CLOSE for accepted DoT"
+    );
+
+    // The 17th DoT flow is rejected at the cap.
+    handle_frame(
+        &connect_frame(17, 853),
+        &connector,
+        9000,
+        &out_tx,
+        &mut conns,
+        &fake_open_ok,
+        &fake_open_tcp_ok,
+    )
+    .await;
+    assert_eq!(conns.len(), 16, "17th DoT flow rejected - TCP cap holds");
+    assert_close(out_rx.try_recv().expect("cap rejection sends CLOSE"), 17);
+
+    // A WireGuard flow still opens: the TCP budget being full must not starve UDP.
+    handle_frame(
+        &connect_frame(100, 51_820),
+        &connector,
+        9000,
+        &out_tx,
+        &mut conns,
+        &fake_open_ok,
+        &fake_open_tcp_ok,
+    )
+    .await;
+    assert_eq!(
+        conns.len(),
+        17,
+        "a UDP flow opens despite a full TCP budget"
+    );
+    assert!(
+        out_rx.try_recv().is_err(),
+        "no FRAME_CLOSE for the accepted UDP flow"
+    );
+}
+
+// ── Integration: DoT TCP relay (issue #913) ───────────────────────────────────────
+
+/// Spawn a loopback TCP server that, per connection, echoes the first chunk it reads
+/// and then closes — standing in for the daemon's local `:853` `DoT` listener while
+/// also exercising the local-EOF teardown path. Returns its port.
+async fn spawn_tcp_echo_then_close() -> u16 {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let port = listener.local_addr().unwrap().port();
+    tokio::spawn(async move {
+        while let Ok((mut socket, _)) = listener.accept().await {
+            tokio::spawn(async move {
+                let mut buf = vec![0u8; 2048];
+                if let Ok(n @ 1..) = socket.read(&mut buf).await {
+                    let _ = socket.write_all(&buf[..n]).await;
+                }
+                // Drop `socket` → the client sees EOF.
+            });
+        }
+    });
+    port
+}
+
+/// Bind then immediately drop a listener to obtain a port guaranteed to refuse
+/// connections — for the `DoT` connect-failure path.
+async fn closed_tcp_port() -> u16 {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    listener.local_addr().unwrap().port()
+    // `listener` drops here.
+}
+
+#[tokio::test]
+async fn dot_relay_sends_ready_first_then_relays_and_closes_on_eof() {
+    let echo_port = spawn_tcp_echo_then_close().await;
+    let connector = connector_with_gates(false, true);
+    let (out_tx, mut out_rx) = mpsc::channel::<Message>(256);
+    let mut conns = HashMap::new();
+
+    // Real DoT opener bound to the loopback echo instead of :853.
+    let open_tcp = move |conn_id, out_tx| connect_dot_relay(conn_id, echo_port, out_tx);
+
+    // CONNECT dest_port=853 opens the TCP relay.
+    handle_frame(
+        &connect_frame(1, 853),
+        &connector,
+        9000,
+        &out_tx,
+        &mut conns,
+        &fake_open_ok,
+        &open_tcp,
+    )
+    .await;
+    assert_eq!(conns.len(), 1, "DoT flow recorded");
+
+    // The very first frame the node sees must be FRAME_READY (before any data).
+    let first = timeout(Duration::from_secs(5), out_rx.recv())
+        .await
+        .expect("READY before timeout")
+        .expect("channel open");
+    let Message::Binary(bytes) = first else {
+        panic!("expected READY frame");
+    };
+    assert_eq!(
+        bytes.as_ref(),
+        &[FRAME_READY, 0, 0, 0, 1],
+        "READY precedes data"
+    );
+
+    // Feed one payload; the echo comes back as FRAME_DATA (bidirectional relay).
+    handle_frame(
+        &tunneller::encode_data(1, b"ping"),
+        &connector,
+        9000,
+        &out_tx,
+        &mut conns,
+        &fake_open_ok,
+        &open_tcp,
+    )
+    .await;
+    let echoed = timeout(Duration::from_secs(5), out_rx.recv())
+        .await
+        .expect("echo before timeout")
+        .expect("channel open");
+    assert_eq!(
+        tunneller::decode(match &echoed {
+            Message::Binary(b) => b.as_ref(),
+            other => panic!("expected binary, got {other:?}"),
+        }),
+        Some(Frame::Data {
+            conn_id: 1,
+            payload: b"ping".to_vec(),
+        }),
+        "the local echo is relayed back as FRAME_DATA"
+    );
+
+    // The echo server then closed: the relay reports local EOF as FRAME_CLOSE.
+    let closed = timeout(Duration::from_secs(5), out_rx.recv())
+        .await
+        .expect("CLOSE before timeout")
+        .expect("channel open");
+    assert_close(closed, 1);
+}
+
+#[tokio::test]
+async fn dot_connect_failure_sends_close() {
+    let dead_port = closed_tcp_port().await;
+    let connector = connector_with_gates(false, true);
+    let (out_tx, mut out_rx) = mpsc::channel::<Message>(256);
+    let mut conns = HashMap::new();
+
+    let open_tcp = move |conn_id, out_tx| connect_dot_relay(conn_id, dead_port, out_tx);
+    handle_frame(
+        &connect_frame(1, 853),
+        &connector,
+        9000,
+        &out_tx,
+        &mut conns,
+        &fake_open_ok,
+        &open_tcp,
+    )
+    .await;
+
+    assert!(conns.is_empty(), "a refused DoT connect records no conn");
+    let msg = timeout(Duration::from_secs(5), out_rx.recv())
+        .await
+        .expect("CLOSE before timeout")
+        .expect("channel open");
+    assert_close(msg, 1);
 }
 
 // ── Fake Tunneller server ───────────────────────────────────────────────────────

--- a/source/daemon/crates/wardnetd-services/src/cloud/tunneller.rs
+++ b/source/daemon/crates/wardnetd-services/src/cloud/tunneller.rs
@@ -24,12 +24,21 @@
 //! ## Frame protocol
 //!
 //! Byte-identical to `wardnet-cloud`'s `crates/tunneller/src/tunnel/handler.rs`.
-//! For the UDP relay path only these matter (`FRAME_READY` 0x02 is the TCP/SNI
-//! path's "local connect succeeded" signal and is **never used** for UDP —
-//! datagrams flow immediately after `FRAME_CONNECT`):
+//! Two relay paths share the same framing:
+//!
+//! * **UDP / `WireGuard`** (`dest_port` advisory): datagrams flow immediately
+//!   after `FRAME_CONNECT` — the daemon opens a loopback UDP socket to its own
+//!   inbound-WG port and relays. `FRAME_READY` is not part of this path.
+//! * **TCP / Private DNS** (`dest_port == 853`): the cloud edge terminates the
+//!   `:853` SNI passthrough and asks the daemon to reach its local `DoT`
+//!   listener. Here `FRAME_READY` is load-bearing — the daemon TCP-connects
+//!   `127.0.0.1:853` and only after the connect succeeds emits `FRAME_READY`,
+//!   the "local end is up, start streaming" signal the cloud waits for before
+//!   forwarding the client's bytes.
 //!
 //! ```text
 //! FRAME_CONNECT 0x01  node→daemon  [type, conn_id:u32be, dest_port:u16be]
+//! FRAME_READY   0x02  daemon→node  [type, conn_id:u32be]   (TCP path: local connect ok)
 //! FRAME_DATA    0x03  both         [type, conn_id:u32be, payload...]
 //! FRAME_CLOSE   0x04  both         [type, conn_id:u32be]
 //! FRAME_PING    0x05  node→daemon  [type, 0u32]   (application-level, not WS ping)
@@ -54,9 +63,12 @@ pub(crate) const TUNNEL_PATH: &str = "/tunneller/v1/tunnel";
 
 // ── Frame protocol constants (mirror wardnet-cloud `handler.rs`) ────────────────
 
-/// `node→daemon`: a new inbound UDP flow — open a local relay socket for `conn_id`.
+/// `node→daemon`: a new inbound flow — open a local relay for `conn_id`.
 pub(crate) const FRAME_CONNECT: u8 = 0x01;
-/// Both directions: one relayed datagram for `conn_id`.
+/// `daemon→node`: the TCP path's local connect succeeded for `conn_id`; the node
+/// may now stream client bytes. Never emitted for the UDP path.
+pub(crate) const FRAME_READY: u8 = 0x02;
+/// Both directions: one relayed datagram/segment for `conn_id`.
 pub(crate) const FRAME_DATA: u8 = 0x03;
 /// Both directions: tear down `conn_id`.
 pub(crate) const FRAME_CLOSE: u8 = 0x04;
@@ -67,7 +79,8 @@ pub(crate) const FRAME_PING: u8 = 0x05;
 pub(crate) const FRAME_PONG: u8 = 0x06;
 
 /// A decoded inbound frame (node→daemon). Anything malformed or unrecognised
-/// (including the unused `FRAME_READY`) decodes to [`None`] and is ignored.
+/// decodes to [`None`] and is ignored. `FRAME_READY` is daemon→node only, so it
+/// is never a valid inbound frame and likewise decodes to [`None`].
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum Frame {
     /// A new inbound flow. `dest_port` is **advisory only** — the runner relays to
@@ -84,7 +97,8 @@ pub(crate) enum Frame {
 
 /// Decode an inbound binary frame, or [`None`] if it is too short, carries an
 /// unrecognised type, or is a well-formed frame the daemon does not act on
-/// (`FRAME_READY`, or a `FRAME_PING` with a non-zero `conn_id`).
+/// inbound (`FRAME_READY`, which only flows daemon→node, or a `FRAME_PING` with a
+/// non-zero `conn_id`).
 pub(crate) fn decode(data: &[u8]) -> Option<Frame> {
     // Every frame is at least `[type, conn_id:u32be]` = 5 bytes.
     if data.len() < 5 {
@@ -113,6 +127,15 @@ pub(crate) fn encode_data(conn_id: u32, payload: &[u8]) -> Vec<u8> {
     f.push(FRAME_DATA);
     f.extend_from_slice(&conn_id.to_be_bytes());
     f.extend_from_slice(payload);
+    f
+}
+
+/// Encode a `FRAME_READY` for `conn_id` (daemon→node) — the TCP path's signal
+/// that the local connect landed and the node may start streaming client bytes.
+pub(crate) fn encode_ready(conn_id: u32) -> Vec<u8> {
+    let mut f = Vec::with_capacity(5);
+    f.push(FRAME_READY);
+    f.extend_from_slice(&conn_id.to_be_bytes());
     f
 }
 

--- a/source/daemon/crates/wardnetd-services/src/cloud/tunneller_runner.rs
+++ b/source/daemon/crates/wardnetd-services/src/cloud/tunneller_runner.rs
@@ -6,20 +6,30 @@
 //! component (`ddns::runner`, `tls::runner`, …) is a fixed-interval poll loop with
 //! no long-lived socket. Here the runner:
 //!
-//! 1. **Gates** on `inbound_wg_enabled()` — it never dials while the inbound
-//!    `WireGuard` server is off, and tears the connection (and every local relay
-//!    socket) down promptly if the server is disabled mid-session.
+//! 1. **Gates** on `inbound_wg_enabled() || private_dns_enabled()` — the tunnel
+//!    carries two independent features (inbound `WireGuard`, issue #809, and
+//!    Private DNS's `:853` `DoT` reachability, issue #913), so it dials while
+//!    *either* is on and tears everything down only once *both* are off. Each
+//!    inbound flow is additionally gated per-frame on the feature it belongs to,
+//!    so turning one feature off rejects its flows without disturbing the other's.
 //! 2. **Dials** via [`TunnelerClient`], reusing the same enrollment identity + region
 //!    the DDNS client uses (seed + `ddns_region` slug the wizard persisted).
-//! 3. **Relays** each `conn_id`: on `FRAME_CONNECT` it opens a loopback UDP socket
-//!    to the daemon's *own* `inbound_wg_listen_port` (deliberately **ignoring** the
-//!    frame's `dest_port`, which the cloud currently hard-codes to a placeholder —
-//!    see its `TODO(wardnet#809)`; trusting a port the daemon didn't configure would
-//!    be a local-relay-target-confusion risk), spawns a reader task for the return
-//!    path, and forwards `FRAME_DATA` both ways until `FRAME_CLOSE` or the NAT-style
-//!    idle timeout.
+//! 3. **Relays** each `conn_id`, choosing the path by the `FRAME_CONNECT`
+//!    `dest_port`:
+//!    * `853` (Private DNS): TCP-connect the daemon's own loopback `DoT` listener
+//!      (`127.0.0.1:853`, 5s timeout), emit `FRAME_READY` once connected, then
+//!      relay bytes both ways until `FRAME_CLOSE`, local EOF, or the idle timeout.
+//!    * `443` (HTTPS SNI passthrough): reserved for the reverse web proxy —
+//!      deferred to #816, closed immediately for now.
+//!    * anything else (inbound `WireGuard`): open a loopback UDP socket to the
+//!      daemon's *own* `inbound_wg_listen_port`, deliberately **ignoring** the
+//!      frame's advisory `dest_port` (trusting a port the daemon didn't configure
+//!      would be a local-relay-target-confusion risk), and forward datagrams.
 //! 4. **Reconnects** with exponential backoff (1s → ×2 → 60s cap), reset after a
 //!    connection stays up past [`STABLE_CONNECTION`].
+//!
+//! The relay-socket count is capped per transport ([`MAX_UDP_CONNS`] /
+//! [`MAX_TCP_CONNS`]) so churn on one feature cannot starve the other of slots.
 //!
 //! WS keepalive: the cloud node pings every 30s and closes after 90s idle. The read
 //! loop stays hot (so the transport's auto-pong fires) and additionally answers a
@@ -33,7 +43,8 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use futures::{SinkExt as _, StreamExt as _};
-use tokio::net::UdpSocket;
+use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _};
+use tokio::net::{TcpStream, UdpSocket};
 use tokio::sync::mpsc;
 use tokio::time::Instant;
 use tokio_tungstenite::tungstenite::Message;
@@ -67,19 +78,39 @@ const GATE_POLL_INTERVAL: Duration = Duration::from_secs(5);
 const DISABLE_CHECK_INTERVAL: Duration = Duration::from_secs(5);
 /// How often the loop sweeps idle `conn_id`s.
 const CLEANUP_INTERVAL: Duration = Duration::from_secs(5);
-/// Idle window after which a relayed `conn_id` is torn down and `FRAME_CLOSE` sent
-/// proactively. Mirrors `wardnet-cloud`'s `UDP_IDLE_TIMEOUT`: UDP/`WireGuard` has no
-/// explicit teardown, so this NAT-style timeout (2 min) comfortably outlasts several
-/// missed keepalives (default 25s) before reclaiming a live-but-quiet peer.
+/// Idle window after which a relayed UDP `conn_id` is torn down and `FRAME_CLOSE`
+/// sent proactively. Mirrors `wardnet-cloud`'s `UDP_IDLE_TIMEOUT`: UDP/`WireGuard`
+/// has no explicit teardown, so this NAT-style timeout (2 min) comfortably outlasts
+/// several missed keepalives (default 25s) before reclaiming a live-but-quiet peer.
 const UDP_IDLE_TIMEOUT: Duration = Duration::from_mins(2);
 
-/// Upper bound on concurrently relayed `conn_id`s over one WS connection. Mirrors
-/// `wardnet-cloud`'s own `UDP_MAX_CONNS = 8`
-/// (`source/crates/tunneller/src/tunnel/udp_relay.rs`) as **defense-in-depth**: the
+/// Idle window for a relayed TCP (`DoT`) `conn_id`. TCP tears down explicitly on
+/// EOF/`FRAME_CLOSE`, so this is only a backstop against a half-open connection that
+/// stops moving bytes without ever closing; a `DoT` query/response is short-lived,
+/// so 2 min is generous headroom.
+const TCP_IDLE_TIMEOUT: Duration = Duration::from_mins(2);
+
+/// The daemon's own loopback `DoT` listener port. A Private-DNS `FRAME_CONNECT`
+/// (`dest_port == 853`) is relayed here — never to a port the frame carries.
+const DOT_PORT: u16 = 853;
+/// HTTPS SNI-passthrough port. The cloud edge can emit this once the reverse web
+/// proxy exists; until #816 the daemon has no local `:443` target and closes it.
+const HTTPS_PORT: u16 = 443;
+/// How long to wait for the loopback `DoT` connect before giving up and closing the
+/// flow, so a stuck local listener can't wedge a `conn_id`.
+const TCP_CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Upper bound on concurrently relayed **UDP** `conn_id`s over one WS connection.
+/// Mirrors `wardnet-cloud`'s own `UDP_MAX_CONNS = 8` as **defense-in-depth**: the
 /// cloud already caps its side, and the daemon independently caps its own so a
 /// misbehaving or compromised node cannot make it open an unbounded number of local
-/// relay sockets before the 2-minute idle sweep reclaims them.
-const MAX_CONNS: usize = 8;
+/// relay sockets before the idle sweep reclaims them.
+const MAX_UDP_CONNS: usize = 8;
+/// Upper bound on concurrently relayed **TCP** (`DoT`) `conn_id`s. Kept separate
+/// from [`MAX_UDP_CONNS`] so a burst of Private-DNS connections cannot exhaust the
+/// slots inbound `WireGuard` needs (and vice versa) — each transport gets its own
+/// independent budget.
+const MAX_TCP_CONNS: usize = 16;
 
 /// Exponential backoff schedule: hands out `initial`, then doubles each call up to
 /// `max`; [`reset`](Self::reset) returns to `initial`. Pure and deterministic so the
@@ -148,12 +179,32 @@ impl TunnelerConnector {
         }
     }
 
-    /// Whether the inbound `WireGuard` server is enabled — the runner's gate.
+    /// The runner's outer gate: the tunnel is wanted while *either* feature it
+    /// carries is enabled. A read error on one flag is treated as that feature
+    /// being off (already logged by the per-feature reader).
     async fn enabled(&self) -> bool {
+        self.wg_enabled().await || self.private_dns_enabled().await
+    }
+
+    /// Whether the inbound `WireGuard` server (issue #809) is enabled — the gate
+    /// for the UDP relay path.
+    async fn wg_enabled(&self) -> bool {
         match self.system_config.inbound_wg_enabled().await {
             Ok(enabled) => enabled,
             Err(error) => {
                 tracing::warn!(%error, "reverse tunnel: failed to read inbound-wg enabled flag");
+                false
+            }
+        }
+    }
+
+    /// Whether Private DNS (issue #913) is enabled — the gate for the `:853` TCP
+    /// relay path.
+    async fn private_dns_enabled(&self) -> bool {
+        match self.system_config.private_dns_enabled().await {
+            Ok(enabled) => enabled,
+            Err(error) => {
+                tracing::warn!(%error, "reverse tunnel: failed to read private-dns enabled flag");
                 false
             }
         }
@@ -334,7 +385,16 @@ async fn run_connection(
                 };
                 match message {
                     Message::Binary(data) => {
-                        handle_frame(&data, connector, port, &out_tx, &mut conns, &open_relay).await;
+                        handle_frame(
+                            &data,
+                            connector,
+                            port,
+                            &out_tx,
+                            &mut conns,
+                            &open_relay,
+                            &open_tcp_relay,
+                        )
+                        .await;
                     }
                     // Answer the WS-level ping explicitly so keepalive never stalls
                     // behind the transport's poll-driven auto-pong.
@@ -388,44 +448,96 @@ async fn run_connection(
     }
 }
 
-/// One active relayed flow: the loopback socket connected to the daemon's inbound
-/// `WireGuard` port, its NAT-style idle deadline, and the cancel handle stopping its
-/// return-path reader task.
+/// The local end of a relayed flow — the transport-specific handle the inbound
+/// `FRAME_DATA` path writes to.
+pub(crate) enum ConnKind {
+    /// Inbound `WireGuard`: a loopback UDP socket connected to the daemon's own
+    /// inbound-WG port; datagrams are written straight to it.
+    Udp(Arc<UdpSocket>),
+    /// Private DNS: the write side of the loopback `DoT` TCP connection, reached
+    /// through the relay task's channel (the task owns the split stream).
+    Tcp(mpsc::Sender<Vec<u8>>),
+}
+
+impl ConnKind {
+    /// The idle window for this transport, used to (re)arm a flow's deadline.
+    fn idle_timeout(&self) -> Duration {
+        match self {
+            ConnKind::Udp(_) => UDP_IDLE_TIMEOUT,
+            ConnKind::Tcp(_) => TCP_IDLE_TIMEOUT,
+        }
+    }
+}
+
+/// One active relayed flow: the local-end handle, its idle deadline, and the cancel
+/// handle stopping its return-path task.
 pub(crate) struct Conn {
-    socket: Arc<UdpSocket>,
+    kind: ConnKind,
     deadline: Instant,
     cancel: CancellationToken,
 }
 
 #[cfg(test)]
 impl Conn {
-    /// Build a `Conn` around an already-bound socket for unit tests, with no
+    /// Build a UDP `Conn` around an already-bound socket for unit tests, with no
     /// return-path reader spawned and a fresh cancel token.
     pub(crate) fn new_for_test(socket: Arc<UdpSocket>) -> Self {
         Self {
-            socket,
+            kind: ConnKind::Udp(socket),
             deadline: Instant::now() + UDP_IDLE_TIMEOUT,
+            cancel: CancellationToken::new(),
+        }
+    }
+
+    /// Build a TCP `Conn` around a write-channel sender for unit tests.
+    pub(crate) fn new_tcp_for_test(tx: mpsc::Sender<Vec<u8>>) -> Self {
+        Self {
+            kind: ConnKind::Tcp(tx),
+            deadline: Instant::now() + TCP_IDLE_TIMEOUT,
             cancel: CancellationToken::new(),
         }
     }
 }
 
+/// Send a `FRAME_CLOSE` for `conn_id` on the outbound funnel — the reject/teardown
+/// signal shared by the cap, gate, open-failure, and data-failure paths so a node
+/// never hangs waiting on a relay that will not (or no longer) exist.
+async fn send_close(out_tx: &mpsc::Sender<Message>, conn_id: u32) {
+    let _ = out_tx
+        .send(Message::Binary(tunneller::encode_close(conn_id).into()))
+        .await;
+}
+
+/// Count the live flows of a given transport, so each cap is enforced against its
+/// own kind rather than the combined total.
+fn count_kind(conns: &HashMap<u32, Conn>, tcp: bool) -> usize {
+    conns
+        .values()
+        .filter(|conn| matches!(conn.kind, ConnKind::Tcp(_)) == tcp)
+        .count()
+}
+
 /// Dispatch one inbound binary frame.
 ///
-/// `open` is the relay-socket opener — production passes [`open_relay`]; tests inject
-/// a fake to force failures or record the resolved port without touching the network.
-/// `fallback_port` is the port captured at connection start, used only when the live
+/// `open_udp` / `open_tcp` are the relay openers — production passes [`open_relay`]
+/// and [`open_tcp_relay`]; tests inject fakes to force failures, record the resolved
+/// port, or stand in for a real socket without touching the network. `fallback_port`
+/// is the inbound-WG port captured at connection start, used only when the live
 /// re-read of `inbound_wg_listen_port` fails.
-pub(crate) async fn handle_frame<F, Fut>(
+#[allow(clippy::too_many_arguments)]
+pub(crate) async fn handle_frame<F, Fut, G, Gut>(
     data: &[u8],
     connector: &TunnelerConnector,
     fallback_port: u16,
     out_tx: &mpsc::Sender<Message>,
     conns: &mut HashMap<u32, Conn>,
-    open: &F,
+    open_udp: &F,
+    open_tcp: &G,
 ) where
     F: Fn(u32, u16, mpsc::Sender<Message>) -> Fut,
     Fut: Future<Output = std::io::Result<Conn>>,
+    G: Fn(u32, mpsc::Sender<Message>) -> Gut,
+    Gut: Future<Output = std::io::Result<Conn>>,
 {
     let Some(frame) = tunneller::decode(data) else {
         return;
@@ -436,75 +548,134 @@ pub(crate) async fn handle_frame<F, Fut>(
                 .send(Message::Binary(tunneller::encode_pong().into()))
                 .await;
         }
-        // `dest_port` is intentionally ignored — always relay to the daemon's own
-        // configured inbound-WG port (see module docs).
-        Frame::Connect {
-            conn_id,
-            dest_port: _,
-        } => {
+        Frame::Connect { conn_id, dest_port } => {
             if conns.contains_key(&conn_id) {
                 // Duplicate CONNECT for a live conn_id — keep the existing relay.
                 return;
             }
-            // Defense-in-depth: cap the number of live flows independently of the
-            // cloud's own `UDP_MAX_CONNS`. Reject a new conn_id at the ceiling and
-            // tell the node with a FRAME_CLOSE (as the idle sweep + data-failure
-            // paths do) so it doesn't silently hang waiting for a relay that will
-            // never open.
-            if conns.len() >= MAX_CONNS {
-                tracing::warn!(
-                    conn_id,
-                    max = MAX_CONNS,
-                    "reverse tunnel: at MAX_CONNS cap, rejecting new conn_id"
-                );
-                let _ = out_tx
-                    .send(Message::Binary(tunneller::encode_close(conn_id).into()))
-                    .await;
-                return;
-            }
-            // Re-read the configured inbound-WG port so a live port change takes
-            // effect for every NEW flow. Already-open relay sockets keep their
-            // original target until they close or idle out (documented limitation).
-            let port = connector.listen_port().await.unwrap_or(fallback_port);
-            match open(conn_id, port, out_tx.clone()).await {
-                Ok(conn) => {
-                    conns.insert(conn_id, conn);
+            // The path is selected by `dest_port`: Private DNS terminates the
+            // cloud's `:853` SNI passthrough here, HTTPS is reserved for #816, and
+            // everything else is the inbound-WireGuard UDP relay (whose `dest_port`
+            // stays advisory — see module docs).
+            match dest_port {
+                DOT_PORT => {
+                    connect_tcp(conn_id, connector, out_tx, conns, open_tcp).await;
                 }
-                Err(error) => {
-                    tracing::warn!(conn_id, %error, "reverse tunnel: failed to open local relay socket");
-                    // Tell the node the flow was rejected instead of leaving it to
-                    // hang (matching the cap + data-failure FRAME_CLOSE paths).
-                    let _ = out_tx
-                        .send(Message::Binary(tunneller::encode_close(conn_id).into()))
-                        .await;
+                // deferred to #816: no local `:443` target exists yet, so close it.
+                HTTPS_PORT => send_close(out_tx, conn_id).await,
+                _ => {
+                    connect_udp(conn_id, connector, fallback_port, out_tx, conns, open_udp).await;
                 }
             }
         }
         Frame::Data { conn_id, payload } => {
-            let failed = if let Some(conn) = conns.get_mut(&conn_id) {
-                if conn.socket.send(&payload).await.is_ok() {
-                    conn.deadline = Instant::now() + UDP_IDLE_TIMEOUT;
-                    false
-                } else {
-                    true
+            let failed = match conns.get_mut(&conn_id) {
+                Some(conn) => {
+                    let sent = match &conn.kind {
+                        ConnKind::Udp(socket) => socket.send(&payload).await.is_ok(),
+                        ConnKind::Tcp(tx) => tx.send(payload).await.is_ok(),
+                    };
+                    if sent {
+                        conn.deadline = Instant::now() + conn.kind.idle_timeout();
+                        false
+                    } else {
+                        true
+                    }
                 }
-            } else {
                 // No CONNECT seen for this conn_id — tolerate and ignore.
-                false
+                None => false,
             };
             if failed {
                 if let Some(conn) = conns.remove(&conn_id) {
                     conn.cancel.cancel();
                 }
-                let _ = out_tx
-                    .send(Message::Binary(tunneller::encode_close(conn_id).into()))
-                    .await;
+                send_close(out_tx, conn_id).await;
             }
         }
         Frame::Close { conn_id } => {
             if let Some(conn) = conns.remove(&conn_id) {
                 conn.cancel.cancel();
             }
+        }
+    }
+}
+
+/// Open the inbound-`WireGuard` UDP relay for a new `conn_id`, gated on the WG
+/// feature and its own [`MAX_UDP_CONNS`] cap.
+async fn connect_udp<F, Fut>(
+    conn_id: u32,
+    connector: &TunnelerConnector,
+    fallback_port: u16,
+    out_tx: &mpsc::Sender<Message>,
+    conns: &mut HashMap<u32, Conn>,
+    open_udp: &F,
+) where
+    F: Fn(u32, u16, mpsc::Sender<Message>) -> Fut,
+    Fut: Future<Output = std::io::Result<Conn>>,
+{
+    // Per-frame gate: reject WG flows while the feature is off, even if the tunnel
+    // is up only for Private DNS.
+    if !connector.wg_enabled().await {
+        send_close(out_tx, conn_id).await;
+        return;
+    }
+    if count_kind(conns, false) >= MAX_UDP_CONNS {
+        tracing::warn!(
+            conn_id,
+            max = MAX_UDP_CONNS,
+            "reverse tunnel: at MAX_UDP_CONNS cap, rejecting new UDP conn_id"
+        );
+        send_close(out_tx, conn_id).await;
+        return;
+    }
+    // Re-read the configured inbound-WG port so a live port change takes effect for
+    // every NEW flow. Already-open relay sockets keep their original target until
+    // they close or idle out (documented limitation).
+    let port = connector.listen_port().await.unwrap_or(fallback_port);
+    match open_udp(conn_id, port, out_tx.clone()).await {
+        Ok(conn) => {
+            conns.insert(conn_id, conn);
+        }
+        Err(error) => {
+            tracing::warn!(conn_id, %error, "reverse tunnel: failed to open local UDP relay socket");
+            send_close(out_tx, conn_id).await;
+        }
+    }
+}
+
+/// Open the Private-DNS TCP relay for a new `conn_id`, gated on the Private-DNS
+/// feature and its own [`MAX_TCP_CONNS`] cap. The opener emits `FRAME_READY` on a
+/// successful connect (before any data), so nothing extra is sent here.
+async fn connect_tcp<G, Gut>(
+    conn_id: u32,
+    connector: &TunnelerConnector,
+    out_tx: &mpsc::Sender<Message>,
+    conns: &mut HashMap<u32, Conn>,
+    open_tcp: &G,
+) where
+    G: Fn(u32, mpsc::Sender<Message>) -> Gut,
+    Gut: Future<Output = std::io::Result<Conn>>,
+{
+    if !connector.private_dns_enabled().await {
+        send_close(out_tx, conn_id).await;
+        return;
+    }
+    if count_kind(conns, true) >= MAX_TCP_CONNS {
+        tracing::warn!(
+            conn_id,
+            max = MAX_TCP_CONNS,
+            "reverse tunnel: at MAX_TCP_CONNS cap, rejecting new DoT conn_id"
+        );
+        send_close(out_tx, conn_id).await;
+        return;
+    }
+    match open_tcp(conn_id, out_tx.clone()).await {
+        Ok(conn) => {
+            conns.insert(conn_id, conn);
+        }
+        Err(error) => {
+            tracing::warn!(conn_id, %error, "reverse tunnel: failed to open local DoT relay");
+            send_close(out_tx, conn_id).await;
         }
     }
 }
@@ -525,10 +696,107 @@ async fn open_relay(
     let span = tracing::Span::current();
     tokio::spawn(udp_reader(conn_id, reader_socket, out_tx, reader_cancel).instrument(span));
     Ok(Conn {
-        socket,
+        kind: ConnKind::Udp(socket),
         deadline: Instant::now() + UDP_IDLE_TIMEOUT,
         cancel,
     })
+}
+
+/// Open the loopback `DoT` TCP relay for `conn_id`, targeting the daemon's own
+/// `:853` listener. Thin wrapper over [`connect_dot_relay`] pinning [`DOT_PORT`] so
+/// no frame-carried port can redirect the relay.
+async fn open_tcp_relay(conn_id: u32, out_tx: mpsc::Sender<Message>) -> std::io::Result<Conn> {
+    connect_dot_relay(conn_id, DOT_PORT, out_tx).await
+}
+
+/// Connect `127.0.0.1:<port>` (bounded by [`TCP_CONNECT_TIMEOUT`]), emit
+/// `FRAME_READY` the instant the connect lands, and spawn the bidirectional relay
+/// task. A connect error/timeout returns `Err`, which the caller turns into a
+/// `FRAME_CLOSE`. Parameterised on `port` so tests can drive it against a loopback
+/// echo; production always calls it through [`open_tcp_relay`] at [`DOT_PORT`].
+pub(crate) async fn connect_dot_relay(
+    conn_id: u32,
+    port: u16,
+    out_tx: mpsc::Sender<Message>,
+) -> std::io::Result<Conn> {
+    let stream = tokio::time::timeout(
+        TCP_CONNECT_TIMEOUT,
+        TcpStream::connect((Ipv4Addr::LOCALHOST, port)),
+    )
+    .await
+    .map_err(|_| std::io::Error::new(std::io::ErrorKind::TimedOut, "DoT connect timed out"))??;
+
+    // FRAME_READY must precede any relayed byte: queue it on the ordered funnel
+    // *before* the relay task can push a FRAME_DATA, so the node sees "local end up"
+    // first exactly as the cloud protocol requires.
+    let _ = out_tx
+        .send(Message::Binary(tunneller::encode_ready(conn_id).into()))
+        .await;
+
+    // The relay task owns the split stream; inbound FRAME_DATA reaches its write half
+    // through this channel.
+    let (write_tx, write_rx) = mpsc::channel::<Vec<u8>>(256);
+    let cancel = CancellationToken::new();
+    let reader_cancel = cancel.clone();
+    let span = tracing::Span::current();
+    tokio::spawn(tcp_relay(conn_id, stream, write_rx, out_tx, reader_cancel).instrument(span));
+    Ok(Conn {
+        kind: ConnKind::Tcp(write_tx),
+        deadline: Instant::now() + TCP_IDLE_TIMEOUT,
+        cancel,
+    })
+}
+
+/// Bidirectional relay for one `DoT` `conn_id`: local socket → `FRAME_DATA` → node,
+/// and node payloads (arriving on `write_rx`) → local socket, until cancelled, either
+/// side EOFs/errors, or the funnel closes. On local EOF it sends a `FRAME_CLOSE` so
+/// the node tears its half down.
+async fn tcp_relay(
+    conn_id: u32,
+    stream: TcpStream,
+    mut write_rx: mpsc::Receiver<Vec<u8>>,
+    out_tx: mpsc::Sender<Message>,
+    cancel: CancellationToken,
+) {
+    let (mut read_half, mut write_half) = stream.into_split();
+    // DoT frames are small (a length-prefixed DNS message), but 16 KiB keeps large
+    // TCP segments in one read without over-allocating per connection.
+    let mut buf = vec![0u8; 16 * 1024];
+    loop {
+        tokio::select! {
+            () = cancel.cancelled() => break,
+
+            // node → local: write each relayed payload to the DoT listener.
+            payload = write_rx.recv() => {
+                // `None` means the Conn (and its write_tx) was dropped — teardown.
+                let Some(payload) = payload else { break };
+                if write_half.write_all(&payload).await.is_err() {
+                    break;
+                }
+            }
+
+            // local → node: forward each segment the DoT listener sends back.
+            result = read_half.read(&mut buf) => match result {
+                Ok(0) => {
+                    // Local EOF: tell the node the flow is done, then stop.
+                    let _ = out_tx
+                        .send(Message::Binary(tunneller::encode_close(conn_id).into()))
+                        .await;
+                    break;
+                }
+                Ok(n) => {
+                    let frame = tunneller::encode_data(conn_id, &buf[..n]);
+                    if out_tx.send(Message::Binary(frame.into())).await.is_err() {
+                        break;
+                    }
+                }
+                Err(error) => {
+                    tracing::debug!(conn_id, %error, "reverse tunnel local DoT socket read error");
+                    break;
+                }
+            },
+        }
+    }
 }
 
 /// Return-path reader for one `conn_id`: forwards each datagram the local inbound-WG


### PR DESCRIPTION
Closes #913.

## Background

The daemon's Tunneller client (`wardnetd-services/src/cloud/tunneller{,_runner}.rs`) was UDP/WireGuard-only. The cloud edge already emits `FRAME_CONNECT dest_port=443|853` and waits for `FRAME_READY`, but the runner ignored both — so a roaming client's `:853` SNI passthrough never reached the box's local DoT listener.

This teaches the client the TCP frame path.

## Changes

- **Codec** — add `FRAME_READY` (0x02) + `encode_ready()`. It only flows daemon→node, so inbound `decode()` still rejects it.
- **Conn** — split into a `ConnKind` of `Udp(socket)` / `Tcp(write channel)`; the data path dispatches on the kind.
- **Gate** — the outer loop (and `disable_check`) now runs while *inbound WireGuard OR Private DNS* is enabled, and each inbound `CONNECT` is gated per-frame on the feature it belongs to, so toggling one feature off rejects its flows without disturbing the other's.
- **TCP relay** — `dest_port 853` connects `127.0.0.1:853` (5s timeout), emits `FRAME_READY` the moment the connect lands, then relays both ways until close or local EOF; a connect failure returns `FRAME_CLOSE`. `dest_port 443` is reserved for the reverse web proxy and closed for now.
- **Split caps** — relay sockets are capped per transport (`MAX_UDP_CONNS = 8` / `MAX_TCP_CONNS = 16`) so DoT churn can't starve WireGuard slots, and vice versa.
- Both module docs rewritten to describe the two-path model.

Entitlement-loss teardown for Private DNS already landed with the DoT listener work, so no change was needed there.

## Testing

Extends the fake-node harness in `cloud/tests/tunneller.rs`:

- `encode_ready` codec shape + inbound-decode rejection
- READY-before-data ordering, bidirectional relay, and local-EOF `FRAME_CLOSE` against a loopback TCP echo
- `FRAME_CLOSE` on DoT connect failure
- gate combinations (WG only / Private DNS only / both off) and the deferred `443` close
- independent UDP/TCP cap enforcement

`cargo test -p wardnetd-services` and `cargo clippy -p wardnetd-services --all-targets` both pass clean.