### PR TITLE
fix(user-app): DNS-stats stale-date race and unbounded daily store growth

### DIFF
--- a/source/user-app/src/hooks/useDnsEventsSync.ts
+++ b/source/user-app/src/hooks/useDnsEventsSync.ts
@@ -5,6 +5,7 @@ import {
   type DnsEventItem,
   notifyStatsChanged,
   openDb,
+  pruneDaily,
   pruneEvents,
 } from "../lib/dnsDb.js";
 
@@ -60,6 +61,9 @@ export function useDnsEventsSync(): void {
         });
         if (db) {
           pruneEvents(db).catch(() => {
+            // Pruning is best-effort housekeeping.
+          });
+          pruneDaily(db).catch(() => {
             // Pruning is best-effort housekeeping.
           });
         }

--- a/source/user-app/src/hooks/useDnsStats.ts
+++ b/source/user-app/src/hooks/useDnsStats.ts
@@ -27,17 +27,23 @@ const EMPTY: DnsStatsData = {
 export function useDnsStats(date: string): DnsStatsData {
   const [data, setData] = useState<DnsStatsData>(EMPTY);
 
-  const load = useCallback(async () => {
+  const load = useCallback(async (): Promise<DnsStatsData> => {
     const snapshot = await loadDnsStats(date, recentDates(TREND_DAYS));
-    setData({ ...snapshot, loading: false });
+    return { ...snapshot, loading: false };
   }, [date]);
 
   useEffect(() => {
     let active = true;
     const run = () => {
-      load().catch(() => {
-        if (active) setData((d) => ({ ...d, loading: false }));
-      });
+      load()
+        .then((next) => {
+          // Guard the commit: a slow read for a previously-selected date must
+          // not overwrite the current one after the effect has been torn down.
+          if (active) setData(next);
+        })
+        .catch(() => {
+          if (active) setData((d) => ({ ...d, loading: false }));
+        });
     };
     run();
 

--- a/source/user-app/src/hooks/useDnsStats.ts
+++ b/source/user-app/src/hooks/useDnsStats.ts
@@ -1,9 +1,12 @@
 import { useCallback, useEffect, useState } from "react";
 
-import { recentDates, subscribeStats } from "@/lib/dnsDb";
+import { recentDates, subscribeStats, TREND_DAYS } from "@/lib/dnsDb";
 import { type DnsStatsSnapshot, loadDnsStats } from "@/lib/dnsStats";
 
-export const TREND_DAYS = 7;
+// TREND_DAYS is defined in dnsDb (the layer pruneDaily also depends on) so the
+// read window and the retention window share one source; re-exported here for
+// the historical import path.
+export { TREND_DAYS };
 
 export interface DnsStatsData extends DnsStatsSnapshot {
   loading: boolean;
@@ -45,6 +48,18 @@ export function useDnsStats(date: string): DnsStatsData {
           if (active) setData((d) => ({ ...d, loading: false }));
         });
     };
+
+    // A newly selected date must not keep showing the previous day's counts
+    // while its read is in flight. Blank the day-specific fields and mark
+    // loading; the window-scoped trend/recent/hasData stay put so the chart
+    // and empty-state don't flash on every switch.
+    setData((d) => ({
+      ...d,
+      headline: EMPTY.headline,
+      topBlocked: [],
+      topQueried: [],
+      loading: true,
+    }));
     run();
 
     // Coalesce bursts of new events into one reload.

--- a/source/user-app/src/lib/dnsDb.ts
+++ b/source/user-app/src/lib/dnsDb.ts
@@ -22,11 +22,16 @@ export const DAILY_STORE = "daily";
 export const META_STORE = "meta";
 
 const EVENTS_RING_CAP = 500;
-// The Stats page only ever reads today plus the prior six days (the trend
-// window — TREND_DAYS in useDnsStats). Keep the aggregate store bounded to the
-// same window so it doesn't grow without limit on a long-lived installed PWA.
-const DAILY_RETENTION_DAYS = 7;
 const CURSOR_KEY = "lastAggregatedId";
+
+/**
+ * The window (today plus the prior six days) that the Stats page reads for its
+ * trend strip and, equivalently, the retention window `pruneDaily` keeps in the
+ * aggregate store. Single source of truth: `useDnsStats` (the reader) and
+ * `pruneDaily` (the pruner) both derive from this constant so the read window
+ * and the retention window can never drift apart.
+ */
+export const TREND_DAYS = 7;
 
 export interface DnsEventItem {
   id: number;
@@ -176,22 +181,30 @@ export function pruneEvents(db: IDBDatabase): Promise<void> {
 }
 
 /**
- * Trim the `daily` aggregate store to the trend window the Stats page reads.
- * Rows keyed by a `date` older than the oldest retained day are deleted; the
- * newest DAILY_RETENTION_DAYS days (today included) are kept. Mirrors
- * `pruneEvents` and runs on the same ack/prune cadence.
+ * Trim the `daily` aggregate store to the `TREND_DAYS` window the Stats page
+ * reads. Rows keyed by a `date` older than the oldest retained day are deleted;
+ * the newest `TREND_DAYS` days (today included) are kept. Mirrors `pruneEvents`
+ * — it likewise skips the write when there is nothing to prune — and runs on
+ * the same ack/prune cadence.
  */
 export function pruneDaily(db: IDBDatabase): Promise<void> {
   return new Promise((resolve, reject) => {
     // Oldest date we keep; anything strictly before it is expired.
-    const cutoff = recentDates(DAILY_RETENTION_DAYS)[0];
+    const cutoff = recentDates(TREND_DAYS)[0];
     const tx = db.transaction(DAILY_STORE, "readwrite");
     const store = tx.objectStore(DAILY_STORE);
     // Composite key [date, domain]. [cutoff, ""] is the smallest possible key
-    // for the cutoff day, so an exclusive upper bound there deletes every row
+    // for the cutoff day, so an exclusive upper bound there covers every row
     // whose date is earlier than the cutoff while keeping the cutoff day itself.
     const range = IDBKeyRange.upperBound([cutoff, ""], true);
-    store.delete(range);
+    // Only open a delete when the range actually holds expired rows — on the
+    // common tick nothing is out of window, so this stays a cheap no-op.
+    const countReq = store.count(range);
+    countReq.onsuccess = () => {
+      if (countReq.result > 0) {
+        store.delete(range);
+      }
+    };
     tx.oncomplete = () => resolve();
     tx.onerror = () => reject(tx.error);
     tx.onabort = () => reject(tx.error ?? new Error("transaction aborted"));

--- a/source/user-app/src/lib/dnsDb.ts
+++ b/source/user-app/src/lib/dnsDb.ts
@@ -22,6 +22,10 @@ export const DAILY_STORE = "daily";
 export const META_STORE = "meta";
 
 const EVENTS_RING_CAP = 500;
+// The Stats page only ever reads today plus the prior six days (the trend
+// window — TREND_DAYS in useDnsStats). Keep the aggregate store bounded to the
+// same window so it doesn't grow without limit on a long-lived installed PWA.
+const DAILY_RETENTION_DAYS = 7;
 const CURSOR_KEY = "lastAggregatedId";
 
 export interface DnsEventItem {
@@ -165,6 +169,29 @@ export function pruneEvents(db: IDBDatabase): Promise<void> {
         }
       };
     };
+    tx.oncomplete = () => resolve();
+    tx.onerror = () => reject(tx.error);
+    tx.onabort = () => reject(tx.error ?? new Error("transaction aborted"));
+  });
+}
+
+/**
+ * Trim the `daily` aggregate store to the trend window the Stats page reads.
+ * Rows keyed by a `date` older than the oldest retained day are deleted; the
+ * newest DAILY_RETENTION_DAYS days (today included) are kept. Mirrors
+ * `pruneEvents` and runs on the same ack/prune cadence.
+ */
+export function pruneDaily(db: IDBDatabase): Promise<void> {
+  return new Promise((resolve, reject) => {
+    // Oldest date we keep; anything strictly before it is expired.
+    const cutoff = recentDates(DAILY_RETENTION_DAYS)[0];
+    const tx = db.transaction(DAILY_STORE, "readwrite");
+    const store = tx.objectStore(DAILY_STORE);
+    // Composite key [date, domain]. [cutoff, ""] is the smallest possible key
+    // for the cutoff day, so an exclusive upper bound there deletes every row
+    // whose date is earlier than the cutoff while keeping the cutoff day itself.
+    const range = IDBKeyRange.upperBound([cutoff, ""], true);
+    store.delete(range);
     tx.oncomplete = () => resolve();
     tx.onerror = () => reject(tx.error);
     tx.onabort = () => reject(tx.error ?? new Error("transaction aborted"));

--- a/source/user-app/tests/helpers/idb.ts
+++ b/source/user-app/tests/helpers/idb.ts
@@ -1,0 +1,24 @@
+// Shared IndexedDB test helpers for the DNS-stats stores. Kept out of the
+// React-oriented test-utils.tsx so both the dnsDb and useDnsEventsSync suites
+// can reuse the same open-transaction plumbing instead of re-declaring it.
+
+import { DAILY_STORE, type DailyStat } from "../../src/lib/dnsDb";
+
+/** Read every row from an object store. */
+export function getAllRows<T>(db: IDBDatabase, store: string): Promise<T[]> {
+  return new Promise((resolve, reject) => {
+    const req = db.transaction(store, "readonly").objectStore(store).getAll();
+    req.onsuccess = () => resolve(req.result as T[]);
+    req.onerror = () => reject(req.error);
+  });
+}
+
+/** Insert a single pre-aggregated daily row. */
+export function putDaily(db: IDBDatabase, row: DailyStat): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(DAILY_STORE, "readwrite");
+    tx.objectStore(DAILY_STORE).put(row);
+    tx.oncomplete = () => resolve();
+    tx.onerror = () => reject(tx.error);
+  });
+}

--- a/source/user-app/tests/hooks/useDnsEventsSync.test.tsx
+++ b/source/user-app/tests/hooks/useDnsEventsSync.test.tsx
@@ -2,7 +2,13 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { act, renderHook } from "@testing-library/react";
 import { IDBFactory } from "fake-indexeddb";
 
-import { openDb, EVENTS_STORE, type DnsEventItem } from "../../src/lib/dnsDb";
+import {
+  openDb,
+  DAILY_STORE,
+  EVENTS_STORE,
+  type DailyStat,
+  type DnsEventItem,
+} from "../../src/lib/dnsDb";
 import { useDnsEventsSync } from "../../src/hooks/useDnsEventsSync";
 
 /** Minimal controllable EventSource stand-in. */
@@ -48,6 +54,36 @@ async function countEvents(): Promise<number> {
   });
   db.close();
   return n;
+}
+
+async function dailyDates(): Promise<string[]> {
+  const db = await openDb();
+  const rows = await new Promise<DailyStat[]>((resolve, reject) => {
+    const req = db
+      .transaction(DAILY_STORE, "readonly")
+      .objectStore(DAILY_STORE)
+      .getAll();
+    req.onsuccess = () => resolve(req.result as DailyStat[]);
+    req.onerror = () => reject(req.error);
+  });
+  db.close();
+  return rows.map((r) => r.date);
+}
+
+async function seedStaleDaily(): Promise<void> {
+  const db = await openDb();
+  await new Promise<void>((resolve, reject) => {
+    const tx = db.transaction(DAILY_STORE, "readwrite");
+    tx.objectStore(DAILY_STORE).put({
+      date: "2000-01-01",
+      domain: "stale.com",
+      blocked: 1,
+      allowed: 0,
+    } satisfies DailyStat);
+    tx.oncomplete = () => resolve();
+    tx.onerror = () => reject(tx.error);
+  });
+  db.close();
 }
 
 let fetchSpy: ReturnType<typeof vi.fn>;
@@ -125,6 +161,43 @@ describe("useDnsEventsSync", () => {
     expect(JSON.parse((ackCall[1] as RequestInit).body as string)).toEqual({
       up_to_id: 50,
     });
+  });
+
+  it("prunes both the events ring and the daily store on the ack tick", async () => {
+    // An out-of-window aggregate row seeded before the hook mounts.
+    await seedStaleDaily();
+
+    renderHook(() => useDnsEventsSync());
+    await vi.waitFor(() => expect(FakeEventSource.instances).toHaveLength(1));
+    const es = FakeEventSource.instances[0];
+
+    // Emit a full batch of in-window events (today) to trigger the ack flush,
+    // which also runs pruneEvents + pruneDaily.
+    const now = new Date().toISOString();
+    await act(async () => {
+      for (let i = 1; i <= 50; i += 1) {
+        es.onmessage?.({
+          data: JSON.stringify({
+            id: i,
+            domain: `d${i}.com`,
+            status: "forwarded",
+            captured_at: now,
+          }),
+        } as MessageEvent<string>);
+        // Let each applyEvent promise chain settle.
+        await Promise.resolve();
+        await Promise.resolve();
+      }
+    });
+
+    // The stale row is pruned; today's freshly aggregated rows survive.
+    await vi.waitFor(async () => {
+      const dates = await dailyDates();
+      expect(dates).not.toContain("2000-01-01");
+      expect(dates.length).toBeGreaterThan(0);
+    });
+    // The event ring is untouched below its cap — pruneEvents behavior intact.
+    expect(await countEvents()).toBe(50);
   });
 
   it("flushes a pending ack on unmount", async () => {

--- a/source/user-app/tests/hooks/useDnsEventsSync.test.tsx
+++ b/source/user-app/tests/hooks/useDnsEventsSync.test.tsx
@@ -9,6 +9,7 @@ import {
   type DailyStat,
   type DnsEventItem,
 } from "../../src/lib/dnsDb";
+import { getAllRows, putDaily } from "../helpers/idb";
 import { useDnsEventsSync } from "../../src/hooks/useDnsEventsSync";
 
 /** Minimal controllable EventSource stand-in. */
@@ -58,30 +59,18 @@ async function countEvents(): Promise<number> {
 
 async function dailyDates(): Promise<string[]> {
   const db = await openDb();
-  const rows = await new Promise<DailyStat[]>((resolve, reject) => {
-    const req = db
-      .transaction(DAILY_STORE, "readonly")
-      .objectStore(DAILY_STORE)
-      .getAll();
-    req.onsuccess = () => resolve(req.result as DailyStat[]);
-    req.onerror = () => reject(req.error);
-  });
+  const rows = await getAllRows<DailyStat>(db, DAILY_STORE);
   db.close();
   return rows.map((r) => r.date);
 }
 
 async function seedStaleDaily(): Promise<void> {
   const db = await openDb();
-  await new Promise<void>((resolve, reject) => {
-    const tx = db.transaction(DAILY_STORE, "readwrite");
-    tx.objectStore(DAILY_STORE).put({
-      date: "2000-01-01",
-      domain: "stale.com",
-      blocked: 1,
-      allowed: 0,
-    } satisfies DailyStat);
-    tx.oncomplete = () => resolve();
-    tx.onerror = () => reject(tx.error);
+  await putDaily(db, {
+    date: "2000-01-01",
+    domain: "stale.com",
+    blocked: 1,
+    allowed: 0,
   });
   db.close();
 }

--- a/source/user-app/tests/hooks/useDnsStats.race.test.tsx
+++ b/source/user-app/tests/hooks/useDnsStats.race.test.tsx
@@ -1,0 +1,59 @@
+import { describe, expect, it, vi } from "vitest";
+import { act, renderHook, waitFor } from "@testing-library/react";
+
+import type { DnsStatsSnapshot } from "../../src/lib/dnsStats";
+import { useDnsStats } from "../../src/hooks/useDnsStats";
+
+// Control loadDnsStats' resolution order so we can force a stale in-flight read
+// for date A to settle *after* the user has already switched to date B.
+const { loadDnsStats } = vi.hoisted(() => ({ loadDnsStats: vi.fn() }));
+vi.mock("../../src/lib/dnsStats", () => ({ loadDnsStats }));
+
+function snapshot(blocked: number): DnsStatsSnapshot {
+  return {
+    headline: { total: blocked, blocked, allowed: 0 },
+    topBlocked: [],
+    topQueried: [],
+    recent: [],
+    trend: [],
+    hasData: true,
+  };
+}
+
+describe("useDnsStats — stale-date race", () => {
+  it("ignores a previous day's load that resolves after the day switched", async () => {
+    // Deferred promises: one per selected date, resolved by hand below.
+    let resolveA!: (s: DnsStatsSnapshot) => void;
+    let resolveB!: (s: DnsStatsSnapshot) => void;
+    const pendingA = new Promise<DnsStatsSnapshot>((r) => {
+      resolveA = r;
+    });
+    const pendingB = new Promise<DnsStatsSnapshot>((r) => {
+      resolveB = r;
+    });
+
+    loadDnsStats.mockResolvedValue(snapshot(0));
+    loadDnsStats.mockReturnValueOnce(pendingA).mockReturnValueOnce(pendingB);
+
+    const { result, rerender } = renderHook(({ d }) => useDnsStats(d), {
+      initialProps: { d: "2026-07-01" },
+    });
+
+    // Switch to date B while A's read is still in flight.
+    rerender({ d: "2026-07-02" });
+
+    // B resolves first and is committed.
+    resolveB(snapshot(2));
+    await waitFor(() => expect(result.current.headline.blocked).toBe(2));
+
+    // The stale A read now resolves last. Flush its promise chain inside act so
+    // that if the success path were unguarded, the commit WOULD land in
+    // result.current — the assertion below proves it does not.
+    await act(async () => {
+      resolveA(snapshot(9));
+      await pendingA;
+      await Promise.resolve();
+    });
+    expect(result.current.headline.blocked).toBe(2);
+  });
+});

--- a/source/user-app/tests/hooks/useDnsStats.race.test.tsx
+++ b/source/user-app/tests/hooks/useDnsStats.race.test.tsx
@@ -89,4 +89,34 @@ describe("useDnsStats — stale-date race", () => {
     expect(result.current.headline.blocked).toBe(5);
     expect(result.current.loading).toBe(false);
   });
+
+  it("blanks the previous day's counts while the newly selected day loads", async () => {
+    let resolveA!: (s: DnsStatsSnapshot) => void;
+    const pendingA = new Promise<DnsStatsSnapshot>((r) => {
+      resolveA = r;
+    });
+    // Date B's read stays in flight for the duration of the assertion.
+    const pendingB = new Promise<DnsStatsSnapshot>(() => {});
+
+    loadDnsStats.mockResolvedValue(snapshot(0));
+    loadDnsStats.mockReturnValueOnce(pendingA).mockReturnValueOnce(pendingB);
+
+    const { result, rerender } = renderHook(({ d }) => useDnsStats(d), {
+      initialProps: { d: "2026-07-01" },
+    });
+    resolveA(snapshot(7));
+    await waitFor(() => expect(result.current.headline.blocked).toBe(7));
+
+    // Switch to day B; its read has not resolved yet.
+    await act(async () => {
+      rerender({ d: "2026-07-02" });
+      await Promise.resolve();
+    });
+
+    // Day A's counts must not still be attributed to day B — the day-specific
+    // fields are blanked and the hook reports loading until B resolves.
+    expect(result.current.headline.blocked).toBe(0);
+    expect(result.current.topBlocked).toEqual([]);
+    expect(result.current.loading).toBe(true);
+  });
 });

--- a/source/user-app/tests/hooks/useDnsStats.race.test.tsx
+++ b/source/user-app/tests/hooks/useDnsStats.race.test.tsx
@@ -56,4 +56,37 @@ describe("useDnsStats — stale-date race", () => {
     });
     expect(result.current.headline.blocked).toBe(2);
   });
+
+  it("ignores a previous day's load that rejects after the day switched", async () => {
+    let rejectA!: (e: unknown) => void;
+    let resolveB!: (s: DnsStatsSnapshot) => void;
+    const pendingA = new Promise<DnsStatsSnapshot>((_, reject) => {
+      rejectA = reject;
+    });
+    const pendingB = new Promise<DnsStatsSnapshot>((r) => {
+      resolveB = r;
+    });
+
+    loadDnsStats.mockResolvedValue(snapshot(0));
+    loadDnsStats.mockReturnValueOnce(pendingA).mockReturnValueOnce(pendingB);
+
+    const { result, rerender } = renderHook(({ d }) => useDnsStats(d), {
+      initialProps: { d: "2026-07-01" },
+    });
+    rerender({ d: "2026-07-02" });
+
+    resolveB(snapshot(5));
+    await waitFor(() => expect(result.current.headline.blocked).toBe(5));
+
+    // The stale A read now fails after its effect was torn down (active = false).
+    // The error path must also be a no-op — it must not force loading nor reset
+    // the current day's stats.
+    await act(async () => {
+      rejectA(new Error("stale read failed"));
+      await pendingA.catch(() => {});
+      await Promise.resolve();
+    });
+    expect(result.current.headline.blocked).toBe(5);
+    expect(result.current.loading).toBe(false);
+  });
 });

--- a/source/user-app/tests/lib/dnsDb.test.ts
+++ b/source/user-app/tests/lib/dnsDb.test.ts
@@ -259,6 +259,22 @@ describe("pruneDaily", () => {
     expect(rows).toHaveLength(window.length);
     db.close();
   });
+
+  it("rejects when the transaction aborts", async () => {
+    const db = await openDb();
+    const realTx = db.transaction.bind(db);
+    const tx = realTx(DAILY_STORE, "readwrite");
+    const spy = vi.spyOn(db, "transaction").mockReturnValue(tx);
+    const promise = pruneDaily(db);
+    tx.abort();
+    let rejected = false;
+    await promise.catch(() => {
+      rejected = true;
+    });
+    expect(rejected).toBe(true);
+    spy.mockRestore();
+    db.close();
+  });
 });
 
 describe("stats pub/sub", () => {

--- a/source/user-app/tests/lib/dnsDb.test.ts
+++ b/source/user-app/tests/lib/dnsDb.test.ts
@@ -9,6 +9,7 @@ import {
   localDate,
   notifyStatsChanged,
   openDb,
+  pruneDaily,
   pruneEvents,
   recentDates,
   subscribeStats,
@@ -32,6 +33,15 @@ function getAll<T>(db: IDBDatabase, store: string): Promise<T[]> {
     const req = db.transaction(store, "readonly").objectStore(store).getAll();
     req.onsuccess = () => resolve(req.result as T[]);
     req.onerror = () => reject(req.error);
+  });
+}
+
+function putDaily(db: IDBDatabase, row: DailyStat): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(DAILY_STORE, "readwrite");
+    tx.objectStore(DAILY_STORE).put(row);
+    tx.oncomplete = () => resolve();
+    tx.onerror = () => reject(tx.error);
   });
 }
 
@@ -207,6 +217,46 @@ describe("pruneEvents", () => {
     expect(events).toHaveLength(500);
     const ids = events.map((e) => e.id).sort((a, b) => a - b);
     expect(ids[0]).toBe(3);
+    db.close();
+  });
+});
+
+describe("pruneDaily", () => {
+  function daily(date: string, domain: string): DailyStat {
+    return { date, domain, blocked: 1, allowed: 0 };
+  }
+
+  it("deletes rows older than the retention window, keeps the rest", async () => {
+    const db = await openDb();
+    // recentDates(7) is the retention window (today + prior six days), oldest
+    // first; recentDates(8)[0] is the day just outside it.
+    const window = recentDates(7);
+    const oldestKept = window[0];
+    const today = window[6];
+    const justOutside = recentDates(8)[0];
+
+    await putDaily(db, daily("2000-01-01", "ancient.com"));
+    await putDaily(db, daily(justOutside, "expired.com"));
+    await putDaily(db, daily(oldestKept, "edge.com"));
+    await putDaily(db, daily(today, "today.com"));
+
+    await pruneDaily(db);
+
+    const rows = await getAll<DailyStat>(db, DAILY_STORE);
+    const dates = rows.map((r) => r.date).sort();
+    expect(dates).toEqual([oldestKept, today].sort());
+    db.close();
+  });
+
+  it("is a no-op when every row is within the window", async () => {
+    const db = await openDb();
+    const window = recentDates(7);
+    for (const date of window) {
+      await putDaily(db, daily(date, "x.com"));
+    }
+    await pruneDaily(db);
+    const rows = await getAll<DailyStat>(db, DAILY_STORE);
+    expect(rows).toHaveLength(window.length);
     db.close();
   });
 });

--- a/source/user-app/tests/lib/dnsDb.test.ts
+++ b/source/user-app/tests/lib/dnsDb.test.ts
@@ -17,6 +17,7 @@ import {
   type DailyStat,
   type DnsEventItem,
 } from "../../src/lib/dnsDb";
+import { getAllRows as getAll, putDaily } from "../helpers/idb";
 
 function ev(overrides: Partial<DnsEventItem> = {}): DnsEventItem {
   return {
@@ -26,23 +27,6 @@ function ev(overrides: Partial<DnsEventItem> = {}): DnsEventItem {
     captured_at: "2026-07-02T12:00:00Z",
     ...overrides,
   };
-}
-
-function getAll<T>(db: IDBDatabase, store: string): Promise<T[]> {
-  return new Promise((resolve, reject) => {
-    const req = db.transaction(store, "readonly").objectStore(store).getAll();
-    req.onsuccess = () => resolve(req.result as T[]);
-    req.onerror = () => reject(req.error);
-  });
-}
-
-function putDaily(db: IDBDatabase, row: DailyStat): Promise<void> {
-  return new Promise((resolve, reject) => {
-    const tx = db.transaction(DAILY_STORE, "readwrite");
-    tx.objectStore(DAILY_STORE).put(row);
-    tx.oncomplete = () => resolve();
-    tx.onerror = () => reject(tx.error);
-  });
 }
 
 function getMeta(db: IDBDatabase, key: string): Promise<unknown> {


### PR DESCRIPTION
Closes #854.

Two adjacent bugs in the user-app's device-local DNS-stats layer.

## 1. Stale-date race in `useDnsStats`

`load`'s success path called `setData` unconditionally, while only the error path honoured the effect-scoped `active` flag. A slow in-flight read for a previously-selected date could resolve *after* the user switched days in the trend strip and overwrite the currently-selected day's stats.

`load` now returns the resolved snapshot and the effect commits it through the same `active` guard that already protects the error path. When `date` changes, the previous effect's cleanup flips `active = false`, so a late-resolving read for the stale date is dropped instead of clobbering the current day.

## 2. Unbounded `daily` store growth

`EVENTS_RING_CAP` bounds the raw `events` ring, but the `daily` aggregate store — written on every event — had no equivalent prune. On a long-lived installed PWA it grew without limit even though the Stats page only ever reads today plus the last week.

Added `pruneDaily`, mirroring `pruneEvents`: it drops `daily` rows whose `date` is older than the retention window (the trend window the Stats page reads) via an exclusive upper bound on the `[date, domain]` composite key. It runs on the existing ack/prune tick in `useDnsEventsSync`, right after `pruneEvents` — no new scheduling mechanism, and the existing event-pruning behaviour is untouched.

## Tests

- `useDnsStats.race.test.tsx` — resolves an earlier day's load after a newer one and asserts the newer day's stats are retained (verified to fail against the pre-fix code path).
- `dnsDb.test.ts` — `pruneDaily` keeps in-window rows (including the boundary day) and deletes older ones; no-op when everything is in-window.
- `useDnsEventsSync.test.tsx` — drives the ack cadence and asserts both the `events` ring and the `daily` store are handled on the tick.

All new code is covered; existing `useDnsStats` / `dnsDb` / `useDnsEventsSync` coverage is unchanged.