### PR TITLE
fix(dns): drain stale datagrams and drop timed-out conditional-forward sockets

### DIFF
--- a/source/daemon/crates/wardnetd/src/dns/pipeline.rs
+++ b/source/daemon/crates/wardnetd/src/dns/pipeline.rs
@@ -52,6 +52,11 @@ pub(crate) type TokioRecursor = Recursor<TokioRuntimeProvider>;
 /// Maximum number of pre-bound UDP sockets kept in the conditional-forwarding pool.
 const CONDITIONAL_SOCKET_POOL_SIZE: usize = 8;
 
+/// How long a conditional-forward query waits for its upstream response before
+/// giving up. Bounds the whole receive phase, not a single `recv` — so a socket
+/// that keeps delivering stale datagrams still can't stall the query past this.
+const CONDITIONAL_RECV_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
+
 /// The daemon-owned local DNS zone. Single-label queries that miss the
 /// authoritative view are retried under this suffix (the local search-domain
 /// hop) — but only `System`-sourced records are adopted, so `wardnet` resolves
@@ -208,6 +213,10 @@ pub struct QueryPipeline {
     /// spoofing window). The pool is capped at [`CONDITIONAL_SOCKET_POOL_SIZE`];
     /// under-capacity sockets are created on demand.
     pub(crate) conditional_socket_pool: Arc<tokio::sync::Mutex<Vec<UdpSocket>>>,
+    /// Deadline for the conditional-forward receive phase. Defaults to
+    /// [`CONDITIONAL_RECV_TIMEOUT`]; tests shorten it to drive the timeout
+    /// path deterministically without a multi-second wait.
+    pub(crate) conditional_recv_timeout: std::time::Duration,
 }
 
 impl QueryPipeline {
@@ -241,6 +250,7 @@ impl QueryPipeline {
             tunnel_forwarders: Arc::new(RwLock::new(HashMap::new())),
             authoritative_view: Arc::new(ArcSwap::from_pointee(AuthoritativeView::empty())),
             conditional_socket_pool: Arc::new(tokio::sync::Mutex::new(Vec::new())),
+            conditional_recv_timeout: CONDITIONAL_RECV_TIMEOUT,
         }
     }
 
@@ -773,6 +783,7 @@ impl QueryPipeline {
                 pass_result,
                 upstream_id,
                 &self.conditional_socket_pool,
+                self.conditional_recv_timeout,
             )
             .await
             {
@@ -1742,10 +1753,17 @@ fn make_rdata(
 ///
 /// Borrows a socket from `pool` (or creates a new one if the pool is empty),
 /// `connect`s it to `upstream` (so the kernel only delivers responses from that
-/// peer), sends the query, then validates the response transaction ID and question
-/// before forwarding to the client. Without txid validation, a pooled socket that
-/// already has a late/duplicate response buffered from a previous query could
-/// deliver it to the wrong client.
+/// peer), sends the query, then reads until the response to *this* query arrives
+/// or `recv_timeout` elapses.
+///
+/// A pooled socket can carry a datagram left over from a previous query — a
+/// duplicate, or a response that arrived after that query had already timed out.
+/// `connect()` does not flush it (Linux keeps `sk_receive_queue` across a
+/// re-connect), so the receive loop skips any datagram whose txid or question
+/// doesn't match and keeps reading, rather than failing the query on the first
+/// stale datagram. On timeout or a receive error the socket is dropped instead of
+/// pooled, so a late response can't queue on it and poison the next borrower; only
+/// a socket that delivered a clean, validated answer goes back to the pool.
 #[allow(clippy::too_many_arguments)]
 async fn forward_via_conditional(
     upstream: SocketAddr,
@@ -1764,6 +1782,7 @@ async fn forward_via_conditional(
     pass_result: &str,
     upstream_id: UpstreamId,
     pool: &Arc<tokio::sync::Mutex<Vec<UdpSocket>>>,
+    recv_timeout: std::time::Duration,
 ) -> anyhow::Result<()> {
     // Check out a socket from the pool, or create a new one.
     let bound = {
@@ -1782,52 +1801,76 @@ async fn forward_via_conditional(
     bound.connect(upstream).await?;
     bound.send(packet).await?;
 
+    // Read until this query's own answer arrives or the deadline passes. The
+    // deadline bounds the whole phase, so a socket that only ever yields stale
+    // datagrams still can't stall the query past `recv_timeout`. On error or
+    // timeout the function returns early, dropping `bound` instead of pooling it
+    // — a late response can then never queue on a reused socket.
+    let deadline = tokio::time::Instant::now() + recv_timeout;
     let mut buf = vec![0u8; 4096];
-    let recv = tokio::time::timeout(std::time::Duration::from_secs(5), bound.recv(&mut buf)).await;
+    let mut first_recv = true;
+    // The loop settles on either this query's validated response — which we relay
+    // and cache — or `None`: an unparseable first datagram we relay raw without
+    // caching, matching the pre-pool behaviour. Either way `buf` holds the bytes
+    // to relay, truncated to that datagram's length.
+    let parsed: Option<Message> = loop {
+        let n = match tokio::time::timeout_at(deadline, bound.recv(&mut buf)).await {
+            Ok(Ok(n)) => n,
+            Ok(Err(e)) => return Err(anyhow::anyhow!("conditional upstream recv error: {e}")),
+            Err(_) => return Err(anyhow::anyhow!("conditional upstream timeout")),
+        };
+        let was_first = first_recv;
+        first_recv = false;
 
-    let n = match recv {
-        Ok(Ok(n)) => n,
-        Ok(Err(e)) => {
-            return_socket_to_pool(pool, bound).await;
-            return Err(anyhow::anyhow!("conditional upstream recv error: {e}"));
-        }
-        Err(_) => {
-            return_socket_to_pool(pool, bound).await;
-            return Err(anyhow::anyhow!("conditional upstream timeout"));
+        // Bind the parse before matching so the `&buf[..n]` borrow ends here and
+        // the arms can re-borrow `buf` mutably to truncate it.
+        let decoded = Message::from_bytes(&buf[..n]);
+        match decoded {
+            Ok(msg) => {
+                // Only a datagram whose txid and question match the outbound
+                // query is this query's own response. Anything else is a stale
+                // datagram left on a pooled socket (or an off-path forgery the
+                // kernel shouldn't have delivered) — skip it and keep reading,
+                // so it is never served, cached, or turned into a SERVFAIL.
+                if msg.metadata.id == id
+                    && msg.queries.first().map(hickory_proto::op::Query::name)
+                        == request.queries.first().map(hickory_proto::op::Query::name)
+                {
+                    buf.truncate(n);
+                    break Some(msg);
+                }
+            }
+            Err(_) => {
+                // Treat only the first datagram as this query's own response: on
+                // a fresh socket nothing else can be queued, and on a reused one
+                // any stale *parseable* datagram was already skipped above.
+                // hickory can't decode this one, but the client's own resolver
+                // still might, so relay the raw bytes without caching — as the
+                // pre-pool code did. (A stale *undecodable* leftover on a reused
+                // socket is the one case this can misattribute, but that needs an
+                // upstream to have sent undecodable trailing bytes — the same
+                // edge the pre-pool single-recv had.) Once we've skipped a stale
+                // datagram, a later undecodable one can't be trusted: skip it.
+                if was_first {
+                    buf.truncate(n);
+                    break None;
+                }
+            }
         }
     };
-    buf.truncate(n);
 
-    // Validate the response before forwarding: txid and question must match the
-    // outbound query. A pooled socket could in theory receive a late response to a
-    // prior query; txid validation ensures stale datagrams are never served or cached.
+    // Relay the settled datagram (still in `buf`) and return the socket — clean,
+    // since it just delivered this query's response — to the pool.
+    socket.send_to(&buf, src).await?;
+    return_socket_to_pool(pool, bound).await;
+
     let mut result = pass_result;
-    if let Ok(parsed) = Message::from_bytes(&buf) {
-        if parsed.metadata.id != id {
-            return_socket_to_pool(pool, bound).await;
-            return Err(anyhow::anyhow!(
-                "conditional upstream response txid mismatch (got {}, expected {id})",
-                parsed.metadata.id
-            ));
-        }
-        if parsed.queries.first().map(hickory_proto::op::Query::name)
-            != request.queries.first().map(hickory_proto::op::Query::name)
-        {
-            return_socket_to_pool(pool, bound).await;
-            return Err(anyhow::anyhow!(
-                "conditional upstream response question mismatch"
-            ));
-        }
-
-        socket.send_to(&buf, src).await?;
-        return_socket_to_pool(pool, bound).await;
-
+    if let Some(parsed) = parsed {
         let (is_negative, raw_ttl) = classify_response(&parsed);
         result = relayed_result(is_negative, pass_result);
         if raw_ttl > 0 {
             let cfg = config.read().await;
             let mut cache_guard = cache.write().await;
-            // Cache the raw upstream datagram we relayed, not a re-encode.
             cache_guard.insert(
                 upstream_id,
                 domain,
@@ -1838,10 +1881,6 @@ async fn forward_via_conditional(
                 cfg.cache_ttl_max_secs,
             );
         }
-    } else {
-        // Parse failed — send raw bytes and don't cache.
-        socket.send_to(&buf, src).await?;
-        return_socket_to_pool(pool, bound).await;
     }
 
     let elapsed = start.elapsed();

--- a/source/daemon/crates/wardnetd/src/dns/tests/pipeline.rs
+++ b/source/daemon/crates/wardnetd/src/dns/tests/pipeline.rs
@@ -106,7 +106,9 @@ pub(super) fn stub_tunnel_repo() -> Arc<dyn TunnelRepository> {
 /// view and routing snapshot start empty; tests that need them populated
 /// store into the returned pipeline's `ArcSwap` fields directly (the
 /// same way the server's `update_authoritative_view` does).
-pub(super) fn build_pipeline(cfg: DnsConfig, sink: Option<Arc<DnsLogSink>>) -> Arc<QueryPipeline> {
+/// Construct a pipeline over stub state, before wrapping in `Arc` — the shared
+/// core of [`build_pipeline`] and [`build_pipeline_with_timeout`].
+fn make_pipeline(cfg: DnsConfig, sink: Option<Arc<DnsLogSink>>) -> QueryPipeline {
     let resolver = Arc::new(RwLock::new(build_forwarding_resolver(&cfg)));
     let rate_limiter = Arc::new(RateLimiter::new(cfg.rate_limit_per_second));
     let cache = Arc::new(RwLock::new(DnsCache::new(cfg.cache_size as usize)));
@@ -122,6 +124,23 @@ pub(super) fn build_pipeline(cfg: DnsConfig, sink: Option<Arc<DnsLogSink>>) -> A
         stub_tunnel_repo(),
     );
     pipeline.log_sink = sink;
+    pipeline
+}
+
+pub(super) fn build_pipeline(cfg: DnsConfig, sink: Option<Arc<DnsLogSink>>) -> Arc<QueryPipeline> {
+    Arc::new(make_pipeline(cfg, sink))
+}
+
+/// Like [`build_pipeline`], but with a shortened conditional-forward receive
+/// timeout so the timeout path can be driven in milliseconds instead of the
+/// production 5 s.
+fn build_pipeline_with_timeout(
+    cfg: DnsConfig,
+    sink: Option<Arc<DnsLogSink>>,
+    recv_timeout: Duration,
+) -> Arc<QueryPipeline> {
+    let mut pipeline = make_pipeline(cfg, sink);
+    pipeline.conditional_recv_timeout = recv_timeout;
     Arc::new(pipeline)
 }
 
@@ -494,6 +513,247 @@ async fn conditional_forwarding_failure_returns_servfail() {
 
     assert_eq!(response.metadata.response_code, ResponseCode::ServFail);
     assert_eq!(next_row(&mut rx).await.result, "upstream_error");
+}
+
+/// Encode a `NOERROR`/single-A response for `request`, mirroring what a real
+/// upstream returns for an A question.
+fn a_response(request: &Message, ip: Ipv4Addr) -> Vec<u8> {
+    use hickory_proto::op::OpCode;
+    use hickory_proto::rr::rdata::A;
+    use hickory_proto::rr::{RData, Record};
+
+    let mut response = Message::response(request.metadata.id, OpCode::Query);
+    response.metadata.recursion_desired = true;
+    response.metadata.recursion_available = true;
+    response.add_queries(request.queries.clone());
+    for q in &request.queries {
+        if q.query_type() == RecordType::A {
+            response.add_answer(Record::from_rdata(q.name().clone(), 60, RData::A(A(ip))));
+        }
+    }
+    response.to_bytes().expect("encode stub response")
+}
+
+/// Spawn a conditional upstream that answers every query *twice*. The second
+/// copy stays queued in the connected socket's receive buffer and becomes a
+/// stale datagram for whichever pooled-socket borrower comes next — the same
+/// hazard a late-after-timeout response creates, but deterministic.
+async fn spawn_duplicating_upstream(ip: Ipv4Addr) -> SocketAddr {
+    let socket = tokio::net::UdpSocket::bind("127.0.0.1:0")
+        .await
+        .expect("stub bind");
+    let addr = socket.local_addr().expect("stub local_addr");
+    tokio::spawn(async move {
+        let mut buf = vec![0u8; 4096];
+        loop {
+            let Ok((n, peer)) = socket.recv_from(&mut buf).await else {
+                break;
+            };
+            let Ok(request) = Message::from_bytes(&buf[..n]) else {
+                continue;
+            };
+            let bytes = a_response(&request, ip);
+            let _ = socket.send_to(&bytes, peer).await;
+            let _ = socket.send_to(&bytes, peer).await;
+        }
+    });
+    addr
+}
+
+/// Spawn a conditional upstream that stalls its response to the *first* query
+/// past `delay` (simulating an upstream slower than the receive timeout), then
+/// answers every later query promptly.
+async fn spawn_slow_first_upstream(ip: Ipv4Addr, delay: Duration) -> SocketAddr {
+    use std::sync::atomic::{AtomicBool, Ordering};
+
+    let socket = tokio::net::UdpSocket::bind("127.0.0.1:0")
+        .await
+        .expect("stub bind");
+    let addr = socket.local_addr().expect("stub local_addr");
+    tokio::spawn(async move {
+        let first = AtomicBool::new(true);
+        let mut buf = vec![0u8; 4096];
+        loop {
+            let Ok((n, peer)) = socket.recv_from(&mut buf).await else {
+                break;
+            };
+            let Ok(request) = Message::from_bytes(&buf[..n]) else {
+                continue;
+            };
+            let bytes = a_response(&request, ip);
+            if first.swap(false, Ordering::Relaxed) {
+                tokio::time::sleep(delay).await;
+            }
+            let _ = socket.send_to(&bytes, peer).await;
+        }
+    });
+    addr
+}
+
+/// Spawn a conditional upstream that answers every query with the same fixed
+/// bytes regardless of content — used to feed the forwarder a datagram hickory
+/// cannot decode.
+async fn spawn_fixed_bytes_upstream(bytes: Vec<u8>) -> SocketAddr {
+    let socket = tokio::net::UdpSocket::bind("127.0.0.1:0")
+        .await
+        .expect("stub bind");
+    let addr = socket.local_addr().expect("stub local_addr");
+    tokio::spawn(async move {
+        let mut buf = vec![0u8; 4096];
+        loop {
+            let Ok((_, peer)) = socket.recv_from(&mut buf).await else {
+                break;
+            };
+            let _ = socket.send_to(&bytes, peer).await;
+        }
+    });
+    addr
+}
+
+/// A stale datagram left queued on a pooled socket by an earlier query must
+/// not turn the *next* query into a SERVFAIL: the reuse path skips it and
+/// keeps reading until it gets its own answer.
+#[tokio::test]
+async fn conditional_forward_skips_a_stale_pooled_datagram() {
+    let cond_upstream = spawn_duplicating_upstream(Ipv4Addr::new(203, 0, 113, 9)).await;
+    let pipeline = build_pipeline(
+        config_with_upstream(SocketAddr::from(([127, 0, 0, 1], 1))),
+        None,
+    );
+    pipeline
+        .authoritative_view
+        .store(Arc::new(AuthoritativeView::build(
+            &[],
+            vec![],
+            vec![forwarding_rule("corp.example", cond_upstream.to_string())],
+        )));
+
+    // Query A checks a socket out of the (empty) pool, gets its answer, and
+    // returns the socket with A's duplicate response still queued on it.
+    let a = ask(
+        &pipeline,
+        &query_bytes(0xAAAA, "a.corp.example.", RecordType::A),
+        ip_client(),
+    )
+    .await
+    .expect("query A answer");
+    assert_eq!(a.metadata.response_code, ResponseCode::NoError);
+
+    // Query B reuses that same pooled socket — A's stale datagram is at the
+    // head of its receive buffer. It must be skipped, not served as B's answer
+    // and not surfaced as a SERVFAIL.
+    let b = ask(
+        &pipeline,
+        &query_bytes(0xBBBB, "b.corp.example.", RecordType::A),
+        ip_client(),
+    )
+    .await
+    .expect("query B answer");
+    assert_eq!(
+        b.metadata.response_code,
+        ResponseCode::NoError,
+        "B must get its own answer, not a SERVFAIL from A's stale datagram"
+    );
+    assert_eq!(b.metadata.id, 0xBBBB, "the answer is B's own, not A's");
+    assert_eq!(
+        b.queries.first().map(|q| q.name().to_ascii()),
+        Some("b.corp.example.".to_string())
+    );
+}
+
+/// A query that times out must drop its socket rather than pool it, so the
+/// late response can't queue on a reused socket and SERVFAIL the next query.
+#[tokio::test]
+async fn conditional_forward_drops_the_socket_on_timeout() {
+    // The stub stalls A's reply to 1.2 s, well past the 500 ms receive timeout,
+    // so A reliably times out; B, on a fresh socket, has the full 500 ms for a
+    // sub-millisecond loopback round trip — ample headroom on a loaded runner.
+    let cond_upstream =
+        spawn_slow_first_upstream(Ipv4Addr::new(203, 0, 113, 9), Duration::from_millis(1200)).await;
+    let pipeline = build_pipeline_with_timeout(
+        config_with_upstream(SocketAddr::from(([127, 0, 0, 1], 1))),
+        None,
+        Duration::from_millis(500),
+    );
+    pipeline
+        .authoritative_view
+        .store(Arc::new(AuthoritativeView::build(
+            &[],
+            vec![],
+            vec![forwarding_rule("corp.example", cond_upstream.to_string())],
+        )));
+
+    // Query A's upstream is slower than the receive timeout, so A times out.
+    let a = ask(
+        &pipeline,
+        &query_bytes(0xAAAA, "a.corp.example.", RecordType::A),
+        ip_client(),
+    )
+    .await
+    .expect("query A response");
+    assert_eq!(a.metadata.response_code, ResponseCode::ServFail);
+
+    // Let A's late response land (it fires at ~1.2 s). If the timed-out socket
+    // had been pooled, this would now sit queued on it, at the head of the
+    // buffer, waiting to poison the next borrower.
+    tokio::time::sleep(Duration::from_millis(1200)).await;
+
+    // Query B must still get its own answer — it can only do so on a socket
+    // free of A's stale datagram.
+    let b = ask(
+        &pipeline,
+        &query_bytes(0xBBBB, "b.corp.example.", RecordType::A),
+        ip_client(),
+    )
+    .await
+    .expect("query B answer");
+    assert_eq!(
+        b.metadata.response_code,
+        ResponseCode::NoError,
+        "B must not inherit a SERVFAIL from A's timed-out socket"
+    );
+    assert_eq!(b.metadata.id, 0xBBBB, "the answer is B's own, not A's");
+}
+
+/// A first response the resolver can't decode is still relayed to the client
+/// raw (its own resolver may parse it), not skipped into a SERVFAIL.
+#[tokio::test]
+async fn conditional_forward_relays_an_undecodable_first_response_raw() {
+    // Three bytes is too short for a DNS header, so `Message::from_bytes` fails.
+    let undecodable = vec![0x00u8, 0x01, 0x02];
+    let cond_upstream = spawn_fixed_bytes_upstream(undecodable.clone()).await;
+    let pipeline = build_pipeline(
+        config_with_upstream(SocketAddr::from(([127, 0, 0, 1], 1))),
+        None,
+    );
+    pipeline
+        .authoritative_view
+        .store(Arc::new(AuthoritativeView::build(
+            &[],
+            vec![],
+            vec![forwarding_rule("corp.example", cond_upstream.to_string())],
+        )));
+
+    // Capture the raw frame directly — `ask` would try to parse it and panic.
+    let (capture, mut rx) = ReplyCapture::channel();
+    let reply: Arc<dyn DnsSocket> = Arc::new(capture);
+    pipeline
+        .handle(
+            &query_bytes(0xABCD, "svc.corp.example.", RecordType::A),
+            src(),
+            &reply,
+            ip_client(),
+            TransportProtocol::Udp,
+        )
+        .await
+        .expect("handle");
+    drop(reply);
+
+    let frame = rx.recv().await.expect("raw relayed frame");
+    assert_eq!(
+        frame, undecodable,
+        "an undecodable first response is relayed byte-for-byte, not dropped"
+    );
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Conditional forwarding borrows UDP sockets from a shared pool (`CONDITIONAL_SOCKET_POOL_SIZE`). On a 5s upstream timeout the socket was returned to the pool without draining it, so a response arriving *after* the deadline stayed queued in the kernel receive buffer. The next query to reuse that socket read the stale datagram, failed the txid/question check, and returned `SERVFAIL` to a client whose upstream was actually healthy — and its own late response then re-queued, poisoning the socket for the following borrower.

The net effect was a self-sustaining trickle of spurious `SERVFAIL`s for conditionally-forwarded domains (e.g. split-horizon corporate resolvers) that never self-healed until the daemon restarted.

`connect()` does not flush a reused socket's receive queue on Linux, so re-connecting to the same peer can't be relied on to clear a stale datagram — it has to be handled explicitly.

## Changes

`forward_via_conditional` in `dns/pipeline.rs`:

- **Read in a deadline-bounded loop.** Instead of validating a single `recv()` and failing on the first mismatch, the receive phase now loops until this query's own answer arrives or the deadline passes, skipping any datagram whose txid or question doesn't match. A single deadline bounds the whole phase, so a socket that only ever yields stale datagrams still can't stall the query.
- **Discard timed-out / errored sockets.** On timeout or a receive error the socket is dropped rather than returned to the pool, so a late response can never queue on a reused socket. Only a socket that delivered a validated answer goes back to the pool.
- An undecodable first response is still relayed to the client raw (its own resolver may parse it), preserving the previous behaviour.

## Tests

New regression coverage in `dns/tests/pipeline.rs`:

- `conditional_forward_skips_a_stale_pooled_datagram` — a stale datagram left on a pooled socket by query A must not turn query B into a `SERVFAIL`; B gets its own answer.
- `conditional_forward_drops_the_socket_on_timeout` — a query that times out drops its socket, so a late response can't poison the next query.
- `conditional_forward_relays_an_undecodable_first_response_raw` — an undecodable first response is relayed byte-for-byte rather than dropped.

The receive timeout is made injectable so the timeout path is exercised in milliseconds rather than the production 5s.

`make check-daemon` passes (fmt, clippy `-D warnings`, full workspace tests).

Fixes #835
