### PR TITLE
chore(deps): patch js-yaml and brace-expansion DoS advisories

### DIFF
--- a/source/package.json
+++ b/source/package.json
@@ -18,7 +18,8 @@
     "path-to-regexp": "8.4.0",
     "ip-address": "10.1.1",
     "js-yaml": "4.3.0",
-    "esbuild": "0.28.1"
+    "esbuild": "0.28.1",
+    "brace-expansion@^5.0.5": "5.0.7"
   },
   "scripts": {
     "build": "turbo run build",

--- a/source/package.json
+++ b/source/package.json
@@ -17,7 +17,7 @@
   "resolutions": {
     "path-to-regexp": "8.4.0",
     "ip-address": "10.1.1",
-    "js-yaml": "4.2.0",
+    "js-yaml": "4.3.0",
     "esbuild": "0.28.1"
   },
   "scripts": {

--- a/source/yarn.lock
+++ b/source/yarn.lock
@@ -8313,14 +8313,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"js-yaml@npm:4.2.0":
-  version: 4.2.0
-  resolution: "js-yaml@npm:4.2.0"
+"js-yaml@npm:4.3.0":
+  version: 4.3.0
+  resolution: "js-yaml@npm:4.3.0"
   dependencies:
     argparse: "npm:^2.0.1"
   bin:
     js-yaml: bin/js-yaml.js
-  checksum: 10c0/1916456c118746603b067d74bbcbb0445d9a1d5e474ad4ae775e7b20525bed902e01d9d97dd0c81fcd8d4f596162309d0eb057f4aa38f3e9647f14075e9dea45
+  checksum: 10c0/058b30473d6915ca5b4feb11e2f7d4d97242f98d00a798ed48dd90b46b7c640398afe9128c5db22c5300f8c6528fe2a174b9a93f351a70ebc28c6203938d8bff
   languageName: node
   linkType: hard
 

--- a/source/yarn.lock
+++ b/source/yarn.lock
@@ -6031,21 +6031,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"brace-expansion@npm:5.0.7":
+  version: 5.0.7
+  resolution: "brace-expansion@npm:5.0.7"
+  dependencies:
+    balanced-match: "npm:^4.0.2"
+  checksum: 10c0/4769109c3c082de178e449a371bcad50d51ab468f644bce2dd9188efe0cf0a080ed102105d7fc8577382cedc45bad7e6443a91bf3d8102264ee8cf927dbaf205
+  languageName: node
+  linkType: hard
+
 "brace-expansion@npm:^2.0.1":
   version: 2.1.2
   resolution: "brace-expansion@npm:2.1.2"
   dependencies:
     balanced-match: "npm:^1.0.0"
   checksum: 10c0/5442ecab84045d21826268bc56c81a6ef4215327ee1f5ee153f67928e93f7a915d130ecec9966623143277fa3cce036ebb50020024bcc4d78853cdd6af9a19f8
-  languageName: node
-  linkType: hard
-
-"brace-expansion@npm:^5.0.5":
-  version: 5.0.6
-  resolution: "brace-expansion@npm:5.0.6"
-  dependencies:
-    balanced-match: "npm:^4.0.2"
-  checksum: 10c0/8c919869b90f61d533b341d3340be5ee4413232ea89b8246cbc2f38eb014f1d8182785c98a006eaf6111d02dc9eeffefdc240d5ac158625b2ed084dccd4bbf9b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

Clears the two open Dependabot alerts on `main` (both high, both DoS in npm dependencies of the `/source` workspace).

| Package | Change | Advisory |
|---|---|---|
| `js-yaml` | `4.2.0` → `4.3.0` | Quadratic parse time on chained merge keys (`<<`) — a sub-100KB document built from `N` mappings that each merge the previous one forces `O(N²)` key re-enumeration and can stall the parse for seconds. `4.3.0` caps merged keys per parse call. |
| `brace-expansion` | `5.0.6` → `5.0.7` | `expand()` computed the trailing expansion before the early-return branches that discard it, so consecutive non-expanding `{}` groups recursed twice per level → `O(2ⁿ)`. ~30 groups (~90 bytes) blocks the event loop for minutes. `5.0.7` defers that work and converts the rewrite into a loop. |

## Notes

- Both bumps go through the existing root `resolutions` block in `source/package.json`, which is already how the workspace pins security-sensitive deps.
- `js-yaml` was pinned at `4.2.0`; updated the pin to the patched `4.3.0`.
- `brace-expansion` is transitive (via `eslint` / `typescript-eslint`). The resolution is scoped to the affected `^5.0.5` range so only the flagged 5.x instance moves — the separate `2.1.2` tree is below the advisory's `>= 3.0.0` range and is left untouched.
- Lockfile regenerated with the repo-pinned Yarn 4.17.0; the change is limited to those two packages and `yarn install --immutable` stays consistent.