### PR TITLE
test(e2e): Playwright coverage for Network Zones surfaces

### DIFF
--- a/source/admin-app/src/pages/Devices.tsx
+++ b/source/admin-app/src/pages/Devices.tsx
@@ -155,7 +155,11 @@ function NewDevicesSection({ onSelect }: { onSelect: (id: string) => void }) {
       </Text>
       <div className="flex flex-col divide-y divide-line rounded-xl border border-line bg-card">
         {pending.map((device) => (
-          <div key={device.id} className="flex items-center gap-3 px-4 py-3">
+          <div
+            key={device.id}
+            className="flex items-center gap-3 px-4 py-3"
+            data-testid="new-device"
+          >
             <button
               onClick={() => onSelect(device.id)}
               className="flex min-w-0 flex-1 flex-col text-left"

--- a/source/admin-site/src/components/features/DeviceZoneCard.tsx
+++ b/source/admin-site/src/components/features/DeviceZoneCard.tsx
@@ -76,7 +76,11 @@ export function DeviceZoneCard({ device }: DeviceZoneCardProps) {
           <>
             <Field label="Network zone" htmlFor="device-zone">
               <Select value={zoneId} onValueChange={setZoneId}>
-                <SelectTrigger id="device-zone" className="w-full sm:w-72">
+                <SelectTrigger
+                  id="device-zone"
+                  data-testid="device-zone-select"
+                  className="w-full sm:w-72"
+                >
                   <SelectValue />
                 </SelectTrigger>
                 <SelectContent>

--- a/source/admin-site/src/components/features/QuarantineSettingsCard.tsx
+++ b/source/admin-site/src/components/features/QuarantineSettingsCard.tsx
@@ -76,7 +76,11 @@ export function QuarantineSettingsCard() {
               })
             }
           >
-            <SelectTrigger id="default-for-new" className="w-full sm:w-72">
+            <SelectTrigger
+              id="default-for-new"
+              data-testid="quarantine-default-for-new"
+              className="w-full sm:w-72"
+            >
               <SelectValue placeholder="Select a zone" />
             </SelectTrigger>
             <SelectContent>
@@ -133,7 +137,10 @@ function PendingDeviceRow({
   );
 
   return (
-    <div className="flex flex-wrap items-center justify-between gap-3 py-3">
+    <div
+      className="flex flex-wrap items-center justify-between gap-3 py-3"
+      data-testid="quarantine-pending-row"
+    >
       <div className="flex flex-col">
         <Text size="sm" weight="medium">
           {deviceDisplayName(device)}

--- a/source/admin-site/src/components/features/ZoneExceptionsCard.tsx
+++ b/source/admin-site/src/components/features/ZoneExceptionsCard.tsx
@@ -465,7 +465,7 @@ function EndpointField({
   return (
     <Field label={label} htmlFor={id} className={className}>
       <Select value={value} onValueChange={onChange}>
-        <SelectTrigger id={id} className="w-full">
+        <SelectTrigger id={id} data-testid={id} className="w-full">
           <SelectValue placeholder="Select a zone or device" />
         </SelectTrigger>
         <SelectContent>

--- a/source/admin-site/src/components/features/ZonesCard.tsx
+++ b/source/admin-site/src/components/features/ZonesCard.tsx
@@ -344,7 +344,11 @@ function ZoneForm({
               value={stance}
               onValueChange={(v) => setStance(v as ZoneStance)}
             >
-              <SelectTrigger id="zone-stance" className="w-full">
+              <SelectTrigger
+                id="zone-stance"
+                data-testid="zone-stance"
+                className="w-full"
+              >
                 <SelectValue />
               </SelectTrigger>
               <SelectContent>

--- a/source/end2end-tests/web-ui/fixtures/devices.ts
+++ b/source/end2end-tests/web-ui/fixtures/devices.ts
@@ -68,16 +68,62 @@ async function agentPost(
   }
 }
 
-/** Make `test_debian` emit a small ARP burst announcing the seed device. */
-async function emitArp(): Promise<void> {
+/** Make `test_debian` emit a small ARP burst announcing a device mac/ip. */
+async function emitArp(mac: string, ip: string): Promise<void> {
   await agentPost(TEST_DEBIAN_AGENT, "/arp/send", {
-    sender_mac: SEED_DEVICE_MAC,
-    sender_ip: SEED_DEVICE_IP,
+    sender_mac: mac,
+    sender_ip: ip,
     target_ip: SEED_TARGET_IP,
     interface: "eth0",
     count: 3,
     interval_ms: 100,
   });
+}
+
+/**
+ * Conjure a discovered device for an arbitrary controlled mac/ip and return
+ * its daemon-assigned id. The general form of `seedDiscoveredDevice` (which
+ * pins the shared `SEED_DEVICE_*` identity); the zone specs reuse it to stand
+ * up their own Trusted/Guest members. The mac must be locally-administered
+ * (`02:…`) and the ip must sit inside the daemon's LAN subnet so discovery's
+ * filter accepts the observation. Idempotent and hard-failing on timeout, for
+ * the same reasons documented on `seedDiscoveredDevice`.
+ */
+export async function seedDiscoveredDeviceByMac(
+  mac: string,
+  ip: string,
+  timeoutMs = 60_000,
+): Promise<{ id: string; mac: string; ip: string }> {
+  const token = await ensureAdminSetup();
+
+  const found = async (): Promise<SeededDevice | undefined> => {
+    const { devices } = await api<ListDevicesResponse>("/devices", { token });
+    return devices.find((d) => d.mac === mac);
+  };
+
+  const existing = await found();
+  if (existing) {
+    return { id: existing.id, mac: existing.mac, ip: existing.last_ip };
+  }
+
+  const deadline = Date.now() + timeoutMs;
+  let lastErr: unknown;
+  while (Date.now() < deadline) {
+    try {
+      await emitArp(mac, ip);
+      const match = await found();
+      if (match) return { id: match.id, mac: match.mac, ip: match.last_ip };
+    } catch (err) {
+      lastErr = err;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 3_000));
+  }
+  throw new Error(
+    `device ${mac} (${ip}) was not discovered within ${timeoutMs}ms — ` +
+      `packet capture may not be reaching wardnet_lan in this environment${
+        lastErr ? `: ${String(lastErr)}` : ""
+      }`,
+  );
 }
 
 /**
@@ -93,40 +139,11 @@ async function emitArp(): Promise<void> {
 export async function seedDiscoveredDevice(
   timeoutMs = 60_000,
 ): Promise<{ id: string; mac: string; ip: string }> {
-  const token = await ensureAdminSetup();
-
   // Match on MAC alone — the device's stable identity. The daemon always
   // records last_ip from the ARP sender (SEED_DEVICE_IP), but keying on the
   // MAC avoids ever returning an unrelated device that happens to share the
   // IP, which the table/detail specs then filter and navigate by.
-  const found = async (): Promise<SeededDevice | undefined> => {
-    const { devices } = await api<ListDevicesResponse>("/devices", { token });
-    return devices.find((d) => d.mac === SEED_DEVICE_MAC);
-  };
-
-  const existing = await found();
-  if (existing) {
-    return { id: existing.id, mac: existing.mac, ip: existing.last_ip };
-  }
-
-  const deadline = Date.now() + timeoutMs;
-  let lastErr: unknown;
-  while (Date.now() < deadline) {
-    try {
-      await emitArp();
-      const match = await found();
-      if (match) return { id: match.id, mac: match.mac, ip: match.last_ip };
-    } catch (err) {
-      lastErr = err;
-    }
-    await new Promise((resolve) => setTimeout(resolve, 3_000));
-  }
-  throw new Error(
-    `device ${SEED_DEVICE_MAC} (${SEED_DEVICE_IP}) was not discovered within ${timeoutMs}ms — ` +
-      `packet capture may not be reaching wardnet_lan in this environment${
-        lastErr ? `: ${String(lastErr)}` : ""
-      }`,
-  );
+  return seedDiscoveredDeviceByMac(SEED_DEVICE_MAC, SEED_DEVICE_IP, timeoutMs);
 }
 
 /**

--- a/source/end2end-tests/web-ui/fixtures/network-zones.ts
+++ b/source/end2end-tests/web-ui/fixtures/network-zones.ts
@@ -1,0 +1,202 @@
+/**
+ * Network-zone seeding helpers for the zone coverage specs (epic #244 → #740).
+ *
+ * The daemon seeds three system zones at migration — Trusted (the `is_default`
+ * "home" anchor), IoT, and Guest (the `is_default_for_new` landing zone). These
+ * helpers layer test state on top over plain `fetch` against the REST API, the
+ * same path the other fixtures use (see seed.ts for why this harness avoids the
+ * source-only `@wardnet/js` SDK):
+ *
+ *  - `seedZoneDevices` stands up two discovered LAN clients and pins one to
+ *    Trusted and one to Guest, so every zone surface has a real member to show,
+ *    reassign, and approve (the issue's "one device in Trusted, a second in
+ *    Guest" seed). Because zone membership is otherwise sticky (set once at
+ *    discovery), it re-pins on every call — so a spec that reassigns a device
+ *    can rely on the next `beforeAll` restoring the canonical layout.
+ *  - The zone/exception lookup + cleanup helpers keep the UI-create specs
+ *    deterministic across a re-run against a persisted state volume.
+ *
+ * The admin lookups here hit the daemon directly (`api` + a session token), so
+ * they work from either runner container — including the LAN-side runner that
+ * drives the device-keyed user-app, whose own `/devices/me` device is resolved
+ * separately (see user-app.ts / lan-device.setup.ts).
+ */
+
+import { api, ensureAdminSetup } from "./seed";
+import { seedDiscoveredDeviceByMac } from "./devices";
+
+/** Seeded system-zone names (migration `20260701000000_network_zones.sql`). */
+export const TRUSTED_ZONE = "Trusted";
+export const GUEST_ZONE = "Guest";
+export const IOT_ZONE = "IoT";
+
+/**
+ * Manual zone the admin-site CRUD spec creates through the UI, then renames.
+ * The renamed value is deliberately NOT a superstring of the original so a
+ * substring row filter for one never matches the other.
+ */
+export const TEST_ZONE_NAME = "e2e-net-zone";
+export const TEST_ZONE_NAME_EDITED = "e2e-zone-renamed";
+
+/**
+ * Two synthetic LAN clients the zone specs pin to Trusted / Guest. The MACs are
+ * locally-administered (`02:…`) so they can't collide with `test_debian`'s real
+ * NIC or the shared `SEED_DEVICE` (`…:00:00:21`), and the IPs sit inside the
+ * daemon's LAN subnet (`10.91.0.0/24`) so discovery accepts them.
+ */
+export const TRUSTED_DEVICE_MAC = "02:e2:e2:00:00:31";
+export const TRUSTED_DEVICE_IP = "10.91.0.131";
+export const GUEST_DEVICE_MAC = "02:e2:e2:00:00:32";
+export const GUEST_DEVICE_IP = "10.91.0.132";
+
+interface Zone {
+  id: string;
+  name: string;
+  provenance: "system" | "manual";
+  is_default: boolean;
+  is_default_for_new: boolean;
+  member_count: number;
+}
+
+interface ExceptionEndpoint {
+  kind: "zone" | "device";
+  id: string;
+}
+interface ZoneException {
+  id: string;
+  from: ExceptionEndpoint;
+  to: ExceptionEndpoint;
+}
+
+export interface SeededZoneDevice {
+  id: string;
+  mac: string;
+  ip: string;
+}
+
+/** List the network zones (with member counts). */
+export async function listZones(): Promise<Zone[]> {
+  const token = await ensureAdminSetup();
+  const { zones } = await api<{ zones: Zone[] }>("/network/zones", { token });
+  return zones;
+}
+
+/** Resolve a zone by name, or throw if it doesn't exist. */
+export async function getZoneByName(name: string): Promise<Zone> {
+  const zone = (await listZones()).find((z) => z.name === name);
+  if (!zone) throw new Error(`network zone "${name}" not found`);
+  return zone;
+}
+
+/** Resolve a zone id by name. */
+export async function getZoneIdByName(name: string): Promise<string> {
+  return (await getZoneByName(name)).id;
+}
+
+/** Assign a device to the named zone (`PUT /devices/{id}/zone`). */
+export async function assignDeviceToZone(
+  deviceId: string,
+  zoneName: string,
+): Promise<void> {
+  const token = await ensureAdminSetup();
+  const zoneId = await getZoneIdByName(zoneName);
+  await api(`/devices/${deviceId}/zone`, {
+    method: "PUT",
+    token,
+    body: JSON.stringify({ zone_id: zoneId }),
+  });
+}
+
+/**
+ * Seed the two zone members and pin them to Trusted / Guest. Idempotent: a
+ * device already discovered is reused, and both are re-assigned to their
+ * canonical zone every call, so a spec that moved one mid-test doesn't leak
+ * into the next. Returns both so specs can filter rows and navigate by id.
+ */
+export async function seedZoneDevices(): Promise<{
+  trusted: SeededZoneDevice;
+  guest: SeededZoneDevice;
+}> {
+  // Discover both in parallel: emitting both ARP bursts before polling lets a
+  // single discovery flush materialise both, so this stays inside the same time
+  // budget as the one-device `seedDiscoveredDevice` (matters in `beforeAll`).
+  const [trusted, guest] = await Promise.all([
+    seedDiscoveredDeviceByMac(TRUSTED_DEVICE_MAC, TRUSTED_DEVICE_IP),
+    seedDiscoveredDeviceByMac(GUEST_DEVICE_MAC, GUEST_DEVICE_IP),
+  ]);
+  await assignDeviceToZone(trusted.id, TRUSTED_ZONE);
+  await assignDeviceToZone(guest.id, GUEST_ZONE);
+  return { trusted, guest };
+}
+
+/** Read the new-device quarantine (notification) toggle. */
+export async function getQuarantine(): Promise<boolean> {
+  const token = await ensureAdminSetup();
+  const { enabled } = await api<{ enabled: boolean }>(
+    "/network/quarantine-new-devices",
+    { token },
+  );
+  return enabled;
+}
+
+/** Set the new-device quarantine (notification) toggle. */
+export async function setQuarantine(enabled: boolean): Promise<void> {
+  const token = await ensureAdminSetup();
+  await api("/network/quarantine-new-devices", {
+    method: "PUT",
+    token,
+    body: JSON.stringify({ enabled }),
+  });
+}
+
+/**
+ * Delete any leftover manual zone the CRUD spec owns (either the created or the
+ * renamed name), so its UI-create step starts clean on a re-run. System zones
+ * are never touched; a zone with members can't be deleted, but the test zones
+ * never gain any.
+ */
+export async function cleanupZones(): Promise<void> {
+  const token = await ensureAdminSetup();
+  const zones = await listZones();
+  for (const z of zones) {
+    if (
+      z.provenance !== "system" &&
+      (z.name === TEST_ZONE_NAME || z.name === TEST_ZONE_NAME_EDITED)
+    ) {
+      await api(`/network/zones/${z.id}`, { method: "DELETE", token });
+    }
+  }
+}
+
+/**
+ * Delete any cross-zone exception between the two named zones (either
+ * direction), so the exceptions-manager spec's UI-create step is deterministic.
+ */
+export async function cleanupZoneExceptions(
+  fromZone: string,
+  toZone: string,
+): Promise<void> {
+  const token = await ensureAdminSetup();
+  const [a, b] = await Promise.all([
+    getZoneIdByName(fromZone),
+    getZoneIdByName(toZone),
+  ]);
+  const { exceptions } = await api<{ exceptions: ZoneException[] }>(
+    "/network/zones/exceptions",
+    { token },
+  );
+  const ids = new Set([a, b]);
+  for (const ex of exceptions) {
+    if (
+      ex.from.kind === "zone" &&
+      ex.to.kind === "zone" &&
+      ids.has(ex.from.id) &&
+      ids.has(ex.to.id)
+    ) {
+      await api(`/network/zones/exceptions/${ex.id}`, {
+        method: "DELETE",
+        token,
+      });
+    }
+  }
+}

--- a/source/end2end-tests/web-ui/fixtures/network-zones.ts
+++ b/source/end2end-tests/web-ui/fixtures/network-zones.ts
@@ -74,23 +74,31 @@ export interface SeededZoneDevice {
   ip: string;
 }
 
-/** List the network zones (with member counts). */
-export async function listZones(): Promise<Zone[]> {
-  const token = await ensureAdminSetup();
-  const { zones } = await api<{ zones: Zone[] }>("/network/zones", { token });
+/**
+ * List the network zones (with member counts). Callers already holding a
+ * session token may pass it to avoid a redundant `ensureAdminSetup` login.
+ */
+export async function listZones(token?: string): Promise<Zone[]> {
+  const session = token ?? (await ensureAdminSetup());
+  const { zones } = await api<{ zones: Zone[] }>("/network/zones", {
+    token: session,
+  });
   return zones;
 }
 
 /** Resolve a zone by name, or throw if it doesn't exist. */
-export async function getZoneByName(name: string): Promise<Zone> {
-  const zone = (await listZones()).find((z) => z.name === name);
+export async function getZoneByName(name: string, token?: string): Promise<Zone> {
+  const zone = (await listZones(token)).find((z) => z.name === name);
   if (!zone) throw new Error(`network zone "${name}" not found`);
   return zone;
 }
 
 /** Resolve a zone id by name. */
-export async function getZoneIdByName(name: string): Promise<string> {
-  return (await getZoneByName(name)).id;
+export async function getZoneIdByName(
+  name: string,
+  token?: string,
+): Promise<string> {
+  return (await getZoneByName(name, token)).id;
 }
 
 /** Assign a device to the named zone (`PUT /devices/{id}/zone`). */
@@ -99,7 +107,7 @@ export async function assignDeviceToZone(
   zoneName: string,
 ): Promise<void> {
   const token = await ensureAdminSetup();
-  const zoneId = await getZoneIdByName(zoneName);
+  const zoneId = await getZoneIdByName(zoneName, token);
   await api(`/devices/${deviceId}/zone`, {
     method: "PUT",
     token,
@@ -139,16 +147,6 @@ export async function getQuarantine(): Promise<boolean> {
   return enabled;
 }
 
-/** Set the new-device quarantine (notification) toggle. */
-export async function setQuarantine(enabled: boolean): Promise<void> {
-  const token = await ensureAdminSetup();
-  await api("/network/quarantine-new-devices", {
-    method: "PUT",
-    token,
-    body: JSON.stringify({ enabled }),
-  });
-}
-
 /**
  * Delete any leftover manual zone the CRUD spec owns (either the created or the
  * renamed name), so its UI-create step starts clean on a re-run. System zones
@@ -178,8 +176,8 @@ export async function cleanupZoneExceptions(
 ): Promise<void> {
   const token = await ensureAdminSetup();
   const [a, b] = await Promise.all([
-    getZoneIdByName(fromZone),
-    getZoneIdByName(toZone),
+    getZoneIdByName(fromZone, token),
+    getZoneIdByName(toZone, token),
   ]);
   const { exceptions } = await api<{ exceptions: ZoneException[] }>(
     "/network/zones/exceptions",

--- a/source/end2end-tests/web-ui/tests/admin-app/network-zones.spec.ts
+++ b/source/end2end-tests/web-ui/tests/admin-app/network-zones.spec.ts
@@ -1,0 +1,79 @@
+import { expect, test } from "@playwright/test";
+
+import {
+  GUEST_DEVICE_IP,
+  GUEST_DEVICE_MAC,
+  GUEST_ZONE,
+  TRUSTED_ZONE,
+  assignDeviceToZone,
+  seedZoneDevices,
+  type SeededZoneDevice,
+} from "../../fixtures/network-zones.js";
+
+/**
+ * admin-app PWA Network Zones coverage (epic #244 → #740): the two mobile zone
+ * flows on `/admin-app/devices` — the quick zone-reassignment sheet and the
+ * "new devices awaiting review" approval inbox.
+ *
+ * Runs in the `admin-app` project — Pixel 7 viewport, seeded daemon, admin
+ * `storageState` (see playwright.config.ts). The shared seeded Guest member (in
+ * the default-for-new zone) drives both flows; each test restores it so the
+ * layout is stable across spec order. Selectors follow the suite's
+ * `data-testid` convention; the per-zone / per-device rows carry a shared
+ * testid, so they're scoped by the device's IP/MAC text.
+ */
+
+let guestDevice: SeededZoneDevice;
+
+test.beforeAll(async () => {
+  ({ guest: guestDevice } = await seedZoneDevices());
+});
+
+test("the routing sheet reassigns a device's zone", async ({ page }) => {
+  await assignDeviceToZone(guestDevice.id, GUEST_ZONE);
+  await page.goto("./devices");
+
+  const row = page
+    .getByTestId("device-row")
+    .filter({ hasText: GUEST_DEVICE_IP });
+  await expect(row).toBeVisible();
+
+  // Tap the device → the sheet opens with the Zone section.
+  await row.click();
+  const sheet = page.getByTestId("device-routing-sheet");
+  await expect(sheet).toBeVisible();
+
+  // Pick the Trusted zone (each zone option shares one testid; scope by name).
+  await sheet
+    .getByTestId("device-zone-option")
+    .filter({ hasText: TRUSTED_ZONE })
+    .click();
+
+  // Success reassigns the zone, toasts, and closes the sheet.
+  await expect(page.getByText("Zone updated")).toBeVisible();
+  await expect(sheet).toBeHidden();
+
+  // Restore for the approval flow below.
+  await assignDeviceToZone(guestDevice.id, GUEST_ZONE);
+});
+
+test("the new-device inbox approves a quarantined device", async ({ page }) => {
+  await assignDeviceToZone(guestDevice.id, GUEST_ZONE);
+  await page.goto("./devices");
+
+  // The seeded Guest member sits in the default-for-new zone, so it surfaces in
+  // the "awaiting review" inbox.
+  await expect(page.getByTestId("new-devices-section")).toBeVisible();
+  const entry = page
+    .getByTestId("new-device")
+    .filter({ hasText: GUEST_DEVICE_MAC });
+  await expect(entry).toBeVisible();
+
+  // Approve → reassigns to the home zone, so the entry leaves the inbox.
+  await entry.getByTestId("new-device-approve").click();
+  await expect(page.getByText("Device approved")).toBeVisible();
+  await expect(entry).toHaveCount(0);
+
+  // Restore the canonical Guest membership.
+  await assignDeviceToZone(guestDevice.id, GUEST_ZONE);
+});

--- a/source/end2end-tests/web-ui/tests/admin-site/network-zones.spec.ts
+++ b/source/end2end-tests/web-ui/tests/admin-site/network-zones.spec.ts
@@ -163,6 +163,16 @@ test("new-device quarantine: toggle, default-for-new, and approve a device", asy
   await toggle.click();
   await expect(toggle).toHaveAttribute("aria-checked", startAttr);
 
+  // Each toggle raised a notification toast; let them expire before the
+  // Approve click below. Sonner pauses its auto-dismiss timer while hovered,
+  // and Playwright's click retries would park the pointer on an intercepting
+  // toast — a deadlock until the test timeout. Move the pointer away first,
+  // then wait the toasts out (mirrors admin-app/pages.spec.ts).
+  await page.mouse.move(0, 0);
+  await expect(page.locator("[data-sonner-toast]")).toHaveCount(0, {
+    timeout: 15_000,
+  });
+
   // The seeded Guest member is awaiting review; approving reassigns it out of
   // the default-for-new zone (to the home zone), so its row disappears.
   const pendingRow = page

--- a/source/end2end-tests/web-ui/tests/admin-site/network-zones.spec.ts
+++ b/source/end2end-tests/web-ui/tests/admin-site/network-zones.spec.ts
@@ -1,0 +1,200 @@
+import { expect, test } from "@playwright/test";
+
+import {
+  GUEST_DEVICE_MAC,
+  GUEST_ZONE,
+  IOT_ZONE,
+  TEST_ZONE_NAME,
+  TEST_ZONE_NAME_EDITED,
+  TRUSTED_ZONE,
+  assignDeviceToZone,
+  cleanupZoneExceptions,
+  cleanupZones,
+  getQuarantine,
+  seedZoneDevices,
+  type SeededZoneDevice,
+} from "../../fixtures/network-zones.js";
+
+/**
+ * Admin-site Network Zones coverage (epic #244 → #740) for `/admin/zones`.
+ *
+ * The page stacks three cards — the zone catalog (`ZonesCard`), the cross-zone
+ * exceptions manager (`ZoneExceptionsCard`), and new-device quarantine
+ * (`QuarantineSettingsCard`) — plus the per-device zone selector on the device
+ * detail page (`DeviceZoneCard`). Each surface is driven through its real UI
+ * flow. Two synthetic LAN members are seeded (one pinned to Trusted, one to
+ * Guest) so the guard-rail, approval, and reassignment paths have real devices;
+ * anything a test mutates it restores, so behaviour never depends on spec order.
+ *
+ * Runs in the `admin-site` project (seeded daemon + admin storageState).
+ * Selectors follow the suite's `data-testid` convention (README.md): testids
+ * locate, human-facing label/text is additionally asserted. Table rows are
+ * located by their unique text and deletes go through the shared
+ * `confirm-dialog-confirm` control.
+ */
+
+let guestDevice: SeededZoneDevice;
+
+test.beforeAll(async () => {
+  ({ guest: guestDevice } = await seedZoneDevices());
+  // Clear any leftover manual zone / casting exception from a prior run so the
+  // UI-create steps below start from a known-empty slate.
+  await cleanupZones();
+  await cleanupZoneExceptions(GUEST_ZONE, IOT_ZONE);
+});
+
+test("zone lifecycle: create, edit, and delete a manual zone", async ({
+  page,
+}) => {
+  await page.goto("./zones");
+  await expect(page.getByTestId("page-title")).toHaveText("Zones");
+
+  // ── Create a manual zone (defaults: shared subnet, direct + tunnel) ──
+  await page.getByTestId("zone-add").click();
+  await page.getByTestId("zone-name").fill(TEST_ZONE_NAME);
+  await page.getByTestId("zone-submit").click();
+
+  const row = page.getByRole("row").filter({ hasText: TEST_ZONE_NAME });
+  await expect(row).toBeVisible();
+  await expect(row).toContainText("Shared subnet");
+
+  // ── Edit: rename and switch the isolation stance ────────────────────
+  await row.getByTestId("zone-row-menu").click();
+  await page.getByTestId("zone-edit").click();
+  await page.getByTestId("zone-name").fill(TEST_ZONE_NAME_EDITED);
+  await page.getByTestId("zone-stance").click();
+  await page.getByRole("option", { name: "Isolate members" }).click();
+  await page.getByTestId("zone-submit").click();
+
+  const editedRow = page
+    .getByRole("row")
+    .filter({ hasText: TEST_ZONE_NAME_EDITED });
+  await expect(editedRow).toBeVisible();
+  await expect(editedRow).toContainText("Isolate members");
+  await expect(
+    page.getByRole("row").filter({ hasText: TEST_ZONE_NAME }),
+  ).toHaveCount(0);
+
+  // ── Delete it ───────────────────────────────────────────────────────
+  await editedRow.getByTestId("zone-row-menu").click();
+  await page.getByTestId("zone-delete").click();
+  await page.getByTestId("confirm-dialog-confirm").click();
+  await expect(editedRow).toHaveCount(0);
+});
+
+test("seeded-zone guard rail: system and home zones offer no Delete", async ({
+  page,
+}) => {
+  await page.goto("./zones");
+
+  // Trusted is the system "home" (is_default) zone: its row menu offers Edit
+  // but neither Delete (system + anchor) nor "Set as home" (already home).
+  const trustedRow = page.getByRole("row").filter({ hasText: TRUSTED_ZONE });
+  await trustedRow.getByTestId("zone-row-menu").click();
+  await expect(page.getByTestId("zone-edit")).toBeVisible();
+  await expect(page.getByTestId("zone-delete")).toHaveCount(0);
+  await expect(page.getByTestId("zone-set-home")).toHaveCount(0);
+  await page.keyboard.press("Escape");
+  await expect(page.getByTestId("zone-edit")).toHaveCount(0);
+
+  // Guest is the system default-for-new zone and holds a seeded member — still
+  // no Delete (system provenance alone forbids it).
+  const guestRow = page.getByRole("row").filter({ hasText: GUEST_ZONE });
+  await guestRow.getByTestId("zone-row-menu").click();
+  await expect(page.getByTestId("zone-edit")).toBeVisible();
+  await expect(page.getByTestId("zone-delete")).toHaveCount(0);
+});
+
+test("cross-zone exceptions: add and remove a casting allowance", async ({
+  page,
+}) => {
+  await page.goto("./zones");
+
+  await page.getByTestId("exception-add").click();
+
+  // Guest → IoT, keeping the default one-click Casting preset.
+  await page.getByTestId("exception-from").click();
+  await page.getByRole("option", { name: `Zone: ${GUEST_ZONE}` }).click();
+  await page.getByTestId("exception-to").click();
+  await page.getByRole("option", { name: `Zone: ${IOT_ZONE}` }).click();
+  await expect(page.getByTestId("exception-service")).toContainText("Casting");
+  await page.getByTestId("exception-submit").click();
+
+  // The allowance is a single row carrying both endpoints + the Casting pill.
+  // A zone row only ever names one zone, so matching both names is unambiguous.
+  const row = page
+    .getByRole("row")
+    .filter({ hasText: GUEST_ZONE })
+    .filter({ hasText: IOT_ZONE });
+  await expect(row).toBeVisible();
+  await expect(row).toContainText("Casting");
+
+  // ── Remove it ───────────────────────────────────────────────────────
+  await row.getByTestId("exception-row-menu").click();
+  await page.getByTestId("exception-delete").click();
+  await page.getByTestId("confirm-dialog-confirm").click();
+  await expect(row).toHaveCount(0);
+});
+
+test("new-device quarantine: toggle, default-for-new, and approve a device", async ({
+  page,
+}) => {
+  // Put the Guest member back in the default-for-new zone so it appears pending,
+  // and capture the current toggle so we can restore it.
+  await assignDeviceToZone(guestDevice.id, GUEST_ZONE);
+  const startEnabled = await getQuarantine();
+
+  await page.goto("./zones");
+
+  // The default-for-new zone is the seeded Guest zone.
+  await expect(page.getByTestId("quarantine-default-for-new")).toContainText(
+    GUEST_ZONE,
+  );
+
+  // Toggle notifications, then flip back to the original state.
+  const toggle = page.getByTestId("quarantine-toggle");
+  const startAttr = startEnabled ? "true" : "false";
+  await expect(toggle).toHaveAttribute("aria-checked", startAttr);
+  await toggle.click();
+  await expect(toggle).toHaveAttribute(
+    "aria-checked",
+    startEnabled ? "false" : "true",
+  );
+  await toggle.click();
+  await expect(toggle).toHaveAttribute("aria-checked", startAttr);
+
+  // The seeded Guest member is awaiting review; approving reassigns it out of
+  // the default-for-new zone (to the home zone), so its row disappears.
+  const pendingRow = page
+    .getByTestId("quarantine-pending-row")
+    .filter({ hasText: GUEST_DEVICE_MAC });
+  await expect(pendingRow).toBeVisible();
+  await pendingRow.getByTestId("quarantine-approve").click();
+  await expect(page.getByText("Device approved")).toBeVisible();
+  await expect(pendingRow).toHaveCount(0);
+
+  // Restore the canonical Trusted/Guest layout for later specs.
+  await assignDeviceToZone(guestDevice.id, GUEST_ZONE);
+});
+
+test("device zone assignment: reassign from the device detail page", async ({
+  page,
+}) => {
+  await assignDeviceToZone(guestDevice.id, GUEST_ZONE);
+
+  await page.goto(`./devices/${guestDevice.id}`);
+
+  // Read mode surfaces the current zone.
+  await expect(page.getByTestId("device-zone-value")).toContainText(GUEST_ZONE);
+
+  // Edit → pick a different zone → save.
+  await page.getByTestId("device-zone-edit").click();
+  await page.getByTestId("device-zone-select").click();
+  await page.getByRole("option", { name: IOT_ZONE, exact: true }).click();
+  await page.getByTestId("device-zone-save").click();
+
+  await expect(page.getByTestId("device-zone-value")).toContainText(IOT_ZONE);
+
+  // Restore.
+  await assignDeviceToZone(guestDevice.id, GUEST_ZONE);
+});

--- a/source/end2end-tests/web-ui/tests/user-app/network-zones.spec.ts
+++ b/source/end2end-tests/web-ui/tests/user-app/network-zones.spec.ts
@@ -1,0 +1,58 @@
+import { expect, test } from "@playwright/test";
+
+import { getLanDeviceId } from "../../fixtures/user-app.js";
+import {
+  GUEST_ZONE,
+  assignDeviceToZone,
+} from "../../fixtures/network-zones.js";
+
+/**
+ * user-app device-keyed Network Zones coverage (epic #244 → #740).
+ *
+ * The user-app is read-only about zones: the caller's own device shows which
+ * zone it's on, but the owner can't change it — only an admin can. This spec
+ * pins the LAN-proxy device (the one `/api/devices/me` resolves to on this
+ * runner — see user-app.ts / lan-device.setup.ts) to a known zone and asserts
+ * the Home tab's zone card renders that zone and offers no control to change it.
+ *
+ * Runs in the `user-app` project (Pixel 7, LAN-side runner, no storageState —
+ * device-keyed). Selectors follow the suite's `data-testid` convention.
+ */
+
+let deviceId: string;
+
+test.beforeAll(async () => {
+  // Pin the device to Guest (a non-home zone → the "isolated" copy) so the
+  // assertions don't depend on prior specs. Guest is also its natural
+  // default-for-new zone, so this is a no-op restore for later specs.
+  deviceId = await getLanDeviceId();
+  await assignDeviceToZone(deviceId, GUEST_ZONE);
+});
+
+test("the home tab shows the caller's zone read-only", async ({ page }) => {
+  await page.goto("./");
+
+  await expect(page.getByText("Network zone")).toBeVisible();
+
+  const card = page.getByTestId("zone-readonly");
+  await expect(card).toBeVisible();
+  // Non-home zone → the "isolated from the home network" copy naming the zone.
+  await expect(card).toContainText(`You're on: ${GUEST_ZONE}`);
+  await expect(card).toContainText("isolated from the home network");
+  // The lock note stating only an admin can move the device between zones.
+  await expect(card).toContainText(
+    "Only your network administrator can change which zone your device is on.",
+  );
+});
+
+test("the owner cannot change the zone", async ({ page }) => {
+  await page.goto("./");
+
+  // The zone card is display-only: no button, select, combobox, or toggle the
+  // owner could use to reassign the zone (that endpoint is admin-gated).
+  const card = page.getByTestId("zone-readonly");
+  await expect(card).toBeVisible();
+  await expect(card.getByRole("button")).toHaveCount(0);
+  await expect(card.getByRole("combobox")).toHaveCount(0);
+  await expect(card.locator("select, input, [role='switch']")).toHaveCount(0);
+});


### PR DESCRIPTION
Extends the Playwright e2e suite to cover the Network Zones surfaces across all three frontends, following the existing suite conventions (`adr-e2e-selector-convention`, `tests-e2e.yml`).

## What's covered

**admin-site** (`/zones` + device detail)
- Zone lifecycle: create, edit (rename + isolation stance), delete a manual zone.
- Seeded-zone guard rail: system / home zones expose no Delete action.
- Cross-zone exceptions: add and remove a casting allowance.
- New-device quarantine: notification toggle, default-for-new zone, and approving a device off the awaiting-review list.
- Per-device zone selector on the device detail page.

**admin-app** (`/devices`)
- Quick zone-reassignment sheet.
- Approve-quarantined-device inbox.

**user-app** (home)
- Read-only zone display for the caller's own device, asserting the owner has no control to change the zone.

## Selectors & seed data

- Adds the `data-testid` hooks the specs need on the zone controls, per the selector-convention ADR (isolation-stance / exception endpoint / quarantine / device-zone selects, quarantine and new-device rows). No behaviour change.
- Extends the local seed with two discovered LAN members pinned to Trusted and Guest so each surface has a real device to show, reassign, and approve; the device seeder is generalised to stand up members for arbitrary MACs. The user-app's own `/devices/me` device is pinned to a known zone via the existing device-keyed convention.
- Specs restore anything they mutate, so they stay order-independent on the shared single-worker daemon. New spec files sort ahead of the `stateful/` restart specs, and dashboard device-count snapshots are unaffected (they're captured before any device seeding, or mask the count).

Closes #740.