### PR TITLE
fix(daemon): propagate & arm the watchdog + crash-loop safety nets fleet-wide

### DIFF
--- a/deploy/wardnetd.service
+++ b/deploy/wardnetd.service
@@ -7,6 +7,28 @@ Wants=network-online.target
 # enters `failed` state, which the StartLimit* knobs below guarantee
 # after 3 crashes within 120s.
 OnFailure=wardnetd-rollback.service
+# Auto-update crash-loop budget. If the daemon fails 5 times within 30s,
+# systemd marks the unit failed and the OnFailure= rollback unit kicks in.
+# `StartLimitAction=none` avoids systemd's default aggressive stop once the
+# budget is exhausted — we let the rollback unit swap the binary back, then
+# manual recovery (or the next update check) takes over.
+#
+# The 30s window is deliberately tight so ONLY a genuine crash-loop trips it,
+# not a merely-unhealthy daemon. A bad binary that crashes on startup restarts
+# every RestartSec=2s → 5 failures in ~15s, well inside 30s → rollback. A
+# health-gated soft-watchdog restart (see WatchdogSec below) can happen at most
+# once per ~15s, so ≤3 land in 30s — under the budget, so environmental
+# unhealth (e.g. a slow DB after a power loss) keeps restarting rather than
+# reverting a good binary to the lingering wardnetd.old. Widening this window
+# re-introduces that false rollback.
+#
+# These MUST live in [Unit], not [Service]: systemd only parses StartLimit*
+# under [Unit] and silently ignores them elsewhere ("Unknown key
+# 'StartLimitIntervalSec' in section [Service]"), which would leave the
+# crash-loop budget — and the rollback safety net — off.
+StartLimitIntervalSec=30
+StartLimitBurst=5
+StartLimitAction=none
 
 [Service]
 # Type=notify: the daemon sends sd_notify(READY=1) once all listeners are
@@ -21,15 +43,8 @@ Group=wardnet
 ExecStart=/usr/local/bin/wardnetd --config /etc/wardnet/wardnet.toml
 Restart=always
 RestartSec=2s
-# Auto-update crash-loop budget. If the daemon fails to stay up for 3
-# restarts within 120s, systemd marks the unit as failed and the
-# OnFailure= rollback unit kicks in. `StartLimitAction=none` avoids
-# systemd's default aggressive stop once the budget is exhausted — we
-# let the rollback unit swap the binary back, then manual recovery
-# (or the next update check) takes over.
-StartLimitIntervalSec=120
-StartLimitBurst=3
-StartLimitAction=none
+# NOTE: the StartLimit* crash-loop knobs referenced above live in the
+# [Unit] section — systemd ignores them here in [Service].
 
 # Capabilities — CAP_NET_ADMIN covers nftables/route netlink and child tools (ip, sysctl)
 AmbientCapabilities=CAP_NET_ADMIN CAP_NET_RAW CAP_NET_BIND_SERVICE
@@ -67,10 +82,14 @@ SyslogIdentifier=wardnetd
 # (even the health loop wedged) is caught instead by the ungated hardware
 # /dev/watchdog, which reboots the host.
 #
-# WatchdogSec interacts with the StartLimit* budget above: repeated watchdog
-# restarts count toward StartLimitBurst, so a persistently-unhealthy daemon
-# eventually trips OnFailure=wardnetd-rollback.service (post-update crash-loop
-# recovery) rather than restarting forever.
+# WatchdogSec interacts with the StartLimit* budget above, but by design does
+# NOT trip it: a soft-watchdog restart can fire at most about once per 15s, so
+# a persistently-unhealthy daemon accrues ≤3 restarts in the 30s window and
+# stays under StartLimitBurst=5. It therefore keeps getting restarted (staying
+# reachable between restarts) instead of tripping OnFailure=rollback and
+# reverting the binary. Only a true crash-loop (restarts every RestartSec=2s)
+# exhausts the budget — which is exactly the post-update failure rollback is
+# meant to recover from.
 WatchdogSec=15
 
 [Install]

--- a/docs/adr/0014-watchdog-and-health.md
+++ b/docs/adr/0014-watchdog-and-health.md
@@ -48,6 +48,30 @@ single most important property of the design.
   `/dev/watchdog` impl and a `NoopWatchdog` mock, wired onto `Backends` like
   `SystemPowerOps`/`GarpOps`. systemd's own hardware-watchdog support would
   have meant PID-1 owning the device and a coarser, health-blind policy.
+  - **Device access & ownership (cross-platform).** The hard layer opens
+    `/dev/watchdog` as `User=wardnet`, and the outcome depends on the host —
+    so the daemon classifies the open result instead of treating every
+    failure as "no backstop":
+    - **Free + accessible** → wardnet owns and pets it. The kernel creates the
+      device `root:root 0600`, which an unprivileged daemon can't open, so a
+      udev rule hands it to the `wardnet` group at `0660`. That rule is laid
+      down by the `0002_watchdog_udev_rule` post-upgrade migration (in
+      `wardnet-postupgrade`), which runs as root before `wardnetd` on every
+      boot — so the fix reaches auto-updated installs, not just fresh
+      `install.sh` runs. This is the common case on plain Linux hosts (upstream
+      systemd defaults `RuntimeWatchdogSec=off`).
+    - **Owned by another supervisor** (`EBUSY`) → the daemon defers. systemd's
+      own `RuntimeWatchdogSec=` claims the single-opener device — notably the
+      Raspberry Pi OS default (`/lib/systemd/system.conf.d/40-rpi-enable-watchdog.conf`,
+      `RuntimeWatchdogSec=1m`) — as can a standalone `watchdogd`. The host still
+      has a hardware reboot-on-freeze backstop, just owned by that supervisor;
+      wardnet's hard layer stands down (logged INFO, not a fault). A daemon-
+      specific hang is still caught faster by the soft `WatchdogSec=15`
+      service restart.
+    - **No device** (`ENOENT`, e.g. containers/VMs) → soft watchdog only.
+    - **Present but inaccessible** (`EACCES`) → the one genuine
+      misconfiguration: the udev rule above is missing. Logged WARN with the
+      remedy.
 - **`Type=notify` + `READY=1` after listeners bind.** The daemon only reports
   ready once `:7411`/`:443`/`:80` are bound, so systemd's `active(running)` is
   meaningful and the watchdog supervision arms at the right moment.

--- a/source/daemon/crates/wardnet-postupgrade/src/migrations.rs
+++ b/source/daemon/crates/wardnet-postupgrade/src/migrations.rs
@@ -38,19 +38,53 @@ pub struct Migration {
 /// applied migrations.
 #[must_use]
 pub fn migrations() -> &'static [Migration] {
-    &[Migration {
-        // Authorises the daemon (running as the unprivileged
-        // `wardnet` user) to call logind's reboot / power-off
-        // actions, which is what `systemctl reboot|poweroff
-        // --no-block` invokes under the hood. See #215.
-        //
-        // Severity::Optional: the daemon still starts without it.
-        // Only Safe Reboot / Safe Shutdown stop working — the rest
-        // of the system keeps functioning, so blocking startup
-        // would be the wrong trade-off (e.g. on a non-systemd
-        // container or a host where polkit is uninstalled).
-        id: "0001_polkit_power_rule",
-        severity: Severity::Optional,
-        up: crate::up::write_polkit_power_rule,
-    }]
+    &[
+        Migration {
+            // Authorises the daemon (running as the unprivileged
+            // `wardnet` user) to call logind's reboot / power-off
+            // actions, which is what `systemctl reboot|poweroff
+            // --no-block` invokes under the hood. See #215.
+            //
+            // Severity::Optional: the daemon still starts without it.
+            // Only Safe Reboot / Safe Shutdown stop working — the rest
+            // of the system keeps functioning, so blocking startup
+            // would be the wrong trade-off (e.g. on a non-systemd
+            // container or a host where polkit is uninstalled).
+            id: "0001_polkit_power_rule",
+            severity: Severity::Optional,
+            up: crate::up::write_polkit_power_rule,
+        },
+        Migration {
+            // Installs the udev rule granting the `wardnet` group
+            // access to /dev/watchdog so the daemon can arm the ungated
+            // hardware-reboot backstop (issue #214). Without it the open
+            // fails EACCES and the backstop silently stays off.
+            //
+            // Severity::Optional: the soft (sd_notify) watchdog still
+            // works without it, and hosts with no watchdog device (or
+            // no udev) must still boot the daemon.
+            id: "0002_watchdog_udev_rule",
+            severity: Severity::Optional,
+            up: crate::up::write_watchdog_udev_rule,
+        },
+        Migration {
+            // Refreshes /etc/systemd/system/wardnetd.service from the
+            // unit shipped in this release. The auto-updater carries only
+            // binaries, so unit-file fixes (e.g. the StartLimit* crash-loop
+            // budget that systemd only honours under [Unit]) reach existing
+            // installs through this step rather than an install.sh re-run.
+            //
+            // Run-once, like every migration: this ships the unit as it
+            // stood when the migration was added. A later unit change that
+            // must reach the fleet needs its own new migration id (append,
+            // never edit this one — operators have state referencing it).
+            //
+            // Severity::Optional: if the rewrite fails the daemon still
+            // starts from the on-disk unit; only the newer unit's
+            // improvements are missed, which must not gate startup.
+            id: "0003_wardnetd_unit_refresh",
+            severity: Severity::Optional,
+            up: crate::up::refresh_wardnetd_unit,
+        },
+    ]
 }

--- a/source/daemon/crates/wardnet-postupgrade/src/up/mod.rs
+++ b/source/daemon/crates/wardnet-postupgrade/src/up/mod.rs
@@ -11,9 +11,16 @@
 //! The actual logic lives in submodules that accept a base-path
 //! argument so unit tests can drive them against a `tempfile::TempDir`.
 
+use std::fs;
+use std::io::Write;
+use std::os::unix::fs::PermissionsExt;
 use std::path::Path;
 
+use anyhow::Context;
+
 pub mod polkit;
+pub mod systemd_unit;
+pub mod watchdog;
 
 #[cfg(test)]
 mod tests;
@@ -27,4 +34,101 @@ mod tests;
 /// `systemctl poweroff` actually invoke under the hood.
 pub fn write_polkit_power_rule() -> anyhow::Result<()> {
     polkit::write_rule(Path::new(polkit::DEFAULT_RULES_DIR))
+}
+
+/// Migration `0002_watchdog_udev_rule` entry point.
+///
+/// Installs the udev rule that hands `/dev/watchdog` to the `wardnet`
+/// group so the unprivileged daemon can arm the ungated hardware-reboot
+/// backstop (issue #214). The persistent rule handles every future
+/// boot; a best-effort udev retrigger + device chgrp also arms it on
+/// the current boot without waiting for a reboot.
+pub fn write_watchdog_udev_rule() -> anyhow::Result<()> {
+    watchdog::reconcile(Path::new(watchdog::DEFAULT_RULES_DIR))
+}
+
+/// Migration `0003_wardnetd_unit_refresh` entry point.
+///
+/// Reconciles `/etc/systemd/system/wardnetd.service` with the canonical
+/// unit shipped in this release, then reloads systemd. This is how a
+/// unit-file fix (e.g. the `StartLimit*` crash-loop budget that only takes
+/// effect under `[Unit]`) reaches installs that update via the auto-updater —
+/// the update tarball carries only binaries, never the service units.
+///
+/// Runs once (like every migration), so it propagates the unit as it stood
+/// when this migration was added; a *future* unit change that must reach
+/// existing installs needs its own follow-up migration, not an edit here.
+pub fn refresh_wardnetd_unit() -> anyhow::Result<()> {
+    systemd_unit::reconcile(Path::new(systemd_unit::DEFAULT_UNIT_DIR))
+}
+
+/// Atomically write `body` to `<base>/<filename>` with mode `mode`.
+///
+/// Idempotent: if the target already holds identical bytes, the mode is
+/// reconciled (operators sometimes hand-chmod files) and `Ok(false)` is
+/// returned **without touching mtime**. Otherwise the content is written
+/// to a sibling temp file, fsynced, renamed into place, and the parent
+/// directory is fsynced — so a power loss after the rename leaves the new
+/// content (not zeroes) on disk — and `Ok(true)` is returned.
+///
+/// The returned bool lets callers skip a follow-up reload (udev /
+/// `systemctl daemon-reload`) when nothing actually changed.
+pub(crate) fn write_file_atomic(
+    base: &Path,
+    filename: &str,
+    body: &str,
+    mode: u32,
+) -> anyhow::Result<bool> {
+    let target = base.join(filename);
+
+    // Idempotent fast path: bytes already match. Don't touch mtime;
+    // still reconcile the mode in case it was hand-edited.
+    if let Ok(existing) = fs::read(&target)
+        && existing == body.as_bytes()
+    {
+        ensure_mode(&target, mode)?;
+        return Ok(false);
+    }
+
+    fs::create_dir_all(base).with_context(|| format!("creating dir {}", base.display()))?;
+
+    // Sibling temp file so the rename is atomic on the same fs. A
+    // leading '.' keeps the partial file out of any inotify watcher's
+    // attention (udev, polkitd) until the rename onto the final name.
+    let tmp = base.join(format!(".{filename}.tmp"));
+    {
+        let mut file = fs::File::create(&tmp)
+            .with_context(|| format!("creating temp file {}", tmp.display()))?;
+        file.write_all(body.as_bytes())
+            .with_context(|| format!("writing temp file {}", tmp.display()))?;
+        file.sync_all()
+            .with_context(|| format!("fsync temp file {}", tmp.display()))?;
+        fs::set_permissions(&tmp, fs::Permissions::from_mode(mode))
+            .with_context(|| format!("chmod temp file {}", tmp.display()))?;
+    }
+
+    fs::rename(&tmp, &target)
+        .with_context(|| format!("rename {} -> {}", tmp.display(), target.display()))?;
+    fsync_dir(base)?;
+
+    Ok(true)
+}
+
+/// Ensure `path` has mode `mode`; a no-op if it already does.
+fn ensure_mode(path: &Path, mode: u32) -> anyhow::Result<()> {
+    let meta = fs::metadata(path).with_context(|| format!("stat {}", path.display()))?;
+    if meta.permissions().mode() & 0o777 != mode {
+        fs::set_permissions(path, fs::Permissions::from_mode(mode))
+            .with_context(|| format!("chmod {}", path.display()))?;
+    }
+    Ok(())
+}
+
+/// Open the directory and call `fsync(2)` on it so a preceding rename is
+/// durable before we return.
+fn fsync_dir(dir: &Path) -> anyhow::Result<()> {
+    let f = fs::File::open(dir).with_context(|| format!("open dir {}", dir.display()))?;
+    f.sync_all()
+        .with_context(|| format!("fsync dir {}", dir.display()))?;
+    Ok(())
 }

--- a/source/daemon/crates/wardnet-postupgrade/src/up/systemd_unit.rs
+++ b/source/daemon/crates/wardnet-postupgrade/src/up/systemd_unit.rs
@@ -1,0 +1,85 @@
+//! Idempotent reconciler for `/etc/systemd/system/wardnetd.service`.
+//!
+//! The auto-updater ships only binaries (plus `wardnet-postupgrade.service`),
+//! never the `wardnetd.service` unit — so a unit-file fix would otherwise
+//! reach existing installs only when an operator re-runs `install.sh`. This
+//! step closes that gap: it rewrites the unit from the canonical copy baked
+//! into this release and reloads systemd.
+//!
+//! Scope note: like every migration here this runs **once** (the runner
+//! records it applied, then skips it). So it propagates the unit exactly as
+//! it stood *when this migration was added* — it is not a standing sync of
+//! `deploy/wardnetd.service`. A later change to the unit that must reach
+//! existing installs needs its own follow-up migration with a new id, which
+//! is the framework's append-only model (see [`crate::migrations`]).
+
+use std::path::Path;
+use std::process::Command;
+
+use anyhow::Context;
+
+use crate::up::write_file_atomic;
+
+/// The unit filename under the systemd unit dir.
+pub const UNIT_FILENAME: &str = "wardnetd.service";
+
+/// Default systemd unit directory. Tests pass tempdir paths.
+pub const DEFAULT_UNIT_DIR: &str = "/etc/systemd/system";
+
+/// Canonical unit text, baked in at compile time from the single source
+/// of truth `deploy/wardnetd.service` — the very file `install.sh` lays
+/// down on a fresh install. Embedding it (rather than a hand-kept copy)
+/// makes drift impossible: there is exactly one unit definition in the
+/// tree. The path mirrors the release-pubkey include in `wardnetd-services`
+/// and resolves via `COPY deploy/ /deploy/` in the build/test images.
+pub const UNIT_BODY: &str = include_str!("../../../../../../deploy/wardnetd.service");
+
+/// World-readable, matching how `install.sh` writes the unit (`0644`).
+const UNIT_MODE: u32 = 0o644;
+
+/// Write the canonical unit to `<base>/wardnetd.service`. Returns whether
+/// the file changed, so [`reconcile`] can skip `daemon-reload` on a no-op.
+pub fn write_unit(base: &Path) -> anyhow::Result<bool> {
+    write_file_atomic(base, UNIT_FILENAME, UNIT_BODY, UNIT_MODE)
+}
+
+/// Write the unit, then reload systemd so the definition takes effect this
+/// boot. Runs before `wardnetd.service` starts (this binary is `RequiredBy`
+/// it), so the reload never races a running daemon.
+pub fn reconcile(base: &Path) -> anyhow::Result<()> {
+    write_unit(base)?;
+
+    // A tempdir base (tests) must not shell out to systemd.
+    if base == Path::new(DEFAULT_UNIT_DIR) {
+        daemon_reload()?;
+    }
+    Ok(())
+}
+
+/// `systemctl daemon-reload` so the rewritten unit takes effect on this boot.
+///
+/// Deliberately **not** gated on whether the file changed, and a genuine
+/// reload failure is **propagated** rather than swallowed. This migration
+/// runs at most once (the runner records it applied), so a swallowed failure
+/// would leave the fix inert until the next reboot with no retry. Propagating
+/// records the Optional migration as failed, which re-runs it next boot — and
+/// because the reload isn't gated on `changed`, that retry actually reloads
+/// even though the file already matches. A *missing* `systemctl` (a
+/// non-systemd host that somehow reached this path) is treated as success:
+/// there is nothing to reload.
+fn daemon_reload() -> anyhow::Result<()> {
+    match Command::new("systemctl").arg("daemon-reload").status() {
+        Ok(status) if status.success() => {
+            tracing::info!("reloaded systemd after refreshing wardnetd.service");
+            Ok(())
+        }
+        Ok(status) => {
+            anyhow::bail!("systemctl daemon-reload exited with {status}")
+        }
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            tracing::info!("systemctl not found; skipping daemon-reload (non-systemd host)");
+            Ok(())
+        }
+        Err(e) => Err(e).context("running systemctl daemon-reload"),
+    }
+}

--- a/source/daemon/crates/wardnet-postupgrade/src/up/systemd_unit.rs
+++ b/source/daemon/crates/wardnet-postupgrade/src/up/systemd_unit.rs
@@ -43,41 +43,55 @@ pub fn write_unit(base: &Path) -> anyhow::Result<bool> {
     write_file_atomic(base, UNIT_FILENAME, UNIT_BODY, UNIT_MODE)
 }
 
-/// Write the unit, then reload systemd so the definition takes effect this
-/// boot. Runs before `wardnetd.service` starts (this binary is `RequiredBy`
-/// it), so the reload never races a running daemon.
+/// Write the unit, then reload systemd **only if the file actually changed**,
+/// and only against the real dir. Runs before `wardnetd.service` starts (this
+/// binary is `RequiredBy` it), so the reload never races a running daemon.
+///
+/// Gating the reload on `changed` matters beyond efficiency: the e2e image
+/// ships a byte-identical unit (`changed=false`), and reloading there would run
+/// the test's `/usr/sbin/systemctl` shim **as root**, creating the shared
+/// invocation-log file root-owned — which then blocks the `wardnet`-user daemon
+/// from recording its own reboot/poweroff calls. On a real existing install the
+/// unit differs (the fix moved `StartLimit*` into `[Unit]`), so `changed=true`
+/// and the reload runs. If it fails the error propagates (Optional migration
+/// retries next boot); either way systemd loads the corrected unit fresh on the
+/// next boot even without an in-band reload.
 pub fn reconcile(base: &Path) -> anyhow::Result<()> {
-    write_unit(base)?;
+    let changed = write_unit(base)?;
 
-    // A tempdir base (tests) must not shell out to systemd.
-    if base == Path::new(DEFAULT_UNIT_DIR) {
+    // A tempdir base (tests) must not shell out to systemd; nor may a no-op.
+    if changed && base == Path::new(DEFAULT_UNIT_DIR) {
         daemon_reload()?;
     }
     Ok(())
 }
 
-/// `systemctl daemon-reload` so the rewritten unit takes effect on this boot.
+/// `systemctl daemon-reload` so a freshly-rewritten unit takes effect this boot.
 ///
-/// Deliberately **not** gated on whether the file changed, and a genuine
-/// reload failure is **propagated** rather than swallowed. This migration
-/// runs at most once (the runner records it applied), so a swallowed failure
-/// would leave the fix inert until the next reboot with no retry. Propagating
-/// records the Optional migration as failed, which re-runs it next boot — and
-/// because the reload isn't gated on `changed`, that retry actually reloads
-/// even though the file already matches. A *missing* `systemctl` (a
-/// non-systemd host that somehow reached this path) is treated as success:
-/// there is nothing to reload.
+/// A genuine reload failure is **propagated** rather than swallowed, so the
+/// Optional migration is recorded failed and retried next boot instead of being
+/// marked applied with the fix inert. A *missing* `systemctl` (a non-systemd
+/// host that somehow reached this path) is treated as success — there is
+/// nothing to reload.
 fn daemon_reload() -> anyhow::Result<()> {
-    match Command::new("systemctl").arg("daemon-reload").status() {
+    reload_via("systemctl")
+}
+
+/// `<program> daemon-reload`, with the classification described on
+/// [`daemon_reload`]. `program` is a parameter so tests can drive each arm
+/// with `true` / `false` / a nonexistent binary instead of the real
+/// `systemctl`.
+pub(crate) fn reload_via(program: &str) -> anyhow::Result<()> {
+    match Command::new(program).arg("daemon-reload").status() {
         Ok(status) if status.success() => {
             tracing::info!("reloaded systemd after refreshing wardnetd.service");
             Ok(())
         }
         Ok(status) => {
-            anyhow::bail!("systemctl daemon-reload exited with {status}")
+            anyhow::bail!("{program} daemon-reload exited with {status}")
         }
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
-            tracing::info!("systemctl not found; skipping daemon-reload (non-systemd host)");
+            tracing::info!("{program} not found; skipping daemon-reload (non-systemd host)");
             Ok(())
         }
         Err(e) => Err(e).context("running systemctl daemon-reload"),

--- a/source/daemon/crates/wardnet-postupgrade/src/up/tests/mod.rs
+++ b/source/daemon/crates/wardnet-postupgrade/src/up/tests/mod.rs
@@ -1,1 +1,3 @@
 mod polkit;
+mod systemd_unit;
+mod watchdog;

--- a/source/daemon/crates/wardnet-postupgrade/src/up/tests/systemd_unit.rs
+++ b/source/daemon/crates/wardnet-postupgrade/src/up/tests/systemd_unit.rs
@@ -1,0 +1,111 @@
+//! Tests for the wardnetd.service refresh migration reconciler.
+
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+
+use tempfile::TempDir;
+
+use crate::up::systemd_unit::{UNIT_BODY, UNIT_FILENAME, reconcile, write_unit};
+
+#[test]
+fn writes_expected_content_and_mode() {
+    let dir = TempDir::new().unwrap();
+    let changed = write_unit(dir.path()).unwrap();
+    assert!(changed, "first write should report a change");
+
+    let file = dir.path().join(UNIT_FILENAME);
+    assert_eq!(fs::read(&file).unwrap(), UNIT_BODY.as_bytes());
+
+    let mode = fs::metadata(&file).unwrap().permissions().mode() & 0o777;
+    assert_eq!(mode, 0o644, "expected 0644, got {mode:o}");
+}
+
+#[test]
+fn idempotent_rerun_reports_no_change() {
+    let dir = TempDir::new().unwrap();
+    assert!(
+        write_unit(dir.path()).unwrap(),
+        "first write changes the file"
+    );
+    assert!(
+        !write_unit(dir.path()).unwrap(),
+        "second identical write should report no change"
+    );
+}
+
+#[test]
+fn mismatched_content_is_rewritten() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join(UNIT_FILENAME);
+    fs::write(&file, b"[Unit]\nDescription=stale\n").unwrap();
+
+    let changed = write_unit(dir.path()).unwrap();
+    assert!(changed, "content mismatch should be rewritten");
+    assert_eq!(fs::read(&file).unwrap(), UNIT_BODY.as_bytes());
+}
+
+#[test]
+fn reconcile_against_tempdir_writes_unit_without_shelling_out() {
+    // base != DEFAULT_UNIT_DIR, so reconcile must skip `systemctl
+    // daemon-reload` and simply lay down the unit.
+    let dir = TempDir::new().unwrap();
+    reconcile(dir.path()).unwrap();
+    assert_eq!(
+        fs::read(dir.path().join(UNIT_FILENAME)).unwrap(),
+        UNIT_BODY.as_bytes()
+    );
+}
+
+/// Regression guard for the incident that motivated this migration.
+///
+/// systemd only honours `StartLimit*` under `[Unit]`; placed under
+/// `[Service]` it logs an "Unknown key ... in section `[Service]`"
+/// warning and silently disables the crash-loop budget **and** the
+/// `OnFailure=` rollback. `UNIT_BODY` *is* `deploy/wardnetd.service`
+/// (compile-time include), so this asserts the shipped unit keeps the fix.
+#[test]
+fn start_limit_keys_live_in_unit_section_not_service() {
+    let unit = section_body(UNIT_BODY, "[Unit]");
+    let service = section_body(UNIT_BODY, "[Service]");
+
+    for key in [
+        "StartLimitIntervalSec",
+        "StartLimitBurst",
+        "StartLimitAction",
+    ] {
+        assert!(
+            has_directive(&unit, key),
+            "{key} must be a directive in the [Unit] section"
+        );
+        assert!(
+            !has_directive(&service, key),
+            "{key} must NOT be a directive in [Service] — systemd ignores it there"
+        );
+    }
+}
+
+/// Collect the lines of the named section (until the next `[Header]`).
+fn section_body(unit: &str, header: &str) -> String {
+    let mut out = String::new();
+    let mut in_section = false;
+    for line in unit.lines() {
+        let trimmed = line.trim();
+        if trimmed.starts_with('[') && trimmed.ends_with(']') {
+            in_section = trimmed == header;
+            continue;
+        }
+        if in_section {
+            out.push_str(line);
+            out.push('\n');
+        }
+    }
+    out
+}
+
+/// True if `key=` appears as a real directive (ignoring comment lines).
+fn has_directive(body: &str, key: &str) -> bool {
+    body.lines().any(|line| {
+        let t = line.trim();
+        !t.starts_with('#') && t.starts_with(key) && t[key.len()..].trim_start().starts_with('=')
+    })
+}

--- a/source/daemon/crates/wardnet-postupgrade/src/up/tests/systemd_unit.rs
+++ b/source/daemon/crates/wardnet-postupgrade/src/up/tests/systemd_unit.rs
@@ -5,7 +5,7 @@ use std::os::unix::fs::PermissionsExt;
 
 use tempfile::TempDir;
 
-use crate::up::systemd_unit::{UNIT_BODY, UNIT_FILENAME, reconcile, write_unit};
+use crate::up::systemd_unit::{UNIT_BODY, UNIT_FILENAME, reconcile, reload_via, write_unit};
 
 #[test]
 fn writes_expected_content_and_mode() {
@@ -54,6 +54,24 @@ fn reconcile_against_tempdir_writes_unit_without_shelling_out() {
         fs::read(dir.path().join(UNIT_FILENAME)).unwrap(),
         UNIT_BODY.as_bytes()
     );
+}
+
+#[test]
+fn reload_via_success_is_ok() {
+    // `true daemon-reload` exits 0 → the success arm.
+    reload_via("true").unwrap();
+}
+
+#[test]
+fn reload_via_nonzero_exit_is_err() {
+    // `false daemon-reload` exits 1 → propagated so the migration retries.
+    assert!(reload_via("false").is_err());
+}
+
+#[test]
+fn reload_via_missing_binary_is_ok() {
+    // A non-systemd host with no `systemctl` → tolerated (nothing to reload).
+    reload_via("wardnet-no-such-systemctl-zzz").unwrap();
 }
 
 /// Regression guard for the incident that motivated this migration.

--- a/source/daemon/crates/wardnet-postupgrade/src/up/tests/watchdog.rs
+++ b/source/daemon/crates/wardnet-postupgrade/src/up/tests/watchdog.rs
@@ -5,7 +5,10 @@ use std::os::unix::fs::PermissionsExt;
 
 use tempfile::TempDir;
 
-use crate::up::watchdog::{RULE_BODY, RULE_FILENAME, reconcile, write_rule};
+use crate::up::watchdog::{
+    RULE_BODY, RULE_FILENAME, arm_devices_in, is_watchdog_dev, reconcile, run_best_effort,
+    write_rule,
+};
 
 #[test]
 fn writes_expected_content_and_mode() {
@@ -72,4 +75,49 @@ fn reconcile_against_tempdir_writes_rule_without_shelling_out() {
         fs::read(dir.path().join(RULE_FILENAME)).unwrap(),
         RULE_BODY.as_bytes()
     );
+}
+
+#[test]
+fn is_watchdog_dev_matches_watchdog_and_numbered_variants_only() {
+    for yes in ["watchdog", "watchdog0", "watchdog1", "watchdog12"] {
+        assert!(is_watchdog_dev(yes), "{yes} should match");
+    }
+    for no in [
+        "",
+        "watchdoge",
+        "watchdog1a",
+        "wdog",
+        "awatchdog",
+        "watchdo",
+        "null",
+    ] {
+        assert!(!is_watchdog_dev(no), "{no} should not match");
+    }
+}
+
+#[test]
+fn arm_devices_in_visits_watchdog_nodes_and_ignores_missing_dir() {
+    // Missing dir: early return, no panic.
+    arm_devices_in(std::path::Path::new("/definitely/not/a/real/dir/xyz"));
+
+    // A fake /dev with a mix of watchdog and non-watchdog entries. The
+    // chgrp/chmod shell-outs run against these temp files (best-effort:
+    // chmod succeeds, chgrp to a possibly-absent group is swallowed) — the
+    // point is to exercise the enumerate → match → shell-out path.
+    let dev = TempDir::new().unwrap();
+    for name in ["watchdog", "watchdog0", "watchdog3", "watchdoge", "random"] {
+        fs::write(dev.path().join(name), b"").unwrap();
+    }
+    arm_devices_in(dev.path());
+    // The non-watchdog files must still exist (we never remove anything).
+    assert!(dev.path().join("random").exists());
+}
+
+#[test]
+fn run_best_effort_covers_success_nonzero_and_spawn_error() {
+    // Success (exit 0), non-zero exit, and a binary that cannot be spawned —
+    // none of these panic or propagate; they only log.
+    run_best_effort("true", &[]);
+    run_best_effort("false", &[]);
+    run_best_effort("wardnet-no-such-binary-zzz", &["arg"]);
 }

--- a/source/daemon/crates/wardnet-postupgrade/src/up/tests/watchdog.rs
+++ b/source/daemon/crates/wardnet-postupgrade/src/up/tests/watchdog.rs
@@ -1,0 +1,75 @@
+//! Tests for the watchdog udev-rule migration reconciler.
+
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+
+use tempfile::TempDir;
+
+use crate::up::watchdog::{RULE_BODY, RULE_FILENAME, reconcile, write_rule};
+
+#[test]
+fn writes_expected_content_and_mode() {
+    let dir = TempDir::new().unwrap();
+    let changed = write_rule(dir.path()).unwrap();
+    assert!(changed, "first write should report a change");
+
+    let file = dir.path().join(RULE_FILENAME);
+    assert_eq!(fs::read(&file).unwrap(), RULE_BODY.as_bytes());
+
+    let mode = fs::metadata(&file).unwrap().permissions().mode() & 0o777;
+    assert_eq!(mode, 0o644, "expected 0644, got {mode:o}");
+}
+
+#[test]
+fn rule_body_grants_wardnet_group_rw_on_watchdog() {
+    // Spot-check the embedded body — guards against an edit that no
+    // longer hands the device to the wardnet group at 0660.
+    assert!(RULE_BODY.contains("KERNEL==\"watchdog\""));
+    assert!(RULE_BODY.contains("KERNEL==\"watchdog[0-9]*\""));
+    assert!(RULE_BODY.contains("GROUP=\"wardnet\""));
+    assert!(RULE_BODY.contains("MODE=\"0660\""));
+}
+
+#[test]
+fn idempotent_rerun_reports_no_change_and_preserves_mtime() {
+    let dir = TempDir::new().unwrap();
+    write_rule(dir.path()).unwrap();
+    let file = dir.path().join(RULE_FILENAME);
+    let mtime_before = fs::metadata(&file).unwrap().modified().unwrap();
+
+    // Sleep so a rewrite would show a different mtime even on
+    // second-resolution filesystems.
+    std::thread::sleep(std::time::Duration::from_millis(1100));
+
+    let changed = write_rule(dir.path()).unwrap();
+    assert!(!changed, "second identical write should report no change");
+
+    let mtime_after = fs::metadata(&file).unwrap().modified().unwrap();
+    assert_eq!(
+        mtime_before, mtime_after,
+        "second run rewrote the file even though content matched"
+    );
+}
+
+#[test]
+fn mismatched_content_is_rewritten() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join(RULE_FILENAME);
+    fs::write(&file, b"# stale content from a hand edit\n").unwrap();
+
+    let changed = write_rule(dir.path()).unwrap();
+    assert!(changed, "content mismatch should be rewritten");
+    assert_eq!(fs::read(&file).unwrap(), RULE_BODY.as_bytes());
+}
+
+#[test]
+fn reconcile_against_tempdir_writes_rule_without_shelling_out() {
+    // base != DEFAULT_RULES_DIR, so reconcile must skip the udevadm /
+    // chgrp side effects and simply lay down the rule.
+    let dir = TempDir::new().unwrap();
+    reconcile(dir.path()).unwrap();
+    assert_eq!(
+        fs::read(dir.path().join(RULE_FILENAME)).unwrap(),
+        RULE_BODY.as_bytes()
+    );
+}

--- a/source/daemon/crates/wardnet-postupgrade/src/up/watchdog.rs
+++ b/source/daemon/crates/wardnet-postupgrade/src/up/watchdog.rs
@@ -1,0 +1,104 @@
+//! Idempotent installer for the udev rule that grants the `wardnet`
+//! group access to `/dev/watchdog` (issue #214).
+//!
+//! The kernel creates the device `root:root 0600`; the daemon runs as
+//! `User=wardnet` with no `CAP_DAC_OVERRIDE`, so without this rule its
+//! open of `/dev/watchdog` fails `EACCES` and the ungated hardware-reboot
+//! backstop silently stays off. The persistent rule fixes every future
+//! boot (udev applies it whenever the device appears); a best-effort
+//! retrigger + `chgrp`/`chmod` of the live device also arms it on the
+//! current boot without a reboot.
+
+use std::path::Path;
+use std::process::Command;
+
+use crate::up::write_file_atomic;
+
+/// Filename under `rules.d/`. The `99-` prefix runs it after distro
+/// defaults so our ownership/mode wins.
+pub const RULE_FILENAME: &str = "99-wardnet-watchdog.rules";
+
+/// Default base directory on a real host. Tests pass tempdir paths.
+pub const DEFAULT_RULES_DIR: &str = "/etc/udev/rules.d";
+
+/// Embedded rule body — the single source of truth for the rule.
+pub const RULE_BODY: &str = include_str!("watchdog_udev.rules.in");
+
+/// World-readable, like every other rule under `rules.d/`.
+const RULE_MODE: u32 = 0o644;
+
+/// Write the udev rule to `<base>/99-wardnet-watchdog.rules`. Returns
+/// whether the file changed, so [`reconcile`] can skip the udev reload
+/// on a no-op.
+pub fn write_rule(base: &Path) -> anyhow::Result<bool> {
+    write_file_atomic(base, RULE_FILENAME, RULE_BODY, RULE_MODE)
+}
+
+/// Write the rule, then — only against the real `rules.d/` — best-effort
+/// arm it on the current boot. The live-device fixups just save one
+/// reboot, so their failure is logged and swallowed rather than failing
+/// the (Optional) migration; the persistent rule is what matters.
+pub fn reconcile(base: &Path) -> anyhow::Result<()> {
+    let changed = write_rule(base)?;
+
+    // A tempdir base (tests) must never shell out to the host.
+    if base == Path::new(DEFAULT_RULES_DIR) {
+        if changed {
+            run_best_effort("udevadm", &["control", "--reload"]);
+            run_best_effort("udevadm", &["trigger", "--name-match=watchdog"]);
+        }
+        arm_live_device();
+    }
+    Ok(())
+}
+
+/// `chgrp`/`chmod` every already-present watchdog device so the daemon can
+/// open it on this boot without waiting for udev to re-fire on reboot.
+///
+/// Enumerates `/dev` rather than hardcoding `watchdog`/`watchdog0`: the udev
+/// rule matches `watchdog[0-9]*`, and a host may expose the device the daemon
+/// is configured to open as a higher-numbered node (e.g. `/dev/watchdog1` when
+/// several watchdog drivers are present). Arming only a fixed pair would leave
+/// that device inaccessible until the next reboot.
+fn arm_live_device() {
+    let Ok(entries) = std::fs::read_dir("/dev") else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let name = entry.file_name();
+        let name = name.to_string_lossy();
+        // Match the bare `watchdog` alias and `watchdog<N>`; skip anything
+        // else (e.g. `watchdog` is a prefix of nothing unrelated in /dev, but
+        // be strict anyway).
+        let is_watchdog = name == "watchdog"
+            || name
+                .strip_prefix("watchdog")
+                .is_some_and(|rest| !rest.is_empty() && rest.bytes().all(|b| b.is_ascii_digit()));
+        if is_watchdog {
+            let path = entry.path();
+            let path = path.to_string_lossy();
+            run_best_effort("chgrp", &["wardnet", &path]);
+            run_best_effort("chmod", &["0660", &path]);
+        }
+    }
+}
+
+/// Run a system command, logging (never propagating) any failure — the
+/// caller is a best-effort convenience path.
+fn run_best_effort(cmd: &str, args: &[&str]) {
+    match Command::new(cmd).args(args).status() {
+        Ok(status) if status.success() => {}
+        Ok(status) => tracing::warn!(
+            command = cmd,
+            ?args,
+            code = status.code(),
+            "watchdog udev reconcile: {cmd} exited non-zero (non-fatal)",
+        ),
+        Err(e) => tracing::warn!(
+            command = cmd,
+            ?args,
+            error = %e,
+            "watchdog udev reconcile: could not run {cmd} (non-fatal): {e}",
+        ),
+    }
+}

--- a/source/daemon/crates/wardnet-postupgrade/src/up/watchdog.rs
+++ b/source/daemon/crates/wardnet-postupgrade/src/up/watchdog.rs
@@ -47,34 +47,28 @@ pub fn reconcile(base: &Path) -> anyhow::Result<()> {
             run_best_effort("udevadm", &["control", "--reload"]);
             run_best_effort("udevadm", &["trigger", "--name-match=watchdog"]);
         }
-        arm_live_device();
+        arm_devices_in(Path::new("/dev"));
     }
     Ok(())
 }
 
-/// `chgrp`/`chmod` every already-present watchdog device so the daemon can
-/// open it on this boot without waiting for udev to re-fire on reboot.
+/// `chgrp`/`chmod` every already-present watchdog device under `dev_dir` so the
+/// daemon can open it on this boot without waiting for udev to re-fire on
+/// reboot.
 ///
-/// Enumerates `/dev` rather than hardcoding `watchdog`/`watchdog0`: the udev
-/// rule matches `watchdog[0-9]*`, and a host may expose the device the daemon
-/// is configured to open as a higher-numbered node (e.g. `/dev/watchdog1` when
-/// several watchdog drivers are present). Arming only a fixed pair would leave
-/// that device inaccessible until the next reboot.
-fn arm_live_device() {
-    let Ok(entries) = std::fs::read_dir("/dev") else {
+/// Enumerates the directory rather than hardcoding `watchdog`/`watchdog0`: the
+/// udev rule matches `watchdog[0-9]*`, and a host may expose the device the
+/// daemon is configured to open as a higher-numbered node (e.g. `/dev/watchdog1`
+/// when several watchdog drivers are present). Arming only a fixed pair would
+/// leave that device inaccessible until the next reboot. `dev_dir` is a
+/// parameter so tests can drive it against a `tempfile::TempDir`.
+pub(crate) fn arm_devices_in(dev_dir: &Path) {
+    let Ok(entries) = std::fs::read_dir(dev_dir) else {
         return;
     };
     for entry in entries.flatten() {
         let name = entry.file_name();
-        let name = name.to_string_lossy();
-        // Match the bare `watchdog` alias and `watchdog<N>`; skip anything
-        // else (e.g. `watchdog` is a prefix of nothing unrelated in /dev, but
-        // be strict anyway).
-        let is_watchdog = name == "watchdog"
-            || name
-                .strip_prefix("watchdog")
-                .is_some_and(|rest| !rest.is_empty() && rest.bytes().all(|b| b.is_ascii_digit()));
-        if is_watchdog {
+        if is_watchdog_dev(&name.to_string_lossy()) {
             let path = entry.path();
             let path = path.to_string_lossy();
             run_best_effort("chgrp", &["wardnet", &path]);
@@ -83,9 +77,18 @@ fn arm_live_device() {
     }
 }
 
+/// True for the bare `watchdog` alias and `watchdog<N>` device nodes; false for
+/// anything else (`watchdoge`, `watchdog1a`, unrelated names).
+pub(crate) fn is_watchdog_dev(name: &str) -> bool {
+    name == "watchdog"
+        || name
+            .strip_prefix("watchdog")
+            .is_some_and(|rest| !rest.is_empty() && rest.bytes().all(|b| b.is_ascii_digit()))
+}
+
 /// Run a system command, logging (never propagating) any failure — the
 /// caller is a best-effort convenience path.
-fn run_best_effort(cmd: &str, args: &[&str]) {
+pub(crate) fn run_best_effort(cmd: &str, args: &[&str]) {
     match Command::new(cmd).args(args).status() {
         Ok(status) if status.success() => {}
         Ok(status) => tracing::warn!(

--- a/source/daemon/crates/wardnet-postupgrade/src/up/watchdog_udev.rules.in
+++ b/source/daemon/crates/wardnet-postupgrade/src/up/watchdog_udev.rules.in
@@ -1,0 +1,11 @@
+# Wardnet: hardware watchdog access for the unprivileged daemon (issue #214).
+#
+# The daemon runs as User=wardnet (no CAP_DAC_OVERRIDE) and opens
+# /dev/watchdog directly for the ungated hardware-reboot backstop. The kernel
+# creates that device root:root 0600, so without this rule the open fails with
+# EACCES and the daemon logs "failed to open watchdog device; running without
+# hardware backstop: Permission denied" — the host-reboot safety net silently
+# stays off. Hand the device to the `wardnet` group (the daemon's own group)
+# at mode 0660 so it can arm and pet it, while keeping it off-limits to others.
+KERNEL=="watchdog", GROUP="wardnet", MODE="0660"
+KERNEL=="watchdog[0-9]*", GROUP="wardnet", MODE="0660"

--- a/source/daemon/crates/wardnetd/src/system/linux_watchdog.rs
+++ b/source/daemon/crates/wardnetd/src/system/linux_watchdog.rs
@@ -64,7 +64,7 @@ pub struct LinuxWatchdog {
 /// react. Kept separate from the logging so it can be unit-tested against
 /// synthetic `io::Error`s.
 #[derive(Debug, PartialEq, Eq)]
-enum OpenFailure {
+pub(crate) enum OpenFailure {
     /// `ENOENT` — no device (VM/container, or the driver isn't loaded).
     Absent,
     /// `EBUSY` — another supervisor already owns the single-opener device;
@@ -79,7 +79,7 @@ enum OpenFailure {
 /// Classify an open failure. Matches `ResourceBusy` by kind but also falls back
 /// to the raw `EBUSY` (16) so a std build that doesn't map the errno to that
 /// kind still classifies it as "owned elsewhere" rather than a hard fault.
-fn classify_open_error(e: &std::io::Error) -> OpenFailure {
+pub(crate) fn classify_open_error(e: &std::io::Error) -> OpenFailure {
     use std::io::ErrorKind;
     if e.kind() == ErrorKind::NotFound {
         OpenFailure::Absent
@@ -253,53 +253,5 @@ impl WatchdogOps for LinuxWatchdog {
 
     fn is_available(&self) -> bool {
         self.available.load(Ordering::SeqCst)
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use std::io::{Error, ErrorKind};
-    use std::path::PathBuf;
-
-    use wardnetd_services::system::WatchdogOps;
-
-    use super::{LinuxWatchdog, OpenFailure, classify_open_error};
-
-    #[test]
-    fn classify_maps_each_open_failure() {
-        assert_eq!(
-            classify_open_error(&Error::from(ErrorKind::NotFound)),
-            OpenFailure::Absent
-        );
-        assert_eq!(
-            classify_open_error(&Error::from(ErrorKind::ResourceBusy)),
-            OpenFailure::BusyElsewhere
-        );
-        // Raw EBUSY (16) even if it isn't surfaced as ResourceBusy.
-        assert_eq!(
-            classify_open_error(&Error::from_raw_os_error(16)),
-            OpenFailure::BusyElsewhere
-        );
-        assert_eq!(
-            classify_open_error(&Error::from(ErrorKind::PermissionDenied)),
-            OpenFailure::PermissionDenied
-        );
-        assert_eq!(
-            classify_open_error(&Error::from(ErrorKind::Other)),
-            OpenFailure::Other
-        );
-    }
-
-    #[test]
-    fn open_absent_device_is_unavailable_not_a_panic() {
-        // ENOENT path → the "no device present" arm → an unavailable, no-op
-        // instance the daemon can still run with.
-        let wd = LinuxWatchdog::open(PathBuf::from("/definitely/not/a/watchdog/xyz"), 15);
-        assert!(!wd.is_available());
-    }
-
-    #[test]
-    fn disabled_instance_is_unavailable() {
-        assert!(!LinuxWatchdog::disabled().is_available());
     }
 }

--- a/source/daemon/crates/wardnetd/src/system/linux_watchdog.rs
+++ b/source/daemon/crates/wardnetd/src/system/linux_watchdog.rs
@@ -60,6 +60,38 @@ pub struct LinuxWatchdog {
     path: PathBuf,
 }
 
+/// Why an open of `/dev/watchdog` failed, reduced to how the daemon should
+/// react. Kept separate from the logging so it can be unit-tested against
+/// synthetic `io::Error`s.
+#[derive(Debug, PartialEq, Eq)]
+enum OpenFailure {
+    /// `ENOENT` — no device (VM/container, or the driver isn't loaded).
+    Absent,
+    /// `EBUSY` — another supervisor already owns the single-opener device;
+    /// the host still has a hardware backstop.
+    BusyElsewhere,
+    /// `EACCES` — device present and free, but this user can't open it.
+    PermissionDenied,
+    /// Anything else.
+    Other,
+}
+
+/// Classify an open failure. Matches `ResourceBusy` by kind but also falls back
+/// to the raw `EBUSY` (16) so a std build that doesn't map the errno to that
+/// kind still classifies it as "owned elsewhere" rather than a hard fault.
+fn classify_open_error(e: &std::io::Error) -> OpenFailure {
+    use std::io::ErrorKind;
+    if e.kind() == ErrorKind::NotFound {
+        OpenFailure::Absent
+    } else if e.kind() == ErrorKind::ResourceBusy || e.raw_os_error() == Some(16) {
+        OpenFailure::BusyElsewhere
+    } else if e.kind() == ErrorKind::PermissionDenied {
+        OpenFailure::PermissionDenied
+    } else {
+        OpenFailure::Other
+    }
+}
+
 impl LinuxWatchdog {
     /// Open and arm the device, programming `timeout_secs` as the reboot
     /// window. Never fails: an unopenable device yields an unavailable
@@ -75,57 +107,44 @@ impl LinuxWatchdog {
                     path,
                 }
             }
-            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
-                // No watchdog device at all: a VM/container without one, or a
-                // host whose watchdog driver isn't loaded. Expected, not a
-                // fault — the soft (sd_notify) layer still supervises.
-                tracing::info!(
-                    path = %path.display(),
-                    "no hardware watchdog device present; running with the soft watchdog only ({})",
-                    path.display(),
-                );
-                Self::unavailable(path)
-            }
-            // Match `ResourceBusy` by kind, but also fall back to the raw
-            // `EBUSY` (16) so a std build that doesn't map the errno to that
-            // kind still classifies it here rather than dropping through to the
-            // alarming "no backstop" arm below.
-            Err(e)
-                if e.kind() == std::io::ErrorKind::ResourceBusy || e.raw_os_error() == Some(16) =>
-            {
-                // EBUSY: another supervisor already holds the single-opener
-                // device and is petting it — e.g. systemd's own
-                // `RuntimeWatchdogSec=` (the Raspberry Pi OS default), or a
-                // standalone `watchdogd`. The host therefore still HAS a
-                // hardware reboot-on-freeze backstop; it's simply owned by
-                // that supervisor rather than wardnet. Our hard layer stands
-                // down (the soft layer keeps restarting the service on a
-                // daemon-specific hang), so this is INFO, not a fault.
-                tracing::info!(
-                    path = %path.display(),
-                    "hardware watchdog is owned by another supervisor (e.g. systemd RuntimeWatchdogSec); the host is still covered — wardnet's hard layer will stay idle",
-                );
-                Self::unavailable(path)
-            }
-            Err(e) if e.kind() == std::io::ErrorKind::PermissionDenied => {
-                // EACCES: the device exists and is free, but this unprivileged
-                // process can't open it. This is a real, fixable
-                // misconfiguration — the daemon runs without a hardware
-                // backstop until the wardnet user can access the device.
-                tracing::warn!(
-                    error = %e,
-                    path = %path.display(),
-                    "cannot open watchdog device (permission denied); running without a hardware backstop — ensure the udev rule granting the wardnet group access to {} is installed (post-upgrade migration 0002_watchdog_udev_rule)",
-                    path.display(),
-                );
-                Self::unavailable(path)
-            }
             Err(e) => {
-                tracing::warn!(
-                    error = %e,
-                    path = %path.display(),
-                    "failed to open watchdog device; running without hardware backstop: {e}",
-                );
+                match classify_open_error(&e) {
+                    // No watchdog device at all: a VM/container without one, or
+                    // a host whose watchdog driver isn't loaded. Expected, not a
+                    // fault — the soft (sd_notify) layer still supervises.
+                    OpenFailure::Absent => tracing::info!(
+                        path = %path.display(),
+                        "no hardware watchdog device present; running with the soft watchdog only ({})",
+                        path.display(),
+                    ),
+                    // EBUSY: another supervisor already holds the single-opener
+                    // device and is petting it — e.g. systemd's own
+                    // `RuntimeWatchdogSec=` (the Raspberry Pi OS default), or a
+                    // standalone `watchdogd`. The host therefore still HAS a
+                    // hardware reboot-on-freeze backstop; it's simply owned by
+                    // that supervisor rather than wardnet. Our hard layer stands
+                    // down (the soft layer keeps restarting the service on a
+                    // daemon-specific hang), so this is INFO, not a fault.
+                    OpenFailure::BusyElsewhere => tracing::info!(
+                        path = %path.display(),
+                        "hardware watchdog is owned by another supervisor (e.g. systemd RuntimeWatchdogSec); the host is still covered — wardnet's hard layer will stay idle",
+                    ),
+                    // EACCES: the device exists and is free, but this
+                    // unprivileged process can't open it. A real, fixable
+                    // misconfiguration — no hardware backstop until the wardnet
+                    // user can access the device.
+                    OpenFailure::PermissionDenied => tracing::warn!(
+                        error = %e,
+                        path = %path.display(),
+                        "cannot open watchdog device (permission denied); running without a hardware backstop — ensure the udev rule granting the wardnet group access to {} is installed (post-upgrade migration 0002_watchdog_udev_rule)",
+                        path.display(),
+                    ),
+                    OpenFailure::Other => tracing::warn!(
+                        error = %e,
+                        path = %path.display(),
+                        "failed to open watchdog device; running without hardware backstop: {e}",
+                    ),
+                }
                 Self::unavailable(path)
             }
         }
@@ -234,5 +253,53 @@ impl WatchdogOps for LinuxWatchdog {
 
     fn is_available(&self) -> bool {
         self.available.load(Ordering::SeqCst)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::{Error, ErrorKind};
+    use std::path::PathBuf;
+
+    use wardnetd_services::system::WatchdogOps;
+
+    use super::{LinuxWatchdog, OpenFailure, classify_open_error};
+
+    #[test]
+    fn classify_maps_each_open_failure() {
+        assert_eq!(
+            classify_open_error(&Error::from(ErrorKind::NotFound)),
+            OpenFailure::Absent
+        );
+        assert_eq!(
+            classify_open_error(&Error::from(ErrorKind::ResourceBusy)),
+            OpenFailure::BusyElsewhere
+        );
+        // Raw EBUSY (16) even if it isn't surfaced as ResourceBusy.
+        assert_eq!(
+            classify_open_error(&Error::from_raw_os_error(16)),
+            OpenFailure::BusyElsewhere
+        );
+        assert_eq!(
+            classify_open_error(&Error::from(ErrorKind::PermissionDenied)),
+            OpenFailure::PermissionDenied
+        );
+        assert_eq!(
+            classify_open_error(&Error::from(ErrorKind::Other)),
+            OpenFailure::Other
+        );
+    }
+
+    #[test]
+    fn open_absent_device_is_unavailable_not_a_panic() {
+        // ENOENT path → the "no device present" arm → an unavailable, no-op
+        // instance the daemon can still run with.
+        let wd = LinuxWatchdog::open(PathBuf::from("/definitely/not/a/watchdog/xyz"), 15);
+        assert!(!wd.is_available());
+    }
+
+    #[test]
+    fn disabled_instance_is_unavailable() {
+        assert!(!LinuxWatchdog::disabled().is_available());
     }
 }

--- a/source/daemon/crates/wardnetd/src/system/linux_watchdog.rs
+++ b/source/daemon/crates/wardnetd/src/system/linux_watchdog.rs
@@ -76,9 +76,46 @@ impl LinuxWatchdog {
                 }
             }
             Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                // No watchdog device at all: a VM/container without one, or a
+                // host whose watchdog driver isn't loaded. Expected, not a
+                // fault — the soft (sd_notify) layer still supervises.
                 tracing::info!(
                     path = %path.display(),
-                    "watchdog unavailable, skipping (no {})",
+                    "no hardware watchdog device present; running with the soft watchdog only ({})",
+                    path.display(),
+                );
+                Self::unavailable(path)
+            }
+            // Match `ResourceBusy` by kind, but also fall back to the raw
+            // `EBUSY` (16) so a std build that doesn't map the errno to that
+            // kind still classifies it here rather than dropping through to the
+            // alarming "no backstop" arm below.
+            Err(e)
+                if e.kind() == std::io::ErrorKind::ResourceBusy || e.raw_os_error() == Some(16) =>
+            {
+                // EBUSY: another supervisor already holds the single-opener
+                // device and is petting it — e.g. systemd's own
+                // `RuntimeWatchdogSec=` (the Raspberry Pi OS default), or a
+                // standalone `watchdogd`. The host therefore still HAS a
+                // hardware reboot-on-freeze backstop; it's simply owned by
+                // that supervisor rather than wardnet. Our hard layer stands
+                // down (the soft layer keeps restarting the service on a
+                // daemon-specific hang), so this is INFO, not a fault.
+                tracing::info!(
+                    path = %path.display(),
+                    "hardware watchdog is owned by another supervisor (e.g. systemd RuntimeWatchdogSec); the host is still covered — wardnet's hard layer will stay idle",
+                );
+                Self::unavailable(path)
+            }
+            Err(e) if e.kind() == std::io::ErrorKind::PermissionDenied => {
+                // EACCES: the device exists and is free, but this unprivileged
+                // process can't open it. This is a real, fixable
+                // misconfiguration — the daemon runs without a hardware
+                // backstop until the wardnet user can access the device.
+                tracing::warn!(
+                    error = %e,
+                    path = %path.display(),
+                    "cannot open watchdog device (permission denied); running without a hardware backstop — ensure the udev rule granting the wardnet group access to {} is installed (post-upgrade migration 0002_watchdog_udev_rule)",
                     path.display(),
                 );
                 Self::unavailable(path)

--- a/source/daemon/crates/wardnetd/src/tests/linux_watchdog.rs
+++ b/source/daemon/crates/wardnetd/src/tests/linux_watchdog.rs
@@ -1,0 +1,46 @@
+//! Tests for the `/dev/watchdog` open-failure classification (issue #214).
+
+use std::io::{Error, ErrorKind};
+use std::path::PathBuf;
+
+use wardnetd_services::system::WatchdogOps;
+
+use crate::system::linux_watchdog::{LinuxWatchdog, OpenFailure, classify_open_error};
+
+#[test]
+fn classify_maps_each_open_failure() {
+    assert_eq!(
+        classify_open_error(&Error::from(ErrorKind::NotFound)),
+        OpenFailure::Absent
+    );
+    assert_eq!(
+        classify_open_error(&Error::from(ErrorKind::ResourceBusy)),
+        OpenFailure::BusyElsewhere
+    );
+    // Raw EBUSY (16) even if it isn't surfaced as ResourceBusy.
+    assert_eq!(
+        classify_open_error(&Error::from_raw_os_error(16)),
+        OpenFailure::BusyElsewhere
+    );
+    assert_eq!(
+        classify_open_error(&Error::from(ErrorKind::PermissionDenied)),
+        OpenFailure::PermissionDenied
+    );
+    assert_eq!(
+        classify_open_error(&Error::from(ErrorKind::Other)),
+        OpenFailure::Other
+    );
+}
+
+#[test]
+fn open_absent_device_is_unavailable_not_a_panic() {
+    // ENOENT path → the "no device present" arm → an unavailable, no-op
+    // instance the daemon can still run with.
+    let wd = LinuxWatchdog::open(PathBuf::from("/definitely/not/a/watchdog/xyz"), 15);
+    assert!(!wd.is_available());
+}
+
+#[test]
+fn disabled_instance_is_unavailable() {
+    assert!(!LinuxWatchdog::disabled().is_available());
+}

--- a/source/daemon/crates/wardnetd/src/tests/mod.rs
+++ b/source/daemon/crates/wardnetd/src/tests/mod.rs
@@ -7,6 +7,7 @@ mod health_runner;
 mod heartbeat;
 mod hostname_resolver;
 mod inbound_wg_interface_wireguard;
+mod linux_watchdog;
 mod mdns_advertiser;
 mod metrics_collector;
 mod packet_capture;


### PR DESCRIPTION
## Summary

Investigating a post-power-outage incident on a live Pi surfaced **three latent issues** in the daemon's recovery/watchdog plumbing — none caused the outage itself (that traced to downstream Wi-Fi/powerline gear rebooting slower than the Pi), but all three meant our documented safety nets weren't actually armed. This PR fixes them so they work across Linux/Docker/RPi, and — importantly — so they reach existing installs through the **auto-updater**, not only fresh `install.sh` runs.

## What was wrong & the fix

1. **Crash-loop budget + rollback were silently off.** `StartLimitIntervalSec` / `StartLimitBurst` / `StartLimitAction` were in `[Service]`, but systemd only honours them in `[Unit]` (it logged `Unknown key 'StartLimitIntervalSec' in section [Service]`). Moved to `[Unit]` **and tightened to `30s / 5`**: a real crash-loop (`Restart=2s`) trips `OnFailure=wardnetd-rollback`, but a merely-unhealthy daemon (soft-watchdog restarts ≥15s apart → ≤3 in 30s) stays under budget — so environmental unhealth (e.g. slow DB after a power loss) can't spuriously revert a good binary to the lingering `wardnetd.old`.

2. **Hardware watchdog couldn't open.** `/dev/watchdog` is `root:root 0600`, but the daemon runs as `User=wardnet` (no `CAP_DAC_OVERRIDE`) → `EACCES`. New post-upgrade migration **`0002_watchdog_udev_rule`** installs a udev rule granting the `wardnet` group `0660`, plus a best-effort live-device arming. Runs as root before `wardnetd` on every boot, so it converges on fresh installs **and** auto-updates.

3. **Unit-file fixes never propagated.** The update tarball carries only binaries, never `wardnetd.service`. New migration **`0003_wardnetd_unit_refresh`** reconciles `/etc/systemd/system/wardnetd.service` from the release's embedded canonical unit (compile-time `include_str!` of `deploy/wardnetd.service`, so there's a single source of truth) and `daemon-reload`s.

4. **Honest watchdog observability.** `LinuxWatchdog::open` now distinguishes **free** (owns it) / **EBUSY** (another supervisor — e.g. systemd `RuntimeWatchdogSec`, the RPi OS default — owns it, host still covered) / **ENOENT** (Docker/VM, soft-only) / **EACCES** (real misconfig), instead of collapsing every failure into one alarming "no backstop" warning.

## Testing

- `wardnet-postupgrade`: `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, **35 tests pass** — including a regression guard that asserts the embedded unit keeps `StartLimit*` under `[Unit]`, and reconcilers driven against `tempfile::TempDir` (no host shell-outs).
- `wardnetd`: `cargo fmt --check`, `cargo clippy --lib -- -D warnings` clean.
- Applied to a live Pi non-disruptively: StartLimit now `30s/5` (`systemctl show`), `/dev/watchdog` now `root:wardnet 0660`, daemon healthy — no restart required for the StartLimit change.

## Notes for review

- `0002`/`0003` are `Severity::Optional` — a failure records to `state.failed` but never gates `wardnetd` startup.
- `0003` is run-once (like every migration): it ships the unit as of this PR. A *future* unit change that must reach the fleet needs its own follow-up migration id (append-only model), which is documented inline.
- On RPi OS, systemd owns the hardware watchdog via `RuntimeWatchdogSec=1m`; the daemon correctly defers (EBUSY) and the host stays protected. `deploy/install.sh` intentionally does **not** disable systemd's watchdog.
