### PR TITLE
refactor(data): hoist fixed SELECT queries to const strings

### DIFF
--- a/source/daemon/crates/wardnetd-data/src/repository/sqlite/device.rs
+++ b/source/daemon/crates/wardnetd-data/src/repository/sqlite/device.rs
@@ -89,7 +89,19 @@ struct RuleRow {
     created_by: String,
 }
 
-const SELECT_COLS: &str = "id, mac, name, hostname, manufacturer, device_type, first_seen, last_seen, last_ip, admin_locked, zone_id, dns_capture_enabled, dns_capture_cap_count, dns_capture_cap_days, connection_mode";
+// Static SQL strings — every column list is inlined so no runtime format!()
+// allocation is needed for these fixed SELECTs. The genuinely dynamic queries
+// further down (JOIN/LIKE against routing_rules) keep their own literals.
+const FIND_BY_IP_SQL: &str = "SELECT id, mac, name, hostname, manufacturer, device_type, first_seen, last_seen, last_ip, admin_locked, zone_id, dns_capture_enabled, dns_capture_cap_count, dns_capture_cap_days, connection_mode \
+     FROM devices WHERE last_ip = ? ORDER BY last_seen DESC LIMIT 1";
+const FIND_BY_ID_SQL: &str = "SELECT id, mac, name, hostname, manufacturer, device_type, first_seen, last_seen, last_ip, admin_locked, zone_id, dns_capture_enabled, dns_capture_cap_count, dns_capture_cap_days, connection_mode \
+     FROM devices WHERE id = ?";
+const FIND_BY_MAC_SQL: &str = "SELECT id, mac, name, hostname, manufacturer, device_type, first_seen, last_seen, last_ip, admin_locked, zone_id, dns_capture_enabled, dns_capture_cap_count, dns_capture_cap_days, connection_mode \
+     FROM devices WHERE mac = ?";
+const FIND_ALL_SQL: &str = "SELECT id, mac, name, hostname, manufacturer, device_type, first_seen, last_seen, last_ip, admin_locked, zone_id, dns_capture_enabled, dns_capture_cap_count, dns_capture_cap_days, connection_mode \
+     FROM devices ORDER BY last_seen DESC";
+const FIND_STALE_SQL: &str = "SELECT id, mac, name, hostname, manufacturer, device_type, first_seen, last_seen, last_ip, admin_locked, zone_id, dns_capture_enabled, dns_capture_cap_count, dns_capture_cap_days, connection_mode \
+     FROM devices WHERE last_seen < ?";
 
 #[async_trait]
 impl DeviceRepository for SqliteDeviceRepository {
@@ -109,10 +121,7 @@ impl DeviceRepository for SqliteDeviceRepository {
         // recently seen (live) device rather than an arbitrary rowid-ordered
         // (stale) one — the IP-keyed self-service auth path relies on this to
         // identify the caller's own device.
-        let query = format!(
-            "SELECT {SELECT_COLS} FROM devices WHERE last_ip = ? ORDER BY last_seen DESC LIMIT 1"
-        );
-        let row = sqlx::query_as::<_, DeviceRow>(sqlx::AssertSqlSafe(query))
+        let row = sqlx::query_as::<_, DeviceRow>(FIND_BY_IP_SQL)
             .bind(ip)
             .fetch_optional(&self.pools.read)
             .await?;
@@ -120,8 +129,7 @@ impl DeviceRepository for SqliteDeviceRepository {
     }
 
     async fn find_by_id(&self, id: &str) -> anyhow::Result<Option<Device>> {
-        let query = format!("SELECT {SELECT_COLS} FROM devices WHERE id = ?");
-        let row = sqlx::query_as::<_, DeviceRow>(sqlx::AssertSqlSafe(query))
+        let row = sqlx::query_as::<_, DeviceRow>(FIND_BY_ID_SQL)
             .bind(id)
             .fetch_optional(&self.pools.read)
             .await?;
@@ -133,8 +141,7 @@ impl DeviceRepository for SqliteDeviceRepository {
         // (issue #312). Inputs from older callers or external probes may
         // arrive uppercase — normalise here so the WHERE-clause hits the
         // canonical row regardless.
-        let query = format!("SELECT {SELECT_COLS} FROM devices WHERE mac = ?");
-        let row = sqlx::query_as::<_, DeviceRow>(sqlx::AssertSqlSafe(query))
+        let row = sqlx::query_as::<_, DeviceRow>(FIND_BY_MAC_SQL)
             .bind(mac.to_lowercase())
             .fetch_optional(&self.pools.read)
             .await?;
@@ -142,8 +149,7 @@ impl DeviceRepository for SqliteDeviceRepository {
     }
 
     async fn find_all(&self) -> anyhow::Result<Vec<Device>> {
-        let query = format!("SELECT {SELECT_COLS} FROM devices ORDER BY last_seen DESC");
-        let rows = sqlx::query_as::<_, DeviceRow>(sqlx::AssertSqlSafe(query))
+        let rows = sqlx::query_as::<_, DeviceRow>(FIND_ALL_SQL)
             .fetch_all(&self.pools.read)
             .await?;
         rows.into_iter().map(DeviceRow::into_device).collect()
@@ -252,8 +258,7 @@ impl DeviceRepository for SqliteDeviceRepository {
     }
 
     async fn find_stale(&self, before: &str) -> anyhow::Result<Vec<Device>> {
-        let query = format!("SELECT {SELECT_COLS} FROM devices WHERE last_seen < ?");
-        let rows = sqlx::query_as::<_, DeviceRow>(sqlx::AssertSqlSafe(query))
+        let rows = sqlx::query_as::<_, DeviceRow>(FIND_STALE_SQL)
             .bind(before)
             .fetch_all(&self.pools.read)
             .await?;

--- a/source/daemon/crates/wardnetd-data/src/repository/sqlite/network_zone.rs
+++ b/source/daemon/crates/wardnetd-data/src/repository/sqlite/network_zone.rs
@@ -68,9 +68,24 @@ impl ZoneRow {
     }
 }
 
-const SELECT_COLS: &str = "id, name, provenance, isolation_stance, allowed_targets, \
-    member_isolation, subnet_cidr, admin_ui_reachable, is_default, is_default_for_new, \
-    created_at, updated_at";
+// Static SQL strings — the column list is inlined into each fixed SELECT so no
+// runtime format!() allocation is needed.
+const FIND_ALL_SQL: &str = "SELECT id, name, provenance, isolation_stance, allowed_targets, \
+     member_isolation, subnet_cidr, admin_ui_reachable, is_default, is_default_for_new, \
+     created_at, updated_at \
+     FROM network_zones ORDER BY name";
+const FIND_BY_ID_SQL: &str = "SELECT id, name, provenance, isolation_stance, allowed_targets, \
+     member_isolation, subnet_cidr, admin_ui_reachable, is_default, is_default_for_new, \
+     created_at, updated_at \
+     FROM network_zones WHERE id = ?";
+const FIND_DEFAULT_SQL: &str = "SELECT id, name, provenance, isolation_stance, allowed_targets, \
+     member_isolation, subnet_cidr, admin_ui_reachable, is_default, is_default_for_new, \
+     created_at, updated_at \
+     FROM network_zones WHERE is_default = 1";
+const FIND_DEFAULT_FOR_NEW_SQL: &str = "SELECT id, name, provenance, isolation_stance, allowed_targets, \
+     member_isolation, subnet_cidr, admin_ui_reachable, is_default, is_default_for_new, \
+     created_at, updated_at \
+     FROM network_zones WHERE is_default_for_new = 1";
 
 /// Serialize a scalar enum to its `snake_case` wire string (strip the JSON quotes).
 fn enum_str<T: serde::Serialize>(value: &T) -> anyhow::Result<String> {
@@ -80,16 +95,14 @@ fn enum_str<T: serde::Serialize>(value: &T) -> anyhow::Result<String> {
 #[async_trait]
 impl NetworkZoneRepository for SqliteNetworkZoneRepository {
     async fn find_all(&self) -> anyhow::Result<Vec<NetworkZone>> {
-        let query = format!("SELECT {SELECT_COLS} FROM network_zones ORDER BY name");
-        let rows = sqlx::query_as::<_, ZoneRow>(sqlx::AssertSqlSafe(query))
+        let rows = sqlx::query_as::<_, ZoneRow>(FIND_ALL_SQL)
             .fetch_all(&self.pools.read)
             .await?;
         rows.into_iter().map(ZoneRow::into_zone).collect()
     }
 
     async fn find_by_id(&self, id: &str) -> anyhow::Result<Option<NetworkZone>> {
-        let query = format!("SELECT {SELECT_COLS} FROM network_zones WHERE id = ?");
-        let row = sqlx::query_as::<_, ZoneRow>(sqlx::AssertSqlSafe(query))
+        let row = sqlx::query_as::<_, ZoneRow>(FIND_BY_ID_SQL)
             .bind(id)
             .fetch_optional(&self.pools.read)
             .await?;
@@ -97,8 +110,7 @@ impl NetworkZoneRepository for SqliteNetworkZoneRepository {
     }
 
     async fn find_default(&self) -> anyhow::Result<NetworkZone> {
-        let query = format!("SELECT {SELECT_COLS} FROM network_zones WHERE is_default = 1");
-        let row = sqlx::query_as::<_, ZoneRow>(sqlx::AssertSqlSafe(query))
+        let row = sqlx::query_as::<_, ZoneRow>(FIND_DEFAULT_SQL)
             .fetch_optional(&self.pools.read)
             .await?
             .ok_or_else(|| anyhow::anyhow!("no default network zone configured"))?;
@@ -106,8 +118,7 @@ impl NetworkZoneRepository for SqliteNetworkZoneRepository {
     }
 
     async fn find_default_for_new(&self) -> anyhow::Result<NetworkZone> {
-        let query = format!("SELECT {SELECT_COLS} FROM network_zones WHERE is_default_for_new = 1");
-        let row = sqlx::query_as::<_, ZoneRow>(sqlx::AssertSqlSafe(query))
+        let row = sqlx::query_as::<_, ZoneRow>(FIND_DEFAULT_FOR_NEW_SQL)
             .fetch_optional(&self.pools.read)
             .await?
             .ok_or_else(|| anyhow::anyhow!("no default-for-new network zone configured"))?;

--- a/source/daemon/crates/wardnetd-data/src/repository/sqlite/zone_exception.rs
+++ b/source/daemon/crates/wardnetd-data/src/repository/sqlite/zone_exception.rs
@@ -82,8 +82,14 @@ fn service_spec(preset: Option<&str>, ports_json: Option<&str>) -> anyhow::Resul
     }
 }
 
-const SELECT_COLS: &str = "id, from_kind, from_id, to_kind, to_id, service_preset, ports_json, \
-    bidirectional, created_at, updated_at";
+// Static SQL strings — the column list is inlined into each fixed SELECT so no
+// runtime format!() allocation is needed.
+const FIND_ALL_SQL: &str = "SELECT id, from_kind, from_id, to_kind, to_id, service_preset, ports_json, \
+     bidirectional, created_at, updated_at \
+     FROM zone_exceptions ORDER BY created_at";
+const FIND_BY_ID_SQL: &str = "SELECT id, from_kind, from_id, to_kind, to_id, service_preset, ports_json, \
+     bidirectional, created_at, updated_at \
+     FROM zone_exceptions WHERE id = ?";
 
 /// Serialize a scalar enum to its `snake_case` wire string (strip the JSON quotes).
 fn enum_str<T: serde::Serialize>(value: &T) -> anyhow::Result<String> {
@@ -101,16 +107,14 @@ fn service_columns(service: &ServiceSpec) -> anyhow::Result<(Option<String>, Opt
 #[async_trait]
 impl ZoneExceptionRepository for SqliteZoneExceptionRepository {
     async fn find_all(&self) -> anyhow::Result<Vec<ZoneException>> {
-        let query = format!("SELECT {SELECT_COLS} FROM zone_exceptions ORDER BY created_at");
-        let rows = sqlx::query_as::<_, ExceptionRow>(sqlx::AssertSqlSafe(query))
+        let rows = sqlx::query_as::<_, ExceptionRow>(FIND_ALL_SQL)
             .fetch_all(&self.pools.read)
             .await?;
         rows.into_iter().map(ExceptionRow::into_exception).collect()
     }
 
     async fn find_by_id(&self, id: &str) -> anyhow::Result<Option<ZoneException>> {
-        let query = format!("SELECT {SELECT_COLS} FROM zone_exceptions WHERE id = ?");
-        let row = sqlx::query_as::<_, ExceptionRow>(sqlx::AssertSqlSafe(query))
+        let row = sqlx::query_as::<_, ExceptionRow>(FIND_BY_ID_SQL)
             .bind(id)
             .fetch_optional(&self.pools.read)
             .await?;


### PR DESCRIPTION
Closes #843.

## What

The eleven fully-static SELECT queries in `wardnetd-data`'s SQLite repositories were rebuilt with `format!()` on every call, purely to splice in a shared `const SELECT_COLS` column list. Since every interpolated component is a compile-time constant, the whole statement is constant — this pays a heap allocation per call and drags `sqlx::AssertSqlSafe` onto queries that never see dynamic input.

This replaces the shared `SELECT_COLS` + per-call `format!()` pattern with one top-level `const &str` per query, spelling the column list out literally in the SQL text. It follows the convention already established by `dns_local.rs` in the same crate.

## Files

- `repository/sqlite/device.rs` — 5 consts (`FIND_BY_IP_SQL`, `FIND_BY_ID_SQL`, `FIND_BY_MAC_SQL`, `FIND_ALL_SQL`, `FIND_STALE_SQL`); `SELECT_COLS` dropped.
- `repository/sqlite/network_zone.rs` — 4 consts (`FIND_ALL_SQL`, `FIND_BY_ID_SQL`, `FIND_DEFAULT_SQL`, `FIND_DEFAULT_FOR_NEW_SQL`).
- `repository/sqlite/zone_exception.rs` — 2 consts (`FIND_ALL_SQL`, `FIND_BY_ID_SQL`).

`sqlx::AssertSqlSafe` is removed from all eleven call sites — a plain `&'static str` needs no safety assertion. The genuinely dynamic query builders in these same files (JOIN/LIKE against `routing_rules`, dynamic WHERE/SET clauses) are left untouched.

## Behavior

No behavioral change — the generated SQL text is byte-identical before and after. The existing repository tests exercise every one of the eleven affected methods (device: `find_by_ip`/`find_by_id`/`find_by_mac`/`find_all`/`find_stale`; network zone: `find_all`/`find_by_id`/`find_default`/`find_default_for_new`; zone exception: `find_all`/`find_by_id`) and pass unmodified, which pins the SQL as unchanged.

## Testing

- `cargo clippy -p wardnetd-data --all-targets -- -D warnings` — clean.
- `cargo test -p wardnetd-data` — 299 passed, 0 failed.