### PR TITLE
docs(services): comment sanctioned auth-guard exceptions; fix routing doc-drift

### DIFF
--- a/source/daemon/crates/wardnetd-services/src/auth/service.rs
+++ b/source/daemon/crates/wardnetd-services/src/auth/service.rs
@@ -324,6 +324,9 @@ impl AuthService for AuthServiceImpl {
     }
 
     async fn validate_session(&self, token: &str) -> Result<Option<Uuid>, AppError> {
+        // Documented exception to the auth-guard rule (.agents/auth.md §Rules #2,
+        // category (b): auth bootstrap): this resolves a session token into an admin
+        // identity, so it necessarily runs before any identity exists to require.
         let token_hash = hash_token(token);
         let now = chrono::Utc::now().to_rfc3339();
 
@@ -354,6 +357,9 @@ impl AuthService for AuthServiceImpl {
     }
 
     async fn validate_api_key(&self, key: &str) -> Result<Option<Uuid>, AppError> {
+        // Documented exception to the auth-guard rule (.agents/auth.md §Rules #2,
+        // category (b): auth bootstrap): this resolves an API key into an admin
+        // identity, so it necessarily runs before any identity exists to require.
         let all_keys = self
             .api_keys
             .find_all_hashes()
@@ -474,6 +480,11 @@ impl AuthService for AuthServiceImpl {
     }
 
     async fn is_setup_completed(&self) -> Result<bool, AppError> {
+        // Documented exception to the auth-guard rule (.agents/auth.md §Rules #2,
+        // category (b): auth bootstrap): backs the unauthenticated
+        // `GET /api/setup/status` surface and delegates to the equally-unguarded
+        // `wizard_state`, so there is no session to require here.
+        //
         // Derived from `wizard_step == Completed` so this matches the
         // value the API surfaces in `SetupStatusResponse.setup_completed`.
         // The legacy `setup_completed` key in `system_config` is no

--- a/source/daemon/crates/wardnetd-services/src/ddns/mod.rs
+++ b/source/daemon/crates/wardnetd-services/src/ddns/mod.rs
@@ -879,6 +879,10 @@ impl DdnsService for DdnsServiceImpl {
     }
 
     async fn sync_premium(&self) -> Result<(), AppError> {
+        // Documented exception to the auth-guard rule (.agents/auth.md §Rules #2,
+        // category (a): startup/restore): reconciles the cached premium flag with
+        // the configured provider on startup and after provider changes, outside
+        // any admin session.
         let provider = self.current_provider().await?;
         self.entitlement
             .set_premium(provider.as_deref() == Some(PROVIDER_WARDNET));

--- a/source/daemon/crates/wardnetd-services/src/device/service.rs
+++ b/source/daemon/crates/wardnetd-services/src/device/service.rs
@@ -292,6 +292,11 @@ impl DeviceService for DeviceServiceImpl {
         ip: &str,
         target: RoutingTarget,
     ) -> Result<SetMyRuleResponse, AppError> {
+        // Category-(c) guard-not-first (.agents/auth.md §Rules #2): the device's MAC
+        // is the subject of the `check_device_mutation_auth` check below, so the
+        // device is resolved first. This deviation from "guard must be first" is
+        // deliberate, not an oversight — the lookup only materializes the subject,
+        // and the auth check remains the first thing done with the caller's identity.
         let device = self
             .devices
             .find_by_ip(ip)
@@ -338,6 +343,11 @@ impl DeviceService for DeviceServiceImpl {
     }
 
     async fn set_rule(&self, device_id: &str, target: RoutingTarget) -> Result<(), AppError> {
+        // Category-(c) guard-not-first (.agents/auth.md §Rules #2): the device's MAC
+        // is the subject of the `check_device_mutation_auth` check below, so the
+        // device is resolved first. This deviation from "guard must be first" is
+        // deliberate, not an oversight — the lookup only materializes the subject,
+        // and the auth check remains the first thing done with the caller's identity.
         let device = self
             .devices
             .find_by_id(device_id)
@@ -504,6 +514,11 @@ impl DeviceService for DeviceServiceImpl {
         ip: &str,
         enabled: bool,
     ) -> Result<DnsCaptureSettingsResponse, AppError> {
+        // Category-(c) guard-not-first (.agents/auth.md §Rules #2): the device's MAC
+        // is the subject of the `check_device_mutation_auth` check below, so the
+        // device is resolved first. This deviation from "guard must be first" is
+        // deliberate, not an oversight — the lookup only materializes the subject,
+        // and the auth check remains the first thing done with the caller's identity.
         let device = self
             .devices
             .find_by_ip(ip)

--- a/source/daemon/crates/wardnetd-services/src/device/tests/device.rs
+++ b/source/daemon/crates/wardnetd-services/src/device/tests/device.rs
@@ -572,6 +572,49 @@ async fn set_rule_by_id_device_not_found() {
     assert!(result.is_err());
 }
 
+// -- Tests: set_my_capture_enabled (auth context) ------------------------
+
+#[tokio::test]
+async fn set_my_capture_enabled_anonymous_forbidden() {
+    let svc = make_svc(false, None);
+
+    let result = auth_context::with_context(AuthContext::Anonymous, async {
+        svc.set_my_capture_enabled("192.168.1.10", true).await
+    })
+    .await;
+
+    assert!(matches!(result, Err(crate::error::AppError::Forbidden(_))));
+}
+
+#[tokio::test]
+async fn set_my_capture_enabled_foreign_device_forbidden() {
+    let svc = make_svc(false, None);
+    let ctx = device_ctx("FF:FF:FF:FF:FF:FF");
+
+    let result = auth_context::with_context(ctx, async {
+        svc.set_my_capture_enabled("192.168.1.10", true).await
+    })
+    .await;
+
+    assert!(matches!(result, Err(crate::error::AppError::Forbidden(_))));
+}
+
+#[tokio::test]
+async fn set_my_capture_enabled_own_device_allowed() {
+    let svc = make_svc(false, None);
+    let ctx = device_ctx("AA:BB:CC:DD:EE:01");
+
+    let result = auth_context::with_context(ctx, async {
+        svc.set_my_capture_enabled("192.168.1.10", true).await
+    })
+    .await;
+
+    assert!(
+        result.is_ok(),
+        "owning device should be allowed: {result:?}"
+    );
+}
+
 // -- Tests: update_admin_locked ------------------------------------------
 
 #[tokio::test]

--- a/source/daemon/crates/wardnetd-services/src/routing/service.rs
+++ b/source/daemon/crates/wardnetd-services/src/routing/service.rs
@@ -88,7 +88,10 @@ pub trait RoutingService: Send + Sync {
     ///
     /// Used by the routing listener to handle `RoutingRuleChanged` events without
     /// the listener needing direct repository access.
-    /// No auth guard — callers wrap this in `auth_context::with_context(...)`.
+    /// Admin-gated like every other method — the impl calls
+    /// `auth_context::require_admin()?` first. The listener drives it under
+    /// `auth_context::with_context(AuthContext::Admin { .. })` so that guard is
+    /// satisfied even though the call originates outside the HTTP request path.
     async fn apply_rule_for_device(
         &self,
         device_id: Uuid,
@@ -98,7 +101,10 @@ pub trait RoutingService: Send + Sync {
     /// Check if a newly-discovered device has a persisted routing rule and apply it.
     ///
     /// Used by the routing listener to handle `DeviceDiscovered` events.
-    /// No auth guard — callers wrap this in `auth_context::with_context(...)`.
+    /// Admin-gated like every other method — the impl calls
+    /// `auth_context::require_admin()?` first. The listener drives it under
+    /// `auth_context::with_context(AuthContext::Admin { .. })` so that guard is
+    /// satisfied even though the call originates outside the HTTP request path.
     async fn apply_rule_for_discovered_device(
         &self,
         device_id: Uuid,

--- a/source/daemon/crates/wardnetd-services/src/routing/tests/routing.rs
+++ b/source/daemon/crates/wardnetd-services/src/routing/tests/routing.rs
@@ -1214,6 +1214,40 @@ async fn devices_using_tunnel_without_auth_context_fails() {
     );
 }
 
+#[tokio::test]
+async fn apply_rule_for_device_without_auth_context_fails() {
+    let ts = setup();
+
+    let result = auth_context::with_context(
+        AuthContext::Anonymous,
+        ts.routing
+            .apply_rule_for_device(device_id_1(), &RoutingTarget::Direct),
+    )
+    .await;
+
+    assert!(
+        matches!(result, Err(AppError::Forbidden(_))),
+        "apply_rule_for_device without admin context should return Forbidden, got: {result:?}"
+    );
+}
+
+#[tokio::test]
+async fn apply_rule_for_discovered_device_without_auth_context_fails() {
+    let ts = setup();
+
+    let result = auth_context::with_context(
+        AuthContext::Anonymous,
+        ts.routing
+            .apply_rule_for_discovered_device(device_id_1(), "192.168.1.10"),
+    )
+    .await;
+
+    assert!(
+        matches!(result, Err(AppError::Forbidden(_))),
+        "apply_rule_for_discovered_device without admin context should return Forbidden, got: {result:?}"
+    );
+}
+
 // -- Tests: apply_rule basics -------------------------------------------------
 
 #[tokio::test]

--- a/source/daemon/crates/wardnetd-services/src/tunnel/service.rs
+++ b/source/daemon/crates/wardnetd-services/src/tunnel/service.rs
@@ -1265,6 +1265,9 @@ impl TunnelService for TunnelServiceImpl {
     }
 
     async fn restore_tunnels(&self) -> Result<(), AppError> {
+        // Documented exception to the auth-guard rule (.agents/auth.md §Rules #2,
+        // category (a): startup/restore): runs during boot, before any admin
+        // session can exist, to rehydrate tunnel state from the database.
         let tunnels = self.tunnels.find_all().await.map_err(AppError::Internal)?;
 
         tracing::info!(


### PR DESCRIPTION
Closes #842.

## Background

`.agents/auth.md` (Rules #2) requires that every sanctioned auth-guard exception carries a comment naming its category, so a reviewer can distinguish a deliberate skip from an oversight. A batch of methods that legitimately skip the guard had no such comment. Separately, two routing trait doc comments claimed "No auth guard" for methods whose impls actually call `require_admin()?` first — inviting a future maintainer to "clean up" that call as dead code.

This is a documentation-consistency pass. No guard logic changes.

## Changes

**Documented the sanctioned exceptions:**

- `auth/service.rs` — `validate_session`, `validate_api_key`, `is_setup_completed`: category (b) auth-bootstrap. These resolve a token/key into an identity (or back the unauthenticated setup-status surface), so they necessarily run before any identity exists to require.
- `tunnel/service.rs::restore_tunnels` and `ddns/mod.rs::sync_premium`: category (a) startup/restore. Both run before the system is ready, outside any admin session. These are the two methods `.agents/auth.md` names by name as its category-(a) examples.
- `device/service.rs` — `set_rule_for_ip`, `set_rule`, `set_my_capture_enabled`: category (c). The device's MAC is the subject of `check_device_mutation_auth`, so the device must be resolved first; the "guard must be first" rule is deliberately relaxed and now says so.

**Fixed the routing doc-drift:**

- `routing/service.rs` — the trait docs for `apply_rule_for_device` / `apply_rule_for_discovered_device` now state that the method calls `require_admin()?` first and is additionally driven by the routing listener under `with_context(Admin)`, instead of claiming no guard exists. The `require_admin()?` calls are untouched — they are the only thing protecting against a caller that forgets to wrap in `with_context`.

## Tests

Confirmed existing coverage for the unauthenticated `validate_session` / `validate_api_key` paths and the anonymous-rejection paths on `set_rule` / `set_rule_for_ip`. Added the missing auth-context coverage:

- `set_my_capture_enabled`: anonymous-forbidden, foreign-device-forbidden, owning-device-allowed.
- `apply_rule_for_device` / `apply_rule_for_discovered_device`: unauthenticated-rejection.

Full `wardnetd-services` suite passes (1386 tests); clippy and rustfmt clean.