### PR TITLE
refactor(web-ui): lift TanStack Query hooks out of features/components into pages

### DIFF
--- a/.agents/code-conventions.md
+++ b/.agents/code-conventions.md
@@ -29,6 +29,13 @@
   - `compound/` — compositions of core components, data via props only, no API calls
   - `features/` — use-case views, data via props + callbacks, no direct API/service calls
   - `layouts/` — page shells, navigation/routing, no business logic
+    - **Carve-out — shell-wide status/auth.** The `AppLayout` shells may call
+      `useDaemonStatus()` (admin-app, user-app) and `useAuth()` (admin-site)
+      directly. These two hooks feed the shell chrome itself — the header
+      version/connection pill and the admin-gated navigation — which live above
+      every route and have no owning `page` to hoist them into. The carve-out is
+      limited to these two read hooks; layouts still perform no mutations and
+      wire no other queries.
   - `pages/` — route-level, wire TanStack Query hooks → feature/compound components
 - **All business logic in `@wardnet/js`** — components are pure presentation.
 - **Hooks** bridge SDK and React: wrap SDK service calls in TanStack Query for caching/loading/error.

--- a/source/admin-app/src/components/DeviceRoutingSheet.tsx
+++ b/source/admin-app/src/components/DeviceRoutingSheet.tsx
@@ -8,9 +8,6 @@ import {
   InboundWgBetaNotice,
 } from "@wardnet/web";
 import {
-  useUpdateDevice,
-  useNetworkZones,
-  useAssignDeviceZone,
   useInboundWgPeers,
   useAddInboundWgPeer,
   countryFlag,
@@ -18,6 +15,7 @@ import {
 import type {
   AddInboundWgPeerResponse,
   Device,
+  NetworkZoneView,
   Tunnel,
   RoutingTarget,
 } from "@wardnet/js";
@@ -27,8 +25,16 @@ import { InboundWgGrantedView } from "./InboundWgGrantedView";
 interface Props {
   device: Device | null;
   tunnels: Tunnel[];
+  /** Network zones the device can be reassigned to (owned by the page). */
+  zones: NetworkZoneView[];
+  /** True while a routing or zone change is in flight; disables the rows. */
+  busy: boolean;
   open: boolean;
   onOpenChange: (open: boolean) => void;
+  /** Apply a routing override to the selected device. */
+  onSelectRoute: (target: RoutingTarget) => void;
+  /** Reassign the selected device to a different zone. */
+  onSelectZone: (zoneId: string) => void;
 }
 
 function activeKey(rule: RoutingTarget | null): string {
@@ -110,15 +116,15 @@ function OptionRow({
 export function DeviceRoutingSheet({
   device,
   tunnels,
+  zones,
+  busy,
   open,
   onOpenChange,
+  onSelectRoute,
+  onSelectZone,
 }: Props) {
-  const updateDevice = useUpdateDevice({ successMessage: "Routing updated" });
-  const { data: zoneData } = useNetworkZones();
-  const assignZone = useAssignDeviceZone({ successMessage: "Zone updated" });
   const { data: peersData } = useInboundWgPeers();
   const addPeer = useAddInboundWgPeer();
-  const zones = zoneData?.zones ?? [];
 
   // The one-time grant response. When set, the sheet swaps to the QR view so
   // the private key (embedded in `client_config`) can be scanned once.
@@ -133,7 +139,6 @@ export function DeviceRoutingSheet({
   const current = activeKey(activeDevice?.current_rule ?? null);
   const deviceLabel =
     activeDevice?.name ?? activeDevice?.hostname ?? activeDevice?.mac ?? "";
-  const busy = updateDevice.isPending || assignZone.isPending;
 
   // Grantable = managed (admin-named; the backend rejects unmanaged devices)
   // AND has no peer row yet. `connection_mode` is monitor-driven liveness, not
@@ -151,19 +156,12 @@ export function DeviceRoutingSheet({
 
   function handleSelect(target: RoutingTarget) {
     if (!activeDevice) return;
-    const id = activeDevice.id;
-    updateDevice.mutate(
-      { id, body: { routing_target: target } },
-      { onSuccess: () => onOpenChange(false) },
-    );
+    onSelectRoute(target);
   }
 
   function handleZoneSelect(zoneId: string) {
     if (!activeDevice || zoneId === activeDevice.zone_id) return;
-    assignZone.mutate(
-      { deviceId: activeDevice.id, zoneId },
-      { onSuccess: () => onOpenChange(false) },
-    );
+    onSelectZone(zoneId);
   }
 
   async function handleGrant() {

--- a/source/admin-app/src/pages/Devices.tsx
+++ b/source/admin-app/src/pages/Devices.tsx
@@ -4,6 +4,8 @@ import {
   useTunnels,
   useDefaultPolicy,
   usePendingDevices,
+  useUpdateDevice,
+  useNetworkZones,
   useAssignDeviceZone,
   useInboundWgPeers,
   countryFlag,
@@ -18,7 +20,12 @@ import { useOnlineStatusContext } from "@/context/OnlineStatusContext";
 import { DeviceRoutingSheet } from "@/components/DeviceRoutingSheet";
 import { InboundWgPeerSheet } from "@/components/InboundWgPeerSheet";
 import { ChevronRightIcon } from "lucide-react";
-import type { Device, InboundWgPeerSummary, Tunnel } from "@wardnet/js";
+import type {
+  Device,
+  InboundWgPeerSummary,
+  RoutingTarget,
+  Tunnel,
+} from "@wardnet/js";
 
 type Filter = "all" | "online" | "vpn";
 
@@ -201,6 +208,9 @@ export default function Devices() {
   const { data: tunnelsData } = useTunnels();
   const { data: policyData, isLoading: policyLoading } = useDefaultPolicy();
   const { data: peersData } = useInboundWgPeers();
+  const { data: zoneData } = useNetworkZones();
+  const updateDevice = useUpdateDevice({ successMessage: "Routing updated" });
+  const assignZone = useAssignDeviceZone({ successMessage: "Zone updated" });
   const isLoading = devicesLoading || policyLoading;
 
   const { showingLastKnownState } = useOnlineStatusContext();
@@ -217,6 +227,8 @@ export default function Devices() {
   const tunnels = tunnelsData?.tunnels ?? [];
   const defaultPolicy = policyData?.policy;
   const peers = peersData?.peers ?? [];
+  const zones = zoneData?.zones ?? [];
+  const routingBusy = updateDevice.isPending || assignZone.isPending;
 
   const peersByDevice = useMemo(() => {
     const map = new Map<string, InboundWgPeerSummary>();
@@ -269,6 +281,25 @@ export default function Devices() {
     setSelectedDeviceId(id);
     setSheetOpen(true);
   }, []);
+
+  // Routing/zone mutations for the open sheet. Hoisted here (not owned by the
+  // sheet) so the sheet stays a presentation component; the page closes the
+  // sheet once the change lands.
+  function handleSelectRoute(target: RoutingTarget) {
+    if (!selectedDevice) return;
+    updateDevice.mutate(
+      { id: selectedDevice.id, body: { routing_target: target } },
+      { onSuccess: () => setSheetOpen(false) },
+    );
+  }
+
+  function handleSelectZone(zoneId: string) {
+    if (!selectedDevice) return;
+    assignZone.mutate(
+      { deviceId: selectedDevice.id, zoneId },
+      { onSuccess: () => setSheetOpen(false) },
+    );
+  }
 
   if (isLoading) {
     return (
@@ -371,8 +402,12 @@ export default function Devices() {
       <DeviceRoutingSheet
         device={selectedDevice}
         tunnels={tunnels}
+        zones={zones}
+        busy={routingBusy}
         open={sheetOpen}
         onOpenChange={setSheetOpen}
+        onSelectRoute={handleSelectRoute}
+        onSelectZone={handleSelectZone}
       />
 
       <InboundWgPeerSheet

--- a/source/admin-app/src/pages/Devices.tsx
+++ b/source/admin-app/src/pages/Devices.tsx
@@ -282,21 +282,25 @@ export default function Devices() {
     setSheetOpen(true);
   }, []);
 
-  // Routing/zone mutations for the open sheet. Hoisted here (not owned by the
-  // sheet) so the sheet stays a presentation component; the page closes the
-  // sheet once the change lands.
+  // Routing/zone mutations for the open sheet, hoisted out of the sheet so it
+  // takes them as props (the sheet still owns its local remote-access grant
+  // flow, which keeps its own one-time response state). Keyed on the selected
+  // id rather than the derived `selectedDevice` so a background refetch that
+  // drops the row still fires the mutation — matching the sheet's old latched
+  // behavior — instead of silently no-oping. The page closes the sheet on
+  // success.
   function handleSelectRoute(target: RoutingTarget) {
-    if (!selectedDevice) return;
+    if (!selectedDeviceId) return;
     updateDevice.mutate(
-      { id: selectedDevice.id, body: { routing_target: target } },
+      { id: selectedDeviceId, body: { routing_target: target } },
       { onSuccess: () => setSheetOpen(false) },
     );
   }
 
   function handleSelectZone(zoneId: string) {
-    if (!selectedDevice) return;
+    if (!selectedDeviceId) return;
     assignZone.mutate(
-      { deviceId: selectedDevice.id, zoneId },
+      { deviceId: selectedDeviceId, zoneId },
       { onSuccess: () => setSheetOpen(false) },
     );
   }

--- a/source/admin-app/tests/components/DeviceRoutingSheet.test.tsx
+++ b/source/admin-app/tests/components/DeviceRoutingSheet.test.tsx
@@ -1,76 +1,45 @@
+import type { ComponentProps } from "react";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const {
-  mutate,
-  useUpdateDevice,
-  assignZone,
-  useNetworkZones,
-  useAssignDeviceZone,
-  useInboundWgPeers,
-  addPeerMutateAsync,
-  useAddInboundWgPeer,
-} = vi.hoisted(() => {
-  const mutate = vi.fn();
-  const assignZone = vi.fn();
-  const addPeerMutateAsync = vi.fn();
-  return {
-    mutate,
-    useUpdateDevice: vi.fn(() => ({ mutate, isPending: false })),
-    assignZone,
-    // The sheet reads the peer list (to decide if a device is already granted)
-    // and an add-peer mutation for the grant action. Default to no peers so
-    // every managed device is grantable; specs override as needed. The return
-    // type is annotated so the empty default isn't inferred as `never[]`, which
-    // would reject the populated-peer override in the "already granted" spec.
-    useInboundWgPeers: vi.fn(
-      (): {
-        data: {
-          peers: Array<{
-            id: string;
-            name: string;
-            public_key: string;
-            allowed_ip: string;
-            enabled: boolean;
-            created_at: string;
-            device_id: string | null;
-          }>;
-        };
-      } => ({ data: { peers: [] } }),
-    ),
-    addPeerMutateAsync,
-    useAddInboundWgPeer: vi.fn(() => ({
-      mutateAsync: addPeerMutateAsync,
-      isPending: false,
-    })),
-    // The sheet reads zones + an assign mutation for its zone-reassignment
-    // section; keep the list empty so these specs stay focused on routing.
-    // `zones` is typed loosely — the hook is mocked, so the component's real
-    // NetworkZoneView type is irrelevant here; only the fields the sheet
-    // reads (id/name/is_default) matter.
-    useNetworkZones: vi.fn(
-      (): {
-        data: {
-          zones: Array<{ id: string; name: string; is_default: boolean }>;
-        };
-      } => ({
-        data: { zones: [] },
-      }),
-    ),
-    useAssignDeviceZone: vi.fn(() => ({
-      mutate: assignZone,
-      isPending: false,
-    })),
-  };
-});
+import type { Device, NetworkZoneView, Tunnel } from "@wardnet/js";
+
+const { useInboundWgPeers, addPeerMutateAsync, useAddInboundWgPeer } =
+  vi.hoisted(() => {
+    const addPeerMutateAsync = vi.fn();
+    return {
+      // The sheet reads the peer list (to decide if a device is already granted)
+      // and an add-peer mutation for the grant action. Default to no peers so
+      // every managed device is grantable; specs override as needed. The return
+      // type is annotated so the empty default isn't inferred as `never[]`, which
+      // would reject the populated-peer override in the "already granted" spec.
+      useInboundWgPeers: vi.fn(
+        (): {
+          data: {
+            peers: Array<{
+              id: string;
+              name: string;
+              public_key: string;
+              allowed_ip: string;
+              enabled: boolean;
+              created_at: string;
+              device_id: string | null;
+            }>;
+          };
+        } => ({ data: { peers: [] } }),
+      ),
+      addPeerMutateAsync,
+      useAddInboundWgPeer: vi.fn(() => ({
+        mutateAsync: addPeerMutateAsync,
+        isPending: false,
+      })),
+    };
+  });
 vi.mock("@wardnet/web", async (importOriginal) => {
   const actual = await importOriginal<Record<string, unknown>>();
   return {
     ...actual,
-    useUpdateDevice,
-    useNetworkZones,
-    useAssignDeviceZone,
     useInboundWgPeers,
     useAddInboundWgPeer,
   };
@@ -79,16 +48,45 @@ vi.mock("@wardnet/web", async (importOriginal) => {
 import { DeviceRoutingSheet } from "@/components/DeviceRoutingSheet";
 import { makeDevice, makeTunnel } from "../test-utils";
 
+// A full zone fixture; the sheet only reads id/name/is_default, but the prop is
+// typed so the rest is filled with harmless defaults.
+function zone(id: string, name: string, isDefault = false): NetworkZoneView {
+  return {
+    id,
+    name,
+    provenance: "manual",
+    isolation_stance: "shared_subnet",
+    allowed_targets: ["direct", "tunnel"],
+    member_isolation: false,
+    subnet: null,
+    admin_ui_reachable: true,
+    is_default: isDefault,
+    is_default_for_new: false,
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+    member_count: 0,
+  };
+}
+
+function renderSheet(
+  props: Partial<ComponentProps<typeof DeviceRoutingSheet>> = {},
+) {
+  const defaults = {
+    device: makeDevice() as Device | null,
+    tunnels: [] as Tunnel[],
+    zones: [] as NetworkZoneView[],
+    busy: false,
+    open: true,
+    onOpenChange: vi.fn(),
+    onSelectRoute: vi.fn(),
+    onSelectZone: vi.fn(),
+  };
+  const merged = { ...defaults, ...props };
+  return { ...render(<DeviceRoutingSheet {...merged} />), props: merged };
+}
+
 describe("DeviceRoutingSheet", () => {
   beforeEach(() => {
-    mutate.mockReset();
-    assignZone.mockReset();
-    useUpdateDevice.mockReturnValue({ mutate, isPending: false });
-    useNetworkZones.mockReturnValue({ data: { zones: [] } });
-    useAssignDeviceZone.mockReturnValue({
-      mutate: assignZone,
-      isPending: false,
-    });
     addPeerMutateAsync.mockReset();
     useInboundWgPeers.mockReturnValue({ data: { peers: [] } });
     useAddInboundWgPeer.mockReturnValue({
@@ -98,14 +96,10 @@ describe("DeviceRoutingSheet", () => {
   });
 
   it("renders default/direct options plus each tunnel", () => {
-    render(
-      <DeviceRoutingSheet
-        device={makeDevice({ name: "Laptop" })}
-        tunnels={[makeTunnel({ id: "t1", label: "US East", status: "down" })]}
-        open
-        onOpenChange={vi.fn()}
-      />,
-    );
+    renderSheet({
+      device: makeDevice({ name: "Laptop" }),
+      tunnels: [makeTunnel({ id: "t1", label: "US East", status: "down" })],
+    });
     expect(screen.getByTestId("device-routing-default")).toBeInTheDocument();
     expect(screen.getByTestId("device-routing-direct")).toBeInTheDocument();
     expect(screen.getByText(/US East/)).toBeInTheDocument();
@@ -114,107 +108,77 @@ describe("DeviceRoutingSheet", () => {
     expect(screen.getByText(/Route: Laptop/)).toBeInTheDocument();
   });
 
-  it("mutates with a direct target and closes on success", async () => {
-    const onOpenChange = vi.fn();
-    mutate.mockImplementation((_vars, opts) => opts?.onSuccess?.());
-    render(
-      <DeviceRoutingSheet
-        device={makeDevice({ id: "dev-9" })}
-        tunnels={[]}
-        open
-        onOpenChange={onOpenChange}
-      />,
-    );
+  it("fires onSelectRoute with a direct target", async () => {
+    const onSelectRoute = vi.fn();
+    renderSheet({ device: makeDevice({ id: "dev-9" }), onSelectRoute });
     await userEvent.click(screen.getByTestId("device-routing-direct"));
-    expect(mutate).toHaveBeenCalledWith(
-      { id: "dev-9", body: { routing_target: { type: "direct" } } },
-      expect.any(Object),
-    );
-    expect(onOpenChange).toHaveBeenCalledWith(false);
+    expect(onSelectRoute).toHaveBeenCalledWith({ type: "direct" });
   });
 
-  it("mutates with a tunnel target when a tunnel row is chosen", async () => {
-    render(
-      <DeviceRoutingSheet
-        device={makeDevice({ id: "dev-2" })}
-        tunnels={[makeTunnel({ id: "t7", label: "JP", status: "up" })]}
-        open
-        onOpenChange={vi.fn()}
-      />,
-    );
+  it("fires onSelectRoute with a tunnel target when a tunnel row is chosen", async () => {
+    const onSelectRoute = vi.fn();
+    renderSheet({
+      device: makeDevice({ id: "dev-2" }),
+      tunnels: [makeTunnel({ id: "t7", label: "JP", status: "up" })],
+      onSelectRoute,
+    });
     await userEvent.click(screen.getByText(/JP/));
-    expect(mutate).toHaveBeenCalledWith(
-      {
-        id: "dev-2",
-        body: { routing_target: { type: "tunnel", tunnel_id: "t7" } },
-      },
-      expect.any(Object),
-    );
+    expect(onSelectRoute).toHaveBeenCalledWith({
+      type: "tunnel",
+      tunnel_id: "t7",
+    });
+  });
+
+  it("disables the routing rows while a change is in flight", async () => {
+    const onSelectRoute = vi.fn();
+    renderSheet({
+      device: makeDevice({ id: "dev-1" }),
+      busy: true,
+      onSelectRoute,
+    });
+    await userEvent.click(screen.getByTestId("device-routing-direct"));
+    expect(onSelectRoute).not.toHaveBeenCalled();
   });
 
   it("falls back to the latched device label after device is cleared", () => {
-    const { rerender } = render(
-      <DeviceRoutingSheet
-        device={makeDevice({ name: "Phone" })}
-        tunnels={[]}
-        open
-        onOpenChange={vi.fn()}
-      />,
-    );
+    const { rerender } = renderSheet({ device: makeDevice({ name: "Phone" }) });
     expect(screen.getByText(/Route: Phone/)).toBeInTheDocument();
     // Parent clears the selection while animating closed — label stays latched.
     rerender(
       <DeviceRoutingSheet
         device={null}
         tunnels={[]}
+        zones={[]}
+        busy={false}
         open
         onOpenChange={vi.fn()}
+        onSelectRoute={vi.fn()}
+        onSelectZone={vi.fn()}
       />,
     );
     expect(screen.getByText(/Route: Phone/)).toBeInTheDocument();
   });
 
-  it("reassigns the device's zone when a zone row is chosen", async () => {
-    const onOpenChange = vi.fn();
-    assignZone.mockImplementation((_vars, opts) => opts?.onSuccess?.());
-    useNetworkZones.mockReturnValue({
-      data: {
-        zones: [
-          { id: "zone-1", name: "Trusted", is_default: true },
-          { id: "zone-2", name: "Guest", is_default: false },
-        ],
-      },
+  it("fires onSelectZone when a different zone row is chosen", async () => {
+    const onSelectZone = vi.fn();
+    renderSheet({
+      device: makeDevice({ id: "dev-5", zone_id: "zone-1" }),
+      zones: [zone("zone-1", "Trusted", true), zone("zone-2", "Guest")],
+      onSelectZone,
     });
-    render(
-      <DeviceRoutingSheet
-        device={makeDevice({ id: "dev-5", zone_id: "zone-1" })}
-        tunnels={[]}
-        open
-        onOpenChange={onOpenChange}
-      />,
-    );
     await userEvent.click(screen.getByText("Guest"));
-    expect(assignZone).toHaveBeenCalledWith(
-      { deviceId: "dev-5", zoneId: "zone-2" },
-      expect.any(Object),
-    );
-    expect(onOpenChange).toHaveBeenCalledWith(false);
+    expect(onSelectZone).toHaveBeenCalledWith("zone-2");
   });
 
-  it("does not reassign when the current zone is re-selected", async () => {
-    useNetworkZones.mockReturnValue({
-      data: { zones: [{ id: "zone-1", name: "Trusted", is_default: true }] },
+  it("does not fire onSelectZone when the current zone is re-selected", async () => {
+    const onSelectZone = vi.fn();
+    renderSheet({
+      device: makeDevice({ id: "dev-6", zone_id: "zone-1" }),
+      zones: [zone("zone-1", "Trusted", true)],
+      onSelectZone,
     });
-    render(
-      <DeviceRoutingSheet
-        device={makeDevice({ id: "dev-6", zone_id: "zone-1" })}
-        tunnels={[]}
-        open
-        onOpenChange={vi.fn()}
-      />,
-    );
     await userEvent.click(screen.getByText("Trusted"));
-    expect(assignZone).not.toHaveBeenCalled();
+    expect(onSelectZone).not.toHaveBeenCalled();
   });
 
   it("grants remote access for the tapped device and shows the config", async () => {
@@ -225,14 +189,7 @@ describe("DeviceRoutingSheet", () => {
       allowed_ip: "10.100.64.2/32",
       client_config: "[Interface]\nPrivateKey = k\n",
     });
-    render(
-      <DeviceRoutingSheet
-        device={makeDevice({ id: "dev-7", name: "Laptop" })}
-        tunnels={[]}
-        open
-        onOpenChange={vi.fn()}
-      />,
-    );
+    renderSheet({ device: makeDevice({ id: "dev-7", name: "Laptop" }) });
     await userEvent.click(screen.getByTestId("device-grant-remote-access"));
     expect(addPeerMutateAsync).toHaveBeenCalledWith({ device_id: "dev-7" });
     // On success the sheet swaps to the one-time QR / config view.
@@ -257,28 +214,14 @@ describe("DeviceRoutingSheet", () => {
         ],
       },
     });
-    render(
-      <DeviceRoutingSheet
-        device={makeDevice({ id: "dev-8", name: "Laptop" })}
-        tunnels={[]}
-        open
-        onOpenChange={vi.fn()}
-      />,
-    );
+    renderSheet({ device: makeDevice({ id: "dev-8", name: "Laptop" }) });
     expect(
       screen.queryByTestId("device-grant-remote-access"),
     ).not.toBeInTheDocument();
   });
 
   it("hides the grant action for an unmanaged (unnamed) device", () => {
-    render(
-      <DeviceRoutingSheet
-        device={makeDevice({ id: "dev-9", name: null })}
-        tunnels={[]}
-        open
-        onOpenChange={vi.fn()}
-      />,
-    );
+    renderSheet({ device: makeDevice({ id: "dev-9", name: null }) });
     expect(
       screen.queryByTestId("device-grant-remote-access"),
     ).not.toBeInTheDocument();

--- a/source/admin-app/tests/pages/Devices.test.tsx
+++ b/source/admin-app/tests/pages/Devices.test.tsx
@@ -7,7 +7,13 @@ const h = vi.hoisted(() => ({
   useTunnels: vi.fn(),
   useDefaultPolicy: vi.fn(),
   useUpdateDevice: vi.fn(() => ({ mutate: vi.fn(), isPending: false })),
-  useNetworkZones: vi.fn(() => ({ data: { zones: [] } })),
+  // Typed return so the empty default isn't inferred as `never[]`, which would
+  // reject the populated-zone override in the zone-reassignment spec.
+  useNetworkZones: vi.fn(
+    (): {
+      data: { zones: Array<{ id: string; name: string; is_default: boolean }> };
+    } => ({ data: { zones: [] } }),
+  ),
   usePendingDevices: vi.fn(),
   useAssignDeviceZone: vi.fn(),
   approve: vi.fn(),

--- a/source/admin-app/tests/pages/Devices.test.tsx
+++ b/source/admin-app/tests/pages/Devices.test.tsx
@@ -1,4 +1,4 @@
-import { screen, within } from "@testing-library/react";
+import { screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -7,6 +7,7 @@ const h = vi.hoisted(() => ({
   useTunnels: vi.fn(),
   useDefaultPolicy: vi.fn(),
   useUpdateDevice: vi.fn(() => ({ mutate: vi.fn(), isPending: false })),
+  useNetworkZones: vi.fn(() => ({ data: { zones: [] } })),
   usePendingDevices: vi.fn(),
   useAssignDeviceZone: vi.fn(),
   approve: vi.fn(),
@@ -20,6 +21,7 @@ vi.mock("@wardnet/web", async (importOriginal) => {
     useTunnels: h.useTunnels,
     useDefaultPolicy: h.useDefaultPolicy,
     useUpdateDevice: h.useUpdateDevice,
+    useNetworkZones: h.useNetworkZones,
     usePendingDevices: h.usePendingDevices,
     useAssignDeviceZone: h.useAssignDeviceZone,
   };
@@ -46,6 +48,7 @@ describe("Devices page", () => {
       isLoading: false,
     });
     h.useUpdateDevice.mockReturnValue({ mutate: vi.fn(), isPending: false });
+    h.useNetworkZones.mockReturnValue({ data: { zones: [] } });
     // Default: no pending devices → the "awaiting review" section stays hidden
     // so the existing specs are unaffected.
     h.usePendingDevices.mockReturnValue({
@@ -139,6 +142,74 @@ describe("Devices page", () => {
     expect(
       within(sheet).getByTestId("device-routing-default"),
     ).toBeInTheDocument();
+  });
+
+  it("routes the tapped device and closes the sheet on success", async () => {
+    const mutate = vi.fn((_vars, opts) => opts?.onSuccess?.());
+    h.useUpdateDevice.mockReturnValue({ mutate, isPending: false });
+    h.useDevices.mockReturnValue({
+      isLoading: false,
+      data: {
+        devices: [makeDevice({ id: "a", name: "Tap-Me", last_seen: now })],
+      },
+    });
+    renderWithProviders(<Devices />);
+
+    await userEvent.click(screen.getByText("Tap-Me"));
+    const sheet = await screen.findByTestId("device-routing-sheet");
+    await userEvent.click(within(sheet).getByTestId("device-routing-default"));
+
+    expect(mutate).toHaveBeenCalledWith(
+      { id: "a", body: { routing_target: { type: "default" } } },
+      expect.any(Object),
+    );
+    // The mutation's onSuccess closes the sheet (Radix unmounts the content).
+    await waitFor(() =>
+      expect(
+        screen.queryByTestId("device-routing-sheet"),
+      ).not.toBeInTheDocument(),
+    );
+  });
+
+  it("reassigns the tapped device's zone and closes the sheet on success", async () => {
+    const assign = vi.fn((_vars, opts) => opts?.onSuccess?.());
+    h.useAssignDeviceZone.mockReturnValue({ mutate: assign, isPending: false });
+    h.useNetworkZones.mockReturnValue({
+      data: {
+        zones: [
+          { id: "z1", name: "Trusted", is_default: true },
+          { id: "z2", name: "Guest", is_default: false },
+        ],
+      },
+    });
+    h.useDevices.mockReturnValue({
+      isLoading: false,
+      data: {
+        devices: [
+          makeDevice({
+            id: "a",
+            name: "Tap-Me",
+            zone_id: "z1",
+            last_seen: now,
+          }),
+        ],
+      },
+    });
+    renderWithProviders(<Devices />);
+
+    await userEvent.click(screen.getByText("Tap-Me"));
+    const sheet = await screen.findByTestId("device-routing-sheet");
+    await userEvent.click(within(sheet).getByText("Guest"));
+
+    expect(assign).toHaveBeenCalledWith(
+      { deviceId: "a", zoneId: "z2" },
+      expect.any(Object),
+    );
+    await waitFor(() =>
+      expect(
+        screen.queryByTestId("device-routing-sheet"),
+      ).not.toBeInTheDocument(),
+    );
   });
 
   it("lists new devices awaiting review and approves one to the home zone", async () => {

--- a/source/user-app/src/features/RequestRuleModal.tsx
+++ b/source/user-app/src/features/RequestRuleModal.tsx
@@ -6,9 +6,8 @@ import {
   DrawerDescription,
   DrawerTitle,
   Textarea,
-  useCreateRuleRequest,
-} from "@wardnet/web";
-import type { RuleRequestKind } from "@wardnet/js";
+} from "@wardnet/ui";
+import type { CreateRuleRequestRequest, RuleRequestKind } from "@wardnet/js";
 
 export interface RequestTarget {
   domain: string;
@@ -20,15 +19,22 @@ export interface RequestTarget {
  * domain. Opened from a domain row (or activity event) in the Stats page; the
  * row decides the sensible default (unblock a blocked domain, block a queried
  * one). Uses the same bottom-Drawer pattern as the admin app's sheets.
+ *
+ * Presentation only: the parent page owns the create-request mutation and
+ * passes `onSubmit` / `isSubmitting`. The sheet stays open after `onSubmit`
+ * fires; the page closes it (by clearing `target`) once the request lands.
  */
 export function RequestRuleModal({
   target,
   onClose,
+  onSubmit,
+  isSubmitting,
 }: {
   target: RequestTarget | null;
   onClose: () => void;
+  onSubmit: (payload: CreateRuleRequestRequest) => void;
+  isSubmitting: boolean;
 }) {
-  const create = useCreateRuleRequest();
   const [kind, setKind] = useState<RuleRequestKind>("block");
   const [reason, setReason] = useState("");
 
@@ -50,10 +56,7 @@ export function RequestRuleModal({
 
   function submit() {
     if (!active) return;
-    create.mutate(
-      { kind, domain: active.domain, reason: reason.trim() || null },
-      { onSuccess: onClose },
-    );
+    onSubmit({ kind, domain: active.domain, reason: reason.trim() || null });
   }
 
   return (
@@ -106,12 +109,8 @@ export function RequestRuleModal({
             <Button variant="outline" className="flex-1" onClick={onClose}>
               Cancel
             </Button>
-            <Button
-              className="flex-1"
-              onClick={submit}
-              disabled={create.isPending}
-            >
-              {create.isPending ? "Sending…" : "Send request"}
+            <Button className="flex-1" onClick={submit} disabled={isSubmitting}>
+              {isSubmitting ? "Sending…" : "Send request"}
             </Button>
           </div>
         </div>

--- a/source/user-app/src/pages/Stats.tsx
+++ b/source/user-app/src/pages/Stats.tsx
@@ -15,6 +15,7 @@ import {
   Sparkline,
   StatTile,
   Text,
+  useCreateRuleRequest,
   useMyDevice,
 } from "@wardnet/web";
 
@@ -186,6 +187,7 @@ export default function Stats() {
   );
   const { data: me, isLoading: meLoading } = useMyDevice();
   const stats = useDnsStats(date);
+  const createRuleRequest = useCreateRuleRequest();
 
   const device = me?.device;
 
@@ -338,6 +340,12 @@ export default function Stats() {
       <RequestRuleModal
         target={requestTarget}
         onClose={() => setRequestTarget(null)}
+        isSubmitting={createRuleRequest.isPending}
+        onSubmit={(payload) =>
+          createRuleRequest.mutate(payload, {
+            onSuccess: () => setRequestTarget(null),
+          })
+        }
       />
     </div>
   );

--- a/source/user-app/tests/features/RequestRuleModal.test.tsx
+++ b/source/user-app/tests/features/RequestRuleModal.test.tsx
@@ -7,30 +7,10 @@ import {
   type RequestTarget,
 } from "../../src/features/RequestRuleModal";
 
-const { useCreateRuleRequest } = vi.hoisted(() => ({
-  useCreateRuleRequest: vi.fn(),
-}));
-
-vi.mock("@wardnet/web", async (importOriginal) => {
-  const actual = await importOriginal<Record<string, unknown>>();
-  return { ...actual, useCreateRuleRequest };
-});
-
-const mutate = vi.fn();
-
-function setup(mutateState: Record<string, unknown> = {}) {
-  useCreateRuleRequest.mockReturnValue({
-    mutate,
-    isPending: false,
-    ...mutateState,
-  });
-}
-
 const target: RequestTarget = { domain: "ads.example.com", kind: "block" };
 
 beforeEach(() => {
   vi.clearAllMocks();
-  setup();
 });
 
 afterEach(() => {
@@ -39,21 +19,42 @@ afterEach(() => {
 
 describe("RequestRuleModal", () => {
   it("renders nothing visible when target is null", () => {
-    render(<RequestRuleModal target={null} onClose={vi.fn()} />);
+    render(
+      <RequestRuleModal
+        target={null}
+        onClose={vi.fn()}
+        onSubmit={vi.fn()}
+        isSubmitting={false}
+      />,
+    );
     expect(
       screen.queryByText("Ask your administrator"),
     ).not.toBeInTheDocument();
   });
 
   it("shows the targeted domain when open", () => {
-    render(<RequestRuleModal target={target} onClose={vi.fn()} />);
+    render(
+      <RequestRuleModal
+        target={target}
+        onClose={vi.fn()}
+        onSubmit={vi.fn()}
+        isSubmitting={false}
+      />,
+    );
     expect(screen.getByText("Ask your administrator")).toBeInTheDocument();
     expect(screen.getByText("ads.example.com")).toBeInTheDocument();
   });
 
-  it("submits the request with the selected kind and trimmed reason", async () => {
-    const onClose = vi.fn();
-    render(<RequestRuleModal target={target} onClose={onClose} />);
+  it("fires onSubmit with the selected kind and trimmed reason", async () => {
+    const onSubmit = vi.fn();
+    render(
+      <RequestRuleModal
+        target={target}
+        onClose={vi.fn()}
+        onSubmit={onSubmit}
+        isSubmitting={false}
+      />,
+    );
 
     // Switch to "allow".
     await userEvent.click(screen.getByRole("button", { name: "Allow it" }));
@@ -63,38 +64,55 @@ describe("RequestRuleModal", () => {
     );
     await userEvent.click(screen.getByRole("button", { name: "Send request" }));
 
-    expect(mutate).toHaveBeenCalledTimes(1);
-    const [payload, opts] = mutate.mock.calls[0];
-    expect(payload).toEqual({
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+    expect(onSubmit).toHaveBeenCalledWith({
       kind: "allow",
       domain: "ads.example.com",
       reason: "please",
     });
-    // onSuccess callback closes the sheet.
-    (opts as { onSuccess: () => void }).onSuccess();
-    expect(onClose).toHaveBeenCalled();
   });
 
-  it("sends a null reason when the note is blank", async () => {
-    render(<RequestRuleModal target={target} onClose={vi.fn()} />);
+  it("submits a null reason when the note is blank", async () => {
+    const onSubmit = vi.fn();
+    render(
+      <RequestRuleModal
+        target={target}
+        onClose={vi.fn()}
+        onSubmit={onSubmit}
+        isSubmitting={false}
+      />,
+    );
     await userEvent.click(screen.getByRole("button", { name: "Send request" }));
-    expect(mutate.mock.calls[0][0]).toEqual({
+    expect(onSubmit).toHaveBeenCalledWith({
       kind: "block",
       domain: "ads.example.com",
       reason: null,
     });
   });
 
-  it("shows a pending label and disables submit while sending", () => {
-    setup({ isPending: true });
-    render(<RequestRuleModal target={target} onClose={vi.fn()} />);
+  it("shows a pending label and disables submit while submitting", () => {
+    render(
+      <RequestRuleModal
+        target={target}
+        onClose={vi.fn()}
+        onSubmit={vi.fn()}
+        isSubmitting
+      />,
+    );
     const btn = screen.getByRole("button", { name: "Sending…" });
     expect(btn).toBeDisabled();
   });
 
   it("calls onClose from the Cancel button", async () => {
     const onClose = vi.fn();
-    render(<RequestRuleModal target={target} onClose={onClose} />);
+    render(
+      <RequestRuleModal
+        target={target}
+        onClose={onClose}
+        onSubmit={vi.fn()}
+        isSubmitting={false}
+      />,
+    );
     await userEvent.click(screen.getByRole("button", { name: "Cancel" }));
     expect(onClose).toHaveBeenCalled();
   });

--- a/source/user-app/tests/pages/Stats.test.tsx
+++ b/source/user-app/tests/pages/Stats.test.tsx
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { screen } from "@testing-library/react";
+import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 import Stats from "../../src/pages/Stats";
@@ -161,6 +161,30 @@ describe("Stats page", () => {
       domain: "bad.com",
       reason: null,
     });
+  });
+
+  it("closes the request modal once the submission succeeds", async () => {
+    // The close-on-success wiring moved from the modal into the page's onSubmit
+    // (setRequestTarget(null)); drive the mutation's onSuccess to exercise it.
+    createRuleMutate.mockImplementation((_payload, opts) =>
+      opts?.onSuccess?.(),
+    );
+    useMyDevice.mockReturnValue({
+      data: { device: makeDevice({ dns_capture_enabled: true }) },
+      isLoading: false,
+    });
+    renderWithProviders(<Stats />);
+
+    const [askBtn] = screen.getAllByLabelText(/Ask admin about bad.com/);
+    await userEvent.click(askBtn);
+    expect(screen.getByText("Ask your administrator")).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole("button", { name: "Send request" }));
+    await waitFor(() =>
+      expect(
+        screen.queryByText("Ask your administrator"),
+      ).not.toBeInTheDocument(),
+    );
   });
 
   it("switches the selected day when a trend button is tapped", async () => {

--- a/source/user-app/tests/pages/Stats.test.tsx
+++ b/source/user-app/tests/pages/Stats.test.tsx
@@ -7,10 +7,16 @@ import { todayLocal } from "../../src/lib/dnsDb";
 import type { DnsStatsData } from "../../src/hooks/useDnsStats";
 import { makeDevice, renderWithProviders } from "../test-utils";
 
-const { useMyDevice, useCreateRuleRequest } = vi.hoisted(() => ({
-  useMyDevice: vi.fn(),
-  useCreateRuleRequest: vi.fn(),
-}));
+// Stats owns the create-rule-request mutation and passes it down to
+// RequestRuleModal as onSubmit/isSubmitting, so the hook is mocked here because
+// the page itself calls it — not because it leaks through the modal.
+const { useMyDevice, useCreateRuleRequest, createRuleMutate } = vi.hoisted(
+  () => ({
+    useMyDevice: vi.fn(),
+    useCreateRuleRequest: vi.fn(),
+    createRuleMutate: vi.fn(),
+  }),
+);
 const { useDnsStats } = vi.hoisted(() => ({ useDnsStats: vi.fn() }));
 
 vi.mock("@wardnet/web", async (importOriginal) => {
@@ -52,7 +58,10 @@ function statsData(overrides: Partial<DnsStatsData> = {}): DnsStatsData {
 
 beforeEach(() => {
   vi.clearAllMocks();
-  useCreateRuleRequest.mockReturnValue({ mutate: vi.fn(), isPending: false });
+  useCreateRuleRequest.mockReturnValue({
+    mutate: createRuleMutate,
+    isPending: false,
+  });
   useDnsStats.mockReturnValue(statsData());
 });
 
@@ -133,6 +142,25 @@ describe("Stats page", () => {
       "aria-pressed",
       "true",
     );
+  });
+
+  it("submits a rule request via the hook the page now owns", async () => {
+    useMyDevice.mockReturnValue({
+      data: { device: makeDevice({ dns_capture_enabled: true }) },
+      isLoading: false,
+    });
+    renderWithProviders(<Stats />);
+
+    const [askBtn] = screen.getAllByLabelText(/Ask admin about bad.com/);
+    await userEvent.click(askBtn);
+    await userEvent.click(screen.getByRole("button", { name: "Send request" }));
+
+    expect(createRuleMutate).toHaveBeenCalledTimes(1);
+    expect(createRuleMutate.mock.calls[0][0]).toEqual({
+      kind: "allow",
+      domain: "bad.com",
+      reason: null,
+    });
   });
 
   it("switches the selected day when a trend button is tapped", async () => {


### PR DESCRIPTION
Closes #850.

Three data-fetching hooks were wired directly inside `features/` and `components/` files instead of in `pages/`, breaking the "Component layers (strict separation)" rule in `.agents/code-conventions.md` (only `pages/` may wire TanStack Query hooks; `features/`/`compound/` get data via props + callbacks). The leak was visible in tests — `Stats.test` had to stub `useCreateRuleRequest` just to render a modal that Stats never calls itself.

This is a mechanical move-up-and-pass-as-props per component, not a new abstraction.

### `RequestRuleModal` (user-app)
- Mutation `useCreateRuleRequest()` moves up into `pages/Stats.tsx`, the only caller.
- The modal takes `onSubmit(payload)` / `isSubmitting` props and now imports design-system primitives from `@wardnet/ui` directly — it no longer touches `@wardnet/web` at all.

### `DeviceRoutingSheet` (admin-app)
- `useUpdateDevice`, `useNetworkZones`, `useAssignDeviceZone` move up into `pages/Devices.tsx`, which already owns `useAssignDeviceZone` for the approve flow.
- The sheet takes `zones`, `busy`, `onSelectRoute`, `onSelectZone` props, matching the existing page pattern. The local grant-peer flow stays as-is.

### `AppLayout` daemon-status / auth hooks
- Rather than leave the rule and the code inconsistent, I documented a narrow carve-out in `.agents/code-conventions.md`: the `AppLayout` shells may call `useDaemonStatus()` / `useAuth()` because those feed shell chrome (header pill, admin-gated nav) that lives above every route with no page to own it. The exemption is limited to those two read hooks; no layout code changes, so the loading/error behavior is untouched.

### Tests
- `RequestRuleModal` and `DeviceRoutingSheet` tests now exercise the prop-driven API (submit/route/zone callbacks fire with the right payloads) instead of mocking the hooks.
- `Stats.test` keeps its `useCreateRuleRequest` stub, but now because the page itself owns the hook — checkable from the diff.