### PR TITLE
e2e: per-tunnel speed test (deterministic stub seam + Playwright spec)

### DIFF
--- a/source/admin-app/src/pages/Tunnels.tsx
+++ b/source/admin-app/src/pages/Tunnels.tsx
@@ -118,7 +118,10 @@ const SpeedTestPanel = memo(function SpeedTestPanel({
           </button>
 
           {expanded && results.length > 1 && (
-            <div className="flex flex-col gap-1 border-t border-line px-3 py-2">
+            <div
+              data-testid="tunnel-speed-test-history"
+              className="flex flex-col gap-1 border-t border-line px-3 py-2"
+            >
               {results.slice(1).map((r) => (
                 <div key={r.id} className="flex items-center justify-between">
                   <Text as="span" size="xs" className="font-mono text-ink-2">

--- a/source/daemon/crates/wardnet-common/src/config.rs
+++ b/source/daemon/crates/wardnet-common/src/config.rs
@@ -32,6 +32,13 @@ pub struct ApplicationConfiguration {
     /// Watchdog settings: the hardware `/dev/watchdog` device and pet cadence
     /// plus the health-gated soft (`sd_notify`) restart toggle. See issue #214.
     pub watchdog: WatchdogConfig,
+    /// Test-only backend overrides. **Never set in production.**
+    ///
+    /// Off by default and not written by `install.sh`; the end-to-end
+    /// compose stack sets `[test] stub_tunnel_backends = true` so the tunnel
+    /// speed-test / tunnel-test path returns deterministic numbers with no
+    /// real `WireGuard` interface or internet egress. See [`TestConfig`].
+    pub test: TestConfig,
     /// Secret-store configuration. **Optional.**
     ///
     /// When absent, no local secret storage is available: tunnels that
@@ -76,6 +83,7 @@ impl Default for ApplicationConfiguration {
             mdns: MdnsConfig::default(),
             health: HealthConfig::default(),
             watchdog: WatchdogConfig::default(),
+            test: TestConfig::default(),
             secret_store: None,
             pidfile_path: default_pidfile_path(),
         }
@@ -786,6 +794,27 @@ impl Default for WatchdogConfig {
             soft_enabled: true,
         }
     }
+}
+
+/// Test-only backend overrides.
+///
+/// The daemon that the end-to-end suite runs is the real production binary,
+/// but the compose stack has no live `WireGuard` tunnel and no guaranteed
+/// internet egress, so the tunnel speed-test / tunnel-test measurement path
+/// has nothing real to measure. Enabling this swaps the `WireGuard` interface,
+/// throughput tester, latency prober and exit probe for deterministic stubs
+/// that return fixed numbers with no kernel or network I/O.
+///
+/// **Never enable in production** — `install.sh` never writes this section,
+/// and every field defaults to off, so a normal deployment behaves exactly
+/// as before.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+pub struct TestConfig {
+    /// When `true`, wire deterministic stub tunnel backends instead of the
+    /// real `WireGuard` / HTTP / ICMP implementations. The speed test and
+    /// tunnel test then report fabricated results. Defaults to `false`.
+    pub stub_tunnel_backends: bool,
 }
 
 /// Pyroscope continuous profiling agent configuration.

--- a/source/daemon/crates/wardnet-common/src/tests/config.rs
+++ b/source/daemon/crates/wardnet-common/src/tests/config.rs
@@ -104,6 +104,34 @@ nordvpn = false
 }
 
 #[test]
+fn stub_tunnel_backends_defaults_off() {
+    // A production config never carries a `[test]` section; the seam must stay
+    // disabled by default so the real WireGuard / HTTP / ICMP backends are used.
+    let config = ApplicationConfiguration::default();
+    assert!(!config.test.stub_tunnel_backends);
+}
+
+#[test]
+fn load_test_stub_tunnel_backends_override() {
+    let dir = std::env::temp_dir().join("wardnet-config-test-section");
+    let _ = std::fs::create_dir_all(&dir);
+    let path = dir.join("wardnet-test-section.toml");
+    std::fs::write(
+        &path,
+        r"
+[test]
+stub_tunnel_backends = true
+",
+    )
+    .unwrap();
+
+    let config = ApplicationConfiguration::load(&path).unwrap();
+    assert!(config.test.stub_tunnel_backends);
+
+    let _ = std::fs::remove_file(&path);
+}
+
+#[test]
 fn load_secret_store_file_system_section() {
     let dir = std::env::temp_dir().join("wardnet-config-secret-store-test");
     let _ = std::fs::create_dir_all(&dir);

--- a/source/daemon/crates/wardnetd/src/lib.rs
+++ b/source/daemon/crates/wardnetd/src/lib.rs
@@ -10,6 +10,8 @@ pub mod inbound_wg_interface_wireguard;
 pub mod packet_capture_pnet;
 pub mod policy_router_netlink;
 mod reqwest_client;
+// Deterministic no-op tunnel backends, wired only under `[test]` config.
+pub mod noop_tunnel_backends;
 pub mod tunnel_exit_probe;
 pub mod tunnel_interface_wireguard;
 pub mod tunnel_latency_prober;

--- a/source/daemon/crates/wardnetd/src/main.rs
+++ b/source/daemon/crates/wardnetd/src/main.rs
@@ -33,6 +33,9 @@ use wardnetd::inbound_wg_interface_wireguard::WireGuardInboundInterface;
 use wardnetd::inbound_wg_peer_monitor::InboundWgPeerMonitor;
 use wardnetd::mdns_advertiser::MdnsAdvertiser;
 use wardnetd::metrics_collector::MetricsCollector;
+use wardnetd::noop_tunnel_backends::{
+    NoopExitProbe, NoopLatencyProber, NoopThroughputTester, NoopTunnelInterface,
+};
 use wardnetd::packet_capture_pnet::PnetCapture;
 use wardnetd::policy_router_netlink::NetlinkPolicyRouter;
 use wardnetd::profiling::ProfilingAgent;
@@ -79,6 +82,16 @@ use wardnetd_services::update::{
     EMBEDDED_PUBLIC_KEY, FsBinaryApplier, HttpsManifestSource, Sha256MinisignVerifier, UpdateRunner,
 };
 use wardnetd_services::{Backends, UpdateBackends, auth_context, init_services_with_factory};
+
+/// The four tunnel network backends the `[test]` config seam selects together:
+/// the real `WireGuard` / HTTP / ICMP implementations in production, or
+/// deterministic stubs when `stub_tunnel_backends` is set.
+type TunnelBackends = (
+    Arc<dyn wardnetd_services::tunnel::TunnelInterface>,
+    Arc<dyn wardnetd_services::tunnel::exit_probe::TunnelExitProbe>,
+    Arc<dyn wardnetd_services::tunnel::latency_prober::TunnelLatencyProber>,
+    Arc<dyn wardnetd_services::tunnel::throughput_tester::ThroughputTester>,
+);
 
 /// Wardnet daemon — self-hosted network privacy gateway.
 #[derive(Parser)]
@@ -341,25 +354,51 @@ async fn run(
     let inbound_wg_interface: Arc<dyn wardnetd_services::InboundWgInterface> =
         Arc::new(WireGuardInboundInterface);
 
+    // Tunnel network backends. In production these are the real WireGuard /
+    // HTTP / ICMP implementations; the `[test]` config seam swaps them for
+    // deterministic stubs so the end-to-end suite can exercise the speed-test
+    // path against a compose stack with no live tunnel or internet egress.
+    let (tunnel_interface, tunnel_exit_probe, tunnel_latency_prober, tunnel_throughput_tester): TunnelBackends =
+        if config.test.stub_tunnel_backends {
+            tracing::warn!(
+                "TEST MODE: [test] stub_tunnel_backends is enabled — tunnel interface, throughput \
+                 tester, latency prober and exit probe are deterministic stubs returning \
+                 fabricated results. This must never be set in production."
+            );
+            (
+                Arc::new(NoopTunnelInterface),
+                Arc::new(NoopExitProbe::new(repo_factory.tunnel())),
+                Arc::new(NoopLatencyProber),
+                Arc::new(NoopThroughputTester),
+            )
+        } else {
+            (
+                Arc::new(WireGuardTunnelInterface),
+                Arc::new(ReqwestTunnelExitProbe::new(
+                    config.tunnel.test_probe_url.clone(),
+                )),
+                Arc::new(SurgePingTunnelLatencyProber::new(
+                    config
+                        .tunnel
+                        .latency_probe_target
+                        .parse()
+                        .expect("tunnel.latency_probe_target must be a valid IP address"),
+                )),
+                Arc::new(HttpThroughputTester::new(
+                    config.tunnel.speed_test_url.clone(),
+                    config.tunnel.speed_test_parallel_streams,
+                    std::time::Duration::from_millis(config.tunnel.speed_test_warmup_ms),
+                    std::time::Duration::from_millis(config.tunnel.speed_test_measure_ms),
+                )),
+            )
+        };
+
     let backends = Backends {
-        tunnel_interface: Arc::new(WireGuardTunnelInterface),
+        tunnel_interface,
         inbound_wg_interface: inbound_wg_interface.clone(),
-        tunnel_exit_probe: Arc::new(ReqwestTunnelExitProbe::new(
-            config.tunnel.test_probe_url.clone(),
-        )),
-        tunnel_latency_prober: Arc::new(SurgePingTunnelLatencyProber::new(
-            config
-                .tunnel
-                .latency_probe_target
-                .parse()
-                .expect("tunnel.latency_probe_target must be a valid IP address"),
-        )),
-        tunnel_throughput_tester: Arc::new(HttpThroughputTester::new(
-            config.tunnel.speed_test_url.clone(),
-            config.tunnel.speed_test_parallel_streams,
-            std::time::Duration::from_millis(config.tunnel.speed_test_warmup_ms),
-            std::time::Duration::from_millis(config.tunnel.speed_test_measure_ms),
-        )),
+        tunnel_exit_probe,
+        tunnel_latency_prober,
+        tunnel_throughput_tester,
         policy_router: Arc::new(
             NetlinkPolicyRouter::new(executor.clone())
                 .expect("failed to initialise netlink policy router"),

--- a/source/daemon/crates/wardnetd/src/noop_tunnel_backends.rs
+++ b/source/daemon/crates/wardnetd/src/noop_tunnel_backends.rs
@@ -1,0 +1,169 @@
+//! Deterministic no-op tunnel backends for end-to-end testing.
+//!
+//! The real daemon runs unchanged in production; these are only wired when
+//! `[test] stub_tunnel_backends = true` is set in `wardnet.toml` (see
+//! [`wardnet_common::config::TestConfig`]). The end-to-end web-ui suite runs
+//! the real binary against a compose stack that has no live `WireGuard` tunnel
+//! and no guaranteed internet egress, so the speed-test / tunnel-test
+//! measurement path has nothing real to measure. Swapping in these no-op
+//! backends makes that path deterministic: fixed throughput and latency
+//! numbers, an instant (fabricated) handshake, and no kernel or network I/O.
+//! They mirror the `wardnetd-mock` backends of the same names, rounded so a
+//! Playwright spec can assert the rendered strings exactly: the tunnel keeps
+//! 90% of a 100 Mbps line and doubles a 10 ms baseline latency.
+//!
+//! Like the real network-bound backends it stands in for, this module is
+//! exercised end-to-end rather than by unit tests, so it is excluded from
+//! coverage. The `noop_` filename prefix is deliberate: it matches the
+//! `noop_.*\.rs` pattern already in the top-level `Makefile`'s `COV_IGNORE`
+//! (the CI coverage gate), so no per-file entry is added to that shared regex
+//! — the same convention the `wardnetd-mock` `noop_*` backends rely on.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use async_trait::async_trait;
+
+use wardnetd_data::repository::TunnelRepository;
+use wardnetd_services::tunnel::exit_probe::{ExitInfo, ProbeError, TunnelExitProbe};
+use wardnetd_services::tunnel::latency_prober::{LatencyProbeError, TunnelLatencyProber};
+use wardnetd_services::tunnel::throughput_tester::{
+    ThroughputError, ThroughputMeasurement, ThroughputTester,
+};
+use wardnetd_services::tunnel::{CreateTunnelParams, TunnelInterface, TunnelStats};
+
+/// Synthetic direct (WAN) throughput, megabits/s.
+const DIRECT_MBPS: f64 = 100.0;
+/// Synthetic through-tunnel throughput, megabits/s (90% of direct).
+const TUNNEL_MBPS: f64 = 90.0;
+/// Synthetic direct (WAN) round-trip latency, milliseconds.
+const DIRECT_LATENCY_MS: u64 = 10;
+/// Synthetic through-tunnel round-trip latency, milliseconds.
+const TUNNEL_LATENCY_MS: u64 = 20;
+
+/// A [`TunnelInterface`] that performs no kernel operations and reports a
+/// fresh handshake, so a speed test can bring a `Down` tunnel "up" (a no-op)
+/// and clear the handshake-readiness gate without a real peer.
+#[derive(Debug, Default, Clone)]
+pub struct NoopTunnelInterface;
+
+#[async_trait]
+impl TunnelInterface for NoopTunnelInterface {
+    async fn create(&self, _params: CreateTunnelParams) -> anyhow::Result<()> {
+        Ok(())
+    }
+
+    async fn bring_up(&self, _interface_name: &str) -> anyhow::Result<()> {
+        Ok(())
+    }
+
+    async fn tear_down(&self, _interface_name: &str) -> anyhow::Result<()> {
+        Ok(())
+    }
+
+    async fn remove(&self, _interface_name: &str) -> anyhow::Result<()> {
+        Ok(())
+    }
+
+    async fn get_stats(&self, _interface_name: &str) -> anyhow::Result<Option<TunnelStats>> {
+        // A current handshake clears `await_fresh_handshake` immediately; the
+        // byte counters are non-zero so per-poll deltas look plausible.
+        Ok(Some(TunnelStats {
+            bytes_tx: 1_000_000,
+            bytes_rx: 3_000_000,
+            last_handshake: Some(chrono::Utc::now()),
+        }))
+    }
+
+    async fn list(&self) -> anyhow::Result<Vec<String>> {
+        Ok(Vec::new())
+    }
+}
+
+/// A [`ThroughputTester`] that returns a fixed rate per leg without any
+/// download: the tunnel leg (`Some(iface)`) is lower than the direct/WAN leg
+/// (`None`), so the comparison always shows retained-but-not-full bandwidth.
+pub struct NoopThroughputTester;
+
+#[async_trait]
+impl ThroughputTester for NoopThroughputTester {
+    async fn download(
+        &self,
+        interface: Option<&str>,
+    ) -> Result<ThroughputMeasurement, ThroughputError> {
+        // A brief feigned transfer so the job spends visible time per leg and
+        // a concurrent run reliably collides with the in-flight guard.
+        tokio::time::sleep(Duration::from_millis(200)).await;
+        let mbps = if interface.is_some() {
+            TUNNEL_MBPS
+        } else {
+            DIRECT_MBPS
+        };
+        Ok(ThroughputMeasurement { mbps })
+    }
+}
+
+/// A [`TunnelLatencyProber`] that returns a fixed RTT per leg. Every sample in
+/// a leg is identical, so the summarised median is the constant and the jitter
+/// is zero — deterministic across runs.
+pub struct NoopLatencyProber;
+
+#[async_trait]
+impl TunnelLatencyProber for NoopLatencyProber {
+    async fn probe(&self, interface_name: Option<&str>) -> Result<u64, LatencyProbeError> {
+        tokio::time::sleep(Duration::from_millis(5)).await;
+        Ok(if interface_name.is_some() {
+            TUNNEL_LATENCY_MS
+        } else {
+            DIRECT_LATENCY_MS
+        })
+    }
+}
+
+/// A [`TunnelExitProbe`] that returns a synthetic public IP plus the tunnel's
+/// stored country code, looked up by interface name. No egress; mirrors the
+/// mock daemon so the tunnel-test flow is deterministic too.
+pub struct NoopExitProbe {
+    tunnels: Arc<dyn TunnelRepository>,
+}
+
+impl NoopExitProbe {
+    #[must_use]
+    pub fn new(tunnels: Arc<dyn TunnelRepository>) -> Self {
+        Self { tunnels }
+    }
+}
+
+#[async_trait]
+impl TunnelExitProbe for NoopExitProbe {
+    async fn probe(&self, interface: &str) -> Result<ExitInfo, ProbeError> {
+        tokio::time::sleep(Duration::from_millis(50)).await;
+
+        let tunnels = self
+            .tunnels
+            .find_all()
+            .await
+            .map_err(|e| ProbeError::Connect(format!("stub probe repo lookup failed: {e}")))?;
+        let tunnel = tunnels
+            .into_iter()
+            .find(|t| t.interface_name == interface)
+            .ok_or_else(|| {
+                ProbeError::Connect(format!(
+                    "stub probe: no tunnel registered for interface '{interface}'"
+                ))
+            })?;
+
+        Ok(ExitInfo {
+            ip: synthetic_ip(&tunnel.id),
+            country_code: tunnel.country_code,
+        })
+    }
+}
+
+/// Map a tunnel id to a stable address in the TEST-NET-2 documentation range
+/// (`198.51.100.0/24`), last octet held to `1..=254` so it never lands on the
+/// network or broadcast address.
+fn synthetic_ip(tunnel_id: &uuid::Uuid) -> String {
+    let last_octet = (u32::from(tunnel_id.as_bytes()[15]) % 254) + 1;
+    format!("198.51.100.{last_octet}")
+}

--- a/source/end2end-tests/web-ui/compose.ui.yaml
+++ b/source/end2end-tests/web-ui/compose.ui.yaml
@@ -110,6 +110,16 @@ services:
           printf '\n[update]\nmanifest_base_url = "http://10.92.0.53:8080/releases"\nhttp_timeout_secs = 5\n' >> /etc/wardnet/wardnet.toml
           echo "wardnetd-ui e2e fixture: pinned update manifest to the cloud mock" >&2
         fi
+        # Swap the tunnel network backends (WireGuard interface, throughput
+        # tester, latency prober, exit probe) for deterministic stubs. The
+        # compose stack has no live tunnel and no guaranteed internet egress,
+        # so the real speed-test / tunnel-test path has nothing to measure;
+        # the stubs return fixed numbers so the tunnel speed-test spec is
+        # deterministic (see issue #691). Idempotent on the [test] key.
+        if ! grep -q '^\[test\]' /etc/wardnet/wardnet.toml; then
+          printf '\n[test]\nstub_tunnel_backends = true\n' >> /etc/wardnet/wardnet.toml
+          echo "wardnetd-ui e2e fixture: enabled stub tunnel backends" >&2
+        fi
         exec /lib/systemd/systemd --log-target=console --log-level=debug --show-status=yes
     networks:
       wardnet_mgmt:

--- a/source/end2end-tests/web-ui/fixtures/tunnels.ts
+++ b/source/end2end-tests/web-ui/fixtures/tunnels.ts
@@ -15,10 +15,17 @@
  * fixtures (see seed.ts for why this harness avoids the source-only SDK).
  */
 
-import { api, ensureAdminSetup } from "./seed";
+import { API_BASE_URL, api, ensureAdminSetup } from "./seed";
 
 /** Label the import→detail→delete lifecycle test creates through the UI. */
 export const TUNNEL_IMPORT_LABEL = "e2e-tunnel-import";
+
+/** Label the admin-site speed-test spec owns (comparison + detail history). */
+export const TUNNEL_SPEED_TEST_LABEL = "e2e-tunnel-speed";
+
+/** Label the admin-app speed-test spec owns. Distinct from the admin-site
+ *  label so the two specs never see each other's card in the shared daemon. */
+export const TUNNEL_SPEED_TEST_APP_LABEL = "e2e-tunnel-speed-app";
 
 /**
  * Label the list-page delete test seeds via the API then deletes through the
@@ -100,4 +107,83 @@ export async function importTunnel(
     }),
   });
   return label;
+}
+
+/**
+ * Import a tunnel and return its daemon-assigned id. The speed-test specs need
+ * the id to drive `POST /tunnels/{id}/speed-test` directly (the concurrency
+ * 409 case and history pre-seeding). Labels are not unique, so callers are
+ * expected to `deleteTestTunnels(label)` first; this returns the id of the
+ * (then only) matching row.
+ */
+export async function importTunnelReturningId(
+  label: string,
+  countryCode = "de",
+): Promise<string> {
+  await importTunnel(label, countryCode);
+  const token = await ensureAdminSetup();
+  const { tunnels } = await api<ListTunnelsResponse>("/tunnels", { token });
+  const found = tunnels.find((t) => t.label === label);
+  if (!found) {
+    throw new Error(`imported tunnel '${label}' not found after create`);
+  }
+  return found.id;
+}
+
+interface JobDispatched {
+  job_id: string;
+}
+
+interface JobState {
+  status: "PENDING" | "RUNNING" | "SUCCEED" | "TERMINATED_WITH_ERRORS";
+}
+
+/**
+ * Dispatch a speed test and return the raw HTTP status without throwing, so a
+ * spec can assert the 409 a concurrent run produces. (`api()` throws on
+ * non-2xx, which would mask the status.)
+ */
+export async function dispatchSpeedTest(
+  token: string,
+  tunnelId: string,
+): Promise<number> {
+  const res = await fetch(`${API_BASE_URL}/tunnels/${tunnelId}/speed-test`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${token}`,
+    },
+  });
+  await res.text(); // Drain the body so the socket is released.
+  return res.status;
+}
+
+/**
+ * Run a speed test to completion via the API: dispatch the job, then poll it
+ * until terminal. Used to pre-seed history rows (e.g. the admin-app expand
+ * case needs a prior run so the latest result has something to expand into).
+ * Throws if the job errors or does not finish in time.
+ */
+export async function runSpeedTest(
+  token: string,
+  tunnelId: string,
+): Promise<void> {
+  const { job_id } = await api<JobDispatched>(
+    `/tunnels/${tunnelId}/speed-test`,
+    { method: "POST", token },
+  );
+
+  const deadline = Date.now() + 30_000;
+  while (Date.now() < deadline) {
+    const job = await api<JobState>(`/jobs/${job_id}`, { token });
+    // Any status other than the two in-flight ones is terminal; surface it
+    // directly rather than polling to the deadline on an unexpected state.
+    if (job.status === "PENDING" || job.status === "RUNNING") {
+      await new Promise((resolve) => setTimeout(resolve, 300));
+      continue;
+    }
+    if (job.status === "SUCCEED") return;
+    throw new Error(`speed test job ${job_id} ended in ${job.status}`);
+  }
+  throw new Error(`speed test job ${job_id} did not complete within 30s`);
 }

--- a/source/end2end-tests/web-ui/tests/admin-app/pages.spec.ts
+++ b/source/end2end-tests/web-ui/tests/admin-app/pages.spec.ts
@@ -34,10 +34,11 @@ import {
  * Two actions are NOT fired, for hard infra reasons documented at their tests:
  *   - Device *reboot* can't recover the compose container (mirrors the
  *     admin-site power.spec, which also avoids reboot/shutdown) — open + cancel.
- *   - Tunnel *rebuild* / *speed test* would run against the only seedable
- *     tunnel, a non-functional dummy (status down, throwaway WireGuard keys),
- *     so firing them is meaningless and flaky — presence + enabled is the
- *     contract.
+ *   - Tunnel *rebuild* would run against the only seedable tunnel, a
+ *     non-functional dummy (status down, throwaway WireGuard keys), so firing
+ *     it is meaningless and flaky — presence + enabled is the contract. (The
+ *     *speed test* is fired end-to-end against the deterministic stub backends
+ *     in tunnel-speed-test.spec.ts; here it too is presence + enabled only.)
  */
 
 const TUNNEL_LABEL = "E2E Test Tunnel";
@@ -158,10 +159,11 @@ test.describe("tunnels", () => {
     await expect(card).toBeVisible();
     await expect(card).toContainText("198.51.100.1");
 
-    // Primary actions are present and actionable. They are NOT fired: the
+    // Primary actions are present and actionable. They are NOT fired here: the
     // only seedable tunnel is a non-functional dummy (status down, throwaway
-    // keys), so a real rebuild / speed test against it is meaningless and
-    // flaky — the contract here is that the controls are wired and enabled.
+    // keys), so a real rebuild against it is meaningless. The speed test's
+    // end-to-end run lives in tunnel-speed-test.spec.ts (deterministic stub
+    // backends); the contract here is that the controls are wired and enabled.
     const speedTest = card.getByTestId("tunnel-speed-test-button");
     await expect(speedTest).toBeVisible();
     await expect(speedTest).toBeEnabled();

--- a/source/end2end-tests/web-ui/tests/admin-app/tunnel-speed-test.spec.ts
+++ b/source/end2end-tests/web-ui/tests/admin-app/tunnel-speed-test.spec.ts
@@ -1,0 +1,64 @@
+import { expect, test } from "@playwright/test";
+
+import { ensureAdminSetup } from "../../fixtures/seed.js";
+import {
+  TUNNEL_SPEED_TEST_APP_LABEL,
+  deleteTestTunnels,
+  importTunnelReturningId,
+  runSpeedTest,
+} from "../../fixtures/tunnels.js";
+
+/**
+ * Admin-app (mobile PWA) per-tunnel speed test coverage (#691).
+ *
+ * The compose daemon runs with `[test] stub_tunnel_backends = true`, so the
+ * speed test returns deterministic numbers (90 of 100 Mbps kept, 20 vs 10 ms).
+ * The mobile card has no tunnel-detail route, so its last-runs history is a
+ * tap-to-expand panel under the latest result rather than a table.
+ *
+ * Runs in the `admin-app` project (seeded daemon + admin storageState).
+ */
+
+test.beforeAll(async () => {
+  await deleteTestTunnels(TUNNEL_SPEED_TEST_APP_LABEL);
+});
+
+test.afterAll(async () => {
+  await deleteTestTunnels(TUNNEL_SPEED_TEST_APP_LABEL);
+});
+
+test("speed test: run from the card, then tap the latest result to expand history", async ({
+  page,
+}) => {
+  const token = await ensureAdminSetup();
+  const id = await importTunnelReturningId(TUNNEL_SPEED_TEST_APP_LABEL);
+  // Seed two prior runs so the latest result has earlier runs to expand into
+  // (the panel only reveals history when more than one result exists).
+  await runSpeedTest(token, id);
+  await runSpeedTest(token, id);
+
+  await page.goto("./tunnels");
+  const card = page
+    .getByTestId("tunnel-card")
+    .filter({ hasText: TUNNEL_SPEED_TEST_APP_LABEL });
+  await expect(card).toBeVisible();
+
+  // ── Run a test from the card ───────────────────────────────────────
+  // The card only fetches its history once a run is requested, so this click
+  // both exercises the button and surfaces the seeded results.
+  await card.getByTestId("tunnel-speed-test-button").click();
+
+  // ── The latest result renders the deterministic stub values ────────
+  const result = card.getByTestId("tunnel-speed-test-result");
+  await expect(result).toBeVisible({ timeout: 20_000 });
+  await expect(result).toContainText("90.0 / 100.0 Mbps");
+  await expect(result).toContainText("20 / 10 ms");
+  await expect(result).toContainText("90% kept");
+
+  // ── History is collapsed until the result is tapped ────────────────
+  await expect(card.getByTestId("tunnel-speed-test-history")).toBeHidden();
+  await result.getByRole("button").click();
+  const history = card.getByTestId("tunnel-speed-test-history");
+  await expect(history).toBeVisible();
+  await expect(history).toContainText("90.0 / 100.0 Mbps");
+});

--- a/source/end2end-tests/web-ui/tests/admin-site/tunnel-speed-test.spec.ts
+++ b/source/end2end-tests/web-ui/tests/admin-site/tunnel-speed-test.spec.ts
@@ -1,0 +1,95 @@
+import { expect, test } from "@playwright/test";
+
+import { ensureAdminSetup } from "../../fixtures/seed.js";
+import {
+  TUNNEL_SPEED_TEST_LABEL,
+  deleteTestTunnels,
+  dispatchSpeedTest,
+  importTunnel,
+  importTunnelReturningId,
+} from "../../fixtures/tunnels.js";
+
+/**
+ * Admin-site per-tunnel speed test coverage (#691, follow-up to #239).
+ *
+ * The daemon under test is the real binary, but the compose stack runs it with
+ * `[test] stub_tunnel_backends = true`, so the throughput tester, latency
+ * prober and (no-op) WireGuard interface return deterministic numbers: the
+ * tunnel keeps 90% of a 100 Mbps line at double the 10 ms direct latency. That
+ * lets these specs assert the rendered comparison exactly, which a real
+ * download through a live tunnel (neither of which exists in CI) never could.
+ *
+ * Runs in the `admin-site` project (seeded daemon + admin storageState).
+ */
+
+// A second label, owned only by the concurrency test, so its rapid-fire runs
+// never collide with the card the UI test acts on.
+const TUNNEL_SPEED_TEST_409_LABEL = "e2e-tunnel-speed-409";
+
+test.beforeAll(async () => {
+  await deleteTestTunnels(TUNNEL_SPEED_TEST_LABEL, TUNNEL_SPEED_TEST_409_LABEL);
+});
+
+test.afterAll(async () => {
+  await deleteTestTunnels(TUNNEL_SPEED_TEST_LABEL, TUNNEL_SPEED_TEST_409_LABEL);
+});
+
+test("speed test: run from the card, see the direct/tunnel comparison and detail history", async ({
+  page,
+}) => {
+  await importTunnel(TUNNEL_SPEED_TEST_LABEL);
+
+  await page.goto("./tunnels");
+  const card = page
+    .getByTestId("tunnel-card")
+    .filter({ hasText: TUNNEL_SPEED_TEST_LABEL });
+  await expect(card).toBeVisible();
+
+  // ── Run the test ───────────────────────────────────────────────────
+  const runButton = card.getByTestId("tunnel-speed-test-button");
+  await expect(runButton).toContainText("Speed test");
+  await runButton.click();
+
+  // ── The inline comparison renders the deterministic stub values ────
+  const result = card.getByTestId("tunnel-speed-test-result");
+  await expect(result).toBeVisible({ timeout: 20_000 });
+  await expect(card.getByTestId("tunnel-speed-test-download")).toHaveText(
+    "90.0 Mbps",
+  );
+  await expect(card.getByTestId("tunnel-speed-test-latency")).toHaveText(
+    "20 ms",
+  );
+  // 90 Mbps tunnel over a 100 Mbps direct baseline → 90% retained.
+  await expect(result).toContainText("90% kept");
+  await expect(result).toContainText("Direct");
+  await expect(result).toContainText("Tunnel");
+
+  // ── Detail page shows the run in the history table ─────────────────
+  await card.getByRole("link").click();
+  await expect(page).toHaveURL(/\/admin\/tunnels\/[0-9a-f-]+$/);
+  const history = page.getByTestId("tunnel-speed-test-history");
+  await expect(history).toBeVisible();
+  await expect(
+    history.getByRole("heading", { name: "Speed test history" }),
+  ).toBeVisible();
+  // tunnel / direct throughput and latency, plus retained percentage.
+  await expect(history).toContainText("90.0 / 100.0 Mbps");
+  await expect(history).toContainText("20 / 10 ms");
+  await expect(history).toContainText("90%");
+});
+
+test("speed test: a concurrent run on the same tunnel returns 409", async ({}) => {
+  const token = await ensureAdminSetup();
+  const id = await importTunnelReturningId(TUNNEL_SPEED_TEST_409_LABEL);
+
+  // Fire two runs at once. The service claims a shared in-flight slot
+  // synchronously before dispatching the job and holds it for the whole run,
+  // so exactly one request wins (202 Accepted) and the other is rejected
+  // (409 Conflict).
+  const statuses = await Promise.all([
+    dispatchSpeedTest(token, id),
+    dispatchSpeedTest(token, id),
+  ]);
+
+  expect(statuses.sort()).toEqual([202, 409]);
+});


### PR DESCRIPTION
Follow-up to #239. Adds end-to-end coverage for the per-tunnel speed test, which #239 deliberately deferred because the measurement path had nothing real to measure in CI.

## The problem

The web-ui e2e harness runs the **real** `wardnetd` against a docker-compose stack, but that stack:

- never brings up a live WireGuard tunnel (the setup wizard only marks the step complete),
- has no guaranteed internet egress (so `speed.cloudflare.com` / `1.1.1.1` are unreliable), and
- offers no way to inject deterministic backends into the production binary.

So "download 10 MB through a live VPN and measure it" can't run as-is.

## Approach

**Config-driven stub seam in the real daemon.** A new `[test]` section in `wardnet.toml` with a single `stub_tunnel_backends` flag. When set, `main.rs` wires deterministic no-op stubs for the tunnel interface, throughput tester, latency prober and exit probe instead of the real WireGuard / HTTP / ICMP implementations. The interface stub is included because a speed test brings a `Down` tunnel up and waits for a handshake — the stub reports a fresh one instantly so the path completes with no real peer.

The flag is **off by default** and is never written by `install.sh`, so production behaviour is unchanged (covered by a config round-trip test). The stubs return fixed numbers — the tunnel keeps 90 of a 100 Mbps line at 20 vs 10 ms — so the rendered comparison is exactly assertable.

**e2e wiring + specs.** The web-ui compose stack appends `[test] stub_tunnel_backends = true` to the daemon config (same idempotent pattern as the existing nordvpn / ddns / update pins). Two Playwright specs, reusing the `data-testid`s from #239 and seeding tunnels through the existing REST fixture:

- **admin-site** — run the test from the tunnel card, assert the direct/tunnel comparison (download, latency, retained %), assert the tunnel-detail history table, and assert a concurrent run returns **409**.
- **admin-app** — run from the mobile card, then tap the latest result to expand the last-runs history (adds the one testid that panel was missing).

The admin-app `pages.spec.ts` note that speed test was "meaningless and flaky to fire" is updated — it now runs deterministically in the dedicated spec.

## Testing

- `cargo test`/`clippy` clean on the touched crates; new config tests cover default-off and the `[test]` override.
- `tsc --noEmit` clean on the e2e specs; admin-app type-check clean.

Closes #691