### PR TITLE
fix(logging): interpolate structured field values into log messages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ LINUX_TARGET := $(CURDIR)/.target-linux
 
 # Coverage: files excluded from cargo-llvm-cov.  Single source of truth —
 # CI calls `make coverage-daemon` with COV_FMT overridden for LCOV output.
-COV_IGNORE := (main\.rs|noop_.*\.rs|db\.rs|web\.rs|api/mod\.rs|auth_context\.rs|command\.rs|policy_router_netlink\.rs|firewall_netlink\.rs|route_monitor\.rs|mdns_advertiser\.rs|pnet_network_probe\.rs|garp_pnet\.rs|tunnel_exit_probe\.rs|tunnel_throughput_tester\.rs|tunnel_latency_prober\.rs|inbound_wg_peer_monitor\.rs|linux_watchdog\.rs|wardnet-test-agent/.*|wardnetd-mock/src/events\.rs|wardnetd-data/src/lib\.rs)
+COV_IGNORE := (main\.rs|noop_.*\.rs|db\.rs|web\.rs|api/mod\.rs|auth_context\.rs|command\.rs|policy_router_netlink\.rs|firewall_netlink\.rs|route_monitor\.rs|mdns_advertiser\.rs|pnet_network_probe\.rs|garp_pnet\.rs|tunnel_exit_probe\.rs|tunnel_throughput_tester\.rs|tunnel_latency_prober\.rs|inbound_wg_peer_monitor\.rs|linux_watchdog\.rs|wardnet-test-agent/.*|wardnet-test-support/.*|wardnetd-mock/src/events\.rs|wardnetd-data/src/lib\.rs)
 # Default: human-readable summary.  CI overrides:
 #   make coverage-daemon COV_FMT="--lcov --output-path ../../coverage/daemon-lcov.info"
 COV_FMT    ?= --summary-only

--- a/source/daemon/Cargo.lock
+++ b/source/daemon/Cargo.lock
@@ -6115,6 +6115,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "wardnet-test-support"
+version = "0.7.0"
+dependencies = [
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "wardnetd"
 version = "0.7.0"
 dependencies = [
@@ -6220,6 +6228,7 @@ dependencies = [
  "tracing",
  "uuid",
  "wardnet-common",
+ "wardnet-test-support",
 ]
 
 [[package]]
@@ -6243,6 +6252,7 @@ dependencies = [
  "tracing-subscriber",
  "uuid",
  "wardnet-common",
+ "wardnet-test-support",
  "wardnetd-api",
  "wardnetd-data",
  "wardnetd-services",
@@ -6298,6 +6308,7 @@ dependencies = [
  "tracing-subscriber",
  "uuid",
  "wardnet-common",
+ "wardnet-test-support",
  "wardnetd-data",
  "web-push-native",
  "wiremock",

--- a/source/daemon/Cargo.toml
+++ b/source/daemon/Cargo.toml
@@ -3,6 +3,7 @@ members = [
     "crates/wardnet-postupgrade",
     "crates/wardnet-postupgrade-runner",
     "crates/wardnet-test-agent",
+    "crates/wardnet-test-support",
     "crates/wardnet-common",
     "crates/wardnetd",
     "crates/wardnetd-api",
@@ -42,6 +43,7 @@ missing_panics_doc = "allow"
 # Internal
 wardnet-common = { path = "crates/wardnet-common" }
 wardnet-postupgrade = { path = "crates/wardnet-postupgrade" }
+wardnet-test-support = { path = "crates/wardnet-test-support" }
 wardnetd-api = { path = "crates/wardnetd-api" }
 wardnetd-data = { path = "crates/wardnetd-data" }
 wardnetd-mock = { path = "crates/wardnetd-mock" }

--- a/source/daemon/crates/wardnet-test-support/Cargo.toml
+++ b/source/daemon/crates/wardnet-test-support/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "wardnet-test-support"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+publish.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]
+# https://crates.io/crates/tracing
+tracing.workspace = true
+# https://crates.io/crates/tracing-subscriber
+tracing-subscriber.workspace = true

--- a/source/daemon/crates/wardnet-test-support/src/lib.rs
+++ b/source/daemon/crates/wardnet-test-support/src/lib.rs
@@ -1,0 +1,69 @@
+//! Shared helpers for daemon unit tests.
+//!
+//! Kept in one crate so tests across the workspace don't each reinvent the
+//! same plumbing. Consumed as a `[dev-dependencies]` entry.
+
+use std::io;
+use std::sync::{Arc, Mutex};
+
+use tracing::subscriber::DefaultGuard;
+use tracing_subscriber::fmt::MakeWriter;
+
+/// A `MakeWriter` that appends everything written to a shared byte buffer.
+#[derive(Clone)]
+struct BufWriter(Arc<Mutex<Vec<u8>>>);
+
+impl io::Write for BufWriter {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.0.lock().unwrap().extend_from_slice(buf);
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+impl<'a> MakeWriter<'a> for BufWriter {
+    type Writer = BufWriter;
+
+    fn make_writer(&'a self) -> Self::Writer {
+        self.clone()
+    }
+}
+
+/// A live in-memory `tracing` capture. Keep it in scope for the duration of
+/// the logging under test — the subscriber is uninstalled when it drops — then
+/// read the accumulated output with [`LogCapture::contents`].
+pub struct LogCapture {
+    buf: Arc<Mutex<Vec<u8>>>,
+    _guard: DefaultGuard,
+}
+
+impl LogCapture {
+    /// The formatted log lines emitted since the capture was installed.
+    #[must_use]
+    pub fn contents(&self) -> String {
+        String::from_utf8(self.buf.lock().unwrap().clone()).unwrap()
+    }
+}
+
+/// Install an in-memory log capture on the current thread up to `max_level`.
+///
+/// Lets a test assert on the *rendered message text* a log line produces — the
+/// part that must carry interpolated field values per `.agents/logging.md`,
+/// not just the structured span fields.
+///
+/// `#[tokio::test]` runs on a current-thread runtime, so the returned capture's
+/// guard stays in effect across `.await` points within the same test body.
+#[must_use]
+pub fn capture_logs(max_level: tracing::Level) -> LogCapture {
+    let buf = Arc::new(Mutex::new(Vec::new()));
+    let subscriber = tracing_subscriber::fmt()
+        .with_max_level(max_level)
+        .without_time()
+        .with_writer(BufWriter(buf.clone()))
+        .finish();
+    let guard = tracing::subscriber::set_default(subscriber);
+    LogCapture { buf, _guard: guard }
+}

--- a/source/daemon/crates/wardnetd-data/Cargo.toml
+++ b/source/daemon/crates/wardnetd-data/Cargo.toml
@@ -46,3 +46,6 @@ libc.workspace = true
 [dev-dependencies]
 # https://crates.io/crates/tokio
 tokio = { workspace = true, features = ["test-util"] }
+# In-memory log capture so tests can assert on rendered message text, not just
+# structured fields.
+wardnet-test-support.workspace = true

--- a/source/daemon/crates/wardnetd-data/src/bootstrap.rs
+++ b/source/daemon/crates/wardnetd-data/src/bootstrap.rs
@@ -60,7 +60,7 @@ pub async fn bootstrap_system_config(
             .await?;
         tracing::info!(
             policy = config_default_policy,
-            "seeded default_policy from config.toml"
+            "seeded default_policy from config.toml: policy={config_default_policy}"
         );
     }
 
@@ -71,7 +71,7 @@ pub async fn bootstrap_system_config(
             "admin"
         };
         system_config.set_wizard_step(initial).await?;
-        tracing::info!(step = initial, "seeded wizard_step");
+        tracing::info!(step = initial, "seeded wizard_step: step={initial}");
     }
 
     Ok(())

--- a/source/daemon/crates/wardnetd-data/src/db.rs
+++ b/source/daemon/crates/wardnetd-data/src/db.rs
@@ -339,7 +339,7 @@ async fn startup_vacuum_if_needed(write: &SqlitePool, db_path: &Path) {
         tracing::debug!(
             freelist,
             threshold = VACUUM_FREELIST_THRESHOLD_PAGES,
-            "legacy auto_vacuum=NONE but freelist under threshold; skipping VACUUM"
+            "legacy auto_vacuum=NONE but freelist ({freelist}) under threshold ({VACUUM_FREELIST_THRESHOLD_PAGES}); skipping VACUUM"
         );
         return;
     }
@@ -351,17 +351,18 @@ async fn startup_vacuum_if_needed(write: &SqlitePool, db_path: &Path) {
             tracing::warn!(
                 db_size,
                 free,
-                "legacy auto_vacuum=NONE database is large and reclaimable, but free disk \
-                 space is < 1.2x DB size; skipping startup VACUUM. Run `sqlite3 {} 'VACUUM;'` \
-                 manually after freeing space.",
+                "legacy auto_vacuum=NONE database is large ({db_size} bytes) and reclaimable, \
+                 but free disk space ({free} bytes) is < 1.2x DB size; skipping startup VACUUM. \
+                 Run `sqlite3 {} 'VACUUM;'` manually after freeing space.",
                 db_path.display(),
             );
             return;
         }
         None => {
             tracing::warn!(
-                "could not determine free disk space on {}; skipping startup VACUUM",
-                parent.display()
+                dir = %parent.display(),
+                "could not determine free disk space on {dir}; skipping startup VACUUM",
+                dir = parent.display()
             );
             return;
         }
@@ -371,7 +372,7 @@ async fn startup_vacuum_if_needed(write: &SqlitePool, db_path: &Path) {
     tracing::info!(
         db_size,
         freelist,
-        "running one-shot VACUUM to migrate database to auto_vacuum=INCREMENTAL"
+        "running one-shot VACUUM to migrate database to auto_vacuum=INCREMENTAL: db_size={db_size}, freelist={freelist}"
     );
     if let Err(e) = sqlx::query("PRAGMA auto_vacuum = INCREMENTAL")
         .execute(write)
@@ -384,11 +385,12 @@ async fn startup_vacuum_if_needed(write: &SqlitePool, db_path: &Path) {
     match sqlx::query("VACUUM").execute(write).await {
         Ok(_) => {
             let new_size = std::fs::metadata(db_path).map_or(db_size, |m| m.len());
+            let elapsed_secs = started.elapsed().as_secs_f64();
             tracing::info!(
-                elapsed_secs = started.elapsed().as_secs_f64(),
+                elapsed_secs,
                 old_size = db_size,
                 new_size,
-                "startup VACUUM complete"
+                "startup VACUUM complete: {db_size} -> {new_size} bytes in {elapsed_secs}s"
             );
         }
         Err(e) => {

--- a/source/daemon/crates/wardnetd-data/src/tests/bootstrap.rs
+++ b/source/daemon/crates/wardnetd-data/src/tests/bootstrap.rs
@@ -229,3 +229,24 @@ async fn bootstrap_system_config_does_not_overwrite_existing_wizard_step() {
         Some("router_mac")
     );
 }
+
+#[tokio::test]
+async fn bootstrap_system_config_seed_logs_name_the_seeded_values() {
+    // On a plain-text backend the seed lines must name *which* policy and step
+    // were written, not just carry them as structured fields — otherwise the
+    // log reads "seeded wizard_step" with no way to tell which one.
+    let capture = wardnet_test_support::capture_logs(tracing::Level::INFO);
+    let repo: Arc<dyn SystemConfigRepository> = Arc::new(MockSystemConfigRepo::new());
+
+    bootstrap_system_config(&repo, "direct").await.unwrap();
+
+    let logs = capture.contents();
+    assert!(
+        logs.contains("seeded default_policy from config.toml: policy=direct"),
+        "default_policy seed line must name the policy, got: {logs}"
+    );
+    assert!(
+        logs.contains("seeded wizard_step: step=admin"),
+        "wizard_step seed line must name the step, got: {logs}"
+    );
+}

--- a/source/daemon/crates/wardnetd-data/src/tests/db.rs
+++ b/source/daemon/crates/wardnetd-data/src/tests/db.rs
@@ -284,6 +284,56 @@ async fn discard_stale_wal_is_a_noop_without_the_marker() {
 }
 
 #[tokio::test]
+async fn startup_vacuum_skip_line_names_the_freelist_and_threshold() {
+    // A legacy `auto_vacuum=NONE` file with a small freelist takes the
+    // skip-VACUUM debug branch. The message must spell out the observed
+    // freelist and the threshold it fell under, not just attach them as
+    // fields — on a plain-text backend "skipping VACUUM" alone says nothing
+    // about why.
+    let dir = std::env::temp_dir();
+    let db = dir.join(format!("wardnet-vacuum-skip-{}.db", Uuid::new_v4()));
+
+    // Pre-create the file with a table under the SQLite default
+    // (`auto_vacuum=NONE`); the existing table locks the mode so the
+    // INCREMENTAL connect pragma init applies afterwards is a no-op and the
+    // startup check sees a genuine legacy database.
+    {
+        let mut conn = SqliteConnectOptions::new()
+            .filename(&db)
+            .create_if_missing(true)
+            .connect()
+            .await
+            .unwrap();
+        sqlx::query("CREATE TABLE __legacy_probe (x INTEGER)")
+            .execute(&mut conn)
+            .await
+            .unwrap();
+        conn.close().await.unwrap();
+    }
+
+    let capture = wardnet_test_support::capture_logs(tracing::Level::DEBUG);
+    let pools = init_db_pools_from_connection_string(db.to_str().unwrap())
+        .await
+        .expect("file-based pool creation should succeed");
+
+    let logs = capture.contents();
+    assert!(
+        logs.contains("under threshold (25000); skipping VACUUM"),
+        "skip line must name the freelist threshold, got: {logs}"
+    );
+    assert!(
+        logs.contains("freelist (0)"),
+        "skip line must name the observed freelist, got: {logs}"
+    );
+
+    pools.write.close().await;
+    pools.read.close().await;
+    for s in ["", "-wal", "-shm"] {
+        let _ = tokio::fs::remove_file(sidecar(&db, s)).await;
+    }
+}
+
+#[tokio::test]
 async fn init_pool_with_path_delegates_to_connection_string() {
     // The legacy `init_pool(&Path)` entrypoint accepts ":memory:" as a path
     // and routes through the same in-memory code path.

--- a/source/daemon/crates/wardnetd-mock/Cargo.toml
+++ b/source/daemon/crates/wardnetd-mock/Cargo.toml
@@ -56,3 +56,7 @@ tracing-subscriber.workspace = true
 uuid.workspace = true
 # https://crates.io/crates/axum
 axum.workspace = true
+
+[dev-dependencies]
+# In-memory log capture for asserting rendered message text in backend tests.
+wardnet-test-support.workspace = true

--- a/source/daemon/crates/wardnetd-mock/src/backends/noop_web_push.rs
+++ b/source/daemon/crates/wardnetd-mock/src/backends/noop_web_push.rs
@@ -18,7 +18,9 @@ impl WebPushSender for NoopWebPushSender {
         tracing::info!(
             endpoint = %target.endpoint,
             payload = %String::from_utf8_lossy(&payload),
-            "mock: pretending to deliver web push",
+            "mock: pretending to deliver web push: endpoint={endpoint}, payload={payload}",
+            endpoint = target.endpoint,
+            payload = String::from_utf8_lossy(&payload),
         );
         SendOutcome::Delivered
     }

--- a/source/daemon/crates/wardnetd-mock/src/tests/backends.rs
+++ b/source/daemon/crates/wardnetd-mock/src/tests/backends.rs
@@ -155,3 +155,37 @@ fn synthetic_rtt_is_in_expected_range() {
 fn synthetic_rtt_is_deterministic() {
     assert_eq!(synthetic_rtt("wg_ward0"), synthetic_rtt("wg_ward0"));
 }
+
+// ── noop web push logging ───────────────────────────────────────────────
+
+use wardnetd_services::push::sender::{PushTarget, VapidKey, WebPushSender};
+
+use crate::backends::noop_web_push::NoopWebPushSender;
+
+#[tokio::test]
+async fn noop_web_push_log_names_the_endpoint_and_payload() {
+    // The mock's delivery line stands in for real push logs during dev runs,
+    // so it must name the endpoint and payload it "sent", not just carry them
+    // as structured fields.
+    let capture = wardnet_test_support::capture_logs(tracing::Level::INFO);
+
+    let vapid = VapidKey::generate();
+    let target = PushTarget {
+        endpoint: "https://push.example.com/mock",
+        p256dh: "p256dh",
+        auth: "auth",
+    };
+    NoopWebPushSender
+        .send(&vapid, target, b"hello-mock".to_vec())
+        .await;
+
+    let logs = capture.contents();
+    assert!(
+        logs.contains("endpoint=https://push.example.com/mock"),
+        "mock log must interpolate the endpoint, got: {logs}"
+    );
+    assert!(
+        logs.contains("payload=hello-mock"),
+        "mock log must interpolate the payload, got: {logs}"
+    );
+}

--- a/source/daemon/crates/wardnetd-services/Cargo.toml
+++ b/source/daemon/crates/wardnetd-services/Cargo.toml
@@ -127,6 +127,8 @@ tempfile.workspace = true
 wiremock.workspace = true
 # https://crates.io/crates/criterion — micro-benchmark harness for the DNS component benches (see benches/)
 criterion.workspace = true
+# In-memory log capture for asserting rendered message text in push tests.
+wardnet-test-support.workspace = true
 
 # Micro-benchmarks for the hot DNS components (cache, and later authoritative
 # view + filter). `harness = false` hands the binary's main() to criterion.

--- a/source/daemon/crates/wardnetd-services/src/push/sender.rs
+++ b/source/daemon/crates/wardnetd-services/src/push/sender.rs
@@ -224,7 +224,7 @@ impl WebPushSender for ReqwestWebPushSender {
             Err(error) => {
                 // A malformed stored subscription can never succeed; treat it as
                 // Gone so the caller prunes it rather than retrying forever.
-                tracing::warn!(%error, endpoint = %endpoint, "push: dropping unbuildable subscription");
+                tracing::warn!(%error, endpoint = %endpoint, "push: dropping unbuildable subscription: endpoint={endpoint}");
                 return SendOutcome::Gone;
             }
         };
@@ -243,15 +243,15 @@ impl WebPushSender for ReqwestWebPushSender {
                 } else if status == reqwest::StatusCode::NOT_FOUND
                     || status == reqwest::StatusCode::GONE
                 {
-                    tracing::debug!(endpoint = %endpoint, %status, "push: subscription gone, pruning");
+                    tracing::debug!(endpoint = %endpoint, %status, "push: subscription gone, pruning: endpoint={endpoint}, status={status}");
                     SendOutcome::Gone
                 } else {
-                    tracing::warn!(endpoint = %endpoint, %status, "push: delivery rejected");
+                    tracing::warn!(endpoint = %endpoint, %status, "push: delivery rejected: endpoint={endpoint}, status={status}");
                     SendOutcome::TransientFailure
                 }
             }
             Err(error) => {
-                tracing::warn!(%error, endpoint = %endpoint, "push: delivery network error");
+                tracing::warn!(%error, endpoint = %endpoint, "push: delivery network error: endpoint={endpoint}");
                 SendOutcome::TransientFailure
             }
         }

--- a/source/daemon/crates/wardnetd-services/src/push/tests.rs
+++ b/source/daemon/crates/wardnetd-services/src/push/tests.rs
@@ -1237,3 +1237,32 @@ fn build_request_rejects_wrong_length_auth() {
         .unwrap_err();
     assert!(err.to_string().contains("16 bytes"), "got {err}");
 }
+
+#[tokio::test]
+async fn send_unbuildable_subscription_warn_names_the_endpoint() {
+    // The drop-on-unbuildable warn must name the offending endpoint in the
+    // message text; on a plain-text backend "dropping unbuildable
+    // subscription" alone gives an operator nothing to act on.
+    let capture = wardnet_test_support::capture_logs(tracing::Level::WARN);
+
+    let sender = ReqwestWebPushSender::new(reqwest::Client::new(), "mailto:a@b.c".to_owned());
+    let vapid = VapidKey::generate();
+    let outcome = sender
+        .send(
+            &vapid,
+            PushTarget {
+                endpoint: "https://push.example.com/x",
+                p256dh: "not-a-valid-point",
+                auth: "YXV0aA",
+            },
+            b"{}".to_vec(),
+        )
+        .await;
+    assert_eq!(outcome, SendOutcome::Gone);
+
+    let logs = capture.contents();
+    assert!(
+        logs.contains("endpoint=https://push.example.com/x"),
+        "warn must interpolate the endpoint, got: {logs}"
+    );
+}

--- a/source/daemon/crates/wardnetd/src/policy_router_netlink.rs
+++ b/source/daemon/crates/wardnetd/src/policy_router_netlink.rs
@@ -200,7 +200,7 @@ impl PolicyRouter for NetlinkPolicyRouter {
                     .any(|a| matches!(a, RouteAttribute::Table(t) if *t == table))
             {
                 if let Err(e) = self.handle.route().del(route).execute().await {
-                    tracing::warn!(table, error = %e, "failed to delete route from table");
+                    tracing::warn!(table, error = %e, "failed to delete route from table {table}: {e}");
                 }
                 return Ok(());
             }


### PR DESCRIPTION
## Summary

`.agents/logging.md` requires that when a log line carries structured fields, the field values must also appear in the message text (via `{field}` interpolation), so lines stay readable on the plain-text/stderr backend where there's no structured-log aggregator to query. A batch of `info!`/`debug!`/`warn!` calls violated this: they attached fields like `policy`, `step`, `freelist`, `db_size`, `endpoint`, `status`, `payload`, and `table` but never named the value in the message, so on stderr they read generically ("seeded wizard_step", "push: delivery rejected", "failed to delete route from table") with no way to tell which entity was involved.

This adds the matching `{field}` token(s) to each message string. The structured field args are left untouched so the JSON/Loki consumers still see them as-is — this is message-text-only.

## Changes

Interpolated the field values into the message for all flagged calls:

- `wardnetd-data/src/bootstrap.rs` — `seeded default_policy` and `seeded wizard_step` now name the policy / step.
- `wardnetd-data/src/db.rs` — the four startup-VACUUM lines (freelist-under-threshold skip, large-DB skip, one-shot VACUUM start, VACUUM complete) now spell out the freelist, threshold, sizes, and elapsed time.
- `wardnetd-services/src/push/sender.rs` — the four delivery lines now name the `endpoint` (and `status` where present).
- `wardnetd-mock/src/backends/noop_web_push.rs` — the mock delivery line names the endpoint and payload.
- `wardnetd/src/policy_router_netlink.rs` — the route-delete failure now names the table and error, matching the interpolation already used in `routing_listener.rs`.

Interpolation captures the in-scope binding (or the threshold const), since `tracing`'s `{name}` resolves against locals in scope rather than the renamed structured-field key; the recorded field set is unchanged.

## Tests

Added log-capture tests that install an in-memory `tracing` subscriber and assert the *rendered message text* carries the interpolated value (not just that the field exists) for a representative call in each unit-testable touched file:

- `bootstrap` seed lines name the policy and step,
- the startup-VACUUM skip line names the freelist and threshold,
- the reqwest push sender's drop-on-unbuildable warn names the endpoint,
- the mock web-push backend line names the endpoint and payload.

The netlink route-delete path is exercised only against a live kernel netlink socket, so it has no unit-level seam; its change mirrors the already-covered `routing_listener.rs` pattern.

`cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, and `cargo test --workspace` all pass.

Closes #844