### PR TITLE
test(e2e): auth-failure paths and admin-coverage matrix

### DIFF
--- a/source/end2end-tests/daemon/tests/auth-coverage.spec.ts
+++ b/source/end2end-tests/daemon/tests/auth-coverage.spec.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import { WardnetClient } from "@wardnet/js";
+
+import { API_BASE_URL, waitForReady } from "./helpers.js";
+
+/**
+ * Admin-coverage matrix: a single table asserting that a representative
+ * slice of the admin API rejects unauthenticated reads with 401.
+ *
+ * The per-feature specs each authenticate first and then exercise their
+ * endpoint, so none of them proves the guard is actually attached. A
+ * dropped `AdminAuth` extractor on a new route — or a router refactor
+ * that mounts a handler outside the guarded layer — would sail through
+ * every one of those specs and only surface in production. This matrix
+ * is the cheap tripwire: one entry per surface, each hit with no
+ * credentials, each expected to be turned away before the handler runs.
+ *
+ * Kept deliberately small and representative (one endpoint per major
+ * subsystem) rather than exhaustive — the goal is to catch a
+ * whole-surface auth regression, not to enumerate every route. Add a row
+ * when a new subsystem's admin surface lands.
+ */
+const ADMIN_ENDPOINTS: ReadonlyArray<{ name: string; path: string }> = [
+  { name: "DHCP config", path: "/dhcp/config" },
+  { name: "DNS config", path: "/dns/config" },
+  { name: "devices list", path: "/devices" },
+  { name: "tunnels list", path: "/tunnels" },
+  { name: "backup status", path: "/backup/status" },
+];
+
+describe("auth — admin endpoints reject unauthenticated reads", () => {
+  beforeAll(async () => {
+    await waitForReady(new WardnetClient({ baseUrl: API_BASE_URL }));
+  }, 120_000);
+
+  it.each(ADMIN_ENDPOINTS)(
+    "GET $path ($name) → 401 without credentials",
+    async ({ path }) => {
+      const res = await fetch(`${API_BASE_URL}${path}`);
+      expect(res.status).toBe(401);
+    },
+  );
+});

--- a/source/end2end-tests/daemon/tests/auth-login.spec.ts
+++ b/source/end2end-tests/daemon/tests/auth-login.spec.ts
@@ -1,10 +1,5 @@
 import { describe, it, expect, beforeAll } from "vitest";
-import {
-  AuthService,
-  SetupService,
-  WardnetApiError,
-  WardnetClient,
-} from "@wardnet/js";
+import { AuthService, SetupService, WardnetClient } from "@wardnet/js";
 
 import {
   ADMIN_PASSWORD,
@@ -19,12 +14,17 @@ import {
  *
  * The happy path (login → bearer → authed call) is exercised all over
  * the suite via `ensureAdminAndLogin`. What's missing is the negative
- * space: a bad password, a call with no credentials at all, and the
- * one-shot nature of setup. Those rejections are load-bearing — they're
- * the difference between "the admin API is locked down" and "it looks
- * locked down until someone omits the header" — so pin them here rather
- * than trusting the unit tests in `auth/tests/` to stand in for the
- * assembled HTTP surface.
+ * space: a bad password, a call carrying a token that doesn't name a
+ * session, and the one-shot nature of setup. Those rejections are
+ * load-bearing — they're the difference between "the admin API is locked
+ * down" and "it looks locked down until someone gets the header wrong" —
+ * so pin them here rather than trusting the unit tests in `auth/tests/`
+ * to stand in for the assembled HTTP surface.
+ *
+ * The missing-credentials case (no header at all) is owned by
+ * `auth-coverage.spec.ts`, which hits every representative admin surface
+ * with no auth; the bad-bearer case below is the complement it doesn't
+ * cover — credentials present but invalid.
  *
  * `beforeAll` runs the idempotent bootstrap so an admin definitely
  * exists; that makes the wrong-password case a genuine "existing admin,
@@ -41,32 +41,19 @@ describe("auth — login and rejection paths", () => {
   }, 180_000);
 
   it("rejects a wrong password with 401", async () => {
-    let caught: unknown;
-    try {
-      await auth.login({
+    await expect(
+      auth.login({
         username: ADMIN_USERNAME,
         password: `${ADMIN_PASSWORD}-not-it`,
-      });
-    } catch (err) {
-      caught = err;
-    }
-    expect(caught).toBeInstanceOf(WardnetApiError);
-    expect((caught as WardnetApiError).status).toBe(401);
+      }),
+    ).rejects.toMatchObject({ name: "WardnetApiError", status: 401 });
   });
 
-  it("rejects an admin endpoint called without a bearer with 401", async () => {
-    // Raw fetch, no Authorization header and no session cookie: the
-    // `AdminAuth` extractor should reject before the handler ever runs.
+  it("rejects an admin endpoint called with a bad bearer with 401", async () => {
+    // A malformed/expired token reaches `validate_session`/`validate_api_key`
+    // and finds nothing, so it must dead-end on the same 401 as no token at
+    // all — a caller can't be allowed to probe for which tokens exist.
     // `/devices` stands in for "any admin-guarded read".
-    const res = await fetch(`${API_BASE_URL}/devices`);
-    expect(res.status).toBe(401);
-  });
-
-  it("rejects a bad bearer token with 401", async () => {
-    // A malformed/expired token is distinct from a missing one — it
-    // reaches `validate_session`/`validate_api_key` and finds nothing.
-    // Both dead ends must land on the same 401 so a caller can't probe
-    // for which tokens exist.
     const res = await fetch(`${API_BASE_URL}/devices`, {
       headers: { Authorization: "Bearer not-a-real-token" },
     });
@@ -80,15 +67,11 @@ describe("auth — login and rejection paths", () => {
     // detail — assert both so a future refactor that swaps the status or
     // drops the message trips here.
     const setup = new SetupService(client);
-    let caught: unknown;
-    try {
-      await setup.setup({ username: "intruder", password: "password123" });
-    } catch (err) {
-      caught = err;
-    }
-    expect(caught).toBeInstanceOf(WardnetApiError);
-    const err = caught as WardnetApiError;
-    expect(err.status).toBe(409);
-    expect(err.body.detail ?? "").toContain("already completed");
+    await expect(
+      setup.setup({ username: "intruder", password: "password123" }),
+    ).rejects.toMatchObject({
+      status: 409,
+      body: { detail: expect.stringContaining("already completed") },
+    });
   });
 });

--- a/source/end2end-tests/daemon/tests/auth-login.spec.ts
+++ b/source/end2end-tests/daemon/tests/auth-login.spec.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import {
+  AuthService,
+  SetupService,
+  WardnetApiError,
+  WardnetClient,
+} from "@wardnet/js";
+
+import {
+  ADMIN_PASSWORD,
+  ADMIN_USERNAME,
+  API_BASE_URL,
+  ensureAdminAndLogin,
+  waitForReady,
+} from "./helpers.js";
+
+/**
+ * Auth-failure paths, over the wire.
+ *
+ * The happy path (login → bearer → authed call) is exercised all over
+ * the suite via `ensureAdminAndLogin`. What's missing is the negative
+ * space: a bad password, a call with no credentials at all, and the
+ * one-shot nature of setup. Those rejections are load-bearing — they're
+ * the difference between "the admin API is locked down" and "it looks
+ * locked down until someone omits the header" — so pin them here rather
+ * than trusting the unit tests in `auth/tests/` to stand in for the
+ * assembled HTTP surface.
+ *
+ * `beforeAll` runs the idempotent bootstrap so an admin definitely
+ * exists; that makes the wrong-password case a genuine "existing admin,
+ * wrong secret" (401 from credential check) rather than a "no admin at
+ * all" accident that could pass for the wrong reason.
+ */
+describe("auth — login and rejection paths", () => {
+  const client = new WardnetClient({ baseUrl: API_BASE_URL });
+  const auth = new AuthService(client);
+
+  beforeAll(async () => {
+    await waitForReady(client);
+    await ensureAdminAndLogin(client);
+  }, 180_000);
+
+  it("rejects a wrong password with 401", async () => {
+    let caught: unknown;
+    try {
+      await auth.login({
+        username: ADMIN_USERNAME,
+        password: `${ADMIN_PASSWORD}-not-it`,
+      });
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(WardnetApiError);
+    expect((caught as WardnetApiError).status).toBe(401);
+  });
+
+  it("rejects an admin endpoint called without a bearer with 401", async () => {
+    // Raw fetch, no Authorization header and no session cookie: the
+    // `AdminAuth` extractor should reject before the handler ever runs.
+    // `/devices` stands in for "any admin-guarded read".
+    const res = await fetch(`${API_BASE_URL}/devices`);
+    expect(res.status).toBe(401);
+  });
+
+  it("rejects a bad bearer token with 401", async () => {
+    // A malformed/expired token is distinct from a missing one — it
+    // reaches `validate_session`/`validate_api_key` and finds nothing.
+    // Both dead ends must land on the same 401 so a caller can't probe
+    // for which tokens exist.
+    const res = await fetch(`${API_BASE_URL}/devices`, {
+      headers: { Authorization: "Bearer not-a-real-token" },
+    });
+    expect(res.status).toBe(401);
+  });
+
+  it("reports setup as already completed once an admin exists", async () => {
+    // Setup is one-shot: `beforeAll` guaranteed an admin, so a second
+    // POST /api/setup must be refused. The daemon guards on
+    // `admins.exists()` and answers 409 with a "setup already completed"
+    // detail — assert both so a future refactor that swaps the status or
+    // drops the message trips here.
+    const setup = new SetupService(client);
+    let caught: unknown;
+    try {
+      await setup.setup({ username: "intruder", password: "password123" });
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(WardnetApiError);
+    const err = caught as WardnetApiError;
+    expect(err.status).toBe(409);
+    expect(err.body.detail ?? "").toContain("already completed");
+  });
+});


### PR DESCRIPTION
## What

Adds the negative auth coverage for the daemon e2e suite (Stage 12 of the e2e roadmap). Every per-feature spec authenticates before touching its endpoint, so nothing in the suite currently proves the admin API rejects the *absence* of credentials. These two specs fill that gap.

## Specs

**`auth-login.spec.ts`** — the login/rejection paths:
- wrong password → `401`
- an admin endpoint hit with a missing bearer → `401`
- an admin endpoint hit with a malformed bearer → `401` (a bad token and no token must dead-end identically, so a caller can't distinguish them)
- `POST /api/setup` refused once an admin exists → `409` with an "already completed" detail

The `beforeAll` runs the idempotent bootstrap so an admin definitely exists — that turns the wrong-password case into a genuine "existing admin, wrong secret" rather than a "no admin at all" pass-for-the-wrong-reason.

**`auth-coverage.spec.ts`** — one table-driven matrix asserting a representative slice of admin endpoints reject unauthenticated reads with `401`:

| endpoint | surface |
| --- | --- |
| `GET /dhcp/config` | DHCP |
| `GET /dns/config` | DNS |
| `GET /devices` | devices |
| `GET /tunnels` | tunnels |
| `GET /backup/status` | backup |

Kept deliberately small — one entry per major subsystem. The point is to catch a whole-surface regression (a dropped `AdminAuth` extractor, or a route mounted outside the guarded layer) that would otherwise slip past every authenticated spec. Add a row when a new subsystem's admin surface lands.

## Notes

No production code changes — tests only. Endpoint status codes and the "setup already completed" message match the existing daemon behavior (`AdminAuth` extractor and `AuthService::setup_admin`).

Closes #250

---
_Generated by [Claude Code](https://claude.ai/code/session_01LiHj2LyfLPwtYVbpV7Gd7L)_