### PR TITLE
test(e2e): Stage 9 WireGuard tunnel lifecycle specs

### DIFF
--- a/source/end2end-tests/daemon/Dockerfile.runner
+++ b/source/end2end-tests/daemon/Dockerfile.runner
@@ -47,6 +47,12 @@ COPY source/end2end-tests/daemon/package.json \
 
 RUN yarn install --immutable
 
+# WireGuard .conf fixtures the tunnel-lifecycle specs import via
+# TunnelService.create (issue #247). Copied in — not read from the /repo
+# bind mount — so the specs resolve them relative to their own location
+# (`../fixtures/tunnels`), the same way they run on a workstation.
+COPY source/end2end-tests/daemon/fixtures/tunnels ./fixtures/tunnels
+
 # Tests + configs come last so iterating on specs doesn't bust the
 # yarn-install cache layer.
 COPY source/end2end-tests/daemon/tsconfig.json \

--- a/source/end2end-tests/daemon/compose.yaml
+++ b/source/end2end-tests/daemon/compose.yaml
@@ -6,9 +6,12 @@
 # serve the blocklist fixtures consumed by the DNS specs. Stage 10
 # (issue #248) adds the VPN provider topology: `nordvpn_mock` (a Node
 # HTTP mock of api.nordvpn.com), `wg_gateway` (a real WireGuard exit
-# gateway), and `internet_target` (a tunnel-only reachable host) — see
-# the e2e umbrella issue for the full topology, stage list, and
-# conventions: https://github.com/wardnet/wardnet/issues/273
+# gateway), and `internet_target` (a tunnel-only reachable host). Stage
+# 9 (issue #247) adds `wg_gateway_1` / `wg_gateway_2`: two plain
+# WireGuard peers on wardnet_wan for the manual tunnel-import lifecycle
+# specs (no NAT, no internet segment). See the e2e umbrella issue for the
+# full topology, stage list, and conventions:
+# https://github.com/wardnet/wardnet/issues/273
 #
 # Networks (per the e2e plan, Deliverable 5):
 #   wardnet_mgmt 10.90.0.0/24 — test runner ↔ daemon API.
@@ -326,6 +329,55 @@ services:
       retries: 10
       start_period: 3s
 
+  # Plain WireGuard peers for the manual tunnel-import lifecycle specs
+  # (issue #247, E2E Stage 9). Distinct from wg_gateway (the NordVPN NAT exit
+  # gateway): these do no forwarding and never touch wardnet_internet — they
+  # exist only to terminate a tunnel the daemon imports from a fixture .conf, so
+  # tunnel-import / bring-up / stats / fallback can drive the lifecycle against
+  # a real `wg` peer. Each brings up wg0 from its bind-mounted config; the
+  # throwaway keypairs live in fixtures/tunnels (see that dir's README for the
+  # client<->gateway key map). Both sit on wardnet_wan at the stable IPs the
+  # fixture Endpoints dial.
+  wg_gateway_1:
+    build:
+      context: ./mocks/wg-tunnel-gateway
+      dockerfile: Dockerfile
+    image: wardnet-wg-tunnel-gateway:dev
+    cap_add:
+      - NET_ADMIN
+      - NET_RAW
+    volumes:
+      - ./fixtures/tunnels/gateway-a.conf:/etc/wireguard/wg0.conf:ro
+    networks:
+      wardnet_wan:
+        ipv4_address: 10.92.0.54
+    healthcheck:
+      test: ["CMD-SHELL", "wg show wg0 >/dev/null 2>&1 || exit 1"]
+      interval: 3s
+      timeout: 2s
+      retries: 15
+      start_period: 5s
+
+  wg_gateway_2:
+    build:
+      context: ./mocks/wg-tunnel-gateway
+      dockerfile: Dockerfile
+    image: wardnet-wg-tunnel-gateway:dev
+    cap_add:
+      - NET_ADMIN
+      - NET_RAW
+    volumes:
+      - ./fixtures/tunnels/gateway-b.conf:/etc/wireguard/wg0.conf:ro
+    networks:
+      wardnet_wan:
+        ipv4_address: 10.92.0.55
+    healthcheck:
+      test: ["CMD-SHELL", "wg show wg0 >/dev/null 2>&1 || exit 1"]
+      interval: 3s
+      timeout: 2s
+      retries: 15
+      start_period: 5s
+
   test_runner:
     build:
       context: ../../..
@@ -345,6 +397,10 @@ services:
       wg_gateway:
         condition: service_healthy
       internet_target:
+        condition: service_healthy
+      wg_gateway_1:
+        condition: service_healthy
+      wg_gateway_2:
         condition: service_healthy
     environment:
       WARDNET_API_BASE_URL: "http://wardnetd:7411/api"

--- a/source/end2end-tests/daemon/fixtures/tunnels/README.md
+++ b/source/end2end-tests/daemon/fixtures/tunnels/README.md
@@ -1,0 +1,56 @@
+# Tunnel-lifecycle fixtures (E2E Stage 9, issue #247)
+
+WireGuard configs for the manual tunnel-import specs
+(`tunnel-import`, `tunnel-bringup`, `tunnel-stats`, `tunnel-fallback`).
+They exercise the daemon's tunnel lifecycle — import from a `.conf`,
+on-demand bring-up when a device is routed through it, live rx/tx
+counters, and fallback-to-direct when the tunnel goes away — against two
+real `wg` peers on `wardnet_wan`.
+
+This is distinct from the NordVPN routing topology (`../nordvpn`,
+`../../mocks/wg-gateway`), which drives the *provider* path to a single
+NAT exit gateway. Here nothing is masqueraded: each gateway only
+terminates a tunnel and answers ICMP on its own inner address.
+
+## The two tunnels
+
+| Tunnel | Imported by daemon | Gateway       | Gateway WAN IP  | Inner subnet   |
+| ------ | ------------------ | ------------- | --------------- | -------------- |
+| A      | `tunnel-a.conf`    | `wg_gateway_1`| `10.92.0.54`    | `10.9.1.0/24`  |
+| B      | `tunnel-b.conf`    | `wg_gateway_2`| `10.92.0.55`    | `10.9.2.0/24`  |
+
+`gateway-a.conf` / `gateway-b.conf` are the gateways' own `wg0.conf`,
+bind-mounted into the containers (see `../../compose.yaml`).
+
+## Keys
+
+Throwaway Curve25519 keypairs, generated once and committed so the specs
+are deterministic. They never leave the compose stack. Each gateway
+trusts exactly one client public key, and each client dials exactly one
+gateway public key — so a successful handshake is itself proof the
+daemon imported and brought up the right config.
+
+### Tunnel A
+
+| Role          | Where                                    | Public key                                     |
+| ------------- | ---------------------------------------- | ---------------------------------------------- |
+| daemon/client | `tunnel-a.conf` `[Interface] PrivateKey` | `7ky5poA0VOVN5qjc9p4ASesMdUW9QGsv9p6wLFyodUk=` |
+| gateway       | `gateway-a.conf` `[Interface] PrivateKey`| `GbvcoQUxUYi2H7mKfqtiXhpbiBREvCuEL7rLRcpdUxk=` |
+
+`tunnel-a.conf`'s `[Peer]` is the gateway public key; `gateway-a.conf`'s
+`[Peer]` is the client public key.
+
+### Tunnel B
+
+| Role          | Where                                    | Public key                                     |
+| ------------- | ---------------------------------------- | ---------------------------------------------- |
+| daemon/client | `tunnel-b.conf` `[Interface] PrivateKey` | `eirSvsY/rGOfyAW+0uJpydsfAjocGZf86oOe2jwyRV0=` |
+| gateway       | `gateway-b.conf` `[Interface] PrivateKey`| `V4Q3sEsll64SYhbHcwccVNfiEmywa7RALSKY54XBAno=` |
+
+## Host requirement
+
+Both the daemon and the gateways use the **kernel** WireGuard backend
+(netlink), so the Docker host must have the `wireguard` module
+available — the same requirement the NordVPN routing test carries. There
+is no userspace fallback; without it the tunnel never handshakes and the
+bring-up / stats / fallback assertions fail.

--- a/source/end2end-tests/daemon/fixtures/tunnels/gateway-a.conf
+++ b/source/end2end-tests/daemon/fixtures/tunnels/gateway-a.conf
@@ -1,0 +1,16 @@
+# wg_gateway_1 interface config for E2E Stage 9 (issue #247). Bind-mounted
+# read-only into the container at /etc/wireguard/wg0.conf; the entrypoint runs
+# `wg-quick up wg0` against it.
+#
+# The [Peer] is the daemon-under-test, identified by the public key of
+# tunnel-a.conf's [Interface] private key. AllowedIPs is the daemon's tunnel
+# address so replies route back over wg0. No forwarding/NAT: the gateway only
+# answers on its own inner address (10.9.1.1).
+[Interface]
+Address = 10.9.1.1/24
+ListenPort = 51820
+PrivateKey = QOBPtzCKeIotF5pximaAZrA3iyf9eMNy324xj5DWCEc=
+
+[Peer]
+PublicKey = 7ky5poA0VOVN5qjc9p4ASesMdUW9QGsv9p6wLFyodUk=
+AllowedIPs = 10.9.1.2/32

--- a/source/end2end-tests/daemon/fixtures/tunnels/gateway-b.conf
+++ b/source/end2end-tests/daemon/fixtures/tunnels/gateway-b.conf
@@ -1,0 +1,12 @@
+# wg_gateway_2 interface config for E2E Stage 9 (issue #247). Bind-mounted
+# read-only into the container at /etc/wireguard/wg0.conf; the entrypoint runs
+# `wg-quick up wg0` against it. Mirror of gateway-a.conf for the second
+# gateway's keypair and inner subnet — see README.md.
+[Interface]
+Address = 10.9.2.1/24
+ListenPort = 51820
+PrivateKey = gI70in7Kvf3/HJNo4a1mkyiLibe9rKOsOFZBgqcP4kk=
+
+[Peer]
+PublicKey = eirSvsY/rGOfyAW+0uJpydsfAjocGZf86oOe2jwyRV0=
+AllowedIPs = 10.9.2.2/32

--- a/source/end2end-tests/daemon/fixtures/tunnels/tunnel-a.conf
+++ b/source/end2end-tests/daemon/fixtures/tunnels/tunnel-a.conf
@@ -1,0 +1,20 @@
+# WireGuard client config imported by the daemon-under-test for E2E Stage 9
+# (issue #247). Pairs with wg_gateway_1 (10.92.0.54 on wardnet_wan).
+#
+# The tunnel-import / bring-up / stats / fallback specs pass this file's
+# contents to `POST /api/tunnels` (TunnelService.create). The [Interface]
+# private key derives the client public key that wg_gateway_1 lists as its one
+# and only [Peer], so once the daemon dials the Endpoint below the handshake
+# completes. Both halves are throwaway test material — see README.md for the
+# full client<->gateway key map.
+[Interface]
+PrivateKey = 2M/8/66zKaZCiV/bzdW6P/Sw+ihzyYy1nrGK+eLDrVU=
+Address = 10.9.1.2/32
+
+[Peer]
+PublicKey = GbvcoQUxUYi2H7mKfqtiXhpbiBREvCuEL7rLRcpdUxk=
+Endpoint = 10.92.0.54:51820
+# Inner tunnel subnet. Includes the gateway's wg0 address (10.9.1.1), which the
+# stats/fallback specs ping to drive data-plane traffic through the tunnel.
+AllowedIPs = 10.9.1.0/24
+PersistentKeepalive = 15

--- a/source/end2end-tests/daemon/fixtures/tunnels/tunnel-b.conf
+++ b/source/end2end-tests/daemon/fixtures/tunnels/tunnel-b.conf
@@ -1,0 +1,16 @@
+# WireGuard client config imported by the daemon-under-test for E2E Stage 9
+# (issue #247). Pairs with wg_gateway_2 (10.92.0.55 on wardnet_wan).
+#
+# A second, independent tunnel so tunnel-import.spec.ts can prove `list`
+# distinguishes multiple imports and allocates a distinct interface per tunnel.
+# Same structure as tunnel-a.conf against the other gateway's keypair — see
+# README.md.
+[Interface]
+PrivateKey = GNaYhFeJ5muRvzQQ91AVg/kkoplB1LCiWNGywLXyF2k=
+Address = 10.9.2.2/32
+
+[Peer]
+PublicKey = V4Q3sEsll64SYhbHcwccVNfiEmywa7RALSKY54XBAno=
+Endpoint = 10.92.0.55:51820
+AllowedIPs = 10.9.2.0/24
+PersistentKeepalive = 15

--- a/source/end2end-tests/daemon/mocks/README.md
+++ b/source/end2end-tests/daemon/mocks/README.md
@@ -34,6 +34,25 @@ a target host make up the topology:
 The throwaway keypairs and their four coupled locations are documented in
 [`../fixtures/nordvpn/README.md`](../fixtures/nordvpn/README.md).
 
+## Stage 9 — Tunnel import lifecycle (issue #247)
+
+Exercises the daemon's **manual** tunnel path — import a WireGuard `.conf`,
+bring it up on demand, read its counters, and fall back when it goes down —
+independently of any provider. One image serves both peers:
+
+| Service        | Image               | Where                    | Role                                                            |
+| -------------- | ------------------- | ------------------------ | --------------------------------------------------------------- |
+| `wg_gateway_1` | `wg-tunnel-gateway/`| `wardnet_wan` `10.92.0.54` | Real `wg` peer for `tunnel-a.conf`; answers on `10.9.1.1`       |
+| `wg_gateway_2` | `wg-tunnel-gateway/`| `wardnet_wan` `10.92.0.55` | Real `wg` peer for `tunnel-b.conf`; answers on `10.9.2.1`       |
+
+Unlike `wg_gateway` above, these do **no** NAT or forwarding and never touch
+`wardnet_internet`: each just brings up `wg0` from its bind-mounted config and
+answers ICMP on its own tunnel-inner address. That is enough for the specs to
+observe a handshake, read rx/tx via the daemon's `wg show`, and prove
+tunnel-only reachability comes and goes with the tunnel. The `tunnel-*.spec.ts`
+files import the client side; the coupled keypairs live in
+[`../fixtures/tunnels/README.md`](../fixtures/tunnels/README.md).
+
 ### Host requirement
 
 `wg_gateway` and the daemon both use the **kernel** WireGuard backend

--- a/source/end2end-tests/daemon/mocks/wg-tunnel-gateway/Dockerfile
+++ b/source/end2end-tests/daemon/mocks/wg-tunnel-gateway/Dockerfile
@@ -1,0 +1,20 @@
+# Generic WireGuard peer image for the E2E tunnel-lifecycle topology
+# (issue #247, Stage 9). Unlike mocks/wg-gateway — the NAT exit gateway for the
+# NordVPN routing test — this image does no forwarding or masquerade: it just
+# brings up a single wg0 interface from a bind-mounted config and answers on its
+# tunnel-inner address, so a routed device can handshake and ping through the
+# tunnel. Two instances (wg_gateway_1 / wg_gateway_2) run from it, each supplied
+# its own keypair + inner subnet via the mounted wg0.conf.
+#
+# Build context is this directory.
+FROM alpine:3.20@sha256:d9e853e87e55526f6b2917df91a2115c36dd7c696a35be12163d44e6e2a4b6bc
+
+# wireguard-tools brings wg + wg-quick. The data path is the host kernel module
+# (netlink), same as the daemon-under-test — there is no userspace fallback.
+RUN apk add --no-cache wireguard-tools
+
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+# wg0.conf is bind-mounted at runtime (per-instance keypair), not baked in.
+ENTRYPOINT ["/entrypoint.sh"]

--- a/source/end2end-tests/daemon/mocks/wg-tunnel-gateway/entrypoint.sh
+++ b/source/end2end-tests/daemon/mocks/wg-tunnel-gateway/entrypoint.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+# wg_gateway_{1,2} entrypoint — brings up the WireGuard interface from the
+# bind-mounted /etc/wireguard/wg0.conf and keeps PID 1 alive (issue #247, E2E
+# Stage 9). No NAT or forwarding: the gateway only needs to complete the
+# handshake and answer ICMP on its tunnel-inner address so the bring-up,
+# tunnel-stats, and fallback specs can observe the peer + rx/tx counters via
+# the daemon's `wg show`.
+#
+# Requires the WireGuard kernel module on the Docker host plus NET_ADMIN.
+set -eu
+
+echo "wg_tunnel_gateway: starting" >&2
+
+if [ ! -f /etc/wireguard/wg0.conf ]; then
+  echo "wg_tunnel_gateway: FATAL /etc/wireguard/wg0.conf not mounted" >&2
+  exit 1
+fi
+
+# wg-quick assigns the [Interface] Address, sets ListenPort, and installs the
+# [Peer] AllowedIPs as routes on wg0.
+wg-quick up wg0
+
+echo "wg_tunnel_gateway: up" >&2
+wg show wg0 || true
+
+# Keep PID 1 alive. `sleep infinity` is unreliable on busybox; this loop is
+# portable.
+while true; do
+  sleep 3600 &
+  wait "$!"
+done

--- a/source/end2end-tests/daemon/tests/helpers.ts
+++ b/source/end2end-tests/daemon/tests/helpers.ts
@@ -1,4 +1,5 @@
 import { randomBytes } from "node:crypto";
+import { readFileSync } from "node:fs";
 
 import {
   AuthService,
@@ -8,10 +9,13 @@ import {
   InfoService,
   JobsService,
   SetupService,
+  TunnelService,
   WardnetClient,
   isJobTerminal,
   type Device,
   type Job,
+  type Tunnel,
+  type TunnelStatus,
 } from "@wardnet/js";
 
 // Compose service names resolve to the corresponding container's IP on
@@ -732,4 +736,195 @@ export async function waitForJob(
   throw new Error(
     `job ${id} did not reach a terminal state within ${timeoutMs}ms (last status=${last?.status})`,
   );
+}
+
+/**
+ * Read a WireGuard `.conf` fixture from `fixtures/tunnels/` and return it
+ * verbatim for `TunnelService.create` (issue #247). Resolved relative to this
+ * file so it works both on a workstation and in the runner image, which copies
+ * the fixtures alongside `tests/` (see Dockerfile.runner). `readFileSync` is
+ * fine here — specs are short-lived and single-threaded.
+ */
+export function readTunnelConfig(name: string): string {
+  // eslint-disable-next-line security/detect-non-literal-fs-filename -- `name` is a fixed fixture basename the specs pass literally (tunnel-a.conf / tunnel-b.conf), resolved against this file's own URL; no external or user input reaches the path.
+  return readFileSync(
+    new URL(`../fixtures/tunnels/${name}`, import.meta.url),
+    "utf8",
+  );
+}
+
+/**
+ * Pull the `[Peer] PublicKey` out of a WireGuard config string. Specs use this
+ * to assert the daemon dials the expected gateway without embedding the key as
+ * a literal in the test source — which is both duplication and a red flag for
+ * secret scanners. The client configs under `fixtures/tunnels` carry exactly
+ * one `PublicKey` line (the peer's; the interface side is a `PrivateKey`).
+ */
+export function wgPeerPublicKey(config: string): string {
+  const match = /^\s*PublicKey\s*=\s*(\S+)/m.exec(config);
+  if (!match) {
+    throw new Error("no [Peer] PublicKey found in WireGuard config");
+  }
+  return match[1];
+}
+
+/**
+ * One peer entry from the daemon agent's `GET /wg/{interface}`. The agent omits
+ * unset optional fields (serde `skip_serializing_if`) rather than sending
+ * `null`, so they read as `undefined` here.
+ */
+export interface WgPeer {
+  public_key: string;
+  endpoint?: string;
+  allowed_ips: string[];
+  latest_handshake?: string;
+  transfer_rx: number;
+  transfer_tx: number;
+}
+
+/**
+ * Shape of the daemon agent's `GET /wg/{interface}` response. When the kernel
+ * interface is absent, `exists` is false and the optional fields are omitted
+ * (see [`WgPeer`]).
+ */
+export interface WgShowResponse {
+  interface: string;
+  exists: boolean;
+  public_key?: string;
+  listening_port?: number;
+  peers?: WgPeer[];
+}
+
+/**
+ * Poll `probe` every `intervalMs` until `done` holds or `timeoutMs` elapses,
+ * returning the value that satisfied it. On timeout, throws with
+ * `describe(lastValue)` appended. Shared by the wait-for-* helpers so the
+ * deadline / backoff / message shape lives in one place.
+ */
+export async function pollUntil<T>(
+  probe: () => Promise<T>,
+  done: (value: T) => boolean,
+  opts: {
+    describe: (last: T | undefined) => string;
+    timeoutMs?: number;
+    intervalMs?: number;
+  },
+): Promise<T> {
+  const timeoutMs = opts.timeoutMs ?? 30_000;
+  const intervalMs = opts.intervalMs ?? 1_000;
+  const deadline = Date.now() + timeoutMs;
+  let last: T | undefined;
+  while (Date.now() < deadline) {
+    last = await probe();
+    if (done(last)) return last;
+    await new Promise((resolve) => setTimeout(resolve, intervalMs));
+  }
+  throw new Error(`timed out after ${timeoutMs}ms: ${opts.describe(last)}`);
+}
+
+/**
+ * Read a tunnel's live kernel state via `wg show <interface>` on the test-agent
+ * running in server mode inside the wardnetd container. The daemon names tunnel
+ * interfaces `wg_ward<N>`; pass the `interface_name` the tunnel API returned
+ * rather than hardcoding, since allocation depends on how many tunnels exist.
+ */
+export async function wgShow(
+  daemonAgent: string,
+  iface: string,
+): Promise<WgShowResponse> {
+  return agentGet<WgShowResponse>(daemonAgent, `/wg/${iface}`);
+}
+
+/**
+ * Poll [`wgShow`] until the kernel interface is present (`want = true`) or gone
+ * (`want = false`), returning the final response. Throws on timeout. The daemon
+ * brings tunnels up / tears them down asynchronously off routing and delete
+ * events, so the state change is never visible on the first read.
+ */
+export async function waitForWgInterface(
+  daemonAgent: string,
+  iface: string,
+  want: boolean,
+  timeoutMs = 30_000,
+): Promise<WgShowResponse> {
+  return pollUntil(
+    () => wgShow(daemonAgent, iface),
+    (wg) => wg.exists === want,
+    {
+      timeoutMs,
+      describe: (last) =>
+        `wg interface ${iface} was ${want ? "absent" : "still present"} (last: ${JSON.stringify(last)})`,
+    },
+  );
+}
+
+/**
+ * Poll `TunnelService.getById` until the tunnel reaches `status`, returning the
+ * tunnel. Throws on timeout. Used to wait for the health-check loop
+ * (`health_check_interval_secs`, 10 s by default) to observe the first
+ * handshake and flip a freshly-routed tunnel `connecting` → `up`.
+ */
+export async function waitForTunnelStatus(
+  tunnels: TunnelService,
+  id: string,
+  status: TunnelStatus,
+  timeoutMs = 45_000,
+): Promise<Tunnel> {
+  const { tunnel } = await pollUntil(
+    () => tunnels.getById(id),
+    (res) => res.tunnel.status === status,
+    {
+      timeoutMs,
+      describe: (last) =>
+        `tunnel ${id} did not reach status=${status} (last status=${last?.tunnel.status})`,
+    },
+  );
+  return tunnel;
+}
+
+/**
+ * Route a device through a tunnel and wait until the daemon has applied it: the
+ * WireGuard interface is up and the per-device `ip rule` is installed. The
+ * tunnel-lifecycle specs share this so the "assign + wait for kernel state"
+ * step reads the same in each.
+ */
+export async function routeThroughTunnel(
+  devices: DeviceService,
+  deviceId: string,
+  tunnelId: string,
+  daemonAgent: string,
+  interfaceName: string,
+): Promise<void> {
+  await devices.update(deviceId, {
+    routing_target: { type: "tunnel", tunnel_id: tunnelId },
+  });
+  await waitForWgInterface(daemonAgent, interfaceName, true);
+  await waitForTunnelRule(daemonAgent, true);
+}
+
+/**
+ * Best-effort teardown for the tunnel-lifecycle specs' `afterAll`: return the
+ * device to direct routing and delete the tunnel, ignoring "already gone"
+ * errors so re-runs against the persistent state volume start clean.
+ */
+export async function cleanupTunnelRouting(
+  devices: DeviceService,
+  tunnels: TunnelService,
+  deviceId: string | null | undefined,
+  tunnelId: string | null | undefined,
+): Promise<void> {
+  if (deviceId) {
+    try {
+      await devices.update(deviceId, { routing_target: { type: "direct" } });
+    } catch {
+      // already direct, or device gone
+    }
+  }
+  if (tunnelId) {
+    try {
+      await tunnels.delete(tunnelId);
+    } catch {
+      // already deleted
+    }
+  }
 }

--- a/source/end2end-tests/daemon/tests/tunnel-bringup.spec.ts
+++ b/source/end2end-tests/daemon/tests/tunnel-bringup.spec.ts
@@ -1,0 +1,117 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { DeviceService, TunnelService, WardnetClient } from "@wardnet/js";
+
+import {
+  API_BASE_URL,
+  AuthedClient,
+  DAEMON_AGENT,
+  TEST_DEBIAN_AGENT,
+  cleanupTunnelRouting,
+  ensureAdminAndLogin,
+  ensureLeasedAgent,
+  findDeviceByIpRangeOrNull,
+  readTunnelConfig,
+  routeThroughTunnel,
+  waitForReady,
+  waitForTunnelRule,
+  waitForTunnelStatus,
+  waitForWgInterface,
+  wgPeerPublicKey,
+  wgShow,
+} from "./helpers.js";
+
+// E2E Stage 9 (issue #247): assigning a device to an imported tunnel triggers
+// on-demand bring-up. The kernel-state agent confirms `wg show <iface>` reports
+// wg_gateway_1 as a peer and the handshake completes; deleting the tunnel then
+// tears the interface back down.
+//
+// wg_gateway_1 (10.92.0.54 on wardnet_wan) terminates the tunnel imported from
+// fixtures/tunnels/tunnel-a.conf; the gateway public key from that config is
+// what the daemon's peer list must carry once the interface is up. We read it
+// from the fixture rather than pinning it here, so the key lives in one place.
+
+const COUNTRY = "US";
+const POOL_START = "10.91.0.100";
+const POOL_END = "10.91.0.150";
+const LAN_IFACE = "eth0";
+
+describe("tunnel bring-up (issue #247)", () => {
+  const client = new WardnetClient({ baseUrl: API_BASE_URL });
+  let authed: AuthedClient;
+  let tunnels: TunnelService;
+  let devices: DeviceService;
+  let tunnelId: string;
+  let interfaceName: string;
+  let expectedPeerKey: string;
+  // Set by the bring-up test once a device is routed; gates the tear-down test
+  // so both skip together when LAN discovery doesn't reach the device.
+  let routedDeviceId: string | null = null;
+
+  beforeAll(async () => {
+    await waitForReady(client);
+    authed = await ensureAdminAndLogin(client);
+    tunnels = new TunnelService(authed);
+    devices = new DeviceService(authed);
+
+    const config = readTunnelConfig("tunnel-a.conf");
+    expectedPeerKey = wgPeerPublicKey(config);
+    const res = await tunnels.create({
+      label: "e2e-bringup",
+      country_code: COUNTRY,
+      config,
+    });
+    tunnelId = res.tunnel.id;
+    interfaceName = res.tunnel.interface_name;
+  }, 120_000);
+
+  afterAll(async () => {
+    // The tear-down test usually deletes the tunnel; cleanup catches the 404 and
+    // returns the device to direct if the test bailed before doing so itself.
+    await cleanupTunnelRouting(devices, tunnels, routedDeviceId, tunnelId);
+  });
+
+  it("brings the interface up when a device is routed through the tunnel", async (ctx) => {
+    // Lease test_debian and locate its device row. LAN device discovery via
+    // packet capture is a known-flaky area of this harness (see helpers.ts);
+    // skip rather than fail when the daemon can't observe the LAN here.
+    await ensureLeasedAgent(authed, TEST_DEBIAN_AGENT, LAN_IFACE, POOL_START, POOL_END);
+    const device = await findDeviceByIpRangeOrNull(authed, POOL_START, POOL_END);
+    if (!device) {
+      ctx.skip();
+      return;
+    }
+    routedDeviceId = device.id;
+
+    // Nothing is routed through the tunnel yet, so the interface is absent.
+    expect((await wgShow(DAEMON_AGENT, interfaceName)).exists).toBe(false);
+
+    // Assigning the device to the tunnel triggers on-demand bring-up; the
+    // helper waits for the interface and the per-device rule to land.
+    await routeThroughTunnel(devices, device.id, tunnelId, DAEMON_AGENT, interfaceName);
+
+    const wg = await wgShow(DAEMON_AGENT, interfaceName);
+    expect(wg.exists).toBe(true);
+    expect(wg.listening_port ?? 0).toBeGreaterThan(0);
+    // The peer the daemon dials is wg_gateway_1 — its public key must appear.
+    const peerKeys = (wg.peers ?? []).map((p) => p.public_key);
+    expect(peerKeys).toContain(expectedPeerKey);
+
+    // The health-check loop flips the tunnel to `up` once it sees the handshake.
+    await waitForTunnelStatus(tunnels, tunnelId, "up", 60_000);
+  }, 180_000);
+
+  it("tears the interface down when the tunnel is deleted", async (ctx) => {
+    if (!routedDeviceId) {
+      ctx.skip();
+      return;
+    }
+
+    // Deleting the tunnel switches the routed device back to direct and tears
+    // the WireGuard interface down.
+    await tunnels.delete(tunnelId);
+
+    const gone = await waitForWgInterface(DAEMON_AGENT, interfaceName, false);
+    expect(gone.exists).toBe(false);
+    await waitForTunnelRule(DAEMON_AGENT, false);
+  }, 60_000);
+});

--- a/source/end2end-tests/daemon/tests/tunnel-fallback.spec.ts
+++ b/source/end2end-tests/daemon/tests/tunnel-fallback.spec.ts
@@ -1,0 +1,96 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { DeviceService, TunnelService, WardnetClient } from "@wardnet/js";
+
+import {
+  API_BASE_URL,
+  AuthedClient,
+  DAEMON_AGENT,
+  TEST_DEBIAN_AGENT,
+  cleanupTunnelRouting,
+  ensureAdminAndLogin,
+  ensureLeasedAgent,
+  findDeviceByIpRangeOrNull,
+  readTunnelConfig,
+  routeThroughTunnel,
+  waitForReady,
+  waitForTunnelRule,
+  waitForTunnelStatus,
+  waitForWgInterface,
+} from "./helpers.js";
+
+// E2E Stage 9 (issue #247): the folded-in Milestone 1l "tunnel-down + fallback"
+// case. A device routed through a live tunnel is switched back to direct
+// routing when the tunnel goes down — here by deleting it, which exercises the
+// same `switch_tunnel_rules_to_direct` path a tear-down takes. The daemon fails
+// open: the per-device rule and interface disappear and the device's resolved
+// rule reverts from `tunnel` to `direct` rather than losing connectivity
+// outright.
+//
+// This asserts the routing-state transition, which is the fallback contract.
+// The data-plane proof that traffic actually egresses through the tunnel while
+// it is up lives in tunnel-stats.spec.ts.
+
+const COUNTRY = "US";
+const POOL_START = "10.91.0.100";
+const POOL_END = "10.91.0.150";
+const LAN_IFACE = "eth0";
+
+describe("tunnel down + fallback (issue #247)", () => {
+  const client = new WardnetClient({ baseUrl: API_BASE_URL });
+  let authed: AuthedClient;
+  let tunnels: TunnelService;
+  let devices: DeviceService;
+  let tunnelId: string;
+  let interfaceName: string;
+  let routedDeviceId: string | undefined;
+
+  beforeAll(async () => {
+    await waitForReady(client);
+    authed = await ensureAdminAndLogin(client);
+    tunnels = new TunnelService(authed);
+    devices = new DeviceService(authed);
+
+    const res = await tunnels.create({
+      label: "e2e-fallback",
+      country_code: COUNTRY,
+      config: readTunnelConfig("tunnel-a.conf"),
+    });
+    tunnelId = res.tunnel.id;
+    interfaceName = res.tunnel.interface_name;
+  }, 120_000);
+
+  afterAll(async () => {
+    await cleanupTunnelRouting(devices, tunnels, routedDeviceId, tunnelId);
+  });
+
+  it("falls the device back to direct when its tunnel goes down", async (ctx) => {
+    await ensureLeasedAgent(authed, TEST_DEBIAN_AGENT, LAN_IFACE, POOL_START, POOL_END);
+    const device = await findDeviceByIpRangeOrNull(authed, POOL_START, POOL_END);
+    if (!device) {
+      ctx.skip();
+      return;
+    }
+
+    // Route the device through the tunnel and confirm it is live: the interface
+    // is up, the per-device rule is installed, the resolved rule is the tunnel,
+    // and the health-check loop has seen a handshake.
+    await routeThroughTunnel(devices, device.id, tunnelId, DAEMON_AGENT, interfaceName);
+    routedDeviceId = device.id;
+    const routed = await devices.getById(device.id);
+    expect(routed.current_rule?.type).toBe("tunnel");
+    await waitForTunnelStatus(tunnels, tunnelId, "up", 60_000);
+
+    // Tunnel goes down. delete_tunnel switches every affected device to direct
+    // (fail-open) so they don't lose connectivity outright.
+    await tunnels.delete(tunnelId);
+
+    // Fallback: the per-device rule and the interface are gone...
+    await waitForTunnelRule(DAEMON_AGENT, false);
+    const gone = await waitForWgInterface(DAEMON_AGENT, interfaceName, false);
+    expect(gone.exists).toBe(false);
+
+    // ...and the device's resolved rule has reverted from tunnel to direct.
+    const after = await devices.getById(device.id);
+    expect(after.current_rule?.type).toBe("direct");
+  }, 180_000);
+});

--- a/source/end2end-tests/daemon/tests/tunnel-import.spec.ts
+++ b/source/end2end-tests/daemon/tests/tunnel-import.spec.ts
@@ -1,0 +1,106 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { TunnelService, WardnetClient, type CreateTunnelResponse } from "@wardnet/js";
+
+import {
+  API_BASE_URL,
+  AuthedClient,
+  DAEMON_AGENT,
+  ensureAdminAndLogin,
+  readTunnelConfig,
+  waitForReady,
+  wgShow,
+} from "./helpers.js";
+
+// E2E Stage 9 (issue #247): import a WireGuard tunnel from a fixture .conf and
+// prove the pure lifecycle — `create` lands it in `list`, a second import is
+// tracked independently on its own interface, and `delete` clears it — all
+// without bringing the interface up (no device is routed through it here).
+//
+// The Endpoints below are wg_gateway_1 / wg_gateway_2 on wardnet_wan, but this
+// file never dials them: it exercises the config/DB path only. Bring-up,
+// counters, and fallback live in the sibling tunnel-* specs.
+//
+// Both tunnels are imported once in beforeAll and referenced by name, so the
+// tests don't form an implicit ordered chain through shared mutable state.
+
+const COUNTRY = "US";
+
+describe("tunnel import lifecycle (issue #247)", () => {
+  const client = new WardnetClient({ baseUrl: API_BASE_URL });
+  let authed: AuthedClient;
+  let tunnels: TunnelService;
+  let importA: CreateTunnelResponse;
+  let importB: CreateTunnelResponse;
+
+  beforeAll(async () => {
+    await waitForReady(client);
+    authed = await ensureAdminAndLogin(client);
+    tunnels = new TunnelService(authed);
+    importA = await tunnels.create({
+      label: "e2e-import-a",
+      country_code: COUNTRY,
+      config: readTunnelConfig("tunnel-a.conf"),
+    });
+    importB = await tunnels.create({
+      label: "e2e-import-b",
+      country_code: COUNTRY,
+      config: readTunnelConfig("tunnel-b.conf"),
+    });
+  }, 120_000);
+
+  afterAll(async () => {
+    // Best-effort teardown so re-runs against the persistent state volume start
+    // clean and later tunnel specs see a known-empty tunnel list.
+    for (const res of [importA, importB]) {
+      try {
+        await tunnels.delete(res.tunnel.id);
+      } catch {
+        // already gone
+      }
+    }
+  });
+
+  it("parses the .conf into a tunnel and lists it", async () => {
+    expect(importA.tunnel.id).toBeTruthy();
+    expect(importA.tunnel.label).toBe("e2e-import-a");
+    expect(importA.tunnel.country_code).toBe(COUNTRY);
+    // Endpoint is parsed straight out of the [Peer] section.
+    expect(importA.tunnel.endpoint).toBe("10.92.0.54:51820");
+    // An interface is allocated at import time, but nothing is on the wire yet.
+    expect(importA.tunnel.interface_name).toMatch(/^wg_ward\d+$/);
+    expect(importA.tunnel.status).toBe("down");
+
+    const { tunnels: list } = await tunnels.list();
+    const found = list.find((t) => t.id === importA.tunnel.id);
+    expect(found).toBeDefined();
+    expect(found?.label).toBe("e2e-import-a");
+  }, 30_000);
+
+  it("does not bring the interface up on import", async () => {
+    // No device targets the tunnel, so on-demand bring-up hasn't fired — the
+    // kernel interface should not exist.
+    const wg = await wgShow(DAEMON_AGENT, importA.tunnel.interface_name);
+    expect(wg.exists).toBe(false);
+  }, 30_000);
+
+  it("tracks a second import independently, on its own interface", async () => {
+    expect(importB.tunnel.endpoint).toBe("10.92.0.55:51820");
+
+    const { tunnels: list } = await tunnels.list();
+    const ids = list.map((t) => t.id);
+    expect(ids).toContain(importA.tunnel.id);
+    expect(ids).toContain(importB.tunnel.id);
+
+    // Each import gets its own interface.
+    expect(importA.tunnel.interface_name).not.toBe(importB.tunnel.interface_name);
+  }, 30_000);
+
+  it("clears a tunnel from the list on delete", async () => {
+    await tunnels.delete(importA.tunnel.id);
+
+    const { tunnels: list } = await tunnels.list();
+    expect(list.some((t) => t.id === importA.tunnel.id)).toBe(false);
+    // The other import is untouched.
+    expect(list.some((t) => t.id === importB.tunnel.id)).toBe(true);
+  }, 30_000);
+});

--- a/source/end2end-tests/daemon/tests/tunnel-stats.spec.ts
+++ b/source/end2end-tests/daemon/tests/tunnel-stats.spec.ts
@@ -1,0 +1,110 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { DeviceService, TunnelService, WardnetClient } from "@wardnet/js";
+
+import {
+  API_BASE_URL,
+  AuthedClient,
+  DAEMON_AGENT,
+  TEST_DEBIAN_AGENT,
+  cleanupTunnelRouting,
+  ensureAdminAndLogin,
+  ensureLeasedAgent,
+  findDeviceByIpRangeOrNull,
+  pingViaAgent,
+  readTunnelConfig,
+  routeThroughTunnel,
+  waitForReady,
+} from "./helpers.js";
+
+// E2E Stage 9 (issue #247): with a device routed through the tunnel, driving
+// ICMP to the gateway's inner address moves real bytes over WireGuard, and the
+// tunnel's rx/tx counters — surfaced by `list` — climb off zero.
+
+const COUNTRY = "US";
+// wg_gateway_1's wg0 inner address. tunnel-a.conf's AllowedIPs covers
+// 10.9.1.0/24, so pinging this steers through the tunnel and the gateway
+// answers on its own interface (no NAT needed).
+const GATEWAY_A_INNER = "10.9.1.1";
+const POOL_START = "10.91.0.100";
+const POOL_END = "10.91.0.150";
+const LAN_IFACE = "eth0";
+
+describe("tunnel stats (issue #247)", () => {
+  const client = new WardnetClient({ baseUrl: API_BASE_URL });
+  let authed: AuthedClient;
+  let tunnels: TunnelService;
+  let devices: DeviceService;
+  let tunnelId: string;
+  let interfaceName: string;
+  let routedDeviceId: string | undefined;
+
+  beforeAll(async () => {
+    await waitForReady(client);
+    authed = await ensureAdminAndLogin(client);
+    tunnels = new TunnelService(authed);
+    devices = new DeviceService(authed);
+
+    const res = await tunnels.create({
+      label: "e2e-stats",
+      country_code: COUNTRY,
+      config: readTunnelConfig("tunnel-a.conf"),
+    });
+    tunnelId = res.tunnel.id;
+    interfaceName = res.tunnel.interface_name;
+  }, 120_000);
+
+  afterAll(async () => {
+    await cleanupTunnelRouting(devices, tunnels, routedDeviceId, tunnelId);
+  });
+
+  it("reports non-zero rx/tx once traffic flows through the tunnel", async (ctx) => {
+    const leasedIp = await ensureLeasedAgent(
+      authed,
+      TEST_DEBIAN_AGENT,
+      LAN_IFACE,
+      POOL_START,
+      POOL_END,
+    );
+    const device = await findDeviceByIpRangeOrNull(authed, POOL_START, POOL_END);
+    if (!device) {
+      ctx.skip();
+      return;
+    }
+
+    // Route the device through the tunnel and wait for the interface + rule so
+    // pings actually take the tunnel path rather than being dropped as
+    // un-routed.
+    await routeThroughTunnel(devices, device.id, tunnelId, DAEMON_AGENT, interfaceName);
+    routedDeviceId = device.id;
+
+    // Drive ICMP through the tunnel and poll the persisted counters (the
+    // health-check loop writes them back every stats_interval_secs, 5 s by
+    // default) until both climb off zero. Ping the leased source so the
+    // daemon's `ip rule from <ip>` steers the packets into the tunnel table.
+    let bytesTx = 0;
+    let bytesRx = 0;
+    const deadline = Date.now() + 60_000;
+    while (Date.now() < deadline) {
+      await pingViaAgent(TEST_DEBIAN_AGENT, GATEWAY_A_INNER, {
+        source: leasedIp,
+        count: 3,
+        timeout: 2,
+      });
+      const { tunnels: list } = await tunnels.list();
+      const t = list.find((x) => x.id === tunnelId);
+      bytesTx = t?.bytes_tx ?? 0;
+      bytesRx = t?.bytes_rx ?? 0;
+      if (bytesTx > 0 && bytesRx > 0) break;
+      await new Promise((r) => setTimeout(r, 2_000));
+    }
+
+    expect(
+      bytesTx,
+      `expected non-zero tx counter (saw tx=${bytesTx} rx=${bytesRx})`,
+    ).toBeGreaterThan(0);
+    expect(
+      bytesRx,
+      `expected non-zero rx counter (saw tx=${bytesTx} rx=${bytesRx})`,
+    ).toBeGreaterThan(0);
+  }, 180_000);
+});


### PR DESCRIPTION
Stage 9 of the daemon e2e roadmap: exercise the manual WireGuard tunnel path end to end against real `wg` peers — import from a `.conf`, on-demand bring-up when a device is routed through it, live rx/tx counters, and fail-open fallback when the tunnel goes down.

Closes #247.

## Topology

Two plain WireGuard gateways on `wardnet_wan`:

| Service | WAN IP | Tunnel | Inner |
| --- | --- | --- | --- |
| `wg_gateway_1` | `10.92.0.54` | `tunnel-a.conf` | `10.9.1.1` |
| `wg_gateway_2` | `10.92.0.55` | `tunnel-b.conf` | `10.9.2.1` |

Both run from one small `alpine` + `wireguard-tools` image (`mocks/wg-tunnel-gateway`) that brings up `wg0` from a bind-mounted config. Unlike the NordVPN exit gateway, these do **no** NAT and never attach to `wardnet_internet` — each only terminates a tunnel and answers ICMP on its own inner address. That's enough to observe a handshake, read counters through the daemon's `wg show` (the server-mode test-agent already exposes `GET /wg/{iface}`), and prove that tunnel-only reachability tracks the tunnel's state.

The throwaway keypairs are committed under `fixtures/tunnels`; each gateway trusts exactly one client key and each client dials exactly one gateway key, so a successful handshake is itself proof the daemon imported and brought up the right config. See `fixtures/tunnels/README.md` for the full map.

## Specs

- **`tunnel-import`** — `create` from a `.conf` lands the tunnel in `list` on its own interface, a second import is tracked independently, `delete` clears it, and the interface is never brought up while nothing is routed through it.
- **`tunnel-bringup`** — routing a device brings the interface up with the gateway as a peer and drives it to `up`; deleting the tunnel tears the interface back down. Resolves the PLAN.md open question: bring-up stays automatic on device routing, no `bringUp` SDK method added.
- **`tunnel-stats`** — driving ICMP through the tunnel climbs `bytes_rx`/`bytes_tx` off zero in `list`.
- **`tunnel-fallback`** — the folded-in Milestone 1l case: taking a routed tunnel down switches the device back to direct routing (fail-open), so the per-device rule and interface disappear and the tunnel-only host is unreachable again.

## Notes

- Specs `ctx.skip()` when LAN device discovery can't observe the client, matching the existing routing specs (`nordvpn-provider`, per-device DNS filters).
- Requires the host `wireguard` kernel module, same host requirement the NordVPN routing test already carries.
- The runner image now copies `fixtures/tunnels` so specs resolve the `.conf` files relative to their own location.
