### PR TITLE
feat(private-dns): admin-site UI, user PWA page, and device onboarding push (#915)

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -15689,6 +15689,167 @@
         }
       }
     },
+    "/api/private-dns/grants/{device_id}/notify": {
+      "post": {
+        "tags": [
+          "private-dns"
+        ],
+        "description": "Send a device-keyed push nudging the granted device's household member to set up Private DNS. The notification deep-links the user PWA to `/private-dns`. Returns `delivered: true` when at least one push subscription for the device was targeted, and `delivered: false` (a 200, not an error) when the device holds a grant but has no subscription — the member simply hasn't enabled notifications yet. Returns 404 when the device has no grant. Admin only.",
+        "operationId": "notify_device",
+        "parameters": [
+          {
+            "name": "device_id",
+            "in": "path",
+            "description": "Device ID",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Notification dispatch result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SendPrivateDnsNotificationResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthenticated - session cookie or API key missing/invalid",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "description": "Standard API error response.",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "detail": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "error": {
+                      "type": "string"
+                    },
+                    "request_id": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "description": "Request ID for correlation with server logs."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden - caller is not an admin",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "description": "Standard API error response.",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "detail": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "error": {
+                      "type": "string"
+                    },
+                    "request_id": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "description": "Request ID for correlation with server logs."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Resource not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "description": "Standard API error response.",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "detail": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "error": {
+                      "type": "string"
+                    },
+                    "request_id": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "description": "Request ID for correlation with server logs."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "description": "Standard API error response.",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "detail": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "error": {
+                      "type": "string"
+                    },
+                    "request_id": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "description": "Request ID for correlation with server logs."
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/private-dns/me": {
       "get": {
         "tags": [
@@ -26088,6 +26249,19 @@
           "approved",
           "rejected"
         ]
+      },
+      "SendPrivateDnsNotificationResponse": {
+        "type": "object",
+        "description": "Response for `POST /api/private-dns/grants/{device_id}/notify` — the result\nof nudging a granted device's household member to set up Private DNS.",
+        "required": [
+          "delivered"
+        ],
+        "properties": {
+          "delivered": {
+            "type": "boolean",
+            "description": "Whether at least one push subscription for the device was targeted.\n`false` (not an error) when the device holds a grant but the household\nmember hasn't enabled notifications, so no subscription exists."
+          }
+        }
       },
       "ServerFilter": {
         "type": "object",

--- a/source/admin-app/vite.config.ts
+++ b/source/admin-app/vite.config.ts
@@ -47,6 +47,18 @@ export default defineConfig({
         target: "http://127.0.0.1:7412",
       },
     },
+    watch: {
+      // Our source workspace packages are Yarn-linked into node_modules, which
+      // Vite's file watcher ignores by default — so edits to @wardnet/web
+      // (shared components/hooks) and @wardnet/js never triggered HMR, only a
+      // server restart picked them up. Un-ignore them so cross-package HMR
+      // works. (They're already excluded from optimizeDeps so Vite reads their
+      // source directly.)
+      ignored: [
+        "!**/node_modules/@wardnet/web/**",
+        "!**/node_modules/@wardnet/js/**",
+      ],
+    },
   },
   optimizeDeps: {
     // CJS deps of the excluded workspace packages (see admin-site/web config).

--- a/source/admin-site/src/components/compound/PrivateDnsGrantsTable.tsx
+++ b/source/admin-site/src/components/compound/PrivateDnsGrantsTable.tsx
@@ -1,0 +1,92 @@
+import { useMemo } from "react";
+import type { ColumnDef } from "@tanstack/react-table";
+import { Text, timeAgo } from "@wardnet/web";
+import { DataTable, RowAction } from "@/components/core/ui/data-table";
+import type { PrivateDnsGrantSummary } from "@wardnet/js";
+
+interface PrivateDnsGrantsTableProps {
+  grants: PrivateDnsGrantSummary[];
+  /** Resolve a device id to a human name for the Device column. */
+  deviceName: (deviceId: string) => string;
+  onSendToDevice: (grant: PrivateDnsGrantSummary) => void;
+  onRevoke: (grant: PrivateDnsGrantSummary) => void;
+}
+
+function buildColumns(
+  deviceName: (deviceId: string) => string,
+): ColumnDef<PrivateDnsGrantSummary>[] {
+  return [
+    {
+      id: "device",
+      header: "Device",
+      cell: ({ row }) => (
+        <Text as="span" weight="medium">
+          {deviceName(row.original.device_id)}
+        </Text>
+      ),
+    },
+    {
+      id: "hostname",
+      header: "Hostname",
+      meta: { className: "hidden md:table-cell" },
+      cell: ({ row }) => (
+        <Text as="span" size="xs" className="font-mono">
+          {row.original.hostname}
+        </Text>
+      ),
+    },
+    {
+      id: "granted",
+      header: "Granted",
+      cell: ({ row }) => (
+        <Text as="span" size="sm" className="text-ink-3">
+          {timeAgo(row.original.created_at)}
+        </Text>
+      ),
+    },
+  ];
+}
+
+/** Per-device Private DNS grants — resend the setup push or revoke, per row.
+ *  Presentational: the page owns the hooks and passes callbacks. */
+export function PrivateDnsGrantsTable({
+  grants,
+  deviceName,
+  onSendToDevice,
+  onRevoke,
+}: PrivateDnsGrantsTableProps) {
+  const columns = useMemo(() => buildColumns(deviceName), [deviceName]);
+
+  if (grants.length === 0) {
+    return (
+      <Text as="p" size="sm" className="py-8 text-center text-ink-3">
+        No devices have Private DNS access yet.
+      </Text>
+    );
+  }
+
+  return (
+    <DataTable
+      columns={columns}
+      data={grants}
+      rowActionsTestId="private-dns-grant-menu"
+      rowActions={(grant) => (
+        <>
+          <RowAction
+            onSelect={() => onSendToDevice(grant)}
+            testId="private-dns-grant-send"
+          >
+            Send to device
+          </RowAction>
+          <RowAction
+            onSelect={() => onRevoke(grant)}
+            destructive
+            testId="private-dns-grant-revoke"
+          >
+            Revoke
+          </RowAction>
+        </>
+      )}
+    />
+  );
+}

--- a/source/admin-site/src/components/features/DeviceSettingsCard.tsx
+++ b/source/admin-site/src/components/features/DeviceSettingsCard.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { Button } from "@wardnet/web";
-import { Form, FormActions, Validator } from "@wardnet/web";
+import { FormActions } from "@wardnet/web";
 import { Text } from "@wardnet/web";
 import {
   Card,
@@ -86,15 +86,16 @@ export function DeviceSettingsCard({
     updateDevice.reset();
   }
 
-  // A managed device is defined by having a name, so a name is required both to
-  // promote an unmanaged device and to keep a managed one managed. The `<Form>`
-  // only fires `onSubmit` once the `required` validator passes, so an empty name
-  // can no longer slip through as a silent no-op.
-  async function handleSave(values: { name: string }) {
+  const trimmedName = name.trim();
+
+  async function handleSave() {
     await updateDevice.mutateAsync({
       id: device.id,
       body: {
-        name: values.name.trim(),
+        // A managed device is defined by having a name. Sending an empty name
+        // leaves the device unmanaged while still persisting routing/type/lock —
+        // so editing an unnamed device's routing works without forcing a name.
+        name: trimmedName || undefined,
         device_type: deviceType,
         routing_target: routingTarget ?? undefined,
         admin_locked: adminLocked,
@@ -103,8 +104,12 @@ export function DeviceSettingsCard({
     setEditing(false);
   }
 
-  const saveLabel = isManaged ? "Save" : "To Managed Device";
-  const savingLabel = isManaged ? "Saving…" : "Promoting…";
+  // Only claim "To Managed Device" when a name will actually make it managed;
+  // otherwise the save just persists settings (the old label promised a
+  // promotion an empty name never delivered).
+  const willPromote = !isManaged && trimmedName !== "";
+  const saveLabel = willPromote ? "To Managed Device" : "Save";
+  const savingLabel = willPromote ? "Promoting…" : "Saving…";
 
   return (
     <Card>
@@ -125,9 +130,15 @@ export function DeviceSettingsCard({
       </CardHeader>
 
       {editing ? (
-        <Form values={{ name }} onSubmit={handleSave}>
+        <>
           <CardContent className="grid grid-cols-1 gap-x-6 gap-y-5 md:grid-cols-2">
-            <Field label="Friendly name" htmlFor="device-name" name="name">
+            <Field
+              label="Friendly name"
+              htmlFor="device-name"
+              help={
+                isManaged ? undefined : "Give the device a name to manage it."
+              }
+            >
               <Input
                 id="device-name"
                 value={name}
@@ -135,11 +146,6 @@ export function DeviceSettingsCard({
                 placeholder={device.hostname ?? device.mac}
               />
             </Field>
-            <Validator
-              name="name"
-              rule="required"
-              message="A name is required to manage this device."
-            />
 
             <Field label="Device type">
               <Select
@@ -197,18 +203,17 @@ export function DeviceSettingsCard({
           <FormActions
             secondaryLabel="Cancel"
             secondaryProps={{
-              type: "button",
               onClick: cancelEdit,
               disabled: updateDevice.isPending,
             }}
             primaryLabel={updateDevice.isPending ? savingLabel : saveLabel}
             primaryProps={{
-              type: "submit",
+              onClick: handleSave,
               disabled: updateDevice.isPending,
               "data-testid": "device-settings-save",
             }}
           />
-        </Form>
+        </>
       ) : (
         <CardContent className="grid grid-cols-1 gap-x-6 gap-y-4 md:grid-cols-2">
           <div className="flex flex-col gap-0.5">

--- a/source/admin-site/src/components/features/DeviceSettingsCard.tsx
+++ b/source/admin-site/src/components/features/DeviceSettingsCard.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { Button } from "@wardnet/web";
-import { FormActions } from "@wardnet/web";
+import { Form, FormActions, Validator } from "@wardnet/web";
 import { Text } from "@wardnet/web";
 import {
   Card,
@@ -86,11 +86,15 @@ export function DeviceSettingsCard({
     updateDevice.reset();
   }
 
-  async function handleSave() {
+  // A managed device is defined by having a name, so a name is required both to
+  // promote an unmanaged device and to keep a managed one managed. The `<Form>`
+  // only fires `onSubmit` once the `required` validator passes, so an empty name
+  // can no longer slip through as a silent no-op.
+  async function handleSave(values: { name: string }) {
     await updateDevice.mutateAsync({
       id: device.id,
       body: {
-        name: name || undefined,
+        name: values.name.trim(),
         device_type: deviceType,
         routing_target: routingTarget ?? undefined,
         admin_locked: adminLocked,
@@ -121,9 +125,9 @@ export function DeviceSettingsCard({
       </CardHeader>
 
       {editing ? (
-        <>
+        <Form values={{ name }} onSubmit={handleSave}>
           <CardContent className="grid grid-cols-1 gap-x-6 gap-y-5 md:grid-cols-2">
-            <Field label="Friendly name" htmlFor="device-name">
+            <Field label="Friendly name" htmlFor="device-name" name="name">
               <Input
                 id="device-name"
                 value={name}
@@ -131,6 +135,11 @@ export function DeviceSettingsCard({
                 placeholder={device.hostname ?? device.mac}
               />
             </Field>
+            <Validator
+              name="name"
+              rule="required"
+              message="A name is required to manage this device."
+            />
 
             <Field label="Device type">
               <Select
@@ -188,17 +197,18 @@ export function DeviceSettingsCard({
           <FormActions
             secondaryLabel="Cancel"
             secondaryProps={{
+              type: "button",
               onClick: cancelEdit,
               disabled: updateDevice.isPending,
             }}
             primaryLabel={updateDevice.isPending ? savingLabel : saveLabel}
             primaryProps={{
-              onClick: handleSave,
+              type: "submit",
               disabled: updateDevice.isPending,
               "data-testid": "device-settings-save",
             }}
           />
-        </>
+        </Form>
       ) : (
         <CardContent className="grid grid-cols-1 gap-x-6 gap-y-4 md:grid-cols-2">
           <div className="flex flex-col gap-0.5">

--- a/source/admin-site/src/components/features/PrivateDnsCard.tsx
+++ b/source/admin-site/src/components/features/PrivateDnsCard.tsx
@@ -1,0 +1,322 @@
+import { useCallback, useMemo, useState } from "react";
+import { CheckCircle2Icon, TriangleAlertIcon, XCircleIcon } from "lucide-react";
+import {
+  Card,
+  CardAction,
+  CardContent,
+  CardHeader,
+  CardTitle,
+  Button,
+  Text,
+  Toggle,
+  deviceDisplayName,
+  useDevices,
+  usePrivateDnsStatus,
+  useSetPrivateDnsEnabled,
+  useGrantPrivateDnsDevice,
+  useRevokePrivateDnsDevice,
+  useSendPrivateDnsToDevice,
+} from "@wardnet/web";
+import type {
+  PrivateDnsGrantSummary,
+  PrivateDnsPrerequisites,
+} from "@wardnet/js";
+import { ConfirmDialog } from "@/components/compound/ConfirmDialog";
+import { DeviceSelect } from "@/components/compound/DeviceSelect";
+import { PrivateDnsGrantsTable } from "@/components/compound/PrivateDnsGrantsTable";
+import { PrivateDnsGrantedModal } from "@/components/features/PrivateDnsGrantedModal";
+
+/**
+ * Private DNS (issue #915) — always mounted on the Remote Access page so the
+ * prerequisite checklist explains what's missing even before a Wardnet hostname
+ * exists. Enabling is gated on three hard prerequisites (wardnet provider, live
+ * certificate, Premium entitlement); the reverse tunnel is informational only.
+ * Once enabled the admin grants managed devices and can push a setup link to
+ * each granted device.
+ */
+export function PrivateDnsCard() {
+  const { data: status, isLoading } = usePrivateDnsStatus();
+  const setEnabled = useSetPrivateDnsEnabled();
+  const grantDevice = useGrantPrivateDnsDevice();
+  const revokeDevice = useRevokePrivateDnsDevice();
+  const sendToDevice = useSendPrivateDnsToDevice();
+  const { data: devicesData } = useDevices();
+
+  const devices = useMemo(
+    () => devicesData?.devices ?? [],
+    [devicesData?.devices],
+  );
+  const deviceById = useMemo(
+    () => new Map(devices.map((d) => [d.id, d])),
+    [devices],
+  );
+  const deviceName = useCallback(
+    (deviceId: string): string => {
+      const device = deviceById.get(deviceId);
+      return device
+        ? deviceDisplayName(device, device.last_ip)
+        : "Unknown device";
+    },
+    [deviceById],
+  );
+
+  // Memoised so the `?? []` fallback can't mint a fresh identity every render
+  // and defeat the `grantable` memo below.
+  const grants = useMemo(() => status?.grants ?? [], [status?.grants]);
+  const enabled = status?.enabled ?? false;
+
+  // Only managed (admin-named) devices can be granted; a granted device drops
+  // out of the picker so the one-grant-per-device guard is never hit.
+  const grantable = useMemo(() => {
+    const grantedIds = new Set(grants.map((g) => g.device_id));
+    return devices.filter((d) => d.name != null && !grantedIds.has(d.id));
+  }, [devices, grants]);
+
+  const [creating, setCreating] = useState(false);
+  const [selectedDeviceId, setSelectedDeviceId] = useState("");
+  const [granted, setGranted] = useState<PrivateDnsGrantSummary | null>(null);
+  const [revokeTarget, setRevokeTarget] =
+    useState<PrivateDnsGrantSummary | null>(null);
+
+  const hardMet = status
+    ? status.prerequisites.wardnet_provider &&
+      status.prerequisites.certificate &&
+      status.prerequisites.entitled
+    : false;
+
+  async function handleGrant() {
+    if (!selectedDeviceId) return;
+    try {
+      const grant = await grantDevice.mutateAsync(selectedDeviceId);
+      setGranted(grant);
+      setCreating(false);
+      setSelectedDeviceId("");
+    } catch {
+      // The mutation's onError already surfaced a toast; keep the panel open so
+      // the admin can retry, and swallow the rejection.
+    }
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Private DNS</CardTitle>
+        <CardAction>
+          <Toggle
+            aria-label="Enable Private DNS"
+            checked={enabled}
+            // Enabling needs every hard prerequisite; disabling is always
+            // allowed.
+            disabled={
+              isLoading || setEnabled.isPending || (!enabled && !hardMet)
+            }
+            onCheckedChange={(next) => setEnabled.mutate(next)}
+          />
+        </CardAction>
+      </CardHeader>
+
+      <CardContent className="flex flex-col gap-5">
+        <Text as="p" size="sm" className="text-ink-3">
+          Let phones resolve DNS through Wardnet everywhere — at home and
+          roaming — with Android Private DNS or an iOS profile. No VPN required.
+        </Text>
+
+        {status && (
+          <PrerequisiteChecklist prerequisites={status.prerequisites} />
+        )}
+
+        {enabled && (
+          <div className="flex flex-col gap-4 border-t border-line pt-5">
+            <div className="flex items-center justify-between">
+              <Text as="h4" size="sm" weight="medium" className="text-ink">
+                Granted devices
+              </Text>
+              {!creating && grantable.length > 0 && (
+                <Button size="sm" onClick={() => setCreating(true)}>
+                  Grant access
+                </Button>
+              )}
+            </div>
+
+            {devices.every((d) => d.name == null) && (
+              <Text as="p" size="sm" className="text-ink-3">
+                Only managed devices can be granted. Name a device on the
+                Devices page, then grant it access here.
+              </Text>
+            )}
+
+            {creating && (
+              <div className="flex flex-col gap-3 rounded-lg border border-line p-4 sm:flex-row sm:items-end">
+                <div className="flex-1">
+                  <Text
+                    as="p"
+                    size="xs"
+                    weight="medium"
+                    className="mb-2 text-ink-3"
+                  >
+                    Device
+                  </Text>
+                  <DeviceSelect
+                    devices={grantable}
+                    value={selectedDeviceId}
+                    onChange={setSelectedDeviceId}
+                    valueKey="id"
+                    includeAny={false}
+                    anyLabel="Choose a device"
+                    emptyLabel="Every managed device already has access."
+                  />
+                </div>
+                <div className="flex gap-2">
+                  <Button
+                    variant="ghost"
+                    onClick={() => {
+                      setCreating(false);
+                      setSelectedDeviceId("");
+                    }}
+                    disabled={grantDevice.isPending}
+                  >
+                    Cancel
+                  </Button>
+                  <Button
+                    onClick={handleGrant}
+                    disabled={!selectedDeviceId || grantDevice.isPending}
+                  >
+                    {grantDevice.isPending ? "Granting…" : "Grant"}
+                  </Button>
+                </div>
+              </div>
+            )}
+
+            <PrivateDnsGrantsTable
+              grants={grants}
+              deviceName={deviceName}
+              onSendToDevice={(grant) => sendToDevice.mutate(grant.device_id)}
+              onRevoke={setRevokeTarget}
+            />
+          </div>
+        )}
+      </CardContent>
+
+      <PrivateDnsGrantedModal
+        grant={granted}
+        deviceName={granted ? deviceName(granted.device_id) : ""}
+        onSendToDevice={(grant) => sendToDevice.mutate(grant.device_id)}
+        sending={sendToDevice.isPending}
+        onDismiss={() => setGranted(null)}
+      />
+
+      <ConfirmDialog
+        open={!!revokeTarget}
+        onOpenChange={(open) => {
+          if (!open) setRevokeTarget(null);
+        }}
+        title="Revoke Private DNS access"
+        description={`This cuts off ${
+          revokeTarget ? deviceName(revokeTarget.device_id) : "this device"
+        } and deletes its hostname. Re-granting later mints a new one.`}
+        confirmLabel="Revoke"
+        onConfirm={() => {
+          if (revokeTarget) revokeDevice.mutate(revokeTarget.device_id);
+          setRevokeTarget(null);
+        }}
+      />
+    </Card>
+  );
+}
+
+const HARD_ROWS: {
+  key: keyof PrivateDnsPrerequisites;
+  label: string;
+  unmetHint: string;
+}[] = [
+  {
+    key: "wardnet_provider",
+    label: "Wardnet hostname",
+    unmetHint:
+      "Requires a Wardnet hostname — set one up under Remote access above.",
+  },
+  {
+    key: "certificate",
+    label: "HTTPS certificate",
+    unmetHint: "No live certificate yet.",
+  },
+  {
+    key: "entitled",
+    label: "Premium subscription",
+    unmetHint: "Private DNS is a Premium feature.",
+  },
+];
+
+/** The three hard gates plus the informational reverse-tunnel row. Reuses the
+ *  Remote Access tone conventions (accent = met, danger = unmet, warning =
+ *  informational). */
+function PrerequisiteChecklist({
+  prerequisites,
+}: {
+  prerequisites: PrivateDnsPrerequisites;
+}) {
+  return (
+    <div
+      className="flex flex-col gap-2"
+      data-testid="private-dns-prerequisites"
+    >
+      {HARD_ROWS.map((row) => (
+        <PrereqRow
+          key={row.key}
+          label={row.label}
+          met={prerequisites[row.key]}
+          hint={prerequisites[row.key] ? undefined : row.unmetHint}
+        />
+      ))}
+      <PrereqRow
+        label="Reverse tunnel"
+        met={prerequisites.relay_connected}
+        informational
+        hint={
+          prerequisites.relay_connected
+            ? undefined
+            : "Not connected — the home network still works; roaming needs this."
+        }
+      />
+    </div>
+  );
+}
+
+function PrereqRow({
+  label,
+  met,
+  hint,
+  informational = false,
+}: {
+  label: string;
+  met: boolean;
+  hint?: string;
+  informational?: boolean;
+}) {
+  const tone = met
+    ? "text-accent-soft-ink"
+    : informational
+      ? "text-warning"
+      : "text-danger-soft-ink";
+  const Icon = met
+    ? CheckCircle2Icon
+    : informational
+      ? TriangleAlertIcon
+      : XCircleIcon;
+
+  return (
+    <div className="flex items-start gap-2">
+      <Icon size={16} className={`mt-0.5 shrink-0 ${tone}`} aria-hidden />
+      <div className="flex flex-col">
+        <Text as="span" size="sm" weight="medium" className="text-ink">
+          {label}
+        </Text>
+        {hint && (
+          <Text as="span" size="xs" className="text-ink-3">
+            {hint}
+          </Text>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/source/admin-site/src/components/features/PrivateDnsGrantedModal.tsx
+++ b/source/admin-site/src/components/features/PrivateDnsGrantedModal.tsx
@@ -1,0 +1,67 @@
+import {
+  Modal,
+  ModalContent,
+  ModalBody,
+  ModalFooter,
+  ModalTitleBlock,
+  Button,
+  PrivateDnsInstructions,
+  privateDnsService,
+} from "@wardnet/web";
+import type { PrivateDnsGrantSummary } from "@wardnet/js";
+
+interface PrivateDnsGrantedModalProps {
+  /** `null` closes the modal. */
+  grant: PrivateDnsGrantSummary | null;
+  /** Human name for the granted device, shown in the title. */
+  deviceName: string;
+  /** Fire the device-keyed setup push. */
+  onSendToDevice: (grant: PrivateDnsGrantSummary) => void;
+  /** Whether a send is in flight (disables the button). */
+  sending: boolean;
+  onDismiss: () => void;
+}
+
+/**
+ * Shown right after a grant. Unlike the WireGuard modal there is no one-time
+ * secret here — the hostname is stable and also lives in the grant table — so
+ * this is a convenience surface: the admin can push the setup link to the
+ * device, or read the hostname/instructions off to the household member.
+ */
+export function PrivateDnsGrantedModal({
+  grant,
+  deviceName,
+  onSendToDevice,
+  sending,
+  onDismiss,
+}: PrivateDnsGrantedModalProps) {
+  if (!grant) return null;
+
+  return (
+    <Modal open onOpenChange={(next) => !next && onDismiss()}>
+      <ModalContent>
+        <ModalTitleBlock
+          title={`Private DNS granted - ${deviceName}`}
+          description="Set this up on the device below, or send it straight there. The hostname stays available in the grants table."
+        />
+        <ModalBody>
+          <PrivateDnsInstructions
+            hostname={grant.hostname}
+            profileUrl={privateDnsService.profileUrl()}
+          />
+        </ModalBody>
+        <ModalFooter>
+          <Button
+            variant="outline"
+            onClick={() => onSendToDevice(grant)}
+            disabled={sending}
+            data-testid="private-dns-modal-send"
+          >
+            {sending ? "Sending…" : "Send to device"}
+          </Button>
+          <Button onClick={onDismiss}>Done</Button>
+        </ModalFooter>
+      </ModalContent>
+    </Modal>
+  );
+}

--- a/source/admin-site/src/pages/RemoteAccess.tsx
+++ b/source/admin-site/src/pages/RemoteAccess.tsx
@@ -26,6 +26,7 @@ import {
   useTlsStatus,
 } from "@wardnet/web";
 import { PageHeader } from "@/components/compound/PageHeader";
+import { PrivateDnsCard } from "@/components/features/PrivateDnsCard";
 import { RemoteAccessStatus } from "@/components/features/RemoteAccessStatus";
 import {
   CloudflareFields,
@@ -308,6 +309,8 @@ export default function RemoteAccess() {
           <CardFooter className="justify-end gap-2">{formActions}</CardFooter>
         </Card>
       )}
+
+      <PrivateDnsCard />
 
       {configured && (
         <Card style={{ background: "var(--danger-soft)" }}>

--- a/source/admin-site/tests/components/compound/PrivateDnsGrantsTable.test.tsx
+++ b/source/admin-site/tests/components/compound/PrivateDnsGrantsTable.test.tsx
@@ -1,0 +1,41 @@
+import { screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import type { PrivateDnsGrantSummary } from "@wardnet/js";
+import { PrivateDnsGrantsTable } from "@/components/compound/PrivateDnsGrantsTable";
+import { renderWithProviders } from "../../test-utils";
+
+const grant: PrivateDnsGrantSummary = {
+  id: "g1",
+  device_id: "d1",
+  hostname: "tok.abc.my.wardnet.services",
+  created_at: "2026-07-21T00:00:00Z",
+};
+
+describe("PrivateDnsGrantsTable", () => {
+  it("shows an empty state when there are no grants", () => {
+    renderWithProviders(
+      <PrivateDnsGrantsTable
+        grants={[]}
+        deviceName={() => "x"}
+        onSendToDevice={vi.fn()}
+        onRevoke={vi.fn()}
+      />,
+    );
+    expect(
+      screen.getByText(/No devices have Private DNS access yet/),
+    ).toBeInTheDocument();
+  });
+
+  it("renders the resolved device name and hostname", () => {
+    renderWithProviders(
+      <PrivateDnsGrantsTable
+        grants={[grant]}
+        deviceName={(id) => (id === "d1" ? "Alice phone" : "?")}
+        onSendToDevice={vi.fn()}
+        onRevoke={vi.fn()}
+      />,
+    );
+    expect(screen.getByText("Alice phone")).toBeInTheDocument();
+    expect(screen.getByText("tok.abc.my.wardnet.services")).toBeInTheDocument();
+  });
+});

--- a/source/admin-site/tests/components/compound/PrivateDnsGrantsTable.test.tsx
+++ b/source/admin-site/tests/components/compound/PrivateDnsGrantsTable.test.tsx
@@ -1,4 +1,5 @@
 import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 import type { PrivateDnsGrantSummary } from "@wardnet/js";
 import { PrivateDnsGrantsTable } from "@/components/compound/PrivateDnsGrantsTable";
@@ -37,5 +38,27 @@ describe("PrivateDnsGrantsTable", () => {
     );
     expect(screen.getByText("Alice phone")).toBeInTheDocument();
     expect(screen.getByText("tok.abc.my.wardnet.services")).toBeInTheDocument();
+  });
+
+  it("fires the send and revoke callbacks from the row menu", async () => {
+    const user = userEvent.setup();
+    const onSendToDevice = vi.fn();
+    const onRevoke = vi.fn();
+    renderWithProviders(
+      <PrivateDnsGrantsTable
+        grants={[grant]}
+        deviceName={() => "Alice"}
+        onSendToDevice={onSendToDevice}
+        onRevoke={onRevoke}
+      />,
+    );
+
+    await user.click(screen.getByTestId("private-dns-grant-menu"));
+    await user.click(await screen.findByTestId("private-dns-grant-send"));
+    expect(onSendToDevice).toHaveBeenCalledWith(grant);
+
+    await user.click(screen.getByTestId("private-dns-grant-menu"));
+    await user.click(await screen.findByTestId("private-dns-grant-revoke"));
+    expect(onRevoke).toHaveBeenCalledWith(grant);
   });
 });

--- a/source/admin-site/tests/components/features/DeviceSettingsCard.test.tsx
+++ b/source/admin-site/tests/components/features/DeviceSettingsCard.test.tsx
@@ -5,6 +5,21 @@ import { DeviceSettingsCard } from "@/components/features/DeviceSettingsCard";
 import { makeDevice, renderWithProviders } from "../../test-utils";
 import type { RoutingTarget, Tunnel } from "@wardnet/js";
 
+// Radix primitives (Select) measure their trigger in a layout effect; jsdom has
+// no ResizeObserver / pointer-capture, so stub them as elsewhere in the suite.
+Element.prototype.hasPointerCapture ??= () => false;
+Element.prototype.setPointerCapture ??= () => {};
+Element.prototype.releasePointerCapture ??= () => {};
+Element.prototype.scrollIntoView ??= () => {};
+vi.stubGlobal(
+  "ResizeObserver",
+  class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  },
+);
+
 vi.mock("@wardnet/web", async (importOriginal) => {
   const actual = await importOriginal<Record<string, unknown>>();
   return { ...actual, useTunnels: vi.fn(), useUpdateDevice: vi.fn() };
@@ -160,6 +175,61 @@ describe("DeviceSettingsCard editing", () => {
     expect(
       screen.getByRole("button", { name: "To Managed Device" }),
     ).toBeInTheDocument();
+  });
+
+  it("blocks promoting an unmanaged device without a name and says why on submit", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(
+      <DeviceSettingsCard
+        device={makeDevice({ name: null })}
+        currentRule={null}
+      />,
+    );
+    await user.click(screen.getByTestId("device-settings-edit"));
+    // The error is not shown just for entering edit mode.
+    expect(screen.queryByText(/name is required/i)).not.toBeInTheDocument();
+    // The whole point of the bug: promoting with an empty name used to "succeed"
+    // as a silent no-op. Submitting surfaces the requirement and blocks the save.
+    await user.click(screen.getByTestId("device-settings-save"));
+    expect(await screen.findByText(/name is required/i)).toBeInTheDocument();
+    expect(mutateAsync).not.toHaveBeenCalled();
+  });
+
+  it("enables promotion and sends the name once one is entered", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(
+      <DeviceSettingsCard
+        device={makeDevice({ name: null })}
+        currentRule={null}
+      />,
+    );
+    await user.click(screen.getByTestId("device-settings-edit"));
+    await user.type(screen.getByLabelText("Friendly name"), "Alice phone");
+    const save = screen.getByRole("button", { name: "To Managed Device" });
+    expect(save).toBeEnabled();
+    await user.click(save);
+    await waitFor(() => expect(mutateAsync).toHaveBeenCalled());
+    expect(mutateAsync).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: "dev-1",
+        body: expect.objectContaining({ name: "Alice phone" }),
+      }),
+    );
+  });
+
+  it("blocks blanking the name of an already-managed device on submit", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(
+      <DeviceSettingsCard
+        device={makeDevice({ name: "TV" })}
+        currentRule={null}
+      />,
+    );
+    await user.click(screen.getByTestId("device-settings-edit"));
+    await user.clear(screen.getByLabelText("Friendly name"));
+    await user.click(screen.getByTestId("device-settings-save"));
+    expect(await screen.findByText(/name is required/i)).toBeInTheDocument();
+    expect(mutateAsync).not.toHaveBeenCalled();
   });
 
   it("shows the saving label and error alert while pending", async () => {

--- a/source/admin-site/tests/components/features/DeviceSettingsCard.test.tsx
+++ b/source/admin-site/tests/components/features/DeviceSettingsCard.test.tsx
@@ -163,7 +163,7 @@ describe("DeviceSettingsCard editing", () => {
     });
   });
 
-  it("uses promote copy for an unmanaged device", async () => {
+  it("labels the save 'Save' until a name will actually promote the device", async () => {
     const user = userEvent.setup();
     renderWithProviders(
       <DeviceSettingsCard
@@ -172,12 +172,18 @@ describe("DeviceSettingsCard editing", () => {
       />,
     );
     await user.click(screen.getByTestId("device-settings-edit"));
+    // No name yet — saving just persists settings, so it isn't a "promotion",
+    // and the form hints how to manage the device.
+    expect(screen.getByRole("button", { name: "Save" })).toBeInTheDocument();
+    expect(screen.getByText(/name to manage it/i)).toBeInTheDocument();
+    // Entering a name turns the save into an actual promotion.
+    await user.type(screen.getByLabelText("Friendly name"), "Alice phone");
     expect(
       screen.getByRole("button", { name: "To Managed Device" }),
     ).toBeInTheDocument();
   });
 
-  it("blocks promoting an unmanaged device without a name and says why on submit", async () => {
+  it("saves an unnamed device's settings without forcing a name", async () => {
     const user = userEvent.setup();
     renderWithProviders(
       <DeviceSettingsCard
@@ -186,16 +192,19 @@ describe("DeviceSettingsCard editing", () => {
       />,
     );
     await user.click(screen.getByTestId("device-settings-edit"));
-    // The error is not shown just for entering edit mode.
-    expect(screen.queryByText(/name is required/i)).not.toBeInTheDocument();
-    // The whole point of the bug: promoting with an empty name used to "succeed"
-    // as a silent no-op. Submitting surfaces the requirement and blocks the save.
+    // The whole regression: changing routing/settings on an unnamed device must
+    // still save (it just doesn't promote); `name` is omitted, not blocked.
     await user.click(screen.getByTestId("device-settings-save"));
-    expect(await screen.findByText(/name is required/i)).toBeInTheDocument();
-    expect(mutateAsync).not.toHaveBeenCalled();
+    await waitFor(() => expect(mutateAsync).toHaveBeenCalled());
+    expect(mutateAsync).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: "dev-1",
+        body: expect.objectContaining({ name: undefined }),
+      }),
+    );
   });
 
-  it("enables promotion and sends the name once one is entered", async () => {
+  it("promotes and sends the name once one is entered", async () => {
     const user = userEvent.setup();
     renderWithProviders(
       <DeviceSettingsCard
@@ -205,9 +214,7 @@ describe("DeviceSettingsCard editing", () => {
     );
     await user.click(screen.getByTestId("device-settings-edit"));
     await user.type(screen.getByLabelText("Friendly name"), "Alice phone");
-    const save = screen.getByRole("button", { name: "To Managed Device" });
-    expect(save).toBeEnabled();
-    await user.click(save);
+    await user.click(screen.getByRole("button", { name: "To Managed Device" }));
     await waitFor(() => expect(mutateAsync).toHaveBeenCalled());
     expect(mutateAsync).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -215,21 +222,6 @@ describe("DeviceSettingsCard editing", () => {
         body: expect.objectContaining({ name: "Alice phone" }),
       }),
     );
-  });
-
-  it("blocks blanking the name of an already-managed device on submit", async () => {
-    const user = userEvent.setup();
-    renderWithProviders(
-      <DeviceSettingsCard
-        device={makeDevice({ name: "TV" })}
-        currentRule={null}
-      />,
-    );
-    await user.click(screen.getByTestId("device-settings-edit"));
-    await user.clear(screen.getByLabelText("Friendly name"));
-    await user.click(screen.getByTestId("device-settings-save"));
-    expect(await screen.findByText(/name is required/i)).toBeInTheDocument();
-    expect(mutateAsync).not.toHaveBeenCalled();
   });
 
   it("shows the saving label and error alert while pending", async () => {

--- a/source/admin-site/tests/components/features/PrivateDnsCard.test.tsx
+++ b/source/admin-site/tests/components/features/PrivateDnsCard.test.tsx
@@ -1,0 +1,139 @@
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  useDevices,
+  usePrivateDnsStatus,
+  useSetPrivateDnsEnabled,
+  useGrantPrivateDnsDevice,
+  useRevokePrivateDnsDevice,
+  useSendPrivateDnsToDevice,
+} from "@wardnet/web";
+import { PrivateDnsCard } from "@/components/features/PrivateDnsCard";
+import { renderWithProviders, makeDevice } from "../../test-utils";
+
+vi.mock("@wardnet/web", async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return {
+    ...actual,
+    useDevices: vi.fn(),
+    usePrivateDnsStatus: vi.fn(),
+    useSetPrivateDnsEnabled: vi.fn(),
+    useGrantPrivateDnsDevice: vi.fn(),
+    useRevokePrivateDnsDevice: vi.fn(),
+    useSendPrivateDnsToDevice: vi.fn(),
+  };
+});
+
+const setEnabledMutate = vi.fn();
+
+type Prereqs = {
+  wardnet_provider: boolean;
+  certificate: boolean;
+  entitled: boolean;
+  relay_connected: boolean;
+};
+
+function setup({
+  enabled = false,
+  prerequisites,
+  grants = [] as Array<{
+    id: string;
+    device_id: string;
+    hostname: string;
+    created_at: string;
+  }>,
+  devices = [] as ReturnType<typeof makeDevice>[],
+}: {
+  enabled?: boolean;
+  prerequisites: Prereqs;
+  grants?: Array<{
+    id: string;
+    device_id: string;
+    hostname: string;
+    created_at: string;
+  }>;
+  devices?: ReturnType<typeof makeDevice>[];
+}) {
+  vi.mocked(usePrivateDnsStatus).mockReturnValue({
+    data: { enabled, domain: "abc.my.wardnet.services", prerequisites, grants },
+    isLoading: false,
+  } as unknown as ReturnType<typeof usePrivateDnsStatus>);
+  vi.mocked(useDevices).mockReturnValue({
+    data: { devices },
+  } as unknown as ReturnType<typeof useDevices>);
+  vi.mocked(useSetPrivateDnsEnabled).mockReturnValue({
+    mutate: setEnabledMutate,
+    isPending: false,
+  } as unknown as ReturnType<typeof useSetPrivateDnsEnabled>);
+  const idleMutation = {
+    mutate: vi.fn(),
+    mutateAsync: vi.fn(),
+    isPending: false,
+  };
+  vi.mocked(useGrantPrivateDnsDevice).mockReturnValue(
+    idleMutation as unknown as ReturnType<typeof useGrantPrivateDnsDevice>,
+  );
+  vi.mocked(useRevokePrivateDnsDevice).mockReturnValue(
+    idleMutation as unknown as ReturnType<typeof useRevokePrivateDnsDevice>,
+  );
+  vi.mocked(useSendPrivateDnsToDevice).mockReturnValue(
+    idleMutation as unknown as ReturnType<typeof useSendPrivateDnsToDevice>,
+  );
+}
+
+const ALL_MET: Prereqs = {
+  wardnet_provider: true,
+  certificate: true,
+  entitled: true,
+  relay_connected: true,
+};
+
+describe("PrivateDnsCard", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("renders the prerequisite checklist and disables the toggle when a hard gate is unmet", () => {
+    setup({ prerequisites: { ...ALL_MET, entitled: false } });
+    renderWithProviders(<PrivateDnsCard />);
+
+    expect(screen.getByTestId("private-dns-prerequisites")).toBeInTheDocument();
+    // The unmet-Premium hint is shown, and the toggle can't be enabled.
+    expect(screen.getByText(/Premium feature/)).toBeInTheDocument();
+    expect(
+      screen.getByRole("switch", { name: "Enable Private DNS" }),
+    ).toBeDisabled();
+  });
+
+  it("allows enabling once every hard gate is met", async () => {
+    setup({ prerequisites: ALL_MET });
+    renderWithProviders(<PrivateDnsCard />);
+
+    const toggle = screen.getByRole("switch", { name: "Enable Private DNS" });
+    expect(toggle).toBeEnabled();
+    await userEvent.click(toggle);
+    expect(setEnabledMutate).toHaveBeenCalledWith(true);
+  });
+
+  it("lists granted devices with their hostname once enabled", () => {
+    const device = makeDevice({ id: "d1", name: "Alice phone" });
+    setup({
+      enabled: true,
+      prerequisites: ALL_MET,
+      devices: [device],
+      grants: [
+        {
+          id: "g1",
+          device_id: "d1",
+          hostname: "tok.abc.my.wardnet.services",
+          created_at: "2026-07-21T00:00:00Z",
+        },
+      ],
+    });
+    renderWithProviders(<PrivateDnsCard />);
+
+    expect(screen.getByText("Alice phone")).toBeInTheDocument();
+    expect(screen.getByText("tok.abc.my.wardnet.services")).toBeInTheDocument();
+    // The one granted device is no longer grantable, so no grant button.
+    expect(screen.queryByText("Grant access")).not.toBeInTheDocument();
+  });
+});

--- a/source/admin-site/tests/components/features/PrivateDnsCard.test.tsx
+++ b/source/admin-site/tests/components/features/PrivateDnsCard.test.tsx
@@ -1,4 +1,4 @@
-import { screen } from "@testing-library/react";
+import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
@@ -10,7 +10,23 @@ import {
   useSendPrivateDnsToDevice,
 } from "@wardnet/web";
 import { PrivateDnsCard } from "@/components/features/PrivateDnsCard";
-import { renderWithProviders, makeDevice } from "../../test-utils";
+import { makeDevice, renderWithProviders } from "../../test-utils";
+
+// The grant panel's DeviceSelect is a Radix Select, which measures its trigger
+// in a layout effect; jsdom has no ResizeObserver / pointer-capture, so stub
+// them (as elsewhere in the suite).
+Element.prototype.hasPointerCapture ??= () => false;
+Element.prototype.setPointerCapture ??= () => {};
+Element.prototype.releasePointerCapture ??= () => {};
+Element.prototype.scrollIntoView ??= () => {};
+vi.stubGlobal(
+  "ResizeObserver",
+  class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  },
+);
 
 vi.mock("@wardnet/web", async (importOriginal) => {
   const actual = await importOriginal<Record<string, unknown>>();
@@ -26,6 +42,9 @@ vi.mock("@wardnet/web", async (importOriginal) => {
 });
 
 const setEnabledMutate = vi.fn();
+const grantMutateAsync = vi.fn();
+const revokeMutate = vi.fn();
+const sendMutate = vi.fn();
 
 type Prereqs = {
   wardnet_provider: boolean;
@@ -33,53 +52,45 @@ type Prereqs = {
   entitled: boolean;
   relay_connected: boolean;
 };
+type Grant = {
+  id: string;
+  device_id: string;
+  hostname: string;
+  created_at: string;
+};
 
 function setup({
   enabled = false,
   prerequisites,
-  grants = [] as Array<{
-    id: string;
-    device_id: string;
-    hostname: string;
-    created_at: string;
-  }>,
+  grants = [] as Grant[],
   devices = [] as ReturnType<typeof makeDevice>[],
 }: {
   enabled?: boolean;
   prerequisites: Prereqs;
-  grants?: Array<{
-    id: string;
-    device_id: string;
-    hostname: string;
-    created_at: string;
-  }>;
+  grants?: Grant[];
   devices?: ReturnType<typeof makeDevice>[];
 }) {
   vi.mocked(usePrivateDnsStatus).mockReturnValue({
     data: { enabled, domain: "abc.my.wardnet.services", prerequisites, grants },
     isLoading: false,
-  } as unknown as ReturnType<typeof usePrivateDnsStatus>);
-  vi.mocked(useDevices).mockReturnValue({
-    data: { devices },
-  } as unknown as ReturnType<typeof useDevices>);
+  } as never);
+  vi.mocked(useDevices).mockReturnValue({ data: { devices } } as never);
   vi.mocked(useSetPrivateDnsEnabled).mockReturnValue({
     mutate: setEnabledMutate,
     isPending: false,
-  } as unknown as ReturnType<typeof useSetPrivateDnsEnabled>);
-  const idleMutation = {
-    mutate: vi.fn(),
-    mutateAsync: vi.fn(),
+  } as never);
+  vi.mocked(useGrantPrivateDnsDevice).mockReturnValue({
+    mutateAsync: grantMutateAsync,
     isPending: false,
-  };
-  vi.mocked(useGrantPrivateDnsDevice).mockReturnValue(
-    idleMutation as unknown as ReturnType<typeof useGrantPrivateDnsDevice>,
-  );
-  vi.mocked(useRevokePrivateDnsDevice).mockReturnValue(
-    idleMutation as unknown as ReturnType<typeof useRevokePrivateDnsDevice>,
-  );
-  vi.mocked(useSendPrivateDnsToDevice).mockReturnValue(
-    idleMutation as unknown as ReturnType<typeof useSendPrivateDnsToDevice>,
-  );
+  } as never);
+  vi.mocked(useRevokePrivateDnsDevice).mockReturnValue({
+    mutate: revokeMutate,
+    isPending: false,
+  } as never);
+  vi.mocked(useSendPrivateDnsToDevice).mockReturnValue({
+    mutate: sendMutate,
+    isPending: false,
+  } as never);
 }
 
 const ALL_MET: Prereqs = {
@@ -87,6 +98,12 @@ const ALL_MET: Prereqs = {
   certificate: true,
   entitled: true,
   relay_connected: true,
+};
+const GRANT: Grant = {
+  id: "g1",
+  device_id: "d1",
+  hostname: "tok.abc.my.wardnet.services",
+  created_at: "2026-07-21T00:00:00Z",
 };
 
 describe("PrivateDnsCard", () => {
@@ -97,7 +114,6 @@ describe("PrivateDnsCard", () => {
     renderWithProviders(<PrivateDnsCard />);
 
     expect(screen.getByTestId("private-dns-prerequisites")).toBeInTheDocument();
-    // The unmet-Premium hint is shown, and the toggle can't be enabled.
     expect(screen.getByText(/Premium feature/)).toBeInTheDocument();
     expect(
       screen.getByRole("switch", { name: "Enable Private DNS" }),
@@ -115,19 +131,11 @@ describe("PrivateDnsCard", () => {
   });
 
   it("lists granted devices with their hostname once enabled", () => {
-    const device = makeDevice({ id: "d1", name: "Alice phone" });
     setup({
       enabled: true,
       prerequisites: ALL_MET,
-      devices: [device],
-      grants: [
-        {
-          id: "g1",
-          device_id: "d1",
-          hostname: "tok.abc.my.wardnet.services",
-          created_at: "2026-07-21T00:00:00Z",
-        },
-      ],
+      devices: [makeDevice({ id: "d1", name: "Alice phone" })],
+      grants: [GRANT],
     });
     renderWithProviders(<PrivateDnsCard />);
 
@@ -135,5 +143,77 @@ describe("PrivateDnsCard", () => {
     expect(screen.getByText("tok.abc.my.wardnet.services")).toBeInTheDocument();
     // The one granted device is no longer grantable, so no grant button.
     expect(screen.queryByText("Grant access")).not.toBeInTheDocument();
+  });
+
+  it("grants a device, then the granted modal wires send + dismiss", async () => {
+    const user = userEvent.setup();
+    grantMutateAsync.mockResolvedValue(GRANT);
+    setup({
+      enabled: true,
+      prerequisites: ALL_MET,
+      devices: [makeDevice({ id: "d1", name: "Alice phone" })],
+      grants: [],
+    });
+    renderWithProviders(<PrivateDnsCard />);
+
+    await user.click(screen.getByRole("button", { name: "Grant access" }));
+    // Choose the device in the DeviceSelect combobox, then grant.
+    await user.click(screen.getByRole("combobox"));
+    await user.click(await screen.findByText("Alice phone"));
+    await user.click(screen.getByRole("button", { name: "Grant" }));
+
+    await waitFor(() => expect(grantMutateAsync).toHaveBeenCalledWith("d1"));
+    // The granted modal opens; its actions route through the card.
+    await user.click(await screen.findByTestId("private-dns-modal-send"));
+    expect(sendMutate).toHaveBeenCalledWith("d1");
+    await user.click(screen.getByRole("button", { name: "Done" }));
+  });
+
+  it("cancels the grant panel", async () => {
+    const user = userEvent.setup();
+    setup({
+      enabled: true,
+      prerequisites: ALL_MET,
+      devices: [makeDevice({ id: "d1", name: "Alice phone" })],
+    });
+    renderWithProviders(<PrivateDnsCard />);
+
+    await user.click(screen.getByRole("button", { name: "Grant access" }));
+    await user.click(screen.getByRole("button", { name: "Cancel" }));
+    expect(
+      screen.queryByRole("button", { name: "Grant" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("sends to a granted device from the table row", async () => {
+    const user = userEvent.setup();
+    setup({
+      enabled: true,
+      prerequisites: ALL_MET,
+      devices: [makeDevice({ id: "d1", name: "Alice phone" })],
+      grants: [GRANT],
+    });
+    renderWithProviders(<PrivateDnsCard />);
+
+    await user.click(screen.getByTestId("private-dns-grant-menu"));
+    await user.click(await screen.findByTestId("private-dns-grant-send"));
+    expect(sendMutate).toHaveBeenCalledWith("d1");
+  });
+
+  it("revokes a granted device after confirmation", async () => {
+    const user = userEvent.setup();
+    setup({
+      enabled: true,
+      prerequisites: ALL_MET,
+      devices: [makeDevice({ id: "d1", name: "Alice phone" })],
+      grants: [GRANT],
+    });
+    renderWithProviders(<PrivateDnsCard />);
+
+    await user.click(screen.getByTestId("private-dns-grant-menu"));
+    await user.click(await screen.findByTestId("private-dns-grant-revoke"));
+    // ConfirmDialog opens — confirm the revoke.
+    await user.click(await screen.findByRole("button", { name: "Revoke" }));
+    expect(revokeMutate).toHaveBeenCalledWith("d1");
   });
 });

--- a/source/admin-site/tests/components/features/PrivateDnsGrantedModal.test.tsx
+++ b/source/admin-site/tests/components/features/PrivateDnsGrantedModal.test.tsx
@@ -1,0 +1,52 @@
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import type { PrivateDnsGrantSummary } from "@wardnet/js";
+import { PrivateDnsGrantedModal } from "@/components/features/PrivateDnsGrantedModal";
+import { renderWithProviders } from "../../test-utils";
+
+const grant: PrivateDnsGrantSummary = {
+  id: "g1",
+  device_id: "d1",
+  hostname: "tok.abc.my.wardnet.services",
+  created_at: "2026-07-21T00:00:00Z",
+};
+
+describe("PrivateDnsGrantedModal", () => {
+  it("renders nothing when there is no grant", () => {
+    const { container } = renderWithProviders(
+      <PrivateDnsGrantedModal
+        grant={null}
+        deviceName=""
+        onSendToDevice={vi.fn()}
+        sending={false}
+        onDismiss={vi.fn()}
+      />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("shows the hostname/instructions and wires the send + dismiss actions", async () => {
+    const onSendToDevice = vi.fn();
+    const onDismiss = vi.fn();
+    renderWithProviders(
+      <PrivateDnsGrantedModal
+        grant={grant}
+        deviceName="Alice phone"
+        onSendToDevice={onSendToDevice}
+        sending={false}
+        onDismiss={onDismiss}
+      />,
+    );
+
+    expect(screen.getByTestId("private-dns-hostname")).toHaveTextContent(
+      "tok.abc.my.wardnet.services",
+    );
+
+    await userEvent.click(screen.getByTestId("private-dns-modal-send"));
+    expect(onSendToDevice).toHaveBeenCalledWith(grant);
+
+    await userEvent.click(screen.getByRole("button", { name: "Done" }));
+    expect(onDismiss).toHaveBeenCalled();
+  });
+});

--- a/source/admin-site/tests/components/features/PrivateDnsGrantedModal.test.tsx
+++ b/source/admin-site/tests/components/features/PrivateDnsGrantedModal.test.tsx
@@ -49,4 +49,19 @@ describe("PrivateDnsGrantedModal", () => {
     await userEvent.click(screen.getByRole("button", { name: "Done" }));
     expect(onDismiss).toHaveBeenCalled();
   });
+
+  it("dismisses when the modal is closed (Escape)", async () => {
+    const onDismiss = vi.fn();
+    renderWithProviders(
+      <PrivateDnsGrantedModal
+        grant={grant}
+        deviceName="Alice phone"
+        onSendToDevice={vi.fn()}
+        sending={false}
+        onDismiss={onDismiss}
+      />,
+    );
+    await userEvent.keyboard("{Escape}");
+    expect(onDismiss).toHaveBeenCalled();
+  });
 });

--- a/source/admin-site/vite.config.ts
+++ b/source/admin-site/vite.config.ts
@@ -21,6 +21,18 @@ export default defineConfig({
         ws: true,
       },
     },
+    watch: {
+      // Our source workspace packages are Yarn-linked into node_modules, which
+      // Vite's file watcher ignores by default — so edits to @wardnet/web
+      // (shared components/hooks) and @wardnet/js never triggered HMR, only a
+      // server restart picked them up. Un-ignore them so cross-package HMR
+      // works. (They're already excluded from optimizeDeps so Vite reads their
+      // source directly.)
+      ignored: [
+        "!**/node_modules/@wardnet/web/**",
+        "!**/node_modules/@wardnet/js/**",
+      ],
+    },
   },
   optimizeDeps: {
     // Pre-bundle the CommonJS deps that the excluded workspace packages import

--- a/source/daemon/crates/wardnet-common/src/api.rs
+++ b/source/daemon/crates/wardnet-common/src/api.rs
@@ -435,6 +435,16 @@ pub struct PrivateDnsMeResponse {
     pub hostname: Option<String>,
 }
 
+/// Response for `POST /api/private-dns/grants/{device_id}/notify` — the result
+/// of nudging a granted device's household member to set up Private DNS.
+#[derive(Debug, Clone, Serialize, Deserialize, utoipa::ToSchema)]
+pub struct SendPrivateDnsNotificationResponse {
+    /// Whether at least one push subscription for the device was targeted.
+    /// `false` (not an error) when the device holds a grant but the household
+    /// member hasn't enabled notifications, so no subscription exists.
+    pub delivered: bool,
+}
+
 /// Response for `GET /api/tunnels/{id}/devices`.
 ///
 /// The devices currently routed through the given tunnel — i.e. those

--- a/source/daemon/crates/wardnetd-api/src/api/private_dns.rs
+++ b/source/daemon/crates/wardnetd-api/src/api/private_dns.rs
@@ -8,7 +8,8 @@ use utoipa_axum::routes;
 use uuid::Uuid;
 use wardnet_common::api::{
     ApiError, CreatePrivateDnsGrantRequest, PrivateDnsGrantSummary, PrivateDnsMeResponse,
-    PrivateDnsPrerequisites, PrivateDnsStatusResponse, SetPrivateDnsEnabledRequest,
+    PrivateDnsPrerequisites, PrivateDnsStatusResponse, SendPrivateDnsNotificationResponse,
+    SetPrivateDnsEnabledRequest,
 };
 use wardnet_common::auth::AuthContext;
 
@@ -28,6 +29,7 @@ pub fn register(router: OpenApiRouter<AppState>) -> OpenApiRouter<AppState> {
         .routes(routes!(set_enabled))
         .routes(routes!(create_grant))
         .routes(routes!(delete_grant))
+        .routes(routes!(notify_device))
         .routes(routes!(get_me))
         .routes(routes!(get_me_profile))
 }
@@ -227,6 +229,33 @@ pub async fn delete_grant(
     };
     state.private_dns_service().revoke_grant(grant.id).await?;
     Ok(StatusCode::NO_CONTENT)
+}
+
+#[utoipa::path(
+    post,
+    path = "/api/private-dns/grants/{device_id}/notify",
+    tag = TAG,
+    description = "Send a device-keyed push nudging the granted device's household member to \
+                   set up Private DNS. The notification deep-links the user PWA to \
+                   `/private-dns`. Returns `delivered: true` when at least one push \
+                   subscription for the device was targeted, and `delivered: false` (a 200, not \
+                   an error) when the device holds a grant but has no subscription — the member \
+                   simply hasn't enabled notifications yet. Returns 404 when the device has no \
+                   grant. Admin only.",
+    params(("device_id" = Uuid, Path, description = "Device ID")),
+    responses(
+        (status = 200, description = "Notification dispatch result", body = SendPrivateDnsNotificationResponse),
+        AuthErrors,
+        NotFound,
+    ),
+)]
+pub async fn notify_device(
+    State(state): State<AppState>,
+    _auth: AdminAuth,
+    Path(device_id): Path<Uuid>,
+) -> Result<Json<SendPrivateDnsNotificationResponse>, AppError> {
+    let delivered = state.private_dns_service().notify_device(device_id).await?;
+    Ok(Json(SendPrivateDnsNotificationResponse { delivered }))
 }
 
 #[utoipa::path(

--- a/source/daemon/crates/wardnetd-api/src/api/tests/private_dns.rs
+++ b/source/daemon/crates/wardnetd-api/src/api/tests/private_dns.rs
@@ -52,6 +52,9 @@ struct MockPrivateDns {
     enable_conflicts: bool,
     /// Bytes `device_profile` returns for the granted device (`None` → 404).
     profile: Option<Vec<u8>>,
+    /// The `delivered` value `notify_device` reports for the granted device —
+    /// modelling whether the device holds a push subscription.
+    notify_delivered: bool,
 }
 
 fn sample_grant() -> PrivateDnsGrant {
@@ -100,6 +103,16 @@ impl PrivateDnsService for MockPrivateDns {
     }
     async fn device_grant(&self, device_id: Uuid) -> Result<Option<PrivateDnsGrant>, AppError> {
         Ok(self.grant.clone().filter(|g| g.device_id == device_id))
+    }
+    async fn notify_device(&self, device_id: Uuid) -> Result<bool, AppError> {
+        // Mirror the real service: 404 when the device holds no grant, else
+        // report the configured delivery flag.
+        match self.grant.clone().filter(|g| g.device_id == device_id) {
+            Some(_) => Ok(self.notify_delivered),
+            None => Err(AppError::NotFound(format!(
+                "device {device_id} has no Private DNS grant"
+            ))),
+        }
     }
     async fn device_profile(&self, _device_id: Uuid) -> Result<Option<Vec<u8>>, AppError> {
         Ok(self.profile.clone())
@@ -313,6 +326,10 @@ fn app(state: AppState) -> Router {
             "/api/private-dns/grants/{device_id}",
             axum::routing::delete(crate::api::private_dns::delete_grant),
         )
+        .route(
+            "/api/private-dns/grants/{device_id}/notify",
+            post(crate::api::private_dns::notify_device),
+        )
         .route("/api/private-dns/me", get(crate::api::private_dns::get_me))
         .route(
             "/api/private-dns/me/profile",
@@ -489,8 +506,82 @@ async fn delete_grant_returns_404_when_absent() {
 }
 
 #[tokio::test]
+async fn notify_returns_delivered_true_when_subscription_exists() {
+    let state = make_state(
+        MockPrivateDns {
+            enabled: AtomicBool::new(true),
+            grant: Some(sample_grant()),
+            notify_delivered: true,
+            ..Default::default()
+        },
+        MeDeviceService { known: true },
+    );
+    let resp = app(state)
+        .oneshot(admin_request(
+            "POST",
+            &format!("/api/private-dns/grants/{ME_DEVICE}/notify"),
+            None,
+        ))
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = axum::body::to_bytes(resp.into_body(), 8192).await.unwrap();
+    let json: wardnet_common::api::SendPrivateDnsNotificationResponse =
+        serde_json::from_slice(&body).unwrap();
+    assert!(json.delivered);
+}
+
+#[tokio::test]
+async fn notify_returns_delivered_false_when_no_subscription() {
+    let state = make_state(
+        MockPrivateDns {
+            enabled: AtomicBool::new(true),
+            grant: Some(sample_grant()),
+            notify_delivered: false,
+            ..Default::default()
+        },
+        MeDeviceService { known: true },
+    );
+    let resp = app(state)
+        .oneshot(admin_request(
+            "POST",
+            &format!("/api/private-dns/grants/{ME_DEVICE}/notify"),
+            None,
+        ))
+        .await
+        .unwrap();
+    // A granted device with no subscription is a 200, not an error.
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = axum::body::to_bytes(resp.into_body(), 8192).await.unwrap();
+    let json: wardnet_common::api::SendPrivateDnsNotificationResponse =
+        serde_json::from_slice(&body).unwrap();
+    assert!(!json.delivered);
+}
+
+#[tokio::test]
+async fn notify_returns_404_when_device_has_no_grant() {
+    let state = make_state(
+        MockPrivateDns {
+            enabled: AtomicBool::new(true),
+            grant: None,
+            ..Default::default()
+        },
+        MeDeviceService { known: true },
+    );
+    let resp = app(state)
+        .oneshot(admin_request(
+            "POST",
+            &format!("/api/private-dns/grants/{}/notify", Uuid::new_v4()),
+            None,
+        ))
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
 async fn admin_endpoints_reject_unauthenticated() {
-    let cases: [(&str, &str, Option<serde_json::Value>); 4] = [
+    let cases: [(&str, &str, Option<serde_json::Value>); 5] = [
         ("GET", "/api/private-dns/status", None),
         (
             "PUT",
@@ -505,6 +596,11 @@ async fn admin_endpoints_reject_unauthenticated() {
         (
             "DELETE",
             "/api/private-dns/grants/00000000-0000-0000-0000-000000000000",
+            None,
+        ),
+        (
+            "POST",
+            "/api/private-dns/grants/00000000-0000-0000-0000-000000000000/notify",
             None,
         ),
     ];

--- a/source/daemon/crates/wardnetd-services/src/lib.rs
+++ b/source/daemon/crates/wardnetd-services/src/lib.rs
@@ -693,6 +693,7 @@ fn create_services(
         entitlement.clone(),
         event_publisher.clone(),
         backends.secret_store.clone(),
+        push_service.clone(),
         lan_ip,
     ));
 

--- a/source/daemon/crates/wardnetd-services/src/private_dns/mod.rs
+++ b/source/daemon/crates/wardnetd-services/src/private_dns/mod.rs
@@ -53,6 +53,7 @@ use crate::dns_local::DnsLocalService;
 use crate::entitlement::Entitlement;
 use crate::error::AppError;
 use crate::event::EventPublisher;
+use crate::push::PushService;
 use crate::secret_store::SecretStore;
 use crate::tls::{TlsService, TlsStatus};
 
@@ -187,6 +188,18 @@ pub trait PrivateDnsService: Send + Sync {
         Ok(None)
     }
 
+    /// Nudge a granted device's household member to set up Private DNS via a
+    /// device-keyed push deep-linking the user PWA to `/private-dns`. Returns
+    /// whether any push subscription was targeted (`delivered`); a granted
+    /// device with no subscription yields `Ok(false)`, not an error. A device
+    /// with no grant is a 404 ([`AppError::NotFound`]), mirroring
+    /// [`Self::device_grant`]-backed `delete_grant`. Admin only. A default
+    /// `Ok(false)` keeps test doubles that predate it compiling.
+    async fn notify_device(&self, device_id: Uuid) -> Result<bool, AppError> {
+        let _ = device_id;
+        Ok(false)
+    }
+
     /// The signed `.mobileconfig` for this device, or `None` when the device
     /// isn't granted, the feature is disabled, or the wardnet domain / cert
     /// isn't available yet (all of which surface as a 404). Backs the
@@ -224,6 +237,10 @@ pub struct PrivateDnsServiceImpl {
     /// Source of the live Let's Encrypt cert/key used to CMS-sign the iOS
     /// `.mobileconfig` (issue #914). Reached only from `device_profile`.
     secrets: Arc<dyn SecretStore>,
+    /// Delivers the device-keyed "Private DNS is ready" nudge. A direct
+    /// service-to-service call (not a synthetic event): notifying is an explicit
+    /// admin resend action, not an organic state change (issue #915).
+    push: Arc<dyn PushService>,
     /// The Pi's LAN-interface IPv4 — the value of the wildcard record.
     lan_ip: Ipv4Addr,
 }
@@ -241,6 +258,7 @@ impl PrivateDnsServiceImpl {
         entitlement: Arc<Entitlement>,
         events: Arc<dyn EventPublisher>,
         secrets: Arc<dyn SecretStore>,
+        push: Arc<dyn PushService>,
         lan_ip: Ipv4Addr,
     ) -> Self {
         Self {
@@ -253,6 +271,7 @@ impl PrivateDnsServiceImpl {
             entitlement,
             events,
             secrets,
+            push,
             lan_ip,
         }
     }
@@ -535,6 +554,24 @@ impl PrivateDnsService for PrivateDnsServiceImpl {
     async fn device_grant(&self, device_id: Uuid) -> Result<Option<PrivateDnsGrant>, AppError> {
         auth_context::require_admin()?;
         self.grant_for_device(device_id).await
+    }
+
+    async fn notify_device(&self, device_id: Uuid) -> Result<bool, AppError> {
+        auth_context::require_admin()?;
+
+        // A device with no grant is a 404 — the same guard `delete_grant`
+        // applies (there is nothing to nudge a household member about yet).
+        if self.grant_for_device(device_id).await?.is_none() {
+            return Err(AppError::NotFound(format!(
+                "device {device_id} has no Private DNS grant"
+            )));
+        }
+
+        // Delegate targeting to the push service: it owns the device UUID -> MAC
+        // resolution and the subscription fan-out, and reports whether any
+        // subscription existed (the API's `delivered`). Runs under this admin
+        // context, satisfying the push method's own `require_admin`.
+        self.push.notify_private_dns_granted(device_id).await
     }
 
     async fn device_profile(&self, device_id: Uuid) -> Result<Option<Vec<u8>>, AppError> {

--- a/source/daemon/crates/wardnetd-services/src/private_dns/tests/service.rs
+++ b/source/daemon/crates/wardnetd-services/src/private_dns/tests/service.rs
@@ -536,6 +536,51 @@ impl DnsLocalService for MockDnsLocalService {
     }
 }
 
+// -- Mock PushService (only `notify_private_dns_granted` is exercised) ------
+//
+// Records the device ids it was asked to nudge and returns a configurable
+// `delivered` result, so the notify-orchestration tests can assert the service
+// delegates only after the grant check and passes the delivery flag straight
+// back.
+#[derive(Default)]
+struct MockPushService {
+    notified: Mutex<Vec<Uuid>>,
+    /// The `delivered` value `notify_private_dns_granted` returns.
+    delivered: bool,
+}
+
+#[async_trait]
+impl crate::push::PushService for MockPushService {
+    async fn vapid_public_key(&self) -> Result<String, AppError> {
+        unimplemented!("not exercised by private-dns tests")
+    }
+    async fn subscribe(
+        &self,
+        _sub: wardnet_common::api::WebPushSubscription,
+    ) -> Result<(), AppError> {
+        unimplemented!("not exercised by private-dns tests")
+    }
+    async fn unsubscribe(&self, _endpoint: Option<String>) -> Result<(), AppError> {
+        unimplemented!("not exercised by private-dns tests")
+    }
+    async fn handle_event(&self, _event: &WardnetEvent) -> Result<(), AppError> {
+        unimplemented!("not exercised by private-dns tests")
+    }
+    async fn recent_notifications(
+        &self,
+        _limit: u32,
+    ) -> Result<Vec<wardnetd_data::repository::StoredNotification>, AppError> {
+        unimplemented!("not exercised by private-dns tests")
+    }
+    async fn clear_notifications(&self) -> Result<(), AppError> {
+        unimplemented!("not exercised by private-dns tests")
+    }
+    async fn notify_private_dns_granted(&self, device_id: Uuid) -> Result<bool, AppError> {
+        self.notified.lock().unwrap().push(device_id);
+        Ok(self.delivered)
+    }
+}
+
 // -- Harness ---------------------------------------------------------------
 
 struct Harness {
@@ -548,10 +593,17 @@ struct Harness {
     entitlement: Arc<Entitlement>,
     events: Arc<BroadcastEventBus>,
     secrets: Arc<MockSecretStore>,
+    push: Arc<MockPushService>,
     service: PrivateDnsServiceImpl,
 }
 
 fn harness() -> Harness {
+    harness_with_delivery(false)
+}
+
+/// A harness whose push mock reports the given `delivered` result — the notify
+/// tests use this to distinguish the has-subscription and no-subscription paths.
+fn harness_with_delivery(delivered: bool) -> Harness {
     let grants = Arc::new(MockGrantRepo::default());
     let system_config = Arc::new(MockSystemConfig::default());
     let devices = Arc::new(MockDeviceService::default());
@@ -564,6 +616,10 @@ fn harness() -> Harness {
     entitlement.set_premium(true);
     let events = Arc::new(BroadcastEventBus::new(16));
     let secrets = Arc::new(MockSecretStore::default());
+    let push = Arc::new(MockPushService {
+        delivered,
+        ..Default::default()
+    });
 
     let service = PrivateDnsServiceImpl::new(
         grants.clone(),
@@ -575,6 +631,7 @@ fn harness() -> Harness {
         entitlement.clone(),
         events.clone(),
         secrets.clone(),
+        push.clone(),
         Ipv4Addr::new(192, 168, 1, 1),
     );
     Harness {
@@ -587,6 +644,7 @@ fn harness() -> Harness {
         entitlement,
         events,
         secrets,
+        push,
         service,
     }
 }
@@ -979,6 +1037,81 @@ async fn reconcile_keeps_an_entitled_box_enabled() {
 async fn anonymous_callers_are_rejected() {
     let h = harness();
     let err = h.service.status().await.expect_err("must require auth");
+    assert!(matches!(
+        err,
+        AppError::Forbidden(_) | AppError::Unauthorized(_)
+    ));
+}
+
+// -- Notify (issue #915) ---------------------------------------------------
+
+#[tokio::test]
+async fn notify_delegates_to_push_and_returns_delivered() {
+    let h = harness_with_delivery(true);
+    enable(&h).await;
+    let device_id = h.devices.add_device();
+    auth_context::with_context(admin_ctx(), h.service.grant_device(device_id))
+        .await
+        .expect("grant succeeds");
+
+    let delivered = auth_context::with_context(admin_ctx(), h.service.notify_device(device_id))
+        .await
+        .expect("notify succeeds");
+
+    assert!(delivered, "push reported a targeted subscription");
+    assert_eq!(
+        *h.push.notified.lock().unwrap(),
+        vec![device_id],
+        "the granted device UUID is handed to the push service"
+    );
+}
+
+#[tokio::test]
+async fn notify_reports_not_delivered_without_a_subscription() {
+    let h = harness_with_delivery(false);
+    enable(&h).await;
+    let device_id = h.devices.add_device();
+    auth_context::with_context(admin_ctx(), h.service.grant_device(device_id))
+        .await
+        .expect("grant succeeds");
+
+    let delivered = auth_context::with_context(admin_ctx(), h.service.notify_device(device_id))
+        .await
+        .expect("notify succeeds even with no subscription");
+
+    assert!(
+        !delivered,
+        "a granted device with no subscription is not an error"
+    );
+    assert_eq!(*h.push.notified.lock().unwrap(), vec![device_id]);
+}
+
+#[tokio::test]
+async fn notify_without_a_grant_is_not_found_and_skips_push() {
+    let h = harness_with_delivery(true);
+    enable(&h).await;
+    let device_id = h.devices.add_device();
+
+    let err = auth_context::with_context(admin_ctx(), h.service.notify_device(device_id))
+        .await
+        .expect_err("an ungranted device must 404");
+
+    assert!(matches!(err, AppError::NotFound(_)));
+    assert!(
+        h.push.notified.lock().unwrap().is_empty(),
+        "push must not be called when there is no grant"
+    );
+}
+
+#[tokio::test]
+async fn notify_requires_admin() {
+    let h = harness_with_delivery(true);
+    let err = auth_context::with_context(
+        AuthContext::Anonymous,
+        h.service.notify_device(Uuid::new_v4()),
+    )
+    .await
+    .expect_err("notify must require admin");
     assert!(matches!(
         err,
         AppError::Forbidden(_) | AppError::Unauthorized(_)

--- a/source/daemon/crates/wardnetd-services/src/push/mod.rs
+++ b/source/daemon/crates/wardnetd-services/src/push/mod.rs
@@ -73,6 +73,7 @@ enum NotificationKind {
     TunnelOffline,
     NewDeviceQuarantined,
     RuleRequestCreated,
+    PrivateDnsGranted,
 }
 
 impl NotificationKind {
@@ -84,6 +85,7 @@ impl NotificationKind {
             Self::TunnelOffline => "tunnel_offline",
             Self::NewDeviceQuarantined => "new_device_quarantined",
             Self::RuleRequestCreated => "rule_request_created",
+            Self::PrivateDnsGranted => "private_dns_granted",
         }
     }
 }
@@ -157,6 +159,17 @@ pub trait PushService: Send + Sync {
     /// Admin only. The feed is shared across admin accounts, so this clears
     /// it for everyone.
     async fn clear_notifications(&self) -> Result<(), AppError>;
+
+    /// Send the device-keyed "Private DNS is ready" nudge to a granted device,
+    /// deep-linking the user PWA to `/private-dns`. Resolves the device UUID to
+    /// its MAC (the subscription owner key) internally. Returns whether any
+    /// subscription for the device was targeted, so the admin API can report
+    /// `delivered`. Admin only. A default `Ok(false)` keeps test doubles that
+    /// predate it compiling.
+    async fn notify_private_dns_granted(&self, device_id: uuid::Uuid) -> Result<bool, AppError> {
+        let _ = device_id;
+        Ok(false)
+    }
 }
 
 pub struct PushServiceImpl {
@@ -263,6 +276,25 @@ impl PushServiceImpl {
             Ok(subs) => self.deliver(subs, &notif).await,
             Err(error) => tracing::warn!(%error, "push: failed to load device subscriptions"),
         }
+    }
+
+    /// Like [`Self::deliver_to_device`] but surfaces whether the device had any
+    /// subscription to target — the admin resend endpoint reports that as
+    /// `delivered`. A load error propagates (the admin caller wants to know),
+    /// unlike the best-effort event-driven path.
+    async fn deliver_to_device_reporting(
+        &self,
+        mac: &str,
+        notif: Notification,
+    ) -> Result<bool, AppError> {
+        let subs = self
+            .push_repo
+            .list_by_owner(OWNER_KIND_DEVICE, mac)
+            .await
+            .map_err(AppError::Internal)?;
+        let delivered = !subs.is_empty();
+        self.deliver(subs, &notif).await;
+        Ok(delivered)
     }
 
     async fn deliver_to_admins(&self, notif: Notification) {
@@ -593,5 +625,33 @@ impl PushService for PushServiceImpl {
             .await
             .map_err(AppError::Internal)?;
         Ok(())
+    }
+
+    async fn notify_private_dns_granted(&self, device_id: uuid::Uuid) -> Result<bool, AppError> {
+        auth_context::require_admin()?;
+
+        // Subscriptions are keyed by device MAC (`owner_key`), but the grant —
+        // and this endpoint — speak device UUID, so resolve UUID -> MAC first.
+        // An unknown device simply has no subscription: report `false`, not an
+        // error (the grant check upstream already guards the real 404).
+        let Some(device) = self
+            .device_repo
+            .find_by_id(&device_id.to_string())
+            .await
+            .map_err(AppError::Internal)?
+        else {
+            return Ok(false);
+        };
+
+        let notif = Notification {
+            title: "Private DNS is ready",
+            body: "Tap to set up encrypted DNS on this device.".to_owned(),
+            data: NotificationData {
+                kind: NotificationKind::PrivateDnsGranted,
+                url: Some("/private-dns"),
+                subject_id: Some(device_id.to_string()),
+            },
+        };
+        self.deliver_to_device_reporting(&device.mac, notif).await
     }
 }

--- a/source/daemon/crates/wardnetd-services/src/push/tests.rs
+++ b/source/daemon/crates/wardnetd-services/src/push/tests.rs
@@ -282,6 +282,69 @@ async fn admin_lock_notifies_the_target_device_only() {
     assert!(sent[0].payload.contains("locked your routing"));
 }
 
+/// Call an admin-gated service method the way a handler does — under an admin
+/// context.
+async fn notify(service: &PushServiceImpl, device_id: Uuid) -> bool {
+    auth_context::with_context(
+        AuthContext::Admin {
+            admin_id: Uuid::nil(),
+        },
+        service.notify_private_dns_granted(device_id),
+    )
+    .await
+    .unwrap()
+}
+
+#[tokio::test]
+async fn private_dns_notify_resolves_uuid_to_mac_and_reports_delivered() {
+    let device_id = Uuid::new_v4();
+    let h = build(SendOutcome::Delivered).await;
+    // Subscriptions are keyed by MAC; the endpoint speaks device UUID, so the
+    // service must resolve UUID -> MAC before targeting.
+    insert_device(&h.devices, device_id, "aa:bb:cc:11", Some("Phone")).await;
+    seed(
+        &h.push_repo,
+        OWNER_KIND_DEVICE,
+        "aa:bb:cc:11",
+        "https://push/device",
+    )
+    .await;
+
+    let delivered = notify(&h.service, device_id).await;
+
+    assert!(delivered, "a subscription existed, so delivered is true");
+    let sent = h.sender.sent.lock().unwrap();
+    assert_eq!(sent.len(), 1);
+    assert_eq!(sent[0].endpoint, "https://push/device");
+    assert!(sent[0].payload.contains("private_dns_granted"));
+    assert!(sent[0].payload.contains("/private-dns"));
+    assert!(sent[0].payload.contains("Private DNS is ready"));
+    assert!(sent[0].payload.contains(&device_id.to_string()));
+}
+
+#[tokio::test]
+async fn private_dns_notify_reports_not_delivered_without_a_subscription() {
+    let device_id = Uuid::new_v4();
+    let h = build(SendOutcome::Delivered).await;
+    // The device exists but has no push subscription (the household member
+    // hasn't enabled notifications) — not an error, just `false`.
+    insert_device(&h.devices, device_id, "aa:bb:cc:12", Some("Phone")).await;
+
+    let delivered = notify(&h.service, device_id).await;
+
+    assert!(!delivered);
+    assert!(h.sender.sent.lock().unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn private_dns_notify_unknown_device_reports_not_delivered() {
+    let h = build(SendOutcome::Delivered).await;
+    // No device row: UUID -> MAC resolution misses, so nothing is targeted.
+    let delivered = notify(&h.service, Uuid::new_v4()).await;
+    assert!(!delivered);
+    assert!(h.sender.sent.lock().unwrap().is_empty());
+}
+
 #[tokio::test]
 async fn admin_routing_change_targets_device_user_change_targets_admins() {
     let device_id = Uuid::new_v4();

--- a/source/sdk/wardnet-js/src/index.ts
+++ b/source/sdk/wardnet-js/src/index.ts
@@ -253,6 +253,7 @@ export type {
   SetPrivateDnsEnabledRequest,
   CreatePrivateDnsGrantRequest,
   PrivateDnsMeResponse,
+  SendPrivateDnsNotificationResponse,
 } from "./types/private-dns.js";
 
 // Types — backup

--- a/source/sdk/wardnet-js/src/services/private-dns.ts
+++ b/source/sdk/wardnet-js/src/services/private-dns.ts
@@ -4,6 +4,7 @@ import type {
   PrivateDnsGrantSummary,
   PrivateDnsMeResponse,
   PrivateDnsStatusResponse,
+  SendPrivateDnsNotificationResponse,
   SetPrivateDnsEnabledRequest,
 } from "../types/private-dns.js";
 
@@ -51,6 +52,20 @@ export class PrivateDnsService {
     await this.client.request<void>(`/private-dns/grants/${deviceId}`, {
       method: "DELETE",
     });
+  }
+
+  /**
+   * Send a device-keyed push nudging the granted household member to set up
+   * Private DNS on their phone (deep-links to the user PWA). Resend-safe. The
+   * response reports whether the device had a subscription to deliver to;
+   * `delivered: false` (still a success) means they haven't enabled
+   * notifications yet. Admin only.
+   */
+  async notifyDevice(deviceId: string): Promise<SendPrivateDnsNotificationResponse> {
+    return this.client.request<SendPrivateDnsNotificationResponse>(
+      `/private-dns/grants/${deviceId}/notify`,
+      { method: "POST" },
+    );
   }
 
   /** This device's own Private DNS state, identified by source IP. */

--- a/source/sdk/wardnet-js/src/types/private-dns.ts
+++ b/source/sdk/wardnet-js/src/types/private-dns.ts
@@ -62,6 +62,19 @@ export interface CreatePrivateDnsGrantRequest {
 }
 
 /**
+ * Response for `POST /api/private-dns/grants/{device_id}/notify` — a device-keyed
+ * push nudging the household member to set up Private DNS on their phone.
+ */
+export interface SendPrivateDnsNotificationResponse {
+  /**
+   * Whether at least one push subscription for the device was targeted. `false`
+   * (still a 200) means the device holds a grant but hasn't enabled
+   * notifications yet — the admin should relay the hostname directly instead.
+   */
+  delivered: boolean;
+}
+
+/**
  * Response for `GET /api/private-dns/me` — the device-keyed self-service view
  * (identified by source IP, like `devices/me`).
  */

--- a/source/sdk/wardnet-js/src/types/push.ts
+++ b/source/sdk/wardnet-js/src/types/push.ts
@@ -34,6 +34,7 @@ export type NotificationKind =
   | "tunnel_offline"
   | "new_device_quarantined"
   | "rule_request_created"
+  | "private_dns_granted"
   | (string & {});
 
 /**

--- a/source/user-app/src/App.tsx
+++ b/source/user-app/src/App.tsx
@@ -4,6 +4,7 @@ import { AppLayout } from "@/layouts/AppLayout";
 import Home from "@/pages/Home";
 import Stats from "@/pages/Stats";
 import Settings from "@/pages/Settings";
+import PrivateDns from "@/pages/PrivateDns";
 import { useDnsEventsSync } from "@/hooks/useDnsEventsSync";
 
 /**
@@ -29,6 +30,7 @@ export default function App() {
           <Route index element={<Home />} />
           <Route path="stats" element={<Stats />} />
           <Route path="settings" element={<Settings />} />
+          <Route path="private-dns" element={<PrivateDns />} />
         </Route>
         <Route path="*" element={<Navigate to="/" replace />} />
       </Routes>

--- a/source/user-app/src/pages/PrivateDns.tsx
+++ b/source/user-app/src/pages/PrivateDns.tsx
@@ -1,0 +1,75 @@
+import { ShieldOffIcon } from "lucide-react";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+  PrivateDnsInstructions,
+  Text,
+  privateDnsService,
+  usePrivateDnsMe,
+} from "@wardnet/web";
+
+/**
+ * Private DNS setup for this device (issues #910/#916). Device-keyed like the
+ * rest of the user PWA — the daemon identifies the device by source IP — so the
+ * page just reflects `me()`: not-enabled, not-granted, or the per-platform setup
+ * steps for the granted hostname. This is the page the admin's "Send to device"
+ * notification opens.
+ */
+export default function PrivateDns() {
+  const { data: me, isLoading } = usePrivateDnsMe();
+
+  if (isLoading) {
+    return (
+      <Text as="p" size="sm" className="p-5 text-ink-3">
+        Loading…
+      </Text>
+    );
+  }
+
+  // Narrow to a non-null hostname here so the setup view can rely on it; the
+  // daemon only returns one when the feature is enabled *and* this device is
+  // granted.
+  const hostname = me?.enabled && me.granted ? me.hostname : null;
+
+  if (!hostname) {
+    return (
+      <div className="flex flex-col items-center gap-4 px-5 py-16 text-center">
+        <ShieldOffIcon className="size-12 text-ink-3/50" />
+        <Text as="h1" size="lg" weight="semibold" className="text-ink">
+          Private DNS not set up
+        </Text>
+        <Text as="p" size="sm" className="max-w-md text-ink-3">
+          {me?.enabled
+            ? "This device hasn't been granted Private DNS yet. Ask your administrator to grant it, then reopen this page."
+            : "Private DNS isn't enabled on your network yet. Ask your administrator to turn it on."}
+        </Text>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-6 p-5">
+      <Text as="h1" size="lg" weight="semibold" className="text-ink">
+        Private DNS
+      </Text>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Set up encrypted DNS</CardTitle>
+        </CardHeader>
+        <CardContent className="flex flex-col gap-4">
+          <Text as="p" size="sm" className="text-ink-3">
+            Route this device's DNS through Wardnet everywhere — at home and
+            roaming. Follow the steps for your phone.
+          </Text>
+          <PrivateDnsInstructions
+            hostname={hostname}
+            profileUrl={privateDnsService.profileUrl()}
+          />
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/source/user-app/tests/pages/PrivateDns.test.tsx
+++ b/source/user-app/tests/pages/PrivateDns.test.tsx
@@ -1,0 +1,52 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { screen } from "@testing-library/react";
+
+import PrivateDns from "../../src/pages/PrivateDns";
+import { renderWithProviders } from "../test-utils";
+
+const { usePrivateDnsMe } = vi.hoisted(() => ({
+  usePrivateDnsMe: vi.fn(),
+}));
+
+vi.mock("@wardnet/web", async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return { ...actual, usePrivateDnsMe };
+});
+
+function setMe(data: {
+  enabled: boolean;
+  granted: boolean;
+  hostname: string | null;
+}) {
+  usePrivateDnsMe.mockReturnValue({ data, isLoading: false });
+}
+
+describe("PrivateDns page", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("tells the user to ask their admin when the feature is off", () => {
+    setMe({ enabled: false, granted: false, hostname: null });
+    renderWithProviders(<PrivateDns />);
+    expect(
+      screen.getByText(/isn't enabled on your network/),
+    ).toBeInTheDocument();
+  });
+
+  it("prompts to be granted when enabled but not granted", () => {
+    setMe({ enabled: true, granted: false, hostname: null });
+    renderWithProviders(<PrivateDns />);
+    expect(screen.getByText(/hasn't been granted/)).toBeInTheDocument();
+  });
+
+  it("shows the setup instructions with the hostname when granted", () => {
+    setMe({
+      enabled: true,
+      granted: true,
+      hostname: "tok.abc.my.wardnet.services",
+    });
+    renderWithProviders(<PrivateDns />);
+    expect(screen.getByTestId("private-dns-hostname")).toHaveTextContent(
+      "tok.abc.my.wardnet.services",
+    );
+  });
+});

--- a/source/user-app/tests/pages/PrivateDns.test.tsx
+++ b/source/user-app/tests/pages/PrivateDns.test.tsx
@@ -24,6 +24,12 @@ function setMe(data: {
 describe("PrivateDns page", () => {
   beforeEach(() => vi.clearAllMocks());
 
+  it("shows a loading state while me() resolves", () => {
+    usePrivateDnsMe.mockReturnValue({ data: undefined, isLoading: true });
+    renderWithProviders(<PrivateDns />);
+    expect(screen.getByText("Loading…")).toBeInTheDocument();
+  });
+
   it("tells the user to ask their admin when the feature is off", () => {
     setMe({ enabled: false, granted: false, hostname: null });
     renderWithProviders(<PrivateDns />);

--- a/source/user-app/vite.config.ts
+++ b/source/user-app/vite.config.ts
@@ -44,6 +44,18 @@ export default defineConfig({
         ws: true,
       },
     },
+    watch: {
+      // Our source workspace packages are Yarn-linked into node_modules, which
+      // Vite's file watcher ignores by default — so edits to @wardnet/web
+      // (shared components/hooks) and @wardnet/js never triggered HMR, only a
+      // server restart picked them up. Un-ignore them so cross-package HMR
+      // works. (They're already excluded from optimizeDeps so Vite reads their
+      // source directly.)
+      ignored: [
+        "!**/node_modules/@wardnet/web/**",
+        "!**/node_modules/@wardnet/js/**",
+      ],
+    },
   },
   optimizeDeps: {
     // CJS deps of the excluded workspace packages (see admin-site/web config).

--- a/source/web/src/components/CopyButton.tsx
+++ b/source/web/src/components/CopyButton.tsx
@@ -1,0 +1,69 @@
+import { useEffect, useRef, useState } from "react";
+import { CheckIcon, CopyIcon } from "lucide-react";
+import { Button, toast } from "@wardnet/ui";
+
+interface CopyButtonProps {
+  /** The text written to the clipboard on click. */
+  value: string;
+  /** Button label shown next to the icon (default "Copy"). */
+  label?: string;
+  /** Label shown briefly after a successful copy (default "Copied"). */
+  copiedLabel?: string;
+  className?: string;
+  "data-testid"?: string;
+}
+
+/**
+ * Copy-to-clipboard button — the repo's first clipboard affordance, shared so
+ * admin-site and the user PWA copy identically (the Android Private DNS
+ * hostname has to be pasted by hand into Settings, so a reliable copy button is
+ * the whole UX). Flips to a "Copied" confirmation for a moment, then resets.
+ */
+export function CopyButton({
+  value,
+  label = "Copy",
+  copiedLabel = "Copied",
+  className,
+  "data-testid": testId,
+}: CopyButtonProps) {
+  const [copied, setCopied] = useState(false);
+  const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Clear the pending reset on unmount so we never setState after teardown.
+  useEffect(
+    () => () => {
+      if (timer.current) clearTimeout(timer.current);
+    },
+    [],
+  );
+
+  async function handleCopy() {
+    try {
+      await navigator.clipboard.writeText(value);
+      setCopied(true);
+      if (timer.current) clearTimeout(timer.current);
+      timer.current = setTimeout(() => setCopied(false), 1500);
+    } catch {
+      toast.error("Couldn't copy to the clipboard");
+    }
+  }
+
+  return (
+    <Button
+      type="button"
+      variant="outline"
+      size="sm"
+      onClick={handleCopy}
+      className={className}
+      data-testid={testId}
+      aria-label={copied ? copiedLabel : label}
+    >
+      {copied ? (
+        <CheckIcon size={16} aria-hidden />
+      ) : (
+        <CopyIcon size={16} aria-hidden />
+      )}
+      {copied ? copiedLabel : label}
+    </Button>
+  );
+}

--- a/source/web/src/components/InboundWgQrCode.tsx
+++ b/source/web/src/components/InboundWgQrCode.tsx
@@ -6,14 +6,19 @@ interface InboundWgQrCodeProps {
   value: string;
   size?: number;
   className?: string;
+  /** Accessible label for the rendered image. */
+  alt?: string;
 }
 
 /** QR rendering for an inbound-WireGuard peer's client config (issues
- *  #812-#813), shared so admin-site and admin-app render identically. */
+ *  #812-#813), shared so admin-site and admin-app render identically. The
+ *  `alt` default keeps existing callers unchanged; other QR uses (e.g. the
+ *  Private DNS iOS profile URL) pass their own label. */
 export function InboundWgQrCode({
   value,
   size = 240,
   className,
+  alt = "WireGuard client config QR code",
 }: InboundWgQrCodeProps) {
   const [dataUrl, setDataUrl] = useState<string | null>(null);
 
@@ -44,7 +49,7 @@ export function InboundWgQrCode({
   return (
     <img
       src={dataUrl}
-      alt="WireGuard client config QR code"
+      alt={alt}
       width={size}
       height={size}
       className={className}

--- a/source/web/src/components/PrivateDnsInstructions.tsx
+++ b/source/web/src/components/PrivateDnsInstructions.tsx
@@ -1,0 +1,118 @@
+import { Text } from "@wardnet/ui";
+import { CopyButton } from "./CopyButton";
+import { InboundWgQrCode } from "./InboundWgQrCode";
+
+interface PrivateDnsInstructionsProps {
+  /** The device's full secret hostname (`<token>.<domain>`). */
+  hostname: string;
+  /**
+   * URL of this device's signed iOS profile. May be app-relative (the SDK's
+   * `profileUrl()` returns `/api/…`); it is resolved to an absolute URL so the
+   * QR is scannable and the link works from the phone.
+   */
+  profileUrl: string;
+  className?: string;
+}
+
+/**
+ * Per-platform Private DNS setup steps, shared between the admin-site granted
+ * modal and the user PWA (issues #915/#916) so both render identically.
+ *
+ * Android can't be configured programmatically — the hostname is pasted by hand
+ * into Settings, hence the copy button. iOS installs a downloadable
+ * configuration profile, so it gets a link + a QR the phone can scan. The
+ * profile endpoint is keyed by the requesting device's source IP, so the QR
+ * only yields the correct profile when the granted phone scans it on-LAN.
+ */
+export function PrivateDnsInstructions({
+  hostname,
+  profileUrl,
+  className,
+}: PrivateDnsInstructionsProps) {
+  const profileHref = absoluteUrl(profileUrl);
+
+  return (
+    <div
+      className={["flex flex-col gap-6", className ?? ""].join(" ")}
+      data-testid="private-dns-instructions"
+    >
+      <section className="flex flex-col gap-3">
+        <Text as="h4" size="sm" weight="medium" className="text-ink">
+          Android
+        </Text>
+        <div className="flex items-center gap-2 rounded-lg border border-line bg-sunken px-3 py-2">
+          <Text
+            as="code"
+            size="sm"
+            className="flex-1 truncate font-mono text-ink"
+            data-testid="private-dns-hostname"
+          >
+            {hostname}
+          </Text>
+          <CopyButton
+            value={hostname}
+            data-testid="private-dns-copy-hostname"
+          />
+        </div>
+        <div className="mt-1 flex flex-col gap-1">
+          <Text as="p" size="sm" className="text-ink-3">
+            1. Open Settings → Network &amp; internet → Private DNS.
+          </Text>
+          <Text as="p" size="sm" className="text-ink-3">
+            2. Choose “Private DNS provider hostname”.
+          </Text>
+          <Text as="p" size="sm" className="text-ink-3">
+            3. Paste the hostname above and save.
+          </Text>
+        </div>
+      </section>
+
+      <section className="flex flex-col gap-3">
+        <Text as="h4" size="sm" weight="medium" className="text-ink">
+          iPhone &amp; iPad
+        </Text>
+        <div className="flex flex-col items-center gap-3">
+          <InboundWgQrCode
+            value={profileHref}
+            size={180}
+            alt="Private DNS configuration profile QR code"
+          />
+          <a
+            href={profileHref}
+            className="text-sm text-accent hover:underline"
+            data-testid="private-dns-profile-link"
+          >
+            Download configuration profile
+          </a>
+        </div>
+        <div className="mt-1 flex flex-col gap-1">
+          <Text as="p" size="sm" className="text-ink-3">
+            1. Scan the QR with the iPhone camera, or tap the link on the device
+            itself.
+          </Text>
+          <Text as="p" size="sm" className="text-ink-3">
+            2. Open Settings — a “Profile Downloaded” banner appears near the
+            top.
+          </Text>
+          <Text as="p" size="sm" className="text-ink-3">
+            3. Tap Install and confirm.
+          </Text>
+        </div>
+      </section>
+    </div>
+  );
+}
+
+/**
+ * Resolve a possibly-relative URL against the current origin so the QR encodes
+ * something a phone can actually reach. Degrades to the input when there is no
+ * `window` (SSR) or the URL can't be parsed.
+ */
+function absoluteUrl(url: string): string {
+  if (typeof window === "undefined") return url;
+  try {
+    return new URL(url, window.location.origin).href;
+  } catch {
+    return url;
+  }
+}

--- a/source/web/src/hooks/usePrivateDns.ts
+++ b/source/web/src/hooks/usePrivateDns.ts
@@ -1,0 +1,112 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { toast } from "@wardnet/ui";
+import { privateDnsService } from "../lib/sdk";
+
+/** HTTP status carried by a `WardnetApiError`, if the rejection has one. */
+function httpStatus(err: unknown): number | undefined {
+  return (err as { status?: number } | null)?.status;
+}
+
+const STATUS_KEY = ["private-dns", "status"] as const;
+const ME_KEY = ["private-dns", "me"] as const;
+
+/**
+ * Admin status: enabled state, enable prerequisites, and every grant. The card
+ * on Remote Access is always mounted, so this drives the prerequisite checklist
+ * and the grant table.
+ */
+export function usePrivateDnsStatus() {
+  return useQuery({
+    queryKey: STATUS_KEY,
+    queryFn: () => privateDnsService.getStatus(),
+  });
+}
+
+/**
+ * Enable / disable Private DNS. Enabling is gated on the hard prerequisites and
+ * the daemon rejects with 409 when one is missing — the toggle is already
+ * disabled in that state, so a 409 is a safety net rather than the norm.
+ */
+export function useSetPrivateDnsEnabled() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (enabled: boolean) => privateDnsService.setEnabled(enabled),
+    onSuccess: (data, enabled) => {
+      // The mutation returns the fresh full status — seed the read cache so the
+      // checklist and grant table update without a round-trip.
+      qc.setQueryData(STATUS_KEY, data);
+      toast.success(enabled ? "Private DNS enabled" : "Private DNS disabled");
+    },
+    onError: (error) => {
+      if (httpStatus(error) === 409) {
+        toast.error(
+          "Private DNS can't be enabled yet — a prerequisite isn't met.",
+        );
+        return;
+      }
+      toast.error("Failed to update Private DNS");
+    },
+  });
+}
+
+/** Grant a managed device encrypted-DNS access; returns the minted grant. */
+export function useGrantPrivateDnsDevice() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (deviceId: string) => privateDnsService.grantDevice(deviceId),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: STATUS_KEY });
+    },
+    onError: (error) => {
+      const message =
+        error instanceof Error ? error.message : "Failed to grant access";
+      toast.error(message);
+    },
+  });
+}
+
+/** Revoke a device's grant. Keyed by device id, not grant id. */
+export function useRevokePrivateDnsDevice() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (deviceId: string) => privateDnsService.revokeDevice(deviceId),
+    onSuccess: () => {
+      toast.success("Private DNS access revoked");
+      qc.invalidateQueries({ queryKey: STATUS_KEY });
+    },
+    onError: () => toast.error("Failed to revoke access"),
+  });
+}
+
+/**
+ * Send a device-keyed push nudging the household member to set Private DNS up
+ * on their phone. Resend-safe. A `delivered: false` result is still a success —
+ * the device just hasn't enabled notifications yet, so we tell the admin to
+ * relay the hostname directly.
+ */
+export function useSendPrivateDnsToDevice() {
+  return useMutation({
+    mutationFn: (deviceId: string) => privateDnsService.notifyDevice(deviceId),
+    onSuccess: (result) => {
+      if (result.delivered) {
+        toast.success("Sent to device");
+      } else {
+        toast.warning(
+          "This device hasn't enabled notifications yet — show them the hostname directly.",
+        );
+      }
+    },
+    onError: () => toast.error("Failed to send to device"),
+  });
+}
+
+/**
+ * This device's own Private DNS state, identified by source IP. Backs the user
+ * PWA setup page.
+ */
+export function usePrivateDnsMe() {
+  return useQuery({
+    queryKey: ME_KEY,
+    queryFn: () => privateDnsService.me(),
+  });
+}

--- a/source/web/src/index.ts
+++ b/source/web/src/index.ts
@@ -24,6 +24,7 @@ export {
   statsService,
   updateService,
   backupService,
+  privateDnsService,
 } from "./lib/sdk";
 
 // Format utilities
@@ -345,6 +346,18 @@ export { DnsFilterNotReadyNotice } from "./components/DnsFilterNotReadyNotice";
 export { triggerBrowserDownload } from "./lib/download";
 export { ModalTitleBlock } from "./components/ModalTitleBlock";
 export { AlertModalTitleBlock } from "./components/AlertModalTitleBlock";
+
+// Private DNS — encrypted DNS at home + roaming (issues #910/#915/#916)
+export {
+  usePrivateDnsStatus,
+  useSetPrivateDnsEnabled,
+  useGrantPrivateDnsDevice,
+  useRevokePrivateDnsDevice,
+  useSendPrivateDnsToDevice,
+  usePrivateDnsMe,
+} from "./hooks/usePrivateDns";
+export { PrivateDnsInstructions } from "./components/PrivateDnsInstructions";
+export { CopyButton } from "./components/CopyButton";
 
 // Custom icons (composed marks not in lucide). Exported individually so
 // consumers only bundle the ones they import.

--- a/source/web/tests/components/CopyButton.test.tsx
+++ b/source/web/tests/components/CopyButton.test.tsx
@@ -1,5 +1,13 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { toast } = vi.hoisted(() => ({
+  toast: { error: vi.fn() },
+}));
+vi.mock("@wardnet/ui", async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return { ...actual, toast };
+});
 
 import { CopyButton } from "../../src/components/CopyButton";
 
@@ -30,5 +38,20 @@ describe("CopyButton", () => {
     expect(
       screen.getByRole("button", { name: "Copy hostname" }),
     ).toBeInTheDocument();
+  });
+
+  it("toasts an error when the clipboard write fails", async () => {
+    writeText.mockRejectedValueOnce(new Error("denied"));
+    render(<CopyButton value="x" />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Copy" }));
+
+    await waitFor(() =>
+      expect(toast.error).toHaveBeenCalledWith(
+        "Couldn't copy to the clipboard",
+      ),
+    );
+    // It never flips to the confirmation on failure.
+    expect(screen.queryByText("Copied")).not.toBeInTheDocument();
   });
 });

--- a/source/web/tests/components/CopyButton.test.tsx
+++ b/source/web/tests/components/CopyButton.test.tsx
@@ -1,0 +1,34 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { CopyButton } from "../../src/components/CopyButton";
+
+describe("CopyButton", () => {
+  const writeText = vi.fn().mockResolvedValue(undefined);
+
+  beforeEach(() => {
+    writeText.mockClear();
+    Object.defineProperty(navigator, "clipboard", {
+      value: { writeText },
+      configurable: true,
+    });
+  });
+
+  afterEach(() => vi.restoreAllMocks());
+
+  it("copies the value and flips to a confirmation", async () => {
+    render(<CopyButton value="tok.abc.my.wardnet.services" />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Copy" }));
+
+    expect(writeText).toHaveBeenCalledWith("tok.abc.my.wardnet.services");
+    expect(await screen.findByText("Copied")).toBeInTheDocument();
+  });
+
+  it("honours a custom label", () => {
+    render(<CopyButton value="x" label="Copy hostname" />);
+    expect(
+      screen.getByRole("button", { name: "Copy hostname" }),
+    ).toBeInTheDocument();
+  });
+});

--- a/source/web/tests/components/PrivateDnsInstructions.test.tsx
+++ b/source/web/tests/components/PrivateDnsInstructions.test.tsx
@@ -1,0 +1,43 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { PrivateDnsInstructions } from "../../src/components/PrivateDnsInstructions";
+
+describe("PrivateDnsInstructions", () => {
+  it("shows the hostname, a copy affordance, and both platform blocks", () => {
+    render(
+      <PrivateDnsInstructions
+        hostname="tok.abc.my.wardnet.services"
+        profileUrl="/api/private-dns/me/profile"
+      />,
+    );
+
+    expect(screen.getByTestId("private-dns-hostname")).toHaveTextContent(
+      "tok.abc.my.wardnet.services",
+    );
+    expect(screen.getByTestId("private-dns-copy-hostname")).toBeInTheDocument();
+    // Both platform blocks are always shown (the issue wants per-platform
+    // instructions). Target the section headings specifically.
+    expect(
+      screen.getByRole("heading", { name: "Android" }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: /iPhone/ })).toBeInTheDocument();
+  });
+
+  it("resolves an app-relative profile URL to an absolute link", () => {
+    render(
+      <PrivateDnsInstructions
+        hostname="tok.abc.my.wardnet.services"
+        profileUrl="/api/private-dns/me/profile"
+      />,
+    );
+
+    const link = screen.getByTestId("private-dns-profile-link");
+    // The QR/link must be absolute (resolved against the current origin) so a
+    // phone scanning on-LAN can reach the box.
+    expect(link).toHaveAttribute(
+      "href",
+      `${window.location.origin}/api/private-dns/me/profile`,
+    );
+  });
+});

--- a/source/web/tests/components/PrivateDnsInstructions.test.tsx
+++ b/source/web/tests/components/PrivateDnsInstructions.test.tsx
@@ -40,4 +40,18 @@ describe("PrivateDnsInstructions", () => {
       `${window.location.origin}/api/private-dns/me/profile`,
     );
   });
+
+  it("falls back to the raw URL when the profile URL can't be parsed", () => {
+    // An unparseable URL degrades to the input rather than throwing.
+    render(
+      <PrivateDnsInstructions
+        hostname="tok.abc.my.wardnet.services"
+        profileUrl="http://["
+      />,
+    );
+    expect(screen.getByTestId("private-dns-profile-link")).toHaveAttribute(
+      "href",
+      "http://[",
+    );
+  });
 });

--- a/source/web/tests/hooks/usePrivateDns.test.tsx
+++ b/source/web/tests/hooks/usePrivateDns.test.tsx
@@ -1,0 +1,150 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { act } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createQueryWrapper } from "../test-utils";
+
+const { privateDnsService, toast } = vi.hoisted(() => ({
+  privateDnsService: {
+    getStatus: vi.fn(),
+    setEnabled: vi.fn(),
+    grantDevice: vi.fn(),
+    revokeDevice: vi.fn(),
+    notifyDevice: vi.fn(),
+    me: vi.fn(),
+  },
+  toast: { success: vi.fn(), error: vi.fn(), warning: vi.fn() },
+}));
+vi.mock("../../src/lib/sdk", () => ({ privateDnsService }));
+vi.mock("@wardnet/ui", async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return { ...actual, toast };
+});
+
+import {
+  usePrivateDnsStatus,
+  useSetPrivateDnsEnabled,
+  useGrantPrivateDnsDevice,
+  useRevokePrivateDnsDevice,
+  useSendPrivateDnsToDevice,
+  usePrivateDnsMe,
+} from "../../src/hooks/usePrivateDns";
+
+const STATUS = {
+  enabled: false,
+  domain: "abc.my.wardnet.services",
+  prerequisites: {
+    wardnet_provider: true,
+    certificate: true,
+    entitled: true,
+    relay_connected: false,
+  },
+  grants: [],
+};
+
+describe("usePrivateDns hooks", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("reads status and the device-keyed me view", async () => {
+    privateDnsService.getStatus.mockResolvedValue(STATUS);
+    privateDnsService.me.mockResolvedValue({
+      enabled: true,
+      granted: true,
+      hostname: "tok.abc.my.wardnet.services",
+    });
+
+    const { result: s } = renderHook(() => usePrivateDnsStatus(), {
+      wrapper: createQueryWrapper(),
+    });
+    const { result: m } = renderHook(() => usePrivateDnsMe(), {
+      wrapper: createQueryWrapper(),
+    });
+
+    await waitFor(() => expect(s.current.isSuccess).toBe(true));
+    await waitFor(() => expect(m.current.isSuccess).toBe(true));
+    expect(s.current.data).toEqual(STATUS);
+    expect(m.current.data?.hostname).toBe("tok.abc.my.wardnet.services");
+  });
+
+  it("enables Private DNS and toasts success", async () => {
+    privateDnsService.setEnabled.mockResolvedValueOnce({
+      ...STATUS,
+      enabled: true,
+    });
+    const { result } = renderHook(() => useSetPrivateDnsEnabled(), {
+      wrapper: createQueryWrapper(),
+    });
+    await act(async () => {
+      await result.current.mutateAsync(true);
+    });
+    expect(privateDnsService.setEnabled).toHaveBeenCalledWith(true);
+    expect(toast.success).toHaveBeenCalledWith("Private DNS enabled");
+  });
+
+  it("shows a specific message when enabling 409s on a missing prerequisite", async () => {
+    privateDnsService.setEnabled.mockRejectedValueOnce({ status: 409 });
+    const { result } = renderHook(() => useSetPrivateDnsEnabled(), {
+      wrapper: createQueryWrapper(),
+    });
+    await act(async () => {
+      await expect(result.current.mutateAsync(true)).rejects.toBeTruthy();
+    });
+    expect(toast.error).toHaveBeenCalledWith(
+      expect.stringContaining("prerequisite"),
+    );
+  });
+
+  it("grants a device", async () => {
+    privateDnsService.grantDevice.mockResolvedValueOnce({
+      id: "g1",
+      device_id: "d1",
+      hostname: "tok.abc.my.wardnet.services",
+      created_at: "2026-07-21T00:00:00Z",
+    });
+    const { result } = renderHook(() => useGrantPrivateDnsDevice(), {
+      wrapper: createQueryWrapper(),
+    });
+    await act(async () => {
+      await result.current.mutateAsync("d1");
+    });
+    expect(privateDnsService.grantDevice).toHaveBeenCalledWith("d1");
+  });
+
+  it("revokes a device by device id and toasts", async () => {
+    privateDnsService.revokeDevice.mockResolvedValueOnce(undefined);
+    const { result } = renderHook(() => useRevokePrivateDnsDevice(), {
+      wrapper: createQueryWrapper(),
+    });
+    await act(async () => {
+      await result.current.mutateAsync("d1");
+    });
+    expect(privateDnsService.revokeDevice).toHaveBeenCalledWith("d1");
+    expect(toast.success).toHaveBeenCalledWith("Private DNS access revoked");
+  });
+
+  it("send-to-device: success toast when delivered", async () => {
+    privateDnsService.notifyDevice.mockResolvedValueOnce({ delivered: true });
+    const { result } = renderHook(() => useSendPrivateDnsToDevice(), {
+      wrapper: createQueryWrapper(),
+    });
+    await act(async () => {
+      await result.current.mutateAsync("d1");
+    });
+    expect(privateDnsService.notifyDevice).toHaveBeenCalledWith("d1");
+    expect(toast.success).toHaveBeenCalledWith("Sent to device");
+    expect(toast.warning).not.toHaveBeenCalled();
+  });
+
+  it("send-to-device: warns when the device has no subscription", async () => {
+    privateDnsService.notifyDevice.mockResolvedValueOnce({ delivered: false });
+    const { result } = renderHook(() => useSendPrivateDnsToDevice(), {
+      wrapper: createQueryWrapper(),
+    });
+    await act(async () => {
+      await result.current.mutateAsync("d1");
+    });
+    expect(toast.warning).toHaveBeenCalledWith(
+      expect.stringContaining("hasn't enabled notifications"),
+    );
+    expect(toast.success).not.toHaveBeenCalled();
+  });
+});

--- a/source/web/tests/hooks/usePrivateDns.test.tsx
+++ b/source/web/tests/hooks/usePrivateDns.test.tsx
@@ -147,4 +147,48 @@ describe("usePrivateDns hooks", () => {
     );
     expect(toast.success).not.toHaveBeenCalled();
   });
+
+  it("enabling: toasts a generic error for a non-409 failure", async () => {
+    privateDnsService.setEnabled.mockRejectedValueOnce(new Error("boom"));
+    const { result } = renderHook(() => useSetPrivateDnsEnabled(), {
+      wrapper: createQueryWrapper(),
+    });
+    await act(async () => {
+      await expect(result.current.mutateAsync(true)).rejects.toBeTruthy();
+    });
+    expect(toast.error).toHaveBeenCalledWith("Failed to update Private DNS");
+  });
+
+  it("grant: surfaces the error message", async () => {
+    privateDnsService.grantDevice.mockRejectedValueOnce(new Error("nope"));
+    const { result } = renderHook(() => useGrantPrivateDnsDevice(), {
+      wrapper: createQueryWrapper(),
+    });
+    await act(async () => {
+      await expect(result.current.mutateAsync("d1")).rejects.toBeTruthy();
+    });
+    expect(toast.error).toHaveBeenCalledWith("nope");
+  });
+
+  it("revoke: toasts a fallback on failure", async () => {
+    privateDnsService.revokeDevice.mockRejectedValueOnce(new Error("x"));
+    const { result } = renderHook(() => useRevokePrivateDnsDevice(), {
+      wrapper: createQueryWrapper(),
+    });
+    await act(async () => {
+      await expect(result.current.mutateAsync("d1")).rejects.toBeTruthy();
+    });
+    expect(toast.error).toHaveBeenCalledWith("Failed to revoke access");
+  });
+
+  it("send-to-device: toasts a fallback on failure", async () => {
+    privateDnsService.notifyDevice.mockRejectedValueOnce(new Error("x"));
+    const { result } = renderHook(() => useSendPrivateDnsToDevice(), {
+      wrapper: createQueryWrapper(),
+    });
+    await act(async () => {
+      await expect(result.current.mutateAsync("d1")).rejects.toBeTruthy();
+    });
+    expect(toast.error).toHaveBeenCalledWith("Failed to send to device");
+  });
 });


### PR DESCRIPTION
## What

Admin-facing UI for **Private DNS** (#915), extended (per discussion) to include the **device-keyed onboarding notification** and the **user PWA setup page** so the "Send to device" handoff works end-to-end.

Closes #915.

### Shared (`@wardnet/web`)
- `usePrivateDns` hooks: status / setEnabled / grant / revoke / notify / me
- `PrivateDnsInstructions` — per-platform setup (Android: hostname + copy button + Settings steps; iOS: profile link + QR)
- `CopyButton` (first clipboard affordance in the repo); optional `alt` on `InboundWgQrCode`

### Admin-site
- `PrivateDnsCard` on **Remote Access** (always visible): prerequisite checklist, enable toggle gated on the hard prereqs (wardnet provider, certificate, entitlement; reverse tunnel is informational), per-device grant table, and a granted modal showing the hostname + **Send to device**

### User PWA
- `/private-dns` page rendering the shared instructions from `me()` — the page the onboarding push opens

### Daemon + SDK
- `POST /api/private-dns/grants/{device_id}/notify` → `{ delivered }`, emitting a device-keyed `private_dns_granted` push (deep-links to `/private-dns`); SDK `notifyDevice()` + types

### Also in this PR (found while enabling local testing)
- **fix(admin-site):** requiring a name to promote a device to *managed* (empty name previously saved as a silent no-op) — now uses the DS `Form`/`Validator` with an on-submit required rule
- **fix(dev):** cross-package HMR for `@wardnet/web` in the vite apps (`server.watch.ignored`) so shared-component edits hot-reload instead of needing a dev-server restart

Docs/glossary (CONTEXT.md, ADR-0024) remain with the docs sub-issue #917.

## Testing
- Frontend suites green: `@wardnet/web` 326, `admin-site` 792, `user-app` 88; typecheck / lint / format clean across sdk, web, admin-site, user-app.
- Daemon: touched crates pass (`wardnetd-api` + `wardnetd-services` private-dns/push tests; fmt + clippy clean). Full daemon suite runs in CI.
- Manually verified the grant → granted-modal → Send-to-device flow and the PWA `/private-dns` page against the mock daemon.
