### PR TITLE
refactor(web-ui): hoist Tunnels page query/mutation hooks into the page

### DIFF
--- a/source/admin-site/src/components/compound/TunnelCard.tsx
+++ b/source/admin-site/src/components/compound/TunnelCard.tsx
@@ -6,7 +6,6 @@ import {
   RotateCcw,
   SlidersHorizontal,
 } from "lucide-react";
-import { useState } from "react";
 import { Link } from "react-router";
 import { Button } from "@wardnet/web";
 import { Text } from "@wardnet/web";
@@ -18,12 +17,6 @@ import {
   formatMs,
   retentionPct,
   timeAgo,
-} from "@wardnet/web";
-import {
-  useTestTunnel,
-  useRebuildTunnel,
-  useSpeedTestResults,
-  useStartSpeedTest,
 } from "@wardnet/web";
 import type {
   Tunnel,
@@ -153,63 +146,75 @@ function statusTooltip(tunnel: Tunnel): string | undefined {
   }
 }
 
+/** A completed (or failed) connectivity test for one tunnel, held by the
+ *  owning page so the mutation is hoisted out of the card per the "Mutation
+ *  hoisting" convention. */
+export interface TunnelTestOutcome {
+  result: TunnelTestResult | null;
+  error: string | null;
+  /** ISO 8601 timestamp of when the test finished. */
+  testedAt: string;
+}
+
 interface TunnelCardProps {
   tunnel: Tunnel;
   providers: ProviderInfo[];
   onDelete: (id: string) => void;
+  onTest: (id: string) => void;
+  onRebuild: (id: string) => void;
+  onSpeedTest: (id: string) => void;
+  /** This card's connectivity-test outcome, or `null` if it hasn't run one. */
+  testOutcome: TunnelTestOutcome | null;
+  /** Whether this card's connectivity test is in flight. */
+  testing: boolean;
+  /** Whether this card's rebuild is in flight. */
+  rebuilding: boolean;
+  /** Whether this card's speed test is running. */
+  speedTestRunning: boolean;
+  /** Progress of the running speed test (0 when not running). */
+  speedTestPercentage: number;
+  /** Latest speed-test result for this card, or `null`. */
+  speedTestResult: TunnelSpeedTestResult | null;
 }
 
 /** Card displaying a single WireGuard tunnel with status and stats.
  *  Consumes the Forge `.tcard` family (`.tcard__head` / `.tcard__flag` /
  *  `.tcard__title` / `.tcard__sub` / `.tcard__grid` / `.tcard__throughput`)
- *  per the studio mock in `forge/docs/screens.jsx`. */
-export function TunnelCard({ tunnel, providers, onDelete }: TunnelCardProps) {
+ *  per the studio mock in `forge/docs/screens.jsx`. Pure presentation: the
+ *  owning page wires the query/mutation hooks and passes data + callbacks in. */
+export function TunnelCard({
+  tunnel,
+  providers,
+  onDelete,
+  onTest,
+  onRebuild,
+  onSpeedTest,
+  testOutcome,
+  testing,
+  rebuilding,
+  speedTestRunning,
+  speedTestPercentage,
+  speedTestResult,
+}: TunnelCardProps) {
   const provider = providers.find((p) => p.id === tunnel.provider);
   const flag = tunnel.country_code ? countryFlag(tunnel.country_code) : "";
 
-  const testTunnel = useTestTunnel();
-  const rebuildTunnel = useRebuildTunnel();
-  const startSpeedTest = useStartSpeedTest();
-  // Only fetch this tunnel's speed-test history once the user has run a test
-  // on this card (avoids one request per card across the whole tunnels grid on
-  // load — persisted history lives on the tunnel detail page). A run in flight
-  // also enables it so the prior result shows while the new test runs.
-  const [speedTestRequested, setSpeedTestRequested] = useState(false);
-  const speedTestRunning =
-    startSpeedTest.isRunning && startSpeedTest.activeTunnelId === tunnel.id;
-  const speedTestResults = useSpeedTestResults(
-    tunnel.id,
-    speedTestRequested || speedTestRunning,
-  );
-  const latestSpeedTest = speedTestResults.data?.results[0] ?? null;
-  const [testResult, setTestResult] = useState<TunnelTestResult | null>(null);
-  const [testError, setTestError] = useState<string | null>(null);
-  const [testedAt, setTestedAt] = useState<string | null>(null);
+  const testResult = testOutcome?.result ?? null;
+  const testError = testOutcome?.error ?? null;
+  const testedAt = testOutcome?.testedAt ?? null;
 
   const onSpeedTestClick = (e: React.MouseEvent) => {
     // Card is wrapped in <Link>; don't navigate when clicking Speed test.
     e.preventDefault();
     e.stopPropagation();
-    setSpeedTestRequested(true);
-    startSpeedTest.start(tunnel.id);
+    onSpeedTest(tunnel.id);
   };
 
   const onTestClick = (e: React.MouseEvent) => {
     // Card is wrapped in <Link>; don't navigate when clicking Test.
     e.preventDefault();
     e.stopPropagation();
-    testTunnel.mutate(tunnel.id, {
-      onSuccess: (data) => {
-        setTestResult(data.result);
-        setTestError(null);
-        setTestedAt(new Date().toISOString());
-      },
-      onError: (err) => {
-        setTestResult(null);
-        setTestError(err instanceof Error ? err.message : "Tunnel test failed");
-        setTestedAt(new Date().toISOString());
-      },
-    });
+    onTest(tunnel.id);
   };
 
   const subParts: string[] = [];
@@ -328,7 +333,7 @@ export function TunnelCard({ tunnel, providers, onDelete }: TunnelCardProps) {
         </Text>
       )}
 
-      {latestSpeedTest && <SpeedTestComparison result={latestSpeedTest} />}
+      {speedTestResult && <SpeedTestComparison result={speedTestResult} />}
 
       <div className="row gap-8" style={{ justifyContent: "flex-end" }}>
         <Button
@@ -341,7 +346,7 @@ export function TunnelCard({ tunnel, providers, onDelete }: TunnelCardProps) {
           {speedTestRunning ? (
             <>
               <Loader2 className="mr-1 size-3 animate-spin" aria-hidden />
-              Testing {startSpeedTest.percentage}%
+              Testing {speedTestPercentage}%
             </>
           ) : (
             <>
@@ -353,10 +358,10 @@ export function TunnelCard({ tunnel, providers, onDelete }: TunnelCardProps) {
         <Button
           size="sm"
           variant="outline"
-          disabled={testTunnel.isPending}
+          disabled={testing}
           onClick={onTestClick}
         >
-          {testTunnel.isPending ? (
+          {testing ? (
             <>
               <Loader2 className="mr-1 size-3 animate-spin" aria-hidden />
               Testing
@@ -368,12 +373,15 @@ export function TunnelCard({ tunnel, providers, onDelete }: TunnelCardProps) {
         <Button
           size="sm"
           variant="outline"
-          disabled={
-            rebuildTunnel.isPending && rebuildTunnel.variables === tunnel.id
-          }
-          onClick={() => rebuildTunnel.mutate(tunnel.id)}
+          disabled={rebuilding}
+          onClick={(e) => {
+            // Card is wrapped in <Link>; don't navigate when clicking Rebuild.
+            e.preventDefault();
+            e.stopPropagation();
+            onRebuild(tunnel.id);
+          }}
         >
-          {rebuildTunnel.isPending && rebuildTunnel.variables === tunnel.id ? (
+          {rebuilding ? (
             <>
               <Loader2 className="mr-1 size-3 animate-spin" aria-hidden />
               Rebuilding

--- a/source/admin-site/src/components/compound/TunnelGrid.tsx
+++ b/source/admin-site/src/components/compound/TunnelGrid.tsx
@@ -2,8 +2,9 @@ import { useMemo } from "react";
 import { Card, CardContent } from "@wardnet/web";
 import { sortByLabel } from "@wardnet/web";
 import { TunnelCard } from "./TunnelCard";
+import type { TunnelTestOutcome } from "./TunnelCard";
 import { EmptyStatePlaceholder } from "./EmptyStatePlaceholder";
-import type { Tunnel, ProviderInfo } from "@wardnet/js";
+import type { Tunnel, ProviderInfo, TunnelSpeedTestResult } from "@wardnet/js";
 
 interface TunnelGridProps {
   /** Rendered alphabetically by label regardless of the order passed in. */
@@ -12,6 +13,21 @@ interface TunnelGridProps {
   isLoading: boolean;
   isError: boolean;
   onDelete: (id: string) => void;
+  onTest: (id: string) => void;
+  onRebuild: (id: string) => void;
+  onSpeedTest: (id: string) => void;
+  /** Connectivity-test outcomes keyed by tunnel id. */
+  testOutcomes: Record<string, TunnelTestOutcome>;
+  /** Latest speed-test result keyed by tunnel id. */
+  speedTestResults: Record<string, TunnelSpeedTestResult | null>;
+  /** Tunnel whose connectivity test is in flight, if any. */
+  testingId: string | null;
+  /** Tunnel whose rebuild is in flight, if any. */
+  rebuildingId: string | null;
+  /** Tunnel whose speed test is running, if any. */
+  speedTestRunningId: string | null;
+  /** Progress of the running speed test (0 when none is running). */
+  speedTestPercentage: number;
   /** Called when the user clicks the "Add tunnel" button in the empty state. */
   onAdd?: () => void;
 }
@@ -23,6 +39,15 @@ export function TunnelGrid({
   isLoading,
   isError,
   onDelete,
+  onTest,
+  onRebuild,
+  onSpeedTest,
+  testOutcomes,
+  speedTestResults,
+  testingId,
+  rebuildingId,
+  speedTestRunningId,
+  speedTestPercentage,
   onAdd,
 }: TunnelGridProps) {
   // Before the loading/empty early-returns: hook order must not depend on state.
@@ -54,14 +79,31 @@ export function TunnelGrid({
 
   return (
     <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
-      {sorted.map((tunnel) => (
-        <TunnelCard
-          key={tunnel.id}
-          tunnel={tunnel}
-          providers={providers}
-          onDelete={onDelete}
-        />
-      ))}
+      {sorted.map((tunnel) => {
+        // eslint-disable-next-line security/detect-object-injection -- tunnel.id is the card's own key; read-only lookups into the page-owned maps
+        const testOutcome = testOutcomes[tunnel.id] ?? null;
+        // eslint-disable-next-line security/detect-object-injection -- tunnel.id is the card's own key; read-only lookups into the page-owned maps
+        const speedTestResult = speedTestResults[tunnel.id] ?? null;
+        return (
+          <TunnelCard
+            key={tunnel.id}
+            tunnel={tunnel}
+            providers={providers}
+            onDelete={onDelete}
+            onTest={onTest}
+            onRebuild={onRebuild}
+            onSpeedTest={onSpeedTest}
+            testOutcome={testOutcome}
+            speedTestResult={speedTestResult}
+            testing={testingId === tunnel.id}
+            rebuilding={rebuildingId === tunnel.id}
+            speedTestRunning={speedTestRunningId === tunnel.id}
+            speedTestPercentage={
+              speedTestRunningId === tunnel.id ? speedTestPercentage : 0
+            }
+          />
+        );
+      })}
     </div>
   );
 }

--- a/source/admin-site/src/pages/Tunnels.tsx
+++ b/source/admin-site/src/pages/Tunnels.tsx
@@ -1,9 +1,17 @@
 import { useState } from "react";
 import { PageHeader } from "@/components/compound/PageHeader";
 import { TunnelGrid } from "@/components/compound/TunnelGrid";
+import type { TunnelTestOutcome } from "@/components/compound/TunnelCard";
 import { ConfirmDialog } from "@/components/compound/ConfirmDialog";
 import { CreateTunnelInline } from "@/components/features/CreateTunnelInline";
-import { useTunnels, useDeleteTunnel } from "@wardnet/web";
+import {
+  useTunnels,
+  useDeleteTunnel,
+  useTestTunnel,
+  useRebuildTunnel,
+  useStartSpeedTest,
+  useSpeedTestResultsList,
+} from "@wardnet/web";
 import { useProviders } from "@wardnet/web";
 import { Button } from "@wardnet/web";
 
@@ -11,19 +19,67 @@ import { Button } from "@wardnet/web";
  *  Composes the ported `PageHeader`, `TunnelGrid` (Forge `.tcard` family
  *  per `forge/docs/screens.jsx` §03), and `CreateTunnelInline` panel
  *  inside a `col gap-20` page wrapper that matches the studio mock.
+ *  Owns the tunnel query and the test/rebuild/speed-test mutations, passing
+ *  data + callbacks down to the grid so the cards stay pure presentation and
+ *  a single mutation drives the in-flight indicator across the whole list.
  *  Public API unchanged — default-exported, no props (consumed via
  *  `<Route element={<Tunnels />} />` in `App.tsx`). */
 export default function Tunnels() {
   const { data, isLoading, isError } = useTunnels();
   const { data: providerData } = useProviders();
   const deleteTunnel = useDeleteTunnel();
+  const testTunnel = useTestTunnel();
+  const rebuildTunnel = useRebuildTunnel();
+  const startSpeedTest = useStartSpeedTest();
+
   const tunnels = data?.tunnels ?? [];
   const providers = providerData?.providers ?? [];
+
   const [deleteId, setDeleteId] = useState<string | null>(null);
   const [creating, setCreating] = useState(false);
-  const tunnelToDelete = tunnels.find((t) => t.id === deleteId);
+  const [testOutcomes, setTestOutcomes] = useState<
+    Record<string, TunnelTestOutcome>
+  >({});
+  // Tunnels the user has run a speed test on this session. Each keeps its
+  // inline comparison visible; the one still running also shows live progress.
+  // Persisted history lives on the tunnel detail page, so the grid only fetches
+  // results for cards that were actually tested here.
+  const [speedTestIds, setSpeedTestIds] = useState<string[]>([]);
 
+  const speedTestResults = useSpeedTestResultsList(speedTestIds);
+
+  const tunnelToDelete = tunnels.find((t) => t.id === deleteId);
   const hasTunnels = tunnels.length > 0;
+
+  const handleTest = (id: string) => {
+    testTunnel.mutate(id, {
+      onSuccess: (response) => {
+        setTestOutcomes((prev) => ({
+          ...prev,
+          [id]: {
+            result: response.result,
+            error: null,
+            testedAt: new Date().toISOString(),
+          },
+        }));
+      },
+      onError: (err) => {
+        setTestOutcomes((prev) => ({
+          ...prev,
+          [id]: {
+            result: null,
+            error: err instanceof Error ? err.message : "Tunnel test failed",
+            testedAt: new Date().toISOString(),
+          },
+        }));
+      },
+    });
+  };
+
+  const handleSpeedTest = (id: string) => {
+    setSpeedTestIds((prev) => (prev.includes(id) ? prev : [...prev, id]));
+    startSpeedTest.start(id);
+  };
 
   return (
     <div className="col gap-20">
@@ -48,6 +104,19 @@ export default function Tunnels() {
         isError={isError}
         onDelete={setDeleteId}
         onAdd={creating ? undefined : () => setCreating(true)}
+        onTest={handleTest}
+        onRebuild={rebuildTunnel.mutate}
+        onSpeedTest={handleSpeedTest}
+        testOutcomes={testOutcomes}
+        speedTestResults={speedTestResults}
+        testingId={testTunnel.isPending ? (testTunnel.variables ?? null) : null}
+        rebuildingId={
+          rebuildTunnel.isPending ? (rebuildTunnel.variables ?? null) : null
+        }
+        speedTestRunningId={
+          startSpeedTest.isRunning ? startSpeedTest.activeTunnelId : null
+        }
+        speedTestPercentage={startSpeedTest.percentage}
       />
 
       <ConfirmDialog

--- a/source/admin-site/src/pages/Tunnels.tsx
+++ b/source/admin-site/src/pages/Tunnels.tsx
@@ -46,7 +46,12 @@ export default function Tunnels() {
   // results for cards that were actually tested here.
   const [speedTestIds, setSpeedTestIds] = useState<string[]>([]);
 
-  const speedTestResults = useSpeedTestResultsList(speedTestIds);
+  // Only fetch for tunnels that still exist: a tunnel deleted after a run must
+  // not leave a live query refetching (404s) against a gone tunnel.
+  const tunnelIds = new Set(tunnels.map((t) => t.id));
+  const speedTestResults = useSpeedTestResultsList(
+    speedTestIds.filter((id) => tunnelIds.has(id)),
+  );
 
   const tunnelToDelete = tunnels.find((t) => t.id === deleteId);
   const hasTunnels = tunnels.length > 0;

--- a/source/admin-site/tests/components/compound/TunnelCard.test.tsx
+++ b/source/admin-site/tests/components/compound/TunnelCard.test.tsx
@@ -1,36 +1,10 @@
 import { screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import type { ProviderInfo, Tunnel, TunnelSpeedTestResult } from "@wardnet/js";
 import { TunnelCard } from "@/components/compound/TunnelCard";
+import type { TunnelTestOutcome } from "@/components/compound/TunnelCard";
 import { renderWithProviders } from "../../test-utils";
-
-vi.mock("@wardnet/web", async (importOriginal) => {
-  const actual = await importOriginal<Record<string, unknown>>();
-  return {
-    ...actual,
-    useTestTunnel: vi.fn(),
-    useRebuildTunnel: vi.fn(),
-    useSpeedTestResults: vi.fn(),
-    useStartSpeedTest: vi.fn(),
-  };
-});
-
-import {
-  useTestTunnel,
-  useRebuildTunnel,
-  useSpeedTestResults,
-  useStartSpeedTest,
-} from "@wardnet/web";
-
-const mockTest = vi.mocked(useTestTunnel);
-const mockRebuild = vi.mocked(useRebuildTunnel);
-const mockSpeedResults = vi.mocked(useSpeedTestResults);
-const mockStartSpeed = vi.mocked(useStartSpeedTest);
-
-const testMutate = vi.fn();
-const rebuildMutate = vi.fn();
-const startSpeed = vi.fn();
 
 function makeTunnel(overrides: Partial<Tunnel> = {}): Tunnel {
   return {
@@ -74,34 +48,31 @@ function makeSpeedResult(
   };
 }
 
-beforeEach(() => {
-  testMutate.mockReset();
-  rebuildMutate.mockReset();
-  startSpeed.mockReset();
-  mockTest.mockReturnValue({ mutate: testMutate, isPending: false } as never);
-  mockRebuild.mockReturnValue({
-    mutate: rebuildMutate,
-    isPending: false,
-    variables: undefined,
-  } as never);
-  mockStartSpeed.mockReturnValue({
-    start: startSpeed,
-    activeTunnelId: null,
-    percentage: 0,
-    isRunning: false,
-  } as never);
-  mockSpeedResults.mockReturnValue({ data: { results: [] } } as never);
-});
+type CardProps = Parameters<typeof TunnelCard>[0];
+
+/** Render a card with sensible presentation defaults; override per test. */
+function renderCard(overrides: Partial<CardProps> = {}) {
+  const props: CardProps = {
+    tunnel: makeTunnel(),
+    providers,
+    onDelete: vi.fn(),
+    onTest: vi.fn(),
+    onRebuild: vi.fn(),
+    onSpeedTest: vi.fn(),
+    testOutcome: null,
+    testing: false,
+    rebuilding: false,
+    speedTestRunning: false,
+    speedTestPercentage: 0,
+    speedTestResult: null,
+    ...overrides,
+  };
+  return renderWithProviders(<TunnelCard {...props} />);
+}
 
 describe("TunnelCard", () => {
   it("renders the tunnel identity, provider, and throughput", () => {
-    renderWithProviders(
-      <TunnelCard
-        tunnel={makeTunnel()}
-        providers={providers}
-        onDelete={vi.fn()}
-      />,
-    );
+    renderCard();
     expect(screen.getByText("US East")).toBeInTheDocument();
     expect(screen.getByText(/NordVPN/)).toBeInTheDocument();
     expect(screen.getByText("wg_ward0")).toBeInTheDocument();
@@ -110,16 +81,12 @@ describe("TunnelCard", () => {
   });
 
   it("falls back to the raw provider id and custom icon when unknown", () => {
-    renderWithProviders(
-      <TunnelCard
-        tunnel={makeTunnel({
-          provider: "mystery",
-          server_selector: { country: "de" },
-        })}
-        providers={providers}
-        onDelete={vi.fn()}
-      />,
-    );
+    renderCard({
+      tunnel: makeTunnel({
+        provider: "mystery",
+        server_selector: { country: "de" },
+      }),
+    });
     expect(screen.getByText(/mystery/)).toBeInTheDocument();
     expect(screen.getByLabelText("Custom configuration")).toBeInTheDocument();
     expect(screen.getByText("Best DE")).toBeInTheDocument();
@@ -131,112 +98,69 @@ describe("TunnelCard", () => {
       ["connecting", "Connecting"],
       ["reconnecting", "Reconnecting"],
     ] as const) {
-      const { unmount } = renderWithProviders(
-        <TunnelCard
-          tunnel={makeTunnel({ status, last_handshake: null })}
-          providers={providers}
-          onDelete={vi.fn()}
-        />,
-      );
+      const { unmount } = renderCard({
+        tunnel: makeTunnel({ status, last_handshake: null }),
+      });
       expect(screen.getByText(label)).toBeInTheDocument();
       unmount();
     }
   });
 
   it("shows a reconnecting tooltip that mentions the last handshake", () => {
-    renderWithProviders(
-      <TunnelCard
-        tunnel={makeTunnel({ status: "reconnecting" })}
-        providers={providers}
-        onDelete={vi.fn()}
-      />,
-    );
+    renderCard({ tunnel: makeTunnel({ status: "reconnecting" }) });
     expect(screen.getByText("Reconnecting")).toBeInTheDocument();
   });
 
-  it("runs a connectivity test and shows the result", async () => {
+  it("fires onTest and renders the outcome passed back in", async () => {
     const user = userEvent.setup();
-    testMutate.mockImplementation((_id, opts) =>
-      opts.onSuccess({
-        result: {
-          tunnel_id: "t1",
-          exit_ip: "9.9.9.9",
-          country_code: "us",
-          latency_ms: 42,
-        },
-      }),
-    );
-    renderWithProviders(
-      <TunnelCard
-        tunnel={makeTunnel()}
-        providers={providers}
-        onDelete={vi.fn()}
-      />,
-    );
+    const onTest = vi.fn();
+    renderCard({ onTest });
     await user.click(screen.getByRole("button", { name: "Test" }));
-    expect(testMutate).toHaveBeenCalledWith("t1", expect.any(Object));
+    expect(onTest).toHaveBeenCalledWith("t1");
+  });
+
+  it("renders a connectivity-test result from testOutcome", () => {
+    const testOutcome: TunnelTestOutcome = {
+      result: {
+        tunnel_id: "t1",
+        exit_ip: "9.9.9.9",
+        country_code: "us",
+        latency_ms: 42,
+      },
+      error: null,
+      testedAt: "2026-01-01T00:00:00Z",
+    };
+    renderCard({ testOutcome });
     expect(screen.getByText("9.9.9.9")).toBeInTheDocument();
     expect(screen.getByText("42 ms")).toBeInTheDocument();
   });
 
-  it("shows an error alert when the connectivity test fails", async () => {
-    const user = userEvent.setup();
-    testMutate.mockImplementation((_id, opts) =>
-      opts.onError(new Error("unreachable")),
-    );
-    renderWithProviders(
-      <TunnelCard
-        tunnel={makeTunnel()}
-        providers={providers}
-        onDelete={vi.fn()}
-      />,
-    );
-    await user.click(screen.getByRole("button", { name: "Test" }));
+  it("renders an error alert when testOutcome carries an error", () => {
+    const testOutcome: TunnelTestOutcome = {
+      result: null,
+      error: "unreachable",
+      testedAt: "2026-01-01T00:00:00Z",
+    };
+    renderCard({ testOutcome });
     expect(screen.getByRole("alert")).toHaveTextContent("unreachable");
   });
 
-  it("starts a speed test on click and reflects a running test", async () => {
+  it("fires onSpeedTest on click", async () => {
     const user = userEvent.setup();
-    renderWithProviders(
-      <TunnelCard
-        tunnel={makeTunnel()}
-        providers={providers}
-        onDelete={vi.fn()}
-      />,
-    );
+    const onSpeedTest = vi.fn();
+    renderCard({ onSpeedTest });
     await user.click(screen.getByTestId("tunnel-speed-test-button"));
-    expect(startSpeed).toHaveBeenCalledWith("t1");
+    expect(onSpeedTest).toHaveBeenCalledWith("t1");
   });
 
   it("renders the running speed-test progress label", () => {
-    mockStartSpeed.mockReturnValue({
-      start: startSpeed,
-      activeTunnelId: "t1",
-      percentage: 55,
-      isRunning: true,
-    } as never);
-    renderWithProviders(
-      <TunnelCard
-        tunnel={makeTunnel()}
-        providers={providers}
-        onDelete={vi.fn()}
-      />,
-    );
+    renderCard({ speedTestRunning: true, speedTestPercentage: 55 });
     expect(screen.getByText(/Testing 55%/)).toBeInTheDocument();
     expect(screen.getByTestId("tunnel-speed-test-button")).toBeDisabled();
   });
 
   it("renders the speed-test comparison with high retention", () => {
-    mockSpeedResults.mockReturnValue({
-      data: { results: [makeSpeedResult()] },
-    } as never);
-    renderWithProviders(
-      <TunnelCard
-        tunnel={makeTunnel()}
-        providers={providers}
-        onDelete={vi.fn()}
-      />,
-    );
+    renderCard({ speedTestResult: makeSpeedResult() });
     const panel = screen.getByTestId("tunnel-speed-test-result");
     expect(within(panel).getByText(/% kept/)).toBeInTheDocument();
     expect(
@@ -245,75 +169,45 @@ describe("TunnelCard", () => {
   });
 
   it("renders the comparison with low retention and negative overheads", () => {
-    mockSpeedResults.mockReturnValue({
-      data: {
-        results: [
-          makeSpeedResult({
-            tunnel_throughput_mbps: 10,
-            tunnel_latency_ms: 5,
-            tunnel_jitter_ms: 0,
-          }),
-        ],
-      },
-    } as never);
-    renderWithProviders(
-      <TunnelCard
-        tunnel={makeTunnel()}
-        providers={providers}
-        onDelete={vi.fn()}
-      />,
-    );
+    renderCard({
+      speedTestResult: makeSpeedResult({
+        tunnel_throughput_mbps: 10,
+        tunnel_latency_ms: 5,
+        tunnel_jitter_ms: 0,
+      }),
+    });
     expect(screen.getByTestId("tunnel-speed-test-result")).toBeInTheDocument();
   });
 
-  it("rebuilds and deletes the tunnel", async () => {
+  it("fires onRebuild and onDelete", async () => {
     const user = userEvent.setup();
+    const onRebuild = vi.fn();
     const onDelete = vi.fn();
-    renderWithProviders(
-      <TunnelCard
-        tunnel={makeTunnel()}
-        providers={providers}
-        onDelete={onDelete}
-      />,
-    );
+    renderCard({ onRebuild, onDelete });
     await user.click(screen.getByRole("button", { name: /Rebuild/ }));
-    expect(rebuildMutate).toHaveBeenCalledWith("t1");
+    expect(onRebuild).toHaveBeenCalledWith("t1");
     await user.click(screen.getByRole("button", { name: "Delete" }));
     expect(onDelete).toHaveBeenCalledWith("t1");
   });
 
   it("shows pending spinners for in-flight test and rebuild", () => {
-    mockTest.mockReturnValue({ mutate: testMutate, isPending: true } as never);
-    mockRebuild.mockReturnValue({
-      mutate: rebuildMutate,
-      isPending: true,
-      variables: "t1",
-    } as never);
-    renderWithProviders(
-      <TunnelCard
-        tunnel={makeTunnel()}
-        providers={providers}
-        onDelete={vi.fn()}
-      />,
-    );
+    renderCard({ testing: true, rebuilding: true });
     expect(screen.getByText("Rebuilding")).toBeInTheDocument();
+    // The connectivity Test button collapses to its spinner label too.
+    expect(screen.getByRole("button", { name: "Rebuilding" })).toBeDisabled();
   });
 
   it("renders a provider icon image when available", () => {
-    renderWithProviders(
-      <TunnelCard
-        tunnel={makeTunnel()}
-        providers={[
-          {
-            id: "nordvpn",
-            name: "NordVPN",
-            auth_methods: ["credentials"],
-            icon_url: "https://example.com/n.png",
-          },
-        ]}
-        onDelete={vi.fn()}
-      />,
-    );
+    renderCard({
+      providers: [
+        {
+          id: "nordvpn",
+          name: "NordVPN",
+          auth_methods: ["credentials"],
+          icon_url: "https://example.com/n.png",
+        },
+      ],
+    });
     const img = document.querySelector("img");
     expect(img).toHaveAttribute("src", "https://example.com/n.png");
   });

--- a/source/admin-site/tests/components/compound/TunnelGrid.test.tsx
+++ b/source/admin-site/tests/components/compound/TunnelGrid.test.tsx
@@ -1,46 +1,9 @@
-import { describe, expect, it, vi, beforeEach } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import {
-  useTestTunnel,
-  useRebuildTunnel,
-  useSpeedTestResults,
-  useStartSpeedTest,
-} from "@wardnet/web";
-import type { Tunnel, ProviderInfo } from "@wardnet/js";
+import type { Tunnel, ProviderInfo, TunnelSpeedTestResult } from "@wardnet/js";
 import { TunnelGrid } from "@/components/compound/TunnelGrid";
 import { renderWithProviders } from "../../test-utils";
-
-vi.mock("@wardnet/web", async (importOriginal) => {
-  const actual = await importOriginal<Record<string, unknown>>();
-  return {
-    ...actual,
-    useTestTunnel: vi.fn(),
-    useRebuildTunnel: vi.fn(),
-    useSpeedTestResults: vi.fn(),
-    useStartSpeedTest: vi.fn(),
-  };
-});
-
-beforeEach(() => {
-  vi.clearAllMocks();
-  vi.mocked(useTestTunnel).mockReturnValue({
-    mutate: vi.fn(),
-    isPending: false,
-  } as never);
-  vi.mocked(useRebuildTunnel).mockReturnValue({
-    mutate: vi.fn(),
-    isPending: false,
-    variables: undefined,
-  } as never);
-  vi.mocked(useSpeedTestResults).mockReturnValue({ data: undefined } as never);
-  vi.mocked(useStartSpeedTest).mockReturnValue({
-    isRunning: false,
-    activeTunnelId: null,
-    percentage: 0,
-    start: vi.fn(),
-  } as never);
-});
 
 const providers: ProviderInfo[] = [
   { id: "nord", name: "NordVPN" } as ProviderInfo,
@@ -62,63 +25,73 @@ function makeTunnel(overrides: Partial<Tunnel> = {}): Tunnel {
   } as Tunnel;
 }
 
+function makeSpeedResult(
+  overrides: Partial<TunnelSpeedTestResult> = {},
+): TunnelSpeedTestResult {
+  return {
+    id: "s1",
+    tunnel_id: "t1",
+    direct_throughput_mbps: 100,
+    tunnel_throughput_mbps: 90,
+    direct_latency_ms: 10,
+    tunnel_latency_ms: 15,
+    direct_jitter_ms: 1,
+    tunnel_jitter_ms: 2,
+    tested_at: "2026-01-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+type GridProps = Parameters<typeof TunnelGrid>[0];
+
+function renderGrid(overrides: Partial<GridProps> = {}) {
+  const props: GridProps = {
+    tunnels: [makeTunnel()],
+    providers,
+    isLoading: false,
+    isError: false,
+    onDelete: vi.fn(),
+    onTest: vi.fn(),
+    onRebuild: vi.fn(),
+    onSpeedTest: vi.fn(),
+    testOutcomes: {},
+    speedTestResults: {},
+    testingId: null,
+    rebuildingId: null,
+    speedTestRunningId: null,
+    speedTestPercentage: 0,
+    ...overrides,
+  };
+  return renderWithProviders(<TunnelGrid {...props} />);
+}
+
 describe("TunnelGrid", () => {
   it("shows a loading state", () => {
-    renderWithProviders(
-      <TunnelGrid
-        tunnels={[]}
-        providers={providers}
-        isLoading={true}
-        isError={false}
-        onDelete={vi.fn()}
-      />,
-    );
+    renderGrid({ tunnels: [], isLoading: true });
     expect(screen.getByText("Loading tunnels...")).toBeInTheDocument();
   });
 
   it("shows the empty state with an Add action", async () => {
     const user = userEvent.setup();
     const onAdd = vi.fn();
-    renderWithProviders(
-      <TunnelGrid
-        tunnels={[]}
-        providers={providers}
-        isLoading={false}
-        isError={false}
-        onDelete={vi.fn()}
-        onAdd={onAdd}
-      />,
-    );
+    renderGrid({ tunnels: [], onAdd });
     expect(screen.getByText("No tunnels configured")).toBeInTheDocument();
     await user.click(screen.getByRole("button", { name: "Add tunnel" }));
     expect(onAdd).toHaveBeenCalledTimes(1);
   });
 
   it("renders null when there are no tunnels and an error occurred", () => {
-    const { container } = renderWithProviders(
-      <TunnelGrid
-        tunnels={[]}
-        providers={providers}
-        isLoading={false}
-        isError={true}
-        onDelete={vi.fn()}
-      />,
-    );
+    const { container } = renderGrid({ tunnels: [], isError: true });
     expect(container).toBeEmptyDOMElement();
   });
 
   it("renders a card per tunnel and forwards delete", async () => {
     const user = userEvent.setup();
     const onDelete = vi.fn();
-    renderWithProviders(
-      <TunnelGrid
-        tunnels={[makeTunnel(), makeTunnel({ id: "t2", label: "Second" })]}
-        providers={providers}
-        isLoading={false}
-        isError={false}
-        onDelete={onDelete}
-      />,
-    );
+    renderGrid({
+      tunnels: [makeTunnel(), makeTunnel({ id: "t2", label: "Second" })],
+      onDelete,
+    });
     expect(screen.getByText("My tunnel")).toBeInTheDocument();
     expect(screen.getByText("Second")).toBeInTheDocument();
 
@@ -127,22 +100,50 @@ describe("TunnelGrid", () => {
     expect(onDelete).toHaveBeenCalledWith("t1");
   });
 
+  it("forwards per-tunnel action callbacks with the card's id", async () => {
+    const user = userEvent.setup();
+    const onTest = vi.fn();
+    const onRebuild = vi.fn();
+    const onSpeedTest = vi.fn();
+    renderGrid({
+      tunnels: [makeTunnel({ id: "t9", label: "Only" })],
+      onTest,
+      onRebuild,
+      onSpeedTest,
+    });
+    await user.click(screen.getByRole("button", { name: "Test" }));
+    await user.click(screen.getByRole("button", { name: /Rebuild/ }));
+    await user.click(screen.getByTestId("tunnel-speed-test-button"));
+    expect(onTest).toHaveBeenCalledWith("t9");
+    expect(onRebuild).toHaveBeenCalledWith("t9");
+    expect(onSpeedTest).toHaveBeenCalledWith("t9");
+  });
+
+  it("routes per-tunnel state to the matching card only", () => {
+    renderGrid({
+      tunnels: [
+        makeTunnel({ id: "t1", label: "Alpha" }),
+        makeTunnel({ id: "t2", label: "Beta" }),
+      ],
+      testingId: "t1",
+      speedTestResults: { t2: makeSpeedResult({ tunnel_id: "t2" }) },
+    });
+    // Exactly one card shows the in-flight connectivity spinner ("Testing"),
+    // and exactly one shows the speed-test comparison panel.
+    expect(screen.getAllByText("Testing")).toHaveLength(1);
+    expect(screen.getAllByTestId("tunnel-speed-test-result")).toHaveLength(1);
+  });
+
   // Card order is the grid's job. Asserted on the rendered sequence so
   // dropping the sort can't pass silently.
   it("renders tunnel cards alphabetically regardless of the order passed in", () => {
-    renderWithProviders(
-      <TunnelGrid
-        tunnels={[
-          makeTunnel({ id: "t1", label: "zeta" }),
-          makeTunnel({ id: "t2", label: "Alpha" }),
-          makeTunnel({ id: "t3", label: "beta" }),
-        ]}
-        providers={providers}
-        isLoading={false}
-        isError={false}
-        onDelete={vi.fn()}
-      />,
-    );
+    renderGrid({
+      tunnels: [
+        makeTunnel({ id: "t1", label: "zeta" }),
+        makeTunnel({ id: "t2", label: "Alpha" }),
+        makeTunnel({ id: "t3", label: "beta" }),
+      ],
+    });
     // Each card is a link wrapping the whole tunnel; assert on href order so
     // the check is about sequence, not card markup.
     expect(

--- a/source/admin-site/tests/pages/Tunnels.test.tsx
+++ b/source/admin-site/tests/pages/Tunnels.test.tsx
@@ -322,6 +322,23 @@ describe("Tunnels", () => {
     expect(useSpeedTestResultsList).toHaveBeenLastCalledWith(["t1"]);
   });
 
+  it("stops fetching speed-test results for a tunnel that no longer exists", async () => {
+    useTunnels.mockReturnValue(oneTunnel);
+    const user = userEvent.setup();
+    const { rerender } = renderWithProviders(<Tunnels />);
+    await user.click(screen.getByText("speed-t1"));
+    expect(useSpeedTestResultsList).toHaveBeenLastCalledWith(["t1"]);
+    // The tunnel is deleted; its speed-test query must drop out rather than
+    // keep refetching against a tunnel that is gone.
+    useTunnels.mockReturnValue({
+      data: { tunnels: [] },
+      isLoading: false,
+      isError: false,
+    });
+    rerender(<Tunnels />);
+    expect(useSpeedTestResultsList).toHaveBeenLastCalledWith([]);
+  });
+
   it("derives the running speed-test id from the shared hook", () => {
     useTunnels.mockReturnValue(oneTunnel);
     useStartSpeedTest.mockReturnValue({

--- a/source/admin-site/tests/pages/Tunnels.test.tsx
+++ b/source/admin-site/tests/pages/Tunnels.test.tsx
@@ -3,15 +3,36 @@ import userEvent from "@testing-library/user-event";
 import type { ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { useTunnels, useProviders, useDeleteTunnel } = vi.hoisted(() => ({
+const {
+  useTunnels,
+  useProviders,
+  useDeleteTunnel,
+  useTestTunnel,
+  useRebuildTunnel,
+  useStartSpeedTest,
+  useSpeedTestResultsList,
+} = vi.hoisted(() => ({
   useTunnels: vi.fn(),
   useProviders: vi.fn(),
   useDeleteTunnel: vi.fn(),
+  useTestTunnel: vi.fn(),
+  useRebuildTunnel: vi.fn(),
+  useStartSpeedTest: vi.fn(),
+  useSpeedTestResultsList: vi.fn(),
 }));
 
 vi.mock("@wardnet/web", async (importOriginal) => {
   const actual = await importOriginal<Record<string, unknown>>();
-  return { ...actual, useTunnels, useProviders, useDeleteTunnel };
+  return {
+    ...actual,
+    useTunnels,
+    useProviders,
+    useDeleteTunnel,
+    useTestTunnel,
+    useRebuildTunnel,
+    useStartSpeedTest,
+    useSpeedTestResultsList,
+  };
 });
 
 vi.mock("@/components/compound/PageHeader", () => ({
@@ -28,6 +49,10 @@ vi.mock("@/components/compound/PageHeader", () => ({
     </div>
   ),
 }));
+
+// The grid is mocked to a thin harness that surfaces the page's wiring: it
+// exposes the per-tunnel callbacks and the derived in-flight ids so the tests
+// assert what the page hoisted, not the grid's own rendering.
 vi.mock("@/components/compound/TunnelGrid", () => ({
   TunnelGrid: ({
     tunnels,
@@ -35,16 +60,36 @@ vi.mock("@/components/compound/TunnelGrid", () => ({
     isError,
     onDelete,
     onAdd,
+    onTest,
+    onRebuild,
+    onSpeedTest,
+    testingId,
+    rebuildingId,
+    speedTestRunningId,
+    testOutcomes,
   }: {
     tunnels: Array<{ id: string }>;
     isLoading?: boolean;
     isError?: boolean;
     onDelete: (id: string) => void;
     onAdd?: () => void;
+    onTest: (id: string) => void;
+    onRebuild: (id: string) => void;
+    onSpeedTest: (id: string) => void;
+    testingId: string | null;
+    rebuildingId: string | null;
+    speedTestRunningId: string | null;
+    testOutcomes: Record<string, { result: unknown; error: string | null }>;
   }) => (
     <div data-testid="grid">
       <span data-testid="grid-state">
         {isLoading ? "loading" : isError ? "error" : `count:${tunnels.length}`}
+      </span>
+      <span data-testid="testing-id">{testingId ?? "-"}</span>
+      <span data-testid="rebuilding-id">{rebuildingId ?? "-"}</span>
+      <span data-testid="speedtest-id">{speedTestRunningId ?? "-"}</span>
+      <span data-testid="outcome-keys">
+        {Object.keys(testOutcomes).join(",")}
       </span>
       {onAdd && (
         <button onClick={() => onAdd()} data-testid="grid-add">
@@ -52,13 +97,17 @@ vi.mock("@/components/compound/TunnelGrid", () => ({
         </button>
       )}
       {tunnels.map((t) => (
-        <button key={t.id} onClick={() => onDelete(t.id)}>
-          {`delete-${t.id}`}
-        </button>
+        <div key={t.id}>
+          <button onClick={() => onDelete(t.id)}>{`delete-${t.id}`}</button>
+          <button onClick={() => onTest(t.id)}>{`test-${t.id}`}</button>
+          <button onClick={() => onRebuild(t.id)}>{`rebuild-${t.id}`}</button>
+          <button onClick={() => onSpeedTest(t.id)}>{`speed-${t.id}`}</button>
+        </div>
       ))}
     </div>
   ),
 }));
+
 vi.mock("@/components/compound/ConfirmDialog", () => ({
   ConfirmDialog: ({
     open,
@@ -90,17 +139,44 @@ vi.mock("@/components/features/CreateTunnelInline", () => ({
 import Tunnels from "@/pages/Tunnels";
 import { renderWithProviders } from "../test-utils";
 
-const mutate = vi.fn();
+const deleteMutate = vi.fn();
+const testMutate = vi.fn();
+const rebuildMutate = vi.fn();
+const startSpeed = vi.fn();
+
 beforeEach(() => {
   vi.clearAllMocks();
   useProviders.mockReturnValue({ data: { providers: [] } });
-  useDeleteTunnel.mockReturnValue({ mutate });
+  useDeleteTunnel.mockReturnValue({ mutate: deleteMutate });
+  useTestTunnel.mockReturnValue({
+    mutate: testMutate,
+    isPending: false,
+    variables: undefined,
+  });
+  useRebuildTunnel.mockReturnValue({
+    mutate: rebuildMutate,
+    isPending: false,
+    variables: undefined,
+  });
+  useStartSpeedTest.mockReturnValue({
+    start: startSpeed,
+    activeTunnelId: null,
+    percentage: 0,
+    isRunning: false,
+  });
+  useSpeedTestResultsList.mockReturnValue({});
   useTunnels.mockReturnValue({
     data: { tunnels: [] },
     isLoading: false,
     isError: false,
   });
 });
+
+const oneTunnel = {
+  data: { tunnels: [{ id: "t1", label: "VPN", status: "up" }] },
+  isLoading: false,
+  isError: false,
+};
 
 describe("Tunnels", () => {
   it("renders empty grid with no Add button in header", () => {
@@ -131,11 +207,7 @@ describe("Tunnels", () => {
   });
 
   it("opens the inline create form via the header Add button", async () => {
-    useTunnels.mockReturnValue({
-      data: { tunnels: [{ id: "t1", label: "VPN", status: "up" }] },
-      isLoading: false,
-      isError: false,
-    });
+    useTunnels.mockReturnValue(oneTunnel);
     const user = userEvent.setup();
     renderWithProviders(<Tunnels />);
     await user.click(screen.getByRole("button", { name: "Add tunnel" }));
@@ -159,31 +231,106 @@ describe("Tunnels", () => {
   });
 
   it("confirms and deletes a tunnel", async () => {
-    useTunnels.mockReturnValue({
-      data: { tunnels: [{ id: "t1", label: "VPN", status: "up" }] },
-      isLoading: false,
-      isError: false,
-    });
+    useTunnels.mockReturnValue(oneTunnel);
     const user = userEvent.setup();
     renderWithProviders(<Tunnels />);
     await user.click(screen.getByText("delete-t1"));
     expect(screen.getByTestId("confirm-desc")).toHaveTextContent("VPN");
     await user.click(screen.getByText("confirm"));
-    expect(mutate).toHaveBeenCalledWith("t1");
+    expect(deleteMutate).toHaveBeenCalledWith("t1");
     expect(screen.queryByTestId("confirm")).not.toBeInTheDocument();
   });
 
   it("cancels the delete dialog without mutating", async () => {
-    useTunnels.mockReturnValue({
-      data: { tunnels: [{ id: "t1", label: "VPN", status: "up" }] },
-      isLoading: false,
-      isError: false,
-    });
+    useTunnels.mockReturnValue(oneTunnel);
     const user = userEvent.setup();
     renderWithProviders(<Tunnels />);
     await user.click(screen.getByText("delete-t1"));
     await user.click(screen.getByText("cancel"));
-    expect(mutate).not.toHaveBeenCalled();
+    expect(deleteMutate).not.toHaveBeenCalled();
     expect(screen.queryByTestId("confirm")).not.toBeInTheDocument();
+  });
+
+  it("hoists the connectivity test and records its outcome", async () => {
+    useTunnels.mockReturnValue(oneTunnel);
+    testMutate.mockImplementation((_id, opts) =>
+      opts.onSuccess({
+        result: {
+          tunnel_id: "t1",
+          exit_ip: "9.9.9.9",
+          country_code: "us",
+          latency_ms: 42,
+        },
+      }),
+    );
+    const user = userEvent.setup();
+    renderWithProviders(<Tunnels />);
+    await user.click(screen.getByText("test-t1"));
+    expect(testMutate).toHaveBeenCalledWith("t1", expect.any(Object));
+    // The page stored the outcome and passed it back down keyed by tunnel id.
+    expect(screen.getByTestId("outcome-keys")).toHaveTextContent("t1");
+  });
+
+  it("records a failed connectivity test as an error outcome", async () => {
+    useTunnels.mockReturnValue(oneTunnel);
+    testMutate.mockImplementation((_id, opts) =>
+      opts.onError(new Error("unreachable")),
+    );
+    const user = userEvent.setup();
+    renderWithProviders(<Tunnels />);
+    await user.click(screen.getByText("test-t1"));
+    expect(screen.getByTestId("outcome-keys")).toHaveTextContent("t1");
+  });
+
+  it("derives the in-flight testing id from the shared mutation", () => {
+    useTunnels.mockReturnValue(oneTunnel);
+    useTestTunnel.mockReturnValue({
+      mutate: testMutate,
+      isPending: true,
+      variables: "t1",
+    });
+    renderWithProviders(<Tunnels />);
+    expect(screen.getByTestId("testing-id")).toHaveTextContent("t1");
+  });
+
+  it("hoists the rebuild mutation to the grid callback", async () => {
+    useTunnels.mockReturnValue(oneTunnel);
+    const user = userEvent.setup();
+    renderWithProviders(<Tunnels />);
+    await user.click(screen.getByText("rebuild-t1"));
+    expect(rebuildMutate).toHaveBeenCalledWith("t1");
+  });
+
+  it("derives the rebuilding id from the shared mutation", () => {
+    useTunnels.mockReturnValue(oneTunnel);
+    useRebuildTunnel.mockReturnValue({
+      mutate: rebuildMutate,
+      isPending: true,
+      variables: "t1",
+    });
+    renderWithProviders(<Tunnels />);
+    expect(screen.getByTestId("rebuilding-id")).toHaveTextContent("t1");
+  });
+
+  it("starts a speed test and fetches results for the tested tunnel", async () => {
+    useTunnels.mockReturnValue(oneTunnel);
+    const user = userEvent.setup();
+    renderWithProviders(<Tunnels />);
+    await user.click(screen.getByText("speed-t1"));
+    expect(startSpeed).toHaveBeenCalledWith("t1");
+    // The tunnel joins the set the page fetches speed-test results for.
+    expect(useSpeedTestResultsList).toHaveBeenLastCalledWith(["t1"]);
+  });
+
+  it("derives the running speed-test id from the shared hook", () => {
+    useTunnels.mockReturnValue(oneTunnel);
+    useStartSpeedTest.mockReturnValue({
+      start: startSpeed,
+      activeTunnelId: "t1",
+      percentage: 30,
+      isRunning: true,
+    });
+    renderWithProviders(<Tunnels />);
+    expect(screen.getByTestId("speedtest-id")).toHaveTextContent("t1");
   });
 });

--- a/source/web/src/hooks/useTunnels.ts
+++ b/source/web/src/hooks/useTunnels.ts
@@ -112,13 +112,19 @@ export function useSetTunnelDnsOverride() {
   });
 }
 
-/** Recent speed test results for a tunnel (newest first). */
-export function useSpeedTestResults(id: string, enabled = true) {
-  return useQuery({
+/** Shared query config for one tunnel's speed-test history, so the single
+ *  (`useSpeedTestResults`) and list (`useSpeedTestResultsList`) hooks read the
+ *  same cache entry and can't drift on key or fetch shape. */
+function speedTestResultsQuery(id: string) {
+  return {
     queryKey: ["tunnels", id, "speed-test"],
     queryFn: () => tunnelService.getSpeedTestResults(id),
-    enabled: !!id && enabled,
-  });
+  };
+}
+
+/** Recent speed test results for a tunnel (newest first). */
+export function useSpeedTestResults(id: string, enabled = true) {
+  return useQuery({ ...speedTestResultsQuery(id), enabled: !!id && enabled });
 }
 
 /**
@@ -129,16 +135,15 @@ export function useSpeedTestResults(id: string, enabled = true) {
  * tunnels whose size changes as more cards are tested — a fixed number of
  * `useSpeedTestResults` calls can't cover that. `useQueries` fans the same
  * per-tunnel query out across `ids`; each entry maps to `results[0]` (or `null`
- * before any result lands), mirroring how `useSpeedTestResults` is read.
+ * before any result lands), mirroring how `useSpeedTestResults` is read. Pass
+ * only ids that still exist so a removed tunnel's query drops out instead of
+ * refetching against a deleted tunnel.
  */
 export function useSpeedTestResultsList(
   ids: string[],
 ): Record<string, TunnelSpeedTestResult | null> {
   const results = useQueries({
-    queries: ids.map((id) => ({
-      queryKey: ["tunnels", id, "speed-test"],
-      queryFn: () => tunnelService.getSpeedTestResults(id),
-    })),
+    queries: ids.map((id) => ({ ...speedTestResultsQuery(id), enabled: !!id })),
   });
   const latest: Record<string, TunnelSpeedTestResult | null> = {};
   ids.forEach((id, i) => {

--- a/source/web/src/hooks/useTunnels.ts
+++ b/source/web/src/hooks/useTunnels.ts
@@ -1,7 +1,16 @@
 import { useEffect, useState } from "react";
-import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import {
+  useQuery,
+  useQueries,
+  useMutation,
+  useQueryClient,
+} from "@tanstack/react-query";
 import { toast } from "@wardnet/ui";
-import type { CreateTunnelRequest, Job } from "@wardnet/js";
+import type {
+  CreateTunnelRequest,
+  Job,
+  TunnelSpeedTestResult,
+} from "@wardnet/js";
 import { isJobTerminal } from "@wardnet/js";
 import { jobsService, tunnelService } from "../lib/sdk";
 
@@ -113,13 +122,42 @@ export function useSpeedTestResults(id: string, enabled = true) {
 }
 
 /**
+ * Latest speed-test result for each tunnel in `ids`, keyed by tunnel id.
+ *
+ * The tunnels grid shows an inline speed-test comparison on every card the user
+ * has run a test on, so the owning page needs the newest result for a set of
+ * tunnels whose size changes as more cards are tested — a fixed number of
+ * `useSpeedTestResults` calls can't cover that. `useQueries` fans the same
+ * per-tunnel query out across `ids`; each entry maps to `results[0]` (or `null`
+ * before any result lands), mirroring how `useSpeedTestResults` is read.
+ */
+export function useSpeedTestResultsList(
+  ids: string[],
+): Record<string, TunnelSpeedTestResult | null> {
+  const results = useQueries({
+    queries: ids.map((id) => ({
+      queryKey: ["tunnels", id, "speed-test"],
+      queryFn: () => tunnelService.getSpeedTestResults(id),
+    })),
+  });
+  const latest: Record<string, TunnelSpeedTestResult | null> = {};
+  ids.forEach((id, i) => {
+    // eslint-disable-next-line security/detect-object-injection -- i is the map index into useQueries' output (ids order); id is the tunnel key being written
+    latest[id] = results[i].data?.results[0] ?? null;
+  });
+  return latest;
+}
+
+/**
  * Start a speed test for a tunnel and track the background job to completion.
  *
  * The server dispatches a job and returns immediately with its id; this hook
  * polls the job (exposing `percentage` for an inline progress bar) and, on
  * success, invalidates the tunnel's speed-test history so the new result
- * renders. Each card uses its own instance, so one in-flight run is tracked
- * per card. A 409 (run already in progress) surfaces as a dedicated toast.
+ * renders. The owning page holds a single instance and passes `start` plus
+ * `activeTunnelId`/`percentage` down to the cards, so one in-flight run is
+ * tracked across the whole list. A 409 (run already in progress) surfaces as a
+ * dedicated toast.
  *
  * Mirrors the job-polling shape of `useRefreshBlocklist`; kept inline rather
  * than extracting a shared poller so the existing blocklist hook is untouched.

--- a/source/web/src/index.ts
+++ b/source/web/src/index.ts
@@ -138,6 +138,7 @@ export {
   useRebuildTunnel,
   useSetTunnelDnsOverride,
   useSpeedTestResults,
+  useSpeedTestResultsList,
   useStartSpeedTest,
 } from "./hooks/useTunnels";
 

--- a/source/web/tests/hooks/useTunnels.test.tsx
+++ b/source/web/tests/hooks/useTunnels.test.tsx
@@ -35,6 +35,7 @@ import {
   useRebuildTunnel,
   useSetTunnelDnsOverride,
   useSpeedTestResults,
+  useSpeedTestResultsList,
   useStartSpeedTest,
 } from "../../src/hooks/useTunnels";
 
@@ -70,6 +71,29 @@ describe("useTunnels queries", () => {
   it("skips fetching a tunnel with an empty id", () => {
     const { result } = renderHook(() => useTunnel(""), { wrapper: wrapper() });
     expect(result.current.fetchStatus).toBe("idle");
+  });
+
+  it("maps the latest speed-test result per id, defaulting missing to null", async () => {
+    tunnelService.getSpeedTestResults.mockImplementation((id: string) =>
+      id === "t1"
+        ? Promise.resolve({ results: [{ id: "s1", tunnel_id: "t1" }] })
+        : Promise.resolve({ results: [] }),
+    );
+    const { result } = renderHook(() => useSpeedTestResultsList(["t1", "t2"]), {
+      wrapper: wrapper(),
+    });
+    await waitFor(() =>
+      expect(result.current.t1).toEqual({ id: "s1", tunnel_id: "t1" }),
+    );
+    // A tunnel with no runs yet resolves to null rather than being absent.
+    expect(result.current.t2).toBeNull();
+  });
+
+  it("returns an empty map when given no ids", () => {
+    const { result } = renderHook(() => useSpeedTestResultsList([]), {
+      wrapper: wrapper(),
+    });
+    expect(result.current).toEqual({});
   });
 });
 


### PR DESCRIPTION
## What

`TunnelCard` (compound) and `TunnelGrid` were calling TanStack Query hooks directly — `useTestTunnel`, `useRebuildTunnel`, `useStartSpeedTest`, `useSpeedTestResults`. That breaks the documented layer rule (`compound/` takes data via props only) and forces the card tests to `vi.mock("@wardnet/web")` and hand-stub hook shapes just to render what is pure presentation.

This lifts all four hooks up to `pages/Tunnels.tsx` and passes data + callbacks down through `TunnelGrid`, leaving the card hook-free.

This is the Tunnels slice of the layering cleanup tracked in #849 (which is split per page-group); it continues the same pattern started in #1035 for admin-app/user-app.

## Key points

- **Shared mutations.** The test and rebuild mutations are now single instances on the page. The in-flight card is derived once (`isPending ? variables : null`) and matched per card by id, so the spinner tracks the actual mid-flight card instead of every card owning its own mutation. This is the case the "Mutation hoisting" convention calls out with `useRebuildTunnel`, and it retires the vestigial per-card `isPending && variables === tunnel.id` guard.
- **Connectivity-test outcomes** move into page state keyed by tunnel id and come back to each card as a `TunnelTestOutcome` prop.
- **Speed-test history** is fetched with a new `useSpeedTestResultsList` hook (`useQueries` over the tunnels the user has actually tested). The page needs one result query per revealed card and the set grows at runtime, so a fixed `useSpeedTestResults` call can't cover it. Behaviour is unchanged: results are only fetched for cards a test was run on, and a removed tunnel's query is dropped so it doesn't refetch against a deleted tunnel; persisted history still lives on the tunnel detail page.

## Tests

- `TunnelCard` and `TunnelGrid` now render entirely from props — no `@wardnet/web` mocking.
- `TunnelGrid` tests assert per-tunnel callbacks and state are routed to the matching card only.
- `Tunnels` page tests cover the hoisted wiring: recording test outcomes (success + error), deriving the in-flight test/rebuild ids from the shared mutations, starting a speed test / fetching its results, and dropping a removed tunnel's result query.
- `useSpeedTestResultsList` has its own unit test in `@wardnet/web`.

## Notes

No API or behaviour change for users — this is layering/testability debt only. `useSpeedTestResults` and `useRebuildTunnel` remain exported for `TunnelDetail`.