### PR TITLE
feat(wctl): implement status, devices, tunnels, update, and backup commands

### DIFF
--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -170,9 +170,26 @@ cd source/site && yarn dev                              # marketing site
 
 ### `wctl` — CLI
 
+`wctl` drives the same HTTP API as the web UI. It reads the daemon URL and an
+API token from `~/.config/wardnet/wctl.toml` (override the path with
+`--config`, or the individual values with the `WARDNET_DAEMON_URL` /
+`WARDNET_TOKEN` environment variables):
+
+```toml
+# ~/.config/wardnet/wctl.toml
+daemon_url = "http://127.0.0.1:7411"
+token = "<session token or API key>"
+```
+
 ```sh
 cd source/daemon && cargo run -p wctl -- status
+cargo run -p wctl -- devices list
+cargo run -p wctl -- tunnels show <id> --json
 ```
+
+Add `--json` to any command for machine-readable output. Commands exit non-zero
+on failure (`2` usage, `3` config, `4` connection, `5` auth, `6` not found,
+`7` I/O, `1` otherwise).
 
 ### Version management
 

--- a/source/daemon/Cargo.lock
+++ b/source/daemon/Cargo.lock
@@ -4261,6 +4261,7 @@ dependencies = [
  "hyper-util",
  "js-sys",
  "log",
+ "mime_guess",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
@@ -6452,11 +6453,16 @@ name = "wctl"
 version = "0.7.0"
 dependencies = [
  "anyhow",
+ "chrono",
  "clap",
  "reqwest 0.12.28",
+ "rpassword",
  "serde",
  "serde_json",
  "tokio",
+ "toml 1.1.3+spec-1.1.0",
+ "uuid",
+ "wardnet-common",
 ]
 
 [[package]]

--- a/source/daemon/Cargo.toml
+++ b/source/daemon/Cargo.toml
@@ -87,6 +87,9 @@ tower-http = { version = "0.6", features = ["catch-panic", "cors", "trace"] }
 rust-embed = { version = "8", features = ["axum"] }
 # https://crates.io/crates/toml
 toml = "1.1"
+# https://crates.io/crates/rpassword — no-echo passphrase prompt for the `wctl`
+# backup export/import commands.
+rpassword = "7"
 
 # https://crates.io/crates/tracing-subscriber
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }

--- a/source/daemon/crates/wardnet-common/src/api.rs
+++ b/source/daemon/crates/wardnet-common/src/api.rs
@@ -143,7 +143,7 @@ pub struct SetMyRuleResponse {
 }
 
 /// Response for GET /api/system/status.
-#[derive(Debug, Serialize, utoipa::ToSchema)]
+#[derive(Debug, Serialize, Deserialize, utoipa::ToSchema)]
 pub struct SystemStatusResponse {
     /// Diagnostic git-derived version. See `InfoResponse.version`.
     pub version: String,
@@ -186,7 +186,7 @@ pub enum LastShutdownState {
 /// `None` only for `unknown` (first-ever boot). `acknowledged_at` is
 /// set by `POST /api/system/shutdown/acknowledge`; the banner is
 /// considered dismissed iff `acknowledged_at >= at`.
-#[derive(Debug, Clone, Serialize, utoipa::ToSchema)]
+#[derive(Debug, Clone, Serialize, Deserialize, utoipa::ToSchema)]
 pub struct LastShutdownStatus {
     pub state: LastShutdownState,
     pub at: Option<DateTime<Utc>>,
@@ -508,7 +508,7 @@ pub struct TunnelTestResponse {
 /// `current_rule` mirrors [`DeviceDetailResponse::current_rule`]: `None` means
 /// the device has no rule of its own and follows the gateway default policy;
 /// `Some(RoutingTarget::Default)` is an explicit persisted default choice.
-#[derive(Debug, Clone, Serialize, utoipa::ToSchema)]
+#[derive(Debug, Clone, Serialize, Deserialize, utoipa::ToSchema)]
 pub struct DeviceWithStatus {
     #[serde(flatten)]
     pub device: Device,
@@ -517,13 +517,13 @@ pub struct DeviceWithStatus {
 }
 
 /// Response for GET /api/devices (admin).
-#[derive(Debug, Serialize, utoipa::ToSchema)]
+#[derive(Debug, Serialize, Deserialize, utoipa::ToSchema)]
 pub struct ListDevicesResponse {
     pub devices: Vec<DeviceWithStatus>,
 }
 
 /// Response for GET /api/devices/:id (admin).
-#[derive(Debug, Serialize, utoipa::ToSchema)]
+#[derive(Debug, Serialize, Deserialize, utoipa::ToSchema)]
 pub struct DeviceDetailResponse {
     pub device: DeviceWithStatus,
     pub current_rule: Option<RoutingTarget>,

--- a/source/daemon/crates/wctl/Cargo.toml
+++ b/source/daemon/crates/wctl/Cargo.toml
@@ -10,15 +10,25 @@ publish.workspace = true
 workspace = true
 
 [dependencies]
+# https://crates.io/crates/wardnet-common
+wardnet-common.workspace = true
 # https://crates.io/crates/clap
 clap.workspace = true
 # https://crates.io/crates/reqwest
-reqwest.workspace = true
+reqwest = { workspace = true, features = ["multipart"] }
 # https://crates.io/crates/serde
 serde.workspace = true
 # https://crates.io/crates/serde_json
 serde_json.workspace = true
+# https://crates.io/crates/toml
+toml.workspace = true
 # https://crates.io/crates/tokio
 tokio.workspace = true
 # https://crates.io/crates/anyhow
 anyhow.workspace = true
+# https://crates.io/crates/uuid
+uuid.workspace = true
+# https://crates.io/crates/chrono
+chrono.workspace = true
+# https://crates.io/crates/rpassword
+rpassword.workspace = true

--- a/source/daemon/crates/wctl/src/client.rs
+++ b/source/daemon/crates/wctl/src/client.rs
@@ -1,0 +1,191 @@
+//! Thin `reqwest` wrapper that speaks the daemon's JSON API.
+//!
+//! Every request carries `Authorization: Bearer <token>`; every non-2xx
+//! response is decoded into a [`wardnet_common::api::ApiError`] and surfaced
+//! as [`CliError::Api`], so callers only ever see typed results.
+
+use std::time::Duration;
+
+use reqwest::{RequestBuilder, Response, StatusCode};
+use serde::Serialize;
+use serde::de::DeserializeOwned;
+use wardnet_common::api::ApiError;
+
+use crate::error::CliError;
+
+/// An authenticated HTTP client bound to one daemon.
+pub struct Client {
+    http: reqwest::Client,
+    base: String,
+    token: String,
+}
+
+impl Client {
+    /// Build a client for `base_url` (no trailing slash) using `token` as the
+    /// bearer credential.
+    ///
+    /// # Errors
+    /// Returns [`CliError::Connection`] if the underlying HTTP client cannot
+    /// be constructed.
+    pub fn new(base_url: &str, token: &str) -> Result<Self, CliError> {
+        let http = reqwest::Client::builder()
+            .timeout(Duration::from_mins(2))
+            .build()
+            .map_err(|e| CliError::Connection(format!("failed to build HTTP client: {e}")))?;
+        Ok(Self {
+            http,
+            base: base_url.to_owned(),
+            token: token.to_owned(),
+        })
+    }
+
+    pub(crate) fn url(&self, path: &str) -> String {
+        format!("{}{}", self.base, path)
+    }
+
+    fn authed(&self, builder: RequestBuilder) -> RequestBuilder {
+        builder.bearer_auth(&self.token)
+    }
+
+    async fn send(&self, builder: RequestBuilder) -> Result<Response, CliError> {
+        self.authed(builder)
+            .send()
+            .await
+            .map_err(|e| CliError::Connection(format!("cannot reach daemon at {}: {e}", self.base)))
+    }
+
+    /// `GET {path}` decoded as `T`.
+    ///
+    /// # Errors
+    /// [`CliError`] on transport failure or a non-2xx response.
+    pub async fn get<T: DeserializeOwned>(&self, path: &str) -> Result<T, CliError> {
+        let resp = self.send(self.http.get(self.url(path))).await?;
+        decode_json(resp).await
+    }
+
+    /// `POST {path}` with no body, decoded as `T`.
+    ///
+    /// # Errors
+    /// [`CliError`] on transport failure or a non-2xx response.
+    pub async fn post_empty<T: DeserializeOwned>(&self, path: &str) -> Result<T, CliError> {
+        let resp = self.send(self.http.post(self.url(path))).await?;
+        decode_json(resp).await
+    }
+
+    /// `POST {path}` with a JSON body, decoded as `T`.
+    ///
+    /// # Errors
+    /// [`CliError`] on transport failure or a non-2xx response.
+    pub async fn post_json<B, T>(&self, path: &str, body: &B) -> Result<T, CliError>
+    where
+        B: Serialize + ?Sized,
+        T: DeserializeOwned,
+    {
+        let resp = self.send(self.http.post(self.url(path)).json(body)).await?;
+        decode_json(resp).await
+    }
+
+    /// `PUT {path}` with a JSON body, decoded as `T`.
+    ///
+    /// # Errors
+    /// [`CliError`] on transport failure or a non-2xx response.
+    pub async fn put_json<B, T>(&self, path: &str, body: &B) -> Result<T, CliError>
+    where
+        B: Serialize + ?Sized,
+        T: DeserializeOwned,
+    {
+        let resp = self.send(self.http.put(self.url(path)).json(body)).await?;
+        decode_json(resp).await
+    }
+
+    /// `DELETE {path}`, decoded as `T`.
+    ///
+    /// # Errors
+    /// [`CliError`] on transport failure or a non-2xx response.
+    pub async fn delete<T: DeserializeOwned>(&self, path: &str) -> Result<T, CliError> {
+        let resp = self.send(self.http.delete(self.url(path))).await?;
+        decode_json(resp).await
+    }
+
+    /// `POST {path}` with a JSON body, returning the raw response bytes.
+    ///
+    /// Used for the backup export endpoint, which streams an
+    /// `application/octet-stream` bundle rather than JSON.
+    ///
+    /// # Errors
+    /// [`CliError`] on transport failure or a non-2xx response.
+    pub async fn post_json_bytes<B: Serialize + ?Sized>(
+        &self,
+        path: &str,
+        body: &B,
+    ) -> Result<Vec<u8>, CliError> {
+        let resp = self.send(self.http.post(self.url(path)).json(body)).await?;
+        let status = resp.status();
+        let bytes = read_body(resp).await?;
+        if status.is_success() {
+            Ok(bytes)
+        } else {
+            Err(api_error(status, &bytes))
+        }
+    }
+
+    /// `POST {path}` with a `multipart/form-data` body, decoded as `T`.
+    ///
+    /// # Errors
+    /// [`CliError`] on transport failure or a non-2xx response.
+    pub async fn post_multipart<T: DeserializeOwned>(
+        &self,
+        path: &str,
+        form: reqwest::multipart::Form,
+    ) -> Result<T, CliError> {
+        let resp = self
+            .send(self.http.post(self.url(path)).multipart(form))
+            .await?;
+        decode_json(resp).await
+    }
+}
+
+/// Read a response body to bytes, mapping transport errors to
+/// [`CliError::Connection`].
+async fn read_body(resp: Response) -> Result<Vec<u8>, CliError> {
+    resp.bytes()
+        .await
+        .map(|b| b.to_vec())
+        .map_err(|e| CliError::Connection(format!("reading response body failed: {e}")))
+}
+
+/// Decode a JSON response, or turn a non-2xx into a [`CliError::Api`].
+async fn decode_json<T: DeserializeOwned>(resp: Response) -> Result<T, CliError> {
+    let status = resp.status();
+    let bytes = read_body(resp).await?;
+    if status.is_success() {
+        serde_json::from_slice(&bytes)
+            .map_err(|e| CliError::Protocol(format!("unexpected response from daemon: {e}")))
+    } else {
+        Err(api_error(status, &bytes))
+    }
+}
+
+/// Build a [`CliError::Api`] from an error response, falling back to the HTTP
+/// status text when the body is not a JSON [`ApiError`].
+pub(crate) fn api_error(status: StatusCode, bytes: &[u8]) -> CliError {
+    let body = serde_json::from_slice::<ApiError>(bytes).unwrap_or_else(|_| {
+        let detail = std::str::from_utf8(bytes)
+            .ok()
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .map(str::to_owned);
+        ApiError {
+            error: status
+                .canonical_reason()
+                .unwrap_or("request failed")
+                .to_lowercase(),
+            detail,
+            request_id: None,
+        }
+    });
+    CliError::Api {
+        status: status.as_u16(),
+        body,
+    }
+}

--- a/source/daemon/crates/wctl/src/commands/backup.rs
+++ b/source/daemon/crates/wctl/src/commands/backup.rs
@@ -1,0 +1,210 @@
+//! `wctl backup status | export | import | snapshots`.
+
+use std::io::Read;
+use std::path::Path;
+
+use wardnet_common::api::{
+    ApplyImportRequest, ApplyImportResponse, BackupStatusResponse, ExportBackupRequest,
+    ListSnapshotsResponse, RestorePreviewResponse,
+};
+use wardnet_common::backup::{BackupStatus, MIN_PASSPHRASE_LEN, RestorePhase};
+
+use crate::client::Client;
+use crate::error::CliError;
+use crate::output;
+
+/// `GET /api/backup/status`.
+///
+/// # Errors
+/// Propagates any [`CliError`] from the request.
+pub async fn status(client: &Client, json: bool) -> Result<(), CliError> {
+    let resp: BackupStatusResponse = client.get("/api/backup/status").await?;
+    if json {
+        return output::print_json(&resp);
+    }
+    println!("{}", backup_state(&resp.status));
+    Ok(())
+}
+
+/// `POST /api/backup/export` — write the encrypted bundle to `out`.
+///
+/// # Errors
+/// [`CliError::Usage`] for a too-short passphrase, [`CliError::Io`] on a write
+/// failure, or any [`CliError`] from the request.
+pub async fn export(
+    client: &Client,
+    json: bool,
+    out: &str,
+    passphrase_file: Option<&str>,
+) -> Result<(), CliError> {
+    let passphrase = read_passphrase(passphrase_file, true)?;
+    if passphrase.chars().count() < MIN_PASSPHRASE_LEN {
+        return Err(CliError::Usage(format!(
+            "passphrase must be at least {MIN_PASSPHRASE_LEN} characters"
+        )));
+    }
+
+    let req = ExportBackupRequest { passphrase };
+    let bytes = client.post_json_bytes("/api/backup/export", &req).await?;
+    std::fs::write(out, &bytes)
+        .map_err(|e| CliError::Io(format!("cannot write bundle to {out}: {e}")))?;
+
+    let written = bytes.len() as u64;
+    if json {
+        return output::print_json(&serde_json::json!({ "out": out, "bytes": written }));
+    }
+    println!("wrote {} to {out}", output::bytes(written));
+    Ok(())
+}
+
+/// `POST /api/backup/import/preview` then `/apply` — restore a bundle.
+///
+/// The preview step is what validates the passphrase and compatibility before
+/// anything on disk changes; only a compatible preview is applied.
+///
+/// # Errors
+/// [`CliError::Io`] if the bundle cannot be read, [`CliError::Protocol`] if the
+/// bundle is incompatible, or any [`CliError`] from the requests.
+pub async fn import(
+    client: &Client,
+    json: bool,
+    bundle_path: &str,
+    passphrase_file: Option<&str>,
+) -> Result<(), CliError> {
+    let passphrase = read_passphrase(passphrase_file, false)?;
+    let data = std::fs::read(bundle_path)
+        .map_err(|e| CliError::Io(format!("cannot read bundle {bundle_path}: {e}")))?;
+    let file_name = Path::new(bundle_path)
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or("bundle.wardnet.age")
+        .to_owned();
+
+    let form = reqwest::multipart::Form::new()
+        .part(
+            "bundle",
+            reqwest::multipart::Part::bytes(data).file_name(file_name),
+        )
+        .text("passphrase", passphrase);
+    let preview: RestorePreviewResponse = client
+        .post_multipart("/api/backup/import/preview", form)
+        .await?;
+
+    if !preview.compatible {
+        let reason = preview
+            .incompatibility_reason
+            .unwrap_or_else(|| "incompatible bundle".to_owned());
+        return Err(CliError::Protocol(format!(
+            "bundle cannot be restored: {reason}"
+        )));
+    }
+
+    if !json {
+        println!(
+            "restoring bundle from host {} (schema v{})",
+            preview.manifest.host_id, preview.manifest.schema_version
+        );
+        for file in &preview.files_to_replace {
+            println!("  will replace: {file}");
+        }
+    }
+
+    let apply_req = ApplyImportRequest {
+        preview_token: preview.preview_token,
+    };
+    let applied: ApplyImportResponse = client
+        .post_json("/api/backup/import/apply", &apply_req)
+        .await?;
+
+    if json {
+        return output::print_json(&applied);
+    }
+    println!("restore applied; restart the daemon to load the new state");
+    for snap in &applied.snapshots {
+        println!("  snapshot: {} ({})", snap.path, snap.kind.as_str());
+    }
+    Ok(())
+}
+
+/// `GET /api/backup/snapshots`.
+///
+/// # Errors
+/// Propagates any [`CliError`] from the request.
+pub async fn snapshots(client: &Client, json: bool) -> Result<(), CliError> {
+    let resp: ListSnapshotsResponse = client.get("/api/backup/snapshots").await?;
+    if json {
+        return output::print_json(&resp);
+    }
+    if resp.snapshots.is_empty() {
+        println!("no snapshots");
+        return Ok(());
+    }
+    println!("{:<10}  {:<12}  {:<26}  PATH", "KIND", "SIZE", "CREATED");
+    for snap in &resp.snapshots {
+        println!(
+            "{:<10}  {:<12}  {:<26}  {}",
+            snap.kind.as_str(),
+            output::bytes(snap.size_bytes),
+            snap.created_at.to_rfc3339(),
+            snap.path,
+        );
+    }
+    Ok(())
+}
+
+/// Obtain the export/import passphrase.
+///
+/// From `--passphrase-file` (a path, or `-` for stdin) when given, otherwise a
+/// no-echo interactive prompt. When `confirm` is set (export), the prompt is
+/// asked twice and the two must match.
+fn read_passphrase(passphrase_file: Option<&str>, confirm: bool) -> Result<String, CliError> {
+    if let Some(source) = passphrase_file {
+        let raw = if source == "-" {
+            let mut buf = String::new();
+            std::io::stdin()
+                .read_to_string(&mut buf)
+                .map_err(|e| CliError::Io(format!("reading passphrase from stdin failed: {e}")))?;
+            buf
+        } else {
+            std::fs::read_to_string(source)
+                .map_err(|e| CliError::Io(format!("cannot read passphrase file {source}: {e}")))?
+        };
+        // Strip only a trailing newline (and CR) that `echo`/editors append —
+        // interior characters are part of the passphrase.
+        return Ok(raw.trim_end_matches(['\r', '\n']).to_owned());
+    }
+
+    let pass = rpassword::prompt_password("Passphrase: ")
+        .map_err(|e| CliError::Io(format!("reading passphrase failed: {e}")))?;
+    if confirm {
+        let again = rpassword::prompt_password("Confirm passphrase: ")
+            .map_err(|e| CliError::Io(format!("reading passphrase failed: {e}")))?;
+        if pass != again {
+            return Err(CliError::Usage("passphrases do not match".to_owned()));
+        }
+    }
+    Ok(pass)
+}
+
+fn backup_state(status: &BackupStatus) -> String {
+    match status {
+        BackupStatus::Idle => "idle".to_owned(),
+        BackupStatus::Exporting => "exporting".to_owned(),
+        BackupStatus::Importing { phase } => format!("importing ({})", restore_phase(phase)),
+        BackupStatus::Failed { reason } => format!("failed: {reason}"),
+    }
+}
+
+fn restore_phase(phase: &RestorePhase) -> String {
+    match phase {
+        RestorePhase::Idle => "idle".to_owned(),
+        RestorePhase::Validating => "validating".to_owned(),
+        RestorePhase::StoppingRunners => "stopping-runners".to_owned(),
+        RestorePhase::BackingUp => "backing-up".to_owned(),
+        RestorePhase::Extracting => "extracting".to_owned(),
+        RestorePhase::Migrating => "migrating".to_owned(),
+        RestorePhase::RestartingRunners => "restarting-runners".to_owned(),
+        RestorePhase::Applied => "applied".to_owned(),
+        RestorePhase::Failed { reason } => format!("failed: {reason}"),
+    }
+}

--- a/source/daemon/crates/wctl/src/commands/devices.rs
+++ b/source/daemon/crates/wctl/src/commands/devices.rs
@@ -1,0 +1,145 @@
+//! `wctl devices list | show | set-rule`.
+
+use wardnet_common::api::{DeviceDetailResponse, DeviceWithStatus, ListDevicesResponse};
+use wardnet_common::device::{Device, DeviceType, DhcpStatus};
+use wardnet_common::routing::RoutingTarget;
+
+use crate::client::Client;
+use crate::commands::{parse_routing_target, parse_uuid};
+use crate::error::CliError;
+use crate::output;
+
+/// `GET /api/devices`.
+///
+/// # Errors
+/// Propagates any [`CliError`] from the request.
+pub async fn list(client: &Client, json: bool) -> Result<(), CliError> {
+    let resp: ListDevicesResponse = client.get("/api/devices").await?;
+    if json {
+        return output::print_json(&resp);
+    }
+
+    if resp.devices.is_empty() {
+        println!("no devices");
+        return Ok(());
+    }
+
+    println!(
+        "{:<36}  {:<18}  {:<15}  {:<13}  RULE",
+        "ID", "NAME", "IP", "TYPE"
+    );
+    for d in &resp.devices {
+        println!(
+            "{:<36}  {:<18}  {:<15}  {:<13}  {}",
+            d.device.id,
+            display_name(&d.device),
+            d.device.last_ip,
+            device_type(d.device.device_type),
+            rule(d.current_rule.as_ref()),
+        );
+    }
+    Ok(())
+}
+
+/// `GET /api/devices/{id}`.
+///
+/// # Errors
+/// Propagates any [`CliError`] from the request, including
+/// [`CliError::Usage`] when `id` is not a UUID.
+pub async fn show(client: &Client, json: bool, id: &str) -> Result<(), CliError> {
+    let id = parse_uuid("device", id)?;
+    let resp: DeviceDetailResponse = client.get(&format!("/api/devices/{id}")).await?;
+    if json {
+        return output::print_json(&resp);
+    }
+    print_detail(&resp.device, resp.current_rule.as_ref());
+    Ok(())
+}
+
+/// `PUT /api/devices/{id}` setting only the routing target.
+///
+/// # Errors
+/// Propagates any [`CliError`] from the request, including
+/// [`CliError::Usage`] for a bad ID or target.
+pub async fn set_rule(client: &Client, json: bool, id: &str, target: &str) -> Result<(), CliError> {
+    let id = parse_uuid("device", id)?;
+    let target = parse_routing_target(target)?;
+    // `UpdateDeviceRequest` is deserialize-only on the daemon side; send just
+    // the one field we're changing so name/type/lock are left untouched.
+    let body = serde_json::json!({ "routing_target": target });
+    let resp: DeviceDetailResponse = client
+        .put_json(&format!("/api/devices/{id}"), &body)
+        .await?;
+    if json {
+        return output::print_json(&resp);
+    }
+    println!(
+        "device {} routing set to {}",
+        resp.device.device.id,
+        rule(resp.current_rule.as_ref())
+    );
+    Ok(())
+}
+
+fn print_detail(d: &DeviceWithStatus, current_rule: Option<&RoutingTarget>) {
+    println!("id:           {}", d.device.id);
+    println!("name:         {}", display_name(&d.device));
+    println!(
+        "hostname:     {}",
+        output::opt(d.device.hostname.as_deref())
+    );
+    println!("mac:          {}", d.device.mac);
+    println!(
+        "manufacturer: {}",
+        output::opt(d.device.manufacturer.as_deref())
+    );
+    println!("type:         {}", device_type(d.device.device_type));
+    println!("ip:           {}", d.device.last_ip);
+    println!("dhcp:         {}", dhcp_status(d.dhcp_status));
+    println!("rule:         {}", rule(current_rule));
+    println!("admin locked: {}", d.device.admin_locked);
+    println!("first seen:   {}", d.device.first_seen.to_rfc3339());
+    println!("last seen:    {}", d.device.last_seen.to_rfc3339());
+}
+
+fn display_name(device: &Device) -> String {
+    device
+        .name
+        .as_deref()
+        .or(device.hostname.as_deref())
+        .unwrap_or("-")
+        .to_owned()
+}
+
+fn rule(rule: Option<&RoutingTarget>) -> String {
+    match rule {
+        None => "(default)".to_owned(),
+        Some(RoutingTarget::Direct) => "direct".to_owned(),
+        Some(RoutingTarget::Default) => "default".to_owned(),
+        Some(RoutingTarget::Tunnel { tunnel_id }) => format!("tunnel:{tunnel_id}"),
+    }
+}
+
+fn device_type(t: DeviceType) -> &'static str {
+    match t {
+        DeviceType::Tv => "tv",
+        DeviceType::Phone => "phone",
+        DeviceType::Laptop => "laptop",
+        DeviceType::Tablet => "tablet",
+        DeviceType::GameConsole => "game-console",
+        DeviceType::SettopBox => "settop-box",
+        DeviceType::Iot => "iot",
+        DeviceType::Router => "router",
+        DeviceType::ManagedSwitch => "managed-switch",
+        DeviceType::Server => "server",
+        DeviceType::Unknown => "unknown",
+    }
+}
+
+fn dhcp_status(status: DhcpStatus) -> &'static str {
+    match status {
+        DhcpStatus::Lease => "lease",
+        DhcpStatus::Reservation => "reservation",
+        DhcpStatus::External => "external",
+    }
+}

--- a/source/daemon/crates/wctl/src/commands/mod.rs
+++ b/source/daemon/crates/wctl/src/commands/mod.rs
@@ -1,0 +1,44 @@
+//! One module per command group. Each `run` builds the request from parsed
+//! arguments, calls the [`Client`](crate::client::Client), and renders the
+//! result (human or, under `--json`, verbatim).
+
+pub mod backup;
+pub mod devices;
+pub mod status;
+pub mod tunnels;
+pub mod update;
+
+use uuid::Uuid;
+use wardnet_common::routing::RoutingTarget;
+
+use crate::error::CliError;
+
+/// Parse an ID argument as a UUID, with a message naming what kind of ID it is.
+///
+/// # Errors
+/// [`CliError::Usage`] when `value` is not a valid UUID.
+pub fn parse_uuid(kind: &str, value: &str) -> Result<Uuid, CliError> {
+    value
+        .parse::<Uuid>()
+        .map_err(|_| CliError::Usage(format!("invalid {kind} ID '{value}': expected a UUID")))
+}
+
+/// Parse a `devices set-rule` target: `direct`, `default`, or a tunnel UUID.
+///
+/// # Errors
+/// [`CliError::Usage`] when `value` is none of those.
+pub fn parse_routing_target(value: &str) -> Result<RoutingTarget, CliError> {
+    match value {
+        "direct" => Ok(RoutingTarget::Direct),
+        "default" => Ok(RoutingTarget::Default),
+        other => other
+            .parse::<Uuid>()
+            .map(|tunnel_id| RoutingTarget::Tunnel { tunnel_id })
+            .map_err(|_| {
+                CliError::Usage(format!(
+                    "invalid routing target '{other}': expected 'direct', 'default', \
+                     or a tunnel UUID"
+                ))
+            }),
+    }
+}

--- a/source/daemon/crates/wctl/src/commands/status.rs
+++ b/source/daemon/crates/wctl/src/commands/status.rs
@@ -1,0 +1,53 @@
+//! `wctl status` — one-shot system health snapshot.
+
+use wardnet_common::api::{LastShutdownState, SystemStatusResponse};
+
+use crate::client::Client;
+use crate::error::CliError;
+use crate::output;
+
+/// Fetch and render `GET /api/system/status`.
+///
+/// # Errors
+/// Propagates any [`CliError`] from the request.
+pub async fn run(client: &Client, json: bool) -> Result<(), CliError> {
+    let status: SystemStatusResponse = client.get("/api/system/status").await?;
+    if json {
+        return output::print_json(&status);
+    }
+
+    println!("version:       {}", status.release_version);
+    println!("build:         {}", status.version);
+    println!("uptime:        {}", output::duration(status.uptime_seconds));
+    println!("devices:       {}", status.device_count);
+    println!(
+        "tunnels:       {} ({} active)",
+        status.tunnel_count, status.tunnel_active_count
+    );
+    println!("cpu:           {:.1}%", status.cpu_usage_percent);
+    println!(
+        "memory:        {} / {}",
+        output::bytes(status.memory_used_bytes),
+        output::bytes(status.memory_total_bytes)
+    );
+    println!(
+        "disk free:     {} / {}",
+        output::bytes(status.disk_free_bytes),
+        output::bytes(status.disk_total_bytes)
+    );
+    println!("database:      {}", output::bytes(status.db_size_bytes));
+    println!(
+        "last shutdown: {} ({})",
+        shutdown_state(status.last_shutdown.state),
+        output::timestamp(status.last_shutdown.at)
+    );
+    Ok(())
+}
+
+fn shutdown_state(state: LastShutdownState) -> &'static str {
+    match state {
+        LastShutdownState::Unknown => "unknown",
+        LastShutdownState::Graceful => "graceful",
+        LastShutdownState::Unclean => "unclean",
+    }
+}

--- a/source/daemon/crates/wctl/src/commands/tunnels.rs
+++ b/source/daemon/crates/wctl/src/commands/tunnels.rs
@@ -1,0 +1,157 @@
+//! `wctl tunnels list | show | add | remove | test`.
+
+use wardnet_common::api::{
+    CreateTunnelRequest, CreateTunnelResponse, DeleteTunnelResponse, ListTunnelsResponse,
+    TunnelDetailResponse, TunnelTestResponse,
+};
+use wardnet_common::tunnel::{Tunnel, TunnelStatus};
+
+use crate::client::Client;
+use crate::commands::parse_uuid;
+use crate::error::CliError;
+use crate::output;
+
+/// `GET /api/tunnels`.
+///
+/// # Errors
+/// Propagates any [`CliError`] from the request.
+pub async fn list(client: &Client, json: bool) -> Result<(), CliError> {
+    let resp: ListTunnelsResponse = client.get("/api/tunnels").await?;
+    if json {
+        return output::print_json(&resp);
+    }
+
+    if resp.tunnels.is_empty() {
+        println!("no tunnels");
+        return Ok(());
+    }
+
+    println!(
+        "{:<36}  {:<16}  {:<7}  {:<12}  {:<12}  RX/TX",
+        "ID", "LABEL", "COUNTRY", "INTERFACE", "STATUS"
+    );
+    for t in &resp.tunnels {
+        println!(
+            "{:<36}  {:<16}  {:<7}  {:<12}  {:<12}  {} / {}",
+            t.id,
+            t.label,
+            t.country_code,
+            t.interface_name,
+            status(t.status),
+            output::bytes(t.bytes_rx),
+            output::bytes(t.bytes_tx),
+        );
+    }
+    Ok(())
+}
+
+/// `GET /api/tunnels/{id}`.
+///
+/// # Errors
+/// Propagates any [`CliError`] from the request, including
+/// [`CliError::Usage`] when `id` is not a UUID.
+pub async fn show(client: &Client, json: bool, id: &str) -> Result<(), CliError> {
+    let id = parse_uuid("tunnel", id)?;
+    let resp: TunnelDetailResponse = client.get(&format!("/api/tunnels/{id}")).await?;
+    if json {
+        return output::print_json(&resp);
+    }
+    print_detail(&resp.tunnel);
+    Ok(())
+}
+
+/// `POST /api/tunnels`, importing a `WireGuard` `.conf` from `conf_path`.
+///
+/// # Errors
+/// [`CliError::Io`] if the config file cannot be read, or any [`CliError`]
+/// from the request.
+pub async fn add(
+    client: &Client,
+    json: bool,
+    label: &str,
+    country: &str,
+    conf_path: &str,
+) -> Result<(), CliError> {
+    let config = std::fs::read_to_string(conf_path)
+        .map_err(|e| CliError::Io(format!("cannot read WireGuard config {conf_path}: {e}")))?;
+    let req = CreateTunnelRequest {
+        label: label.to_owned(),
+        country_code: country.to_owned(),
+        provider: None,
+        config,
+        server_selector: None,
+        resolved_server_name: None,
+    };
+    let resp: CreateTunnelResponse = client.post_json("/api/tunnels", &req).await?;
+    if json {
+        return output::print_json(&resp);
+    }
+    println!("{}", resp.message);
+    println!(
+        "created tunnel {} ({}) on interface {}",
+        resp.tunnel.id, resp.tunnel.label, resp.tunnel.interface_name
+    );
+    Ok(())
+}
+
+/// `DELETE /api/tunnels/{id}`.
+///
+/// # Errors
+/// Propagates any [`CliError`] from the request, including
+/// [`CliError::Usage`] when `id` is not a UUID.
+pub async fn remove(client: &Client, json: bool, id: &str) -> Result<(), CliError> {
+    let id = parse_uuid("tunnel", id)?;
+    let resp: DeleteTunnelResponse = client.delete(&format!("/api/tunnels/{id}")).await?;
+    if json {
+        return output::print_json(&resp);
+    }
+    println!("{}", resp.message);
+    Ok(())
+}
+
+/// `POST /api/tunnels/{id}/test` — probe exit IP, country, and latency.
+///
+/// # Errors
+/// Propagates any [`CliError`] from the request, including
+/// [`CliError::Usage`] when `id` is not a UUID.
+pub async fn test(client: &Client, json: bool, id: &str) -> Result<(), CliError> {
+    let id = parse_uuid("tunnel", id)?;
+    let resp: TunnelTestResponse = client
+        .post_empty(&format!("/api/tunnels/{id}/test"))
+        .await?;
+    if json {
+        return output::print_json(&resp);
+    }
+    let r = &resp.result;
+    println!("exit ip:  {}", r.exit_ip);
+    println!("country:  {}", r.country_code);
+    println!("latency:  {} ms", r.latency_ms);
+    Ok(())
+}
+
+fn print_detail(t: &Tunnel) {
+    println!("id:           {}", t.id);
+    println!("label:        {}", t.label);
+    println!("country:      {}", t.country_code);
+    println!("provider:     {}", output::opt(t.provider.as_deref()));
+    println!("interface:    {}", t.interface_name);
+    println!("endpoint:     {}", t.endpoint);
+    println!("status:       {}", status(t.status));
+    println!("last handshake: {}", output::timestamp(t.last_handshake));
+    println!(
+        "traffic:      {} rx / {} tx",
+        output::bytes(t.bytes_rx),
+        output::bytes(t.bytes_tx)
+    );
+    println!("dns override: {}", t.override_default_dns);
+    println!("created:      {}", t.created_at.to_rfc3339());
+}
+
+fn status(status: TunnelStatus) -> &'static str {
+    match status {
+        TunnelStatus::Up => "up",
+        TunnelStatus::Down => "down",
+        TunnelStatus::Connecting => "connecting",
+        TunnelStatus::Reconnecting => "reconnecting",
+    }
+}

--- a/source/daemon/crates/wctl/src/commands/update.rs
+++ b/source/daemon/crates/wctl/src/commands/update.rs
@@ -1,0 +1,110 @@
+//! `wctl update status | check | install | rollback`.
+
+use wardnet_common::api::{
+    InstallUpdateRequest, InstallUpdateResponse, RollbackResponse, UpdateCheckResponse,
+    UpdateStatusResponse,
+};
+use wardnet_common::update::{InstallPhase, UpdateStatus};
+
+use crate::client::Client;
+use crate::error::CliError;
+use crate::output;
+
+/// `GET /api/update/status`.
+///
+/// # Errors
+/// Propagates any [`CliError`] from the request.
+pub async fn status(client: &Client, json: bool) -> Result<(), CliError> {
+    let resp: UpdateStatusResponse = client.get("/api/update/status").await?;
+    if json {
+        return output::print_json(&resp);
+    }
+    print_status(&resp.status);
+    Ok(())
+}
+
+/// `POST /api/update/check` — force a manifest refresh.
+///
+/// # Errors
+/// Propagates any [`CliError`] from the request.
+pub async fn check(client: &Client, json: bool) -> Result<(), CliError> {
+    let resp: UpdateCheckResponse = client.post_empty("/api/update/check").await?;
+    if json {
+        return output::print_json(&resp);
+    }
+    print_status(&resp.status);
+    Ok(())
+}
+
+/// `POST /api/update/install`, optionally pinning a version.
+///
+/// # Errors
+/// Propagates any [`CliError`] from the request.
+pub async fn install(client: &Client, json: bool, version: Option<&str>) -> Result<(), CliError> {
+    let req = InstallUpdateRequest {
+        version: version.map(str::to_owned),
+    };
+    let resp: InstallUpdateResponse = client.post_json("/api/update/install", &req).await?;
+    if json {
+        return output::print_json(&resp);
+    }
+    println!("{}", resp.message);
+    println!(
+        "install {} targeting {}",
+        resp.handle.install_id, resp.handle.target_version
+    );
+    Ok(())
+}
+
+/// `POST /api/update/rollback`.
+///
+/// # Errors
+/// Propagates any [`CliError`] from the request.
+pub async fn rollback(client: &Client, json: bool) -> Result<(), CliError> {
+    let resp: RollbackResponse = client.post_empty("/api/update/rollback").await?;
+    if json {
+        return output::print_json(&resp);
+    }
+    println!("{}", resp.message);
+    Ok(())
+}
+
+fn print_status(s: &UpdateStatus) {
+    println!("current version: {}", s.current_version);
+    println!(
+        "latest version:  {}",
+        output::opt(s.latest_version.as_deref())
+    );
+    println!("update available: {}", s.update_available);
+    println!("channel:         {}", s.channel.as_str());
+    println!("auto-update:     {}", s.auto_update_enabled);
+    println!("phase:           {}", install_phase(&s.install_phase));
+    println!(
+        "pending version: {}",
+        output::opt(s.pending_version.as_deref())
+    );
+    println!("rollback ready:  {}", s.rollback_available);
+    println!("last check:      {}", output::timestamp(s.last_check_at));
+    println!("last install:    {}", output::timestamp(s.last_install_at));
+}
+
+fn install_phase(phase: &InstallPhase) -> String {
+    match phase {
+        InstallPhase::Idle => "idle".to_owned(),
+        InstallPhase::Checking => "checking".to_owned(),
+        InstallPhase::Downloading { bytes, total } => match total {
+            Some(total) => format!(
+                "downloading ({} / {})",
+                output::bytes(*bytes),
+                output::bytes(*total)
+            ),
+            None => format!("downloading ({})", output::bytes(*bytes)),
+        },
+        InstallPhase::Verifying => "verifying".to_owned(),
+        InstallPhase::Staging => "staging".to_owned(),
+        InstallPhase::Swapping => "swapping".to_owned(),
+        InstallPhase::RestartPending => "restart-pending".to_owned(),
+        InstallPhase::Applied => "applied".to_owned(),
+        InstallPhase::Failed { reason } => format!("failed: {reason}"),
+    }
+}

--- a/source/daemon/crates/wctl/src/config.rs
+++ b/source/daemon/crates/wctl/src/config.rs
@@ -1,0 +1,121 @@
+//! Client configuration: where the daemon lives and how to authenticate.
+//!
+//! Resolved from, in order of precedence:
+//! 1. `WARDNET_DAEMON_URL` / `WARDNET_TOKEN` environment variables,
+//! 2. the TOML file (`--config`, else `$XDG_CONFIG_HOME/wardnet/wctl.toml`,
+//!    else `~/.config/wardnet/wctl.toml`),
+//! 3. the built-in default URL.
+//!
+//! ```toml
+//! # ~/.config/wardnet/wctl.toml
+//! daemon_url = "http://127.0.0.1:7411"
+//! token = "<session token or API key>"
+//! ```
+
+use std::path::{Path, PathBuf};
+
+use serde::Deserialize;
+
+use crate::error::CliError;
+
+/// The daemon's default plain-HTTP LAN admin port (`ServerConfig::port`).
+pub const DEFAULT_DAEMON_URL: &str = "http://127.0.0.1:7411";
+
+/// Raw TOML shape — every field optional so a partial (or absent) file is
+/// still valid and env/defaults can fill the gaps.
+#[derive(Debug, Default, Deserialize)]
+pub(crate) struct RawConfig {
+    pub(crate) daemon_url: Option<String>,
+    pub(crate) token: Option<String>,
+}
+
+/// Fully-resolved client configuration.
+#[derive(Debug, Clone)]
+pub struct Config {
+    /// Base URL of the daemon, without a trailing slash.
+    pub daemon_url: String,
+    /// Bearer credential, if one was configured. Read-only commands work
+    /// without it against an unauthenticated daemon, but every admin endpoint
+    /// needs it — [`Config::token`] surfaces a clear error when it is missing.
+    pub(crate) token: Option<String>,
+}
+
+impl Config {
+    /// Resolve configuration, honouring an explicit `--config` path.
+    ///
+    /// A missing file is not an error: it is treated as an empty file so the
+    /// daemon URL falls back to the default and the token comes from the
+    /// environment (or is absent). An explicit `--config` that does not exist
+    /// *is* an error, because the operator clearly meant to use it.
+    ///
+    /// # Errors
+    /// Returns [`CliError::Config`] if the file exists but cannot be read or
+    /// parsed, or if an explicit `--config` path is missing.
+    pub fn resolve(config_flag: Option<&str>) -> Result<Self, CliError> {
+        let raw = match config_flag {
+            Some(path) => {
+                let path = Path::new(path);
+                if !path.exists() {
+                    return Err(CliError::Config(format!(
+                        "config file not found: {}",
+                        path.display()
+                    )));
+                }
+                load_file(path)?
+            }
+            None => match default_config_path() {
+                Some(path) if path.exists() => load_file(&path)?,
+                _ => RawConfig::default(),
+            },
+        };
+
+        let daemon_url = std::env::var("WARDNET_DAEMON_URL")
+            .ok()
+            .filter(|v| !v.trim().is_empty())
+            .or(raw.daemon_url)
+            .unwrap_or_else(|| DEFAULT_DAEMON_URL.to_owned());
+
+        let token = std::env::var("WARDNET_TOKEN")
+            .ok()
+            .filter(|v| !v.trim().is_empty())
+            .or(raw.token);
+
+        Ok(Self {
+            daemon_url: daemon_url.trim_end_matches('/').to_owned(),
+            token,
+        })
+    }
+
+    /// The configured bearer token, or a [`CliError::Config`] pointing the
+    /// operator at where to set one.
+    ///
+    /// # Errors
+    /// Returns [`CliError::Config`] when no token is configured.
+    pub fn token(&self) -> Result<&str, CliError> {
+        self.token.as_deref().ok_or_else(|| {
+            CliError::Config(
+                "no API token configured — set `token` in wctl.toml or the \
+                 WARDNET_TOKEN environment variable"
+                    .to_owned(),
+            )
+        })
+    }
+}
+
+/// Read and parse a TOML config file.
+fn load_file(path: &Path) -> Result<RawConfig, CliError> {
+    let contents = std::fs::read_to_string(path)
+        .map_err(|e| CliError::Config(format!("cannot read {}: {e}", path.display())))?;
+    toml::from_str(&contents)
+        .map_err(|e| CliError::Config(format!("invalid config {}: {e}", path.display())))
+}
+
+/// The default config path: `$XDG_CONFIG_HOME/wardnet/wctl.toml`, falling back
+/// to `$HOME/.config/wardnet/wctl.toml`. `None` when neither variable is set.
+fn default_config_path() -> Option<PathBuf> {
+    let base = std::env::var_os("XDG_CONFIG_HOME")
+        .map(PathBuf::from)
+        .filter(|p| !p.as_os_str().is_empty())
+        .or_else(|| std::env::var_os("HOME").map(|h| PathBuf::from(h).join(".config")))?;
+    Some(base.join("wardnet").join("wctl.toml"))
+}

--- a/source/daemon/crates/wctl/src/error.rs
+++ b/source/daemon/crates/wctl/src/error.rs
@@ -1,0 +1,74 @@
+//! Error taxonomy and the exit codes it maps to.
+//!
+//! Every failure path funnels into [`CliError`]. `main` prints the message to
+//! stderr and exits with [`CliError::exit_code`], so scripts can branch on
+//! *why* a command failed, not just that it did.
+
+use std::fmt;
+
+use wardnet_common::api::ApiError;
+
+/// A recoverable failure surfaced to the operator.
+#[derive(Debug)]
+pub enum CliError {
+    /// Configuration is missing or unusable (no config file, unparseable
+    /// TOML, or no token for a command that needs one).
+    Config(String),
+    /// The daemon could not be reached at all — connection refused, timeout,
+    /// DNS, or TLS failure.
+    Connection(String),
+    /// The daemon answered with a non-2xx status and an [`ApiError`] body.
+    Api { status: u16, body: ApiError },
+    /// A local filesystem operation failed (reading a `.conf`, writing a
+    /// bundle to `--out`).
+    Io(String),
+    /// The caller passed something clap could not reject on its own — an
+    /// unparseable routing target or ID.
+    Usage(String),
+    /// The daemon replied but the body was not what this version expects.
+    Protocol(String),
+}
+
+impl CliError {
+    /// Process exit code for this failure.
+    ///
+    /// The values are stable and documented in the `wctl` help so scripts can
+    /// rely on them: `2` usage, `3` config, `4` connection, `5` auth, `6` not
+    /// found, `7` I/O, `1` everything else.
+    #[must_use]
+    pub fn exit_code(&self) -> i32 {
+        match self {
+            Self::Usage(_) => 2,
+            Self::Config(_) => 3,
+            Self::Connection(_) => 4,
+            Self::Io(_) => 7,
+            Self::Protocol(_) => 1,
+            Self::Api { status, .. } => match *status {
+                401 | 403 => 5,
+                404 => 6,
+                _ => 1,
+            },
+        }
+    }
+}
+
+impl fmt::Display for CliError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Config(msg)
+            | Self::Connection(msg)
+            | Self::Io(msg)
+            | Self::Usage(msg)
+            | Self::Protocol(msg) => write!(f, "{msg}"),
+            Self::Api { status, body } => {
+                write!(f, "daemon returned {status}: {}", body.error)?;
+                if let Some(detail) = &body.detail {
+                    write!(f, " ({detail})")?;
+                }
+                Ok(())
+            }
+        }
+    }
+}
+
+impl std::error::Error for CliError {}

--- a/source/daemon/crates/wctl/src/main.rs
+++ b/source/daemon/crates/wctl/src/main.rs
@@ -1,4 +1,26 @@
+//! `wctl` — the Wardnet command-line client.
+//!
+//! A thin front-end over the daemon's HTTP API: it reads the daemon URL and an
+//! API token from `~/.config/wardnet/wctl.toml` (see [`config`]) and drives the
+//! same endpoints the web UI uses, so the gateway can be scripted from a shell.
+//!
+//! Every command exits non-zero on failure; the codes are documented on
+//! [`error::CliError::exit_code`].
+
+mod client;
+mod commands;
+mod config;
+mod error;
+mod output;
+
+#[cfg(test)]
+mod tests;
+
 use clap::{Parser, Subcommand};
+
+use crate::client::Client;
+use crate::config::Config;
+use crate::error::CliError;
 
 #[derive(Parser)]
 #[command(name = "wctl", about = "Wardnet CLI", version = env!("WARDNET_VERSION"))]
@@ -7,9 +29,10 @@ struct Cli {
     #[arg(long, global = true)]
     json: bool,
 
-    /// Path to config file
-    #[arg(long, global = true, default_value = "/etc/wardnet/wardnet.toml")]
-    config: String,
+    /// Path to the wctl config file
+    /// (default: `$XDG_CONFIG_HOME/wardnet/wctl.toml`)
+    #[arg(long, global = true)]
+    config: Option<String>,
 
     #[command(subcommand)]
     command: Commands,
@@ -103,7 +126,7 @@ enum TunnelsCommand {
         /// Tunnel ID
         id: String,
     },
-    /// Add a new tunnel
+    /// Add a new tunnel by importing a `WireGuard` `.conf` file
     Add {
         /// Tunnel label
         #[arg(long)]
@@ -111,9 +134,9 @@ enum TunnelsCommand {
         /// Country code (e.g., US, DE)
         #[arg(long)]
         country: String,
-        /// `WireGuard` interface name
+        /// Path to the `WireGuard` `.conf` file to import
         #[arg(long)]
-        interface: String,
+        conf: String,
     },
     /// Remove a tunnel
     Remove {
@@ -127,69 +150,61 @@ enum TunnelsCommand {
     },
 }
 
-fn main() {
+#[tokio::main]
+async fn main() {
     let cli = Cli::parse();
+    if let Err(err) = run(cli).await {
+        eprintln!("error: {err}");
+        std::process::exit(err.exit_code());
+    }
+}
+
+async fn run(cli: Cli) -> Result<(), CliError> {
+    let config = Config::resolve(cli.config.as_deref())?;
+    // Every admin endpoint requires a bearer token, so resolve it up front and
+    // fail with a clear message rather than a 401 from each command.
+    let client = Client::new(&config.daemon_url, config.token()?)?;
+    let json = cli.json;
 
     match cli.command {
-        Commands::Status => println!("status: not yet implemented"),
+        Commands::Status => commands::status::run(&client, json).await,
         Commands::Devices(cmd) => match cmd {
-            DevicesCommand::List => println!("devices list: not yet implemented"),
-            DevicesCommand::Show { id } => println!("devices show {id}: not yet implemented"),
+            DevicesCommand::List => commands::devices::list(&client, json).await,
+            DevicesCommand::Show { id } => commands::devices::show(&client, json, &id).await,
             DevicesCommand::SetRule { id, target } => {
-                println!("devices set-rule {id} {target}: not yet implemented");
+                commands::devices::set_rule(&client, json, &id, &target).await
             }
         },
         Commands::Tunnels(cmd) => match cmd {
-            TunnelsCommand::List => println!("tunnels list: not yet implemented"),
-            TunnelsCommand::Show { id } => println!("tunnels show {id}: not yet implemented"),
+            TunnelsCommand::List => commands::tunnels::list(&client, json).await,
+            TunnelsCommand::Show { id } => commands::tunnels::show(&client, json, &id).await,
             TunnelsCommand::Add {
                 label,
                 country,
-                interface,
-            } => {
-                println!(
-                    "tunnels add --label {label} --country {country} --interface {interface}: not yet implemented"
-                );
-            }
-            TunnelsCommand::Remove { id } => {
-                println!("tunnels remove {id}: not yet implemented");
-            }
-            TunnelsCommand::Test { id } => {
-                println!("tunnels test {id}: not yet implemented");
-            }
+                conf,
+            } => commands::tunnels::add(&client, json, &label, &country, &conf).await,
+            TunnelsCommand::Remove { id } => commands::tunnels::remove(&client, json, &id).await,
+            TunnelsCommand::Test { id } => commands::tunnels::test(&client, json, &id).await,
         },
         Commands::Update(cmd) => match cmd {
-            UpdateCommand::Status => println!("update status: not yet implemented"),
-            UpdateCommand::Check => println!("update check: not yet implemented"),
-            UpdateCommand::Install { version } => match version {
-                Some(v) => println!("update install --version {v}: not yet implemented"),
-                None => println!("update install: not yet implemented"),
-            },
-            UpdateCommand::Rollback => println!("update rollback: not yet implemented"),
+            UpdateCommand::Status => commands::update::status(&client, json).await,
+            UpdateCommand::Check => commands::update::check(&client, json).await,
+            UpdateCommand::Install { version } => {
+                commands::update::install(&client, json, version.as_deref()).await
+            }
+            UpdateCommand::Rollback => commands::update::rollback(&client, json).await,
         },
         Commands::Backup(cmd) => match cmd {
-            BackupCommand::Status => println!("backup status: not yet implemented"),
+            BackupCommand::Status => commands::backup::status(&client, json).await,
             BackupCommand::Export {
                 out,
                 passphrase_file,
-            } => match passphrase_file {
-                Some(p) => {
-                    println!(
-                        "backup export --out {out} --passphrase-file {p}: not yet implemented"
-                    );
-                }
-                None => println!("backup export --out {out}: not yet implemented"),
-            },
+            } => commands::backup::export(&client, json, &out, passphrase_file.as_deref()).await,
             BackupCommand::Import {
                 bundle,
                 passphrase_file,
-            } => match passphrase_file {
-                Some(p) => {
-                    println!("backup import {bundle} --passphrase-file {p}: not yet implemented");
-                }
-                None => println!("backup import {bundle}: not yet implemented"),
-            },
-            BackupCommand::Snapshots => println!("backup snapshots: not yet implemented"),
+            } => commands::backup::import(&client, json, &bundle, passphrase_file.as_deref()).await,
+            BackupCommand::Snapshots => commands::backup::snapshots(&client, json).await,
         },
     }
 }

--- a/source/daemon/crates/wctl/src/output.rs
+++ b/source/daemon/crates/wctl/src/output.rs
@@ -1,0 +1,82 @@
+//! Small formatting helpers shared by the command modules.
+//!
+//! Every command supports two renderings: a human-readable one and, under the
+//! global `--json` flag, the response serialized verbatim so it can be piped
+//! into `jq` and friends.
+
+use chrono::{DateTime, Utc};
+use serde::Serialize;
+
+use crate::error::CliError;
+
+/// Print a value as pretty JSON on stdout.
+///
+/// # Errors
+/// Returns [`CliError::Protocol`] if the value cannot be serialized, which for
+/// the response types in this crate should never happen.
+pub fn print_json<T: Serialize>(value: &T) -> Result<(), CliError> {
+    let rendered = serde_json::to_string_pretty(value)
+        .map_err(|e| CliError::Protocol(format!("failed to render JSON: {e}")))?;
+    println!("{rendered}");
+    Ok(())
+}
+
+/// Render an optional timestamp as RFC 3339, or `-` when absent.
+#[must_use]
+pub fn timestamp(value: Option<DateTime<Utc>>) -> String {
+    value.map_or_else(|| "-".to_owned(), |t| t.to_rfc3339())
+}
+
+/// Render an optional string, or `-` when absent.
+#[must_use]
+pub fn opt(value: Option<&str>) -> String {
+    value.map_or_else(|| "-".to_owned(), str::to_owned)
+}
+
+/// Human-readable byte count (binary units).
+#[must_use]
+pub fn bytes(mut value: u64) -> String {
+    const UNITS: [&str; 6] = ["B", "KiB", "MiB", "GiB", "TiB", "PiB"];
+    if value < 1024 {
+        return format!("{value} B");
+    }
+    let mut unit = 0;
+    let mut rem = 0u64;
+    while value >= 1024 && unit < UNITS.len() - 1 {
+        rem = value % 1024;
+        value /= 1024;
+        unit += 1;
+    }
+    // One decimal place, derived from the remainder of the final division.
+    let tenths = rem * 10 / 1024;
+    format!("{value}.{tenths} {}", UNITS[unit])
+}
+
+/// Human-readable duration from a whole number of seconds (`1d 2h 3m 4s`).
+#[must_use]
+pub fn duration(mut secs: u64) -> String {
+    if secs == 0 {
+        return "0s".to_owned();
+    }
+    let days = secs / 86_400;
+    secs %= 86_400;
+    let hours = secs / 3_600;
+    secs %= 3_600;
+    let mins = secs / 60;
+    secs %= 60;
+
+    let mut parts = Vec::new();
+    if days > 0 {
+        parts.push(format!("{days}d"));
+    }
+    if hours > 0 {
+        parts.push(format!("{hours}h"));
+    }
+    if mins > 0 {
+        parts.push(format!("{mins}m"));
+    }
+    if secs > 0 {
+        parts.push(format!("{secs}s"));
+    }
+    parts.join(" ")
+}

--- a/source/daemon/crates/wctl/src/tests/client.rs
+++ b/source/daemon/crates/wctl/src/tests/client.rs
@@ -1,0 +1,40 @@
+use reqwest::StatusCode;
+
+use crate::client::{Client, api_error};
+use crate::error::CliError;
+
+#[test]
+fn api_error_parses_structured_body() {
+    let body = br#"{"error":"not found","detail":"device x","request_id":"r1"}"#;
+    let err = api_error(StatusCode::NOT_FOUND, body);
+    match err {
+        CliError::Api { status, body } => {
+            assert_eq!(status, 404);
+            assert_eq!(body.error, "not found");
+            assert_eq!(body.detail.as_deref(), Some("device x"));
+        }
+        other => panic!("expected Api, got {other:?}"),
+    }
+}
+
+#[test]
+fn api_error_falls_back_to_status_text() {
+    let err = api_error(StatusCode::BAD_GATEWAY, b"<html>oops</html>");
+    match err {
+        CliError::Api { status, body } => {
+            assert_eq!(status, 502);
+            assert_eq!(body.error, "bad gateway");
+            assert_eq!(body.detail.as_deref(), Some("<html>oops</html>"));
+        }
+        other => panic!("expected Api, got {other:?}"),
+    }
+}
+
+#[test]
+fn url_join_has_no_double_slash() {
+    let client = Client::new("http://127.0.0.1:7411", "t").unwrap();
+    assert_eq!(
+        client.url("/api/system/status"),
+        "http://127.0.0.1:7411/api/system/status"
+    );
+}

--- a/source/daemon/crates/wctl/src/tests/commands.rs
+++ b/source/daemon/crates/wctl/src/tests/commands.rs
@@ -1,0 +1,43 @@
+use wardnet_common::routing::RoutingTarget;
+
+use crate::commands::{parse_routing_target, parse_uuid};
+use crate::error::CliError;
+
+#[test]
+fn routing_target_keywords() {
+    assert_eq!(
+        parse_routing_target("direct").unwrap(),
+        RoutingTarget::Direct
+    );
+    assert_eq!(
+        parse_routing_target("default").unwrap(),
+        RoutingTarget::Default
+    );
+}
+
+#[test]
+fn routing_target_tunnel_uuid() {
+    let id = "550e8400-e29b-41d4-a716-446655440000";
+    assert_eq!(
+        parse_routing_target(id).unwrap(),
+        RoutingTarget::Tunnel {
+            tunnel_id: id.parse().unwrap()
+        }
+    );
+}
+
+#[test]
+fn routing_target_rejects_garbage() {
+    assert!(matches!(
+        parse_routing_target("nope"),
+        Err(CliError::Usage(_))
+    ));
+}
+
+#[test]
+fn uuid_parse_rejects_non_uuid() {
+    assert!(matches!(
+        parse_uuid("device", "abc"),
+        Err(CliError::Usage(_))
+    ));
+}

--- a/source/daemon/crates/wctl/src/tests/config.rs
+++ b/source/daemon/crates/wctl/src/tests/config.rs
@@ -1,0 +1,35 @@
+use crate::config::{Config, DEFAULT_DAEMON_URL, RawConfig};
+use crate::error::CliError;
+
+#[test]
+fn parses_daemon_url_and_token() {
+    let raw: RawConfig =
+        toml::from_str("daemon_url = \"http://host:9000\"\ntoken = \"abc\"").unwrap();
+    assert_eq!(raw.daemon_url.as_deref(), Some("http://host:9000"));
+    assert_eq!(raw.token.as_deref(), Some("abc"));
+}
+
+#[test]
+fn empty_config_is_valid() {
+    let raw: RawConfig = toml::from_str("").unwrap();
+    assert!(raw.daemon_url.is_none());
+    assert!(raw.token.is_none());
+}
+
+#[test]
+fn missing_token_yields_config_error() {
+    let cfg = Config {
+        daemon_url: DEFAULT_DAEMON_URL.to_owned(),
+        token: None,
+    };
+    assert!(matches!(cfg.token(), Err(CliError::Config(_))));
+}
+
+#[test]
+fn token_is_returned_when_present() {
+    let cfg = Config {
+        daemon_url: DEFAULT_DAEMON_URL.to_owned(),
+        token: Some("secret".to_owned()),
+    };
+    assert_eq!(cfg.token().unwrap(), "secret");
+}

--- a/source/daemon/crates/wctl/src/tests/error.rs
+++ b/source/daemon/crates/wctl/src/tests/error.rs
@@ -1,0 +1,48 @@
+use wardnet_common::api::ApiError;
+
+use crate::error::CliError;
+
+fn api(status: u16) -> CliError {
+    CliError::Api {
+        status,
+        body: ApiError {
+            error: "boom".to_owned(),
+            detail: None,
+            request_id: None,
+        },
+    }
+}
+
+#[test]
+fn exit_codes_are_stable() {
+    assert_eq!(CliError::Usage(String::new()).exit_code(), 2);
+    assert_eq!(CliError::Config(String::new()).exit_code(), 3);
+    assert_eq!(CliError::Connection(String::new()).exit_code(), 4);
+    assert_eq!(CliError::Io(String::new()).exit_code(), 7);
+    assert_eq!(CliError::Protocol(String::new()).exit_code(), 1);
+}
+
+#[test]
+fn api_status_maps_to_category() {
+    assert_eq!(api(401).exit_code(), 5);
+    assert_eq!(api(403).exit_code(), 5);
+    assert_eq!(api(404).exit_code(), 6);
+    assert_eq!(api(400).exit_code(), 1);
+    assert_eq!(api(500).exit_code(), 1);
+}
+
+#[test]
+fn api_display_includes_detail() {
+    let err = CliError::Api {
+        status: 400,
+        body: ApiError {
+            error: "bad request".to_owned(),
+            detail: Some("missing field".to_owned()),
+            request_id: None,
+        },
+    };
+    assert_eq!(
+        err.to_string(),
+        "daemon returned 400: bad request (missing field)"
+    );
+}

--- a/source/daemon/crates/wctl/src/tests/mod.rs
+++ b/source/daemon/crates/wctl/src/tests/mod.rs
@@ -1,0 +1,5 @@
+mod client;
+mod commands;
+mod config;
+mod error;
+mod output;

--- a/source/daemon/crates/wctl/src/tests/output.rs
+++ b/source/daemon/crates/wctl/src/tests/output.rs
@@ -1,0 +1,26 @@
+use crate::output::{bytes, duration, opt, timestamp};
+
+#[test]
+fn bytes_scales_units() {
+    assert_eq!(bytes(0), "0 B");
+    assert_eq!(bytes(512), "512 B");
+    assert_eq!(bytes(1024), "1.0 KiB");
+    assert_eq!(bytes(1536), "1.5 KiB");
+    assert_eq!(bytes(1_048_576), "1.0 MiB");
+}
+
+#[test]
+fn duration_composes_units() {
+    assert_eq!(duration(0), "0s");
+    assert_eq!(duration(59), "59s");
+    assert_eq!(duration(60), "1m");
+    assert_eq!(duration(3_661), "1h 1m 1s");
+    assert_eq!(duration(90_061), "1d 1h 1m 1s");
+}
+
+#[test]
+fn opt_and_timestamp_render_dash_when_absent() {
+    assert_eq!(opt(None), "-");
+    assert_eq!(opt(Some("x")), "x");
+    assert_eq!(timestamp(None), "-");
+}


### PR DESCRIPTION
## What

Replaces the `println!("… not yet implemented")` stubs in `wctl` with real `reqwest` calls against the local daemon, so the gateway can be driven from the terminal (Milestone 1i / FR-130–FR-139).

Commands wired up:
- `wctl status`
- `wctl devices list | show | set-rule`
- `wctl tunnels list | show | add | remove | test`
- `wctl update status | check | install | rollback`
- `wctl backup status | export | import | snapshots`

## How

- Config loader for `~/.config/wardnet/wctl.toml` (`daemon_url` + `token`), overridable with `--config` or the `WARDNET_DAEMON_URL` / `WARDNET_TOKEN` environment variables. Auth is a bearer token in the `Authorization` header.
- A thin `reqwest` client wrapper; every non-2xx response is decoded into the shared `ApiError` and surfaced with a clear stderr message.
- Requests/responses reuse the `wardnet-common` types directly rather than duplicating them. The response structs that were serialize-only (`SystemStatusResponse` and the devices responses) now also derive `Deserialize` so the client can decode them.
- Every command supports `--json`. Failures map to distinct non-zero exit codes: `2` usage, `3` config, `4` connection, `5` auth, `6` not found, `7` I/O, `1` otherwise.

## Notes

- The global `--config` flag previously defaulted to the daemon's `/etc/wardnet/wardnet.toml`; it now points at the wctl client config, which is what a client CLI actually needs.
- `tunnels add` imports a WireGuard `.conf` via `--conf` (the daemon assigns the interface name), matching `POST /api/tunnels`. This replaces the old `--interface` placeholder, which had no request-body counterpart.

## Testing

- Unit tests for config parsing, routing-target parsing, error→exit-code mapping, and output formatting.
- Manually exercised every command against `wardnetd-mock`: output matches the web UI state, and error paths return the expected non-zero exit codes (bad UUID → 2, 404 → 6, 401 → 5, connection refused → 4).

Closes #228