### PR TITLE
fix(daemon): harden CORS, DHCPRELEASE auth, and DNS stats-label escaping

### DIFF
--- a/.agentic-toolkit.lock.yaml
+++ b/.agentic-toolkit.lock.yaml
@@ -8,4 +8,4 @@ sources:
   sha: 13fbcd81632de892d516a451b64fa07197a93893
 - url: github.com/anthropics/skills.git
   ref: main
-  sha: 9d2f1ae187231d8199c64b5b762e1bdf2244733d
+  sha: 1f630fdf9259cec4a14913127dfd7c3b69ef72eb

--- a/.serena/project.yml
+++ b/.serena/project.yml
@@ -1,38 +1,5 @@
-# the name by which the project can be referenced within Serena
+# the name by which the project can be referenced within Serena/when chatting with the LLM.
 project_name: "consume-design-system"
-
-
-# list of languages for which language servers are started; choose from:
-#   al                  angular             ansible             bash                clojure
-#   cpp                 cpp_ccls            crystal             csharp              csharp_omnisharp
-#   dart                elixir              elm                 erlang              fortran
-#   fsharp              go                  groovy              haskell             haxe
-#   hlsl                html                java                json                julia
-#   kotlin              lean4               lua                 luau                markdown
-#   matlab              msl                 nix                 ocaml               pascal
-#   perl                php                 php_phpactor        powershell          python
-#   python_jedi         python_ty           r                   rego                ruby
-#   ruby_solargraph     rust                scala               scss                solidity
-#   svelte              swift               systemverilog       terraform           toml
-#   typescript          typescript_vts      vue                 yaml                zig
-#   (This list may be outdated. For the current list, see values of Language enum here:
-#   https://github.com/oraios/serena/blob/main/src/solidlsp/ls_config.py
-#   For some languages, there are alternative language servers, e.g. csharp_omnisharp, ruby_solargraph.)
-# Note:
-#   - For C, use cpp
-#   - For JavaScript, use typescript
-#   - For Angular projects, use angular (subsumes typescript+html; requires `npm install` in the project root)
-#   - For Svelte projects, use svelte (subsumes typescript/javascript for .svelte projects; requires npm)
-#   - For SCSS / Sass / plain CSS, use scss (some-sass-language-server handles all three)
-#   - For Free Pascal/Lazarus, use pascal
-# Special requirements:
-#   Some languages require additional setup/installations.
-#   See here for details: https://oraios.github.io/serena/01-about/020_programming-languages.html#language-servers
-# When using multiple languages, the first language server that supports a given file will be used for that file.
-# The first language is the default language and the respective language server will be used as a fallback.
-# Note that when using the JetBrains backend, language servers are not used and this list is correspondingly ignored.
-languages:
-- rust
 
 # the encoding used by text files in the project
 # For a list of possible encodings, see https://docs.python.org/3.11/library/codecs.html#standard-encodings
@@ -55,12 +22,19 @@ ignore_all_files_in_gitignore: true
 
 # advanced configuration option allowing to configure language server-specific options.
 # Maps the language key to the options.
-# Have a look at the docstring of the constructors of the LS implementations within solidlsp (e.g., for C# or PHP) to see which options are available.
-# No documentation on options means no options are available.
+# The settings are considered only if the project is trusted (see global configuration to define trusted projects).
+# See https://oraios.github.io/serena/02-usage/050_configuration.html#language-server-specific-settings
 ls_specific_settings: {}
 
 # list of additional paths to ignore in this project.
 # Same syntax as gitignore, so you can use * and **.
+# Important: quote patterns that start with `*`, otherwise YAML treats them as aliases.
+# Example:
+#   ignored_paths:
+#     - "examples/**"
+#     - ".worktrees/**"
+#     - "**/bin/**"
+#     - "**/obj/**"
 # Note: global ignored_paths from serena_config.yml are also applied additively.
 ignored_paths: []
 
@@ -143,6 +117,14 @@ ls_additional_workspace_folders: []
 #     - "./subproject2"
 ls_workspace_folders:
 - .
+
+# optional shell command to run before the language backend (LSP or JetBrains) is initialised.
+# the command runs in the project root directory and is only executed if the project is trusted
+# (see trusted_project_path_patterns in the global configuration).
+# serena waits for the command to exit: a non-zero exit code is logged as an error but does not
+# abort activation. a per-project timeout (activation_command_timeout, default 180s) is the safety
+# backstop for non-terminating commands; on expiry the process is killed and activation continues.
+# example: activation_command: "npx nx run-many -t build"
 activation_command:
 
 # maximum time in seconds to wait for activation_command to complete before killing it (default 180s).
@@ -159,3 +141,38 @@ activation_command_timeout: 180.0
 #     - ../sibling-package
 #     - ../shared-lib
 additional_workspace_folders: []
+
+# list of language servers to start when using the LSP backend; choose from:
+#   ada                 al                  angular             ansible             bash
+#   bsl                 clojure             cpp                 cpp_ccls            crystal
+#   csharp              csharp_omnisharp    cue                 dart                elixir
+#   elm                 erlang              fortran             fsharp              gdscript
+#   go                  groovy              haskell             haxe                hlsl
+#   html                java                json                julia               kotlin
+#   latex               lean4               lua                 luau                markdown
+#   matlab              msl                 nix                 ocaml               pascal
+#   perl                php                 php_phpactor        php_phpantom        powershell
+#   python              python_jedi         python_pyrefly      python_ty           r
+#   rego                ruby                ruby_solargraph     rust                scala
+#   scss                solidity            svelte              swift               systemverilog
+#   terraform           toml                typescript          typescript_vts      vue
+#   yaml                zig
+#   (This list may be outdated; generated with scripts/print_language_list.py;
+#   For the current list, see values of Language enum here:
+#   https://github.com/oraios/serena/blob/main/src/solidlsp/ls_config.py)
+# For some languages, there are several alternative language servers, e.g. csharp_omnisharp, ruby_solargraph.)
+# Note:
+#   - For C, use cpp
+#   - For JavaScript, use typescript
+#   - For Angular projects, use angular (subsumes typescript+html; requires `npm install` in the project root)
+#   - For Svelte projects, use svelte (subsumes typescript/javascript for .svelte projects; requires npm)
+#   - For SCSS / Sass / plain CSS, use scss (some-sass-language-server handles all three)
+#   - For Free Pascal/Lazarus, use pascal
+# Special requirements:
+#   Some language servers require additional setup/installations.
+#   See here for details: https://oraios.github.io/serena/01-about/020_programming-languages.html#language-servers
+# When using multiple language servers, the first language server that supports a given file will be used for that file.
+# The first language server is the default language and the respective language server will be used as a fallback.
+# Note that when using the JetBrains backend, language servers are not used and this list is correspondingly ignored.
+language_servers:
+- rust

--- a/source/daemon/Cargo.toml
+++ b/source/daemon/Cargo.toml
@@ -79,7 +79,7 @@ sqlx = { version = "0.9", features = ["runtime-tokio", "sqlite", "uuid", "chrono
 # https://crates.io/crates/tower
 tower = { version = "0.5", features = ["util"] }
 # https://crates.io/crates/tower-http
-tower-http = { version = "0.6", features = ["catch-panic", "cors", "trace"] }
+tower-http = { version = "0.6", features = ["catch-panic", "trace"] }
 
 # https://crates.io/crates/rust-embed
 rust-embed = { version = "8", features = ["axum"] }

--- a/source/daemon/crates/wardnetd-api/src/api/mod.rs
+++ b/source/daemon/crates/wardnetd-api/src/api/mod.rs
@@ -46,7 +46,6 @@ use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
 use axum::routing::get;
 use tower_http::catch_panic::CatchPanicLayer;
-use tower_http::cors::CorsLayer;
 use tower_http::trace::TraceLayer;
 use utoipa::OpenApi;
 use utoipa_axum::router::OpenApiRouter;
@@ -150,8 +149,22 @@ pub(crate) fn build_openapi_router() -> OpenApiRouter<AppState> {
 /// attribute — and contains route-registration alongside the handlers instead
 /// of concentrating it here.
 ///
-/// Assembles all API routes under `/api/`, applies middleware (CORS, tracing),
-/// and falls back to the embedded static file handler for the web UI.
+/// Assembles all API routes under `/api/`, applies middleware (tracing,
+/// request/auth context), and falls back to the embedded static file handler
+/// for the web UI.
+///
+/// Note the deliberate absence of a CORS layer: every web surface the daemon
+/// serves (the user PWA at `/app/`, the admin mobile PWA at `/admin-app/`, and
+/// the desktop admin site at `/admin/`) is embedded and served from this same
+/// origin, so no legitimate caller is cross-origin. Emitting any
+/// `Access-Control-Allow-Origin` here would be actively harmful: the
+/// self-service endpoints authenticate the caller by TCP peer IP
+/// ([`AuthContext::Device`](wardnet_common::auth::AuthContext), ambient
+/// authority that `SameSite` cookies cannot protect), so a permissive CORS policy
+/// let any web page a LAN user visited drive authenticated state changes and
+/// read responses cross-origin (CWE-352). With no CORS layer the browser's
+/// same-origin policy blocks cross-origin reads and fails the preflight for the
+/// non-simple `PUT`/`PATCH`/`DELETE`/JSON-`POST` requests those endpoints use.
 pub fn router(state: AppState) -> Router {
     // `split_for_parts` merges every handler path into the seeded `ApiDoc`
     // and returns the fully populated OpenAPI document.
@@ -273,6 +286,10 @@ pub fn router(state: AppState) -> Router {
                     },
                 ),
         )
-        .layer(CorsLayer::permissive())
+        // No CORS layer, intentionally — see this function's doc comment. Every
+        // served web surface is same-origin, and the IP-authenticated
+        // self-service endpoints must never answer a cross-origin preflight or
+        // emit `Access-Control-Allow-Origin`, or a hostile web page could forge
+        // authenticated requests / read responses cross-origin (CWE-352).
         .with_state(state)
 }

--- a/source/daemon/crates/wardnetd-api/src/api/tests/router.rs
+++ b/source/daemon/crates/wardnetd-api/src/api/tests/router.rs
@@ -3,12 +3,17 @@
 //! These tests verify that the full router can be constructed and that every
 //! registered route is reachable (i.e. returns something other than 404).
 //!
-//! We send HTTP `OPTIONS` requests because the `CorsLayer::permissive()` layer
-//! intercepts them before any handler runs, so the stub services never panic.
-//! A matched route returns `200 OK` with CORS headers; an unmatched route
-//! falls through to the static-file fallback (which also returns 200 for
-//! index.html). To distinguish, we check the `access-control-allow-origin`
-//! header that CORS adds on OPTIONS responses to matched routes.
+//! We send HTTP `OPTIONS` requests because no route registers an `OPTIONS`
+//! handler, so the request never reaches (and cannot panic) a stub service. A
+//! matched path returns `405 Method Not Allowed` (the path exists, the method
+//! doesn't); an unmatched path falls through to the static-file fallback (a
+//! `308` redirect into `/app/`). The two are distinguishable by status.
+//!
+//! There is deliberately **no** CORS layer (see [`crate::api::router`]): every
+//! served web surface is same-origin, and answering a cross-origin preflight
+//! or emitting `Access-Control-Allow-Origin` would reopen the CWE-352 hole
+//! against the IP-authenticated self-service endpoints. These tests assert that
+//! no `access-control-allow-origin` header is ever emitted.
 
 use axum::body::Body;
 use axum::http::{Request, StatusCode};
@@ -58,11 +63,12 @@ async fn router_can_be_constructed() {
 
 /// Verify every API route is registered by sending OPTIONS to each path.
 ///
-/// CORS permissive returns 200 for OPTIONS on any matched route. The
-/// fallback (static handler) also returns 200 but that is fine — the
-/// important thing is that none of these paths cause an error in the
-/// router itself. We additionally verify that a few representative
-/// routes get proper CORS headers.
+/// With no CORS layer to intercept it, an `OPTIONS` to a registered path
+/// returns `405 Method Not Allowed` (the path matched; no `OPTIONS` handler is
+/// registered) rather than falling through to the static-file fallback. That
+/// `405` is the proof the route exists. We additionally assert that the
+/// response carries **no** `access-control-allow-origin` header, i.e. the
+/// router never answers a cross-origin preflight (CWE-352 regression guard).
 #[tokio::test]
 async fn all_api_routes_are_reachable() {
     // Every route declared in api::router(). We use a dummy UUID for path
@@ -119,14 +125,16 @@ async fn all_api_routes_are_reachable() {
         let status = resp.status();
         assert_eq!(
             status,
-            StatusCode::OK,
-            "OPTIONS preflight for {method} {path} returned {status} (expected 200)"
+            StatusCode::METHOD_NOT_ALLOWED,
+            "OPTIONS for {method} {path} returned {status} (expected 405, proving the \
+             path is registered and no CORS layer answers the preflight)"
         );
 
-        // CORS permissive should set Access-Control-Allow-Origin on matched routes.
+        // The router must never answer a cross-origin preflight: no
+        // Access-Control-Allow-Origin header may be emitted (CWE-352 guard).
         assert!(
-            resp.headers().contains_key("access-control-allow-origin"),
-            "missing CORS header for {method} {path}"
+            !resp.headers().contains_key("access-control-allow-origin"),
+            "cross-origin preflight was answered for {method} {path}"
         );
     }
 }
@@ -190,13 +198,14 @@ async fn authenticated_routes_return_401_without_credentials() {
 }
 
 /// A non-existent API path should NOT return 404 from the router — it falls
-/// through to the static file handler (SPA fallback), which returns 200.
-/// This verifies the fallback is wired up correctly.
+/// through to the static file handler, which treats an unmatched path as a
+/// legacy root path and permanently redirects it into `/app/`. This verifies
+/// the fallback is wired up correctly. (With no CORS layer intercepting it, the
+/// `OPTIONS` reaches the fallback and gets the same 308 as any other method.)
 #[tokio::test]
 async fn unknown_path_hits_fallback() {
     let status = options_status(full_router(), "/api/nonexistent/path").await;
-    // OPTIONS with CORS permissive returns 200 regardless, which is fine.
-    assert_eq!(status, StatusCode::OK);
+    assert_eq!(status, StatusCode::PERMANENT_REDIRECT);
 }
 
 /// Paths outside every app surface — the user PWA's pre-move root tree — are
@@ -250,8 +259,7 @@ async fn legacy_root_paths_redirect_into_app_scope() {
 
 /// The `.info` sentinel embedded in each web tree (it keeps the `dist/`
 /// directory tracked for rust-embed; see `source/*/dist/.info`) must never be
-/// served. A GET to it returns 404, not the SPA shell. We use GET because the
-/// CORS layer would short-circuit OPTIONS before the static handler runs.
+/// served. A GET to it returns 404, not the SPA shell.
 #[tokio::test]
 async fn info_sentinel_is_not_served() {
     for path in ["/app/.info", "/admin/.info", "/admin-app/.info"] {
@@ -271,4 +279,59 @@ async fn info_sentinel_is_not_served() {
             "GET {path} should be 404 but returned {status}"
         );
     }
+}
+
+/// CWE-352 regression guard for the self-service, IP-authenticated endpoints.
+///
+/// Those endpoints (`PUT /api/devices/me/rule`, `PATCH
+/// /api/devices/me/dns-capture`, the DNS-events stream/ack, rule-requests)
+/// authenticate the caller by TCP peer IP — ambient authority a `SameSite` cookie
+/// cannot protect. The daemon must therefore never help a cross-origin page
+/// reach them: a cross-origin preflight must not be answered, and no actual
+/// response may carry `Access-Control-Allow-Origin`. This test pins both so a
+/// future re-introduction of a permissive/wildcard CORS layer fails CI.
+#[tokio::test]
+async fn cross_origin_requests_get_no_cors_headers() {
+    // A preflight for the exact request the exploit used: PUT + JSON. Without a
+    // CORS layer the browser gets a 405 with no allow-origin, so it never sends
+    // the real PUT.
+    let preflight = Request::builder()
+        .method("OPTIONS")
+        .uri("/api/devices/me/rule")
+        .header("Origin", "http://attacker.example")
+        .header("Access-Control-Request-Method", "PUT")
+        .header("Access-Control-Request-Headers", "content-type")
+        .body(Body::empty())
+        .expect("valid request");
+    let resp = full_router()
+        .oneshot(preflight)
+        .await
+        .expect("router should respond");
+    assert_eq!(
+        resp.status(),
+        StatusCode::METHOD_NOT_ALLOWED,
+        "cross-origin preflight must not be answered with a success status"
+    );
+    assert!(
+        !resp.headers().contains_key("access-control-allow-origin"),
+        "preflight must not grant a cross-origin allow-origin"
+    );
+
+    // An actual cross-origin GET is still sent by the browser, but the response
+    // must not carry allow-origin, so the attacker page cannot read it.
+    let get = Request::builder()
+        .method("GET")
+        .uri("/api/info")
+        .header("Origin", "http://attacker.example")
+        .body(Body::empty())
+        .expect("valid request");
+    let resp = full_router()
+        .oneshot(get)
+        .await
+        .expect("router should respond");
+    assert_eq!(resp.status(), StatusCode::OK);
+    assert!(
+        !resp.headers().contains_key("access-control-allow-origin"),
+        "cross-origin GET response must not be readable cross-origin"
+    );
 }

--- a/source/daemon/crates/wardnetd-services/src/dhcp/service.rs
+++ b/source/daemon/crates/wardnetd-services/src/dhcp/service.rs
@@ -103,6 +103,25 @@ pub trait DhcpService: Send + Sync {
     /// Requires admin auth context.
     async fn release_lease(&self, mac: &str) -> Result<(), AppError>;
 
+    /// Look up the active lease currently recorded for a MAC, if any.
+    ///
+    /// Used by the DHCP server runtime to authorize a DHCPRELEASE: because the
+    /// wire `chaddr` is attacker-controllable it is never treated as proof of
+    /// ownership (CWE-639). Per RFC 2131 a legitimate release is unicast from
+    /// the client's own leased address, so the runtime releases only when the
+    /// packet's UDP source address matches the IP recorded here. Requires admin
+    /// auth context.
+    ///
+    /// Defaults to `Ok(None)` so stubs/mocks need not implement it; the real
+    /// [`DhcpServiceImpl`] overrides it with the authenticated repository
+    /// lookup. The default is fail-secure: a runtime backed by a
+    /// non-overriding impl simply never authorises a release. Any real override
+    /// MUST still open with `auth_context::require_admin()?`, like every other
+    /// method on this trait — the fail-secure default is not licence to skip it.
+    async fn active_lease(&self, _mac: &str) -> Result<Option<DhcpLease>, AppError> {
+        Ok(None)
+    }
+
     /// Expire all stale leases whose `lease_end` is in the past.
     ///
     /// Called periodically by the DHCP runner. Returns the number of expired leases.
@@ -1277,6 +1296,15 @@ impl DhcpService for DhcpServiceImpl {
         }
 
         Ok(())
+    }
+
+    async fn active_lease(&self, mac: &str) -> Result<Option<DhcpLease>, AppError> {
+        auth_context::require_admin()?;
+        // Casing is canonicalised at the repository boundary (issue #312).
+        self.dhcp
+            .find_active_lease_by_mac(mac)
+            .await
+            .map_err(AppError::Internal)
     }
 
     async fn cleanup_expired(&self) -> Result<u64, AppError> {

--- a/source/daemon/crates/wardnetd-services/src/dhcp/tests/dhcp.rs
+++ b/source/daemon/crates/wardnetd-services/src/dhcp/tests/dhcp.rs
@@ -1522,6 +1522,33 @@ async fn release_lease_noop_when_no_active_lease() {
 }
 
 #[tokio::test]
+async fn active_lease_returns_recorded_lease() {
+    let (svc, dhcp, _cfg) = build_service_with_deps();
+
+    seed_active_lease(&dhcp, "aa:bb:cc:dd:ee:40", "192.168.1.130");
+
+    // The DHCP runtime uses this to authorise a DHCPRELEASE against the lease's
+    // recorded IP; a query by MAC returns the active lease (casing canonicalised
+    // at the repository boundary).
+    let lease = auth_context::with_context(admin_ctx(), svc.active_lease("AA:BB:CC:DD:EE:40"))
+        .await
+        .unwrap()
+        .expect("an active lease should be found for the seeded MAC");
+    assert_eq!(lease.ip_address, Ipv4Addr::new(192, 168, 1, 130));
+}
+
+#[tokio::test]
+async fn active_lease_none_when_no_active_lease() {
+    let (svc, _dhcp, _cfg) = build_service_with_deps();
+
+    // No active lease recorded for this MAC -> no ownership record to release against.
+    let result = auth_context::with_context(admin_ctx(), svc.active_lease("AA:BB:CC:DD:EE:41"))
+        .await
+        .unwrap();
+    assert!(result.is_none());
+}
+
+#[tokio::test]
 async fn release_lease_frees_ip_for_reassignment() {
     let (svc, _dhcp, system_config) = build_service_with_deps();
 

--- a/source/daemon/crates/wardnetd-services/src/dns/log_sink.rs
+++ b/source/daemon/crates/wardnetd-services/src/dns/log_sink.rs
@@ -234,10 +234,15 @@ fn record_dns_stats(inst: &DnsStatInstruments, row: &QueryLogRow) {
     inst.latency.set(&outcome_labels, row.latency_ms);
 
     if outcome == "blocked" {
-        // Escape any double-quotes in the domain (extremely rare but safe).
-        let domain = row.domain.replace('"', r#"\""#);
-        inst.by_domain
-            .add(&format!(r#"{{"domain":"{domain}"}}"#), 1.0);
+        // Serialize the label via serde_json so every JSON-significant byte in
+        // the attacker-controlled DNS name (double-quote, backslash, control
+        // chars) is escaped correctly. Hand-building the string with a partial
+        // `.replace('"', ...)` mis-escaped hickory's `\"` rendering of a raw
+        // 0x22 byte and let a crafted query inject arbitrary JSON structure
+        // into the persisted `dns.queries.by_domain` label. `json!` emits the
+        // compact `{"domain":"<name>"}` shape the stats schema expects.
+        let domain_label = serde_json::json!({ "domain": row.domain }).to_string();
+        inst.by_domain.add(&domain_label, 1.0);
 
         // Attribute the block to its operating company when the domain is a
         // recognised tracker. The catalogue is small and lookups are cheap;

--- a/source/daemon/crates/wardnetd-services/src/dns/tests/log_sink.rs
+++ b/source/daemon/crates/wardnetd-services/src/dns/tests/log_sink.rs
@@ -197,6 +197,56 @@ fn blocked_outcome_records_by_domain_stat() {
     // the by_domain counter is an internal implementation detail.
 }
 
+/// A malicious DNS name containing JSON-significant bytes (double-quote,
+/// backslash, control char) must be escaped so the `dns.queries.by_domain`
+/// label is still valid JSON whose parsed `domain` field round-trips exactly
+/// to the raw name — proving the label can't be used to inject JSON structure
+/// (F4, CWE-116). An ordinary domain still serializes to the canonical shape.
+#[test]
+fn by_domain_label_escapes_malicious_domain_and_round_trips() {
+    // hickory renders a raw 0x22 byte in a label as `\"`; include that plus a
+    // literal backslash and a control byte to exercise every escape path.
+    let malicious = "evil\\\".com\u{0007}\"}injected";
+
+    let buf = StatsBuffer::new();
+    let meter = Meter::new(buf.clone());
+    let (sink, _channels) = DnsLogSink::new_with_stats(&meter);
+
+    let mut row = sample_row(malicious);
+    row.result = "blocked".to_owned();
+    sink.record(row);
+
+    let rows = buf.drain();
+    let domain_row = rows
+        .iter()
+        .find(|r| r.metric == "dns.queries.by_domain")
+        .expect("by_domain must be recorded for a blocked query");
+
+    // The label must parse as valid JSON (a partial `.replace` would have
+    // produced a malformed / structure-injected string here).
+    let parsed: serde_json::Value =
+        serde_json::from_str(&domain_row.labels).expect("label must be valid JSON");
+
+    assert_eq!(
+        parsed["domain"], malicious,
+        "parsed domain must round-trip exactly to the raw name, got {}",
+        domain_row.labels
+    );
+
+    // Ordinary domains keep the exact canonical shape existing dashboards read.
+    let (sink, _channels) = DnsLogSink::new_with_stats(&meter);
+    let mut plain = sample_row("example.com");
+    plain.result = "blocked".to_owned();
+    sink.record(plain);
+
+    let plain_row = buf
+        .drain()
+        .into_iter()
+        .find(|r| r.metric == "dns.queries.by_domain")
+        .expect("by_domain must be recorded for a blocked query");
+    assert_eq!(plain_row.labels, r#"{"domain":"example.com"}"#);
+}
+
 /// A query attributed to a device records `dns.queries.by_device` keyed on
 /// the device id; an unattributed query does not.
 #[tokio::test]

--- a/source/daemon/crates/wardnetd/src/dhcp/server.rs
+++ b/source/daemon/crates/wardnetd/src/dhcp/server.rs
@@ -1,5 +1,5 @@
 use std::collections::HashSet;
-use std::net::{Ipv4Addr, SocketAddr};
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 
@@ -315,14 +315,7 @@ pub(crate) async fn server_loop(
                 }
             },
             MessageType::Release => {
-                let admin_ctx = AuthContext::Admin {
-                    admin_id: Uuid::nil(),
-                };
-                if let Err(e) =
-                    auth_context::with_context(admin_ctx, service.release_lease(&mac)).await
-                {
-                    tracing::error!(%mac, error = %e, "failed to handle DHCPRELEASE for {mac}: {e}");
-                }
+                handle_release(&service, &msg, &mac, src_addr).await;
             }
             other => {
                 tracing::debug!(%mac, ?other, "ignoring unsupported DHCP message type: mac={mac}, type={other:?}");
@@ -420,6 +413,99 @@ pub(crate) async fn handle_request(
     );
 
     Ok(build_response(msg, MessageType::Ack, &lease, &scope))
+}
+
+/// Handle a DHCPRELEASE message.
+///
+/// A DHCPRELEASE elicits no server response; it just frees the client's lease.
+/// The wire `chaddr` is attacker-controllable, so it is **never** treated as
+/// proof of lease ownership: any unauthenticated LAN device could otherwise
+/// forge a victim's MAC and free the victim's lease, enabling denial of
+/// service and IP takeover (CWE-639, finding F3).
+///
+/// Per RFC 2131 a legitimate DHCPRELEASE is unicast by the client from its own
+/// leased address, so we authorize the release on the **network-layer UDP
+/// source address** (`src_addr`) — the one field an on-LAN attacker cannot set
+/// without genuinely spoofing their IP at the network layer. We require it to
+/// match the IP currently recorded for that MAC's active lease, reject an
+/// unspecified/broadcast source (which cannot be a legitimate unicast release),
+/// and drop the packet without releasing on any mismatch. Only an exact match
+/// with the lease's recorded IP runs `release_lease`.
+///
+/// The wire `ciaddr` is deliberately **not** trusted as the ownership claim:
+/// it is attacker-controlled packet payload, decoded straight from the message
+/// body exactly as forgeable as `chaddr`. Trusting it would let anyone who
+/// knows the victim's IP (trivially, via ARP) forge a release with a plain UDP
+/// socket and no spoofing at all, reopening CWE-639. It is only logged, as an
+/// informational hint.
+pub(crate) async fn handle_release(
+    service: &Arc<dyn DhcpService>,
+    msg: &Message,
+    mac: &str,
+    src_addr: SocketAddr,
+) {
+    let admin_ctx = AuthContext::Admin {
+        admin_id: Uuid::nil(),
+    };
+
+    // Authorize on the real UDP source address only. `ciaddr` is an untrusted
+    // wire field (see this function's doc comment) — kept solely for logging.
+    let ciaddr = msg.ciaddr();
+    let claimed_ip = match src_addr.ip() {
+        IpAddr::V4(v4) => v4,
+        // A DHCPv4 client is always reached over IPv4; an IPv6 source cannot
+        // own an IPv4 lease, so treat it as unauthenticated.
+        IpAddr::V6(_) => Ipv4Addr::UNSPECIFIED,
+    };
+
+    // A legitimate unicast release never originates from 0.0.0.0 or the limited
+    // broadcast address; such a packet carries no verifiable ownership claim.
+    if claimed_ip.is_unspecified() || claimed_ip.is_broadcast() {
+        tracing::warn!(
+            %mac,
+            %src_addr,
+            %ciaddr,
+            "dropping DHCPRELEASE from unspecified/broadcast source: mac={mac}, src={src_addr}"
+        );
+        return;
+    }
+
+    // Look up the lease currently recorded for this MAC. Only a release whose
+    // source matches that lease's own IP is authorised to free it.
+    let active = match auth_context::with_context(admin_ctx.clone(), service.active_lease(mac))
+        .await
+    {
+        Ok(a) => a,
+        Err(e) => {
+            tracing::error!(%mac, error = %e, "failed to look up active lease for DHCPRELEASE: {e}");
+            return;
+        }
+    };
+
+    let Some(lease) = active else {
+        tracing::debug!(
+            %mac,
+            %claimed_ip,
+            "dropping DHCPRELEASE: no active lease recorded for mac={mac}"
+        );
+        return;
+    };
+
+    if lease.ip_address != claimed_ip {
+        tracing::warn!(
+            %mac,
+            %claimed_ip,
+            %ciaddr,
+            lease_ip = %lease.ip_address,
+            "dropping forged DHCPRELEASE: UDP source does not match the lease's recorded IP (mac={mac}, src={claimed_ip}, lease_ip={lease_ip})",
+            lease_ip = lease.ip_address,
+        );
+        return;
+    }
+
+    if let Err(e) = auth_context::with_context(admin_ctx, service.release_lease(mac)).await {
+        tracing::error!(%mac, error = %e, "failed to handle DHCPRELEASE for {mac}: {e}");
+    }
 }
 
 /// Extract the IP address a DHCPREQUEST client wants to keep. In RENEWING /

--- a/source/daemon/crates/wardnetd/src/dhcp/tests/server.rs
+++ b/source/daemon/crates/wardnetd/src/dhcp/tests/server.rs
@@ -112,6 +112,10 @@ struct MockDhcpService {
     lease: DhcpLease,
     /// Records `(method_name, mac)` calls.
     calls: Mutex<Vec<(String, String)>>,
+    /// When set, `active_lease` returns an error instead of a lookup result.
+    active_lease_errors: bool,
+    /// When set, `release_lease` records the call then returns an error.
+    release_errors: bool,
 }
 
 impl MockDhcpService {
@@ -119,7 +123,22 @@ impl MockDhcpService {
         Self {
             lease,
             calls: Mutex::new(Vec::new()),
+            active_lease_errors: false,
+            release_errors: false,
         }
+    }
+
+    /// Make `active_lease` fail, to exercise the release runtime's lookup-error path.
+    fn failing_active_lease(mut self) -> Self {
+        self.active_lease_errors = true;
+        self
+    }
+
+    /// Make `release_lease` fail after recording the call, to exercise the
+    /// release runtime's release-error path.
+    fn failing_release(mut self) -> Self {
+        self.release_errors = true;
+        self
     }
 
     async fn recorded_calls(&self) -> Vec<(String, String)> {
@@ -200,7 +219,26 @@ impl DhcpService for MockDhcpService {
             .lock()
             .await
             .push(("release_lease".to_owned(), mac.to_owned()));
+        if self.release_errors {
+            return Err(AppError::Internal(anyhow::anyhow!("mock release failure")));
+        }
         Ok(())
+    }
+
+    /// Returns the configured lease when its MAC is queried, mirroring an
+    /// active lease recorded for that device. Intentionally does NOT record a
+    /// call so ownership lookups don't perturb `release_lease` assertions.
+    async fn active_lease(&self, mac: &str) -> Result<Option<DhcpLease>, AppError> {
+        if self.active_lease_errors {
+            return Err(AppError::Internal(anyhow::anyhow!(
+                "mock active_lease failure"
+            )));
+        }
+        if mac == self.lease.mac_address {
+            Ok(Some(self.lease.clone()))
+        } else {
+            Ok(None)
+        }
     }
 
     async fn cleanup_expired(&self) -> Result<u64, AppError> {
@@ -290,6 +328,16 @@ fn build_release(mac: [u8; 6]) -> Message {
     msg.set_opcode(Opcode::BootRequest).set_chaddr(&mac);
     msg.opts_mut()
         .insert(DhcpOption::MessageType(MessageType::Release));
+    msg
+}
+
+/// Like [`build_release`] but with `ciaddr` set. An RFC 2131 conformant client
+/// fills `ciaddr` with its own leased address, but the field is decoded
+/// straight from the packet body, so a forging attacker can set it to any
+/// value with no spoofing. Used to prove the release authorization ignores it.
+fn build_release_with_ciaddr(mac: [u8; 6], ciaddr: Ipv4Addr) -> Message {
+    let mut msg = build_release(mac);
+    msg.set_ciaddr(ciaddr);
     msg
 }
 
@@ -975,12 +1023,15 @@ async fn server_loop_responds_to_request_with_ack() {
 #[tokio::test]
 async fn server_loop_handles_release_without_response() {
     let lease = test_lease();
+    // A legitimate release is unicast from the client's own leased address, so
+    // the packet source must match the lease IP for the release to be honoured.
+    let lease_src = SocketAddr::from((lease.ip_address, 68));
     let mock_service = Arc::new(MockDhcpService::new(lease));
     let service: Arc<dyn DhcpService> = Arc::clone(&mock_service) as Arc<dyn DhcpService>;
     let socket = Arc::new(MockDhcpSocket::new());
 
     let release = build_release([0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff]);
-    socket.push_message(&release, client_addr()).await;
+    socket.push_message(&release, lease_src).await;
 
     let socket = run_server_loop_until_idle(socket, service).await;
 
@@ -989,6 +1040,184 @@ async fn server_loop_handles_release_without_response() {
     assert!(messages.is_empty(), "RELEASE should not produce a response");
 
     // But the service should have been called.
+    let calls = mock_service.recorded_calls().await;
+    assert_eq!(calls.len(), 1);
+    assert_eq!(calls[0].0, "release_lease");
+    assert_eq!(calls[0].1, "aa:bb:cc:dd:ee:ff");
+}
+
+#[tokio::test]
+async fn server_loop_release_from_lease_ip_releases_lease() {
+    // A DHCPRELEASE whose source is the lease's own recorded IP is a legitimate
+    // client releasing its own lease and must free it (RFC 2131 unicast release).
+    let lease = test_lease(); // ip 192.168.1.100, mac aa:bb:cc:dd:ee:ff
+    let lease_src = SocketAddr::from((lease.ip_address, 68));
+    let mock_service = Arc::new(MockDhcpService::new(lease));
+    let service: Arc<dyn DhcpService> = Arc::clone(&mock_service) as Arc<dyn DhcpService>;
+    let socket = Arc::new(MockDhcpSocket::new());
+
+    let release = build_release([0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff]);
+    socket.push_message(&release, lease_src).await;
+
+    let socket = run_server_loop_until_idle(socket, service).await;
+
+    // RELEASE never produces a response.
+    assert!(socket.sent_messages().await.is_empty());
+
+    // The lease was released because the source matched its recorded IP.
+    let calls = mock_service.recorded_calls().await;
+    assert_eq!(calls.len(), 1);
+    assert_eq!(calls[0].0, "release_lease");
+    assert_eq!(calls[0].1, "aa:bb:cc:dd:ee:ff");
+}
+
+#[tokio::test]
+async fn server_loop_release_from_spoofed_source_does_not_release_lease() {
+    // Attacker forges the victim's MAC in a DHCPRELEASE but sends it from a
+    // different source IP (and no ciaddr). The claimed source does not match the
+    // victim's recorded lease IP, so the release MUST be dropped — the victim's
+    // lease stays intact (CWE-639, finding F3).
+    let lease = test_lease(); // victim: ip 192.168.1.100, mac aa:bb:cc:dd:ee:ff
+    let mock_service = Arc::new(MockDhcpService::new(lease));
+    let service: Arc<dyn DhcpService> = Arc::clone(&mock_service) as Arc<dyn DhcpService>;
+    let socket = Arc::new(MockDhcpSocket::new());
+
+    let forged = build_release([0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff]);
+    let attacker_src: SocketAddr = "192.168.1.66:68".parse().unwrap();
+    socket.push_message(&forged, attacker_src).await;
+
+    let socket = run_server_loop_until_idle(socket, service).await;
+
+    // RELEASE never produces a response.
+    assert!(socket.sent_messages().await.is_empty());
+
+    // Crucially, `release_lease` was never called — the victim keeps its lease.
+    let calls = mock_service.recorded_calls().await;
+    assert!(
+        !calls.iter().any(|(method, _)| method == "release_lease"),
+        "forged DHCPRELEASE from a spoofed source must not release the victim's lease, got: {calls:?}"
+    );
+}
+
+#[tokio::test]
+async fn server_loop_release_with_forged_ciaddr_does_not_release_lease() {
+    // The `ciaddr` wire field is attacker-controlled packet payload. An attacker
+    // forges the victim's MAC AND sets `ciaddr` to the victim's lease IP — both
+    // discoverable via ARP — but sends from their own source address, with no
+    // network-layer spoofing. Authorization is on the real UDP source, not
+    // `ciaddr`, so the source (192.168.1.66) does not match the victim's lease
+    // IP (192.168.1.100) and the release MUST be dropped (CWE-639, finding F3).
+    let lease = test_lease(); // victim: ip 192.168.1.100, mac aa:bb:cc:dd:ee:ff
+    let mock_service = Arc::new(MockDhcpService::new(lease));
+    let service: Arc<dyn DhcpService> = Arc::clone(&mock_service) as Arc<dyn DhcpService>;
+    let socket = Arc::new(MockDhcpSocket::new());
+
+    let victim_ip: Ipv4Addr = "192.168.1.100".parse().unwrap();
+    let forged = build_release_with_ciaddr([0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff], victim_ip);
+    let attacker_src: SocketAddr = "192.168.1.66:68".parse().unwrap();
+    socket.push_message(&forged, attacker_src).await;
+
+    let socket = run_server_loop_until_idle(socket, service).await;
+
+    // RELEASE never produces a response.
+    assert!(socket.sent_messages().await.is_empty());
+
+    // The victim keeps its lease: trusting `ciaddr` would have wrongly freed it.
+    let calls = mock_service.recorded_calls().await;
+    assert!(
+        !calls.iter().any(|(method, _)| method == "release_lease"),
+        "a DHCPRELEASE with a forged ciaddr from a mismatched source must not release the victim's lease, got: {calls:?}"
+    );
+}
+
+#[tokio::test]
+async fn server_loop_release_from_ipv6_source_does_not_release_lease() {
+    // A DHCPv4 client is always reached over IPv4. A release arriving from an
+    // IPv6 source cannot own an IPv4 lease, so its claimed IPv4 source collapses
+    // to 0.0.0.0 and the packet is dropped as unauthenticated.
+    let lease = test_lease();
+    let mock_service = Arc::new(MockDhcpService::new(lease));
+    let service: Arc<dyn DhcpService> = Arc::clone(&mock_service) as Arc<dyn DhcpService>;
+    let socket = Arc::new(MockDhcpSocket::new());
+
+    let release = build_release([0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff]);
+    let ipv6_src: SocketAddr = "[fe80::1]:68".parse().unwrap();
+    socket.push_message(&release, ipv6_src).await;
+
+    let socket = run_server_loop_until_idle(socket, service).await;
+    assert!(socket.sent_messages().await.is_empty());
+
+    let calls = mock_service.recorded_calls().await;
+    assert!(
+        !calls.iter().any(|(method, _)| method == "release_lease"),
+        "a DHCPRELEASE from an IPv6 source must not release an IPv4 lease, got: {calls:?}"
+    );
+}
+
+#[tokio::test]
+async fn server_loop_release_for_unknown_mac_does_not_release_lease() {
+    // A release for a MAC with no recorded active lease is dropped: there is
+    // nothing to authorise the release against.
+    let lease = test_lease(); // recorded mac aa:bb:cc:dd:ee:ff
+    let mock_service = Arc::new(MockDhcpService::new(lease));
+    let service: Arc<dyn DhcpService> = Arc::clone(&mock_service) as Arc<dyn DhcpService>;
+    let socket = Arc::new(MockDhcpSocket::new());
+
+    let release = build_release([0x11, 0x22, 0x33, 0x44, 0x55, 0x66]);
+    let src: SocketAddr = "192.168.1.77:68".parse().unwrap();
+    socket.push_message(&release, src).await;
+
+    let socket = run_server_loop_until_idle(socket, service).await;
+    assert!(socket.sent_messages().await.is_empty());
+
+    let calls = mock_service.recorded_calls().await;
+    assert!(
+        !calls.iter().any(|(method, _)| method == "release_lease"),
+        "a DHCPRELEASE for a MAC with no active lease must not release anything, got: {calls:?}"
+    );
+}
+
+#[tokio::test]
+async fn server_loop_release_lookup_error_does_not_release_lease() {
+    // If the active-lease lookup itself fails, the release is dropped
+    // (fail-closed): we never release without a verified ownership match.
+    let lease = test_lease();
+    let lease_src = SocketAddr::from((lease.ip_address, 68));
+    let mock_service = Arc::new(MockDhcpService::new(lease).failing_active_lease());
+    let service: Arc<dyn DhcpService> = Arc::clone(&mock_service) as Arc<dyn DhcpService>;
+    let socket = Arc::new(MockDhcpSocket::new());
+
+    let release = build_release([0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff]);
+    socket.push_message(&release, lease_src).await;
+
+    let socket = run_server_loop_until_idle(socket, service).await;
+    assert!(socket.sent_messages().await.is_empty());
+
+    let calls = mock_service.recorded_calls().await;
+    assert!(
+        !calls.iter().any(|(method, _)| method == "release_lease"),
+        "a failed active-lease lookup must not release the lease, got: {calls:?}"
+    );
+}
+
+#[tokio::test]
+async fn server_loop_release_service_error_is_logged_and_swallowed() {
+    // An authorised release whose service call fails is logged and does not
+    // crash the loop. The release was attempted (the call is recorded before
+    // the service returns its error).
+    let lease = test_lease();
+    let lease_src = SocketAddr::from((lease.ip_address, 68));
+    let mock_service = Arc::new(MockDhcpService::new(lease).failing_release());
+    let service: Arc<dyn DhcpService> = Arc::clone(&mock_service) as Arc<dyn DhcpService>;
+    let socket = Arc::new(MockDhcpSocket::new());
+
+    let release = build_release([0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff]);
+    socket.push_message(&release, lease_src).await;
+
+    let socket = run_server_loop_until_idle(socket, service).await;
+    assert!(socket.sent_messages().await.is_empty());
+
+    // The release was authorised and attempted even though the service errored.
     let calls = mock_service.recorded_calls().await;
     assert_eq!(calls.len(), 1);
     assert_eq!(calls[0].0, "release_lease");


### PR DESCRIPTION
## Summary

Three security fixes to the daemon's network-facing surface, surfaced by a Claude Security scan of `source/daemon` (verified by an adversarial panel) and then put through a multi-agent pre-PR review that caught and closed a bypass in the first cut of the DHCP fix.

All changes are in `source/daemon`; no behaviour changes for legitimate clients.

### 1. Permissive CORS on IP-authenticated endpoints — CWE-352 / CWE-942
`source/daemon/crates/wardnetd-api/src/api/mod.rs`

The whole API router was wrapped in `CorsLayer::permissive()` (wildcard `Access-Control-Allow-Origin`/methods/headers). The self-service endpoints (`devices/me/rule`, `devices/me/dns-capture`, `devices/me/dns-events/*`, `rule-requests`, `private-dns/me`) authenticate the caller purely by TCP peer IP — ambient authority that SameSite cookies cannot protect. So any web page a LAN user visited could:

- forge authenticated state changes (force a device off its privacy tunnel — deanonymizing it, toggle DNS capture, destroy captured DNS history), and
- read responses cross-origin, exfiltrating the device's live DNS stream and its **Private-DNS credential** (the signed profile / secret DoT hostname).

Every web surface the daemon serves (`/app/`, `/admin-app/`, `/admin/`) is embedded and same-origin, so no legitimate caller is cross-origin. Fix: remove the CORS layer entirely, drop the now-unused tower-http `cors` feature, and add a regression test pinning that no `access-control-allow-origin` header is ever emitted (preflight → 405, cross-origin GET → no allow-origin).

### 2. Forgeable DHCPRELEASE — CWE-639
`source/daemon/crates/wardnetd/src/dhcp/server.rs`

`DHCPRELEASE` freed a lease keyed only on the wire-supplied MAC, with no ownership check, so any unauthenticated LAN device could forge a victim's MAC and free the victim's lease (connectivity DoS + IP takeover). Fix: authorize the release on the **real UDP source address** matching the MAC's recorded active lease IP; reject unspecified/broadcast sources and any mismatch. The wire `ciaddr` is deliberately **not** trusted (it is attacker-controlled payload — the pre-PR review caught a first version that trusted it, which would have left the hole open). Adds `DhcpService::active_lease` (admin-gated, fail-secure default) and tests for the legitimate, spoofed-source, and forged-`ciaddr` cases.

### 3. Incomplete JSON escaping of DNS name in stats label — CWE-116
`source/daemon/crates/wardnetd-services/src/dns/log_sink.rs`

The blocked-domain stats label was hand-built with a partial `.replace('"', ...)` that mis-escaped hickory's `\"` rendering of a raw quote byte, letting a crafted DNS query inject JSON structure into the persisted `dns.queries.by_domain` label. Fix: serialize the label with `serde_json`, which escapes every JSON-significant byte; the canonical `{"domain":"..."}` shape is preserved for ordinary names. Test asserts a malicious name round-trips exactly through valid JSON.

## Verification

- `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings` clean on `wardnetd`, `wardnetd-services`, `wardnetd-api` (Linux `rust:1.96` container).
- New/updated unit tests pass: router CORS regression guard; DHCP release (legitimate / spoofed-source / forged-ciaddr); DNS stats-label escaping round-trip.
- Nothing executed against production; no exploit fired.
