### PR TITLE
fix(ci): match codeql-action/init to analyze's version

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -50,7 +50,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@7188fc363630916deb702c7fdcf4e481b751f97a # v4
+        uses: github/codeql-action/init@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4
         with:
           languages: ${{ matrix.language }}
           build-mode: none


### PR DESCRIPTION
## Summary

CodeQL has been failing on `main` since #1060, and on every PR opened against it, with:

```
Loaded a configuration file for version '4.37.1', but running version '4.37.3'
```

#1059 bumped `github/codeql-action/analyze` from 4.37.1 to 4.37.3. Dependabot pins each sub-action of a repository independently, and it had no corresponding update open for `init`, so `init` stayed on 4.37.1. `init` writes the CodeQL config file stamped with its own version and `analyze` refuses to load a config written by a different one, so all three matrix legs (`actions`, `javascript-typescript`, `rust`) fail in the analyze step.

## What changed

Pin `github/codeql-action/init` to `e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81` — v4.37.3, the exact commit `analyze` is already on.

`upload-sarif` in `build-daemon.yml` and `scorecard.yml` is left alone: it uploads a SARIF produced by another tool and is not paired with an `init`, so it does not share the config file that carries the version stamp.

## Verification

Last green CodeQL run on main was 87ca7278 (Jul 27), before #1059 landed; every run since has failed on the message above. This restores the version pairing that was intact then.

## Merge Commit Message

fix(ci): match codeql-action/init to analyze's version