### PR TITLE
fix(ci): group codeql-action bumps so init and analyze move together

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -48,6 +48,23 @@ updates:
       prefix: "chore(ci):"
     cooldown:
       default-days: 3
+    # codeql-action/init and codeql-action/analyze MUST move in lockstep:
+    # init writes a config file stamped with its own version and analyze
+    # refuses to read one written by a different version, failing with
+    # "Loaded a configuration file for version X, but running version Y".
+    #
+    # Dependabot treats each action path as its own dependency, so without
+    # this group it opens a separate PR per path. The daily auto-merge batch
+    # then lands one of them alone and main goes red — and because the
+    # sibling PR now fails that same broken CodeQL job, auto-merge won't
+    # merge it either, so main stays red until a human intervenes. That
+    # deadlock cost us #991, #1059 and #1069.
+    #
+    # Grouping makes every codeql-action bump a single atomic PR.
+    groups:
+      codeql-action:
+        patterns:
+          - "github/codeql-action*"
 
   # source/daemon/ Dockerfiles — all FROM lines are pinned by digest
   # for Scorecard / supply-chain integrity, so Dependabot is the


### PR DESCRIPTION
## Problem

`codeql-action/init` writes a config file stamped with its own version, and `codeql-action/analyze` refuses to read one written by a different version:

```
Loaded a configuration file for version '4.37.1', but running version '4.37.3'
```

Dependabot treats each action *path* as a separate dependency, so it opens **one PR per path** — `init` and `analyze` never move together.

## Why it keeps deadlocking

The daily `dependabot-auto-merge.yml` batch merges patch/minor bumps. It lands one of the two alone, `main` goes red — and the sibling PR then *can't* auto-merge, because it fails that very same broken CodeQL job. `main` stays red until a human fixes it by hand.

This has now happened three times:

| PR | what landed |
|---|---|
| #991 | bumped **analyze** 4.36.3 → 4.37.1, `init` left at 4.36.3 |
| #1059 | bumped **analyze** 4.37.1 → 4.37.3, `init` still behind |
| #1069 | `fix(ci): match codeql-action/init to analyze's version` — manual cleanup |

\#1079 / #1080 were lined up to make it four.

## Fix

A Dependabot `groups` block, so every `github/codeql-action*` bump becomes a single atomic PR:

```yaml
groups:
  codeql-action:
    patterns:
      - "github/codeql-action*"
```

Scoped to `codeql-action` only — every other action keeps its own individually reviewable PR.

`upload-sarif` is swept in by the same pattern, which is harmless: it's independent of the init/analyze config handshake, and moving it in lockstep costs nothing.

## Note on the already-open PRs

Grouping only applies to PRs Dependabot opens *after* this lands, so #1079 and #1080 were handled by hand: the `analyze` bump was folded into #1079 so both move together, and #1080 is closed as redundant.

## Merge Commit Message

fix(ci): group codeql-action bumps so init and analyze move together