### PR TITLE
fix(test-support): route log captures through a global subscriber

### DIFF
--- a/source/daemon/crates/wardnet-test-support/src/lib.rs
+++ b/source/daemon/crates/wardnet-test-support/src/lib.rs
@@ -3,19 +3,35 @@
 //! Kept in one crate so tests across the workspace don't each reinvent the
 //! same plumbing. Consumed as a `[dev-dependencies]` entry.
 
+use std::cell::RefCell;
 use std::io;
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, Once};
 
-use tracing::subscriber::DefaultGuard;
 use tracing_subscriber::fmt::MakeWriter;
 
-/// A `MakeWriter` that appends everything written to a shared byte buffer.
-#[derive(Clone)]
-struct BufWriter(Arc<Mutex<Vec<u8>>>);
+/// Where the current thread's capture, if any, wants its log lines.
+struct Sink {
+    buf: Arc<Mutex<Vec<u8>>>,
+    max_level: tracing::Level,
+}
 
-impl io::Write for BufWriter {
+thread_local! {
+    /// The capture installed on this thread, set by [`capture_logs`] and
+    /// cleared when the returned [`LogCapture`] drops.
+    static SINK: RefCell<Option<Sink>> = const { RefCell::new(None) };
+}
+
+/// The writer end of a capture: either this thread's buffer, or nowhere.
+enum RoutedWriter {
+    Buf(Arc<Mutex<Vec<u8>>>),
+    Discard,
+}
+
+impl io::Write for RoutedWriter {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-        self.0.lock().unwrap().extend_from_slice(buf);
+        if let Self::Buf(sink) = self {
+            sink.lock().unwrap().extend_from_slice(buf);
+        }
         Ok(buf.len())
     }
 
@@ -24,20 +40,48 @@ impl io::Write for BufWriter {
     }
 }
 
-impl<'a> MakeWriter<'a> for BufWriter {
-    type Writer = BufWriter;
+/// Routes each formatted log line to the capture installed on the thread that
+/// emitted it, discarding lines from threads that aren't capturing.
+struct ThreadRouter;
+
+impl ThreadRouter {
+    /// `None` means "no capture on this thread", so the line is dropped.
+    fn writer_for(level: Option<&tracing::Level>) -> RoutedWriter {
+        SINK.with(|sink| {
+            // `try_borrow` because a log emitted while `capture_logs` or the
+            // drop glue holds the mutable borrow must not panic.
+            match sink.try_borrow().as_deref() {
+                Ok(Some(sink)) if level.is_none_or(|level| *level <= sink.max_level) => {
+                    RoutedWriter::Buf(Arc::clone(&sink.buf))
+                }
+                _ => RoutedWriter::Discard,
+            }
+        })
+    }
+}
+
+impl<'a> MakeWriter<'a> for ThreadRouter {
+    type Writer = RoutedWriter;
 
     fn make_writer(&'a self) -> Self::Writer {
-        self.clone()
+        Self::writer_for(None)
+    }
+
+    fn make_writer_for(&'a self, meta: &tracing::Metadata<'_>) -> Self::Writer {
+        Self::writer_for(Some(meta.level()))
     }
 }
 
 /// A live in-memory `tracing` capture. Keep it in scope for the duration of
-/// the logging under test — the subscriber is uninstalled when it drops — then
-/// read the accumulated output with [`LogCapture::contents`].
+/// the logging under test — the thread's capture is uninstalled when it drops
+/// — then read the accumulated output with [`LogCapture::contents`].
+///
+/// Only events emitted on the thread that called [`capture_logs`] are
+/// recorded, so this does not compose with
+/// `#[tokio::test(flavor = "multi_thread")]`.
 pub struct LogCapture {
     buf: Arc<Mutex<Vec<u8>>>,
-    _guard: DefaultGuard,
+    prev: Option<Sink>,
 }
 
 impl LogCapture {
@@ -48,22 +92,65 @@ impl LogCapture {
     }
 }
 
+impl Drop for LogCapture {
+    fn drop(&mut self) {
+        SINK.with(|sink| {
+            *sink.borrow_mut() = self.prev.take();
+        });
+    }
+}
+
+/// Install the one process-wide subscriber that every capture routes through.
+///
+/// This has to be a *global* subscriber, and it has to stay installed for the
+/// life of the process. `tracing` caches each callsite's `Interest`
+/// process-wide, computed by folding over the dispatchers registered at the
+/// moment the callsite is first reached, and that fold bottoms out at
+/// `Interest::never()` when no dispatcher is registered. A thread-local
+/// subscriber (`tracing::subscriber::set_default`) is only registered while its
+/// guard is alive, so under `cargo test` — many threads, one capture — whichever
+/// test reaches a callsite first while no capture is running pins it to `never`
+/// for the whole process, and the capturing test then sees an empty buffer.
+/// Re-running `rebuild_interest_cache()` afterwards does not reliably undo it:
+/// registration happens later, at event time, on whichever thread gets there
+/// first.
+///
+/// With a permanently-registered global subscriber the fold can never be empty,
+/// so no callsite is ever pinned to `never`, and per-thread routing is left to
+/// [`ThreadRouter`] instead of to the dispatcher.
+fn install_global_subscriber() {
+    static INIT: Once = Once::new();
+    INIT.call_once(|| {
+        let subscriber = tracing_subscriber::fmt()
+            // Permissive here; the per-capture level is applied in
+            // `ThreadRouter::writer_for`.
+            .with_max_level(tracing::Level::TRACE)
+            .without_time()
+            .with_writer(ThreadRouter)
+            .finish();
+        // A binary under test may legitimately have installed its own global
+        // subscriber already; nothing to do if so.
+        let _ = tracing::subscriber::set_global_default(subscriber);
+    });
+}
+
 /// Install an in-memory log capture on the current thread up to `max_level`.
 ///
 /// Lets a test assert on the *rendered message text* a log line produces — the
 /// part that must carry interpolated field values per `.agents/logging.md`,
 /// not just the structured span fields.
 ///
-/// `#[tokio::test]` runs on a current-thread runtime, so the returned capture's
-/// guard stays in effect across `.await` points within the same test body.
+/// Captures nest: dropping the returned guard restores whatever capture was
+/// installed on this thread before it.
 #[must_use]
 pub fn capture_logs(max_level: tracing::Level) -> LogCapture {
+    install_global_subscriber();
     let buf = Arc::new(Mutex::new(Vec::new()));
-    let subscriber = tracing_subscriber::fmt()
-        .with_max_level(max_level)
-        .without_time()
-        .with_writer(BufWriter(buf.clone()))
-        .finish();
-    let guard = tracing::subscriber::set_default(subscriber);
-    LogCapture { buf, _guard: guard }
+    let prev = SINK.with(|sink| {
+        sink.borrow_mut().replace(Sink {
+            buf: Arc::clone(&buf),
+            max_level,
+        })
+    });
+    LogCapture { buf, prev }
 }


### PR DESCRIPTION
## Summary

`push::tests::send_unbuildable_subscription_warn_names_the_endpoint` fails intermittently, taking `Build Daemon / Check Daemon` red on unrelated PRs (seen on #1050 and #1054):

```
warn must interpolate the endpoint, got: 
test result: FAILED. 1419 passed; 1 failed
```

The capture buffer comes back empty. The warn itself is fine — `sender.rs:227` does interpolate `endpoint={endpoint}` — the event never reaches the subscriber at all.

## Root cause

`tracing` caches each callsite's `Interest` **process-wide**. `rebuild_callsite_interest` computes it by folding over the dispatchers registered at the moment the callsite is first reached, and falls back to `Interest::never()` when that set is empty.

`capture_logs` installed its subscriber with `tracing::subscriber::set_default`, which is thread-local: its dispatcher is only registered while the guard is alive. Under `cargo test` — many threads, one capturing test — the set is empty most of the time, so whichever of the other 1419 tests reaches `sender.rs:227` first (here, `send_maps_unbuildable_subscription_to_gone`, which hits the same callsite) pins it to `never` for the rest of the process.

Constructing the capture's `Dispatch` does trigger a cache rebuild, but that rebuild races the in-flight `Identifier::register()` — last writer wins, and when the `never` lands second the capture silently records nothing.

## What changed

`capture_logs` now installs **one permissive global subscriber** for the life of the process and routes each formatted line to the emitting thread's buffer via `MakeWriter::make_writer_for`, applying the per-capture level there rather than in the subscriber. With a permanently-registered dispatcher the fold can never be empty, so no callsite can be pinned to `never`.

The rendered output format is unchanged (still `tracing_subscriber::fmt`), so all four existing capture assertions are untouched. Captures nest, and still only observe events on their own thread — that constraint is now documented on `LogCapture`, since it means they don't compose with `#[tokio::test(flavor = "multi_thread")]`.

## Verification

Reproduce with the **full crate suite, multi-threaded** — a single filtered test or `--test-threads=1` passes either way and proves nothing:

```
cargo test -p wardnetd-services --lib -- --test-threads=4
```

- Before: **2 failures in 12 runs**.
- After: **13 consecutive clean runs**.
- `wardnetd-mock` and `wardnetd-data` suites green, covering the other three `capture_logs` assertions.
- `cargo fmt --check` and `cargo clippy --all-targets` clean.

## Merge Commit Message

fix(test-support): route log captures through a global subscriber