### PR TITLE
chore(deps): patch four npm advisories in source/yarn.lock

### DIFF
--- a/source/package.json
+++ b/source/package.json
@@ -19,7 +19,7 @@
     "ip-address": "10.1.1",
     "js-yaml": "4.3.0",
     "esbuild": "0.28.1",
-    "brace-expansion@^5.0.5": "5.0.7"
+    "brace-expansion@^5.0.5": "5.0.8"
   },
   "scripts": {
     "build": "turbo run build",

--- a/source/yarn.lock
+++ b/source/yarn.lock
@@ -6100,21 +6100,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"brace-expansion@npm:5.0.7":
-  version: 5.0.7
-  resolution: "brace-expansion@npm:5.0.7"
+"brace-expansion@npm:5.0.8":
+  version: 5.0.8
+  resolution: "brace-expansion@npm:5.0.8"
   dependencies:
     balanced-match: "npm:^4.0.2"
-  checksum: 10c0/4769109c3c082de178e449a371bcad50d51ab468f644bce2dd9188efe0cf0a080ed102105d7fc8577382cedc45bad7e6443a91bf3d8102264ee8cf927dbaf205
+  checksum: 10c0/73304caafd00fdc5b0168e693ac15bf25b6357dec76d1195fcd628fe2cf99c46f9c889a7ecfa3cfe236dbd2d5ce3e27a6ccc4370b46d475d0d19081e11f86019
   languageName: node
   linkType: hard
 
 "brace-expansion@npm:^2.0.1":
-  version: 2.1.2
-  resolution: "brace-expansion@npm:2.1.2"
+  version: 2.1.4
+  resolution: "brace-expansion@npm:2.1.4"
   dependencies:
     balanced-match: "npm:^1.0.0"
-  checksum: 10c0/5442ecab84045d21826268bc56c81a6ef4215327ee1f5ee153f67928e93f7a915d130ecec9966623143277fa3cce036ebb50020024bcc4d78853cdd6af9a19f8
+  checksum: 10c0/6c0a0e2573eac1dc565b52b1e1bfbeba39bf1830d106ebbc61ff1eaefcf610e9111cd3baa091addd18e33292135c99e019d3184d966389d85dc958fdcdc1449f
   languageName: node
   linkType: hard
 
@@ -9647,15 +9647,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nanoid@npm:^3.3.12":
-  version: 3.3.13
-  resolution: "nanoid@npm:3.3.13"
-  bin:
-    nanoid: bin/nanoid.cjs
-  checksum: 10c0/e913cd6d081e3b646788aa36e686964f2746f15935759425c98344053676b9444efedff4d87915bfb38b1626057e66c788f59ee7746b48c2b7886a4b049ca2ac
-  languageName: node
-  linkType: hard
-
 "nanoid@npm:^3.3.16":
   version: 3.3.16
   resolution: "nanoid@npm:3.3.16"
@@ -10064,18 +10055,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"postcss@npm:^8.5.15":
-  version: 8.5.15
-  resolution: "postcss@npm:8.5.15"
-  dependencies:
-    nanoid: "npm:^3.3.12"
-    picocolors: "npm:^1.1.1"
-    source-map-js: "npm:^1.2.1"
-  checksum: 10c0/7f2e63ae22fbe43aace1bf652bd99da4e90737c64194d49e51ddc9cd0f9e51ff2861a7d734379b494deffa03a880a5c65eec70bc29ee9ebaa7136dde3eee8f31
-  languageName: node
-  linkType: hard
-
-"postcss@npm:^8.5.23":
+"postcss@npm:^8.5.15, postcss@npm:^8.5.23":
   version: 8.5.25
   resolution: "postcss@npm:8.5.25"
   dependencies:
@@ -11560,15 +11540,15 @@ __metadata:
   linkType: hard
 
 "tar@npm:^7.5.4":
-  version: 7.5.20
-  resolution: "tar@npm:7.5.20"
+  version: 7.5.22
+  resolution: "tar@npm:7.5.22"
   dependencies:
     "@isaacs/fs-minipass": "npm:^4.0.0"
     chownr: "npm:^3.0.0"
     minipass: "npm:^7.1.2"
     minizlib: "npm:^3.1.0"
     yallist: "npm:^5.0.0"
-  checksum: 10c0/4df4335c6d958b76adf1eaced55889dec3ca1c51f450658a074af80694bb0d9c154a8e93fdf4da617372d1575b121295379993961bbe4cd4b0867c0e5689846a
+  checksum: 10c0/1311f6be85a8157ac4c9147bae43e13923d2a1aae15e4aa1bd5239e4e03d2cf53cfe103dde7f35832fbb4c938b042856bc8e9a0afd29abd05e2d1608788c4fea
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Closes all four open Dependabot alerts (#98, #99, #102, #103). All are transitive npm dependencies in `source/yarn.lock`.

## What was wrong

| Alert | Severity | Package | Advisory | Was | Now |
|---|---|---|---|---|---|
| 103 | high | brace-expansion | [GHSA-mh99-v99m-4gvg](https://github.com/advisories/GHSA-mh99-v99m-4gvg) | 2.1.2 | 2.1.4 |
| 102 | high | brace-expansion | [GHSA-mh99-v99m-4gvg](https://github.com/advisories/GHSA-mh99-v99m-4gvg) | 5.0.7 | 5.0.8 |
| 98 | high | postcss | [GHSA-r28c-9q8g-f849](https://github.com/advisories/GHSA-r28c-9q8g-f849) | 8.5.15 | 8.5.25 |
| 99 | medium | tar | [GHSA-r292-9mhp-454m](https://github.com/advisories/GHSA-r292-9mhp-454m) | 7.5.20 | 7.5.22 |

Three of the four resolved cleanly within existing semver ranges via `yarn up -R`. The fourth — alert 102 — did not, and that is the interesting one: it was pinned in place by **our own `resolutions` entry**, `"brace-expansion@^5.0.5": "5.0.7"`, added in #1026 to patch the *previous* brace-expansion advisory. That pin is exactly what stopped Dependabot from being able to fix this itself. Bumping the pin to `5.0.8` unblocked it.

Worth remembering: every `resolutions` pin we add for a security fix becomes a thing that can silently hold back the *next* security fix for the same package.

## Changes

- `source/package.json` — one line: the `brace-expansion@^5.0.5` resolution pin `5.0.7` → `5.0.8`.
- `source/yarn.lock` — regenerated for the four packages. Net -20 lines, because the two `postcss` descriptors (`^8.5.15` and `^8.5.23`) now collapse onto a single 8.5.25 entry, dropping the duplicate `nanoid@^3.3.12` entry with it.

No workspace manifest changes — no direct dependency ranges needed to move.

## Verification

- `yarn install --immutable` — clean, no `YN0028` (this repo has a history of npm dep PRs leaving `source/yarn.lock` stale).
- `make check-web check-site` — 9/9 turbo tasks pass.
- `make build-web build-site` — 4/4 pass. This matters because `postcss` is a build-time dependency, so a green build is the real test that the 8.5.15 → 8.5.25 jump is safe.

The pre-existing peer-dependency warnings (`typescript` vs `openapi-typescript`, `@wardnet/web` not providing `react`/`react-dom`/`lucide-react`) and the 2 `admin-site` lint warnings are unchanged by this PR.