### PR TITLE
fix(zones): replace interface-wide proxy_arp with per-member proxy-neighbour entries

### DIFF
--- a/docs/adr/0021-network-zone-deep-isolation.md
+++ b/docs/adr/0021-network-zone-deep-isolation.md
@@ -21,7 +21,7 @@ device IP, live-reloaded by a dedicated `ZoneEnforcementService` +
 owns DHCP**, so it can put each zone on its **own subnet** and route (and filter)
 the traffic between them. It gives the recorded-only fields teeth — per-zone
 subnets, cross-zone default-deny, opt-in isolate-members (per-device `/32` +
-proxy-ARP), a cross-zone exception engine, and a casting preset.
+per-member proxy-neighbour entries), a cross-zone exception engine, and a casting preset.
 
 Several decisions here are hard to reverse (an addressing convention, a new
 firewall chain, a new event) or surprising (there is deliberately **no** mDNS
@@ -50,7 +50,8 @@ while Guest/IoT opt into carved subnets.
 
 ### 2. DHCP-mode gates everything; storing a subnet while DHCP is off is inert, not rejected
 
-Per-zone subnets, gateway aliasing, cross-subnet deny, and proxy-ARP all require
+Per-zone subnets, gateway aliasing, cross-subnet deny, and proxy-neighbour
+entries all require
 Wardnet to control addressing, i.e. `dhcp_enabled`. When Wardnet is not the DHCP
 server the enforcer applies **none** of it and degrades to `#736` (egress +
 admin-UI gating, which work on any topology). Storing a subnet while DHCP is off
@@ -93,7 +94,8 @@ The issue asks for an Avahi-style mDNS reflector. **We deliberately do not build
 one.** All zones share **one physical LAN interface via IP aliasing** (VLAN is an
 epic non-goal), so they share a single L2 broadcast domain: mDNS/SSDP multicast is
 flooded to every device regardless of IP subnet — even under isolate-members,
-where the per-device `/32` + proxy-ARP affect only *unicast* ARP, not multicast.
+where the per-device `/32` + proxy-neighbour entries affect only *unicast* ARP,
+not multicast.
 Discovery therefore already crosses the subnet split for free. What blocks casting
 by default is the **L3 unicast deny** on the routed connection; what enables it is
 the **exception allow-rule**. A reflector would add a large, CI-only multicast
@@ -120,13 +122,13 @@ segmentation. Both are out of scope here and left as a follow-up.
 ## Consequences
 
 - **Blast radius:** `FirewallManager` gains `apply_zone_isolation` + the
-  `zone_isolation` chain; `PolicyRouter` gains interface aliasing, proxy-ARP, and
-  `/32` host routes; the enforcer gains the exception repository, a DHCP-service
+  `zone_isolation` chain; `PolicyRouter` gains interface aliasing, per-member
+  proxy-neighbour (pneigh) entries, and `/32` host routes; the enforcer gains the exception repository, a DHCP-service
   handle (lease revoke on zone move), and the LAN IP; a new
   `WardnetEvent::ZoneExceptionsChanged` is added to the bus and both exhaustive
   matches.
 - **Verification:** the decision logic (which subnets, deny pairs, exception
-  expansion, alias/proxy-ARP/host-route choices) is unit-tested natively with
+  expansion, alias/pneigh/host-route choices) is unit-tested natively with
   recording firewall + policy-router spies over real in-memory repositories. The
   rustables rendering and the netlink address/route ops compile only on Linux, so
   they are gated behind `make check-daemon` / CI.
@@ -134,3 +136,29 @@ segmentation. Both are out of scope here and left as a follow-up.
   collapses it back onto the base subnet; disabling DHCP degrades cleanly to
   `#736`. The addressing convention (`10.44.0.0/16` suggestions, `.1` gateway) is
   a default, not a stored contract.
+
+## Amendment (issue #1107): per-member proxy-neighbour entries, not `proxy_arp=1`
+
+The original implementation realised the ARP-interception leg of isolate-members
+with the interface-wide `net.ipv4.conf.<lan>.proxy_arp=1` sysctl. That mechanism
+was doubly wrong:
+
+- **It answered for everything a tunnel-bound device probed.** The kernel's
+  proxy-ARP decision is a FIB lookup of the ARP *target* using the ARP *sender*
+  as source. For a tunnel-bound sender that lookup hits its `from <ip> lookup
+  <table>` policy rule, whose only route egresses `wg_ward*` — a different
+  interface than the LAN — so the Pi proxy-replied for **any** target,
+  including the sender's own gratuitous ARP (macOS "duplicate IP", DHCP
+  decline loops) and same-LAN peers (traffic hijacked into a table with no LAN
+  routes).
+- **It never fired for the intended case.** A same-zone, non-tunnel-bound peer's
+  lookup resolves out the same interface the ARP arrived on, and plain
+  `proxy_arp` never answers same-interface lookups.
+
+The enforcer now installs **per-member proxy-neighbour entries**
+(`ip neigh add proxy <member-ip> dev <lan>`) instead: the Pi answers ARP for
+exactly the members of isolate-members zones, regardless of route egress
+interface. The desired set is reconciled (with pruning of stale entries) in
+`reconcile_isolation`, and startup reconcile clears any `proxy_arp=1` left
+behind by a pre-#1107 daemon. The interface-wide sysctl must never be
+re-enabled.

--- a/source/daemon/crates/wardnetd-mock/src/backends/noop_routing.rs
+++ b/source/daemon/crates/wardnetd-mock/src/backends/noop_routing.rs
@@ -307,6 +307,29 @@ impl PolicyRouter for NoopPolicyRouter {
         Ok(())
     }
 
+    async fn add_neigh_proxy(&self, ip: &str, interface: &str) -> anyhow::Result<()> {
+        tracing::debug!(
+            ip,
+            interface,
+            "mock policy add_neigh_proxy: proxy {ip} dev {interface}",
+        );
+        Ok(())
+    }
+
+    async fn remove_neigh_proxy(&self, ip: &str, interface: &str) -> anyhow::Result<()> {
+        tracing::debug!(
+            ip,
+            interface,
+            "mock policy remove_neigh_proxy: proxy {ip} dev {interface}",
+        );
+        Ok(())
+    }
+
+    async fn list_neigh_proxies(&self, interface: &str) -> anyhow::Result<Vec<String>> {
+        tracing::debug!(interface, "mock policy list_neigh_proxies");
+        Ok(Vec::new())
+    }
+
     async fn add_host_route(&self, ip: &str, interface: &str) -> anyhow::Result<()> {
         tracing::debug!(
             ip,

--- a/source/daemon/crates/wardnetd-services/src/routing/policy_router.rs
+++ b/source/daemon/crates/wardnetd-services/src/routing/policy_router.rs
@@ -155,14 +155,38 @@ pub trait PolicyRouter: Send + Sync {
     /// by the gateway-alias reconciler to drop aliases no longer backed by a zone.
     async fn list_interface_aliases(&self, interface: &str) -> anyhow::Result<Vec<(String, u8)>>;
 
-    /// Enable or disable proxy-ARP on `interface`
+    /// Enable or disable interface-wide proxy-ARP on `interface`
     /// (`/proc/sys/net/ipv4/conf/<iface>/proxy_arp`).
     ///
-    /// An isolate-members zone hands each device a `/32`, so the device treats
-    /// every peer as off-link and ARPs the gateway for it; proxy-ARP makes the
-    /// Pi answer, pulling intra-subnet peer traffic through the forward chain
-    /// where it can be filtered. Cooperating devices only (see the ADR).
+    /// Retained only so startup reconcile can clear a `proxy_arp=1` left behind
+    /// by older daemon versions. The interface-wide sysctl must never be
+    /// re-enabled: its FIB-lookup semantics let a tunnel-bound device's policy
+    /// rule make the Pi answer ARP for *any* address that device probes
+    /// (macOS "duplicate IP", LAN-peer hijack — issue #1107). Member isolation
+    /// uses per-member proxy-neighbour entries instead (see
+    /// [`Self::add_neigh_proxy`]).
     async fn set_proxy_arp(&self, interface: &str, enabled: bool) -> anyhow::Result<()>;
+
+    /// Add a proxy-neighbour (pneigh) entry for `ip` on `interface`
+    /// (`ip neigh add proxy <ip> dev <iface>`). Idempotent.
+    ///
+    /// An isolate-members zone hands each device a `/32`, so the device treats
+    /// every peer as off-link and ARPs the gateway for it; a pneigh entry makes
+    /// the Pi answer ARP for exactly that member's address — regardless of the
+    /// route's egress interface — pulling intra-subnet peer traffic through the
+    /// forward chain where it can be filtered. Unlike the interface-wide
+    /// `proxy_arp` sysctl it never answers for arbitrary targets (issue #1107).
+    /// Cooperating devices only (see the ADR).
+    async fn add_neigh_proxy(&self, ip: &str, interface: &str) -> anyhow::Result<()>;
+
+    /// Remove the proxy-neighbour entry for `ip` on `interface`. Idempotent:
+    /// a missing entry is treated as success.
+    async fn remove_neigh_proxy(&self, ip: &str, interface: &str) -> anyhow::Result<()>;
+
+    /// List the IPv4 proxy-neighbour entries currently present on `interface`
+    /// (`ip neigh show proxy`), so reconcile can prune entries no longer backed
+    /// by an isolate-members device.
+    async fn list_neigh_proxies(&self, interface: &str) -> anyhow::Result<Vec<String>>;
 
     /// Add a `/32` host route for `ip` via `interface` so the Pi has an on-link
     /// path to an isolate-members device. Idempotent.

--- a/source/daemon/crates/wardnetd-services/src/routing/tests/routing.rs
+++ b/source/daemon/crates/wardnetd-services/src/routing/tests/routing.rs
@@ -645,6 +645,26 @@ impl PolicyRouter for MockNetlink {
         Ok(())
     }
 
+    async fn add_neigh_proxy(&self, ip: &str, i: &str) -> anyhow::Result<()> {
+        self.calls
+            .lock()
+            .await
+            .push(format!("add_neigh_proxy:{ip}:{i}"));
+        Ok(())
+    }
+
+    async fn remove_neigh_proxy(&self, ip: &str, i: &str) -> anyhow::Result<()> {
+        self.calls
+            .lock()
+            .await
+            .push(format!("remove_neigh_proxy:{ip}:{i}"));
+        Ok(())
+    }
+
+    async fn list_neigh_proxies(&self, _i: &str) -> anyhow::Result<Vec<String>> {
+        Ok(Vec::new())
+    }
+
     async fn add_host_route(&self, ip: &str, i: &str) -> anyhow::Result<()> {
         self.calls
             .lock()

--- a/source/daemon/crates/wardnetd-services/src/tests/init.rs
+++ b/source/daemon/crates/wardnetd-services/src/tests/init.rs
@@ -213,6 +213,15 @@ impl PolicyRouter for StubPolicyRouter {
     async fn set_proxy_arp(&self, _i: &str, _e: bool) -> anyhow::Result<()> {
         unimplemented!()
     }
+    async fn add_neigh_proxy(&self, _ip: &str, _i: &str) -> anyhow::Result<()> {
+        unimplemented!()
+    }
+    async fn remove_neigh_proxy(&self, _ip: &str, _i: &str) -> anyhow::Result<()> {
+        unimplemented!()
+    }
+    async fn list_neigh_proxies(&self, _i: &str) -> anyhow::Result<Vec<String>> {
+        unimplemented!()
+    }
     async fn add_host_route(&self, _ip: &str, _i: &str) -> anyhow::Result<()> {
         unimplemented!()
     }

--- a/source/daemon/crates/wardnetd-services/src/zone_enforcement/service.rs
+++ b/source/daemon/crates/wardnetd-services/src/zone_enforcement/service.rs
@@ -549,13 +549,86 @@ impl ZoneEnforcementServiceImpl {
         }
     }
 
+    /// Bring the LAN interface's IPv4 proxy-neighbour entries to exactly
+    /// `desired` (issue #1107): add the missing entries, prune the rest. The Pi
+    /// owns the LAN interface's IPv4 pneigh entries — a stale one is exactly
+    /// the "answers ARP for an address nobody isolates" failure of #1107, so
+    /// pruning is unconditional. The diff runs against the kernel's own listing
+    /// (never a stored snapshot), so a purged or half-applied state heals on
+    /// the next pass. If the listing fails, `existing` degrades to empty: the
+    /// idempotent adds still run and pruning naturally no-ops until a listing
+    /// succeeds. Errors are warn-logged, never fatal.
+    async fn reconcile_proxy_neigh(&self, desired: BTreeSet<String>) {
+        let existing: BTreeSet<String> = match self
+            .policy_router
+            .list_neigh_proxies(&self.lan_interface)
+            .await
+        {
+            Ok(entries) => entries.into_iter().collect(),
+            Err(e) => {
+                tracing::warn!(
+                    error = %e,
+                    interface = %self.lan_interface,
+                    "zone enforcer: failed to list proxy-neighbour entries on {interface}: {e}",
+                    interface = self.lan_interface,
+                    e = e,
+                );
+                BTreeSet::new()
+            }
+        };
+        if desired == existing {
+            return;
+        }
+        // The per-entry netlink calls are independent, so run each direction
+        // concurrently instead of serializing the round-trips.
+        futures::future::join_all(desired.difference(&existing).map(|ip| async move {
+            if let Err(e) = self
+                .policy_router
+                .add_neigh_proxy(ip, &self.lan_interface)
+                .await
+            {
+                tracing::warn!(
+                    error = %e,
+                    ip,
+                    "zone enforcer: failed to add proxy-neighbour entry for {ip}: {e}",
+                    ip = ip,
+                    e = e,
+                );
+            }
+        }))
+        .await;
+        futures::future::join_all(existing.difference(&desired).map(|ip| async move {
+            if let Err(e) = self
+                .policy_router
+                .remove_neigh_proxy(ip, &self.lan_interface)
+                .await
+            {
+                tracing::warn!(
+                    error = %e,
+                    ip,
+                    "zone enforcer: failed to remove stale proxy-neighbour entry for {ip}: {e}",
+                    ip = ip,
+                    e = e,
+                );
+            }
+        }))
+        .await;
+        let members = desired.len();
+        tracing::info!(
+            members,
+            "zone enforcer: proxy-neighbour entries reconciled ({members} members)",
+        );
+    }
+
     /// Recompute the FULL desired L3 isolation state and apply it atomically:
     /// the `zone_isolation` chain (allows → cross-subnet denies → member denies),
-    /// the per-zone gateway aliases, and proxy-ARP. See the module design notes.
+    /// the per-zone gateway aliases, and the per-member proxy-neighbour entries
+    /// (issue #1107). See the module design notes.
     ///
     /// When Wardnet does not own DHCP the whole surface degrades gracefully to
-    /// the #736 baseline: an empty isolation chain, no gateway aliases, proxy-ARP
-    /// off. All firewall/policy errors are warn-logged, never fatal.
+    /// the #736 baseline: an empty isolation chain, no gateway aliases, no
+    /// proxy-neighbour entries. All firewall/policy errors are warn-logged,
+    /// never fatal.
     #[allow(clippy::too_many_lines)]
     async fn reconcile_isolation(&self) -> Result<(), AppError> {
         let base_cidr = self.base_cidr().await;
@@ -584,7 +657,11 @@ impl ZoneEnforcementServiceImpl {
         let mut rules;
         let mut desired_alias_map: std::collections::BTreeMap<Ipv4Addr, u8> =
             std::collections::BTreeMap::new();
-        let member_isolation_present;
+        // Per-member proxy-neighbour entries (issue #1107): the IPs the Pi
+        // should answer ARP for on the LAN interface — exactly the members of
+        // isolate-members subnetted zones, nothing else. Empty when Wardnet
+        // does not own DHCP.
+        let mut desired_proxy_neigh: BTreeSet<String> = BTreeSet::new();
 
         if dhcp_enabled {
             let zones = self.zones.find_all().await.map_err(AppError::Internal)?;
@@ -675,7 +752,6 @@ impl ZoneEnforcementServiceImpl {
                 .into_iter()
                 .collect();
 
-            member_isolation_present = !member_isolation_subnets.is_empty();
             rules = ZoneIsolationRules {
                 allows,
                 deny_pairs,
@@ -687,10 +763,42 @@ impl ZoneEnforcementServiceImpl {
             for net in zone_nets.values() {
                 desired_alias_map.insert(crate::subnet::gateway_for(*net), net.prefix());
             }
+
+            // Per-member proxy-neighbour entries: every device in an
+            // isolate-members subnetted zone whose address actually lies inside
+            // that zone's subnet. NEVER the interface-wide `proxy_arp` sysctl —
+            // its FIB-lookup semantics made the Pi answer ARP for any address a
+            // tunnel-bound device probed, while never firing for the
+            // same-interface case it was meant to serve (issue #1107). The
+            // in-subnet check matters: a device freshly moved into the zone can
+            // still hold its old base-subnet address until it re-DHCPs, and a
+            // pneigh entry for that address would answer ARP for a base-subnet
+            // IP the DHCP pool may re-lease — the very duplicate-IP failure
+            // this mechanism replaces. Own addresses are excluded for the same
+            // reason as everywhere else (#886).
+            let member_zone_nets: HashMap<Uuid, Ipv4Network> = zones
+                .iter()
+                .filter(|z| z.member_isolation)
+                .filter_map(|z| zone_nets.get(&z.id).map(|net| (z.id, *net)))
+                .collect();
+            for dev in &all_devices {
+                let Some(net) = member_zone_nets.get(&dev.zone_id) else {
+                    continue;
+                };
+                let Ok(parsed) = dev.last_ip.parse::<Ipv4Addr>() else {
+                    continue;
+                };
+                if !net.contains(parsed) {
+                    continue;
+                }
+                if parsed == self.lan_ip || desired_alias_map.contains_key(&parsed) {
+                    continue;
+                }
+                desired_proxy_neigh.insert(dev.last_ip.clone());
+            }
         } else {
             // Graceful degrade when Wardnet is not the DHCP authority: empty
-            // isolation chain, no gateway aliases, proxy-ARP off.
-            member_isolation_present = false;
+            // isolation chain, no gateway aliases, no proxy-neighbour entries.
             rules = ZoneIsolationRules::default();
         }
 
@@ -736,7 +844,19 @@ impl ZoneEnforcementServiceImpl {
         let iso_changed = self.last_isolation.lock().await.as_ref()
             != Some(&(rules.clone(), desired_alias_strings.clone()));
 
-        // Nothing to do when neither changed (FIX 6, extended to switchback).
+        // Reconcile the per-member proxy-neighbour entries on EVERY pass, before
+        // the change-skip below: unlike nftables rules there is no in-memory
+        // snapshot to debounce against, because the kernel itself forgets pneigh
+        // entries (a link flap purges them via `pneigh_ifdown`) and a netlink
+        // call can fail transiently — a stored "last applied" set would mask
+        // both and never retry. Diffing against the kernel's own listing makes
+        // every reconcile self-healing, and costs one cheap netlink dump when
+        // nothing changed. (Honest limit: a link flap with no subsequent
+        // zone/device event is only repaired by the next event or restart.)
+        self.reconcile_proxy_neigh(desired_proxy_neigh).await;
+
+        // Nothing else to do when nothing changed (FIX 6, extended to
+        // switchback).
         if !iso_changed && !switchback_changed {
             tracing::debug!("zone enforcer: isolation + switchback unchanged, skipping");
             return Ok(());
@@ -761,8 +881,8 @@ impl ZoneEnforcementServiceImpl {
             *self.last_switchback.lock().await = Some(switchback_snapshot);
         }
 
-        // The expensive nftables/alias/proxy-arp kernel work only runs when the
-        // isolation state itself changed.
+        // The expensive nftables/alias kernel work only runs when the isolation
+        // state itself changed.
         if iso_changed {
             let summary = (
                 rules.allows.len(),
@@ -787,15 +907,6 @@ impl ZoneEnforcementServiceImpl {
             }
             self.remove_stale_gateway_aliases(&desired_gateways, &base_cidr)
                 .await;
-
-            // proxy-ARP is only needed when at least one zone isolates members.
-            if let Err(e) = self
-                .policy_router
-                .set_proxy_arp(&self.lan_interface, member_isolation_present)
-                .await
-            {
-                tracing::warn!(error = %e, "zone enforcer: failed to set proxy-arp");
-            }
 
             // Record the applied state so the next identical reconcile is a no-op.
             *self.last_isolation.lock().await = Some((rules, desired_alias_strings));
@@ -871,6 +982,27 @@ impl ZoneEnforcementService for ZoneEnforcementServiceImpl {
         auth_context::require_admin()?;
         tracing::info!("reconciling network-zone enforcement with kernel");
 
+        // Migration (#1107): older daemons enabled interface-wide `proxy_arp`
+        // for member isolation, which made the Pi answer ARP for any address a
+        // tunnel-bound device probed. Member isolation now uses per-member
+        // proxy-neighbour entries, so force the legacy sysctl off. First thing,
+        // before anything fallible can abort reconcile: nothing else re-touches
+        // the sysctl, and leaving it set is the #1107 bug itself. Best-effort:
+        // a failure must not abort reconcile.
+        if let Err(e) = self
+            .policy_router
+            .set_proxy_arp(&self.lan_interface, false)
+            .await
+        {
+            tracing::warn!(
+                error = %e,
+                interface = %self.lan_interface,
+                "zone enforcer: failed to clear legacy interface-wide proxy-arp on {interface}: {e}",
+                interface = self.lan_interface,
+                e = e,
+            );
+        }
+
         let devices = self.devices.find_all().await.map_err(AppError::Internal)?;
         let all_zones = self.zones.find_all().await.map_err(AppError::Internal)?;
         let zone_by_id: HashMap<Uuid, &NetworkZone> = all_zones.iter().map(|z| (z.id, z)).collect();
@@ -942,7 +1074,8 @@ impl ZoneEnforcementService for ZoneEnforcementServiceImpl {
         self.clamp_default_bindings(&policy).await?;
 
         // Recompute the whole L3 isolation state (cross-subnet deny + exception
-        // allows + member isolation + gateway aliases + proxy-ARP) from scratch.
+        // allows + member isolation + gateway aliases + proxy-neighbour
+        // entries) from scratch.
         self.reconcile_isolation().await?;
 
         tracing::info!(

--- a/source/daemon/crates/wardnetd-services/src/zone_enforcement/tests/service.rs
+++ b/source/daemon/crates/wardnetd-services/src/zone_enforcement/tests/service.rs
@@ -144,6 +144,12 @@ struct RecordingPolicy {
     existing_aliases: Arc<Mutex<Vec<(String, u8)>>>,
     /// Entries `list_neigh_proxies` should report (existing pneigh on iface).
     existing_neigh_proxies: Arc<Mutex<Vec<String>>>,
+    /// When set, `list_neigh_proxies` fails, to exercise the enforcer's
+    /// degrade-to-adds-only path.
+    fail_list_neigh: Arc<std::sync::atomic::AtomicBool>,
+    /// When set, the pneigh add/remove + proxy-arp mutations fail, to exercise
+    /// the enforcer's warn-and-continue error paths.
+    fail_neigh_mutations: Arc<std::sync::atomic::AtomicBool>,
 }
 
 #[async_trait]
@@ -244,6 +250,12 @@ impl PolicyRouter for RecordingPolicy {
     }
     async fn set_proxy_arp(&self, i: &str, e: bool) -> anyhow::Result<()> {
         self.calls.lock().await.push(format!("proxy_arp:{i}:{e}"));
+        if self
+            .fail_neigh_mutations
+            .load(std::sync::atomic::Ordering::SeqCst)
+        {
+            anyhow::bail!("mock proxy_arp failure");
+        }
         Ok(())
     }
     async fn add_neigh_proxy(&self, ip: &str, i: &str) -> anyhow::Result<()> {
@@ -251,6 +263,12 @@ impl PolicyRouter for RecordingPolicy {
             .lock()
             .await
             .push(format!("add_neigh_proxy:{ip}:{i}"));
+        if self
+            .fail_neigh_mutations
+            .load(std::sync::atomic::Ordering::SeqCst)
+        {
+            anyhow::bail!("mock add_neigh_proxy failure");
+        }
         Ok(())
     }
     async fn remove_neigh_proxy(&self, ip: &str, i: &str) -> anyhow::Result<()> {
@@ -258,9 +276,21 @@ impl PolicyRouter for RecordingPolicy {
             .lock()
             .await
             .push(format!("remove_neigh_proxy:{ip}:{i}"));
+        if self
+            .fail_neigh_mutations
+            .load(std::sync::atomic::Ordering::SeqCst)
+        {
+            anyhow::bail!("mock remove_neigh_proxy failure");
+        }
         Ok(())
     }
     async fn list_neigh_proxies(&self, _i: &str) -> anyhow::Result<Vec<String>> {
+        if self
+            .fail_list_neigh
+            .load(std::sync::atomic::Ordering::SeqCst)
+        {
+            anyhow::bail!("mock list_neigh_proxies failure");
+        }
         Ok(self.existing_neigh_proxies.lock().await.clone())
     }
     async fn add_host_route(&self, ip: &str, i: &str) -> anyhow::Result<()> {
@@ -406,6 +436,8 @@ struct Harness {
     policy_calls: Arc<Mutex<Vec<String>>>,
     existing_aliases: Arc<Mutex<Vec<(String, u8)>>>,
     existing_neigh_proxies: Arc<Mutex<Vec<String>>>,
+    fail_list_neigh: Arc<std::sync::atomic::AtomicBool>,
+    fail_neigh_mutations: Arc<std::sync::atomic::AtomicBool>,
     clamps: Arc<Mutex<Vec<String>>>,
     switchback: Arc<Mutex<Vec<String>>>,
 }
@@ -443,10 +475,14 @@ async fn build() -> Harness {
     let policy_calls = Arc::new(Mutex::new(Vec::new()));
     let existing_aliases = Arc::new(Mutex::new(Vec::new()));
     let existing_neigh_proxies = Arc::new(Mutex::new(Vec::new()));
+    let fail_list_neigh = Arc::new(std::sync::atomic::AtomicBool::new(false));
+    let fail_neigh_mutations = Arc::new(std::sync::atomic::AtomicBool::new(false));
     let policy_router: Arc<dyn PolicyRouter> = Arc::new(RecordingPolicy {
         calls: policy_calls.clone(),
         existing_aliases: existing_aliases.clone(),
         existing_neigh_proxies: existing_neigh_proxies.clone(),
+        fail_list_neigh: fail_list_neigh.clone(),
+        fail_neigh_mutations: fail_neigh_mutations.clone(),
     });
     let clamps = Arc::new(Mutex::new(Vec::new()));
     let switchback = Arc::new(Mutex::new(Vec::new()));
@@ -493,6 +529,8 @@ async fn build() -> Harness {
         policy_calls,
         existing_aliases,
         existing_neigh_proxies,
+        fail_list_neigh,
+        fail_neigh_mutations,
         clamps,
         switchback,
     }
@@ -1071,6 +1109,105 @@ async fn proxy_neigh_entries_self_heal_against_kernel_state() {
         .filter(|c| c == "add_neigh_proxy:10.44.1.10:eth0")
         .count();
     assert_eq!(adds, 2, "each pass re-converges against kernel state");
+}
+
+#[tokio::test]
+async fn unusable_and_own_address_members_get_no_proxy_neigh_entry() {
+    // A member row without a parseable IP (a repaired #886 row) and a member
+    // row claiming the zone's own gateway address are both skipped — only the
+    // real in-subnet member gets a pneigh entry.
+    let h = build().await;
+    enable_dhcp(&h).await;
+    insert_subnet_zone(&h.zones, ZONE_A, "IsoZone", "10.44.1.0/24", true).await;
+    let member = insert_device(&h.devices, "10.44.1.10", ZONE_A).await;
+    insert_device(&h.devices, "", ZONE_A).await;
+    insert_device(&h.devices, "10.44.1.1", ZONE_A).await;
+
+    as_admin(h.svc.apply_device(member)).await.unwrap();
+
+    let adds: Vec<String> = policy_calls(&h)
+        .await
+        .into_iter()
+        .filter(|c| c.starts_with("add_neigh_proxy:"))
+        .collect();
+    assert_eq!(
+        adds,
+        vec!["add_neigh_proxy:10.44.1.10:eth0".to_owned()],
+        "only the real member gets an entry"
+    );
+}
+
+#[tokio::test]
+async fn proxy_neigh_list_failure_degrades_to_adds_only() {
+    // A failed kernel listing must not block the idempotent adds (existing
+    // degrades to empty) and must not prune blind — and with no stored
+    // snapshot, the next pass simply retries the listing.
+    let h = build().await;
+    enable_dhcp(&h).await;
+    insert_subnet_zone(&h.zones, ZONE_A, "IsoZone", "10.44.1.0/24", true).await;
+    let member = insert_device(&h.devices, "10.44.1.10", ZONE_A).await;
+    *h.existing_neigh_proxies.lock().await = vec!["10.44.1.99".to_owned()];
+    h.fail_list_neigh
+        .store(true, std::sync::atomic::Ordering::SeqCst);
+
+    as_admin(h.svc.apply_device(member)).await.unwrap();
+
+    let pc = policy_calls(&h).await;
+    assert!(
+        pc.contains(&"add_neigh_proxy:10.44.1.10:eth0".to_owned()),
+        "adds still run when the listing fails: {pc:?}"
+    );
+    assert!(
+        !pc.iter().any(|c| c.starts_with("remove_neigh_proxy:")),
+        "no blind pruning without a listing: {pc:?}"
+    );
+}
+
+#[tokio::test]
+async fn proxy_neigh_mutation_failures_are_nonfatal() {
+    // A failed add or remove is warn-logged and never aborts the reconcile —
+    // the remaining enforcement (isolation rules, aliases) must still land.
+    let h = build().await;
+    enable_dhcp(&h).await;
+    insert_subnet_zone(&h.zones, ZONE_A, "IsoZone", "10.44.1.0/24", true).await;
+    let member = insert_device(&h.devices, "10.44.1.10", ZONE_A).await;
+    *h.existing_neigh_proxies.lock().await = vec!["10.44.1.99".to_owned()];
+    h.fail_neigh_mutations
+        .store(true, std::sync::atomic::Ordering::SeqCst);
+
+    as_admin(h.svc.apply_device(member)).await.unwrap();
+
+    let pc = policy_calls(&h).await;
+    assert!(
+        pc.contains(&"add_neigh_proxy:10.44.1.10:eth0".to_owned())
+            && pc.contains(&"remove_neigh_proxy:10.44.1.99:eth0".to_owned()),
+        "both mutations attempted despite failing: {pc:?}"
+    );
+    assert!(
+        calls(&h).await.iter().any(|c| c.starts_with("isolation:")),
+        "isolation rebuild still ran after pneigh failures"
+    );
+}
+
+#[tokio::test]
+async fn reconcile_survives_legacy_proxy_arp_clear_failure() {
+    // The migration clear is best-effort: a sysctl failure must not abort the
+    // startup reconcile that installs every device's rules.
+    let h = build().await;
+    enable_dhcp(&h).await;
+    insert_subnet_zone(&h.zones, ZONE_A, "IsoZone", "10.44.1.0/24", true).await;
+    insert_device(&h.devices, "10.44.1.10", ZONE_A).await;
+    h.fail_neigh_mutations
+        .store(true, std::sync::atomic::Ordering::SeqCst);
+
+    as_admin(h.svc.reconcile()).await.unwrap();
+
+    assert!(
+        policy_calls(&h)
+            .await
+            .contains(&"proxy_arp:eth0:false".to_owned()),
+        "legacy clear attempted"
+    );
 }
 
 #[tokio::test]

--- a/source/daemon/crates/wardnetd-services/src/zone_enforcement/tests/service.rs
+++ b/source/daemon/crates/wardnetd-services/src/zone_enforcement/tests/service.rs
@@ -142,6 +142,8 @@ struct RecordingPolicy {
     calls: Arc<Mutex<Vec<String>>>,
     /// Aliases `list_interface_aliases` should report (existing addrs on iface).
     existing_aliases: Arc<Mutex<Vec<(String, u8)>>>,
+    /// Entries `list_neigh_proxies` should report (existing pneigh on iface).
+    existing_neigh_proxies: Arc<Mutex<Vec<String>>>,
 }
 
 #[async_trait]
@@ -243,6 +245,23 @@ impl PolicyRouter for RecordingPolicy {
     async fn set_proxy_arp(&self, i: &str, e: bool) -> anyhow::Result<()> {
         self.calls.lock().await.push(format!("proxy_arp:{i}:{e}"));
         Ok(())
+    }
+    async fn add_neigh_proxy(&self, ip: &str, i: &str) -> anyhow::Result<()> {
+        self.calls
+            .lock()
+            .await
+            .push(format!("add_neigh_proxy:{ip}:{i}"));
+        Ok(())
+    }
+    async fn remove_neigh_proxy(&self, ip: &str, i: &str) -> anyhow::Result<()> {
+        self.calls
+            .lock()
+            .await
+            .push(format!("remove_neigh_proxy:{ip}:{i}"));
+        Ok(())
+    }
+    async fn list_neigh_proxies(&self, _i: &str) -> anyhow::Result<Vec<String>> {
+        Ok(self.existing_neigh_proxies.lock().await.clone())
     }
     async fn add_host_route(&self, ip: &str, i: &str) -> anyhow::Result<()> {
         self.calls
@@ -386,6 +405,7 @@ struct Harness {
     fw_isolation: Arc<Mutex<Option<ZoneIsolationRules>>>,
     policy_calls: Arc<Mutex<Vec<String>>>,
     existing_aliases: Arc<Mutex<Vec<(String, u8)>>>,
+    existing_neigh_proxies: Arc<Mutex<Vec<String>>>,
     clamps: Arc<Mutex<Vec<String>>>,
     switchback: Arc<Mutex<Vec<String>>>,
 }
@@ -422,9 +442,11 @@ async fn build() -> Harness {
     });
     let policy_calls = Arc::new(Mutex::new(Vec::new()));
     let existing_aliases = Arc::new(Mutex::new(Vec::new()));
+    let existing_neigh_proxies = Arc::new(Mutex::new(Vec::new()));
     let policy_router: Arc<dyn PolicyRouter> = Arc::new(RecordingPolicy {
         calls: policy_calls.clone(),
         existing_aliases: existing_aliases.clone(),
+        existing_neigh_proxies: existing_neigh_proxies.clone(),
     });
     let clamps = Arc::new(Mutex::new(Vec::new()));
     let switchback = Arc::new(Mutex::new(Vec::new()));
@@ -470,6 +492,7 @@ async fn build() -> Harness {
         fw_isolation,
         policy_calls,
         existing_aliases,
+        existing_neigh_proxies,
         clamps,
         switchback,
     }
@@ -969,7 +992,12 @@ async fn casting_exception_yields_bidirectional_allows() {
 }
 
 #[tokio::test]
-async fn member_isolation_zone_sets_proxy_arp_and_host_route() {
+async fn member_isolation_adds_proxy_neigh_entry_not_interface_proxy_arp() {
+    // Issue #1107: interface-wide `proxy_arp=1` made the Pi answer ARP for ANY
+    // address a tunnel-bound device probed (macOS "duplicate IP", LAN-peer
+    // hijack) while never firing for the intended same-interface case. Member
+    // isolation must install a per-member pneigh entry instead, and must never
+    // enable the interface-wide sysctl.
     let h = build().await;
     enable_dhcp(&h).await;
     insert_subnet_zone(&h.zones, ZONE_A, "IsoZone", "10.44.1.0/24", true).await;
@@ -987,12 +1015,130 @@ async fn member_isolation_zone_sets_proxy_arp_and_host_route() {
     );
     let pc = policy_calls(&h).await;
     assert!(
-        pc.contains(&"proxy_arp:eth0:true".to_owned()),
-        "proxy-arp enabled: {pc:?}"
+        pc.contains(&"add_neigh_proxy:10.44.1.10:eth0".to_owned()),
+        "per-member proxy-neighbour entry added: {pc:?}"
+    );
+    assert!(
+        !pc.contains(&"proxy_arp:eth0:true".to_owned()),
+        "interface-wide proxy-arp must never be enabled (#1107): {pc:?}"
     );
     assert!(
         pc.contains(&"add_host_route:10.44.1.10:eth0".to_owned()),
         "member host route added: {pc:?}"
+    );
+}
+
+#[tokio::test]
+async fn out_of_subnet_member_gets_no_proxy_neigh_entry() {
+    // A device freshly moved into an isolate-members zone can still hold its
+    // old base-subnet address until it re-DHCPs. A pneigh entry for that
+    // address would make the Pi answer ARP for a base-subnet IP the DHCP pool
+    // may re-lease — the duplicate-IP failure of #1107, re-created. Only
+    // in-subnet members get entries.
+    let h = build().await;
+    enable_dhcp(&h).await;
+    insert_subnet_zone(&h.zones, ZONE_A, "IsoZone", "10.44.1.0/24", true).await;
+    let straggler = insert_device(&h.devices, "192.168.1.50", ZONE_A).await;
+
+    as_admin(h.svc.apply_device(straggler)).await.unwrap();
+
+    let pc = policy_calls(&h).await;
+    assert!(
+        !pc.iter().any(|c| c.starts_with("add_neigh_proxy:")),
+        "no pneigh entry for an out-of-subnet member address: {pc:?}"
+    );
+}
+
+#[tokio::test]
+async fn proxy_neigh_entries_self_heal_against_kernel_state() {
+    // The kernel purges pneigh entries on a link flap, and a netlink call can
+    // fail transiently — so the reconcile must diff against the kernel's own
+    // listing every pass, not a stored snapshot. With the kernel still
+    // reporting no entries, a second identical reconcile must re-add.
+    let h = build().await;
+    enable_dhcp(&h).await;
+    insert_subnet_zone(&h.zones, ZONE_A, "IsoZone", "10.44.1.0/24", true).await;
+    let member = insert_device(&h.devices, "10.44.1.10", ZONE_A).await;
+
+    as_admin(h.svc.apply_device(member)).await.unwrap();
+    // The mock kernel never records the add (list stays empty), simulating a
+    // purge/failed apply; an unchanged second pass must retry, not skip.
+    as_admin(h.svc.apply_device(member)).await.unwrap();
+
+    let adds = policy_calls(&h)
+        .await
+        .into_iter()
+        .filter(|c| c == "add_neigh_proxy:10.44.1.10:eth0")
+        .count();
+    assert_eq!(adds, 2, "each pass re-converges against kernel state");
+}
+
+#[tokio::test]
+async fn stale_proxy_neigh_entries_pruned() {
+    // A pneigh entry no longer backed by an isolate-members device (departed
+    // device, or member isolation turned off) is removed on reconcile.
+    let h = build().await;
+    enable_dhcp(&h).await;
+    insert_subnet_zone(&h.zones, ZONE_A, "IsoZone", "10.44.1.0/24", true).await;
+    let member = insert_device(&h.devices, "10.44.1.10", ZONE_A).await;
+    *h.existing_neigh_proxies.lock().await = vec!["10.44.1.99".to_owned()];
+
+    as_admin(h.svc.apply_device(member)).await.unwrap();
+
+    let pc = policy_calls(&h).await;
+    assert!(
+        pc.contains(&"remove_neigh_proxy:10.44.1.99:eth0".to_owned()),
+        "stale pneigh entry removed: {pc:?}"
+    );
+    assert!(
+        !pc.contains(&"remove_neigh_proxy:10.44.1.10:eth0".to_owned()),
+        "live member's pneigh entry preserved: {pc:?}"
+    );
+}
+
+#[tokio::test]
+async fn member_isolation_off_removes_proxy_neigh_entries() {
+    // Zone exists but does not isolate members: no entry is added, and an
+    // entry left over from when isolation was on is removed.
+    let h = build().await;
+    enable_dhcp(&h).await;
+    insert_subnet_zone(&h.zones, ZONE_A, "PlainZone", "10.44.1.0/24", false).await;
+    let member = insert_device(&h.devices, "10.44.1.10", ZONE_A).await;
+    *h.existing_neigh_proxies.lock().await = vec!["10.44.1.10".to_owned()];
+
+    as_admin(h.svc.apply_device(member)).await.unwrap();
+
+    let pc = policy_calls(&h).await;
+    assert!(
+        !pc.iter().any(|c| c.starts_with("add_neigh_proxy:")),
+        "no pneigh entry for a non-isolating zone: {pc:?}"
+    );
+    assert!(
+        pc.contains(&"remove_neigh_proxy:10.44.1.10:eth0".to_owned()),
+        "leftover pneigh entry removed: {pc:?}"
+    );
+}
+
+#[tokio::test]
+async fn reconcile_clears_legacy_interface_proxy_arp() {
+    // Migration for boxes that ran a pre-#1107 daemon: startup reconcile must
+    // force the interface-wide sysctl off — even when member isolation is
+    // active — because pneigh entries have replaced it.
+    let h = build().await;
+    enable_dhcp(&h).await;
+    insert_subnet_zone(&h.zones, ZONE_A, "IsoZone", "10.44.1.0/24", true).await;
+    insert_device(&h.devices, "10.44.1.10", ZONE_A).await;
+
+    as_admin(h.svc.reconcile()).await.unwrap();
+
+    let pc = policy_calls(&h).await;
+    assert!(
+        pc.contains(&"proxy_arp:eth0:false".to_owned()),
+        "legacy interface-wide proxy-arp cleared on startup: {pc:?}"
+    );
+    assert!(
+        !pc.contains(&"proxy_arp:eth0:true".to_owned()),
+        "interface-wide proxy-arp never re-enabled: {pc:?}"
     );
 }
 
@@ -1002,16 +1148,21 @@ async fn dhcp_disabled_degrades_to_empty_isolation() {
     // DHCP left off (the default). A subnetted, member-isolating zone exists but
     // must not take effect.
     insert_subnet_zone(&h.zones, ZONE_A, "IsoZone", "10.44.1.0/24", true).await;
+    // A pneigh entry left over from when Wardnet owned DHCP.
+    *h.existing_neigh_proxies.lock().await = vec!["10.44.1.10".to_owned()];
 
     as_admin(h.svc.handle_exceptions_changed()).await.unwrap();
 
     let rules = isolation(&h).await;
     assert_eq!(rules, ZoneIsolationRules::default(), "empty isolation");
+    let pc = policy_calls(&h).await;
     assert!(
-        policy_calls(&h)
-            .await
-            .contains(&"proxy_arp:eth0:false".to_owned()),
-        "proxy-arp disabled on degrade"
+        !pc.iter().any(|c| c.starts_with("add_neigh_proxy:")),
+        "no pneigh entries while degraded: {pc:?}"
+    );
+    assert!(
+        pc.contains(&"remove_neigh_proxy:10.44.1.10:eth0".to_owned()),
+        "leftover pneigh entry removed on degrade: {pc:?}"
     );
 }
 

--- a/source/daemon/crates/wardnetd/src/policy_router_netlink.rs
+++ b/source/daemon/crates/wardnetd/src/policy_router_netlink.rs
@@ -5,6 +5,9 @@ use async_trait::async_trait;
 use futures::TryStreamExt;
 use rtnetlink::packet_route::AddressFamily;
 use rtnetlink::packet_route::address::AddressAttribute;
+use rtnetlink::packet_route::neighbour::{
+    NeighbourAddress, NeighbourAttribute, NeighbourFlags, NeighbourMessage,
+};
 use rtnetlink::packet_route::route::{RouteAddress, RouteAttribute, RouteScope};
 use rtnetlink::packet_route::rule::{RuleAction, RuleAttribute, RuleMessage};
 use rtnetlink::{Handle, RouteMessageBuilder};
@@ -835,6 +838,84 @@ impl PolicyRouter for NetlinkPolicyRouter {
         Ok(())
     }
 
+    async fn add_neigh_proxy(&self, ip: &str, interface: &str) -> anyhow::Result<()> {
+        let addr: Ipv4Addr = ip
+            .parse()
+            .map_err(|e| anyhow::anyhow!("invalid neigh-proxy IP {ip}: {e}"))?;
+        let index = self.link_index(interface).await?;
+
+        // `replace()` makes re-adding an existing entry a no-op success, the
+        // same idempotency `ip neigh replace proxy` provides.
+        match self
+            .handle
+            .neighbours()
+            .add(index, IpAddr::V4(addr))
+            .flags(NeighbourFlags::Proxy)
+            .replace()
+            .execute()
+            .await
+        {
+            Ok(()) => Ok(()),
+            Err(e) => anyhow::bail!("failed to add neigh proxy {ip} dev {interface}: {e}"),
+        }
+    }
+
+    async fn remove_neigh_proxy(&self, ip: &str, interface: &str) -> anyhow::Result<()> {
+        let addr: Ipv4Addr = ip
+            .parse()
+            .map_err(|e| anyhow::anyhow!("invalid neigh-proxy IP {ip}: {e}"))?;
+        let index = self.link_index(interface).await?;
+
+        // Unlike an address (where round-tripping the kernel's message preserves
+        // attributes we don't model), a pneigh delete is keyed on exactly
+        // family + ifindex + NTF_PROXY + destination, so the message can be
+        // built directly — no table dump per removal.
+        let mut msg = NeighbourMessage::default();
+        msg.header.family = AddressFamily::Inet;
+        msg.header.ifindex = index;
+        msg.header.flags = NeighbourFlags::Proxy;
+        msg.attributes
+            .push(NeighbourAttribute::Destination(NeighbourAddress::Inet(
+                addr,
+            )));
+
+        match self.handle.neighbours().del(msg).execute().await {
+            Ok(()) => Ok(()),
+            // Idempotent: a missing entry is success, like the other removals.
+            Err(rtnetlink::Error::NetlinkError(m)) if m.raw_code() == -libc::ENOENT => {
+                tracing::debug!(
+                    ip,
+                    interface,
+                    "neigh proxy {ip} dev {interface} not present, nothing to remove",
+                    ip = ip,
+                    interface = interface,
+                );
+                Ok(())
+            }
+            Err(e) => anyhow::bail!("failed to remove neigh proxy {ip} dev {interface}: {e}"),
+        }
+    }
+
+    async fn list_neigh_proxies(&self, interface: &str) -> anyhow::Result<Vec<String>> {
+        let index = self.link_index(interface).await?;
+        let mut entries = self
+            .handle
+            .neighbours()
+            .get()
+            .proxies()
+            .set_family(rtnetlink::IpVersion::V4)
+            .execute();
+        let mut out = Vec::new();
+        while let Some(msg) = entries.try_next().await? {
+            if msg.header.ifindex == index
+                && let Some(addr) = neigh_destination(&msg)
+            {
+                out.push(addr.to_string());
+            }
+        }
+        Ok(out)
+    }
+
     async fn add_host_route(&self, ip: &str, interface: &str) -> anyhow::Result<()> {
         let addr: Ipv4Addr = ip
             .parse()
@@ -875,6 +956,14 @@ impl PolicyRouter for NetlinkPolicyRouter {
         tracing::debug!(ip, interface, "host route not present, nothing to remove");
         Ok(())
     }
+}
+
+/// The IPv4 destination of a neighbour message, if it carries one.
+fn neigh_destination(msg: &NeighbourMessage) -> Option<Ipv4Addr> {
+    msg.attributes.iter().find_map(|a| match a {
+        NeighbourAttribute::Destination(NeighbourAddress::Inet(v)) => Some(*v),
+        _ => None,
+    })
 }
 
 /// True if `route` is a host route that [`PolicyRouter::add_host_route`] itself


### PR DESCRIPTION
Closes #1107

## Problem

When any zone has member isolation enabled, `ZoneEnforcementService` set interface-wide `proxy_arp=1` on the LAN interface. The kernel's proxy-ARP decision FIB-looks-up the ARP *target* with the ARP *sender* as source — for a tunnel-bound sender that resolves out `wg_ward*` (a different interface), so the Pi proxy-replied for **any** target the device probed:

- macOS "duplicate IP" on the device's own gratuitous ARP; DHCP decline/retry loops; every manual IP rejected (the trap re-arms on each move since rules follow `last_ip`).
- Same-LAN peer traffic hijacked into the tunnel table, which has no LAN routes.
- And the intended same-zone case **never fired**: plain `proxy_arp` doesn't answer same-interface lookups.

## Fix

- Per-member proxy-neighbour entries (`ip neigh add proxy <ip> dev <lan>`) for exactly the **in-subnet** members of isolate-members zones — the Pi answers ARP for those addresses only, regardless of route egress interface. Out-of-subnet stragglers (moved but not yet re-DHCPed) are excluded so a stale base-subnet address never gets an entry.
- The desired set is diffed against the **kernel's own listing** on every reconcile pass (no in-memory snapshot), so link-flap purges and transient netlink failures self-heal on the next pass; stale entries are pruned unconditionally.
- Migration: startup `reconcile()` forces the legacy sysctl off **first**, before any fallible call, for boxes that ran a pre-fix daemon. `set_proxy_arp` is retained solely for this; the interface-wide sysctl must never be re-enabled (documented in the ADR 0021 amendment).
- `PolicyRouter` gains `add_neigh_proxy` / `remove_neigh_proxy` / `list_neigh_proxies`, implemented via rtnetlink (`NTF_PROXY`; replace-idempotent add; direct-message delete with `ENOENT` as idempotent success — no table dump per removal).

## Tests

TDD: 7 new/updated service tests reproduced the bug first (interface-wide `proxy_arp:true`, no pneigh calls) and now pass — per-member add, no-sysctl invariant, in-subnet gate, self-healing against kernel state, stale-entry pruning, isolation-off / DHCP-off removal, startup sysctl clear. `make check-daemon` exit 0; wardnetd-services suite 1435 passing.