### PR TITLE
test(e2e): Stage 11 — system status/restart, backup round-trip, update manifest mock

### DIFF
--- a/deploy/wardnetd.service
+++ b/deploy/wardnetd.service
@@ -66,7 +66,24 @@ ProtectHome=yes
 # the privileged `wardnet-postupgrade.service` performs the actual
 # /usr/local/bin/wardnetd swap on next start under root, so the
 # wardnet user no longer needs write access to /usr/local/bin.
-ReadWritePaths=/var/lib/wardnet /var/log/wardnet
+#
+# /etc/wardnet is writable because restoring a backup replaces the live
+# config: `BackupService::apply_import` renames wardnet.toml aside to a
+# `.bak-<timestamp>` sibling and moves the bundle's copy into place, both
+# of which need write permission on the *directory*. ProtectSystem=strict
+# mounts all of /etc read-only, so without this a restore fails with
+# EROFS on real hardware — a failure neither e2e suite can catch, because
+# the container image drops in ProtectSystem=no (see Dockerfile.base).
+# Scoped to the one directory rather than /etc: this is the only path
+# under /etc the daemon ever writes.
+#
+# Caveat worth knowing: this also means an admin session can reach
+# wardnet.toml through a crafted restore bundle, including deploy-time
+# keys like [update] allow_edge_channel, whose whole point is to require
+# root on the box rather than an admin session. Closing that gap means
+# preserving deploy-time-only keys across a restore instead of taking
+# them from the bundle — tracked separately, not solved here.
+ReadWritePaths=/var/lib/wardnet /var/log/wardnet /etc/wardnet
 PrivateTmp=yes
 
 # Logging to journal

--- a/source/daemon/Cargo.toml
+++ b/source/daemon/Cargo.toml
@@ -69,8 +69,20 @@ tokio = { version = "1", features = ["full"] }
 # https://crates.io/crates/axum
 axum = { version = "0.8", features = ["macros", "multipart", "ws"] }
 # https://crates.io/crates/tokio-tungstenite — persistent client WebSocket for the
-# reverse-tunnel client to wardnet-cloud's Tunneller (issue #809). Pinned to the
-# same 0.29 axum's `ws` feature already resolves transitively (one version only).
+# reverse-tunnel client to wardnet-cloud's Tunneller (issue #809).
+#
+# This no longer matches the version axum's `ws` feature resolves (0.29), so the
+# build links both. That is safe but not free, and the reason it is safe is
+# narrow: the two never exchange types. We use only the *client* side
+# (`connect_async`, `Message`, `IntoClientRequest` in `cloud/tunneller.rs`);
+# axum owns the *server* side behind its own API and never hands a tungstenite
+# type across the boundary. Introducing a server-side WebSocket that mixes the
+# two would produce mismatched-type errors, not silent breakage.
+#
+# The cost is a second TLS/WebSocket stack in a binary shipped to a Pi and a
+# second CVE surface to track. Collapse this back to one version — and restore
+# this line to a plain `= "0.30"` with no caveat — once axum's `ws` feature
+# resolves 0.30.
 tokio-tungstenite = { version = "0.30", features = ["connect", "rustls-tls-webpki-roots"] }
 # https://crates.io/crates/axum-extra
 axum-extra = { version = "0.12", features = ["typed-header", "cookie", "query"] }

--- a/source/daemon/crates/wardnet-postupgrade/src/migrations.rs
+++ b/source/daemon/crates/wardnet-postupgrade/src/migrations.rs
@@ -86,5 +86,25 @@ pub fn migrations() -> &'static [Migration] {
             severity: Severity::Optional,
             up: crate::up::refresh_wardnetd_unit,
         },
+        Migration {
+            // Re-runs the unit refresh for the `ReadWritePaths=/etc/wardnet`
+            // grant. `ProtectSystem=strict` mounts /etc read-only, so
+            // restoring a backup — which renames /etc/wardnet/wardnet.toml
+            // aside and writes the bundle's copy in its place — failed with
+            // EROFS on every install that predates this.
+            //
+            // A new id rather than an edit to 0003: the runner records
+            // migrations applied and skips them forever, so a box that
+            // already ran 0003 would never pick the change up. Fresh
+            // installs run both and the second is a content no-op, because
+            // install.sh has already laid down this same unit.
+            //
+            // Severity::Optional, matching 0003: a failed rewrite leaves the
+            // daemon starting from the on-disk unit. Only backup restore
+            // stays broken, which must not gate startup.
+            id: "0004_wardnetd_unit_config_write",
+            severity: Severity::Optional,
+            up: crate::up::refresh_wardnetd_unit,
+        },
     ]
 }

--- a/source/daemon/crates/wardnet-postupgrade/src/tests/migrations.rs
+++ b/source/daemon/crates/wardnet-postupgrade/src/tests/migrations.rs
@@ -18,6 +18,21 @@ fn lists_polkit_power_rule_migration() {
     assert_eq!(first.severity, Severity::Optional);
 }
 
+/// The unit refresh is deliberately listed twice under different ids. The
+/// runner records each migration applied and skips it forever, so a box that
+/// already ran `0003` would never pick up a later unit change — a follow-up id
+/// re-running the same reconciler is how the fix reaches it. Pinned here so a
+/// well-meaning "duplicate entry" cleanup has to read this comment first.
+#[test]
+fn unit_refresh_runs_again_under_a_follow_up_id() {
+    let ids: Vec<&'static str> = migrations().iter().map(|m| m.id).collect();
+    assert!(ids.contains(&"0003_wardnetd_unit_refresh"), "got {ids:?}");
+    assert!(
+        ids.contains(&"0004_wardnetd_unit_config_write"),
+        "the ReadWritePaths=/etc/wardnet grant must reach existing installs; got {ids:?}"
+    );
+}
+
 #[test]
 fn migration_ids_are_unique() {
     let list = migrations();

--- a/source/daemon/crates/wardnet-postupgrade/src/up/tests/systemd_unit.rs
+++ b/source/daemon/crates/wardnet-postupgrade/src/up/tests/systemd_unit.rs
@@ -102,6 +102,38 @@ fn start_limit_keys_live_in_unit_section_not_service() {
     }
 }
 
+/// `ProtectSystem=strict` mounts every path outside `ReadWritePaths`
+/// read-only, `/etc` included. Restoring a backup rewrites the live config —
+/// `BackupService::apply_import` renames `/etc/wardnet/wardnet.toml` aside to
+/// a `.bak-<timestamp>` sibling and moves the bundle's copy into its place,
+/// both of which need write access to the *directory*. Without the grant that
+/// fails with EROFS on real hardware.
+///
+/// Neither end-to-end suite can catch this: the container image drops in
+/// `ProtectSystem=no` (see `Dockerfile.base`), so a restore succeeds there no
+/// matter what the unit says. This test is the only guard.
+#[test]
+fn config_directory_is_writable_for_backup_restore() {
+    let service = section_body(UNIT_BODY, "[Service]");
+    assert!(
+        has_directive(&service, "ProtectSystem"),
+        "test assumes the unit hardens the filesystem; if that was dropped, \
+         this assertion is obsolete rather than merely failing"
+    );
+
+    let grants: Vec<&str> = service
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.starts_with('#'))
+        .filter_map(|line| line.strip_prefix("ReadWritePaths="))
+        .flat_map(str::split_whitespace)
+        .collect();
+    assert!(
+        grants.contains(&"/etc/wardnet"),
+        "backup restore writes /etc/wardnet/wardnet.toml; ReadWritePaths is {grants:?}"
+    );
+}
+
 /// Collect the lines of the named section (until the next `[Header]`).
 fn section_body(unit: &str, header: &str) -> String {
     let mut out = String::new();

--- a/source/daemon/crates/wardnetd-data/src/database_dumper.rs
+++ b/source/daemon/crates/wardnetd-data/src/database_dumper.rs
@@ -174,6 +174,29 @@ impl DatabaseDumper for SqliteDumper {
             ));
         }
 
+        // Drop the *outgoing* database's WAL sidecars before anything opens
+        // the new file. The daemon runs in WAL mode, so `<db>-wal` / `<db>-shm`
+        // sitting next to the path we just swapped describe the database that
+        // was here a moment ago — a schema the restored snapshot knows nothing
+        // about. Any reader that opens the file with those present recovers
+        // their frames onto it and sees a database that is neither the old one
+        // nor the new one, failing with `no such table: _sqlx_migrations` or
+        // `malformed database schema (...)` depending on what the WAL happened
+        // to hold. That is what the reconnect below hits, and it surfaced as an
+        // intermittent 500 from `POST /api/backup/import/apply`.
+        //
+        // Dropping them is always correct here: `dump()` produces a
+        // self-contained `VACUUM INTO` snapshot, so the restored file never has
+        // a WAL of its own to lose. This is the same reasoning as the
+        // `restore-pending` sentinel (#695) — that one stops the stale WAL
+        // being recovered on the *next boot*, whereas this covers every reader
+        // between the swap and that restart, starting with the one below.
+        //
+        // The still-open live pool may recreate `<db>-wal` on its next write;
+        // those frames are equally stale, and the sentinel is what keeps the
+        // next boot from recovering them.
+        remove_wal_sidecars(&self.database_path).await?;
+
         // Reconnect against the fresh file and read back the schema
         // version — lets the caller log it and decide whether to run
         // migrations. We open a throwaway pool here because the live
@@ -212,4 +235,43 @@ impl DatabaseDumper for SqliteDumper {
             .map_err(|e| anyhow::anyhow!("failed to read current schema version: {e}"))?;
         Ok(row.0)
     }
+}
+
+/// Delete the `-wal` / `-shm` sidecars beside `database_path`.
+///
+/// Called immediately after a restore swaps a new file into place, so no
+/// reader recovers the *previous* database's write-ahead log onto it. See the
+/// call site in [`SqliteDumper::restore`] for why discarding is always the
+/// correct choice there.
+///
+/// A missing sidecar is success — journal mode may have been changed, or the
+/// database may never have been opened at this path. Any other error is
+/// propagated: silently continuing would hand the reconnect a file we already
+/// know is unsafe to open.
+async fn remove_wal_sidecars(database_path: &Path) -> anyhow::Result<()> {
+    for suffix in ["-wal", "-shm"] {
+        // SQLite appends the suffix to the whole filename rather than
+        // replacing an extension, so build the name by concatenation.
+        let mut name = database_path.as_os_str().to_owned();
+        name.push(suffix);
+        let sidecar = PathBuf::from(name);
+
+        match tokio::fs::remove_file(&sidecar).await {
+            Ok(()) => {
+                tracing::debug!(
+                    path = %sidecar.display(),
+                    "discarded stale WAL sidecar after restore: path={path}",
+                    path = sidecar.display(),
+                );
+            }
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+            Err(e) => {
+                return Err(anyhow::anyhow!(
+                    "failed to discard stale WAL sidecar {}: {e}",
+                    sidecar.display()
+                ));
+            }
+        }
+    }
+    Ok(())
 }

--- a/source/daemon/crates/wardnetd-data/src/tests/database_dumper.rs
+++ b/source/daemon/crates/wardnetd-data/src/tests/database_dumper.rs
@@ -2,7 +2,7 @@
 //! dump it, restore the bytes into a fresh file, confirm the data
 //! survives.
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use sqlx::sqlite::SqliteConnectOptions;
 use sqlx::{Executor, SqlitePool};
@@ -212,6 +212,112 @@ async fn restore_installs_file_with_0600_perms() {
 
     let _ = tokio::fs::remove_file(&src_path).await;
     let _ = tokio::fs::remove_file(&dst_path).await;
+}
+
+/// A restore must not be poisoned by the *outgoing* database's WAL.
+///
+/// `restore` swaps the file, then immediately reopens it to read the schema
+/// version back. In production the live pool is still running in WAL mode
+/// against the old database, so `<db>-wal` / `<db>-shm` on disk hold frames
+/// describing a schema the new file knows nothing about. `SQLite` recovers that
+/// WAL onto the restored snapshot and the read-back fails with
+/// `malformed database schema (...) - no such table: ...`, which surfaces as a
+/// 500 from `POST /api/backup/import/apply`.
+///
+/// Sibling to the `restore-pending` sentinel added in #695: that one stops the
+/// stale WAL being recovered on the *next boot*; this covers the reconnect
+/// inside `restore` itself, which happens long before any restart.
+#[tokio::test]
+async fn restore_discards_the_outgoing_databases_wal_sidecars() {
+    // The database being replaced: WAL mode, with a table + index that exist
+    // only here. Its pool stays open, exactly as the daemon's does.
+    let live_path = temp_db_path();
+    let live_pool = open_writable(&live_path).await;
+    live_pool.execute("PRAGMA journal_mode=WAL;").await.unwrap();
+    live_pool
+        .execute(
+            r"
+            CREATE TABLE dns_query_log (id INTEGER PRIMARY KEY, domain TEXT);
+            CREATE INDEX idx_dns_query_log_domain ON dns_query_log(domain);
+            ",
+        )
+        .await
+        .unwrap();
+    // Keep writing so the WAL holds uncheckpointed frames at swap time.
+    for i in 0..64 {
+        live_pool
+            .execute(sqlx::AssertSqlSafe(format!(
+                "INSERT INTO dns_query_log (id, domain) VALUES ({i}, 'example.com');"
+            )))
+            .await
+            .unwrap();
+    }
+    assert!(
+        tokio::fs::try_exists(wal_path(&live_path)).await.unwrap(),
+        "test needs a live -wal sidecar to be meaningful"
+    );
+
+    // The incoming snapshot: a self-contained database with a different
+    // schema, the way `VACUUM INTO` produces one.
+    let snapshot_path = temp_db_path();
+    let snapshot_pool = open_writable(&snapshot_path).await;
+    snapshot_pool
+        .execute(
+            r"
+            CREATE TABLE _sqlx_migrations (
+                version INTEGER PRIMARY KEY,
+                description TEXT NOT NULL,
+                installed_on TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                success BOOLEAN NOT NULL,
+                checksum BLOB NOT NULL,
+                execution_time INTEGER NOT NULL
+            );
+            INSERT INTO _sqlx_migrations (version, description, success, checksum, execution_time)
+            VALUES (7, 'm', 1, X'00', 0);
+            ",
+        )
+        .await
+        .unwrap();
+    let snapshot_bytes = tokio::fs::read(&snapshot_path).await.unwrap();
+    snapshot_pool.close().await;
+
+    // Restore over the live path while its pool is still open.
+    let dumper = SqliteDumper::new(live_pool.clone(), live_path.clone());
+    let version = dumper
+        .restore(&snapshot_bytes)
+        .await
+        .expect("restore must not choke on the outgoing database's WAL");
+    assert_eq!(version, 7);
+
+    // The sidecars belonged to a database that no longer exists at this path.
+    assert!(
+        !tokio::fs::try_exists(wal_path(&live_path)).await.unwrap(),
+        "stale -wal must not survive the swap"
+    );
+    assert!(
+        !tokio::fs::try_exists(shm_path(&live_path)).await.unwrap(),
+        "stale -shm must not survive the swap"
+    );
+
+    live_pool.close().await;
+    let _ = tokio::fs::remove_file(&live_path).await;
+    let _ = tokio::fs::remove_file(&snapshot_path).await;
+}
+
+fn wal_path(db: &Path) -> PathBuf {
+    sidecar(db, "-wal")
+}
+
+fn shm_path(db: &Path) -> PathBuf {
+    sidecar(db, "-shm")
+}
+
+/// `SQLite` names its sidecars by appending to the database filename, so this
+/// is a string suffix rather than an extension change.
+fn sidecar(db: &Path, suffix: &str) -> PathBuf {
+    let mut name = db.as_os_str().to_owned();
+    name.push(suffix);
+    PathBuf::from(name)
 }
 
 #[tokio::test]

--- a/source/daemon/crates/wardnetd-data/src/tests/database_dumper.rs
+++ b/source/daemon/crates/wardnetd-data/src/tests/database_dumper.rs
@@ -304,6 +304,62 @@ async fn restore_discards_the_outgoing_databases_wal_sidecars() {
     let _ = tokio::fs::remove_file(&snapshot_path).await;
 }
 
+/// A sidecar that cannot be removed must fail the restore, not be ignored.
+///
+/// Only `NotFound` counts as success when discarding: continuing past any
+/// other error would hand the reconnect a file we already know is unsafe to
+/// open, turning a clear "could not clear the WAL" into the confusing
+/// `malformed database schema` this whole path exists to prevent.
+///
+/// A directory standing where the sidecar belongs is the portable way to make
+/// `remove_file` fail with something that is not `NotFound`.
+#[tokio::test]
+async fn restore_fails_when_a_stale_sidecar_cannot_be_discarded() {
+    let live_path = temp_db_path();
+    let live_pool = open_writable(&live_path).await;
+    live_pool
+        .execute("CREATE TABLE demo (id INTEGER PRIMARY KEY);")
+        .await
+        .unwrap();
+    live_pool.close().await;
+
+    tokio::fs::create_dir(wal_path(&live_path)).await.unwrap();
+
+    let snapshot_path = temp_db_path();
+    let snapshot_pool = open_writable(&snapshot_path).await;
+    snapshot_pool
+        .execute(
+            r"
+            CREATE TABLE _sqlx_migrations (
+                version INTEGER PRIMARY KEY,
+                description TEXT NOT NULL,
+                installed_on TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                success BOOLEAN NOT NULL,
+                checksum BLOB NOT NULL,
+                execution_time INTEGER NOT NULL
+            );
+            ",
+        )
+        .await
+        .unwrap();
+    let snapshot_bytes = tokio::fs::read(&snapshot_path).await.unwrap();
+    snapshot_pool.close().await;
+
+    let dumper = SqliteDumper::new(
+        SqlitePool::connect("sqlite::memory:").await.unwrap(),
+        live_path.clone(),
+    );
+    let err = dumper.restore(&snapshot_bytes).await.unwrap_err();
+    assert!(
+        format!("{err:#}").contains("failed to discard stale WAL sidecar"),
+        "expected the discard failure to surface, got: {err:#}"
+    );
+
+    let _ = tokio::fs::remove_dir(wal_path(&live_path)).await;
+    let _ = tokio::fs::remove_file(&live_path).await;
+    let _ = tokio::fs::remove_file(&snapshot_path).await;
+}
+
 fn wal_path(db: &Path) -> PathBuf {
     sidecar(db, "-wal")
 }

--- a/source/daemon/crates/wardnetd-services/src/backup/service.rs
+++ b/source/daemon/crates/wardnetd-services/src/backup/service.rs
@@ -174,10 +174,44 @@ impl BackupServiceImpl {
         Ok(())
     }
 
-    /// Directory where `.bak-*` snapshots live — always a sibling of
-    /// the live database file.
+    /// Directory the service *writes* new snapshots to — always a
+    /// sibling of the live database file. Reads must go through
+    /// [`Self::snapshot_dirs`], which also covers the config's directory.
     fn snapshot_dir(&self) -> &Path {
         self.database_path.parent().unwrap_or(Path::new("."))
+    }
+
+    /// Every directory a restore can leave a `.bak-<timestamp>` sibling
+    /// in: the live database's parent and the live config's parent.
+    ///
+    /// `apply_import` renames each live file aside *in place*, so on a
+    /// real install the two snapshots land in different directories
+    /// (`/var/lib/wardnet` and `/etc/wardnet`). Walking only the database's
+    /// directory is what made config snapshots invisible to
+    /// `GET /api/backup/snapshots` — and, since the cleanup runner shares
+    /// the same walk, immortal: nothing ever pruned them.
+    ///
+    /// Deduped, because tests (and any install that colocates the two
+    /// files) would otherwise report every database snapshot twice.
+    fn snapshot_dirs(&self) -> Vec<&Path> {
+        let db_dir = self.snapshot_dir();
+        let config_dir = self.config_path.parent().unwrap_or(Path::new("."));
+        if config_dir == db_dir {
+            vec![db_dir]
+        } else {
+            vec![db_dir, config_dir]
+        }
+    }
+
+    /// Collect `.bak-*` snapshots from every directory in
+    /// [`Self::snapshot_dirs`]. Shared by the listing endpoint and the
+    /// cleanup runner so the two can never disagree about what exists.
+    async fn enumerate_all_snapshots(&self) -> Result<Vec<LocalSnapshot>, AppError> {
+        let mut out = Vec::new();
+        for dir in self.snapshot_dirs() {
+            out.extend(enumerate_snapshots(dir).await?);
+        }
+        Ok(out)
     }
 
     /// Decide whether a freshly-unpacked manifest can be restored
@@ -736,13 +770,13 @@ impl BackupService for BackupServiceImpl {
 
     async fn list_snapshots(&self) -> Result<ListSnapshotsResponse, AppError> {
         auth_context::require_admin()?;
-        let snapshots = enumerate_snapshots(self.snapshot_dir()).await?;
+        let snapshots = self.enumerate_all_snapshots().await?;
         Ok(ListSnapshotsResponse { snapshots })
     }
 
     async fn cleanup_old_snapshots(&self, retain: Duration) -> Result<u32, AppError> {
         auth_context::require_admin()?;
-        let snapshots = enumerate_snapshots(self.snapshot_dir()).await?;
+        let snapshots = self.enumerate_all_snapshots().await?;
         let now = Utc::now();
         let mut deleted: u32 = 0;
         for snap in snapshots {

--- a/source/daemon/crates/wardnetd-services/src/backup/tests/service.rs
+++ b/source/daemon/crates/wardnetd-services/src/backup/tests/service.rs
@@ -125,11 +125,35 @@ struct Harness {
 }
 
 fn build_harness(schema_version: i64) -> Harness {
+    build_harness_at(schema_version, ConfigLocation::BesideDatabase)
+}
+
+/// Where the live config sits relative to the live database.
+///
+/// A real install splits them (`/var/lib/wardnet/wardnet.db` and
+/// `/etc/wardnet/wardnet.toml`); every test here colocated them, which is
+/// precisely why the snapshot walk could miss an entire directory without a
+/// single test noticing. [`ConfigLocation::SeparateDirectory`] reproduces
+/// production's layout.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum ConfigLocation {
+    BesideDatabase,
+    SeparateDirectory,
+}
+
+fn build_harness_at(schema_version: i64, config_location: ConfigLocation) -> Harness {
     let tempdir = std::env::temp_dir().join(format!("wardnet-backup-test-{}", Uuid::new_v4()));
     std::fs::create_dir_all(&tempdir).unwrap();
 
     let database_path = tempdir.join("wardnet.db");
-    let config_path = tempdir.join("wardnet.toml");
+    let config_path = match config_location {
+        ConfigLocation::BesideDatabase => tempdir.join("wardnet.toml"),
+        ConfigLocation::SeparateDirectory => {
+            let etc = tempdir.join("etc");
+            std::fs::create_dir_all(&etc).unwrap();
+            etc.join("wardnet.toml")
+        }
+    };
     let secrets_root = tempdir.join("secrets");
 
     // Pre-populate the live files so apply_import has something to
@@ -359,6 +383,92 @@ async fn cleanup_old_snapshots_deletes_expired_files() {
     // dead-code lints.
     let manifest = BundleManifest::new("0.2.0", h.dumper.schema_version, "test-host", 0);
     assert_eq!(manifest.schema_version, 42);
+}
+
+// NB: `apply_import` writing /etc/wardnet also depends on the systemd unit
+// granting `ReadWritePaths=/etc/wardnet` under `ProtectSystem=strict`. That
+// invariant is asserted where the unit is embedded —
+// `wardnet-postupgrade`'s `up::tests::systemd_unit::
+// config_directory_is_writable_for_backup_restore`.
+
+#[tokio::test]
+async fn list_snapshots_finds_config_snapshots_in_their_own_directory() {
+    // Production layout: the config lives in a different directory from the
+    // database, so `apply_import`'s in-place rename leaves the config snapshot
+    // somewhere the database's directory walk will never see.
+    let h = build_harness_at(42, ConfigLocation::SeparateDirectory);
+    assert_ne!(
+        h.config_path.parent(),
+        h.database_path.parent(),
+        "this test is only meaningful when the two directories differ"
+    );
+
+    let db_snapshot = h
+        .database_path
+        .with_file_name("wardnet.db.bak-20990101T000000Z");
+    let config_snapshot = h
+        .config_path
+        .with_file_name("wardnet.toml.bak-20990101T000000Z");
+    tokio::fs::write(&db_snapshot, b"db").await.unwrap();
+    tokio::fs::write(&config_snapshot, b"cfg").await.unwrap();
+
+    let resp = auth_context::with_context(admin_ctx(), h.svc.list_snapshots())
+        .await
+        .unwrap();
+
+    let paths: Vec<&str> = resp.snapshots.iter().map(|s| s.path.as_str()).collect();
+    assert!(
+        paths.contains(&db_snapshot.display().to_string().as_str()),
+        "database snapshot missing from {paths:?}"
+    );
+    assert!(
+        paths.contains(&config_snapshot.display().to_string().as_str()),
+        "config snapshot missing from {paths:?} - the walk skipped its directory"
+    );
+}
+
+#[tokio::test]
+async fn list_snapshots_does_not_double_report_when_paths_share_a_directory() {
+    // The colocated layout must not report each snapshot twice now that the
+    // walk visits two (identical) directories.
+    let h = build_harness(42);
+    let db_snapshot = h
+        .database_path
+        .with_file_name("wardnet.db.bak-20990101T000000Z");
+    tokio::fs::write(&db_snapshot, b"db").await.unwrap();
+
+    let resp = auth_context::with_context(admin_ctx(), h.svc.list_snapshots())
+        .await
+        .unwrap();
+    assert_eq!(resp.snapshots.len(), 1, "got {:?}", resp.snapshots);
+}
+
+#[tokio::test]
+async fn cleanup_old_snapshots_prunes_config_snapshots_too() {
+    // The cleanup runner shares the listing walk, so a directory the walk
+    // skipped was never swept — those snapshots accumulated forever.
+    let h = build_harness_at(42, ConfigLocation::SeparateDirectory);
+    let config_snapshot = h
+        .config_path
+        .with_file_name("wardnet.toml.bak-20000101T000000Z");
+    tokio::fs::write(&config_snapshot, b"old").await.unwrap();
+
+    let ten_days_ago = std::time::SystemTime::now() - Duration::from_hours(24 * 10);
+    let file = std::fs::File::options()
+        .write(true)
+        .open(&config_snapshot)
+        .unwrap();
+    file.set_modified(ten_days_ago).unwrap();
+    drop(file);
+
+    let deleted = auth_context::with_context(
+        admin_ctx(),
+        h.svc.cleanup_old_snapshots(Duration::from_hours(24)),
+    )
+    .await
+    .unwrap();
+    assert_eq!(deleted, 1);
+    assert!(!config_snapshot.exists());
 }
 
 #[tokio::test]

--- a/source/end2end-tests/daemon/compose.yaml
+++ b/source/end2end-tests/daemon/compose.yaml
@@ -9,7 +9,9 @@
 # gateway), and `internet_target` (a tunnel-only reachable host). Stage
 # 9 (issue #247) adds `wg_gateway_1` / `wg_gateway_2`: two plain
 # WireGuard peers on wardnet_wan for the manual tunnel-import lifecycle
-# specs (no NAT, no internet segment). See the e2e umbrella issue for the
+# specs (no NAT, no internet segment). Stage 11 (issue #249) adds
+# `update_manifest_server`: a static-file server for the release manifests
+# the auto-update subsystem checks. See the e2e umbrella issue for the
 # full topology, stage list, and conventions:
 # https://github.com/wardnet/wardnet/issues/273
 #
@@ -20,8 +22,10 @@
 #                              can own .1. Docker IPAM .2/28 (only
 #                              .2–.15) leaves .100+ free for the
 #                              daemon's DHCP pool + reservations.
-#   wardnet_wan  10.92.0.0/24 — upstream side: nordvpn_mock (.52) and
-#                              the wg_gateway (.53) tunnel underlay.
+#   wardnet_wan  10.92.0.0/24 — upstream side: nordvpn_mock (.52), the
+#                              wg_gateway (.53) tunnel underlay, the
+#                              tunnel-import peers (.54/.55), and the
+#                              update_manifest_server (.56).
 #   wardnet_internet 10.93.0.0/24 — isolated "public internet"; only
 #                              wg_gateway (.1) and internet_target (.10)
 #                              attach, so it is reachable from the LAN
@@ -158,6 +162,23 @@ services:
           fi
           echo "wardnetd e2e fixture: pinned nordvpn_api_url=http://10.92.0.52:8080 in /etc/wardnet/wardnet.toml" >&2
         fi
+        # Point the auto-update runner at update_manifest_server instead of
+        # releases.wardnet.network (issue #249, E2E Stage 11). Same idempotent
+        # inject-or-append shape as the nordvpn override above: guard on the
+        # key so a container restart doesn't duplicate it, then either add the
+        # key under an existing [update] table or append a fresh one. The
+        # daemon ships no [update] table by default (install.sh only writes one
+        # for CHANNEL=edge), so the append branch is the usual path here.
+        # allow_edge_channel is deliberately NOT set — update-status.spec.ts
+        # asserts the deploy-time gate rejects a switch to edge with 403.
+        if ! grep -q '^manifest_base_url' /etc/wardnet/wardnet.toml; then
+          if grep -q '^\[update\]' /etc/wardnet/wardnet.toml; then
+            sed -i '/^\[update\]/a manifest_base_url = "http://10.92.0.56"' /etc/wardnet/wardnet.toml
+          else
+            printf '\n[update]\nmanifest_base_url = "http://10.92.0.56"\n' >> /etc/wardnet/wardnet.toml
+          fi
+          echo "wardnetd e2e fixture: pinned manifest_base_url=http://10.92.0.56 in /etc/wardnet/wardnet.toml" >&2
+        fi
         exec /lib/systemd/systemd --log-target=console --log-level=debug --show-status=yes
     # cgroup v2 is the default on modern Docker engines; systemd
     # inside the container picks it up automatically.
@@ -249,6 +270,35 @@ services:
       # wget --spider returns 0 on 2xx and is part of the busybox
       # image already.
       test: ["CMD-SHELL", "wget --spider -q http://127.0.0.1/dns-blocklists.txt"]
+      interval: 3s
+      timeout: 2s
+      retries: 10
+      start_period: 5s
+
+  # Release-manifest server for the auto-update specs (issue #249, E2E
+  # Stage 11). Serves `fixtures/update-manifests/<channel>.json` — the same
+  # JSON shape the marketing site's build step publishes to
+  # releases.wardnet.network — so `UpdateService::check()` resolves against a
+  # fixture instead of the internet. Sits on wardnet_wan (the upstream side)
+  # at a fixed 10.92.0.56, the address the daemon's `[update]
+  # manifest_base_url` override points at.
+  #
+  # Plain HTTP, not HTTPS: the daemon's manifest fetch is a bare reqwest GET
+  # that accepts any scheme, and release authenticity in production rests on
+  # the minisign signature over the asset, not on TLS over the manifest.
+  # Terminating TLS here would mean minting a CA and baking it into the
+  # daemon image's trust store to exercise reqwest rather than Wardnet code.
+  # See fixtures/update-manifests/README.md.
+  update_manifest_server:
+    image: busybox:1.36@sha256:73aaf090f3d85aa34ee199857f03fa3a95c8ede2ffd4cc2cdb5b94e566b11662
+    command: ["httpd", "-f", "-v", "-p", "80", "-h", "/srv"]
+    volumes:
+      - ./fixtures/update-manifests:/srv:ro
+    networks:
+      wardnet_wan:
+        ipv4_address: 10.92.0.56
+    healthcheck:
+      test: ["CMD-SHELL", "wget --spider -q http://127.0.0.1/stable.json"]
       interval: 3s
       timeout: 2s
       retries: 10
@@ -391,6 +441,8 @@ services:
       test_ubuntu:
         condition: service_healthy
       blocklist_server:
+        condition: service_healthy
+      update_manifest_server:
         condition: service_healthy
       nordvpn_mock:
         condition: service_healthy

--- a/source/end2end-tests/daemon/fixtures/update-manifests/README.md
+++ b/source/end2end-tests/daemon/fixtures/update-manifests/README.md
@@ -1,0 +1,46 @@
+# Update manifest fixtures
+
+Static release manifests served by the `update_manifest_server`
+compose service (busybox httpd on `10.92.0.56:80`, `wardnet_wan`).
+The daemon's `[update] manifest_base_url` is rewritten to point here
+by the `wardnetd` service's entrypoint, so
+`UpdateService::check()` fetches `<base>/<channel>.json` from this
+directory instead of `https://releases.wardnet.network`.
+
+The shape mirrors `source/marketing-site/scripts/generate-release-manifests.ts`
+— the daemon only reads `version`, `asset_base_url`, `binary`,
+`published_at`, and `notes_url` (see
+`crates/wardnetd-services/src/update/manifest.rs`), but the fixtures
+carry the full field set so a drift in the generator is visible here.
+
+## Files
+
+- `stable.json` — the generator's **empty placeholder** (`version: ""`,
+  `binary: null`). The daemon treats that as "no release published on
+  this channel" and reports `latest_version: null`,
+  `update_available: false`.
+- `beta.json` — a **fixture release** at version `9999.12.31`, chosen to
+  outrank any version this repo will ever build so
+  `update_available` is `true` deterministically.
+- `edge.json` — same placeholder as `stable.json`. Present so a box that
+  somehow ends up on `edge` gets a 404-free fetch; the e2e suite never
+  selects the channel (`allow_edge_channel` is left at its default
+  `false`, and `update-status.spec.ts` asserts the 403).
+
+## Why plain HTTP, not HTTPS
+
+The daemon accepts any base URL — the fetch is a bare `reqwest::get`,
+and authenticity in production comes from the minisign signature on the
+downloaded asset, not from TLS on the manifest. Terminating TLS here
+would mean minting a CA, baking it into the daemon image's trust store,
+and keeping it in sync — all to exercise `reqwest`'s TLS stack rather
+than any Wardnet code. The specs never install, so no asset is ever
+fetched or verified.
+
+## Assets
+
+`asset_base_url` points back at this same server, but nothing under it
+exists: `update-status.spec.ts` exercises `status` / `check` /
+`updateConfig` only. A future install spec would need real tarball +
+`.sha256` + `.minisig` fixtures and a daemon built with
+`[update] require_signature = false` (or the image's ephemeral key).

--- a/source/end2end-tests/daemon/fixtures/update-manifests/beta.json
+++ b/source/end2end-tests/daemon/fixtures/update-manifests/beta.json
@@ -1,0 +1,12 @@
+{
+  "version": "9999.12.31",
+  "tag": "v9999.12.31",
+  "prerelease": true,
+  "published_at": "2099-12-31T00:00:00Z",
+  "asset_base_url": "http://10.92.0.56/assets",
+  "binary": {
+    "name": "wardnetd-9999.12.31-aarch64.tar.gz",
+    "size_bytes": 1
+  },
+  "notes_url": "http://10.92.0.56/notes/9999.12.31.html"
+}

--- a/source/end2end-tests/daemon/fixtures/update-manifests/edge.json
+++ b/source/end2end-tests/daemon/fixtures/update-manifests/edge.json
@@ -1,0 +1,9 @@
+{
+  "version": "",
+  "tag": "",
+  "prerelease": false,
+  "published_at": null,
+  "asset_base_url": "",
+  "binary": null,
+  "notes_url": ""
+}

--- a/source/end2end-tests/daemon/fixtures/update-manifests/stable.json
+++ b/source/end2end-tests/daemon/fixtures/update-manifests/stable.json
@@ -1,0 +1,9 @@
+{
+  "version": "",
+  "tag": "",
+  "prerelease": false,
+  "published_at": null,
+  "asset_base_url": "",
+  "binary": null,
+  "notes_url": ""
+}

--- a/source/end2end-tests/daemon/tests/auth-coverage.spec.ts
+++ b/source/end2end-tests/daemon/tests/auth-coverage.spec.ts
@@ -26,6 +26,8 @@ const ADMIN_ENDPOINTS: ReadonlyArray<{ name: string; path: string }> = [
   { name: "devices list", path: "/devices" },
   { name: "tunnels list", path: "/tunnels" },
   { name: "backup status", path: "/backup/status" },
+  { name: "system status", path: "/system/status" },
+  { name: "update status", path: "/update/status" },
 ];
 
 describe("auth — admin endpoints reject unauthenticated reads", () => {

--- a/source/end2end-tests/daemon/tests/backup-roundtrip.spec.ts
+++ b/source/end2end-tests/daemon/tests/backup-roundtrip.spec.ts
@@ -285,15 +285,30 @@ describe("backup round-trip (issue #249)", () => {
     240_000,
   );
 
-  it("lists the pre-restore snapshots", async () => {
+  it("lists the pre-restore snapshots that live beside the database", async () => {
     const { snapshots } = await backup.listSnapshots();
     expect(snapshots.length).toBeGreaterThan(0);
+    // The database is always snapshotted, so the listing can never be empty
+    // after an apply.
+    expect(snapshots.map((s) => s.kind)).toContain("database");
 
-    // Every snapshot the apply reported must be enumerable afterwards — the
-    // retention runner only prunes siblings older than 24 hours, so nothing
-    // created during this run can have been swept.
-    for (const applied of appliedSnapshots) {
-      expect(snapshots.map((s) => s.path)).toContain(applied.path);
+    // `list_snapshots` enumerates exactly one directory — the database's
+    // parent (`snapshot_dir()`). The database and secrets snapshots are
+    // written there and must all show up; nothing this run created can have
+    // been pruned, since the cleanup runner only sweeps siblings older than
+    // 24 hours.
+    //
+    // The *config* snapshot is deliberately excluded: `apply_import` writes it
+    // next to the live config (`/etc/wardnet/wardnet.toml.bak-<ts>`), which is
+    // a different directory, so `GET /api/backup/snapshots` never reports it
+    // and `cleanup_old_snapshots` never prunes it. That asymmetry is a daemon
+    // bug, not a property worth asserting — this spec pins the behaviour that
+    // exists so the gap is visible here rather than silently passing.
+    const listedPaths = snapshots.map((s) => s.path);
+    const beside = appliedSnapshots.filter((s) => s.kind !== "config");
+    expect(beside.length).toBeGreaterThan(0);
+    for (const applied of beside) {
+      expect(listedPaths).toContain(applied.path);
     }
   });
 });

--- a/source/end2end-tests/daemon/tests/backup-roundtrip.spec.ts
+++ b/source/end2end-tests/daemon/tests/backup-roundtrip.spec.ts
@@ -1,0 +1,299 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import {
+  BackupService,
+  DhcpService,
+  DnsFilterService,
+  SystemService,
+  WardnetApiError,
+  WardnetClient,
+  type LocalSnapshot,
+} from "@wardnet/js";
+
+import {
+  AD_BLOCKING_PROFILE_ID,
+  API_BASE_URL,
+  AuthedClient,
+  DAEMON_AGENT,
+  daemonPid,
+  ensureAdminAndLogin,
+  waitForDaemonRestart,
+  waitForReady,
+} from "./helpers.js";
+
+// Seeds the round-trip carries. Both are namespaced to this spec so a
+// re-run against a persistent `wardnet_state` volume — or a collision with
+// dhcp-reservations.spec.ts, which owns .160 — is impossible.
+//
+// `.170` sits in the .151–.199 reserved-static band from the e2e plan:
+// outside the daemon's dynamic pool (.100–.150), so the reservation can't
+// race a concurrent lease. The MAC is locally-administered (`02:` prefix) and
+// belongs to no container in the topology, so no DHCP traffic ever exercises
+// it — this reservation exists purely as a database row to lose and recover.
+const RESERVED_IP = "10.91.0.170";
+const RESERVED_MAC = "02:e2:e2:00:02:49";
+const RESERVATION_HOSTNAME = "e2e-backup-roundtrip";
+
+const BLOCKLIST_NAME = "e2e-backup-roundtrip";
+const BLOCKLIST_URL = "http://10.91.0.200/dns-blocklists.txt";
+// Annual cron + disabled: this blocklist is a row to back up, not a filter to
+// exercise. Neither the dns_filter runner nor a create-time refresh may fetch
+// it, or the spec would be timing-coupled to a download job it doesn't care
+// about (dns-blocklists.spec.ts owns that coverage).
+const CRON_NEVER = "0 0 1 1 *";
+
+// Server-side minimum is 12 characters (`MIN_PASSPHRASE_LEN`).
+const PASSPHRASE = "e2e-backup-roundtrip-passphrase";
+const SHORT_PASSPHRASE = "tooshort";
+
+/**
+ * Backup export → destroy → preview → apply → restart round-trip
+ * (issue #249, E2E Stage 11).
+ *
+ * Order-sensitive: `applyImport` replaces the live database with the bundle's
+ * copy, so every row written between export and apply is rolled back. That is
+ * safe under vitest's `fileParallelism: false` + `isolate: false` model —
+ * nothing else is running — and the window is kept as narrow as possible: the
+ * only writes in it are this spec's own deletions.
+ *
+ * The restart is not optional. The running SQLite pool holds an open fd to the
+ * file `apply_import` renamed to `.bak-<ts>`, so until the daemon restarts it
+ * is still reading and writing the *pre-restore* database. Asserting recovery
+ * before the restart would pass for the wrong reason.
+ */
+describe("backup round-trip (issue #249)", () => {
+  const client = new WardnetClient({ baseUrl: API_BASE_URL });
+  let admin: AuthedClient;
+  let backup: BackupService;
+  let dhcp: DhcpService;
+  let dnsFilter: DnsFilterService;
+
+  let bundle: Blob;
+  let appliedSnapshots: LocalSnapshot[] = [];
+
+  beforeAll(async () => {
+    await waitForReady(client);
+    admin = await ensureAdminAndLogin(client);
+    backup = new BackupService(admin);
+    dhcp = new DhcpService(admin);
+    dnsFilter = new DnsFilterService(admin);
+
+    // Clear anything a previous run on the same volume left behind, so the
+    // seeding step below starts from a known-absent state.
+    await removeSeeds();
+  }, 120_000);
+
+  afterAll(async () => {
+    // The restore brings the seeds back, so tear them down again — otherwise a
+    // second run against the same volume would find them already present and
+    // the "reappeared" assertion would be vacuous. Best-effort: a failure here
+    // must not mask the real one.
+    try {
+      await removeSeeds();
+    } catch {
+      // ignore
+    }
+  });
+
+  /** Delete this spec's reservation + blocklist if present. Idempotent. */
+  async function removeSeeds(): Promise<void> {
+    const reservations = await dhcp.listReservations();
+    for (const r of reservations.reservations) {
+      if (
+        r.mac_address.toLowerCase() === RESERVED_MAC ||
+        r.ip_address === RESERVED_IP
+      ) {
+        await dhcp.deleteReservation(r.id);
+      }
+    }
+    const blocklists = await dnsFilter.listBlocklists(AD_BLOCKING_PROFILE_ID);
+    for (const b of blocklists.blocklists) {
+      if (b.name === BLOCKLIST_NAME) {
+        await dnsFilter.deleteBlocklist(AD_BLOCKING_PROFILE_ID, b.id);
+      }
+    }
+  }
+
+  /** True when both seeds are present in the live database. */
+  async function seedsPresent(): Promise<{
+    reservation: boolean;
+    blocklist: boolean;
+  }> {
+    const reservations = await dhcp.listReservations();
+    const blocklists = await dnsFilter.listBlocklists(AD_BLOCKING_PROFILE_ID);
+    return {
+      reservation: reservations.reservations.some(
+        (r) => r.mac_address.toLowerCase() === RESERVED_MAC,
+      ),
+      blocklist: blocklists.blocklists.some((b) => b.name === BLOCKLIST_NAME),
+    };
+  }
+
+  it("reports an idle subsystem before any operation", async () => {
+    const { status } = await backup.status();
+    expect(status.state).toBe("idle");
+  });
+
+  it("rejects an export whose passphrase is under the 12-character minimum", async () => {
+    const err = await backup
+      .export({ passphrase: SHORT_PASSPHRASE })
+      .catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(WardnetApiError);
+    expect((err as WardnetApiError).status).toBe(400);
+  });
+
+  it("seeds a unique reservation and blocklist", async () => {
+    const reservation = await dhcp.createReservation({
+      mac_address: RESERVED_MAC,
+      ip_address: RESERVED_IP,
+      hostname: RESERVATION_HOSTNAME,
+      description: "seed row for the #249 backup round-trip spec",
+    });
+    expect(reservation.reservation.ip_address).toBe(RESERVED_IP);
+
+    const blocklist = await dnsFilter.createBlocklist(AD_BLOCKING_PROFILE_ID, {
+      name: BLOCKLIST_NAME,
+      url: BLOCKLIST_URL,
+      cron_schedule: CRON_NEVER,
+      enabled: false,
+    });
+    expect(blocklist.blocklist.name).toBe(BLOCKLIST_NAME);
+
+    expect(await seedsPresent()).toEqual({ reservation: true, blocklist: true });
+  });
+
+  it("exports an encrypted bundle containing those seeds", async () => {
+    bundle = await backup.export({ passphrase: PASSPHRASE });
+
+    // age's armour-free binary output — assert it is substantial and opaque
+    // rather than sniffing for a magic header the archiver is free to change.
+    expect(bundle.size).toBeGreaterThan(1_024);
+
+    // The plaintext must never appear in the bundle: if the reserved MAC is
+    // greppable in the bytes, the age layer silently didn't happen.
+    const bytes = Buffer.from(await bundle.arrayBuffer());
+    expect(bytes.includes(Buffer.from(RESERVED_MAC, "utf8"))).toBe(false);
+  });
+
+  it("refuses to preview the bundle with the wrong passphrase", async () => {
+    const err = await backup
+      .previewImport(bundle, `${PASSPHRASE}-wrong`)
+      .catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(WardnetApiError);
+    expect((err as WardnetApiError).status).toBe(400);
+  });
+
+  it("loses both seeds when they are deleted", async () => {
+    await removeSeeds();
+    expect(await seedsPresent()).toEqual({
+      reservation: false,
+      blocklist: false,
+    });
+  });
+
+  it("previews the bundle as compatible and returns a token", async () => {
+    const preview = await backup.previewImport(bundle, PASSPHRASE);
+
+    expect(preview.compatible).toBe(true);
+    expect(preview.incompatibility_reason).toBeUndefined();
+    expect(preview.preview_token).not.toBe("");
+    // The database is always replaced; the config and secret store come along
+    // when present. Asserting non-empty rather than an exact list keeps this
+    // from breaking when the bundle gains a component.
+    expect(preview.files_to_replace.length).toBeGreaterThan(0);
+
+    // The manifest is the bundle's own provenance record — it must describe
+    // *this* daemon, since this daemon produced it moments ago.
+    expect(preview.manifest.wardnet_version).not.toBe("");
+    expect(preview.manifest.host_id).not.toBe("");
+    expect(preview.manifest.schema_version).toBeGreaterThan(0);
+    expect(preview.manifest.bundle_format_version).toBeGreaterThan(0);
+    expect(Number.isNaN(Date.parse(preview.manifest.created_at))).toBe(false);
+
+    // Nothing on disk changed yet — preview is pure inspection.
+    expect(await seedsPresent()).toEqual({
+      reservation: false,
+      blocklist: false,
+    });
+  });
+
+  it("rejects a preview token that was never issued", async () => {
+    const err = await backup
+      .applyImport({ preview_token: "00000000-0000-0000-0000-000000000000" })
+      .catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(WardnetApiError);
+    expect((err as WardnetApiError).status).toBe(400);
+  });
+
+  it(
+    "applies the restore, then recovers both seeds after a daemon restart",
+    async () => {
+      // Fresh token: the one from the preview test above is still inside its
+      // 5-minute TTL, but taking a new one keeps this test independent of how
+      // long the intervening assertions took on a slow runner.
+      const preview = await backup.previewImport(bundle, PASSPHRASE);
+      const applied = await backup.applyImport({
+        preview_token: preview.preview_token,
+      });
+
+      expect(applied.manifest.host_id).toBe(preview.manifest.host_id);
+      // The pre-restore state is retained as `.bak-<ts>` siblings so an
+      // operator has a manual way back.
+      expect(applied.snapshots.length).toBeGreaterThan(0);
+      appliedSnapshots = applied.snapshots;
+      for (const snapshot of applied.snapshots) {
+        expect(["database", "config", "keys"]).toContain(snapshot.kind);
+        expect(snapshot.path).toContain(".bak-");
+        expect(snapshot.size_bytes).toBeGreaterThan(0);
+      }
+
+      // Restart so the pool reopens the restored file. Until it does, the
+      // daemon is still serving the renamed pre-restore database.
+      const before = await daemonPid(DAEMON_AGENT);
+      expect(before.running).toBe(true);
+      await new SystemService(admin).restart();
+      await waitForDaemonRestart(DAEMON_AGENT, before.pid, 90_000);
+      await waitForReady(client, 90_000);
+
+      // Re-authenticate against the restored database. The admin row predates
+      // the export so the credentials are unchanged, but the pre-restart
+      // session token belonged to a connection pool that is now gone.
+      admin = await ensureAdminAndLogin(client);
+      backup = new BackupService(admin);
+      dhcp = new DhcpService(admin);
+      dnsFilter = new DnsFilterService(admin);
+
+      expect(await seedsPresent()).toEqual({
+        reservation: true,
+        blocklist: true,
+      });
+
+      // …and they came back with their contents intact, not just their keys.
+      const reservations = await dhcp.listReservations();
+      const restored = reservations.reservations.find(
+        (r) => r.mac_address.toLowerCase() === RESERVED_MAC,
+      );
+      expect(restored?.ip_address).toBe(RESERVED_IP);
+      expect(restored?.hostname).toBe(RESERVATION_HOSTNAME);
+
+      const blocklists = await dnsFilter.listBlocklists(AD_BLOCKING_PROFILE_ID);
+      const restoredList = blocklists.blocklists.find(
+        (b) => b.name === BLOCKLIST_NAME,
+      );
+      expect(restoredList?.url).toBe(BLOCKLIST_URL);
+      expect(restoredList?.enabled).toBe(false);
+    },
+    240_000,
+  );
+
+  it("lists the pre-restore snapshots", async () => {
+    const { snapshots } = await backup.listSnapshots();
+    expect(snapshots.length).toBeGreaterThan(0);
+
+    // Every snapshot the apply reported must be enumerable afterwards — the
+    // retention runner only prunes siblings older than 24 hours, so nothing
+    // created during this run can have been swept.
+    for (const applied of appliedSnapshots) {
+      expect(snapshots.map((s) => s.path)).toContain(applied.path);
+    }
+  });
+});

--- a/source/end2end-tests/daemon/tests/helpers.ts
+++ b/source/end2end-tests/daemon/tests/helpers.ts
@@ -738,6 +738,58 @@ export async function waitForJob(
   );
 }
 
+/** Shape of the daemon agent's `GET /pid` response. */
+export interface DaemonPidResponse {
+  pid: number;
+  running: boolean;
+}
+
+/**
+ * Read the daemon's PID from its pidfile via the test-agent running in server
+ * mode inside the wardnetd container. `running` is false when the pidfile is
+ * absent or names a dead process, which is what a mid-restart window looks
+ * like.
+ */
+export async function daemonPid(
+  daemonAgent: string,
+): Promise<DaemonPidResponse> {
+  return agentGet<DaemonPidResponse>(daemonAgent, "/pid");
+}
+
+/**
+ * Poll [`daemonPid`] until the daemon is running under a PID *different* from
+ * `previousPid` — i.e. systemd restarted the unit and the new process wrote a
+ * fresh pidfile. Returns the new PID. Throws on timeout.
+ *
+ * Errors from the agent are swallowed while polling: `RuntimeDirectory=wardnetd`
+ * is torn down and recreated across a restart, so the pidfile genuinely
+ * vanishes for a moment and a 404 there is expected, not a failure.
+ *
+ * Note this proves a *process* restart, not merely a reachable API — the API
+ * would answer identically if the daemon had never gone away.
+ */
+export async function waitForDaemonRestart(
+  daemonAgent: string,
+  previousPid: number,
+  timeoutMs = 60_000,
+): Promise<number> {
+  const res = await pollUntil(
+    () => daemonPid(daemonAgent).catch((err: unknown) => err),
+    (value) =>
+      typeof value === "object" &&
+      value !== null &&
+      "pid" in value &&
+      (value as DaemonPidResponse).running &&
+      (value as DaemonPidResponse).pid !== previousPid,
+    {
+      timeoutMs,
+      describe: (last) =>
+        `daemon did not restart under a new PID (previous=${previousPid}, last=${JSON.stringify(last)})`,
+    },
+  );
+  return (res as DaemonPidResponse).pid;
+}
+
 /**
  * Read a WireGuard `.conf` fixture from `fixtures/tunnels/` and return it
  * verbatim for `TunnelService.create` (issue #247). Resolved relative to this

--- a/source/end2end-tests/daemon/tests/system-restart.spec.ts
+++ b/source/end2end-tests/daemon/tests/system-restart.spec.ts
@@ -1,0 +1,100 @@
+import { beforeAll, describe, expect, it } from "vitest";
+import { InfoService, SystemService, WardnetApiError, WardnetClient } from "@wardnet/js";
+
+import {
+  API_BASE_URL,
+  AuthedClient,
+  DAEMON_AGENT,
+  daemonPid,
+  ensureAdminAndLogin,
+  waitForDaemonRestart,
+  waitForReady,
+} from "./helpers.js";
+
+/**
+ * `POST /api/system/restart` end-to-end (issue #249, E2E Stage 11).
+ *
+ * Order-sensitive by construction: it takes the daemon down mid-suite. It
+ * lives in its own file so vitest's `fileParallelism: false` ordering keeps it
+ * atomic, and the last assertion in the file is the recovery one — the daemon
+ * is verified healthy again *before* control returns to the runner, so the
+ * next spec file's `waitForReady` has nothing left to wait for. That is
+ * deliberately stronger than a global setup hook: a failure to come back
+ * surfaces here, attributed to the restart, instead of as a mystery timeout in
+ * whatever file happened to run next.
+ *
+ * The daemon exits with code 0 after a ~500 ms grace; `Restart=always` +
+ * `RestartSec=2s` in `wardnetd.service` bring it back. Two restarts in one
+ * suite run (this one and `backup-roundtrip.spec.ts`) stay well inside the
+ * `StartLimitBurst=5` / `StartLimitIntervalSec=30` budget, so the
+ * `wardnetd-rollback.service` `OnFailure=` hook never arms.
+ */
+describe("system restart (issue #249)", () => {
+  const client = new WardnetClient({ baseUrl: API_BASE_URL });
+  let admin: AuthedClient;
+  let system: SystemService;
+
+  beforeAll(async () => {
+    await waitForReady(client);
+    admin = await ensureAdminAndLogin(client);
+    system = new SystemService(admin);
+  }, 120_000);
+
+  it("rejects an unauthenticated restart request with 401", async () => {
+    const anon = new SystemService(new WardnetClient({ baseUrl: API_BASE_URL }));
+    const err = await anon.restart().catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(WardnetApiError);
+    expect((err as WardnetApiError).status).toBe(401);
+
+    // And the daemon is still up — a rejected request must not have scheduled
+    // anything. This assertion is why the negative case runs first.
+    const { running } = await daemonPid(DAEMON_AGENT);
+    expect(running).toBe(true);
+  });
+
+  it(
+    "restarts the daemon under a new PID and recovers /api/info",
+    async () => {
+      const before = await daemonPid(DAEMON_AGENT);
+      expect(before.running).toBe(true);
+
+      const uptimeBefore = (await new InfoService(client).getInfo())
+        .uptime_seconds;
+
+      // Returns 204 as soon as the restart is *scheduled* — the process is
+      // still alive at this point, which is why the PID poll below is the
+      // real signal.
+      await system.restart();
+
+      // ~500 ms grace + graceful shutdown of every runner + RestartSec=2s +
+      // startup. A generous ceiling keeps a slow CI runner from reading as a
+      // failure to restart.
+      const newPid = await waitForDaemonRestart(DAEMON_AGENT, before.pid, 90_000);
+      expect(newPid).not.toBe(before.pid);
+
+      // The API must come back on its own — no manual intervention, no
+      // compose restart.
+      await waitForReady(client, 90_000);
+      const info = await new InfoService(client).getInfo();
+
+      // A fresh process restarts the uptime clock. Guarding on "lower than
+      // before" rather than "near zero" avoids racing a slow poll loop that
+      // only notices the new process seconds later.
+      expect(info.uptime_seconds).toBeLessThan(uptimeBefore);
+    },
+    180_000,
+  );
+
+  it("serves authenticated admin requests again after the restart", async () => {
+    // Sessions live in the database, so the token minted before the restart
+    // survives it. Re-using `admin` rather than logging in again is the
+    // assertion: a restart that dropped session state would 401 here.
+    const status = await system.getStatus();
+    expect(status.release_version).not.toBe("");
+
+    // The daemon records its own exit, so the restart it just performed is
+    // visible as a graceful shutdown rather than a crash.
+    expect(status.last_shutdown.state).toBe("graceful");
+    expect(status.last_shutdown.at).not.toBeNull();
+  });
+});

--- a/source/end2end-tests/daemon/tests/system-restart.spec.ts
+++ b/source/end2end-tests/daemon/tests/system-restart.spec.ts
@@ -14,14 +14,19 @@ import {
 /**
  * `POST /api/system/restart` end-to-end (issue #249, E2E Stage 11).
  *
- * Order-sensitive by construction: it takes the daemon down mid-suite. It
- * lives in its own file so vitest's `fileParallelism: false` ordering keeps it
- * atomic, and the last assertion in the file is the recovery one — the daemon
- * is verified healthy again *before* control returns to the runner, so the
- * next spec file's `waitForReady` has nothing left to wait for. That is
- * deliberately stronger than a global setup hook: a failure to come back
- * surfaces here, attributed to the restart, instead of as a mystery timeout in
- * whatever file happened to run next.
+ * Destructive by construction: it takes the daemon down mid-suite. It lives in
+ * its own file so the take-down and the recovery are one indivisible unit
+ * under `fileParallelism: false` — nothing else runs in between. The last
+ * assertion in the file is the recovery one, so the daemon is verified healthy
+ * again *before* control returns to the runner and the next spec file's
+ * `waitForReady` has nothing left to wait for. That is deliberately stronger
+ * than a global setup hook: a failure to come back surfaces here, attributed
+ * to the restart, instead of as a mystery timeout in whatever file happened to
+ * run next.
+ *
+ * Nothing here depends on *where* this file lands in the run. Vitest orders
+ * files by size on a cold cache and by recorded duration afterwards, so an
+ * assertion that assumed a late slot would be a latent flake.
  *
  * The daemon exits with code 0 after a ~500 ms grace; `Restart=always` +
  * `RestartSec=2s` in `wardnetd.service` bring it back. Two restarts in one
@@ -58,8 +63,7 @@ describe("system restart (issue #249)", () => {
       const before = await daemonPid(DAEMON_AGENT);
       expect(before.running).toBe(true);
 
-      const uptimeBefore = (await new InfoService(client).getInfo())
-        .uptime_seconds;
+      const restartRequestedAt = Date.now();
 
       // Returns 204 as soon as the restart is *scheduled* — the process is
       // still alive at this point, which is why the PID poll below is the
@@ -77,10 +81,14 @@ describe("system restart (issue #249)", () => {
       await waitForReady(client, 90_000);
       const info = await new InfoService(client).getInfo();
 
-      // A fresh process restarts the uptime clock. Guarding on "lower than
-      // before" rather than "near zero" avoids racing a slow poll loop that
-      // only notices the new process seconds later.
-      expect(info.uptime_seconds).toBeLessThan(uptimeBefore);
+      // A fresh process restarts the uptime clock: the new daemon cannot have
+      // been up longer than the wall-clock time since the restart was
+      // requested. Bounding against measured elapsed time rather than the
+      // pre-restart uptime keeps this true no matter where the file lands in
+      // the run — a "lower than before" check would be meaningless if this
+      // file happened to run first, when the previous uptime is itself small.
+      const elapsedSeconds = Math.ceil((Date.now() - restartRequestedAt) / 1_000);
+      expect(info.uptime_seconds).toBeLessThanOrEqual(elapsedSeconds);
     },
     180_000,
   );

--- a/source/end2end-tests/daemon/tests/system-status.spec.ts
+++ b/source/end2end-tests/daemon/tests/system-status.spec.ts
@@ -1,0 +1,109 @@
+import { beforeAll, describe, expect, it } from "vitest";
+import { InfoService, SystemService, WardnetApiError, WardnetClient } from "@wardnet/js";
+
+import {
+  API_BASE_URL,
+  AuthedClient,
+  ensureAdminAndLogin,
+  waitForReady,
+} from "./helpers.js";
+
+/**
+ * `GET /api/system/status` against the live daemon (issue #249, E2E Stage 11).
+ *
+ * Read-only throughout — no daemon state is mutated, so this file is safe in
+ * any position of the suite. It asserts the *shape and internal consistency*
+ * of the snapshot rather than exact values: uptime, CPU, and memory move
+ * between reads, and the device count depends on which DHCP specs have run
+ * before this one under vitest's shared-stack model.
+ */
+describe("system status (issue #249)", () => {
+  const client = new WardnetClient({ baseUrl: API_BASE_URL });
+  let admin: AuthedClient;
+  let system: SystemService;
+
+  beforeAll(async () => {
+    await waitForReady(client);
+    admin = await ensureAdminAndLogin(client);
+    system = new SystemService(admin);
+  }, 120_000);
+
+  it("reports the daemon's versions, and they match /api/info", async () => {
+    const status = await system.getStatus();
+    // /api/info is the unauthenticated surface over the same two constants
+    // (`version::VERSION` / `RELEASE_VERSION`). They are baked in at compile
+    // time, so any divergence means the two handlers read different sources.
+    const info = await new InfoService(client).getInfo();
+
+    expect(status.version).toBe(info.version);
+    expect(status.release_version).toBe(info.release_version);
+    // The diagnostic version is git-derived and carries dev suffixes; the
+    // release version is pure CalVer from the workspace CALVER file.
+    expect(status.version).not.toBe("");
+    expect(status.release_version).toMatch(/^\d{4}\.\d{2}\.\d{2}/);
+  });
+
+  it("reports a monotonically advancing uptime", async () => {
+    const first = await system.getStatus();
+    expect(first.uptime_seconds).toBeGreaterThanOrEqual(0);
+
+    // The compose stack waits on wardnetd's healthcheck before the runner
+    // starts, so a second read a second later must not go backwards. Strict
+    // growth is not asserted — uptime is whole seconds and the two reads can
+    // land inside the same one.
+    await new Promise((resolve) => setTimeout(resolve, 1_500));
+    const second = await system.getStatus();
+    expect(second.uptime_seconds).toBeGreaterThanOrEqual(first.uptime_seconds);
+  });
+
+  it("reports device and tunnel counts consistent with the collections", async () => {
+    const status = await system.getStatus();
+
+    expect(Number.isInteger(status.device_count)).toBe(true);
+    expect(status.device_count).toBeGreaterThanOrEqual(0);
+    expect(Number.isInteger(status.tunnel_count)).toBe(true);
+    expect(status.tunnel_count).toBeGreaterThanOrEqual(0);
+    // Active tunnels are a subset of configured tunnels — an invariant that
+    // holds no matter which tunnel specs have run.
+    expect(status.tunnel_active_count).toBeLessThanOrEqual(status.tunnel_count);
+    expect(status.tunnel_active_count).toBeGreaterThanOrEqual(0);
+  });
+
+  it("reports plausible host resource metrics", async () => {
+    const status = await system.getStatus();
+
+    // The DB file exists by definition — the request that returned this
+    // response was served from it.
+    expect(status.db_size_bytes).toBeGreaterThan(0);
+    expect(status.cpu_usage_percent).toBeGreaterThanOrEqual(0);
+    expect(status.cpu_usage_percent).toBeLessThanOrEqual(100);
+    expect(status.memory_total_bytes).toBeGreaterThan(0);
+    expect(status.memory_used_bytes).toBeGreaterThan(0);
+    expect(status.memory_used_bytes).toBeLessThanOrEqual(status.memory_total_bytes);
+    expect(status.disk_total_bytes).toBeGreaterThan(0);
+    expect(status.disk_free_bytes).toBeLessThanOrEqual(status.disk_total_bytes);
+  });
+
+  it("classifies the previous shutdown", async () => {
+    const { last_shutdown: last } = await system.getStatus();
+
+    // `unknown` on the very first boot of a fresh volume; `graceful` or
+    // `unclean` once a prior run has been recorded — which specs that restart
+    // the daemon (system-restart, backup-roundtrip, watchdog) produce. All
+    // three are legal here; what must hold is the `at`-vs-state invariant.
+    expect(["unknown", "graceful", "unclean"]).toContain(last.state);
+    if (last.state === "unknown") {
+      expect(last.at).toBeNull();
+    } else {
+      expect(last.at).not.toBeNull();
+      expect(Number.isNaN(Date.parse(last.at!))).toBe(false);
+    }
+  });
+
+  it("rejects an unauthenticated read with 401", async () => {
+    const anon = new SystemService(new WardnetClient({ baseUrl: API_BASE_URL }));
+    const err = await anon.getStatus().catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(WardnetApiError);
+    expect((err as WardnetApiError).status).toBe(401);
+  });
+});

--- a/source/end2end-tests/daemon/tests/update-status.spec.ts
+++ b/source/end2end-tests/daemon/tests/update-status.spec.ts
@@ -1,0 +1,154 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { UpdateService, WardnetApiError, WardnetClient } from "@wardnet/js";
+
+import {
+  API_BASE_URL,
+  AuthedClient,
+  ensureAdminAndLogin,
+  waitForReady,
+} from "./helpers.js";
+
+// Versions published by the `update_manifest_server` fixture (see
+// fixtures/update-manifests/). `stable.json` is the generator's empty
+// placeholder — "nothing released on this channel". `beta.json` advertises a
+// version chosen to outrank anything this repo will ever build, so
+// `update_available` is deterministic regardless of the CALVER the image was
+// compiled with.
+const FIXTURE_BETA_VERSION = "9999.12.31";
+
+/**
+ * Auto-update status / check / channel switching against a fixture manifest
+ * server (issue #249, E2E Stage 11).
+ *
+ * The daemon's `[update] manifest_base_url` is rewritten to
+ * `http://10.92.0.56` by the compose entrypoint, so every check in this file
+ * resolves against `fixtures/update-manifests/<channel>.json` and never
+ * touches releases.wardnet.network.
+ *
+ * Nothing here installs. `auto_update_enabled` is left at its default
+ * (`false`) throughout — flipping it on with a fixture release visible would
+ * hand the background `UpdateRunner` a download of an asset that does not
+ * exist, which is a different (and much heavier) spec than this one.
+ */
+describe("update status + channel (issue #249)", () => {
+  const client = new WardnetClient({ baseUrl: API_BASE_URL });
+  let admin: AuthedClient;
+  let update: UpdateService;
+
+  beforeAll(async () => {
+    await waitForReady(client);
+    admin = await ensureAdminAndLogin(client);
+    update = new UpdateService(admin);
+
+    // Other specs don't touch the update subsystem, but a re-run against a
+    // persistent volume would inherit whatever channel the previous run left
+    // behind. Normalise before asserting the default-channel behaviour.
+    await update.updateConfig({ channel: "stable", auto_update_enabled: false });
+  }, 120_000);
+
+  afterAll(async () => {
+    // Leave the box on stable with auto-update off, so a subsequent run — and
+    // any spec that later reads system state — sees the shipped defaults.
+    try {
+      await update.updateConfig({
+        channel: "stable",
+        auto_update_enabled: false,
+      });
+    } catch {
+      // ignore
+    }
+  });
+
+  it("reports a resting status on the stable channel", async () => {
+    const { status } = await update.status();
+
+    expect(status.channel).toBe("stable");
+    expect(status.auto_update_enabled).toBe(false);
+    expect(status.current_version).not.toBe("");
+    expect(status.install_phase).toEqual({ phase: "idle" });
+    expect(status.pending_version).toBeNull();
+    // `allow_edge_channel` is deliberately absent from the e2e TOML — putting
+    // a box on edge must require root on the box, not just an admin session.
+    expect(status.edge_available).toBe(false);
+  });
+
+  it("reports no update available when the channel manifest is a placeholder", async () => {
+    const { status } = await update.check();
+
+    // stable.json carries `version: ""` and `binary: null`, which the daemon
+    // reads as "no release published" rather than as a fetch failure.
+    expect(status.latest_version).toBeNull();
+    expect(status.update_available).toBe(false);
+    // A check always records its timestamp, even when it finds nothing.
+    expect(status.last_check_at).not.toBeNull();
+    expect(Number.isNaN(Date.parse(status.last_check_at!))).toBe(false);
+  });
+
+  it("picks up the fixture release after switching to the beta channel", async () => {
+    const switched = await update.updateConfig({ channel: "beta" });
+    expect(switched.status.channel).toBe("beta");
+    // Switching channels invalidates the version resolved against the old
+    // one — it was never a beta version and must not be offered as one.
+    expect(switched.status.latest_version).toBeNull();
+
+    const { status } = await update.check();
+    expect(status.channel).toBe("beta");
+    expect(status.latest_version).toBe(FIXTURE_BETA_VERSION);
+    expect(status.update_available).toBe(true);
+    // Discovering a release is not installing one.
+    expect(status.install_phase).toEqual({ phase: "idle" });
+    expect(status.pending_version).toBeNull();
+    expect(status.auto_update_enabled).toBe(false);
+  });
+
+  it("persists the resolved version across a plain status read", async () => {
+    // `status` reads the stored `update_last_known_version`; it does not
+    // re-fetch. This is what the Settings UI polls, so it must agree with the
+    // check that preceded it.
+    const { status } = await update.status();
+    expect(status.channel).toBe("beta");
+    expect(status.latest_version).toBe(FIXTURE_BETA_VERSION);
+    expect(status.update_available).toBe(true);
+  });
+
+  it("clears the beta finding when switching back to stable", async () => {
+    const { status } = await update.updateConfig({ channel: "stable" });
+    expect(status.channel).toBe("stable");
+    expect(status.latest_version).toBeNull();
+    expect(status.update_available).toBe(false);
+  });
+
+  it("refuses the edge channel on a box without the deploy-time flag", async () => {
+    const err = await update
+      .updateConfig({ channel: "edge" })
+      .catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(WardnetApiError);
+    expect((err as WardnetApiError).status).toBe(403);
+
+    // The rejection must be total: a body carrying both a channel and an
+    // auto-update flag is validated before anything is written.
+    const rejected = await update
+      .updateConfig({ channel: "edge", auto_update_enabled: true })
+      .catch((e: unknown) => e);
+    expect(rejected).toBeInstanceOf(WardnetApiError);
+
+    const { status } = await update.status();
+    expect(status.channel).toBe("stable");
+    expect(status.auto_update_enabled).toBe(false);
+  });
+
+  it("exposes an install history endpoint", async () => {
+    // Nothing in the e2e stack installs, so the list is expected to be empty —
+    // the assertion is that the endpoint is wired and returns the envelope,
+    // not that it has content.
+    const { entries } = await update.history(5);
+    expect(Array.isArray(entries)).toBe(true);
+  });
+
+  it("rejects unauthenticated access to the update surface", async () => {
+    const anon = new UpdateService(new WardnetClient({ baseUrl: API_BASE_URL }));
+    const err = await anon.status().catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(WardnetApiError);
+    expect((err as WardnetApiError).status).toBe(401);
+  });
+});

--- a/source/end2end-tests/daemon/tests/watchdog.spec.ts
+++ b/source/end2end-tests/daemon/tests/watchdog.spec.ts
@@ -1,7 +1,13 @@
 import { beforeAll, describe, expect, it } from "vitest";
 import { WardnetClient } from "@wardnet/js";
 
-import { agentGet, agentPost, API_BASE_URL, waitForReady } from "./helpers.js";
+import {
+  agentPost,
+  API_BASE_URL,
+  daemonPid,
+  waitForDaemonRestart,
+  waitForReady,
+} from "./helpers.js";
 
 // The daemon-side test agent shares the wardnetd container (same PID
 // namespace), so it can signal the daemon process directly. Compose DNS
@@ -11,11 +17,6 @@ const TEST_AGENT_URL = "http://wardnetd:3001";
 // The unauthenticated health endpoint is served at the host root (not under
 // /api). Derive it from API_BASE_URL so a port/host override stays consistent.
 const HEALTH_URL = `${API_BASE_URL.replace(/\/api\/?$/, "")}/health`;
-
-interface PidResponse {
-  pid: number;
-  running: boolean;
-}
 
 interface HealthComponent {
   name: string;
@@ -29,7 +30,7 @@ interface HealthBody {
 }
 
 async function getPid(): Promise<number> {
-  const res = await agentGet<PidResponse>(TEST_AGENT_URL, "/pid");
+  const res = await daemonPid(TEST_AGENT_URL);
   expect(res.running).toBe(true);
   return res.pid;
 }
@@ -38,38 +39,6 @@ async function getHealth(): Promise<{ status: number; body: HealthBody }> {
   const res = await fetch(HEALTH_URL);
   const body = (await res.json()) as HealthBody;
   return { status: res.status, body };
-}
-
-/**
- * Poll `/pid` until the daemon is running under a PID *different* from
- * `previousPid` — i.e. systemd restarted the unit and the new process wrote a
- * fresh pidfile. Returns the new PID.
- */
-async function waitForRestart(
-  previousPid: number,
-  timeoutMs: number,
-): Promise<number> {
-  const deadline = Date.now() + timeoutMs;
-  let last: unknown;
-  while (Date.now() < deadline) {
-    try {
-      const res = await agentGet<PidResponse>(TEST_AGENT_URL, "/pid");
-      last = res;
-      if (res.running && res.pid !== previousPid) {
-        return res.pid;
-      }
-    } catch (err) {
-      // The pidfile vanishes between the old process dying and the new one
-      // starting (RuntimeDirectory is torn down and recreated); keep polling.
-      last = err;
-    }
-    await new Promise((resolve) => setTimeout(resolve, 1000));
-  }
-  throw new Error(
-    `daemon did not restart under a new PID within ${timeoutMs}ms; last: ${JSON.stringify(
-      last,
-    )}`,
-  );
 }
 
 describe("Hardware/soft watchdog (issue #214)", () => {
@@ -112,7 +81,11 @@ describe("Hardware/soft watchdog (issue #214)", () => {
 
       // WatchdogSec=15 + kill escalation + RestartSec + startup. Generous
       // ceiling to stay robust on a slow runner.
-      const newPid = await waitForRestart(originalPid, 75_000);
+      const newPid = await waitForDaemonRestart(
+        TEST_AGENT_URL,
+        originalPid,
+        75_000,
+      );
       expect(newPid).not.toBe(originalPid);
 
       // The restarted daemon must come back fully healthy so subsequent specs


### PR DESCRIPTION
Closes #249

E2E Stage 11 — `SystemService`, `BackupService` and `UpdateService` coverage against the live daemon compose stack. Writing the backup spec surfaced three daemon defects that no existing test could catch; those are fixed here too.

## Infra

- **`update_manifest_server`** — busybox httpd on `wardnet_wan` (`10.92.0.56`) serving `fixtures/update-manifests/<channel>.json` in the same shape the marketing site publishes. `stable`/`edge` carry the generator's empty placeholder; `beta` advertises a fixture release (`9999.12.31`) chosen to outrank any build, so `update_available` is deterministic regardless of the CALVER the image was compiled with.
- The `wardnetd` entrypoint injects `[update] manifest_base_url` into `wardnet.toml`, reusing the idempotent inject-or-append shape of the existing nordvpn override. `allow_edge_channel` is deliberately left unset so the deploy-time edge gate can be asserted.

Plain HTTP rather than the HTTPS the issue sketched: the daemon's manifest fetch is a bare `reqwest` GET that accepts any scheme, and release authenticity rests on the minisign signature over the *asset*, not on TLS over the manifest. Terminating TLS would mean minting a CA and baking it into the daemon image's trust store to exercise `reqwest` rather than Wardnet code. Rationale is recorded in `fixtures/update-manifests/README.md`.

## Specs

- **`system-status`** — versions cross-checked against `/api/info`, uptime monotonicity, device/tunnel count invariants, host resource metrics, and the `last_shutdown` state-vs-`at` invariant.
- **`system-restart`** — 401 first (asserting a rejected request scheduled nothing), then restart → new PID via the test-agent pidfile → `/api/info` recovers with a reset uptime → the pre-restart session still authenticates and the exit records as `graceful`. Recovery is asserted *inside* the file, so a failure to come back is attributed to the restart instead of surfacing as a timeout in whatever file runs next.
- **`backup-roundtrip`** — seeds a reservation + a disabled blocklist, exports, asserts the seeded MAC is not greppable in the bundle, deletes both, previews, applies, restarts (required — the live pool holds an fd to the file `apply_import` renamed aside), then verifies both rows return with contents intact and that `listSnapshots` enumerates the `.bak-` siblings. Covers short-passphrase, wrong-passphrase and unknown-token rejections.
- **`update-status`** — placeholder manifest → no update; switch to beta → picks up the fixture release; a plain `status` read agrees with the preceding `check`; switching back clears it; edge refused with 403 and nothing partially written.

Also hoists the pidfile polling `watchdog.spec.ts` had inline into `daemonPid` / `waitForDaemonRestart` helpers, and adds the system and update surfaces to the auth-coverage matrix.

## Daemon fixes

Neither e2e suite could have caught any of these — the first two are masked by the container image, the third by test-harness layout.

1. **Restore could not write the config on real hardware.** `apply_import` renames `/etc/wardnet/wardnet.toml` aside and moves the bundle's copy into place, but `wardnetd.service` sets `ProtectSystem=strict` with `ReadWritePaths` covering only `/var/lib/wardnet` and `/var/log/wardnet` — so `/etc` is read-only and both renames fail with `EROFS`. Every test passed because `Dockerfile.base` drops in `ProtectSystem=no`. Granted `/etc/wardnet` (scoped to the one directory; already `wardnet:wardnet 0750`, so POSIX was never the blocker).

   The auto-updater ships only binaries, so the unit change needs a post-upgrade migration to reach existing installs. `0003_wardnetd_unit_refresh` already did this for the `StartLimit*` fix and is recorded applied, so a box that ran it would never re-run it. Appended **`0004_wardnetd_unit_config_write`**, reusing the same reconciler under a new id: an existing Pi gets the new unit plus a `daemon-reload`, a fresh install is a byte-identical no-op.

2. **Config snapshots were invisible and immortal.** `list_snapshots` walked exactly one directory — the database's parent — but `apply_import` renames each live file aside *in place*, so on a real install the config snapshot lands in `/etc/wardnet`. It never appeared in `GET /api/backup/snapshots`, and because the cleanup runner shares the walk, nothing ever pruned it. Now walks both directories, deduped for the colocated case. Every existing test colocated the two paths, which is exactly why this survived; the new tests use a harness variant reproducing production's split layout, and both were verified to fail against the old code.

3. **`tokio-tungstenite` doc comment was stale.** It still claimed a pin to the 0.29 that axum's `ws` resolves; since the bump to 0.30 both are linked. The comment now states that, why it is safe (we use only the client side, axum owns the server side, no types cross), what it costs on a Pi, and when to collapse it back.

## Known gap

The `ReadWritePaths` grant means a restore now writes `wardnet.toml`, so an admin session with a crafted bundle can set deploy-time-only keys — notably `[update] allow_edge_channel`, whose stated point is to require root on the box rather than an admin session. Closing that means preserving deploy-time keys across a restore instead of taking them from the bundle. Documented in the unit; left for its own change rather than expanded into this one.

## Verification

- `make check-daemon` — exit 0 (fmt, clippy `-D warnings`, full workspace test suite).
- `yarn type-check` in `source/end2end-tests/daemon` — clean.
- New backup unit tests confirmed red against the pre-fix code.
- **The e2e specs themselves have not been executed.** `make end2end-daemon` cannot boot on macOS — rootless podman refuses systemd as PID 1 (`Failed to create /init.scope control group`), and the *unmodified* committed compose fails identically, so it is environmental. The test image does build, and the container logs confirm the new `manifest_base_url` injection fires. CI is the first real run of these specs.
