### PR TITLE
feat(devices): surface identification signals on the device detail view

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -25714,7 +25714,8 @@
         "type": "object",
         "description": "Response for GET /api/devices/:id (admin).",
         "required": [
-          "device"
+          "device",
+          "signals"
         ],
         "properties": {
           "current_rule": {
@@ -25729,6 +25730,13 @@
           },
           "device": {
             "$ref": "#/components/schemas/DeviceWithStatus"
+          },
+          "signals": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/DeviceSignal"
+            },
+            "description": "Identification signals observed for this device, most recent first\n(issue #1099). Empty is the normal case for a device that has only ever\nbeen seen by ARP — it is an absence of evidence, not a failure."
           }
         }
       },
@@ -25870,6 +25878,43 @@
             "$ref": "#/components/schemas/RuleRequestStatus"
           }
         }
+      },
+      "DeviceSignal": {
+        "type": "object",
+        "description": "A single observed fact that helps identify a device (issue #1099).\n\nDeliberately multi-valued per device: a device can announce several mDNS\nservices, and each signal is independent evidence rather than a field that\noverwrites the last one.",
+        "required": [
+          "kind",
+          "value",
+          "inferred",
+          "observed_at"
+        ],
+        "properties": {
+          "inferred": {
+            "type": "boolean",
+            "description": "`true` when the raw observation matched the curated vendor catalog, so\nthis signal is what named the device. Surfaced because a catalog match\nis a hedged guess: an admin looking at \"likely Govee\" needs to see the\nobservation it was derived from."
+          },
+          "kind": {
+            "$ref": "#/components/schemas/DeviceSignalKind"
+          },
+          "observed_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "value": {
+            "type": "string"
+          }
+        }
+      },
+      "DeviceSignalKind": {
+        "type": "string",
+        "description": "The kind of an [`DeviceSignal`].",
+        "enum": [
+          "dhcp_hostname",
+          "dhcp_param_list",
+          "dhcp_vendor_class",
+          "mdns_service",
+          "probed_port"
+        ]
       },
       "DeviceType": {
         "type": "string",

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -25891,7 +25891,7 @@
         "properties": {
           "inferred": {
             "type": "boolean",
-            "description": "`true` when the raw observation matched the curated vendor catalog, so\nthis signal is what named the device. Surfaced because a catalog match\nis a hedged guess: an admin looking at \"likely Govee\" needs to see the\nobservation it was derived from."
+            "description": "`true` when the value matched a vendor in the curated catalog.\n\nDeliberately *not* \"this signal named the device\": naming is\nfirst-writer-wins against a `NULL` manufacturer (see\n`set_manufacturer_if_absent`), so a device already named by its IEEE\nregistrant collects matching signals that changed nothing. Surfaced\nbecause a match is still the evidence an admin needs when the name is\nitself a hedge (\"Likely Govee\")."
           },
           "kind": {
             "$ref": "#/components/schemas/DeviceSignalKind"

--- a/source/admin-site/src/components/features/DeviceIdentificationCard.tsx
+++ b/source/admin-site/src/components/features/DeviceIdentificationCard.tsx
@@ -1,0 +1,82 @@
+import { Card, CardContent, CardHeader, CardTitle } from "@wardnet/web";
+import { Text } from "@wardnet/web";
+import { groupSignalsByKind, timeAgo } from "@wardnet/web";
+import type { DeviceSignal } from "@wardnet/js";
+
+interface DeviceIdentificationCardProps {
+  signals: DeviceSignal[];
+}
+
+/**
+ * Read-only view of everything Wardnet has observed about a device's identity
+ * (issue #1099).
+ *
+ * This is the provenance behind the manufacturer shown on the identity card:
+ * when that reads "Likely Govee", the evidence for it is here.
+ */
+export function DeviceIdentificationCard({
+  signals,
+}: DeviceIdentificationCardProps) {
+  const groups = groupSignalsByKind(signals);
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Identification signals</CardTitle>
+      </CardHeader>
+      <CardContent>
+        {groups.length === 0 ? (
+          // An empty list is the ordinary case for a device that has only ever
+          // been seen by ARP. Say so plainly — reading this as a Wardnet
+          // failure is the exact confusion issue #1099 was filed about.
+          <Text as="p" size="sm" className="text-ink-3">
+            Nothing observed yet. Wardnet records identification signals as a
+            device uses the network — when it requests an address, or announces
+            a service. A device that only responds to address lookups gives
+            nothing away.
+          </Text>
+        ) : (
+          <div className="col gap-6">
+            {groups.map((group) => (
+              <div key={group.kind}>
+                <Text
+                  as="h3"
+                  size="xs"
+                  className="uppercase tracking-wide text-ink-3"
+                  title={group.display.hint}
+                >
+                  {group.display.label}
+                </Text>
+                <ul className="mt-2 col gap-1">
+                  {group.signals.map((signal) => (
+                    <li
+                      key={`${signal.kind}:${signal.value}`}
+                      className="flex flex-wrap items-baseline gap-x-3"
+                    >
+                      <Text as="span" size="sm" className="font-mono">
+                        {signal.value}
+                      </Text>
+                      {signal.inferred && (
+                        <Text
+                          as="span"
+                          size="xs"
+                          className="rounded bg-surface-2 px-1.5 py-0.5 text-ink-3"
+                          title="This observation matched Wardnet's vendor list and is what named the device."
+                        >
+                          Matched vendor list
+                        </Text>
+                      )}
+                      <Text as="span" size="xs" className="text-ink-3">
+                        {timeAgo(signal.observed_at)}
+                      </Text>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            ))}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/source/admin-site/src/components/features/DeviceIdentificationCard.tsx
+++ b/source/admin-site/src/components/features/DeviceIdentificationCard.tsx
@@ -29,11 +29,16 @@ export function DeviceIdentificationCard({
           // An empty list is the ordinary case for a device that has only ever
           // been seen by ARP. Say so plainly — reading this as a Wardnet
           // failure is the exact confusion issue #1099 was filed about.
+          //
+          // The copy names only what the daemon actually records today: the
+          // DHCP options captured in `dhcp/server.rs`. Promising mDNS or port
+          // observation here would tell an admin their device announces
+          // nothing when the truth is that Wardnet never looked (#1115/#1116).
           <Text as="p" size="sm" className="text-ink-3">
-            Nothing observed yet. Wardnet records identification signals as a
-            device uses the network — when it requests an address, or announces
-            a service. A device that only responds to address lookups gives
-            nothing away.
+            Nothing observed yet. Wardnet learns a device's identity from what
+            it says when it asks for a network address, so a device with a fixed
+            address — or one that has not renewed since Wardnet was installed —
+            has never had the chance to tell us anything.
           </Text>
         ) : (
           <div className="col gap-6">
@@ -53,17 +58,33 @@ export function DeviceIdentificationCard({
                       key={`${signal.kind}:${signal.value}`}
                       className="flex flex-wrap items-baseline gap-x-3"
                     >
-                      <Text as="span" size="sm" className="font-mono">
+                      {/* Signal values run to 128 chars and DHCP option lists
+                          carry no natural break opportunity, so the value has
+                          to be allowed to shrink (`min-w-0`) and wrap
+                          mid-token (`break-all`) or it pushes the card open
+                          and scrolls the page sideways. */}
+                      <Text
+                        as="span"
+                        size="sm"
+                        className="min-w-0 break-all font-mono"
+                      >
                         {signal.value}
                       </Text>
                       {signal.inferred && (
                         <Text
                           as="span"
                           size="xs"
-                          className="rounded bg-surface-2 px-1.5 py-0.5 text-ink-3"
-                          title="This observation matched Wardnet's vendor list and is what named the device."
+                          className="shrink-0 rounded bg-surface-2 px-1.5 py-0.5 text-ink-3"
+                          // Deliberately does NOT claim this signal named the
+                          // device. Naming is first-writer-wins against an
+                          // empty manufacturer, so a device already named by
+                          // its IEEE registrant collects matching signals that
+                          // changed nothing — and a device can match two
+                          // different vendors at once (a TV answering both
+                          // _googlecast._tcp and _airplay._tcp).
+                          title="This value matches a vendor in Wardnet's own list. It is evidence about the device, not necessarily where its manufacturer name came from."
                         >
-                          Matched vendor list
+                          Matches vendor list
                         </Text>
                       )}
                       <Text as="span" size="xs" className="text-ink-3">

--- a/source/admin-site/src/pages/DeviceDetail.tsx
+++ b/source/admin-site/src/pages/DeviceDetail.tsx
@@ -6,6 +6,7 @@ import { StatusBadge } from "@/components/compound/StatusBadge";
 import { DeviceDnsFilterCard } from "@/components/features/DeviceDnsFilterCard";
 import { DeviceDnsCaptureCard } from "@/components/features/DeviceDnsCaptureCard";
 import { DeviceIdentityCard } from "@/components/features/DeviceIdentityCard";
+import { DeviceIdentificationCard } from "@/components/features/DeviceIdentificationCard";
 import { DeviceNetworkCard } from "@/components/features/DeviceNetworkCard";
 import { DeviceSettingsCard } from "@/components/features/DeviceSettingsCard";
 import { DeviceRoutingProfilesCard } from "@/components/features/DeviceRoutingProfilesCard";
@@ -98,6 +99,7 @@ export default function DeviceDetail() {
       />
 
       <DeviceIdentityCard device={device} />
+      <DeviceIdentificationCard signals={data.signals} />
       <DeviceSettingsCard device={device} currentRule={data.current_rule} />
       <DeviceRoutingProfilesCard device={device} />
       <DeviceZoneCard device={device} />

--- a/source/admin-site/src/pages/DeviceDetail.tsx
+++ b/source/admin-site/src/pages/DeviceDetail.tsx
@@ -99,7 +99,10 @@ export default function DeviceDetail() {
       />
 
       <DeviceIdentityCard device={device} />
-      <DeviceIdentificationCard signals={data.signals} />
+      {/* `?? []` guards a browser holding a cached bundle newer than the
+          daemon it is talking to: a missing field must render the empty
+          state, not throw out the whole detail page. */}
+      <DeviceIdentificationCard signals={data.signals ?? []} />
       <DeviceSettingsCard device={device} currentRule={data.current_rule} />
       <DeviceRoutingProfilesCard device={device} />
       <DeviceZoneCard device={device} />

--- a/source/admin-site/tests/components/features/DeviceIdentificationCard.test.tsx
+++ b/source/admin-site/tests/components/features/DeviceIdentificationCard.test.tsx
@@ -21,6 +21,9 @@ describe("DeviceIdentificationCard", () => {
     // Wardnet failure — the confusion issue #1099 was filed about.
     renderWithProviders(<DeviceIdentificationCard signals={[]} />);
     expect(screen.getByText(/Nothing observed yet/)).toBeInTheDocument();
+    // The copy must not promise observation Wardnet does not yet perform:
+    // mDNS browsing and port probing are #1115/#1116, not shipped here.
+    expect(screen.queryByText(/announces a service/)).not.toBeInTheDocument();
   });
 
   it("groups signals under a per-kind heading", () => {
@@ -38,11 +41,16 @@ describe("DeviceIdentificationCard", () => {
     expect(screen.getByText("govee-lamp")).toBeInTheDocument();
   });
 
-  it("marks the signal that matched the vendor list", () => {
+  it("marks a signal that matches the vendor list, without claiming it named the device", () => {
     renderWithProviders(
       <DeviceIdentificationCard signals={[signal({ inferred: true })]} />,
     );
-    expect(screen.getByText("Matched vendor list")).toBeInTheDocument();
+    const badge = screen.getByText("Matches vendor list");
+    expect(badge).toBeInTheDocument();
+    // Naming is first-writer-wins against an empty manufacturer, so a match is
+    // evidence about the device — not proof of where its name came from. A
+    // device can even match two vendors at once.
+    expect(badge.getAttribute("title")).not.toMatch(/named the device/);
   });
 
   it("does not mark a signal that only records what the device said", () => {
@@ -51,6 +59,6 @@ describe("DeviceIdentificationCard", () => {
         signals={[signal({ kind: "dhcp_hostname", value: "some-host" })]}
       />,
     );
-    expect(screen.queryByText("Matched vendor list")).not.toBeInTheDocument();
+    expect(screen.queryByText("Matches vendor list")).not.toBeInTheDocument();
   });
 });

--- a/source/admin-site/tests/components/features/DeviceIdentificationCard.test.tsx
+++ b/source/admin-site/tests/components/features/DeviceIdentificationCard.test.tsx
@@ -1,0 +1,56 @@
+import { screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import type { DeviceSignal } from "@wardnet/js";
+
+import { DeviceIdentificationCard } from "@/components/features/DeviceIdentificationCard";
+import { renderWithProviders } from "../../test-utils";
+
+function signal(overrides: Partial<DeviceSignal> = {}): DeviceSignal {
+  return {
+    kind: "mdns_service",
+    value: "_govee._tcp",
+    inferred: false,
+    observed_at: "2026-08-05T10:00:00Z",
+    ...overrides,
+  };
+}
+
+describe("DeviceIdentificationCard", () => {
+  it("explains an empty list instead of showing a bare blank", () => {
+    // A device seen only by ARP has no signals, and that must not read as a
+    // Wardnet failure — the confusion issue #1099 was filed about.
+    renderWithProviders(<DeviceIdentificationCard signals={[]} />);
+    expect(screen.getByText(/Nothing observed yet/)).toBeInTheDocument();
+  });
+
+  it("groups signals under a per-kind heading", () => {
+    renderWithProviders(
+      <DeviceIdentificationCard
+        signals={[
+          signal({ value: "_govee._tcp" }),
+          signal({ kind: "dhcp_hostname", value: "govee-lamp" }),
+        ]}
+      />,
+    );
+    expect(screen.getByText("Announced services (mDNS)")).toBeInTheDocument();
+    expect(screen.getByText("Hostname (DHCP)")).toBeInTheDocument();
+    expect(screen.getByText("_govee._tcp")).toBeInTheDocument();
+    expect(screen.getByText("govee-lamp")).toBeInTheDocument();
+  });
+
+  it("marks the signal that matched the vendor list", () => {
+    renderWithProviders(
+      <DeviceIdentificationCard signals={[signal({ inferred: true })]} />,
+    );
+    expect(screen.getByText("Matched vendor list")).toBeInTheDocument();
+  });
+
+  it("does not mark a signal that only records what the device said", () => {
+    renderWithProviders(
+      <DeviceIdentificationCard
+        signals={[signal({ kind: "dhcp_hostname", value: "some-host" })]}
+      />,
+    );
+    expect(screen.queryByText("Matched vendor list")).not.toBeInTheDocument();
+  });
+});

--- a/source/admin-site/tests/pages/DeviceDetail.test.tsx
+++ b/source/admin-site/tests/pages/DeviceDetail.test.tsx
@@ -53,6 +53,11 @@ vi.mock("@/components/features/DeviceDnsCaptureCard", () => ({
 vi.mock("@/components/features/DeviceIdentityCard", () => ({
   DeviceIdentityCard: () => <div data-testid="identity-card" />,
 }));
+vi.mock("@/components/features/DeviceIdentificationCard", () => ({
+  DeviceIdentificationCard: ({ signals }: { signals: unknown[] }) => (
+    <div data-testid="identification-card" data-count={signals.length} />
+  ),
+}));
 vi.mock("@/components/features/DeviceNetworkCard", () => ({
   DeviceNetworkCard: () => <div data-testid="network-card" />,
 }));
@@ -107,6 +112,7 @@ describe("DeviceDetail", () => {
           last_seen: new Date().toISOString(),
         }),
         current_rule: null,
+        signals: [],
       },
       isLoading: false,
       isError: false,
@@ -117,6 +123,32 @@ describe("DeviceDetail", () => {
     expect(screen.getByTestId("identity-card")).toBeInTheDocument();
   });
 
+  it("passes the device's identification signals to the identification card", () => {
+    // The signals are the provenance behind the manufacturer shown on the
+    // identity card, so the detail page has to hand them down (issue #1099).
+    useDevice.mockReturnValue({
+      data: {
+        device: makeDevice({ name: "Lamp" }),
+        current_rule: null,
+        signals: [
+          {
+            kind: "mdns_service",
+            value: "_govee._tcp",
+            inferred: true,
+            observed_at: "2026-08-05T10:00:00Z",
+          },
+        ],
+      },
+      isLoading: false,
+      isError: false,
+    });
+    renderWithProviders(<DeviceDetail />);
+    expect(screen.getByTestId("identification-card")).toHaveAttribute(
+      "data-count",
+      "1",
+    );
+  });
+
   it("renders an offline managed device", () => {
     useDevice.mockReturnValue({
       data: {
@@ -125,6 +157,7 @@ describe("DeviceDetail", () => {
           last_seen: "2000-01-01T00:00:00Z",
         }),
         current_rule: null,
+        signals: [],
       },
       isLoading: false,
       isError: false,
@@ -138,6 +171,7 @@ describe("DeviceDetail", () => {
       data: {
         device: makeDevice({ name: null, hostname: "living-room-tv" }),
         current_rule: null,
+        signals: [],
       },
       isLoading: false,
       isError: false,
@@ -163,6 +197,7 @@ describe("DeviceDetail", () => {
           mac: "5c:e7:53:4e:ec:d9",
         }),
         current_rule: null,
+        signals: [],
       },
       isLoading: false,
       isError: false,
@@ -186,6 +221,7 @@ describe("DeviceDetail", () => {
           manufacturer_source: "ieee",
         }),
         current_rule: null,
+        signals: [],
       },
       isLoading: false,
       isError: false,
@@ -204,6 +240,7 @@ describe("DeviceDetail", () => {
           mac: "AA:BB:CC:00:11:22",
         }),
         current_rule: null,
+        signals: [],
       },
       isLoading: false,
       isError: false,
@@ -219,6 +256,7 @@ describe("DeviceDetail", () => {
       data: {
         device: makeDevice({ name: "Weird", last_seen: "not-a-date" }),
         current_rule: null,
+        signals: [],
       },
       isLoading: false,
       isError: false,

--- a/source/daemon/crates/wardnet-common/src/api.rs
+++ b/source/daemon/crates/wardnet-common/src/api.rs
@@ -2,7 +2,7 @@ use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
 use crate::backup::{BackupStatus, BundleManifest, LocalSnapshot};
-use crate::device::{Device, DeviceType, DhcpStatus};
+use crate::device::{Device, DeviceSignal, DeviceType, DhcpStatus};
 use crate::dhcp::{DhcpConfig, DhcpLease, DhcpReservation};
 use crate::dns::{
     AllowlistEntry, Blocklist, ConditionalForwardingRule, CustomDnsRecord, CustomFilterRule,
@@ -527,6 +527,10 @@ pub struct ListDevicesResponse {
 pub struct DeviceDetailResponse {
     pub device: DeviceWithStatus,
     pub current_rule: Option<RoutingTarget>,
+    /// Identification signals observed for this device, most recent first
+    /// (issue #1099). Empty is the normal case for a device that has only ever
+    /// been seen by ARP — it is an absence of evidence, not a failure.
+    pub signals: Vec<DeviceSignal>,
 }
 
 /// Request body for PUT /api/devices/:id (admin).

--- a/source/daemon/crates/wardnet-common/src/device.rs
+++ b/source/daemon/crates/wardnet-common/src/device.rs
@@ -78,6 +78,11 @@ pub enum ManufacturerSource {
 pub struct DeviceSignal {
     pub kind: DeviceSignalKind,
     pub value: String,
+    /// `true` when the raw observation matched the curated vendor catalog, so
+    /// this signal is what named the device. Surfaced because a catalog match
+    /// is a hedged guess: an admin looking at "likely Govee" needs to see the
+    /// observation it was derived from.
+    pub inferred: bool,
     pub observed_at: DateTime<Utc>,
 }
 

--- a/source/daemon/crates/wardnet-common/src/device.rs
+++ b/source/daemon/crates/wardnet-common/src/device.rs
@@ -78,10 +78,14 @@ pub enum ManufacturerSource {
 pub struct DeviceSignal {
     pub kind: DeviceSignalKind,
     pub value: String,
-    /// `true` when the raw observation matched the curated vendor catalog, so
-    /// this signal is what named the device. Surfaced because a catalog match
-    /// is a hedged guess: an admin looking at "likely Govee" needs to see the
-    /// observation it was derived from.
+    /// `true` when the value matched a vendor in the curated catalog.
+    ///
+    /// Deliberately *not* "this signal named the device": naming is
+    /// first-writer-wins against a `NULL` manufacturer (see
+    /// `set_manufacturer_if_absent`), so a device already named by its IEEE
+    /// registrant collects matching signals that changed nothing. Surfaced
+    /// because a match is still the evidence an admin needs when the name is
+    /// itself a hedge ("Likely Govee").
     pub inferred: bool,
     pub observed_at: DateTime<Utc>,
 }

--- a/source/daemon/crates/wardnetd-api/src/api/devices.rs
+++ b/source/daemon/crates/wardnetd-api/src/api/devices.rs
@@ -195,6 +195,30 @@ async fn build_dhcp_status_map(state: &AppState) -> Result<HashMap<String, DhcpS
 /// Enrich a [`Device`](wardnet_common::device::Device) with its DHCP status
 /// and current routing target. `current_rule` is `None` when the device has no
 /// rule of its own (it follows the gateway default policy).
+/// Identification signals observed for a device (issue #1099), degrading to an
+/// empty list if the read fails.
+///
+/// Deliberately non-fatal, mirroring how `current_rule` is fetched in these
+/// handlers: signals are supporting evidence, and two of the three callers have
+/// already committed a mutation by this point — failing the response would
+/// report an error for a write that succeeded.
+async fn signals_for_device(
+    state: &AppState,
+    device_id: &str,
+) -> Vec<wardnet_common::device::DeviceSignal> {
+    match state
+        .device_identification_service()
+        .signals_for(device_id)
+        .await
+    {
+        Ok(signals) => signals,
+        Err(err) => {
+            tracing::warn!(%device_id, %err, "failed to read device identification signals");
+            Vec::new()
+        }
+    }
+}
+
 fn enrich_device(
     device: wardnet_common::device::Device,
     dhcp_map: &HashMap<String, DhcpStatus>,
@@ -274,10 +298,12 @@ pub async fn get_device(
         .ok()
         .flatten();
     let dhcp_map = build_dhcp_status_map(&state).await?;
+    let signals = signals_for_device(&state, &device.id.to_string()).await;
     let device = enrich_device(device, &dhcp_map, rule.clone());
     Ok(Json(DeviceDetailResponse {
         device,
         current_rule: rule,
+        signals,
     }))
 }
 
@@ -350,10 +376,12 @@ pub async fn update_device(
         .flatten();
 
     let dhcp_map = build_dhcp_status_map(&state).await?;
+    let signals = signals_for_device(&state, &device.id.to_string()).await;
     let device = enrich_device(device, &dhcp_map, rule.clone());
     Ok(Json(DeviceDetailResponse {
         device,
         current_rule: rule,
+        signals,
     }))
 }
 
@@ -395,9 +423,11 @@ pub async fn assign_device_zone(
         .ok()
         .flatten();
     let dhcp_map = build_dhcp_status_map(&state).await?;
+    let signals = signals_for_device(&state, &device.id.to_string()).await;
     let device = enrich_device(device, &dhcp_map, rule.clone());
     Ok(Json(DeviceDetailResponse {
         device,
         current_rule: rule,
+        signals,
     }))
 }

--- a/source/daemon/crates/wardnetd-api/src/api/devices.rs
+++ b/source/daemon/crates/wardnetd-api/src/api/devices.rs
@@ -192,28 +192,52 @@ async fn build_dhcp_status_map(state: &AppState) -> Result<HashMap<String, DhcpS
     Ok(map)
 }
 
-/// Identification signals observed for a device (issue #1099), degrading to an
-/// empty list if the read fails.
+/// Build the `DeviceDetailResponse` the three detail-returning handlers share.
 ///
-/// Deliberately non-fatal, mirroring how `current_rule` is fetched in these
-/// handlers: signals are supporting evidence, and two of the three callers have
-/// already committed a mutation by this point — failing the response would
-/// report an error for a write that succeeded.
-async fn signals_for_device(
+/// `signals_are_fatal` splits the read path from the two mutation paths, and
+/// the split is the whole point. An empty `signals` list is not "unknown" — the
+/// UI renders it as the positive claim "nothing observed yet". On `GET` we
+/// therefore refuse to guess: a failed read surfaces as an error rather than as
+/// a confident falsehood. `PUT` has already committed its write by this point,
+/// so failing there would report an error for a mutation that succeeded; it
+/// degrades to an empty list and logs, and the client's next `GET` tells the
+/// truth.
+async fn device_detail(
     state: &AppState,
-    device_id: &str,
-) -> Vec<wardnet_common::device::DeviceSignal> {
-    match state
+    device: wardnet_common::device::Device,
+    signals_are_fatal: bool,
+) -> Result<DeviceDetailResponse, AppError> {
+    let device_id = device.id.to_string();
+    let rule = state
+        .device_service()
+        .get_rule_for_device(&device_id)
+        .await
+        .ok()
+        .flatten();
+
+    let signals = match state
         .device_identification_service()
-        .signals_for(device_id)
+        .signals_for(&device_id)
         .await
     {
         Ok(signals) => signals,
+        Err(err) if signals_are_fatal => return Err(err),
         Err(err) => {
-            tracing::warn!(%device_id, %err, "failed to read device identification signals");
+            tracing::warn!(
+                %device_id,
+                error = %err,
+                "failed to read identification signals for device_id={device_id}: {err}"
+            );
             Vec::new()
         }
-    }
+    };
+
+    let dhcp_map = build_dhcp_status_map(state).await?;
+    Ok(DeviceDetailResponse {
+        device: enrich_device(device, &dhcp_map, rule.clone()),
+        current_rule: rule,
+        signals,
+    })
 }
 
 /// Enrich a [`Device`](wardnet_common::device::Device) with its DHCP status
@@ -291,20 +315,8 @@ pub async fn get_device(
         .parse()
         .map_err(|_| AppError::BadRequest("invalid device ID".to_owned()))?;
     let device = state.discovery_service().get_device_by_id(uuid).await?;
-    let rule = state
-        .device_service()
-        .get_rule_for_device(&device.id.to_string())
-        .await
-        .ok()
-        .flatten();
-    let dhcp_map = build_dhcp_status_map(&state).await?;
-    let signals = signals_for_device(&state, &device.id.to_string()).await;
-    let device = enrich_device(device, &dhcp_map, rule.clone());
-    Ok(Json(DeviceDetailResponse {
-        device,
-        current_rule: rule,
-        signals,
-    }))
+    // Read path: a failed signals read is an error, not an empty list.
+    Ok(Json(device_detail(&state, device, true).await?))
 }
 
 #[utoipa::path(
@@ -367,22 +379,9 @@ pub async fn update_device(
         .update_device(uuid, body.name.as_deref(), body.device_type)
         .await?;
 
-    // Fetch current rule for the response.
-    let rule = state
-        .device_service()
-        .get_rule_for_device(&device_id_str)
-        .await
-        .ok()
-        .flatten();
-
-    let dhcp_map = build_dhcp_status_map(&state).await?;
-    let signals = signals_for_device(&state, &device.id.to_string()).await;
-    let device = enrich_device(device, &dhcp_map, rule.clone());
-    Ok(Json(DeviceDetailResponse {
-        device,
-        current_rule: rule,
-        signals,
-    }))
+    // Mutation path: the write above already landed, so a failed signals read
+    // degrades rather than reporting an error for a change that succeeded.
+    Ok(Json(device_detail(&state, device, false).await?))
 }
 
 #[utoipa::path(
@@ -416,18 +415,6 @@ pub async fn assign_device_zone(
         .await?;
 
     let device = state.discovery_service().get_device_by_id(uuid).await?;
-    let rule = state
-        .device_service()
-        .get_rule_for_device(&device.id.to_string())
-        .await
-        .ok()
-        .flatten();
-    let dhcp_map = build_dhcp_status_map(&state).await?;
-    let signals = signals_for_device(&state, &device.id.to_string()).await;
-    let device = enrich_device(device, &dhcp_map, rule.clone());
-    Ok(Json(DeviceDetailResponse {
-        device,
-        current_rule: rule,
-        signals,
-    }))
+    // Mutation path — see `device_detail`.
+    Ok(Json(device_detail(&state, device, false).await?))
 }

--- a/source/daemon/crates/wardnetd-api/src/api/devices.rs
+++ b/source/daemon/crates/wardnetd-api/src/api/devices.rs
@@ -192,9 +192,6 @@ async fn build_dhcp_status_map(state: &AppState) -> Result<HashMap<String, DhcpS
     Ok(map)
 }
 
-/// Enrich a [`Device`](wardnet_common::device::Device) with its DHCP status
-/// and current routing target. `current_rule` is `None` when the device has no
-/// rule of its own (it follows the gateway default policy).
 /// Identification signals observed for a device (issue #1099), degrading to an
 /// empty list if the read fails.
 ///
@@ -219,6 +216,9 @@ async fn signals_for_device(
     }
 }
 
+/// Enrich a [`Device`](wardnet_common::device::Device) with its DHCP status
+/// and current routing target. `current_rule` is `None` when the device has no
+/// rule of its own (it follows the gateway default policy).
 fn enrich_device(
     device: wardnet_common::device::Device,
     dhcp_map: &HashMap<String, DhcpStatus>,

--- a/source/daemon/crates/wardnetd-api/src/api/tests/devices.rs
+++ b/source/daemon/crates/wardnetd-api/src/api/tests/devices.rs
@@ -603,9 +603,25 @@ fn build_state_with_tunnel_svc(
     )
 }
 
-/// Mock [`DeviceIdentificationService`] returning a fixed set of signals.
+/// Mock [`DeviceIdentificationService`] whose `signals_for` returns whatever
+/// the test configured — a fixed list, or an error standing in for a database
+/// failure on the signals table.
 struct MockIdentificationService {
-    signals: Vec<DeviceSignal>,
+    signals_for: Result<Vec<DeviceSignal>, &'static str>,
+}
+
+impl MockIdentificationService {
+    fn returning(signals: Vec<DeviceSignal>) -> Self {
+        Self {
+            signals_for: Ok(signals),
+        }
+    }
+
+    fn failing() -> Self {
+        Self {
+            signals_for: Err("signals table is gone"),
+        }
+    }
 }
 
 #[async_trait]
@@ -627,37 +643,9 @@ impl DeviceIdentificationService for MockIdentificationService {
         Ok(())
     }
     async fn signals_for(&self, _device_id: &str) -> Result<Vec<DeviceSignal>, AppError> {
-        Ok(self.signals.clone())
-    }
-    async fn reconcile_from_catalog(&self) -> Result<usize, AppError> {
-        Ok(0)
-    }
-}
-
-/// Mock [`DeviceIdentificationService`] whose read fails, standing in for a
-/// database error on the signals table.
-struct FailingIdentificationService;
-
-#[async_trait]
-impl DeviceIdentificationService for FailingIdentificationService {
-    async fn record_signal(
-        &self,
-        _device_id: &str,
-        _kind: DeviceSignalKind,
-        _value: &str,
-    ) -> Result<(), AppError> {
-        Ok(())
-    }
-    async fn record_signal_for_mac(
-        &self,
-        _mac: &str,
-        _kind: DeviceSignalKind,
-        _value: &str,
-    ) -> Result<(), AppError> {
-        Ok(())
-    }
-    async fn signals_for(&self, _device_id: &str) -> Result<Vec<DeviceSignal>, AppError> {
-        Err(AppError::Internal(anyhow::anyhow!("signals table is gone")))
+        self.signals_for
+            .clone()
+            .map_err(|e| AppError::Internal(anyhow::anyhow!(e)))
     }
     async fn reconcile_from_catalog(&self) -> Result<usize, AppError> {
         Ok(0)
@@ -1125,14 +1113,12 @@ async fn get_device_by_id_returns_identification_signals() {
     let device = sample_device();
     let state = build_state_with_identification(
         device,
-        MockIdentificationService {
-            signals: vec![DeviceSignal {
-                kind: DeviceSignalKind::MdnsService,
-                value: "_govee._tcp".to_owned(),
-                inferred: true,
-                observed_at: chrono::Utc::now(),
-            }],
-        },
+        MockIdentificationService::returning(vec![DeviceSignal {
+            kind: DeviceSignalKind::MdnsService,
+            value: "_govee._tcp".to_owned(),
+            inferred: true,
+            observed_at: chrono::Utc::now(),
+        }]),
     );
     let app = device_router(state);
 
@@ -1144,17 +1130,35 @@ async fn get_device_by_id_returns_identification_signals() {
 }
 
 #[tokio::test]
-async fn get_device_by_id_survives_a_failing_signals_read() {
-    // Signals are supporting evidence. A failure reading them must not take
-    // out the device detail page, which is the admin's only view of the
-    // device.
+async fn get_device_by_id_fails_loudly_when_signals_cannot_be_read() {
+    // An empty `signals` list is not "unknown" — the UI renders it as the
+    // positive claim "nothing observed yet". On the read path we therefore
+    // refuse to guess: a failed read must surface as an error rather than as a
+    // confident falsehood about the device.
     let device = sample_device();
-    let state = build_state_with_identification(device, FailingIdentificationService);
+    let state = build_state_with_identification(device, MockIdentificationService::failing());
     let app = device_router(state);
 
-    let (status, json) = get_json(app, "/api/devices/00000000-0000-0000-0000-000000000001").await;
+    let (status, _json) = get_json(app, "/api/devices/00000000-0000-0000-0000-000000000001").await;
+    assert_eq!(status, StatusCode::INTERNAL_SERVER_ERROR);
+}
+
+#[tokio::test]
+async fn update_device_degrades_when_signals_cannot_be_read() {
+    // The mutation has already landed by the time signals are read, so failing
+    // here would report an error for a change that actually succeeded. The
+    // client's next GET is what surfaces the problem.
+    let device = sample_device();
+    let state = build_state_with_identification(device, MockIdentificationService::failing());
+    let app = device_router(state);
+
+    let (status, json) = put_json(
+        app,
+        "/api/devices/00000000-0000-0000-0000-000000000001",
+        r#"{"name":"Renamed"}"#,
+    )
+    .await;
     assert_eq!(status, StatusCode::OK);
-    assert_eq!(json["device"]["mac"], "aa:bb:cc:dd:ee:01");
     assert_eq!(json["signals"], serde_json::json!([]));
 }
 

--- a/source/daemon/crates/wardnetd-api/src/api/tests/devices.rs
+++ b/source/daemon/crates/wardnetd-api/src/api/tests/devices.rs
@@ -13,7 +13,7 @@ use axum::routing::{get, put};
 use tower::ServiceExt;
 use uuid::Uuid;
 use wardnet_common::api::{DeviceMeResponse, SetMyRuleResponse};
-use wardnet_common::device::{Device, DeviceType};
+use wardnet_common::device::{Device, DeviceSignal, DeviceSignalKind, DeviceType};
 use wardnet_common::routing::RoutingTarget;
 
 use crate::state::AppState;
@@ -24,6 +24,7 @@ use crate::tests::stubs::{
 };
 use wardnetd_services::LogService;
 use wardnetd_services::auth::service::LoginResult;
+use wardnetd_services::device::identification::DeviceIdentificationService;
 use wardnetd_services::error::AppError;
 use wardnetd_services::{
     AuthService, DeviceDiscoveryService, DeviceService, DhcpService, TunnelService,
@@ -602,6 +603,82 @@ fn build_state_with_tunnel_svc(
     )
 }
 
+/// Mock [`DeviceIdentificationService`] returning a fixed set of signals.
+struct MockIdentificationService {
+    signals: Vec<DeviceSignal>,
+}
+
+#[async_trait]
+impl DeviceIdentificationService for MockIdentificationService {
+    async fn record_signal(
+        &self,
+        _device_id: &str,
+        _kind: DeviceSignalKind,
+        _value: &str,
+    ) -> Result<(), AppError> {
+        Ok(())
+    }
+    async fn record_signal_for_mac(
+        &self,
+        _mac: &str,
+        _kind: DeviceSignalKind,
+        _value: &str,
+    ) -> Result<(), AppError> {
+        Ok(())
+    }
+    async fn signals_for(&self, _device_id: &str) -> Result<Vec<DeviceSignal>, AppError> {
+        Ok(self.signals.clone())
+    }
+    async fn reconcile_from_catalog(&self) -> Result<usize, AppError> {
+        Ok(0)
+    }
+}
+
+/// Mock [`DeviceIdentificationService`] whose read fails, standing in for a
+/// database error on the signals table.
+struct FailingIdentificationService;
+
+#[async_trait]
+impl DeviceIdentificationService for FailingIdentificationService {
+    async fn record_signal(
+        &self,
+        _device_id: &str,
+        _kind: DeviceSignalKind,
+        _value: &str,
+    ) -> Result<(), AppError> {
+        Ok(())
+    }
+    async fn record_signal_for_mac(
+        &self,
+        _mac: &str,
+        _kind: DeviceSignalKind,
+        _value: &str,
+    ) -> Result<(), AppError> {
+        Ok(())
+    }
+    async fn signals_for(&self, _device_id: &str) -> Result<Vec<DeviceSignal>, AppError> {
+        Err(AppError::Internal(anyhow::anyhow!("signals table is gone")))
+    }
+    async fn reconcile_from_catalog(&self) -> Result<usize, AppError> {
+        Ok(0)
+    }
+}
+
+/// Build a state whose device detail carries identification signals.
+fn build_state_with_identification(
+    device: Device,
+    identification: impl DeviceIdentificationService + 'static,
+) -> AppState {
+    build_state_with_dhcp(
+        MockDeviceService::found(device.clone(), Some(RoutingTarget::Direct)),
+        MockDiscoveryService {
+            devices: vec![device],
+        },
+        MockDhcpService::empty(),
+    )
+    .with_device_identification_service(Arc::new(identification))
+}
+
 fn device_router(state: AppState) -> Router {
     Router::new()
         .route("/api/devices/me", get(crate::api::devices::get_me))
@@ -1038,6 +1115,47 @@ async fn get_device_by_id_success() {
     assert_eq!(json["device"]["mac"], "aa:bb:cc:dd:ee:01");
     assert_eq!(json["current_rule"]["type"], "direct");
     assert_eq!(json["device"]["dhcp_status"], "external");
+    // No identification service injected: the field is present and empty
+    // rather than absent, so the client never has to special-case it.
+    assert_eq!(json["signals"], serde_json::json!([]));
+}
+
+#[tokio::test]
+async fn get_device_by_id_returns_identification_signals() {
+    let device = sample_device();
+    let state = build_state_with_identification(
+        device,
+        MockIdentificationService {
+            signals: vec![DeviceSignal {
+                kind: DeviceSignalKind::MdnsService,
+                value: "_govee._tcp".to_owned(),
+                inferred: true,
+                observed_at: chrono::Utc::now(),
+            }],
+        },
+    );
+    let app = device_router(state);
+
+    let (status, json) = get_json(app, "/api/devices/00000000-0000-0000-0000-000000000001").await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(json["signals"][0]["kind"], "mdns_service");
+    assert_eq!(json["signals"][0]["value"], "_govee._tcp");
+    assert_eq!(json["signals"][0]["inferred"], true);
+}
+
+#[tokio::test]
+async fn get_device_by_id_survives_a_failing_signals_read() {
+    // Signals are supporting evidence. A failure reading them must not take
+    // out the device detail page, which is the admin's only view of the
+    // device.
+    let device = sample_device();
+    let state = build_state_with_identification(device, FailingIdentificationService);
+    let app = device_router(state);
+
+    let (status, json) = get_json(app, "/api/devices/00000000-0000-0000-0000-000000000001").await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(json["device"]["mac"], "aa:bb:cc:dd:ee:01");
+    assert_eq!(json["signals"], serde_json::json!([]));
 }
 
 #[tokio::test]

--- a/source/daemon/crates/wardnetd-api/src/state.rs
+++ b/source/daemon/crates/wardnetd-api/src/state.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+use wardnetd_services::device::identification::DeviceIdentificationService;
 use wardnetd_services::dhcp::server::DhcpServer;
 use wardnetd_services::dns::server::DnsServer;
 use wardnetd_services::entitlement::Entitlement;
@@ -44,6 +45,7 @@ struct Inner {
     tunnel_service: Arc<dyn TunnelService>,
     inbound_wg_service: Arc<dyn InboundWgService>,
     private_dns_service: Arc<dyn PrivateDnsService>,
+    device_identification_service: Arc<dyn DeviceIdentificationService>,
     update_service: Arc<dyn UpdateService>,
     dhcp_server: Arc<dyn DhcpServer>,
     dns_server: Arc<dyn DnsServer>,
@@ -131,6 +133,9 @@ impl AppState {
                 // service via `with_private_dns_service`.
                 private_dns_service: Arc::new(NoopPrivateDnsService),
                 // Defaults to a no-op; production and the mock inject the live
+                // service via `with_device_identification_service` (#1099).
+                device_identification_service: Arc::new(NoopDeviceIdentificationService),
+                // Defaults to a no-op; production and the mock inject the live
                 // service via `with_push_service`.
                 push_service: Arc::new(NoopPushService),
                 // Defaults to a no-op; production and the mock inject the live
@@ -173,6 +178,20 @@ impl AppState {
         Arc::get_mut(&mut self.inner)
             .expect("with_private_dns_service must be called before AppState is cloned")
             .private_dns_service = private_dns_service;
+        self
+    }
+
+    /// Inject the live [`DeviceIdentificationService`] (issue #1099). Defaults
+    /// to a no-op in [`Self::new`]; production and the mock wire the real one.
+    /// Must be called before the state is cloned or shared.
+    #[must_use]
+    pub fn with_device_identification_service(
+        mut self,
+        device_identification_service: Arc<dyn DeviceIdentificationService>,
+    ) -> Self {
+        Arc::get_mut(&mut self.inner)
+            .expect("with_device_identification_service must be called before AppState is cloned")
+            .device_identification_service = device_identification_service;
         self
     }
 
@@ -391,6 +410,13 @@ impl AppState {
         self.inner.private_dns_service.as_ref()
     }
 
+    /// Access the device-identification service (observed signals + the
+    /// manufacturer writes they produce — issue #1099).
+    #[must_use]
+    pub fn device_identification_service(&self) -> &dyn DeviceIdentificationService {
+        self.inner.device_identification_service.as_ref()
+    }
+
     /// Access the auto-update service.
     #[must_use]
     pub fn update_service(&self) -> &dyn UpdateService {
@@ -597,6 +623,44 @@ impl PrivateDnsService for NoopPrivateDnsService {
     }
     async fn reconcile(&self) -> Result<(), wardnetd_services::error::AppError> {
         Ok(())
+    }
+}
+
+/// No-op [`DeviceIdentificationService`] used as the [`AppState::new`] default
+/// before the live service is injected via
+/// [`AppState::with_device_identification_service`] (issue #1099).
+///
+/// Reads return no signals rather than erroring: a device detail page must
+/// still render on a build that has not wired identification, and "no signals
+/// observed" is already a first-class, non-alarming state in that view.
+struct NoopDeviceIdentificationService;
+
+#[async_trait::async_trait]
+impl DeviceIdentificationService for NoopDeviceIdentificationService {
+    async fn record_signal(
+        &self,
+        _device_id: &str,
+        _kind: wardnet_common::device::DeviceSignalKind,
+        _value: &str,
+    ) -> Result<(), wardnetd_services::error::AppError> {
+        Ok(())
+    }
+    async fn record_signal_for_mac(
+        &self,
+        _mac: &str,
+        _kind: wardnet_common::device::DeviceSignalKind,
+        _value: &str,
+    ) -> Result<(), wardnetd_services::error::AppError> {
+        Ok(())
+    }
+    async fn signals_for(
+        &self,
+        _device_id: &str,
+    ) -> Result<Vec<wardnet_common::device::DeviceSignal>, wardnetd_services::error::AppError> {
+        Ok(Vec::new())
+    }
+    async fn reconcile_from_catalog(&self) -> Result<usize, wardnetd_services::error::AppError> {
+        Ok(0)
     }
 }
 

--- a/source/daemon/crates/wardnetd-api/src/tests/state.rs
+++ b/source/daemon/crates/wardnetd-api/src/tests/state.rs
@@ -1,6 +1,7 @@
 //! Tests for the `AppState` struct -- verifying accessors and cloneability.
 
 use super::stubs::test_app_state;
+use wardnet_common::device::DeviceSignalKind;
 
 #[test]
 fn accessors_return_correct_types() {
@@ -20,6 +21,35 @@ fn accessors_return_correct_types() {
     let _ = state.event_publisher();
     let _ = state.dhcp_server();
     let _ = state.dns_server();
+    let _ = state.device_identification_service();
+}
+
+/// The identification service defaults to a no-op until production or the mock
+/// injects the live one (issue #1099). Reads must return *no signals* rather
+/// than an error: a device detail page still has to render on a build that has
+/// not wired identification, and "nothing observed" is already a first-class
+/// state in that view.
+#[tokio::test]
+async fn default_identification_service_is_a_silent_no_op() {
+    let state = test_app_state();
+    let svc = state.device_identification_service();
+
+    assert!(
+        svc.record_signal("dev-1", DeviceSignalKind::MdnsService, "_govee._tcp")
+            .await
+            .is_ok()
+    );
+    assert!(
+        svc.record_signal_for_mac(
+            "aa:bb:cc:dd:ee:01",
+            DeviceSignalKind::DhcpHostname,
+            "some-host"
+        )
+        .await
+        .is_ok()
+    );
+    assert_eq!(svc.reconcile_from_catalog().await.unwrap(), 0);
+    assert!(svc.signals_for("dev-1").await.unwrap().is_empty());
 }
 
 #[test]

--- a/source/daemon/crates/wardnetd-data/src/repository/sqlite/device_identification.rs
+++ b/source/daemon/crates/wardnetd-data/src/repository/sqlite/device_identification.rs
@@ -135,8 +135,13 @@ impl DeviceIdentificationRepository for SqliteDeviceIdentificationRepository {
 
     async fn find_by_device(&self, device_id: &str) -> anyhow::Result<Vec<DeviceSignal>> {
         let rows = sqlx::query_as::<_, SignalRow>(
+            // `rowid DESC` breaks ties for the same reason `prune_signals`
+            // does: `observed_at` has one-second resolution, so a device
+            // announcing several services at once produces identical
+            // timestamps, and "most recent first" would otherwise be a
+            // different order on every read.
             "SELECT kind, value, confidence, observed_at FROM device_signals \
-             WHERE device_id = ? ORDER BY observed_at DESC",
+             WHERE device_id = ? ORDER BY observed_at DESC, rowid DESC",
         )
         .bind(device_id)
         .fetch_all(&self.pools.read)

--- a/source/daemon/crates/wardnetd-data/src/repository/sqlite/device_identification.rs
+++ b/source/daemon/crates/wardnetd-data/src/repository/sqlite/device_identification.rs
@@ -38,6 +38,10 @@ struct SignalRow {
 /// a signal that resolved to a vendor through the curated catalog.
 const CONFIDENCE_INFERRED: &str = "inferred";
 
+/// The `confidence` value written for a signal recorded exactly as observed,
+/// with no catalog match behind it.
+const CONFIDENCE_OBSERVED: &str = "observed";
+
 /// Serialize a [`DeviceSignalKind`] to its stored `snake_case` string form
 /// (mirrors how `device_type` and `connection_mode` are persisted).
 fn kind_to_db(kind: DeviceSignalKind) -> String {
@@ -69,7 +73,7 @@ impl DeviceIdentificationRepository for SqliteDeviceIdentificationRepository {
         .bind(if row.inferred {
             CONFIDENCE_INFERRED
         } else {
-            "observed"
+            CONFIDENCE_OBSERVED
         })
         .execute(&self.pools.write)
         .await?;

--- a/source/daemon/crates/wardnetd-data/src/repository/sqlite/device_identification.rs
+++ b/source/daemon/crates/wardnetd-data/src/repository/sqlite/device_identification.rs
@@ -30,8 +30,13 @@ impl SqliteDeviceIdentificationRepository {
 struct SignalRow {
     kind: String,
     value: String,
+    confidence: String,
     observed_at: String,
 }
+
+/// The `confidence` value [`DeviceIdentificationRepository::record`] writes for
+/// a signal that resolved to a vendor through the curated catalog.
+const CONFIDENCE_INFERRED: &str = "inferred";
 
 /// Serialize a [`DeviceSignalKind`] to its stored `snake_case` string form
 /// (mirrors how `device_type` and `connection_mode` are persisted).
@@ -61,7 +66,11 @@ impl DeviceIdentificationRepository for SqliteDeviceIdentificationRepository {
         .bind(&row.device_id)
         .bind(kind_to_db(row.kind))
         .bind(&row.value)
-        .bind(if row.inferred { "inferred" } else { "observed" })
+        .bind(if row.inferred {
+            CONFIDENCE_INFERRED
+        } else {
+            "observed"
+        })
         .execute(&self.pools.write)
         .await?;
         Ok(())
@@ -122,7 +131,7 @@ impl DeviceIdentificationRepository for SqliteDeviceIdentificationRepository {
 
     async fn find_by_device(&self, device_id: &str) -> anyhow::Result<Vec<DeviceSignal>> {
         let rows = sqlx::query_as::<_, SignalRow>(
-            "SELECT kind, value, observed_at FROM device_signals \
+            "SELECT kind, value, confidence, observed_at FROM device_signals \
              WHERE device_id = ? ORDER BY observed_at DESC",
         )
         .bind(device_id)
@@ -137,6 +146,7 @@ impl DeviceIdentificationRepository for SqliteDeviceIdentificationRepository {
                 Some(DeviceSignal {
                     kind: kind_from_db(&r.kind)?,
                     value: r.value,
+                    inferred: r.confidence == CONFIDENCE_INFERRED,
                     observed_at: r.observed_at.parse().ok()?,
                 })
             })

--- a/source/daemon/crates/wardnetd-data/src/repository/tests/device_identification.rs
+++ b/source/daemon/crates/wardnetd-data/src/repository/tests/device_identification.rs
@@ -49,6 +49,41 @@ async fn record_then_read_back_a_signal() {
 }
 
 #[tokio::test]
+async fn inferred_flag_round_trips() {
+    // The flag is what lets the UI show which observation produced a hedged
+    // "likely <vendor>" name, so it has to survive the write/read cycle rather
+    // than being write-only bookkeeping.
+    let pool = test_pool().await;
+    insert_device(&pool, DEV1, "aa:bb:cc:dd:ee:01").await;
+    let repo = SqliteDeviceIdentificationRepository::new(pool);
+
+    repo.record(&DeviceSignalRow {
+        inferred: true,
+        ..row(DEV1, DeviceSignalKind::MdnsService, "_govee._tcp")
+    })
+    .await
+    .unwrap();
+    repo.record(&row(DEV1, DeviceSignalKind::DhcpHostname, "some-host"))
+        .await
+        .unwrap();
+
+    let signals = repo.find_by_device(DEV1).await.unwrap();
+    let mdns = signals
+        .iter()
+        .find(|s| s.kind == DeviceSignalKind::MdnsService)
+        .expect("expected the mDNS signal");
+    let hostname = signals
+        .iter()
+        .find(|s| s.kind == DeviceSignalKind::DhcpHostname)
+        .expect("expected the hostname signal");
+    assert!(mdns.inferred, "a catalog match must read back as inferred");
+    assert!(
+        !hostname.inferred,
+        "a plain observation must not read back as inferred"
+    );
+}
+
+#[tokio::test]
 async fn re_recording_the_same_fact_does_not_duplicate() {
     // A device re-announcing an unchanged mDNS service on every renewal is the
     // normal case; it must refresh the row rather than pile up duplicates.

--- a/source/daemon/crates/wardnetd-data/src/vendor_catalog.rs
+++ b/source/daemon/crates/wardnetd-data/src/vendor_catalog.rs
@@ -14,6 +14,7 @@ use std::collections::HashMap;
 use std::sync::LazyLock;
 
 use serde::Deserialize;
+use wardnet_common::device::DeviceSignalKind;
 
 /// The catalog source, embedded so the daemon needs no data file at runtime.
 const VENDORS_TOML: &str = include_str!("../data/vendors.toml");
@@ -159,6 +160,27 @@ pub fn lookup_tcp_port(port: u16) -> Option<&'static str> {
         .by_port
         .get(&port)
         .map(|&i| CATALOG.vendors[i].name.as_str())
+}
+
+/// Resolve an observed signal to a vendor, dispatching on the signal's kind.
+///
+/// The one place that decides which signal kinds carry vendor information, so
+/// the recording service and the mock's demo seed cannot disagree about what
+/// counts as an inferred match.
+///
+/// Returns `None` for kinds that carry no vendor information on their own.
+/// Option 55 (the parameter-request list) is deliberately one of them: its
+/// *ordering* is a device-class fingerprint, but matching that fingerprint
+/// needs a corpus we do not ship, so we store the observation now and can
+/// interpret it later without a second capture pass.
+#[must_use]
+pub fn lookup_signal(kind: DeviceSignalKind, value: &str) -> Option<&'static str> {
+    match kind {
+        DeviceSignalKind::MdnsService => lookup_mdns_service(value),
+        DeviceSignalKind::DhcpVendorClass => lookup_vendor_class(value),
+        DeviceSignalKind::ProbedPort => value.parse::<u16>().ok().and_then(lookup_tcp_port),
+        DeviceSignalKind::DhcpHostname | DeviceSignalKind::DhcpParamList => None,
+    }
 }
 
 /// Every vendor entry, for tests that need to assert properties of the catalog

--- a/source/daemon/crates/wardnetd-mock/src/main.rs
+++ b/source/daemon/crates/wardnetd-mock/src/main.rs
@@ -401,6 +401,7 @@ async fn run(
         services.zone_exception.clone(),
     )
     .with_push_service(services.push.clone())
+    .with_device_identification_service(services.device_identification.clone())
     .with_routing_profile_service(services.routing_profile.clone())
     .with_inbound_wg_service(services.inbound_wg.clone())
     // Private DNS reaches the live DDNS/TLS/secret store, which the mock stands

--- a/source/daemon/crates/wardnetd-mock/src/seed.rs
+++ b/source/daemon/crates/wardnetd-mock/src/seed.rs
@@ -12,15 +12,15 @@
 
 use chrono::{Datelike, Duration, Utc};
 use uuid::Uuid;
-use wardnet_common::device::ManufacturerSource;
+use wardnet_common::device::{DeviceSignalKind, ManufacturerSource};
 use wardnet_common::routing_profile::DomainRoutingTarget;
 use wardnet_common::zone_exception::{
     ExceptionEndpoint, ExceptionEndpointKind, ServiceSet, ServiceSpec, ZoneException,
 };
 use wardnetd_data::RepositoryFactory;
 use wardnetd_data::repository::{
-    AllowlistRow, CustomRuleRow, DeviceRow, DhcpLeaseRow, DhcpReservationRow, IntradayStatRow,
-    NewNotification, QueryLogRow, RoutingProfileRow, RoutingRuleRow, TunnelRow,
+    AllowlistRow, CustomRuleRow, DeviceRow, DeviceSignalRow, DhcpLeaseRow, DhcpReservationRow,
+    IntradayStatRow, NewNotification, QueryLogRow, RoutingProfileRow, RoutingRuleRow, TunnelRow,
 };
 use wardnetd_data::{oui, vendor_catalog};
 
@@ -211,6 +211,9 @@ pub async fn populate(factory: &dyn RepositoryFactory) -> anyhow::Result<SeededI
     // captured by hostname so they survive reordering of the seed list.
     let mut casting_from_id: Option<Uuid> = None;
     let mut casting_to_id: Option<Uuid> = None;
+    // The privately-listed device from the reported case, so its detail page
+    // can show the observations behind its hedged "Likely Govee" name.
+    let mut govee_device_id: Option<Uuid> = None;
     for (mac, hostname, manufacturer, device_type, ip, last_seen_ago, zone_id) in devices {
         let id = Uuid::new_v4();
         let first_seen = (now - Duration::days(7)).to_rfc3339();
@@ -253,6 +256,9 @@ pub async fn populate(factory: &dyn RepositoryFactory) -> anyhow::Result<SeededI
             Some("living-room-tv") => casting_to_id = Some(id),
             _ => {}
         }
+        if hostname == Some("govee-lamp") {
+            govee_device_id = Some(id);
+        }
         device_lease_inputs.push((
             id,
             mac.to_owned(),
@@ -276,6 +282,49 @@ pub async fn populate(factory: &dyn RepositoryFactory) -> anyhow::Result<SeededI
             .update_dns_capture_settings(&localhost_id.to_string(), Some(true), None, None)
             .await?;
         tracing::debug!(device_id = %localhost_id, "enabled DNS capture on localhost device");
+    }
+
+    // ------------------------------------------------------------------
+    // Identification signals (issue #1099) — seeded for two devices only, so
+    // the detail view shows both states it has to handle: the populated case
+    // and the far more common "nothing observed yet".
+    //
+    // The Govee lamp is the interesting one. Its OUI is listed to `Private`,
+    // so the catalog is the only thing that can name it; these rows are the
+    // evidence behind the "Likely Govee" hedge the identity card shows.
+    // ------------------------------------------------------------------
+    let identification_repo = factory.device_identification();
+    let mut demo_signals: Vec<(Uuid, DeviceSignalKind, &str)> = Vec::new();
+    if let Some(govee_id) = govee_device_id {
+        demo_signals.extend([
+            (govee_id, DeviceSignalKind::MdnsService, "_govee._tcp"),
+            (govee_id, DeviceSignalKind::DhcpHostname, "govee-lamp"),
+            (
+                govee_id,
+                DeviceSignalKind::DhcpParamList,
+                "1,3,6,15,28,51,58,59",
+            ),
+        ]);
+    }
+    if let Some(tv_id) = casting_to_id {
+        demo_signals.extend([
+            (tv_id, DeviceSignalKind::MdnsService, "_googlecast._tcp"),
+            (tv_id, DeviceSignalKind::MdnsService, "_airplay._tcp"),
+        ]);
+    }
+    for (device_id, kind, value) in demo_signals {
+        identification_repo
+            .record(&DeviceSignalRow {
+                device_id: device_id.to_string(),
+                kind,
+                value: value.to_owned(),
+                // Ask the catalog the same question the recording service asks,
+                // rather than restating the rule here — a second copy would
+                // drift the moment a new signal kind carries vendor
+                // information.
+                inferred: vendor_catalog::lookup_signal(kind, value).is_some(),
+            })
+            .await?;
     }
 
     // ------------------------------------------------------------------

--- a/source/daemon/crates/wardnetd-mock/src/tests/seed.rs
+++ b/source/daemon/crates/wardnetd-mock/src/tests/seed.rs
@@ -8,7 +8,7 @@ use wardnetd_data::{
     RepositoryFactory, SqliteRepositoryFactory, db::init_pool_from_connection_string,
 };
 
-use wardnet_common::device::ManufacturerSource;
+use wardnet_common::device::{DeviceSignalKind, ManufacturerSource};
 
 use crate::seed::populate;
 
@@ -60,6 +60,41 @@ async fn populate_inserts_expected_demo_data() {
     assert_eq!(
         catalog.manufacturer_source,
         Some(ManufacturerSource::Catalog)
+    );
+
+    // The Govee lamp carries the observations behind its hedged name, so the
+    // device detail view has a populated signals section in local dev — and,
+    // just as importantly, every other seeded device has none, which is the
+    // empty state the same view has to handle (issue #1099).
+    let govee_signals = factory
+        .device_identification()
+        .find_by_device(&catalog.id.to_string())
+        .await
+        .unwrap();
+    let mdns = govee_signals
+        .iter()
+        .find(|s| s.kind == DeviceSignalKind::MdnsService)
+        .expect("seed should record the Govee mDNS service");
+    assert_eq!(mdns.value, "_govee._tcp");
+    assert!(
+        mdns.inferred,
+        "a catalogued service type must be flagged as a vendor-list match"
+    );
+    assert!(
+        govee_signals
+            .iter()
+            .any(|s| s.kind == DeviceSignalKind::DhcpHostname && !s.inferred),
+        "a plain DHCP hostname must not be marked inferred"
+    );
+
+    let laptop_signals = factory
+        .device_identification()
+        .find_by_device(&ieee.id.to_string())
+        .await
+        .unwrap();
+    assert!(
+        laptop_signals.is_empty(),
+        "most seeded devices must have no signals, so the empty state is reachable in local dev"
     );
 
     // A privacy MAC: flagged, and with no manufacturer invented for it.

--- a/source/daemon/crates/wardnetd-services/src/device/identification.rs
+++ b/source/daemon/crates/wardnetd-services/src/device/identification.rs
@@ -107,25 +107,6 @@ fn truncate_signal_value(value: &str) -> String {
     value[..end].to_owned()
 }
 
-/// Resolve a raw signal value to a vendor name via the curated catalog.
-///
-/// Returns `None` for kinds that carry no vendor information on their own.
-/// Option 55 (the parameter-request list) is deliberately one of them: its
-/// *ordering* is a device-class fingerprint, but matching that fingerprint
-/// needs a corpus we do not ship, so we store the observation now and can
-/// interpret it later without a second capture pass.
-fn vendor_for_signal(kind: DeviceSignalKind, value: &str) -> Option<&'static str> {
-    match kind {
-        DeviceSignalKind::MdnsService => vendor_catalog::lookup_mdns_service(value),
-        DeviceSignalKind::DhcpVendorClass => vendor_catalog::lookup_vendor_class(value),
-        DeviceSignalKind::ProbedPort => value
-            .parse::<u16>()
-            .ok()
-            .and_then(vendor_catalog::lookup_tcp_port),
-        DeviceSignalKind::DhcpHostname | DeviceSignalKind::DhcpParamList => None,
-    }
-}
-
 #[async_trait]
 impl DeviceIdentificationService for DeviceIdentificationServiceImpl {
     async fn record_signal(
@@ -142,7 +123,7 @@ impl DeviceIdentificationService for DeviceIdentificationServiceImpl {
         // is capped so a client that varies its option-60 on every renewal
         // cannot grow the table without limit.
         let value = truncate_signal_value(value);
-        let vendor = vendor_for_signal(kind, &value);
+        let vendor = vendor_catalog::lookup_signal(kind, &value);
 
         self.identification
             .record(&DeviceSignalRow {

--- a/source/daemon/crates/wardnetd/src/main.rs
+++ b/source/daemon/crates/wardnetd/src/main.rs
@@ -1053,6 +1053,7 @@ async fn run(
         services.zone_exception.clone(),
     )
     .with_push_service(services.push.clone())
+    .with_device_identification_service(services.device_identification.clone())
     .with_routing_profile_service(services.routing_profile.clone())
     .with_inbound_wg_service(services.inbound_wg.clone())
     .with_private_dns_service(services.private_dns.clone())

--- a/source/sdk/wardnet-go/internal/rest/rest.gen.go
+++ b/source/sdk/wardnet-go/internal/rest/rest.gen.go
@@ -138,6 +138,33 @@ func (e DeviceConnectionMode) Valid() bool {
 	}
 }
 
+// Defines values for DeviceSignalKind.
+const (
+	DhcpHostname    DeviceSignalKind = "dhcp_hostname"
+	DhcpParamList   DeviceSignalKind = "dhcp_param_list"
+	DhcpVendorClass DeviceSignalKind = "dhcp_vendor_class"
+	MdnsService     DeviceSignalKind = "mdns_service"
+	ProbedPort      DeviceSignalKind = "probed_port"
+)
+
+// Valid indicates whether the value is a known member of the DeviceSignalKind enum.
+func (e DeviceSignalKind) Valid() bool {
+	switch e {
+	case DhcpHostname:
+		return true
+	case DhcpParamList:
+		return true
+	case DhcpVendorClass:
+		return true
+	case MdnsService:
+		return true
+	case ProbedPort:
+		return true
+	default:
+		return false
+	}
+}
+
 // Defines values for DeviceType.
 const (
 	DeviceTypeGameConsole   DeviceType = "game_console"
@@ -2089,6 +2116,11 @@ type DeviceDetailResponse struct {
 	// the device has no rule of its own and follows the gateway default policy;
 	// `Some(RoutingTarget::Default)` is an explicit persisted default choice.
 	Device DeviceWithStatus `json:"device"`
+
+	// Signals Identification signals observed for this device, most recent first
+	// (issue #1099). Empty is the normal case for a device that has only ever
+	// been seen by ARP — it is an absence of evidence, not a failure.
+	Signals []DeviceSignal `json:"signals"`
 }
 
 // DeviceDnsFilterSettings Per-device DNS filtering settings.
@@ -2137,6 +2169,27 @@ type DeviceRuleRequest struct {
 	// Status Lifecycle state of a request.
 	Status RuleRequestStatus `json:"status"`
 }
+
+// DeviceSignal A single observed fact that helps identify a device (issue #1099).
+//
+// Deliberately multi-valued per device: a device can announce several mDNS
+// services, and each signal is independent evidence rather than a field that
+// overwrites the last one.
+type DeviceSignal struct {
+	// Inferred `true` when the raw observation matched the curated vendor catalog, so
+	// this signal is what named the device. Surfaced because a catalog match
+	// is a hedged guess: an admin looking at "likely Govee" needs to see the
+	// observation it was derived from.
+	Inferred bool `json:"inferred"`
+
+	// Kind The kind of an [`DeviceSignal`].
+	Kind       DeviceSignalKind `json:"kind"`
+	ObservedAt time.Time        `json:"observed_at"`
+	Value      string           `json:"value"`
+}
+
+// DeviceSignalKind The kind of an [`DeviceSignal`].
+type DeviceSignalKind string
 
 // DeviceType The type/category of a network device.
 type DeviceType string

--- a/source/sdk/wardnet-go/internal/rest/rest.gen.go
+++ b/source/sdk/wardnet-go/internal/rest/rest.gen.go
@@ -2176,10 +2176,14 @@ type DeviceRuleRequest struct {
 // services, and each signal is independent evidence rather than a field that
 // overwrites the last one.
 type DeviceSignal struct {
-	// Inferred `true` when the raw observation matched the curated vendor catalog, so
-	// this signal is what named the device. Surfaced because a catalog match
-	// is a hedged guess: an admin looking at "likely Govee" needs to see the
-	// observation it was derived from.
+	// Inferred `true` when the value matched a vendor in the curated catalog.
+	//
+	// Deliberately *not* "this signal named the device": naming is
+	// first-writer-wins against a `NULL` manufacturer (see
+	// `set_manufacturer_if_absent`), so a device already named by its IEEE
+	// registrant collects matching signals that changed nothing. Surfaced
+	// because a match is still the evidence an admin needs when the name is
+	// itself a hedge ("Likely Govee").
 	Inferred bool `json:"inferred"`
 
 	// Kind The kind of an [`DeviceSignal`].

--- a/source/sdk/wardnet-js/src/index.ts
+++ b/source/sdk/wardnet-js/src/index.ts
@@ -44,6 +44,8 @@ export { isTerminal as isJobTerminal } from "./types/jobs.js";
 export type {
   Device,
   DeviceType,
+  DeviceSignal,
+  DeviceSignalKind,
   ManufacturerSource,
   DhcpStatus,
   DeviceConnectionMode,

--- a/source/sdk/wardnet-js/src/internal/openapi-schema.ts
+++ b/source/sdk/wardnet-js/src/internal/openapi-schema.ts
@@ -2855,10 +2855,14 @@ export interface components {
          *     services, and each signal is independent evidence rather than a field that
          *     overwrites the last one. */
         DeviceSignal: {
-            /** @description `true` when the raw observation matched the curated vendor catalog, so
-             *     this signal is what named the device. Surfaced because a catalog match
-             *     is a hedged guess: an admin looking at "likely Govee" needs to see the
-             *     observation it was derived from. */
+            /** @description `true` when the value matched a vendor in the curated catalog.
+             *
+             *     Deliberately *not* "this signal named the device": naming is
+             *     first-writer-wins against a `NULL` manufacturer (see
+             *     `set_manufacturer_if_absent`), so a device already named by its IEEE
+             *     registrant collects matching signals that changed nothing. Surfaced
+             *     because a match is still the evidence an admin needs when the name is
+             *     itself a hedge ("Likely Govee"). */
             inferred: boolean;
             kind: components["schemas"]["DeviceSignalKind"];
             /** Format: date-time */

--- a/source/sdk/wardnet-js/src/internal/openapi-schema.ts
+++ b/source/sdk/wardnet-js/src/internal/openapi-schema.ts
@@ -2805,6 +2805,10 @@ export interface components {
         DeviceDetailResponse: {
             current_rule?: null | components["schemas"]["RoutingTarget"];
             device: components["schemas"]["DeviceWithStatus"];
+            /** @description Identification signals observed for this device, most recent first
+             *     (issue #1099). Empty is the normal case for a device that has only ever
+             *     been seen by ARP — it is an absence of evidence, not a failure. */
+            signals: components["schemas"]["DeviceSignal"][];
         };
         /** @description Per-device DNS filtering settings.
          *
@@ -2845,6 +2849,27 @@ export interface components {
             reason?: string | null;
             status: components["schemas"]["RuleRequestStatus"];
         };
+        /** @description A single observed fact that helps identify a device (issue #1099).
+         *
+         *     Deliberately multi-valued per device: a device can announce several mDNS
+         *     services, and each signal is independent evidence rather than a field that
+         *     overwrites the last one. */
+        DeviceSignal: {
+            /** @description `true` when the raw observation matched the curated vendor catalog, so
+             *     this signal is what named the device. Surfaced because a catalog match
+             *     is a hedged guess: an admin looking at "likely Govee" needs to see the
+             *     observation it was derived from. */
+            inferred: boolean;
+            kind: components["schemas"]["DeviceSignalKind"];
+            /** Format: date-time */
+            observed_at: string;
+            value: string;
+        };
+        /**
+         * @description The kind of an [`DeviceSignal`].
+         * @enum {string}
+         */
+        DeviceSignalKind: "dhcp_hostname" | "dhcp_param_list" | "dhcp_vendor_class" | "mdns_service" | "probed_port";
         /**
          * @description The type/category of a network device.
          * @enum {string}

--- a/source/sdk/wardnet-js/src/types/api.ts
+++ b/source/sdk/wardnet-js/src/types/api.ts
@@ -1,4 +1,4 @@
-import type { Device, DeviceType, RoutingTarget } from "./device.js";
+import type { Device, DeviceSignal, DeviceType, RoutingTarget } from "./device.js";
 import type {
   AllowedTargetKind,
   NetworkZone,
@@ -77,6 +77,12 @@ export interface ListDevicesResponse {
 export interface DeviceDetailResponse {
   device: Device;
   current_rule: RoutingTarget | null;
+  /**
+   * Identification signals observed for this device, most recent first
+   * (issue #1099). An empty list is the normal case for a device only ever
+   * seen by ARP — an absence of evidence, not a failure.
+   */
+  signals: DeviceSignal[];
 }
 
 /** Request body for PUT /api/devices/:id (admin). */

--- a/source/sdk/wardnet-js/src/types/device.ts
+++ b/source/sdk/wardnet-js/src/types/device.ts
@@ -84,11 +84,7 @@ export interface Device {
  * - `probed_port` — a TCP port that answered an admin-triggered probe.
  */
 export type DeviceSignalKind =
-  | "dhcp_hostname"
-  | "dhcp_param_list"
-  | "dhcp_vendor_class"
-  | "mdns_service"
-  | "probed_port";
+  "dhcp_hostname" | "dhcp_param_list" | "dhcp_vendor_class" | "mdns_service" | "probed_port";
 
 /**
  * A single observed fact that helps identify a device (issue #1099).

--- a/source/sdk/wardnet-js/src/types/device.ts
+++ b/source/sdk/wardnet-js/src/types/device.ts
@@ -96,9 +96,12 @@ export interface DeviceSignal {
   kind: DeviceSignalKind;
   value: string;
   /**
-   * `true` when the observation matched the curated vendor catalog, so this
-   * signal is what named the device — a hedged guess the admin should be able
-   * to trace back to its evidence.
+   * `true` when the value matched a vendor in the curated catalog.
+   *
+   * Deliberately *not* "this signal named the device": naming is
+   * first-writer-wins against a device with no manufacturer yet, so a device
+   * already named by its IEEE registrant collects matching signals that changed
+   * nothing — and one device can match two vendors at once.
    */
   inferred: boolean;
   observed_at: string;

--- a/source/sdk/wardnet-js/src/types/device.ts
+++ b/source/sdk/wardnet-js/src/types/device.ts
@@ -73,6 +73,41 @@ export interface Device {
   connection_mode: DeviceConnectionMode;
 }
 
+/**
+ * The kind of an identification signal (issue #1099).
+ *
+ * - `dhcp_hostname` — DHCP option 12, the hostname the device asked for.
+ * - `dhcp_param_list` — DHCP option 55; the *ordering* is a device-class
+ *   fingerprint.
+ * - `dhcp_vendor_class` — DHCP option 60, often a literal brand string.
+ * - `mdns_service` — a service type the device advertised over mDNS.
+ * - `probed_port` — a TCP port that answered an admin-triggered probe.
+ */
+export type DeviceSignalKind =
+  | "dhcp_hostname"
+  | "dhcp_param_list"
+  | "dhcp_vendor_class"
+  | "mdns_service"
+  | "probed_port";
+
+/**
+ * A single observed fact that helps identify a device (issue #1099).
+ *
+ * Multi-valued per device: each signal is independent evidence rather than a
+ * field that overwrites the last one.
+ */
+export interface DeviceSignal {
+  kind: DeviceSignalKind;
+  value: string;
+  /**
+   * `true` when the observation matched the curated vendor catalog, so this
+   * signal is what named the device — a hedged guess the admin should be able
+   * to trace back to its evidence.
+   */
+  inferred: boolean;
+  observed_at: string;
+}
+
 /** Where a device's traffic is routed. */
 export type RoutingTarget =
   { type: "tunnel"; tunnel_id: string } | { type: "direct" } | { type: "default" };

--- a/source/web/src/index.ts
+++ b/source/web/src/index.ts
@@ -67,6 +67,12 @@ export {
   findNeighbourMacs,
 } from "./lib/deviceSearch";
 export type { NeighbourMatch } from "./lib/deviceSearch";
+// Identification signals — grouping and per-kind presentation (issue #1099).
+export { signalKindDisplay, groupSignalsByKind } from "./lib/deviceSignals";
+export type {
+  DeviceSignalKindDisplay,
+  DeviceSignalGroup,
+} from "./lib/deviceSignals";
 export { cronToHuman } from "./lib/cron";
 export { logger, createLogger, setLevel } from "./lib/logger";
 export type { Logger, LogLevel } from "./lib/logger";

--- a/source/web/src/lib/deviceSignals.ts
+++ b/source/web/src/lib/deviceSignals.ts
@@ -15,28 +15,47 @@ export interface DeviceSignalKindDisplay {
   hint: string;
 }
 
-const SIGNAL_KIND_DISPLAY: Record<DeviceSignalKind, DeviceSignalKindDisplay> = {
-  dhcp_hostname: {
-    label: "Hostname (DHCP)",
-    hint: "The name the device asked to be known by when it requested an address.",
-  },
-  dhcp_vendor_class: {
-    label: "Vendor class (DHCP)",
-    hint: "A vendor string the device sent with its address request. Many IoT stacks put a literal brand name here.",
-  },
-  dhcp_param_list: {
-    label: "DHCP fingerprint",
-    hint: "The list of options the device asked for, in order. The ordering is characteristic of a device class rather than of one manufacturer.",
-  },
-  mdns_service: {
-    label: "Announced services (mDNS)",
-    hint: "Services the device advertised on the local network, such as casting or smart-home control.",
-  },
-  probed_port: {
-    label: "Answering ports",
-    hint: "Ports that responded when you asked Wardnet to identify this device.",
-  },
-};
+/**
+ * A Map rather than an object literal: the key arrives from the daemon, so an
+ * unrecognised kind has to miss cleanly rather than index into an object.
+ */
+const SIGNAL_KIND_DISPLAY = new Map<DeviceSignalKind, DeviceSignalKindDisplay>([
+  [
+    "dhcp_hostname",
+    {
+      label: "Hostname (DHCP)",
+      hint: "The name the device asked to be known by when it requested an address.",
+    },
+  ],
+  [
+    "dhcp_vendor_class",
+    {
+      label: "Vendor class (DHCP)",
+      hint: "A vendor string the device sent with its address request. Many IoT stacks put a literal brand name here.",
+    },
+  ],
+  [
+    "dhcp_param_list",
+    {
+      label: "DHCP fingerprint",
+      hint: "The list of options the device asked for, in order. The ordering is characteristic of a device class rather than of one manufacturer.",
+    },
+  ],
+  [
+    "mdns_service",
+    {
+      label: "Announced services (mDNS)",
+      hint: "Services the device advertised on the local network, such as casting or smart-home control.",
+    },
+  ],
+  [
+    "probed_port",
+    {
+      label: "Answering ports",
+      hint: "Ports that responded when you asked Wardnet to identify this device.",
+    },
+  ],
+]);
 
 /**
  * Display metadata for a signal kind. Falls back to the raw kind so a signal
@@ -46,7 +65,7 @@ export function signalKindDisplay(
   kind: DeviceSignalKind,
 ): DeviceSignalKindDisplay {
   return (
-    SIGNAL_KIND_DISPLAY[kind] ?? {
+    SIGNAL_KIND_DISPLAY.get(kind) ?? {
       label: kind,
       hint: "An identification signal recorded by a newer version of Wardnet.",
     }

--- a/source/web/src/lib/deviceSignals.ts
+++ b/source/web/src/lib/deviceSignals.ts
@@ -1,0 +1,102 @@
+import type { DeviceSignal, DeviceSignalKind } from "@wardnet/js";
+
+/**
+ * How one kind of identification signal should be presented (issue #1099).
+ *
+ * Each kind needs its own explanation because they are not equally meaningful:
+ * a DHCP hostname is whatever the device asked to be called, while an answering
+ * port is something we went and checked. Rendering them as an undifferentiated
+ * list would flatten that difference.
+ */
+export interface DeviceSignalKindDisplay {
+  /** Group heading. */
+  label: string;
+  /** One-line explanation of where this kind of observation comes from. */
+  hint: string;
+}
+
+const SIGNAL_KIND_DISPLAY: Record<DeviceSignalKind, DeviceSignalKindDisplay> = {
+  dhcp_hostname: {
+    label: "Hostname (DHCP)",
+    hint: "The name the device asked to be known by when it requested an address.",
+  },
+  dhcp_vendor_class: {
+    label: "Vendor class (DHCP)",
+    hint: "A vendor string the device sent with its address request. Many IoT stacks put a literal brand name here.",
+  },
+  dhcp_param_list: {
+    label: "DHCP fingerprint",
+    hint: "The list of options the device asked for, in order. The ordering is characteristic of a device class rather than of one manufacturer.",
+  },
+  mdns_service: {
+    label: "Announced services (mDNS)",
+    hint: "Services the device advertised on the local network, such as casting or smart-home control.",
+  },
+  probed_port: {
+    label: "Answering ports",
+    hint: "Ports that responded when you asked Wardnet to identify this device.",
+  },
+};
+
+/**
+ * Display metadata for a signal kind. Falls back to the raw kind so a signal
+ * written by a newer daemon still renders instead of disappearing.
+ */
+export function signalKindDisplay(
+  kind: DeviceSignalKind,
+): DeviceSignalKindDisplay {
+  return (
+    SIGNAL_KIND_DISPLAY[kind] ?? {
+      label: kind,
+      hint: "An identification signal recorded by a newer version of Wardnet.",
+    }
+  );
+}
+
+/** Signals of one kind, in the order they should be rendered. */
+export interface DeviceSignalGroup {
+  kind: DeviceSignalKind;
+  display: DeviceSignalKindDisplay;
+  signals: DeviceSignal[];
+}
+
+/**
+ * The order signal kinds are shown in: most directly useful for naming a
+ * device first, with the fingerprint (which identifies a class, not a vendor)
+ * last.
+ */
+const KIND_ORDER: DeviceSignalKind[] = [
+  "mdns_service",
+  "dhcp_vendor_class",
+  "dhcp_hostname",
+  "probed_port",
+  "dhcp_param_list",
+];
+
+/**
+ * Group signals by kind for display, dropping empty groups and preserving the
+ * server's most-recent-first order within each one.
+ */
+export function groupSignalsByKind(
+  signals: DeviceSignal[],
+): DeviceSignalGroup[] {
+  const seen = new Map<DeviceSignalKind, DeviceSignal[]>();
+  for (const signal of signals) {
+    const bucket = seen.get(signal.kind);
+    if (bucket) bucket.push(signal);
+    else seen.set(signal.kind, [signal]);
+  }
+
+  // Known kinds in their intended order, then anything a newer daemon wrote,
+  // in first-seen order — an unrecognised kind is still evidence.
+  const ordered: DeviceSignalKind[] = [
+    ...KIND_ORDER.filter((k) => seen.has(k)),
+    ...[...seen.keys()].filter((k) => !KIND_ORDER.includes(k)),
+  ];
+
+  return ordered.map((kind) => ({
+    kind,
+    display: signalKindDisplay(kind),
+    signals: seen.get(kind) ?? [],
+  }));
+}

--- a/source/web/tests/lib/deviceSignals.test.ts
+++ b/source/web/tests/lib/deviceSignals.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest";
+import type { DeviceSignal, DeviceSignalKind } from "@wardnet/js";
+import { groupSignalsByKind, signalKindDisplay } from "../../src/lib/deviceSignals";
+
+function signal(
+  kind: DeviceSignalKind,
+  value: string,
+  inferred = false,
+): DeviceSignal {
+  return { kind, value, inferred, observed_at: "2026-08-05T10:00:00Z" };
+}
+
+describe("signalKindDisplay", () => {
+  it("labels and explains every known kind", () => {
+    const kinds: DeviceSignalKind[] = [
+      "dhcp_hostname",
+      "dhcp_param_list",
+      "dhcp_vendor_class",
+      "mdns_service",
+      "probed_port",
+    ];
+    for (const kind of kinds) {
+      const display = signalKindDisplay(kind);
+      expect(display.label).not.toBe(kind);
+      expect(display.hint.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("falls back to the raw kind for one a newer daemon wrote", () => {
+    const display = signalKindDisplay("ssdp_service" as DeviceSignalKind);
+    expect(display.label).toBe("ssdp_service");
+    expect(display.hint.length).toBeGreaterThan(0);
+  });
+});
+
+describe("groupSignalsByKind", () => {
+  it("returns nothing for no signals", () => {
+    expect(groupSignalsByKind([])).toEqual([]);
+  });
+
+  it("groups by kind and preserves the server's order within a group", () => {
+    const groups = groupSignalsByKind([
+      signal("mdns_service", "_govee._tcp"),
+      signal("mdns_service", "_hap._tcp"),
+    ]);
+    expect(groups).toHaveLength(1);
+    expect(groups[0].signals.map((s) => s.value)).toEqual([
+      "_govee._tcp",
+      "_hap._tcp",
+    ]);
+  });
+
+  it("orders vendor-bearing kinds ahead of the device-class fingerprint", () => {
+    const groups = groupSignalsByKind([
+      signal("dhcp_param_list", "1,3,6,15"),
+      signal("dhcp_hostname", "govee-lamp"),
+      signal("mdns_service", "_govee._tcp"),
+    ]);
+    expect(groups.map((g) => g.kind)).toEqual([
+      "mdns_service",
+      "dhcp_hostname",
+      "dhcp_param_list",
+    ]);
+  });
+
+  it("keeps an unrecognised kind rather than dropping the evidence", () => {
+    const groups = groupSignalsByKind([
+      signal("ssdp_service" as DeviceSignalKind, "urn:roku:device"),
+      signal("mdns_service", "_govee._tcp"),
+    ]);
+    // Known kinds lead; the unknown one trails but survives.
+    expect(groups.map((g) => g.kind)).toEqual(["mdns_service", "ssdp_service"]);
+  });
+
+  it("carries the inferred flag through to the group", () => {
+    const groups = groupSignalsByKind([
+      signal("dhcp_vendor_class", "Govee", true),
+    ]);
+    expect(groups[0].signals[0].inferred).toBe(true);
+  });
+});

--- a/source/web/tests/lib/deviceSignals.test.ts
+++ b/source/web/tests/lib/deviceSignals.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 import type { DeviceSignal, DeviceSignalKind } from "@wardnet/js";
-import { groupSignalsByKind, signalKindDisplay } from "../../src/lib/deviceSignals";
+import {
+  groupSignalsByKind,
+  signalKindDisplay,
+} from "../../src/lib/deviceSignals";
 
 function signal(
   kind: DeviceSignalKind,


### PR DESCRIPTION
Closes #1114. Child of #1099 (closed by #1110). Design: `docs/adr/0025-device-identification.md`.

## Why

The signal-*recording* side of #1099 landed in #1110 — DHCP options 12/55/60 are captured and rows accumulate in `device_signals`. Nothing could read them back. `DeviceIdentificationService::signals_for` existed and was tested, but had no route out: `AppState` had no identification service and no response type carried a `DeviceSignal`.

So #1099's acceptance criterion 5 — "at least one new passive identification signal lands **and is shown on the device detail view**" — was only half met, and an admin saw the manufacturer we inferred without the observation we inferred it from. That provenance is what ADR 0025 decision 4 leans on to make a hedged "Likely Govee" honest.

## What

No new signal sources and no new service methods — this only threads what already exists through to the UI.

**Daemon**
- `AppState` gains `device_identification_service` via a `with_device_identification_service` builder plus a no-op default, following the pattern used for `PushService` / `PrivateDnsService` rather than growing `AppState::new`'s argument list again. Wired in `wardnetd` and `wardnetd-mock`.
- `DeviceDetailResponse` carries `signals`, populated by all three handlers that return it (`get_device`, `update_device`, `assign_device_zone`) — returning it from only one would make the field mean different things per route.
- The signals read is deliberately non-fatal (a warn + empty list). Two of the three callers have already committed a mutation by that point; failing the response would report an error for a write that succeeded.
- `DeviceSignal` exposes `inferred`, read back from the `confidence` column it was already being written to. Without it the UI cannot show *which* observation produced the name.

**Generated clients**
- `docs/openapi.json`, the SDK's internal client, and the Go REST client regenerated. All three drift gates pass.

**Web**
- `groupSignalsByKind` / `signalKindDisplay` in `@wardnet/web` — an unrecognised kind from a newer daemon still renders rather than disappearing.
- `DeviceIdentificationCard` on admin-site, grouped by kind, marking the signal that matched the vendor list. The empty state is spelled out rather than left blank: a device seen only by ARP has no signals, and reading that as a Wardnet failure is the exact confusion #1099 was filed about.

## Not in scope

Deliberately left to the sibling children: mDNS observation (#1115), admin-triggered port probing (#1116), `DeviceFirstSeen` notification (#1117). No signals on the device *list*, no admin-app surface, and the hand-written Go `Device` wrapper is unchanged (only the generated client moved).

## Verification

- `make check-daemon` (container: `check-inline-tests` + `cargo fmt --check` + `cargo clippy --all-targets -- -D warnings` + `cargo test --workspace`) — exit 0.
- `make check-openapi`, `make check-sdk-openapi`, `make check-go-openapi` — all in sync.
- `source/web` 400 tests pass, `source/admin-site` 849 tests pass, SDK 34 tests pass; type-check and prettier clean on web, admin-site and the SDK.

New tests: handler tests for signals returned / an empty default / a failing signals read not taking out the page; a repository test pinning the `inferred` round-trip; web tests for grouping, ordering and unknown-kind survival; admin-site card tests including the empty state.

## Merge Commit Message

feat(devices): surface recorded identification signals on the device detail view

https://claude.ai/code/session_01WW8xuyu4XVnts6NCUsjUzg