### PR TITLE
feat(uninstall): tear down runtime state on stop and add `wardnetd uninstall`

### DIFF
--- a/.agents/workflow.md
+++ b/.agents/workflow.md
@@ -66,7 +66,7 @@ We use `cargo-llvm-cov` for code coverage. Before starting work, compute the cur
 make coverage-daemon
 ```
 
-The `--ignore-filename-regex` (defined once in the Makefile's `COV_IGNORE` variable) excludes files that are not unit-testable (binary entrypoint, no-op/stub implementations prefixed with `noop_`, database pool setup, static file serving, Tower middleware boilerplate, auth context thread-locals, and Linux-only kernel interface modules). CI calls the same Makefile target with `COV_FMT` overridden for LCOV output.
+The `--ignore-filename-regex` (defined once in the Makefile's `COV_IGNORE` variable) excludes files that are not unit-testable (binary entrypoint, no-op/stub implementations prefixed with `noop_`, database pool setup, static file serving, Tower middleware boilerplate, auth context thread-locals, and Linux-only kernel interface modules — including `uninstall/ops.rs`, the `UninstallOps` impl that shells out to `systemctl`/`chown`/`userdel` and drives netlink; the decisions above it live in `uninstall/mod.rs` and are covered against a recording double). A file only belongs on this list if it holds no decisions of its own — if you find yourself wanting to exclude something with branching logic in it, extract the logic instead. CI calls the same Makefile target with `COV_FMT` overridden for LCOV output.
 
 ## Boundaries
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,6 +72,22 @@ you're about to make, rather than the whole set.
   (`ieee` | `catalog` | `signal`) and why a curated override always renders as
   a hedge; the ±4-over-48-bit neighbour search for the BLE-vs-Wi-Fi MAC trap.
   Invariant: **nothing probes a device without a direct admin action.**
+- **[Uninstall + shutdown teardown](docs/adr/0028-shutdown-teardown-and-uninstall.md)** —
+  why a stopped daemon now deletes the `inet wardnet` table and its
+  `wg_ward*` interfaces, and why a **self-initiated restart deliberately
+  does not** (the replacement process inherits correct kernel state, so
+  tearing down on every six-hourly auto-update is pure churn). Critically:
+  shutdown tears tunnels down **through `TunnelService`, not the raw
+  interface**, so each tunnel is recorded `Down` and the next boot's
+  routing reconcile brings it back on demand — deleting the interface
+  behind the database's back is unrecoverable, because
+  `handle_tunnel_down` strips the routing and nothing recreates the
+  interface. Covers the
+  `ShutdownCause` gate, `wardnetd uninstall` owning the implementation
+  because ADR 0013 removed the `nft` CLI dependency, the generated
+  `/usr/local/sbin/wardnet-uninstall` escape hatch, and the
+  default/`--purge` tiers. Invariant: **teardown deletes only our named
+  table, never a ruleset flush.**
 - **[Auth model](.agents/auth.md)** — setup wizard,
   unauthenticated vs admin endpoints, and the HARD REQUIREMENT
   that every service method opens with

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -240,6 +240,14 @@ binary is still preserved — one step back, not a history.
 
 **Hard watchdog** — The last-resort backstop: the daemon pets `/dev/watchdog` on a fixed cadence **ungated** by health (a `WatchdogOps` trait with a Linux impl and a `NoopWatchdog` mock). If the entire runtime freezes — even the health loop and the soft sd_notify ping can no longer run — the pets stop and the kernel **reboots the host**. On clean shutdown it disarms (magic close) so a graceful `systemctl stop` does not reboot. **Invariant: this layer is never health-gated.** See [0014-watchdog-and-health.md](docs/adr/0014-watchdog-and-health.md).
 
+## Uninstall and teardown (issue #864)
+
+**Runtime state** — The state the daemon installs in the *kernel*, as distinct from the files the installer put on disk: the `inet wardnet` nftables table and the `wg_ward*` `WireGuard` interfaces (outbound tunnels plus the inbound remote-access server). It is removed by name, never by flushing the whole ruleset, so rules belonging to Docker or to the operator are untouched. A stopped daemon leaves none of it behind; the installed files are a separate concern, removed by **uninstall**.
+
+**Shutdown cause** — Why the daemon is shutting down: a **signal** (SIGINT/SIGTERM from outside the process) or a **restart** (the daemon cancelling its own shutdown token to hand over to a replacement, as the auto-updater, the rollback path and the admin Restart button all do). **Runtime state** is torn down only on a signal, because a restart's replacement process is seconds away while tunnels are only rebuilt on the tunnel monitor's next tick. `systemctl restart` is indistinguishable from `systemctl stop` and therefore counts as a signal. See [0028-shutdown-teardown-and-uninstall.md](docs/adr/0028-shutdown-teardown-and-uninstall.md).
+
+**Purge** — The uninstall tier that additionally destroys `/var/lib/wardnet`: the database, the `WireGuard` private keys, the backup passphrase and the DDNS credentials. The default tier keeps them and re-owns them to root. Purged data is unrecoverable, so it is the only operation that demands the word typed in full rather than a yes.
+
 ## Monetization and entitlement
 
 **Free tier** — Self-host the daemon with your **own** domain (the **BYOD-Cloudflare DnsProvider**). Full features via the desktop admin website and `/api/*`, uncapped, forever-free; touches no wardnet-operated service beyond release downloads, so it costs Wardnet nothing. The growth surface. Does **not** include the mobile PWAs — see **Premium tier**.

--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ LINUX_TARGET := $(CURDIR)/.target-linux
 
 # Coverage: files excluded from cargo-llvm-cov.  Single source of truth —
 # CI calls `make coverage-daemon` with COV_FMT overridden for LCOV output.
-COV_IGNORE := (main\.rs|noop_.*\.rs|db\.rs|web\.rs|api/mod\.rs|auth_context\.rs|command\.rs|policy_router_netlink\.rs|firewall_netlink\.rs|route_monitor\.rs|mdns_advertiser\.rs|pnet_network_probe\.rs|garp_pnet\.rs|tunnel_exit_probe\.rs|tunnel_throughput_tester\.rs|tunnel_latency_prober\.rs|inbound_wg_peer_monitor\.rs|linux_watchdog\.rs|wardnet-test-agent/.*|wardnet-test-support/.*|wardnetd-mock/src/events\.rs|wardnetd-data/src/lib\.rs)
+COV_IGNORE := (main\.rs|noop_.*\.rs|db\.rs|web\.rs|api/mod\.rs|auth_context\.rs|command\.rs|policy_router_netlink\.rs|firewall_netlink\.rs|uninstall/ops\.rs|route_monitor\.rs|mdns_advertiser\.rs|pnet_network_probe\.rs|garp_pnet\.rs|tunnel_exit_probe\.rs|tunnel_throughput_tester\.rs|tunnel_latency_prober\.rs|inbound_wg_peer_monitor\.rs|linux_watchdog\.rs|wardnet-test-agent/.*|wardnet-test-support/.*|wardnetd-mock/src/events\.rs|wardnetd-data/src/lib\.rs)
 # Default: human-readable summary.  CI overrides:
 #   make coverage-daemon COV_FMT="--lcov --output-path ../../coverage/daemon-lcov.info"
 COV_FMT    ?= --summary-only

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -85,6 +85,16 @@ Options:
                         only. Use this on existing Pis to bootstrap the
                         post-upgrade framework without disturbing operator
                         config. Idempotent.
+  -u, --uninstall       Remove Wardnet from this host instead of installing.
+                        Hands over to /usr/local/sbin/wardnet-uninstall (which
+                        the installer writes) or, failing that, to
+                        \`wardnetd uninstall\`. Everything after this flag is
+                        passed straight through, so:
+                          --uninstall --dry-run   list what would be removed
+                          --uninstall             remove, keeping the database
+                                                  and secrets under
+                                                  /var/lib/wardnet
+                          --uninstall --purge     also destroy that data
   -h, --help            Show this help text.
 
 Environment overrides:
@@ -102,6 +112,41 @@ while [[ $# -gt 0 ]]; do
         --lan-interface)  LAN_INTERFACE="$2";     shift 2 ;;
         --static-ip)      STATIC_IP="$2";         shift 2 ;;
         --container-mode) CONTAINER_MODE=true;    shift   ;;
+        # Uninstall short-circuits everything below: it needs none of the
+        # channel validation, dependency checks or arch detection, and must
+        # still work when this script is the only thing the user has (the
+        # `curl | sudo bash` case, where $0 is not a file on disk).
+        -u|--uninstall)
+            shift
+            # `--dry-run` changes nothing, so it must not demand root — both the
+            # docs and the Rust path treat it as usable unprivileged.
+            uninstall_dry_run=""
+            for a in "$@"; do
+                [[ "$a" == "--dry-run" ]] && uninstall_dry_run=true
+            done
+            if [[ -z "$uninstall_dry_run" && $EUID -ne 0 ]]; then
+                echo "Error: uninstall must be run as root" >&2
+                exit 1
+            fi
+            if [[ -x /usr/local/sbin/wardnet-uninstall ]]; then
+                # The generated wrapper knows how this host was installed
+                # (container mode), so it re-adds the flag itself.
+                exec /usr/local/sbin/wardnet-uninstall "$@"
+            elif [[ -x /usr/local/bin/wardnetd ]]; then
+                # No wrapper (an install that failed before it was written), so
+                # nothing recorded the install mode. Forward --container-mode
+                # only if this invocation was given it, and otherwise let the
+                # caller pass it: guessing would make the printed plan claim
+                # drop-ins that were never written.
+                if [[ -n "$CONTAINER_MODE" ]]; then
+                    exec /usr/local/bin/wardnetd uninstall "$@" --container-mode
+                fi
+                exec /usr/local/bin/wardnetd uninstall "$@"
+            fi
+            echo "Error: Wardnet does not appear to be installed" >&2
+            echo "  (no /usr/local/sbin/wardnet-uninstall and no /usr/local/bin/wardnetd)" >&2
+            exit 1
+            ;;
         --upgrade-only)   UPGRADE_ONLY=true;      shift   ;;
         -h|--help)        print_usage; exit 0 ;;
         *) echo "Unknown option: $1" >&2; print_usage >&2; exit 1 ;;
@@ -583,6 +628,268 @@ for unit in wardnetd.service wardnetd-rollback.service wardnet-postupgrade.servi
     fi
 done
 
+# 6a. Escape-hatch uninstaller. Written *before* the units are enabled so a
+#     half-failed install is still removable, and written to disk because
+#     `curl | sudo bash` leaves $0 unusable — there is no script on disk to
+#     re-run with an --uninstall flag.
+#
+#     Deliberately thin. `wardnetd uninstall` is the real implementation: only
+#     the daemon can delete the nftables table, because Wardnet talks nftables
+#     over netlink (ADR 0013) and never depends on the `nft` CLI, which may not
+#     exist on this host at all. The fallback below therefore does file removal
+#     only, and says so rather than claiming a clean uninstall.
+create_uninstall_script() {
+    install -d -m 0755 /usr/local/sbin
+
+    # Recorded at install time: in container mode the installer never wrote the
+    # sysctl / dhcpcd / module-load drop-ins, so uninstall must not claim it is
+    # removing them.
+    #
+    # An --upgrade-only run does not re-state how the box was originally
+    # installed, so carry forward whatever the existing wrapper recorded rather
+    # than overwriting it with this invocation's (absent) flag. Otherwise
+    # upgrading a container install would silently turn it into a bare-metal
+    # one in the uninstall plan.
+    recorded_container_mode="${CONTAINER_MODE:-}"
+    if [[ -z "$recorded_container_mode" && -n "$UPGRADE_ONLY" \
+          && -f /usr/local/sbin/wardnet-uninstall ]] \
+       && grep -qE "^CONTAINER_MODE=(true|'true')$" /usr/local/sbin/wardnet-uninstall; then
+        recorded_container_mode=true
+    fi
+
+    {
+        printf '%s\n' '#!/usr/bin/env bash'
+        printf '%s\n' '# Generated by Wardnet install.sh — do not edit.'
+        printf '%s\n' 'set -euo pipefail'
+        printf 'CONTAINER_MODE=%q\n' "$recorded_container_mode"
+        cat <<'UNINSTALL_EOF'
+
+DAEMON=/usr/local/bin/wardnetd
+
+# Preferred path: hand over to the daemon, which can delete the nftables table
+# and the WireGuard interfaces through the same netlink code that created them.
+if [[ -x "$DAEMON" ]] && "$DAEMON" --version >/dev/null 2>&1; then
+    args=("$@")
+    if [[ -n "$CONTAINER_MODE" ]]; then
+        args+=(--container-mode)
+    fi
+    exec "$DAEMON" uninstall "${args[@]}"
+fi
+
+# Fallback: the binary is missing or will not run. Remove what shell can
+# remove, and be explicit about what we could not.
+echo "wardnetd binary is missing or will not run; falling back to file removal only." >&2
+echo "" >&2
+
+DRY_RUN=""
+PURGE=""
+ASSUME_YES=""
+for arg in "$@"; do
+    case "$arg" in
+        --dry-run) DRY_RUN=true ;;
+        --purge)   PURGE=true ;;
+        -y|--yes)  ASSUME_YES=true ;;
+        --container-mode) CONTAINER_MODE=true ;;
+        *) echo "Unknown option: $arg" >&2; exit 1 ;;
+    esac
+done
+
+UNITS=(wardnetd.service wardnetd-rollback.service wardnet-postupgrade.service)
+
+PATHS=(
+    /usr/local/bin/wardnetd
+    /usr/local/bin/wardnetd.old
+    /usr/local/libexec/wardnet
+    /etc/wardnet
+    /var/log/wardnet
+    /var/lib/wardnet-postupgrade
+)
+if [[ -n "$PURGE" ]]; then
+    PATHS+=(/var/lib/wardnet)
+else
+    PATHS+=(/var/lib/wardnet/updates /var/lib/wardnet/postupgrade)
+fi
+if [[ -z "$CONTAINER_MODE" ]]; then
+    PATHS+=(
+        /etc/sysctl.d/99-wardnet.conf
+        /etc/dhcpcd.conf.d/wardnet.conf
+        /etc/modules-load.d/wardnet-watchdog.conf
+    )
+fi
+
+if [[ -n "$DRY_RUN" ]]; then
+    echo "Would disable and remove these units:"
+    printf '  %s\n' "${UNITS[@]}"
+    echo "Would remove these paths:"
+    printf '  %s\n' "${PATHS[@]}"
+    if [[ -z "$PURGE" ]]; then
+        # The plan claims to mark everything removed *or kept*, so the retained
+        # tree has to appear even though it is absent from PATHS.
+        echo "Would KEEP these paths (re-owned to root; --purge destroys them):"
+        echo "  /var/lib/wardnet (database and secrets)"
+    fi
+    if [[ -n "$PURGE" ]]; then
+        echo "Would remove the wardnet system user."
+    else
+        echo "Would remove the wardnet system user (kept if /var/lib/wardnet cannot"
+        echo "  be re-owned to root)."
+    fi
+    echo "Would delete every wg_ward* interface."
+    # Probe for the table the same way the real run does, so the plan reports
+    # what would actually happen rather than what is merely possible. Listing
+    # nftables needs root, and --dry-run is deliberately usable unprivileged, so
+    # only probe when we can: a denied probe looks identical to an absent table,
+    # and reporting "nothing to delete" on a host that has one would be a lie in
+    # exactly the case this feature exists for.
+    if ! command -v nft >/dev/null 2>&1; then
+        echo "Would NOT be able to delete the 'inet wardnet' nftables table:"
+        echo "  neither a working wardnetd binary nor the nft command is available."
+    elif [[ $EUID -ne 0 ]]; then
+        echo "Would delete the 'inet wardnet' nftables table if present (via the nft"
+        echo "  command); re-run with sudo to check whether it currently exists."
+    elif nft list table inet wardnet >/dev/null 2>&1; then
+        echo "Would delete the 'inet wardnet' nftables table (via the nft command)."
+    else
+        echo "The 'inet wardnet' nftables table is not present; nothing to delete."
+    fi
+    exit 0
+fi
+
+# Checked after --dry-run, which changes nothing and so needs no privileges.
+if [[ $EUID -ne 0 ]]; then
+    echo "Error: wardnet-uninstall must be run as root (try: sudo $0 $*)" >&2
+    exit 1
+fi
+
+# Confirm before destroying anything. The Rust path refuses to act without a
+# confirmation, and this fallback must not be the softer option — it runs
+# exactly when the daemon binary is broken, i.e. when the operator is least
+# likely to be here deliberately. Read from /dev/tty, not stdin, so the
+# documented `curl ... | sudo bash -s -- --uninstall` form can still answer.
+echo ""
+echo "This host is your LAN's DHCP server and DNS resolver. Removing Wardnet"
+echo "leaves the network without either until you re-enable DHCP on your router."
+if [[ -n "$PURGE" ]]; then
+    echo ""
+    echo "--purge DESTROYS /var/lib/wardnet: the database, WireGuard private keys,"
+    echo "the backup passphrase and any DDNS credentials. This cannot be undone."
+    prompt="Type PURGE to destroy all data and uninstall: "
+    expected="PURGE"
+else
+    prompt="Type yes to uninstall: "
+    expected="yes"
+fi
+
+if [[ -z "$ASSUME_YES" ]]; then
+    if [[ ! -r /dev/tty ]]; then
+        echo "Error: refusing to uninstall without --yes: no terminal to confirm on" >&2
+        exit 1
+    fi
+    printf '%s' "$prompt" > /dev/tty
+    read -r answer < /dev/tty
+    if [[ "$answer" != "$expected" ]]; then
+        echo "Aborted; nothing was changed."
+        exit 0
+    fi
+fi
+
+# Stop cleanly, never SIGKILL: the daemon disarms the hardware watchdog on a
+# clean exit, and an ungraceful kill reboots this host ~15s later. Verify it
+# actually went down — deleting the binary, units and interfaces out from under
+# a live daemon is the very situation that arms the watchdog.
+systemctl stop wardnetd.service 2>/dev/null || true
+if systemctl is-active --quiet wardnetd.service 2>/dev/null; then
+    echo "Error: wardnetd.service is still running after 'systemctl stop'." >&2
+    echo "  Refusing to continue: removing files under a live daemon risks a" >&2
+    echo "  forced kill, which leaves the hardware watchdog armed and reboots" >&2
+    echo "  this host. Investigate with: systemctl status wardnetd" >&2
+    exit 1
+fi
+for unit in "${UNITS[@]}"; do
+    systemctl disable "$unit" 2>/dev/null || true
+    rm -f "/etc/systemd/system/$unit"
+done
+
+# `ip` is present on any systemd host, so the interfaces we can clean up.
+for iface in $(ip -o link show 2>/dev/null | awk -F': ' '{print $2}' | grep '^wg_ward' || true); do
+    ip link delete "$iface" 2>/dev/null || true
+done
+
+for path in "${PATHS[@]}"; do
+    rm -rf "$path"
+done
+
+# Re-own retained data: the wardnet user is about to go, and an orphaned UID
+# can be silently reassigned to another service later.
+#
+# Deleting the account is what turns a failed re-own into that hazard, so the
+# user only goes once the data is safely root-owned. A leftover system user is
+# trivially removable by hand; a recycled UID silently owning the WireGuard
+# keys is not. Mirrors the same gating in `wardnetd uninstall`.
+data_is_root_owned=true
+if [[ -z "$PURGE" && -d /var/lib/wardnet ]]; then
+    if ! chown -R -h root:root -- /var/lib/wardnet 2>/dev/null; then
+        data_is_root_owned=""
+    fi
+fi
+
+if [[ -n "$data_is_root_owned" ]]; then
+    userdel wardnet 2>/dev/null || true
+else
+    echo "Keeping the wardnet user: /var/lib/wardnet could not be re-owned to root," >&2
+    echo "  and removing the account would leave its data owned by an orphaned UID." >&2
+fi
+systemctl daemon-reload 2>/dev/null || true
+
+echo ""
+if [[ -z "$PURGE" ]]; then
+    echo "Kept /var/lib/wardnet (database and secrets), now owned by root."
+    echo "Delete it with: sudo rm -rf /var/lib/wardnet"
+    echo ""
+fi
+
+# The daemon is the only thing guaranteed to be able to delete the nftables
+# table, but if the `nft` CLI happens to be installed we can finish the job and
+# report an honest success instead of an unresolved warning. Deleting only our
+# named table, never a ruleset flush.
+#
+# This script only deletes itself once the job is genuinely done. On the
+# unresolved path below the firewall table is still live, and `nft` is
+# deliberately not an install dependency (ADR 0013), so that path is a real
+# outcome rather than a corner case — leaving the uninstaller on disk is what
+# makes the documented "safe to re-run" promise true.
+if command -v nft >/dev/null 2>&1; then
+    if nft list table inet wardnet >/dev/null 2>&1; then
+        if nft delete table inet wardnet >/dev/null 2>&1; then
+            echo "Removed the 'inet wardnet' nftables table."
+        else
+            echo "Failed to delete the 'inet wardnet' nftables table; it is still active." >&2
+            echo "Leaving $0 in place so you can re-run it." >&2
+            exit 1
+        fi
+    fi
+    rm -f /usr/local/sbin/wardnet-uninstall
+    echo "Wardnet has been removed."
+    exit 0
+fi
+
+echo "Wardnet files were removed, but firewall state may still be present:" >&2
+echo "  the 'inet wardnet' nftables table needs either the daemon or the 'nft'" >&2
+echo "  command to delete, and neither is available on this host. Check with:" >&2
+echo "    sudo nft list table inet wardnet" >&2
+echo "    sudo nft delete table inet wardnet" >&2
+echo "  This uninstaller has been left at $0 so you can re-run it after" >&2
+echo "  installing nftables." >&2
+echo "  Otherwise it clears on the next reboot." >&2
+exit 1
+UNINSTALL_EOF
+    } > /usr/local/sbin/wardnet-uninstall
+    chmod 0755 /usr/local/sbin/wardnet-uninstall
+    echo "Wrote uninstaller to /usr/local/sbin/wardnet-uninstall"
+}
+
+create_uninstall_script
+
 # 6b. IP forwarding. Per-device VPN routing forwards LAN traffic into the
 #     WireGuard tunnels, which requires net.ipv4.ip_forward=1. The daemon
 #     runs as an unprivileged user (User=wardnet, no CAP_DAC_OVERRIDE) and
@@ -620,6 +927,12 @@ if [[ -n "$CONTAINER_MODE" ]]; then
 else
     systemctl enable wardnet-postupgrade.service
     systemctl enable --now wardnetd
+    # NOTE: this is a bare SIGTERM, so the daemon classifies it as a *stop*
+    # (ShutdownCause::Signal) and tears down its nftables table and wg_ward*
+    # interfaces. Both come back on the next boot: startup reconcile rebuilds
+    # the table, and because teardown records each tunnel as Down, the same
+    # reconcile's per-device pass brings the tunnels back up on demand.
+    # See docs/adr/0028-shutdown-teardown-and-uninstall.md.
     systemctl restart wardnetd
 
     # Wait briefly for the daemon to bind its HTTP port so the URL we print is

--- a/docs/adr/0028-shutdown-teardown-and-uninstall.md
+++ b/docs/adr/0028-shutdown-teardown-and-uninstall.md
@@ -1,0 +1,177 @@
+---
+status: accepted
+date: 2026-08-08
+issue: "#864 — Provide a proper uninstall path"
+---
+
+# ADR: Tear down runtime state on shutdown, but only when the daemon is stopping rather than restarting
+
+---
+
+## Context
+
+Wardnet shipped `install.sh` with no uninstall path. Underneath that convenience
+gap sat a real defect: **the daemon never removed the kernel state it created.**
+The `inet wardnet` nftables table is created at startup and was never deleted,
+and the `wg_ward*` `WireGuard` interfaces likewise survived a stop. After
+`systemctl stop wardnetd`, every forward/input/NAT rule stayed live in the
+kernel until the next reboot. A stopped daemon was still filtering the user's
+traffic.
+
+The capability was already there and unused: `FirewallManager` has had a
+`destroy_wardnet_table()` since the netlink migration, documented as "cleanup on
+shutdown", implemented idempotently, and called by nothing. The work was wiring,
+not implementation.
+
+Two facts about the codebase shape the decision:
+
+1. **The daemon restarts itself far more often than it is stopped.** The
+   auto-update runner, the rollback path, and the admin Restart button all
+   cancel the shared shutdown token to hand over to a replacement process under
+   `Restart=always`. On a live box the six-hourly update poll makes restart the
+   overwhelmingly common shutdown.
+2. **Tunnels have no boot reconcile of their own.** `routing.reconcile()` runs
+   at startup and rebuilds the nftables table (it already begins with a
+   `flush_wardnet_table()`), but there is no `services.tunnel.reconcile()` in
+   `main.rs`. The only thing that recreates a `wg_ward*` interface is the
+   on-demand bring-up inside `RoutingService::apply_rule`, and that fires only
+   when the tunnel is *recorded* as `Down`. Which record the database holds is
+   therefore load-bearing — see decision 2.
+
+## Decision
+
+### 1. Teardown is gated on the cause of the shutdown
+
+`shutdown_signal` previously collapsed all three `select!` arms to `()`,
+discarding which one fired. It now returns a `ShutdownCause`:
+
+- **`Signal`** — SIGINT or SIGTERM arrived from outside the process.
+- **`Restart`** — the daemon cancelled its own shutdown token.
+
+Runtime state is torn down only for `Signal`.
+
+The alternative — unconditional teardown — is simpler and was rejected. Even
+with decision 2 making teardown recoverable, it would still tear down and
+re-establish every tunnel on **every auto-update**, six-hourly, for no benefit:
+the replacement process is seconds away and inherits a kernel state that was
+already correct. Users would notice the churn far more than a leftover table.
+
+`systemctl restart` typed by a human is indistinguishable from `systemctl stop`:
+both arrive as a bare SIGTERM, and systemd offers the process nothing to tell
+them apart. It therefore classifies as `Signal` and tears down. That costs one
+bring-up cycle but is not otherwise harmful, given decision 2 below. We accepted
+it rather than inventing an on-disk "expect a restart" marker, which would be a
+new correctness hazard (a stale marker would suppress teardown on a real stop)
+in exchange for tidying a rare case.
+
+### 2. Tunnels are torn down *through the service*, not the interface
+
+This is what makes signal teardown safe, and it is easy to get wrong.
+
+Deleting a `wg_ward*` interface behind the database's back leaves the tunnel
+recorded as `Up` with no interface, and **the daemon never recovers from that on
+its own**. The monitor's `reconcile_iface_presence` flips it to `Down` and
+publishes `TunnelDown`; `RoutingService::handle_tunnel_down` then *removes* the
+routing for every device using that tunnel and drops its route table. Nothing
+recreates the interface: the on-demand bring-up inside `apply_rule` only fires
+for a tunnel already recorded as `Down`, and startup reconcile runs before the
+monitor's first tick, when the record still says `Up`. The observable result
+would be tunnel-routed devices silently falling back to direct WAN after any
+`systemctl stop`, until an admin brought each tunnel up by hand — a regression
+against the previous behaviour, where interfaces simply survived a restart.
+
+So shutdown calls `TunnelService::tear_down_internal` per live tunnel, which
+removes the interface *and* records `Down`. The next boot's
+`routing.reconcile()` per-device `apply_rule` pass then sees `Down` and uses the
+existing on-demand bring-up to recreate exactly the interfaces the configured
+devices need. Uninstall keeps using the raw interface path, because there is no
+database left to keep in step — and with `--purge` it is about to delete it.
+
+Both halves ride the same gate even though the nftables half would be safe
+unconditionally. One rule is easier to reason about than two, and the cost of
+the extra caution is a table that startup reconcile flushes anyway.
+
+### 3. Teardown runs after the hardware watchdog is disarmed
+
+The shutdown sequence already disarmed the hardware watchdog first, so "a slow
+shutdown can't trip a reboot". Netlink teardown is exactly that slow thing, so
+it belongs after that point and before the graceful-shutdown marker is recorded.
+
+Every step is best-effort and logged rather than propagated: failing loudly on
+the shutdown path would turn an untidy exit into a failed unit.
+
+### 4. `wardnetd uninstall` owns the uninstall implementation
+
+This follows directly from `0013-nftables-pure-netlink.md`. That ADR removed the
+`nft` shell-out in favour of `rustables` so that nothing C links at runtime, and
+`install.sh` accordingly does **not** list `nft` as a dependency — it may not
+exist on the host at all. A shell uninstaller therefore cannot be relied on to
+delete `table inet wardnet`.
+
+So the uninstaller calls the same abstraction that installed the state, the same
+instinct as the `WatchdogOps` boundary. `install.sh` additionally generates a
+thin `/usr/local/sbin/wardnet-uninstall` wrapper (k3s-style, written before the
+units are enabled so a half-failed install is still removable, and on disk
+because `curl | sudo bash` leaves no script to re-run). The wrapper execs the
+subcommand when the binary works; when it does not, it falls back to file
+removal only and **exits non-zero saying firewall state may remain**, rather
+than reporting a clean uninstall it did not achieve.
+
+The fallback is deliberately dumber than the subcommand rather than a mirror of
+it. Two implementations of the same inventory would drift.
+
+### 5. Two tiers, with retained data re-owned to root
+
+The default run keeps `/var/lib/wardnet/wardnet.db*` and
+`/var/lib/wardnet/secrets/` and prints where they are; `--purge` destroys them.
+Anything retained is `chown -R root:root`, because the `wardnet` system user is
+deleted in the same run and files owned by an orphaned UID can be silently
+inherited by whatever service is assigned that ID next.
+
+Confirmation is inverted relative to `install.sh`: the installer degrades to
+non-interactive defaults with no tty because installing is safe, whereas
+uninstall refuses without `--yes`. `--purge` requires the word `PURGE` in full.
+No automatic backup is taken before `--purge` — it would need a passphrase we
+cannot prompt for in a piped context, and a half-written backup is worse than
+none.
+
+## Consequences
+
+- A stopped daemon no longer filters traffic. Uninstall becomes mostly file
+  removal, because the clean stop has already done the kernel work; the
+  subcommand repeats it as an idempotent sweep in case the daemon was killed
+  ungracefully.
+- Restart behaviour is unchanged, so auto-updates cost no tunnel downtime.
+- The shutdown asymmetry is invisible from the code alone, which is the main
+  reason this ADR exists: a reader will ask why `systemctl stop` deletes the
+  table and an auto-update restart does not.
+- `TunnelInterface::list()` enumerates *every* `WireGuard` device on the host,
+  so teardown filters on the `wg_ward` prefix (now a shared
+  `TUNNEL_INTERFACE_PREFIX` constant rather than three scattered literals).
+  Without that filter we would delete tunnels the user created themselves.
+- An ungraceful kill still leaves the hardware watchdog armed and reboots the
+  host ~15s later. The uninstaller always stops the unit cleanly for this
+  reason, and the behaviour is now documented rather than merely true.
+- `install.sh` ends with `systemctl restart wardnetd` on every run, including
+  `--upgrade-only`. That is a bare SIGTERM, so it classifies as `Signal` and
+  does tear down. Decision 2 is what makes this benign: the tunnels come back
+  during the next boot's routing reconcile rather than staying down.
+- Tunnel bring-up at boot is **demand-driven, not blanket**. Only tunnels that
+  a configured device actually routes through are recreated, because the
+  bring-up rides the per-device `apply_rule` loop. A tunnel with no devices
+  pointing at it stays `Down`, which is both correct and consistent with the
+  idle-tunnel watcher's behaviour.
+
+## Not decided here
+
+Whether to add an explicit `services.tunnel.reconcile()` at startup instead of
+relying on the routing reconcile's per-device bring-up. The current route reuses
+a well-tested path and keeps bring-up demand-driven; a dedicated reconcile would
+be more obvious to a reader but would need its own answer to "which tunnels
+should be up with no devices on them?", which is really the idle-tunnel
+watcher's question.
+
+## References
+
+- `0013-nftables-pure-netlink.md` — why `nft` is not an install dependency.
+- `0014-watchdog-and-health.md` — the disarm-first shutdown contract.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -42,3 +42,4 @@ edge-release-channel one.
 | [0025](0025-device-identification.md) | Device identification — a shared vendor catalog, hedged guesses, and no background probing | 2026-08-03 | Accepted |
 | [0026](0026-switchback-and-cross-zone-return.md) | Switchback — cross-zone exceptions reaching a tunnel-bound device | 2026-07-19 | Accepted |
 | [0027](0027-e2e-auto-update-version-skew.md) | The auto-update e2e synthesises its version skew from one source tree | 2026-08-08 | Accepted |
+| [0028](0028-shutdown-teardown-and-uninstall.md) | Runtime-state teardown on shutdown, gated on stop vs restart; `wardnetd uninstall` | 2026-08-08 | Accepted |

--- a/source/daemon/crates/wardnetd-services/src/routing/service.rs
+++ b/source/daemon/crates/wardnetd-services/src/routing/service.rs
@@ -928,7 +928,10 @@ impl RoutingServiceImpl {
 ///
 /// For example, `"wg_ward0"` returns `Some(0)` and `"wg_ward12"` returns `Some(12)`.
 fn parse_interface_index(interface_name: &str) -> Option<u32> {
-    interface_name.strip_prefix("wg_ward")?.parse().ok()
+    interface_name
+        .strip_prefix(crate::tunnel::interface::TUNNEL_INTERFACE_PREFIX)?
+        .parse()
+        .ok()
 }
 
 /// Compute the routing table number for a tunnel interface index.

--- a/source/daemon/crates/wardnetd-services/src/tunnel/interface.rs
+++ b/source/daemon/crates/wardnetd-services/src/tunnel/interface.rs
@@ -3,6 +3,17 @@ use chrono::{DateTime, Utc};
 use ipnetwork::IpNetwork;
 use std::net::SocketAddr;
 
+/// Name prefix shared by every `WireGuard` interface Wardnet owns.
+///
+/// Outbound tunnels are `wg_ward{idx}`; the inbound remote-access server
+/// (`INBOUND_WG_INTERFACE`) deliberately shares the prefix so the zone-egress
+/// drop rule can match tunnels with a single wildcard.
+///
+/// The prefix is what distinguishes our interfaces from any the user created
+/// themselves, so anything that enumerates or sweeps interfaces must filter on
+/// it — `TunnelInterface::list` returns every `WireGuard` device on the host.
+pub const TUNNEL_INTERFACE_PREFIX: &str = "wg_ward";
+
 /// Configuration for creating a tunnel interface.
 #[derive(Debug, Clone)]
 pub struct CreateTunnelParams {

--- a/source/daemon/crates/wardnetd-services/src/tunnel/service.rs
+++ b/source/daemon/crates/wardnetd-services/src/tunnel/service.rs
@@ -950,7 +950,7 @@ impl TunnelService for TunnelServiceImpl {
             .next_interface_index()
             .await
             .map_err(AppError::Internal)?;
-        let interface_name = format!("wg_ward{idx}");
+        let interface_name = format!("{}{idx}", crate::tunnel::interface::TUNNEL_INTERFACE_PREFIX);
 
         // Generate tunnel ID.
         let id = Uuid::new_v4();

--- a/source/daemon/crates/wardnetd/src/firewall_netlink.rs
+++ b/source/daemon/crates/wardnetd/src/firewall_netlink.rs
@@ -18,8 +18,10 @@
 use std::collections::HashSet;
 use std::net::{IpAddr, Ipv4Addr};
 
+use anyhow::Context as _;
 use async_trait::async_trait;
 use ipnetwork::IpNetwork;
+use rustables::error::QueryError;
 use rustables::expr::{
     Bitwise, Cmp, CmpOp, ConnTrackState, Conntrack, ConntrackKey, Immediate, Meta, MetaType,
     Payload, Register, Reject, RejectType, VerdictKind,
@@ -1080,19 +1082,56 @@ impl FirewallManager for NetlinkFirewallManager {
             let table = wardnet_table();
             let mut batch = Batch::new();
             batch.add(&table, MsgType::Del);
+            // Preserve the `QueryError` instead of interpolating it into a new
+            // `anyhow!`. The kernel's "no such table" answer lives only in
+            // `nlmsgerr.error`; `QueryError`'s `Display` is the static string
+            // "Error received from the kernel" and the variant carries no
+            // `#[source]`, so stringifying here would destroy the one piece of
+            // information `is_table_absent_error` needs.
             batch
                 .send()
-                .map_err(|e| anyhow::anyhow!("destroy wardnet table: {e}"))?;
+                .map_err(anyhow::Error::new)
+                .context("destroy wardnet table")?;
             Ok(())
         })
         .await;
         match result {
-            Ok(()) => tracing::info!("nftables: wardnet table destroyed"),
-            // Ignore errors when the table doesn't exist (first run / already gone).
-            Err(e) => {
-                tracing::debug!(error = %e, "nftables: ignoring error during table destruction: {e}");
+            Ok(()) => {
+                tracing::info!("nftables: wardnet table destroyed");
+                Ok(())
             }
+            // An absent table is success: this runs on shutdown and on
+            // uninstall, both of which must be safe to repeat.
+            Err(e) if is_table_absent_error(&e) => {
+                tracing::debug!(error = %e, "nftables: wardnet table already absent");
+                Ok(())
+            }
+            // Anything else is real and must propagate. Swallowing it would let
+            // `wardnetd uninstall` report a clean removal while the table was
+            // still filtering the user's traffic — see issue #864.
+            Err(e) => Err(e),
         }
-        Ok(())
     }
+}
+
+/// Whether a table-delete error means "there was no table", as opposed to a
+/// real failure such as `EPERM` in a restricted namespace or a busy socket.
+///
+/// The kernel answers a delete of a non-existent table with `ENOENT`, which
+/// `rustables` reports as [`QueryError::NetlinkError`] carrying the raw
+/// `nlmsgerr`. That struct's `error` field is the only place the errno appears:
+/// the variant has no `#[source]`, and its `Display` is a fixed string. So this
+/// must downcast to the concrete error and read the field — matching on message
+/// text would silently never fire, and the absent-table case is the *common*
+/// one (a clean `systemctl stop` already removed the table before
+/// `wardnetd uninstall` sweeps again).
+///
+/// The kernel reports errnos negated, so compare on the magnitude.
+pub(crate) fn is_table_absent_error(err: &anyhow::Error) -> bool {
+    err.chain().any(|cause| {
+        matches!(
+            cause.downcast_ref::<QueryError>(),
+            Some(QueryError::NetlinkError(e)) if e.error.abs() == libc::ENOENT
+        )
+    })
 }

--- a/source/daemon/crates/wardnetd/src/lib.rs
+++ b/source/daemon/crates/wardnetd/src/lib.rs
@@ -25,6 +25,15 @@ pub mod dns;
 // Host-power operations (systemctl reboot/poweroff).
 pub mod system;
 
+// Shutdown-cause classification and teardown of the kernel state the daemon
+// created (nftables table, wireguard interfaces) — see issue #864.
+pub mod shutdown;
+
+// `wardnetd uninstall` — removes the daemon, its host state, and (with
+// --purge) its data. Lives here because only the binary can delete the
+// nftables table via netlink; see ADR 0013 and issue #864.
+pub mod uninstall;
+
 // Daemon-owned TLS termination: :443 RustlsConfig + hot cert reload, :80→:443
 // redirect, and the 503 "not provisioned" guard.
 pub mod tls_server;

--- a/source/daemon/crates/wardnetd/src/main.rs
+++ b/source/daemon/crates/wardnetd/src/main.rs
@@ -2,10 +2,10 @@ use std::ffi::OsStr;
 use std::future::IntoFuture;
 use std::net::SocketAddr;
 use std::path::{Path, PathBuf};
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 use std::time::{Duration, Instant};
 
-use clap::Parser;
+use clap::{Parser, Subcommand};
 use opentelemetry::trace::TracerProvider as _;
 use opentelemetry::{Key, KeyValue, Value};
 use opentelemetry_otlp::WithExportConfig;
@@ -45,6 +45,7 @@ use wardnetd::policy_router_netlink::NetlinkPolicyRouter;
 use wardnetd::profiling::ProfilingAgent;
 use wardnetd::route_monitor::RouteMonitor;
 use wardnetd::routing_listener::RoutingListener;
+use wardnetd::shutdown::ShutdownCause;
 use wardnetd::system::{
     LinuxWatchdog, PnetNetworkProbe, ProcNetNetworkInspector, SystemctlPowerOps,
 };
@@ -55,6 +56,7 @@ use wardnetd::tunnel_interface_wireguard::WireGuardTunnelInterface;
 use wardnetd::tunnel_latency_prober::SurgePingTunnelLatencyProber;
 use wardnetd::tunnel_monitor::TunnelMonitor;
 use wardnetd::tunnel_throughput_tester::HttpThroughputTester;
+use wardnetd::uninstall::UninstallArgs;
 use wardnetd::watchdog::{HardwareWatchdogRunner, Notifier, SdNotifier, SoftWatchdogRunner};
 use wardnetd::zone_enforcement_listener::ZoneEnforcementListener;
 use wardnetd_api::state::AppState;
@@ -121,11 +123,34 @@ struct Cli {
     /// Run in foreground mode (default). Use with systemd or as a regular process.
     #[arg(long)]
     foreground: bool,
+
+    /// Optional subcommand. Absent means "run the daemon", which is what
+    /// `wardnetd.service` invokes — the unit passes only `--config`, so this
+    /// must stay optional.
+    #[command(subcommand)]
+    command: Option<Command>,
+}
+
+#[derive(Subcommand)]
+enum Command {
+    /// Remove Wardnet from this host: the daemon, its systemd units, its user,
+    /// its configuration and the firewall/`WireGuard` state it created.
+    ///
+    /// Keeps the database and secret store unless `--purge` is given.
+    Uninstall(UninstallArgs),
 }
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     let cli = Cli::parse();
+
+    // Uninstall runs before any config load or tracing setup: it must work on
+    // a host whose config is already gone or malformed, and its output is a
+    // human-readable plan on stdout rather than structured logs.
+    if let Some(Command::Uninstall(args)) = &cli.command {
+        return wardnetd::uninstall::run(args).await;
+    }
+
     let config = ApplicationConfiguration::load(&cli.config)?;
 
     // Build the log service BEFORE init_tracing so its tracing layers can
@@ -397,6 +422,13 @@ async fn run(
             )
         };
 
+    // Hold a clone of the firewall backend outside `Backends`, for the same
+    // reason as `garp_ops` and `watchdog_ops`: the shutdown block runs after
+    // `init_services_with_factory` has consumed `Backends`, and it needs to
+    // delete the `inet wardnet` table (issue #864).
+    let firewall: Arc<dyn wardnetd_services::routing::FirewallManager> =
+        Arc::new(NetlinkFirewallManager::new());
+
     let backends = Backends {
         tunnel_interface,
         inbound_wg_interface: inbound_wg_interface.clone(),
@@ -407,7 +439,7 @@ async fn run(
             NetlinkPolicyRouter::new(executor.clone())
                 .expect("failed to initialise netlink policy router"),
         ),
-        firewall: Arc::new(NetlinkFirewallManager::new()),
+        firewall: firewall.clone(),
         packet_capture: packet_capture.clone(),
         hostname_resolver: Arc::new(SystemHostnameResolver),
         secret_store: secret_store.clone(),
@@ -1170,12 +1202,23 @@ async fn run(
     // watchdog supervision and `systemctl start`'s return. No-op outside systemd.
     notifier.notify_ready();
 
+    // `with_graceful_shutdown` takes a `Future<Output = ()>`, so the cause
+    // `shutdown_signal` resolves to is stashed here for the teardown block
+    // below to read once serving has finished.
+    let shutdown_cause: Arc<OnceLock<ShutdownCause>> = Arc::new(OnceLock::new());
+
     let api_span = tracing::info_span!(parent: &root_span, "api_server");
     axum::serve(
         listener,
         app.into_make_service_with_connect_info::<SocketAddr>(),
     )
-    .with_graceful_shutdown(shutdown_signal(shutdown_token.clone()))
+    .with_graceful_shutdown({
+        let token = shutdown_token.clone();
+        let cause_slot = shutdown_cause.clone();
+        async move {
+            let _ = cause_slot.set(shutdown_signal(token).await);
+        }
+    })
     .into_future()
     .instrument(api_span)
     .await?;
@@ -1259,6 +1302,51 @@ async fn run(
     }
     if let Some(agent) = profiling_agent {
         agent.shutdown();
+    }
+
+    // Remove the kernel state we created — the `inet wardnet` nftables table
+    // and our `wg_ward*` interfaces — so a stopped daemon is not still
+    // filtering the user's traffic (issue #864).
+    //
+    // Deliberately skipped for a self-initiated restart: the replacement
+    // process is seconds away, and tunnels have no synchronous boot reconcile,
+    // so tearing them down would black out the user's VPN until the next
+    // tunnel-monitor tick. See `wardnetd::shutdown` for the full rationale.
+    //
+    // Safe to run here because the hardware watchdog was disarmed above: a
+    // slow netlink round-trip can no longer trip a reboot. An unset slot means
+    // serving ended without `shutdown_signal` resolving, which we treat as a
+    // signal — leaning towards cleaning up.
+    let cause = shutdown_cause
+        .get()
+        .copied()
+        .unwrap_or(ShutdownCause::Signal);
+    if cause.tears_down_runtime_state() {
+        // Through the tunnel *service*, not the raw interface, so each tunnel's
+        // recorded status follows the kernel. That is what lets the next boot's
+        // routing reconcile bring the tunnels back up on demand — see
+        // `TunnelTeardown`. Wrapped in an admin context because `list_tunnels`
+        // is auth-gated and this runs outside the HTTP middleware chain, the
+        // same pattern as the GARP farewell above.
+        //
+        // Failures are already logged by the callee; the returned list exists
+        // for `wardnetd uninstall`, which has no tracing subscriber.
+        let teardown_ctx = AuthContext::Admin {
+            admin_id: uuid::Uuid::nil(),
+        };
+        let _ = auth_context::with_context(
+            teardown_ctx,
+            wardnetd::shutdown::teardown_runtime_state(
+                &firewall,
+                wardnetd::shutdown::TunnelTeardown::Service(&services.tunnel),
+                &inbound_wg_interface,
+            ),
+        )
+        .await;
+    } else {
+        tracing::info!(
+            "restart in progress; leaving nftables table and wireguard interfaces in place"
+        );
     }
 
     // Mark this shutdown as graceful so the next boot's
@@ -1536,27 +1624,38 @@ fn init_tracing(
     }
 }
 
-async fn shutdown_signal(restart_token: tokio_util::sync::CancellationToken) {
+/// Wait for a reason to shut down, and report which one arrived.
+///
+/// The distinction matters because it decides whether the teardown block
+/// removes the kernel state we own (issue #864). Only the daemon itself
+/// cancels `restart_token` — the auto-update runner, the rollback path and the
+/// admin Restart button — so a cancellation reliably means "a replacement
+/// process is coming". The two OS signals carry no such promise: `systemctl
+/// stop` and `systemctl restart` both arrive as a bare SIGTERM and are
+/// indistinguishable from each other, so both classify as
+/// [`ShutdownCause::Signal`].
+async fn shutdown_signal(restart_token: tokio_util::sync::CancellationToken) -> ShutdownCause {
     let ctrl_c = tokio::signal::ctrl_c();
 
     #[cfg(unix)]
-    {
+    let cause = {
         let mut sigterm = tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())
             .expect("failed to install SIGTERM handler");
         tokio::select! {
-            _ = ctrl_c => {},
-            _ = sigterm.recv() => {},
-            () = restart_token.cancelled() => {},
+            _ = ctrl_c => ShutdownCause::Signal,
+            _ = sigterm.recv() => ShutdownCause::Signal,
+            () = restart_token.cancelled() => ShutdownCause::Restart,
         }
-    }
+    };
 
     #[cfg(not(unix))]
-    {
+    let cause = {
         tokio::select! {
-            _ = ctrl_c => {},
-            () = restart_token.cancelled() => {},
+            _ = ctrl_c => ShutdownCause::Signal,
+            () = restart_token.cancelled() => ShutdownCause::Restart,
         }
-    }
+    };
 
-    tracing::info!("shutdown signal received");
+    tracing::info!(?cause, "shutdown signal received");
+    cause
 }

--- a/source/daemon/crates/wardnetd/src/shutdown/mod.rs
+++ b/source/daemon/crates/wardnetd/src/shutdown/mod.rs
@@ -1,0 +1,234 @@
+//! Shutdown-cause classification and teardown of the kernel state the daemon
+//! created.
+//!
+//! # Runtime state
+//!
+//! "Runtime state" is the state the daemon installs in the *kernel*, as
+//! distinct from the files the installer put on disk: the `inet wardnet`
+//! nftables table and the `wg_ward*` `WireGuard` interfaces. Historically none
+//! of it was ever removed — `systemctl stop wardnetd` left every
+//! forward/input/NAT rule live until the next reboot, so a stopped daemon was
+//! still filtering the user's traffic (issue #864).
+//!
+//! # Why teardown is gated on the cause
+//!
+//! The daemon restarts itself far more often than it is stopped: the
+//! auto-update runner, the rollback path, and the admin "Restart" button all
+//! cancel the shutdown token to hand over to a fresh process under
+//! systemd's `Restart=always`. Tearing runtime state down on *those* shutdowns
+//! would be actively harmful, because tunnels have **no synchronous boot
+//! reconcile** — `wg_ward*` interfaces are only rebuilt lazily by the tunnel
+//! monitor's health-check tick, so every six-hourly auto-update would drop
+//! the user's VPN tunnels for a full health-check interval.
+//!
+//! So teardown runs only for [`ShutdownCause::Signal`]. The nftables side
+//! would in fact be safe either way (startup reconcile flushes the table
+//! anyway), but keeping both halves on the same gate means one rule to reason
+//! about rather than two.
+//!
+//! A human typing `systemctl restart wardnetd` is indistinguishable from
+//! `systemctl stop` — both arrive as a bare SIGTERM — so it classifies as
+//! `Signal` and tears down. That costs one bring-up cycle but nothing more:
+//! startup reconcile rebuilds the nftables table, and because teardown records
+//! each tunnel as `Down` (see [`TunnelTeardown`]), the same reconcile's
+//! per-device `apply_rule` pass brings the tunnels back up on demand.
+
+use std::sync::Arc;
+
+use wardnet_common::tunnel::TunnelStatus;
+use wardnetd_services::inbound_wg::InboundWgInterface;
+use wardnetd_services::inbound_wg::service::INBOUND_WG_INTERFACE;
+use wardnetd_services::routing::FirewallManager;
+use wardnetd_services::tunnel::interface::TUNNEL_INTERFACE_PREFIX;
+use wardnetd_services::tunnel::{TunnelInterface, TunnelService};
+
+#[cfg(test)]
+mod tests;
+
+/// What caused the daemon to begin shutting down.
+///
+/// Produced by the `shutdown_signal` future in `main.rs`, which selects over
+/// SIGINT, SIGTERM and the shared shutdown token. The token is cancelled only
+/// by the daemon itself (auto-update, rollback, admin restart), so cancelling
+/// it is a reliable signal of *intended restart*; the two OS signals are not.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ShutdownCause {
+    /// SIGINT or SIGTERM arrived from outside the process — `systemctl stop`,
+    /// a `kill`, or Ctrl-C. Indistinguishable from `systemctl restart`.
+    Signal,
+    /// The daemon cancelled its own shutdown token to hand over to a
+    /// replacement process (auto-update, rollback, or admin restart).
+    Restart,
+}
+
+impl ShutdownCause {
+    /// Whether this shutdown should remove the kernel state the daemon owns.
+    ///
+    /// See the module docs for why a restart deliberately leaves it in place.
+    #[must_use]
+    pub fn tears_down_runtime_state(self) -> bool {
+        matches!(self, Self::Signal)
+    }
+}
+
+/// Pick out the tunnel interfaces Wardnet owns from every `WireGuard` device
+/// on the host.
+///
+/// [`TunnelInterface::list`] enumerates *all* `WireGuard` devices, including
+/// ones the user created for their own purposes, so filtering by our prefix is
+/// what keeps teardown from deleting someone else's tunnel.
+///
+/// `wg_wardin0` deliberately shares the `wg_ward` prefix (so the zone-egress
+/// drop rule can match tunnels with one wildcard) but is the inbound remote-
+/// access server, not an outbound tunnel. It is excluded here and torn down
+/// separately through [`InboundWgInterface::tear_down_server`], which owns any
+/// extra cleanup that interface needs.
+#[must_use]
+pub fn wardnet_tunnel_interfaces(all_interfaces: Vec<String>) -> Vec<String> {
+    all_interfaces
+        .into_iter()
+        .filter(|name| name.starts_with(TUNNEL_INTERFACE_PREFIX) && name != INBOUND_WG_INTERFACE)
+        .collect()
+}
+
+/// Remove the kernel state the daemon created: the `inet wardnet` nftables
+/// table and every `wg_ward*` interface.
+///
+/// Every step is best-effort and logged rather than propagated: this runs on
+/// the shutdown path, where failing loudly would only turn an untidy exit into
+/// a failed unit. The caller has already disarmed the hardware watchdog, so a
+/// slow netlink round-trip here cannot trip a reboot.
+///
+/// Idempotent — safe to call when some or all of the state is already gone,
+/// which is what lets `wardnetd uninstall` reuse it as a belt-and-braces sweep
+/// after an ungraceful kill.
+///
+/// Failures are both logged *and* returned. The daemon only needs the log, but
+/// `wardnetd uninstall` runs before tracing is initialised, so a log-only
+/// contract would let it report a clean uninstall while `table inet wardnet`
+/// was still filtering traffic — the exact failure this module exists to
+/// prevent.
+pub async fn teardown_runtime_state(
+    firewall: &Arc<dyn FirewallManager>,
+    tunnels: TunnelTeardown<'_>,
+    inbound_wg_interface: &Arc<dyn InboundWgInterface>,
+) -> Vec<String> {
+    tracing::info!("tearing down runtime state (nftables table and wireguard interfaces)");
+    let mut failures = Vec::new();
+
+    // Deletes only our named table. Never a full ruleset flush — that would
+    // take Docker's and the user's own rules with it.
+    if let Err(e) = firewall.destroy_wardnet_table().await {
+        tracing::warn!(error = %e, "failed to destroy wardnet nftables table; continuing: {e}");
+        failures.push(format!("nftables table `inet wardnet`: {e}"));
+    }
+
+    failures.extend(tunnels.tear_down().await);
+
+    if let Err(e) = inbound_wg_interface
+        .tear_down_server(INBOUND_WG_INTERFACE)
+        .await
+    {
+        tracing::warn!(
+            interface = %INBOUND_WG_INTERFACE,
+            error = %e,
+            "failed to tear down inbound wireguard server; continuing: {e}"
+        );
+        failures.push(format!("inbound server {INBOUND_WG_INTERFACE}: {e}"));
+    }
+
+    failures
+}
+
+/// How outbound tunnels get removed, which differs by caller.
+///
+/// The distinction is not cosmetic. Deleting a `wg_ward*` interface while the
+/// database still records the tunnel as `Up` leaves the two out of step, and
+/// the daemon never recovers from that on its own: the tunnel monitor's
+/// `reconcile_iface_presence` flips the tunnel to `Down` and publishes
+/// `TunnelDown`, whereupon `RoutingService::handle_tunnel_down` *removes* the
+/// routing for every device using it and drops the route table. Nothing
+/// recreates the interface — the on-demand bring-up in `apply_rule` only fires
+/// for a tunnel already recorded as `Down`, and startup reconcile runs before
+/// the monitor's first tick. The result would be tunnel-routed devices
+/// silently falling back to direct WAN after any `systemctl stop`, until an
+/// admin brought each tunnel up by hand.
+pub enum TunnelTeardown<'a> {
+    /// Daemon shutdown: tear down through the service so the recorded status
+    /// follows the kernel. Marking tunnels `Down` is what lets the next boot's
+    /// `routing.reconcile()` hit the existing on-demand bring-up in
+    /// `apply_rule` and recreate each interface for the devices that need it.
+    Service(&'a Arc<dyn TunnelService>),
+    /// Uninstall: there is no database left to keep in step (and it may be
+    /// about to be deleted), so remove the interfaces directly.
+    Interface(&'a Arc<dyn TunnelInterface>),
+}
+
+impl TunnelTeardown<'_> {
+    async fn tear_down(self) -> Vec<String> {
+        match self {
+            Self::Service(service) => Self::tear_down_via_service(service).await,
+            Self::Interface(interface) => Self::tear_down_via_interface(interface).await,
+        }
+    }
+
+    async fn tear_down_via_service(service: &Arc<dyn TunnelService>) -> Vec<String> {
+        let mut failures = Vec::new();
+
+        let listed = match service.list_tunnels().await {
+            Ok(response) => response.tunnels,
+            Err(e) => {
+                tracing::warn!(error = %e, "failed to list tunnels; skipping tunnel teardown: {e}");
+                return vec![format!("listing tunnels: {e}")];
+            }
+        };
+
+        for tunnel in listed {
+            // Already down: no interface to remove and the status is already
+            // right, so the next boot will bring it up on demand if needed.
+            if tunnel.status == TunnelStatus::Down {
+                continue;
+            }
+            if let Err(e) = service
+                .tear_down_internal(tunnel.id, "daemon shutdown")
+                .await
+            {
+                tracing::warn!(
+                    tunnel_id = %tunnel.id,
+                    interface = %tunnel.interface_name,
+                    error = %e,
+                    "failed to tear down tunnel {}; continuing: {e}",
+                    tunnel.interface_name
+                );
+                failures.push(format!("tunnel {}: {e}", tunnel.interface_name));
+            }
+        }
+
+        failures
+    }
+
+    async fn tear_down_via_interface(interface: &Arc<dyn TunnelInterface>) -> Vec<String> {
+        let mut failures = Vec::new();
+
+        match interface.list().await {
+            Ok(all) => {
+                for name in wardnet_tunnel_interfaces(all) {
+                    if let Err(e) = interface.remove(&name).await {
+                        tracing::warn!(
+                            interface = %name,
+                            error = %e,
+                            "failed to remove tunnel interface {name}; continuing: {e}"
+                        );
+                        failures.push(format!("tunnel interface {name}: {e}"));
+                    }
+                }
+            }
+            Err(e) => {
+                tracing::warn!(error = %e, "failed to list wireguard interfaces; skipping tunnel teardown: {e}");
+                failures.push(format!("listing wireguard interfaces: {e}"));
+            }
+        }
+
+        failures
+    }
+}

--- a/source/daemon/crates/wardnetd/src/shutdown/tests/cause.rs
+++ b/source/daemon/crates/wardnetd/src/shutdown/tests/cause.rs
@@ -1,0 +1,59 @@
+//! Which shutdown causes remove the kernel state the daemon owns, and which
+//! `WireGuard` interfaces count as ours.
+
+use crate::shutdown::{ShutdownCause, wardnet_tunnel_interfaces};
+
+#[test]
+fn signal_tears_down_runtime_state() {
+    assert!(ShutdownCause::Signal.tears_down_runtime_state());
+}
+
+#[test]
+fn restart_leaves_runtime_state_in_place() {
+    // A self-initiated restart hands over to a replacement process. Tunnels
+    // have no synchronous boot reconcile, so removing them here would black
+    // out the user's VPN until the next tunnel-monitor tick.
+    assert!(!ShutdownCause::Restart.tears_down_runtime_state());
+}
+
+#[test]
+fn selects_wardnet_tunnel_interfaces_by_prefix() {
+    let all = vec![
+        "wg_ward0".to_owned(),
+        "wg_ward12".to_owned(),
+        "wg0".to_owned(),
+        "utun3".to_owned(),
+    ];
+
+    assert_eq!(
+        wardnet_tunnel_interfaces(all),
+        vec!["wg_ward0".to_owned(), "wg_ward12".to_owned()]
+    );
+}
+
+#[test]
+fn leaves_foreign_wireguard_interfaces_alone() {
+    // `TunnelInterface::list` enumerates every WireGuard device on the host.
+    // Deleting one the user created themselves would be a serious overreach.
+    let all = vec![
+        "wg0".to_owned(),
+        "corp-vpn".to_owned(),
+        "wgward0".to_owned(), // no underscore: not ours
+    ];
+
+    assert!(wardnet_tunnel_interfaces(all).is_empty());
+}
+
+#[test]
+fn excludes_the_inbound_server_from_the_tunnel_sweep() {
+    // `wg_wardin0` shares the `wg_ward` prefix by design, but it is torn down
+    // through `tear_down_server`, not the outbound-tunnel sweep.
+    let all = vec!["wg_ward0".to_owned(), "wg_wardin0".to_owned()];
+
+    assert_eq!(wardnet_tunnel_interfaces(all), vec!["wg_ward0".to_owned()]);
+}
+
+#[test]
+fn tolerates_a_host_with_no_wireguard_devices() {
+    assert!(wardnet_tunnel_interfaces(Vec::new()).is_empty());
+}

--- a/source/daemon/crates/wardnetd/src/shutdown/tests/doubles.rs
+++ b/source/daemon/crates/wardnetd/src/shutdown/tests/doubles.rs
@@ -1,0 +1,379 @@
+//! Recording doubles for the three backends the teardown path touches.
+//!
+//! Each one appends a description of every call it receives to a shared log,
+//! so tests can assert both *what* was called and *in what order* — the same
+//! pattern the routing service tests use for `FirewallManager`.
+
+use std::sync::{Arc, Mutex};
+
+use async_trait::async_trait;
+use uuid::Uuid;
+use wardnet_common::api::{
+    CreateTunnelRequest, CreateTunnelResponse, DeleteTunnelResponse, ListTunnelsResponse,
+    TunnelDevicesResponse, TunnelTestResult,
+};
+use wardnet_common::jobs::JobDispatchedResponse;
+use wardnet_common::speed_test::TunnelSpeedTestHistoryResponse;
+use wardnet_common::tunnel::{Tunnel, TunnelStatus};
+use wardnetd_services::error::AppError;
+use wardnetd_services::inbound_wg::InboundWgInterface;
+use wardnetd_services::inbound_wg::interface::{
+    InboundWgPeerConfig, InboundWgPeerStats, InboundWgServerConfig,
+};
+use wardnetd_services::routing::FirewallManager;
+use wardnetd_services::routing::firewall::{ZoneIsolationRules, ZoneRules};
+use wardnetd_services::tunnel::TunnelInterface;
+use wardnetd_services::tunnel::TunnelService;
+use wardnetd_services::tunnel::interface::{CreateTunnelParams, TunnelStats};
+
+/// Shared, ordered record of every backend call made during a test.
+pub type CallLog = Arc<Mutex<Vec<String>>>;
+
+/// Create an empty call log.
+pub fn call_log() -> CallLog {
+    Arc::new(Mutex::new(Vec::new()))
+}
+
+/// Read the recorded calls back out.
+pub fn recorded(log: &CallLog) -> Vec<String> {
+    log.lock().expect("call log poisoned").clone()
+}
+
+fn record(log: &CallLog, call: impl Into<String>) {
+    log.lock().expect("call log poisoned").push(call.into());
+}
+
+/// `FirewallManager` double. Only `destroy_wardnet_table` is exercised by the
+/// teardown path; the rest satisfy the trait and record nothing.
+pub struct RecordingFirewall {
+    log: CallLog,
+    /// When true, `destroy_wardnet_table` returns an error so tests can prove
+    /// teardown continues past a firewall failure.
+    fail_destroy: bool,
+}
+
+impl RecordingFirewall {
+    pub fn new(log: CallLog) -> Self {
+        Self {
+            log,
+            fail_destroy: false,
+        }
+    }
+
+    pub fn failing(log: CallLog) -> Self {
+        Self {
+            log,
+            fail_destroy: true,
+        }
+    }
+}
+
+#[async_trait]
+impl FirewallManager for RecordingFirewall {
+    async fn init_wardnet_table(&self) -> anyhow::Result<()> {
+        Ok(())
+    }
+    async fn ensure_isolation_jumps(&self) -> anyhow::Result<()> {
+        Ok(())
+    }
+    async fn flush_wardnet_table(&self) -> anyhow::Result<()> {
+        Ok(())
+    }
+    async fn add_masquerade(&self, _interface: &str) -> anyhow::Result<()> {
+        Ok(())
+    }
+    async fn remove_masquerade(&self, _interface: &str) -> anyhow::Result<()> {
+        Ok(())
+    }
+    async fn add_inbound_wg_accept(&self, _port: u16) -> anyhow::Result<()> {
+        Ok(())
+    }
+    async fn remove_inbound_wg_accept(&self) -> anyhow::Result<()> {
+        Ok(())
+    }
+    async fn cleanup_legacy_dns_redirects(&self) -> anyhow::Result<()> {
+        Ok(())
+    }
+    async fn add_tcp_reset_reject(&self, _device_ip: &str) -> anyhow::Result<()> {
+        Ok(())
+    }
+    async fn remove_tcp_reset_reject(&self, _device_ip: &str) -> anyhow::Result<()> {
+        Ok(())
+    }
+    async fn apply_zone_rules(
+        &self,
+        _device_ip: &str,
+        _rules: ZoneRules,
+        _lan_interface: &str,
+    ) -> anyhow::Result<()> {
+        Ok(())
+    }
+    async fn remove_zone_rules(&self, _device_ip: &str) -> anyhow::Result<()> {
+        Ok(())
+    }
+    async fn list_zone_rule_ips(&self) -> anyhow::Result<Vec<String>> {
+        Ok(Vec::new())
+    }
+    async fn apply_zone_isolation(&self, _rules: ZoneIsolationRules) -> anyhow::Result<()> {
+        Ok(())
+    }
+    async fn check_tools_available(&self) -> anyhow::Result<()> {
+        Ok(())
+    }
+
+    async fn destroy_wardnet_table(&self) -> anyhow::Result<()> {
+        record(&self.log, "destroy_wardnet_table");
+        if self.fail_destroy {
+            anyhow::bail!("simulated netlink failure");
+        }
+        Ok(())
+    }
+}
+
+/// `TunnelInterface` double returning a fixed device list from `list()`.
+pub struct RecordingTunnelInterface {
+    log: CallLog,
+    interfaces: Vec<String>,
+    /// When true, `list` fails so tests can prove teardown skips the sweep
+    /// rather than panicking.
+    fail_list: bool,
+}
+
+impl RecordingTunnelInterface {
+    pub fn new(log: CallLog, interfaces: &[&str]) -> Self {
+        Self {
+            log,
+            interfaces: interfaces.iter().map(|s| (*s).to_owned()).collect(),
+            fail_list: false,
+        }
+    }
+
+    pub fn failing_list(log: CallLog) -> Self {
+        Self {
+            log,
+            interfaces: Vec::new(),
+            fail_list: true,
+        }
+    }
+}
+
+#[async_trait]
+impl TunnelInterface for RecordingTunnelInterface {
+    async fn create(&self, _params: CreateTunnelParams) -> anyhow::Result<()> {
+        Ok(())
+    }
+    async fn bring_up(&self, _interface_name: &str) -> anyhow::Result<()> {
+        Ok(())
+    }
+    async fn tear_down(&self, _interface_name: &str) -> anyhow::Result<()> {
+        Ok(())
+    }
+    async fn get_stats(&self, _interface_name: &str) -> anyhow::Result<Option<TunnelStats>> {
+        Ok(None)
+    }
+
+    async fn remove(&self, interface_name: &str) -> anyhow::Result<()> {
+        record(&self.log, format!("remove:{interface_name}"));
+        Ok(())
+    }
+
+    async fn list(&self) -> anyhow::Result<Vec<String>> {
+        record(&self.log, "list");
+        if self.fail_list {
+            anyhow::bail!("simulated wireguard enumeration failure");
+        }
+        Ok(self.interfaces.clone())
+    }
+}
+
+/// `TunnelService` double for the shutdown path.
+///
+/// Only `list_tunnels` and `tear_down_internal` are reachable from teardown;
+/// the rest panic rather than returning plausible-looking defaults, so a future
+/// change that starts calling one fails loudly instead of silently testing
+/// nothing.
+pub struct RecordingTunnelService {
+    log: CallLog,
+    tunnels: Vec<Tunnel>,
+    /// Interface names whose teardown should fail.
+    failing: Vec<String>,
+    fail_list: bool,
+}
+
+impl RecordingTunnelService {
+    pub fn new(log: CallLog, tunnels: Vec<Tunnel>) -> Self {
+        Self {
+            log,
+            tunnels,
+            failing: Vec::new(),
+            fail_list: false,
+        }
+    }
+
+    pub fn failing_teardown(log: CallLog, tunnels: Vec<Tunnel>, failing: &[&str]) -> Self {
+        Self {
+            log,
+            tunnels,
+            failing: failing.iter().map(|s| (*s).to_owned()).collect(),
+            fail_list: false,
+        }
+    }
+
+    pub fn failing_list(log: CallLog) -> Self {
+        Self {
+            log,
+            tunnels: Vec::new(),
+            failing: Vec::new(),
+            fail_list: true,
+        }
+    }
+}
+
+/// Build a tunnel row with just the fields teardown reads.
+pub fn tunnel(interface_name: &str, status: TunnelStatus) -> Tunnel {
+    Tunnel {
+        id: Uuid::new_v4(),
+        label: interface_name.to_owned(),
+        country_code: "NL".to_owned(),
+        provider: None,
+        interface_name: interface_name.to_owned(),
+        endpoint: "198.51.100.1:51820".to_owned(),
+        status,
+        last_handshake: None,
+        bytes_tx: 0,
+        bytes_rx: 0,
+        created_at: chrono::Utc::now(),
+        override_default_dns: false,
+        server_selector: None,
+        resolved_server_name: None,
+        endpoint_resolved_at: None,
+    }
+}
+
+#[async_trait]
+impl TunnelService for RecordingTunnelService {
+    async fn list_tunnels(&self) -> Result<ListTunnelsResponse, AppError> {
+        record(&self.log, "list_tunnels");
+        if self.fail_list {
+            return Err(AppError::Internal(anyhow::anyhow!(
+                "simulated tunnel listing failure"
+            )));
+        }
+        Ok(ListTunnelsResponse {
+            tunnels: self.tunnels.clone(),
+        })
+    }
+
+    async fn tear_down_internal(&self, id: Uuid, reason: &str) -> Result<(), AppError> {
+        let name = self
+            .tunnels
+            .iter()
+            .find(|t| t.id == id)
+            .map_or_else(|| id.to_string(), |t| t.interface_name.clone());
+        record(&self.log, format!("tear_down_internal:{name}:{reason}"));
+        if self.failing.contains(&name) {
+            return Err(AppError::Internal(anyhow::anyhow!(
+                "simulated teardown failure"
+            )));
+        }
+        Ok(())
+    }
+
+    async fn import_tunnel(
+        &self,
+        _req: CreateTunnelRequest,
+    ) -> Result<CreateTunnelResponse, AppError> {
+        unimplemented!("not reachable from shutdown teardown")
+    }
+    async fn get_tunnel(&self, _id: Uuid) -> Result<Tunnel, AppError> {
+        unimplemented!("not reachable from shutdown teardown")
+    }
+    async fn test_tunnel(&self, _id: Uuid) -> Result<TunnelTestResult, AppError> {
+        unimplemented!("not reachable from shutdown teardown")
+    }
+    async fn list_tunnel_devices(&self, _id: Uuid) -> Result<TunnelDevicesResponse, AppError> {
+        unimplemented!("not reachable from shutdown teardown")
+    }
+    async fn set_dns_override(&self, _id: Uuid, _value: bool) -> Result<Tunnel, AppError> {
+        unimplemented!("not reachable from shutdown teardown")
+    }
+    async fn rebuild(&self, _id: Uuid) -> Result<(), AppError> {
+        unimplemented!("not reachable from shutdown teardown")
+    }
+    async fn bring_up(&self, _id: Uuid) -> Result<(), AppError> {
+        unimplemented!("not reachable from shutdown teardown")
+    }
+    async fn tear_down(&self, _id: Uuid, _reason: &str) -> Result<(), AppError> {
+        unimplemented!("not reachable from shutdown teardown")
+    }
+    async fn delete_tunnel(&self, _id: Uuid) -> Result<DeleteTunnelResponse, AppError> {
+        unimplemented!("not reachable from shutdown teardown")
+    }
+    async fn bring_up_internal(&self, _id: Uuid) -> Result<(), AppError> {
+        unimplemented!("not reachable from shutdown teardown")
+    }
+    async fn restore_tunnels(&self) -> Result<(), AppError> {
+        unimplemented!("not reachable from shutdown teardown")
+    }
+    async fn collect_stats(&self) -> Result<(), AppError> {
+        unimplemented!("not reachable from shutdown teardown")
+    }
+    async fn run_health_check(&self) -> Result<(), AppError> {
+        unimplemented!("not reachable from shutdown teardown")
+    }
+    async fn probe_latencies(&self) -> Result<(), AppError> {
+        unimplemented!("not reachable from shutdown teardown")
+    }
+    async fn start_speed_test(
+        self: Arc<Self>,
+        _id: Uuid,
+    ) -> Result<JobDispatchedResponse, AppError> {
+        unimplemented!("not reachable from shutdown teardown")
+    }
+    async fn list_speed_tests(
+        &self,
+        _id: Uuid,
+    ) -> Result<TunnelSpeedTestHistoryResponse, AppError> {
+        unimplemented!("not reachable from shutdown teardown")
+    }
+}
+
+/// `InboundWgInterface` double recording only the server teardown.
+pub struct RecordingInboundWg {
+    log: CallLog,
+}
+
+impl RecordingInboundWg {
+    pub fn new(log: CallLog) -> Self {
+        Self { log }
+    }
+}
+
+#[async_trait]
+impl InboundWgInterface for RecordingInboundWg {
+    async fn ensure_server(&self, _config: InboundWgServerConfig) -> anyhow::Result<()> {
+        Ok(())
+    }
+    async fn add_peer(
+        &self,
+        _interface_name: &str,
+        _peer: InboundWgPeerConfig,
+    ) -> anyhow::Result<()> {
+        Ok(())
+    }
+    async fn remove_peer(
+        &self,
+        _interface_name: &str,
+        _public_key: [u8; 32],
+    ) -> anyhow::Result<()> {
+        Ok(())
+    }
+    async fn peer_stats(&self, _interface_name: &str) -> anyhow::Result<Vec<InboundWgPeerStats>> {
+        Ok(Vec::new())
+    }
+
+    async fn tear_down_server(&self, interface_name: &str) -> anyhow::Result<()> {
+        record(&self.log, format!("tear_down_server:{interface_name}"));
+        Ok(())
+    }
+}

--- a/source/daemon/crates/wardnetd/src/shutdown/tests/mod.rs
+++ b/source/daemon/crates/wardnetd/src/shutdown/tests/mod.rs
@@ -1,0 +1,5 @@
+mod cause;
+mod service_teardown;
+mod teardown;
+
+pub mod doubles;

--- a/source/daemon/crates/wardnetd/src/shutdown/tests/service_teardown.rs
+++ b/source/daemon/crates/wardnetd/src/shutdown/tests/service_teardown.rs
@@ -1,0 +1,146 @@
+//! Shutdown tears tunnels down *through the service*, so the recorded status
+//! follows the kernel.
+//!
+//! This is what makes the teardown recoverable. Deleting the interface behind
+//! the database's back leaves the tunnel recorded as `Up` with no interface;
+//! the monitor then flips it to `Down`, `handle_tunnel_down` strips the routing
+//! for every device using it, and nothing ever recreates it — tunnel-routed
+//! devices would silently sit on direct WAN after any `systemctl stop`.
+
+use std::sync::Arc;
+
+use wardnet_common::tunnel::TunnelStatus;
+use wardnetd_services::inbound_wg::InboundWgInterface;
+use wardnetd_services::routing::FirewallManager;
+use wardnetd_services::tunnel::TunnelService;
+
+use super::doubles::{
+    CallLog, RecordingFirewall, RecordingInboundWg, RecordingTunnelService, call_log, recorded,
+    tunnel,
+};
+use crate::shutdown::{TunnelTeardown, teardown_runtime_state};
+
+fn wire(
+    log: &CallLog,
+    service: RecordingTunnelService,
+) -> (
+    Arc<dyn FirewallManager>,
+    Arc<dyn TunnelService>,
+    Arc<dyn InboundWgInterface>,
+) {
+    (
+        Arc::new(RecordingFirewall::new(log.clone())),
+        Arc::new(service),
+        Arc::new(RecordingInboundWg::new(log.clone())),
+    )
+}
+
+#[tokio::test]
+async fn tears_down_every_live_tunnel_through_the_service() {
+    let log = call_log();
+    let tunnels = vec![
+        tunnel("wg_ward0", TunnelStatus::Up),
+        tunnel("wg_ward1", TunnelStatus::Connecting),
+    ];
+    let (firewall, service, inbound) =
+        wire(&log, RecordingTunnelService::new(log.clone(), tunnels));
+
+    let failures =
+        teardown_runtime_state(&firewall, TunnelTeardown::Service(&service), &inbound).await;
+
+    assert!(failures.is_empty(), "got {failures:?}");
+    assert_eq!(
+        recorded(&log),
+        vec![
+            "destroy_wardnet_table",
+            "list_tunnels",
+            "tear_down_internal:wg_ward0:daemon shutdown",
+            "tear_down_internal:wg_ward1:daemon shutdown",
+            "tear_down_server:wg_wardin0",
+        ]
+    );
+}
+
+#[tokio::test]
+async fn leaves_already_down_tunnels_alone() {
+    // Nothing to remove, and the status is already what the next boot's
+    // on-demand bring-up keys off.
+    let log = call_log();
+    let tunnels = vec![
+        tunnel("wg_ward0", TunnelStatus::Down),
+        tunnel("wg_ward1", TunnelStatus::Up),
+    ];
+    let (firewall, service, inbound) =
+        wire(&log, RecordingTunnelService::new(log.clone(), tunnels));
+
+    teardown_runtime_state(&firewall, TunnelTeardown::Service(&service), &inbound).await;
+
+    let calls = recorded(&log);
+    assert!(
+        !calls.iter().any(|c| c.contains("wg_ward0")),
+        "already-down tunnel was torn down again: {calls:?}"
+    );
+    assert!(calls.iter().any(|c| c.contains("wg_ward1")), "{calls:?}");
+}
+
+#[tokio::test]
+async fn reports_a_tunnel_that_would_not_tear_down() {
+    let log = call_log();
+    let tunnels = vec![
+        tunnel("wg_ward0", TunnelStatus::Up),
+        tunnel("wg_ward1", TunnelStatus::Up),
+    ];
+    let (firewall, service, inbound) = wire(
+        &log,
+        RecordingTunnelService::failing_teardown(log.clone(), tunnels, &["wg_ward0"]),
+    );
+
+    let failures =
+        teardown_runtime_state(&firewall, TunnelTeardown::Service(&service), &inbound).await;
+
+    assert_eq!(failures.len(), 1, "got {failures:?}");
+    assert!(failures[0].contains("wg_ward0"), "got {failures:?}");
+    // The failure must not stop the rest of the teardown.
+    let calls = recorded(&log);
+    assert!(calls.iter().any(|c| c.contains("wg_ward1")), "{calls:?}");
+    assert!(
+        calls.contains(&"tear_down_server:wg_wardin0".to_owned()),
+        "{calls:?}"
+    );
+}
+
+#[tokio::test]
+async fn reports_a_failed_listing_and_still_tears_down_the_inbound_server() {
+    let log = call_log();
+    let (firewall, service, inbound) =
+        wire(&log, RecordingTunnelService::failing_list(log.clone()));
+
+    let failures =
+        teardown_runtime_state(&firewall, TunnelTeardown::Service(&service), &inbound).await;
+
+    assert_eq!(failures.len(), 1, "got {failures:?}");
+    assert!(failures[0].contains("listing tunnels"), "got {failures:?}");
+    assert!(
+        recorded(&log).contains(&"tear_down_server:wg_wardin0".to_owned()),
+        "{:?}",
+        recorded(&log)
+    );
+}
+
+#[tokio::test]
+async fn does_nothing_tunnel_shaped_when_there_are_no_tunnels() {
+    let log = call_log();
+    let (firewall, service, inbound) =
+        wire(&log, RecordingTunnelService::new(log.clone(), Vec::new()));
+
+    teardown_runtime_state(&firewall, TunnelTeardown::Service(&service), &inbound).await;
+
+    assert_eq!(
+        recorded(&log),
+        vec![
+            "destroy_wardnet_table",
+            "list_tunnels",
+            "tear_down_server:wg_wardin0",
+        ]
+    );
+}

--- a/source/daemon/crates/wardnetd/src/shutdown/tests/teardown.rs
+++ b/source/daemon/crates/wardnetd/src/shutdown/tests/teardown.rs
@@ -1,0 +1,195 @@
+//! `teardown_runtime_state` removes every piece of kernel state the daemon
+//! owns, and keeps going when any single step fails.
+
+use std::sync::Arc;
+
+use wardnetd_services::inbound_wg::InboundWgInterface;
+use wardnetd_services::routing::FirewallManager;
+use wardnetd_services::tunnel::TunnelInterface;
+
+use super::doubles::{
+    CallLog, RecordingFirewall, RecordingInboundWg, RecordingTunnelInterface, call_log, recorded,
+};
+use crate::shutdown::{TunnelTeardown, teardown_runtime_state};
+
+/// Wire the three doubles up as the trait objects `teardown_runtime_state`
+/// takes, sharing one call log.
+fn backends(
+    log: &CallLog,
+    firewall: RecordingFirewall,
+    tunnels: RecordingTunnelInterface,
+) -> (
+    Arc<dyn FirewallManager>,
+    Arc<dyn TunnelInterface>,
+    Arc<dyn InboundWgInterface>,
+) {
+    (
+        Arc::new(firewall),
+        Arc::new(tunnels),
+        Arc::new(RecordingInboundWg::new(log.clone())),
+    )
+}
+
+#[tokio::test]
+async fn removes_the_table_then_every_tunnel_then_the_inbound_server() {
+    let log = call_log();
+    let (firewall, tunnels, inbound) = backends(
+        &log,
+        RecordingFirewall::new(log.clone()),
+        RecordingTunnelInterface::new(log.clone(), &["wg_ward0", "wg_ward1", "wg_wardin0", "wg0"]),
+    );
+
+    teardown_runtime_state(&firewall, TunnelTeardown::Interface(&tunnels), &inbound).await;
+
+    assert_eq!(
+        recorded(&log),
+        vec![
+            "destroy_wardnet_table",
+            "list",
+            "remove:wg_ward0",
+            "remove:wg_ward1",
+            "tear_down_server:wg_wardin0",
+        ]
+    );
+}
+
+#[tokio::test]
+async fn never_removes_a_wireguard_interface_we_do_not_own() {
+    let log = call_log();
+    let (firewall, tunnels, inbound) = backends(
+        &log,
+        RecordingFirewall::new(log.clone()),
+        RecordingTunnelInterface::new(log.clone(), &["wg0", "corp-vpn"]),
+    );
+
+    teardown_runtime_state(&firewall, TunnelTeardown::Interface(&tunnels), &inbound).await;
+
+    let calls = recorded(&log);
+    assert!(
+        !calls.iter().any(|c| c.starts_with("remove:")),
+        "expected no interface removals, got {calls:?}"
+    );
+}
+
+#[tokio::test]
+async fn reports_a_firewall_failure_to_the_caller() {
+    // `wardnetd uninstall` runs before tracing is initialised, so a log-only
+    // contract would let it print "Wardnet has been removed" while the table
+    // was still filtering traffic.
+    let log = call_log();
+    let (firewall, tunnels, inbound) = backends(
+        &log,
+        RecordingFirewall::failing(log.clone()),
+        RecordingTunnelInterface::new(log.clone(), &[]),
+    );
+
+    let failures =
+        teardown_runtime_state(&firewall, TunnelTeardown::Interface(&tunnels), &inbound).await;
+
+    assert_eq!(failures.len(), 1, "got {failures:?}");
+    assert!(failures[0].contains("inet wardnet"), "got {failures:?}");
+}
+
+#[tokio::test]
+async fn reports_nothing_when_teardown_succeeds() {
+    let log = call_log();
+    let (firewall, tunnels, inbound) = backends(
+        &log,
+        RecordingFirewall::new(log.clone()),
+        RecordingTunnelInterface::new(log.clone(), &["wg_ward0"]),
+    );
+
+    assert!(
+        teardown_runtime_state(&firewall, TunnelTeardown::Interface(&tunnels), &inbound)
+            .await
+            .is_empty()
+    );
+}
+
+#[tokio::test]
+async fn reports_a_failed_enumeration_rather_than_silently_skipping() {
+    let log = call_log();
+    let (firewall, tunnels, inbound) = backends(
+        &log,
+        RecordingFirewall::new(log.clone()),
+        RecordingTunnelInterface::failing_list(log.clone()),
+    );
+
+    let failures =
+        teardown_runtime_state(&firewall, TunnelTeardown::Interface(&tunnels), &inbound).await;
+
+    assert_eq!(failures.len(), 1, "got {failures:?}");
+    assert!(failures[0].contains("listing"), "got {failures:?}");
+}
+
+#[tokio::test]
+async fn continues_tearing_down_after_a_firewall_failure() {
+    // Shutdown is the wrong place to give up: a failed table delete must not
+    // strand the WireGuard interfaces.
+    let log = call_log();
+    let (firewall, tunnels, inbound) = backends(
+        &log,
+        RecordingFirewall::failing(log.clone()),
+        RecordingTunnelInterface::new(log.clone(), &["wg_ward0"]),
+    );
+
+    teardown_runtime_state(&firewall, TunnelTeardown::Interface(&tunnels), &inbound).await;
+
+    assert_eq!(
+        recorded(&log),
+        vec![
+            "destroy_wardnet_table",
+            "list",
+            "remove:wg_ward0",
+            "tear_down_server:wg_wardin0",
+        ]
+    );
+}
+
+#[tokio::test]
+async fn still_tears_down_the_inbound_server_when_enumeration_fails() {
+    let log = call_log();
+    let (firewall, tunnels, inbound) = backends(
+        &log,
+        RecordingFirewall::new(log.clone()),
+        RecordingTunnelInterface::failing_list(log.clone()),
+    );
+
+    teardown_runtime_state(&firewall, TunnelTeardown::Interface(&tunnels), &inbound).await;
+
+    assert_eq!(
+        recorded(&log),
+        vec![
+            "destroy_wardnet_table",
+            "list",
+            "tear_down_server:wg_wardin0",
+        ]
+    );
+}
+
+#[tokio::test]
+async fn is_idempotent_on_an_already_clean_host() {
+    let log = call_log();
+    let (firewall, tunnels, inbound) = backends(
+        &log,
+        RecordingFirewall::new(log.clone()),
+        RecordingTunnelInterface::new(log.clone(), &[]),
+    );
+
+    teardown_runtime_state(&firewall, TunnelTeardown::Interface(&tunnels), &inbound).await;
+    teardown_runtime_state(&firewall, TunnelTeardown::Interface(&tunnels), &inbound).await;
+
+    // Both passes make the same calls; nothing errors on the second run. This
+    // is what lets `wardnetd uninstall` re-run the sweep after a clean stop.
+    assert_eq!(
+        recorded(&log),
+        vec![
+            "destroy_wardnet_table",
+            "list",
+            "tear_down_server:wg_wardin0",
+            "destroy_wardnet_table",
+            "list",
+            "tear_down_server:wg_wardin0",
+        ]
+    );
+}

--- a/source/daemon/crates/wardnetd/src/tests/firewall_netlink.rs
+++ b/source/daemon/crates/wardnetd/src/tests/firewall_netlink.rs
@@ -9,11 +9,50 @@ use crate::firewall_netlink::{
     IFNAMSIZ, ZONE_ESTABLISHED_COMMENT, ZONE_ISOJUMP_COMMENT, ZONE_ISOLATION, ZONE_NATEXEMPT,
     ZONE_NATEXEMPT_COMMENT, ZONE_NATEXEMPT_JUMP_COMMENT, build_natexempt_batch,
     build_zone_isolation_batch, chain_has_comment, chain_ref, comment_udata,
-    inbound_wg_iface_exact_value, masquerade_rule, natexempt_jump_rule, parse_comment_udata,
-    rule_comment, wardnet_table, zone_rule_ip,
+    inbound_wg_iface_exact_value, is_table_absent_error, masquerade_rule, natexempt_jump_rule,
+    parse_comment_udata, rule_comment, wardnet_table, zone_rule_ip,
 };
+use rustables::error::QueryError;
 use rustables::{Batch, Rule};
 use wardnetd_services::routing::firewall::{ExceptionAllow, ZoneIsolationRules};
+
+/// Build the error rustables produces for a netlink reply carrying `errno`.
+///
+/// The kernel reports errnos negated. `nlmsgerr` is a bindgen-generated FFI
+/// struct whose only field we care about is `error`; zeroing the rest is safe
+/// because it is plain-old-data with no invariants.
+fn netlink_error(errno: i32) -> anyhow::Error {
+    let mut raw: rustables::sys::nlmsgerr = unsafe { std::mem::zeroed() };
+    raw.error = -errno;
+    anyhow::Error::new(QueryError::NetlinkError(raw)).context("destroy wardnet table")
+}
+
+#[test]
+fn absent_table_is_recognised_from_the_netlink_errno() {
+    // The errno lives only in `nlmsgerr.error`: `QueryError::NetlinkError` has
+    // no `#[source]` and its Display is the fixed string "Error received from
+    // the kernel". Matching on message text would silently never fire, and
+    // this is the *common* path — a clean `systemctl stop` already removed the
+    // table before `wardnetd uninstall` sweeps again.
+    assert!(is_table_absent_error(&netlink_error(libc::ENOENT)));
+}
+
+#[test]
+fn a_real_failure_is_not_mistaken_for_an_absent_table() {
+    // EPERM in a restricted namespace must propagate, or uninstall would
+    // report a clean removal while the table kept filtering traffic.
+    assert!(!is_table_absent_error(&netlink_error(libc::EPERM)));
+    assert!(!is_table_absent_error(&netlink_error(libc::EBUSY)));
+}
+
+#[test]
+fn an_unrelated_error_is_not_an_absent_table() {
+    let err = anyhow::anyhow!("No such file or directory");
+    assert!(
+        !is_table_absent_error(&err),
+        "message text must not be treated as evidence of an absent table"
+    );
+}
 
 #[test]
 fn comment_udata_encodes_type_len_value_nul() {

--- a/source/daemon/crates/wardnetd/src/uninstall/inventory.rs
+++ b/source/daemon/crates/wardnetd/src/uninstall/inventory.rs
@@ -1,0 +1,284 @@
+//! The list of everything `install.sh` created, and what each tier does with
+//! it.
+//!
+//! Kept pure — building the inventory touches no filesystem — so the two tiers
+//! and the container/bare-metal split can be unit-tested, and so `--dry-run`
+//! prints exactly the list the real run will work from. Nothing here checks
+//! whether a path exists; the executor tolerates absence, which is what makes
+//! uninstall safe to re-run and safe on a partial install.
+
+use std::fmt;
+
+/// What kind of thing an inventory entry refers to. Drives both how it is
+/// removed and how it is labelled in the printed plan.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Kind {
+    /// A single file.
+    File,
+    /// A directory, removed recursively.
+    Directory,
+    /// A systemd unit: disabled, then its unit file removed.
+    Unit,
+    /// A system user account.
+    User,
+    /// Kernel state (nftables table, `WireGuard` interfaces, conntrack).
+    Runtime,
+}
+
+impl fmt::Display for Kind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let label = match self {
+            Self::File => "file",
+            Self::Directory => "dir",
+            Self::Unit => "unit",
+            Self::User => "user",
+            Self::Runtime => "runtime",
+        };
+        f.write_str(label)
+    }
+}
+
+/// What the current tier does with an entry.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Action {
+    /// Delete it.
+    Remove,
+    /// Leave it on disk. Retained data is re-owned by root, because the
+    /// `wardnet` user is deleted in the same run.
+    Keep,
+}
+
+/// One thing the uninstaller will touch.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Item {
+    pub kind: Kind,
+    pub target: String,
+    pub action: Action,
+    /// Why this entry is interesting, shown in the printed plan. Only set
+    /// where the reason is not obvious from the path.
+    pub note: Option<String>,
+}
+
+impl Item {
+    fn new(kind: Kind, target: &str, action: Action, note: Option<&str>) -> Self {
+        Self {
+            kind,
+            target: target.to_owned(),
+            action,
+            note: note.map(ToOwned::to_owned),
+        }
+    }
+}
+
+/// The systemd units `install.sh` installs. Deliberately the same three, in
+/// the same order — `wardnetd-dev.service` is a dev-only unit the installer
+/// never places on a real host, so uninstall must not touch it.
+pub const UNITS: [&str; 3] = [
+    "wardnetd.service",
+    "wardnetd-rollback.service",
+    "wardnet-postupgrade.service",
+];
+
+/// The system user `install.sh` creates.
+pub const SERVICE_USER: &str = "wardnet";
+
+/// The data directory. Retained by default, destroyed by `--purge`.
+pub const DATA_DIR: &str = "/var/lib/wardnet";
+
+/// Paths under [`DATA_DIR`] that hold user data worth keeping: the `SQLite`
+/// database (plus its WAL sidecars) and the secret store, which contains the
+/// `WireGuard` private keys, the backup passphrase and the DDNS credentials.
+pub const RETAINED_DATA: [&str; 4] = [
+    "/var/lib/wardnet/wardnet.db",
+    "/var/lib/wardnet/wardnet.db-wal",
+    "/var/lib/wardnet/wardnet.db-shm",
+    "/var/lib/wardnet/secrets",
+];
+
+/// Build the full list of things to touch for this run.
+///
+/// `container_mode` mirrors `install.sh --container-mode`: in a container the
+/// installer never writes the sysctl drop-in, the dhcpcd drop-in or the
+/// watchdog module-load file, because the container's networking owns
+/// forwarding and `/proc/sys` is read-only. Listing them anyway would be
+/// dishonest in `--dry-run` output.
+#[must_use]
+pub fn build_inventory(purge: bool, container_mode: bool) -> Vec<Item> {
+    let mut items = Vec::new();
+    // Runtime state first: it is the part of the removal a reader most needs
+    // to see in a dry run, and the part no other tool would do for them.
+    items.extend(runtime_items());
+    items.extend(unit_items());
+    items.extend(installed_file_items());
+    items.extend(data_items(purge));
+    if !container_mode {
+        items.extend(host_dropin_items());
+    }
+    items.push(Item::new(
+        Kind::User,
+        SERVICE_USER,
+        Action::Remove,
+        Some("system user"),
+    ));
+    items
+}
+
+/// Kernel state the daemon created (issue #864).
+fn runtime_items() -> Vec<Item> {
+    vec![
+        Item::new(
+            Kind::Runtime,
+            "nftables table `inet wardnet`",
+            Action::Remove,
+            Some("only our named table; never a full ruleset flush"),
+        ),
+        Item::new(
+            Kind::Runtime,
+            "wireguard interfaces `wg_ward*`",
+            Action::Remove,
+            Some("outbound tunnels and the inbound remote-access server"),
+        ),
+    ]
+}
+
+fn unit_items() -> Vec<Item> {
+    UNITS
+        .iter()
+        .map(|unit| {
+            Item::new(
+                Kind::Unit,
+                &format!("/etc/systemd/system/{unit}"),
+                Action::Remove,
+                None,
+            )
+        })
+        .collect()
+}
+
+/// Binaries, config and logs — everything outside the data directory.
+fn installed_file_items() -> Vec<Item> {
+    vec![
+        Item::new(Kind::File, "/usr/local/bin/wardnetd", Action::Remove, None),
+        Item::new(
+            Kind::File,
+            "/usr/local/bin/wardnetd.old",
+            Action::Remove,
+            Some("previous binary kept for rollback"),
+        ),
+        Item::new(
+            Kind::File,
+            "/usr/local/sbin/wardnet-uninstall",
+            Action::Remove,
+            Some("this uninstaller's escape-hatch wrapper"),
+        ),
+        Item::new(
+            Kind::Directory,
+            "/usr/local/libexec/wardnet",
+            Action::Remove,
+            None,
+        ),
+        Item::new(
+            Kind::Directory,
+            "/etc/wardnet",
+            Action::Remove,
+            Some("configuration"),
+        ),
+        Item::new(Kind::Directory, "/var/log/wardnet", Action::Remove, None),
+        Item::new(
+            Kind::Directory,
+            "/var/lib/wardnet-postupgrade",
+            Action::Remove,
+            Some("root-owned, outside the wardnet tree"),
+        ),
+    ]
+}
+
+/// The data directory, split by tier.
+fn data_items(purge: bool) -> Vec<Item> {
+    if purge {
+        return vec![Item::new(
+            Kind::Directory,
+            DATA_DIR,
+            Action::Remove,
+            Some("DESTROYS the database, wireguard keys and secret store"),
+        )];
+    }
+
+    // Scratch subdirectories go in both tiers; only genuine user data survives
+    // the default run.
+    let mut items = vec![
+        Item::new(
+            Kind::Directory,
+            "/var/lib/wardnet/updates",
+            Action::Remove,
+            Some("downloaded release artefacts"),
+        ),
+        Item::new(
+            Kind::Directory,
+            "/var/lib/wardnet/postupgrade",
+            Action::Remove,
+            Some("staged post-upgrade migration binary"),
+        ),
+    ];
+    items.extend(RETAINED_DATA.iter().copied().map(|path| {
+        // `secrets` is a directory; the database and its WAL sidecars are
+        // files. Labelling them all `file` would misdescribe the plan.
+        let kind = if path.ends_with("/secrets") {
+            Kind::Directory
+        } else {
+            Kind::File
+        };
+        Item::new(
+            kind,
+            path,
+            Action::Keep,
+            Some("re-owned to root; delete with --purge"),
+        )
+    }));
+    items
+}
+
+/// Drop-ins the installer only writes on a bare-metal host.
+fn host_dropin_items() -> Vec<Item> {
+    vec![
+        Item::new(
+            Kind::File,
+            "/etc/sysctl.d/99-wardnet.conf",
+            Action::Remove,
+            Some("stops net.ipv4.ip_forward persisting; live value survives until reboot"),
+        ),
+        Item::new(
+            Kind::File,
+            "/etc/dhcpcd.conf.d/wardnet.conf",
+            Action::Remove,
+            Some("static IP drop-in; the host reverts to DHCP at next boot"),
+        ),
+        Item::new(
+            Kind::File,
+            "/etc/modules-load.d/wardnet-watchdog.conf",
+            Action::Remove,
+            Some("hardware watchdog module load"),
+        ),
+    ]
+}
+
+/// Render the inventory as the plan printed before acting (and the whole
+/// output of `--dry-run`).
+#[must_use]
+pub fn render_plan(items: &[Item]) -> String {
+    use std::fmt::Write as _;
+
+    let mut out = String::new();
+    for item in items {
+        let verb = match item.action {
+            Action::Remove => "remove",
+            Action::Keep => "KEEP  ",
+        };
+        let _ = write!(out, "  {verb}  [{:<7}] {}", item.kind, item.target);
+        if let Some(note) = &item.note {
+            let _ = write!(out, "\n              ({note})");
+        }
+        out.push('\n');
+    }
+    out
+}

--- a/source/daemon/crates/wardnetd/src/uninstall/mod.rs
+++ b/source/daemon/crates/wardnetd/src/uninstall/mod.rs
@@ -29,25 +29,27 @@
 //! Inverted relative to `install.sh`: the installer degrades to
 //! non-interactive defaults when there is no tty, because installing is safe.
 //! Uninstalling is not, so with no way to reach a terminal and no `--yes` this
-//! refuses outright. The confirmation is read from `/dev/tty` rather than
-//! stdin, so the piped `curl … | sudo bash -s -- --uninstall` form can still
-//! answer it — see [`confirm`].
+//! refuses outright.
+//!
+//! # Structure
+//!
+//! Every side effect goes through [`UninstallOps`]; this module only decides.
+//! That is what makes the branches worth testing — abort when the daemon will
+//! not stop, keep the account when the re-own fails, report honestly on
+//! partial failure — reachable from tests with a recording double.
 
-use std::io::{BufRead, IsTerminal, Write};
-use std::path::Path;
-use std::sync::Arc;
+use std::path::{Path, PathBuf};
 
 use clap::Args;
-use wardnetd_services::tunnel::interface::TUNNEL_INTERFACE_PREFIX;
-
-use crate::shutdown::{TunnelTeardown, teardown_runtime_state};
 
 pub mod inventory;
+pub mod ops;
 
 #[cfg(test)]
 mod tests;
 
 use inventory::{Action, Item, Kind, SERVICE_USER, UNITS};
+use ops::{LinuxUninstallOps, SystemctlError, UninstallOps};
 
 /// Flags for `wardnetd uninstall`.
 #[allow(clippy::struct_excessive_bools)] // four independent CLI flags, not a state machine
@@ -73,17 +75,16 @@ pub struct UninstallArgs {
     pub container_mode: bool,
 }
 
-/// Outcome of a single removal step, accumulated so the summary can be honest
+/// Outcome of the removal steps, accumulated so the summary can be honest
 /// about partial failure rather than claiming success.
-struct Report {
+#[derive(Default)]
+pub(crate) struct Report {
     failures: Vec<String>,
 }
 
 impl Report {
-    fn new() -> Self {
-        Self {
-            failures: Vec::new(),
-        }
+    pub(crate) fn new() -> Self {
+        Self::default()
     }
 
     fn record(&mut self, what: &str, result: anyhow::Result<()>) {
@@ -107,8 +108,8 @@ impl Report {
     /// Matching is on whole identifiers, not substrings: `wg_ward1` occurs
     /// inside `wg_ward10`, and a substring test would treat a still-live
     /// `wg_ward10` as already reported and drop it from the summary — turning
-    /// a duplicate-reporting nit into the under-reporting this module exists to
-    /// avoid.
+    /// a duplicate-reporting nit into the under-reporting this module exists
+    /// to avoid.
     pub(crate) fn mentions_interface(&self, name: &str) -> bool {
         self.failures
             .iter()
@@ -116,9 +117,16 @@ impl Report {
     }
 }
 
-/// Run the uninstaller. Returns an error when any step failed, so the process
-/// exits non-zero and a caller (or the wrapper script) can tell.
+/// Run the uninstaller against the real host.
 pub async fn run(args: &UninstallArgs) -> anyhow::Result<()> {
+    run_with(args, &LinuxUninstallOps).await
+}
+
+/// Run the uninstaller against `ops`.
+///
+/// Returns an error when any step failed, so the process exits non-zero and a
+/// caller (or the wrapper script) can tell.
+pub(crate) async fn run_with(args: &UninstallArgs, ops: &dyn UninstallOps) -> anyhow::Result<()> {
     let items = inventory::build_inventory(args.purge, args.container_mode);
 
     print_warnings(args);
@@ -135,9 +143,11 @@ pub async fn run(args: &UninstallArgs) -> anyhow::Result<()> {
         println!("--dry-run: nothing was changed.");
         return Ok(());
     }
-    require_root()?;
+    if !ops.is_root() {
+        anyhow::bail!("uninstall must be run as root (try: sudo wardnet-uninstall)");
+    }
 
-    if !confirm(args)? {
+    if !confirm(args, ops)? {
         println!("Aborted; nothing was changed.");
         return Ok(());
     }
@@ -148,13 +158,13 @@ pub async fn run(args: &UninstallArgs) -> anyhow::Result<()> {
     // database moved to another disk) would otherwise make `--purge` unlink
     // just the symlink while we printed that the keys were destroyed, and make
     // the retained-data `chown` a no-op on the real tree.
-    let data_dir = resolved_data_dir();
+    let data_dir = resolved_data_dir(ops);
 
     // Abort rather than continue past a daemon that would not stop. Removing
     // the binary, units and interfaces out from under a live daemon risks the
     // forced kill that leaves the hardware watchdog armed and reboots this
     // host. Nothing has been changed at this point, so bailing is clean.
-    if !stop_service(&mut report).await {
+    if !stop_service(ops).await {
         anyhow::bail!(
             "could not confirm wardnetd.service is stopped; refusing to remove anything \
              while the daemon may still be running (a forced kill would leave the hardware \
@@ -163,23 +173,24 @@ pub async fn run(args: &UninstallArgs) -> anyhow::Result<()> {
         );
     }
 
-    teardown_kernel_state(&mut report).await;
-    remove_units(&mut report).await;
-    remove_paths(&items, &data_dir, &mut report);
+    teardown_kernel_state(ops, &mut report).await;
+    remove_units(ops, &mut report).await;
+    remove_paths(ops, &items, &data_dir, &mut report);
 
     // Deleting the user is what turns a failed re-own into the orphaned-UID
     // hazard this step exists to prevent, so if the chown did not succeed the
     // account stays. A leftover system user is trivially removable by hand; a
     // recycled UID silently owning the WireGuard keys is not.
+    //
     // `protect_retained_data` prints the specific reason when it declines —
     // "the purge left the tree behind" and "the chown failed" are different
     // facts, and reporting one as the other is the kind of small lie this
     // command must not tell.
-    let data_is_root_owned = protect_retained_data(args, &data_dir, &mut report);
+    let data_is_root_owned = protect_retained_data(ops, args, &data_dir, &mut report);
     if data_is_root_owned {
-        remove_user(&mut report).await;
+        remove_user(ops, &mut report).await;
     }
-    reload_systemd().await;
+    ops.daemon_reload().await;
 
     finish(args, &items, &report, data_is_root_owned)
 }
@@ -192,18 +203,10 @@ pub async fn run(args: &UninstallArgs) -> anyhow::Result<()> {
 /// symlink operand re-owns the link without traversing into it — both would
 /// report success while the database and secret store sat untouched.
 ///
-/// Falls back to the literal path when it does not exist or cannot be resolved.
-fn resolved_data_dir() -> std::path::PathBuf {
-    std::fs::canonicalize(inventory::DATA_DIR)
-        .unwrap_or_else(|_| std::path::PathBuf::from(inventory::DATA_DIR))
-}
-
-/// Whether anything exists at `path`, including a symlink whose target does
-/// not. `Path::exists` follows links and so answers "no" for a dangling one,
-/// which for our purposes is the wrong answer: the link is still there, and
-/// whatever it points at may simply be unmounted.
-fn path_present(path: &Path) -> bool {
-    std::fs::symlink_metadata(path).is_ok()
+/// Falls back to the literal path when it cannot be resolved.
+fn resolved_data_dir(ops: &dyn UninstallOps) -> PathBuf {
+    ops.canonicalize(Path::new(inventory::DATA_DIR))
+        .unwrap_or_else(|| PathBuf::from(inventory::DATA_DIR))
 }
 
 /// Whether `haystack` contains `name` as a whole identifier rather than as a
@@ -215,19 +218,6 @@ pub(crate) fn mentions_identifier(haystack: &str, name: &str) -> bool {
     haystack
         .split(|c: char| !(c.is_ascii_alphanumeric() || c == '_'))
         .any(|token| token == name)
-}
-
-/// Everything past the plan needs `CAP_NET_ADMIN` and write access to `/etc`,
-/// `/usr/local` and `/var/lib`. Fail with one clear message rather than a dozen
-/// permission errors.
-fn require_root() -> anyhow::Result<()> {
-    // SAFETY: `geteuid` is always safe — it takes no arguments, reads
-    // process-local state and cannot fail.
-    let euid = unsafe { libc::geteuid() };
-    if euid == 0 {
-        return Ok(());
-    }
-    anyhow::bail!("uninstall must be run as root (try: sudo wardnet-uninstall)")
 }
 
 /// Everything the operator needs to know *before* deciding, not after.
@@ -262,62 +252,63 @@ fn print_warnings(args: &UninstallArgs) {
     }
 }
 
+/// The exact word a tier requires before it will proceed.
+///
+/// `--purge` is unrecoverable, so a bare "y" is not enough.
+pub(crate) fn confirmation_word(purge: bool) -> &'static str {
+    if purge { "PURGE" } else { "yes" }
+}
+
 /// Ask before doing anything destructive.
-///
-/// With no way to ask, this refuses rather than assuming yes — the opposite of
-/// `install.sh`, which safely degrades to defaults when piped.
-///
-/// Reading the answer from `/dev/tty` rather than stdin is what makes the
-/// documented `curl -sSL … | sudo bash -s -- --uninstall` form work. In that
-/// shape the script arrives on stdin, `exec` preserves it, and stdin is a spent
-/// pipe — so a stdin-only prompt would make the advertised command fail every
-/// time. The controlling terminal is still there; we just have to ask it
-/// directly. When there is genuinely no terminal (cron, a CI step), opening
-/// `/dev/tty` fails and we refuse.
-fn confirm(args: &UninstallArgs) -> anyhow::Result<bool> {
+fn confirm(args: &UninstallArgs, ops: &dyn UninstallOps) -> anyhow::Result<bool> {
     if args.yes {
         return Ok(true);
     }
 
-    // `--purge` is unrecoverable, so a bare "y" is not enough.
-    let (prompt, expected) = if args.purge {
-        ("Type PURGE to destroy all data and uninstall: ", "PURGE")
+    let expected = confirmation_word(args.purge);
+    let prompt = if args.purge {
+        "Type PURGE to destroy all data and uninstall: "
     } else {
-        ("Type yes to uninstall: ", "yes")
+        "Type yes to uninstall: "
     };
 
-    let answer = read_from_terminal(prompt)?;
-    Ok(answer.trim() == expected)
+    Ok(ops.prompt(prompt)?.trim() == expected)
 }
 
-/// Prompt on the controlling terminal and read one line back from it.
-fn read_from_terminal(prompt: &str) -> anyhow::Result<String> {
-    let no_terminal =
-        || anyhow::anyhow!("refusing to uninstall without --yes: no terminal to confirm on");
+/// What a post-stop liveness probe told us.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum Liveness {
+    /// Confirmed down — safe to proceed.
+    Stopped,
+    /// Confirmed still up, or unanswerable. Either way, do not touch anything.
+    NotConfirmed,
+}
 
-    // Prefer stdin when it really is a terminal; fall back to /dev/tty for the
-    // piped case.
-    if std::io::stdin().is_terminal() {
-        print!("{prompt}");
-        std::io::stdout().flush()?;
-        let mut answer = String::new();
-        std::io::stdin().read_line(&mut answer)?;
-        return Ok(answer);
+/// Interpret `systemctl is-active`.
+///
+/// Only a *confirmed* stop lets the uninstall proceed: an unanswerable probe (a
+/// D-Bus hiccup, an unexpected systemctl failure) says nothing about whether
+/// the daemon is alive, and guessing "down" there is the guess that reboots the
+/// box via the still-armed hardware watchdog.
+pub(crate) fn classify_liveness(probe: &Result<(), SystemctlError>) -> Liveness {
+    match probe {
+        // 3 = inactive, 4 = no such unit. Both mean it is genuinely not up.
+        Err(SystemctlError::Status {
+            code: Some(3 | 4), ..
+        }) => Liveness::Stopped,
+        // No systemd to ask (container, chroot): nothing is supervising the
+        // daemon, so there is no stop to confirm.
+        Err(SystemctlError::Spawn(e)) if e.kind() == std::io::ErrorKind::NotFound => {
+            Liveness::Stopped
+        }
+        Err(SystemctlError::Status { stderr, .. }) if is_systemd_not_booted(stderr) => {
+            Liveness::Stopped
+        }
+        // `Ok(())` is exit 0 — still running. Any other failure tells us
+        // nothing about liveness, and the two collapse deliberately: both mean
+        // "not confirmed down", which is the only safe reading.
+        Ok(()) | Err(_) => Liveness::NotConfirmed,
     }
-
-    let tty = std::fs::OpenOptions::new()
-        .read(true)
-        .write(true)
-        .open("/dev/tty")
-        .map_err(|_| no_terminal())?;
-
-    let mut writer = &tty;
-    write!(writer, "{prompt}")?;
-    writer.flush()?;
-
-    let mut answer = String::new();
-    std::io::BufReader::new(&tty).read_line(&mut answer)?;
-    Ok(answer)
 }
 
 /// Stop the unit cleanly.
@@ -328,56 +319,33 @@ fn read_from_terminal(prompt: &str) -> anyhow::Result<String> {
 /// in the middle of the uninstall. `systemctl stop` blocks until the unit is
 /// down, so by the time this returns the daemon's own shutdown path has
 /// already torn most of the kernel state down.
-/// Returns `false` when the unit is demonstrably still running, in which case
-/// the caller must abort rather than delete anything.
-async fn stop_service(report: &mut Report) -> bool {
+///
+/// Returns whether the unit is *confirmed* stopped.
+async fn stop_service(ops: &dyn UninstallOps) -> bool {
     println!("Stopping wardnetd (cleanly, so the hardware watchdog is disarmed)...");
-    match systemctl(&["stop", "wardnetd.service"]).await {
+    match ops.stop_unit("wardnetd.service").await {
         Ok(()) => {}
         // Exit 5 is "unit not loaded" — the normal answer on a re-run or a
         // partial install, and this module promises to tolerate both.
         Err(SystemctlError::Status { code: Some(5), .. }) => {
             println!("  wardnetd.service is not loaded; nothing to stop.");
         }
-        // No systemd to talk to. Expected in a container or chroot, where
-        // `systemctl` either is absent or exits 1 with "System has not been
-        // booted with systemd". Treating that as a failure would make an
-        // otherwise clean container uninstall report as partial.
-        Err(SystemctlError::Spawn(e)) if e.kind() == std::io::ErrorKind::NotFound => {
+        // No systemd to talk to: expected in a container or chroot.
+        Err(SystemctlError::Spawn(ref e)) if e.kind() == std::io::ErrorKind::NotFound => {
             println!("  systemctl is not available; skipping service stop.");
         }
-        Err(SystemctlError::Status { stderr, .. }) if is_systemd_not_booted(&stderr) => {
+        Err(SystemctlError::Status { ref stderr, .. }) if is_systemd_not_booted(stderr) => {
             println!("  systemd is not running here; skipping service stop.");
         }
-        Err(e) => report.record("stop wardnetd.service", Err(e.into())),
+        Err(e) => eprintln!("  ! failed to stop wardnetd.service: {e}"),
     }
 
-    // A stop that timed out escalates to SIGKILL, which leaves the hardware
-    // watchdog armed and reboots this host ~15s later — in the middle of the
-    // uninstall. Only proceed on a *confirmed* stop: an unanswerable probe (a
-    // D-Bus hiccup, an unexpected systemctl failure) says nothing about whether
-    // the daemon is alive, and guessing "down" there is the guess that reboots
-    // the box.
-    match systemctl(&["is-active", "--quiet", "wardnetd.service"]).await {
-        // Exit 0 — still running.
-        Ok(()) => false,
-        // 3 = inactive, 4 = no such unit. Both mean it is genuinely not up.
-        Err(SystemctlError::Status {
-            code: Some(3 | 4), ..
-        }) => true,
-        // No systemd to ask (container, chroot): nothing is supervising the
-        // daemon, so there is no stop to confirm.
-        Err(SystemctlError::Spawn(e)) if e.kind() == std::io::ErrorKind::NotFound => true,
-        Err(SystemctlError::Status { ref stderr, .. }) if is_systemd_not_booted(stderr) => true,
-        Err(e) => {
-            eprintln!("  ! could not confirm wardnetd.service is stopped: {e}");
-            false
-        }
-    }
+    let liveness = classify_liveness(&ops.unit_is_active("wardnetd.service").await);
+    liveness == Liveness::Stopped
 }
 
 /// Whether `systemctl` failed because there is no systemd to talk to, rather
-/// than because the stop itself went wrong.
+/// than because the operation itself went wrong.
 fn is_systemd_not_booted(stderr: &str) -> bool {
     stderr.contains("has not been booted with systemd")
         || stderr.contains("Failed to connect to bus")
@@ -389,45 +357,34 @@ fn is_systemd_not_booted(stderr: &str) -> bool {
 /// previously been killed ungracefully — or was not running at all — the
 /// nftables table and `wg_ward*` interfaces are still live. Both operations
 /// are idempotent, so repeating them costs nothing.
-async fn teardown_kernel_state(report: &mut Report) {
+async fn teardown_kernel_state(ops: &dyn UninstallOps, report: &mut Report) {
     println!("Removing firewall table and wireguard interfaces...");
 
-    let firewall: Arc<dyn wardnetd_services::routing::FirewallManager> =
-        Arc::new(crate::firewall_netlink::NetlinkFirewallManager::new());
-    let tunnels: Arc<dyn wardnetd_services::tunnel::TunnelInterface> =
-        Arc::new(crate::tunnel_interface_wireguard::WireGuardTunnelInterface);
-    let inbound: Arc<dyn wardnetd_services::inbound_wg::InboundWgInterface> =
-        Arc::new(crate::inbound_wg_interface_wireguard::WireGuardInboundInterface);
-
-    // There is no tracing subscriber on this path, so the returned failures are
-    // the only way these reach the operator. Leaving a live firewall table
+    // There is no tracing subscriber on this path, so the returned failures
+    // are the only way these reach the operator. Leaving a live firewall table
     // behind while printing "Wardnet has been removed" is the worst outcome
     // this command could produce.
-    // Interface-level teardown, not service-level: uninstall has no database
-    // to keep in step, and with `--purge` it is about to delete the one there.
-    for failure in
-        teardown_runtime_state(&firewall, TunnelTeardown::Interface(&tunnels), &inbound).await
-    {
+    for failure in ops.teardown_runtime_state().await {
         eprintln!("  ! {failure}");
         report.push_failure(failure);
     }
 
     // `ip link delete` reaps links the WireGuard netlink family cannot see —
     // wrong-type or partially-created leftovers from a crash.
-    match wardnet_links().await {
+    match ops.wardnet_links().await {
         Ok(names) => {
             for name in &names {
-                crate::wireguard_interface::remove_stale_link(name, "wardnet interface").await;
+                ops.delete_link(name).await;
             }
-            // `remove_stale_link` is best-effort and logs nothing we can see
-            // here, so confirm by re-enumerating. A link we could not delete
-            // must reach the summary rather than being reported as removed.
-            match wardnet_links().await {
+            // The delete is best-effort and reports nothing we can see here,
+            // so confirm by re-enumerating. A link we could not delete must
+            // reach the summary rather than being reported as removed.
+            match ops.wardnet_links().await {
                 Ok(remaining) => {
                     for name in remaining {
                         // The typed teardown may already have reported this
-                        // interface; counting it again would overstate how much
-                        // is left behind.
+                        // interface; counting it again would overstate how
+                        // much is left behind.
                         if report.mentions_interface(&name) {
                             continue;
                         }
@@ -451,55 +408,18 @@ async fn teardown_kernel_state(report: &mut Report) {
     }
 }
 
-/// Every `wg_ward*` link currently on the host, per `ip link`.
-///
-/// Enumerated rather than guessed from a fixed range, because the case this
-/// sweep exists for is precisely the one where the typed teardown found nothing
-/// — a failed enumeration, or a link of the wrong type that the `WireGuard`
-/// netlink family cannot see. A hardcoded `wg_ward0..N` would leave anything
-/// above `N` behind with nothing reporting it.
-///
-/// Errors propagate rather than collapsing to an empty list: "no wardnet links"
-/// and "could not ask" must not look the same to the caller, or a failed sweep
-/// would be reported as a clean one.
-async fn wardnet_links() -> anyhow::Result<Vec<String>> {
-    let output = tokio::process::Command::new("ip")
-        .args(["-o", "link", "show"])
-        .output()
-        .await
-        .map_err(|e| anyhow::anyhow!("failed to run `ip link show`: {e}"))?;
-
-    if !output.status.success() {
-        anyhow::bail!(
-            "`ip link show` exited with {}: {}",
-            output.status,
-            String::from_utf8_lossy(&output.stderr).trim()
-        );
-    }
-
-    Ok(String::from_utf8_lossy(&output.stdout)
-        .lines()
-        // `ip -o link show` lines look like `2: eth0: <BROADCAST,...> mtu ...`.
-        .filter_map(|line| line.split(": ").nth(1))
-        // `ip -o link show` renders VLANs and peers as `name@parent`.
-        .map(|name| name.split('@').next().unwrap_or(name).trim().to_owned())
-        .filter(|name| name.starts_with(TUNNEL_INTERFACE_PREFIX))
-        .collect())
-}
-
-async fn remove_units(report: &mut Report) {
+async fn remove_units(ops: &dyn UninstallOps, report: &mut Report) {
     println!("Disabling systemd units...");
     for unit in UNITS {
-        // Already-disabled units make this a no-op; a missing unit is fine.
-        let _ = systemctl(&["disable", unit]).await;
+        ops.disable_unit(unit).await;
         report.record(
             &format!("unit file {unit}"),
-            remove_path(Path::new(&format!("/etc/systemd/system/{unit}"))),
+            ops.remove_path(Path::new(&format!("/etc/systemd/system/{unit}"))),
         );
     }
 }
 
-fn remove_paths(items: &[Item], data_dir: &Path, report: &mut Report) {
+fn remove_paths(ops: &dyn UninstallOps, items: &[Item], data_dir: &Path, report: &mut Report) {
     println!("Removing files...");
     for item in items {
         if item.action != Action::Remove {
@@ -507,20 +427,20 @@ fn remove_paths(items: &[Item], data_dir: &Path, report: &mut Report) {
         }
         match item.kind {
             Kind::File | Kind::Directory => {
-                // `--purge` lists the data directory by its literal path; delete
-                // the resolved tree so a symlinked data dir really is destroyed,
-                // then drop the symlink itself.
+                // `--purge` lists the data directory by its literal path;
+                // delete the resolved tree so a symlinked data dir really is
+                // destroyed, then drop the symlink itself.
                 if item.target == inventory::DATA_DIR {
-                    report.record(&item.target, remove_path(data_dir));
+                    report.record(&item.target, ops.remove_path(data_dir));
                     if data_dir != Path::new(inventory::DATA_DIR) {
                         report.record(
                             inventory::DATA_DIR,
-                            remove_path(Path::new(inventory::DATA_DIR)),
+                            ops.remove_path(Path::new(inventory::DATA_DIR)),
                         );
                     }
                     continue;
                 }
-                report.record(&item.target, remove_path(Path::new(&item.target)));
+                report.record(&item.target, ops.remove_path(Path::new(&item.target)));
             }
             // Units are handled by `remove_units`; runtime state and the user
             // account have their own steps.
@@ -529,31 +449,6 @@ fn remove_paths(items: &[Item], data_dir: &Path, report: &mut Report) {
     }
 }
 
-/// Delete a file or directory, treating "already absent" as success.
-///
-/// Absence is the normal case on a re-run or a partial install, so it must not
-/// count as a failure — that is what keeps the summary honest.
-fn remove_path(path: &Path) -> anyhow::Result<()> {
-    let metadata = match std::fs::symlink_metadata(path) {
-        Ok(m) => m,
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(()),
-        Err(e) => return Err(e.into()),
-    };
-
-    if metadata.is_dir() {
-        std::fs::remove_dir_all(path)?;
-    } else {
-        std::fs::remove_file(path)?;
-    }
-    Ok(())
-}
-
-/// Re-own retained data to root.
-///
-/// The `wardnet` user is deleted moments later. Left alone, the user's
-/// database and private keys would be owned by a numeric UID with no account
-/// behind it, which a future `useradd` on the same host can silently hand to
-/// an unrelated service.
 /// What the retained tree needs before the `wardnet` account can be deleted.
 ///
 /// Split out from the filesystem work so the branch that decides whether the
@@ -578,14 +473,28 @@ pub(crate) fn classify_retained_data(purge: bool, data_dir_exists: bool) -> Reta
     }
 }
 
+/// Re-own retained data to root.
+///
+/// The `wardnet` user is deleted moments later. Left alone, the user's
+/// database and private keys would be owned by a numeric UID with no account
+/// behind it, which a future `useradd` on the same host can silently hand to
+/// an unrelated service.
+///
 /// Returns whether the retained tree is now safely owned by root — `true` when
-/// there was nothing to protect (purge, or no data directory).
-fn protect_retained_data(args: &UninstallArgs, data_dir: &Path, report: &mut Report) -> bool {
-    // `symlink_metadata`, not `exists()`: a dangling `/var/lib/wardnet` symlink
-    // (unmounted disk, tree moved) satisfies neither `exists()` nor
-    // `canonicalize`, so `exists()` would call it `Gone`, free the UID, and
-    // announce "now owned by root" over data that is merely out of reach.
-    let still_there = path_present(data_dir) || path_present(Path::new(inventory::DATA_DIR));
+/// there was nothing to protect.
+fn protect_retained_data(
+    ops: &dyn UninstallOps,
+    args: &UninstallArgs,
+    data_dir: &Path,
+    report: &mut Report,
+) -> bool {
+    // `path_present` uses `symlink_metadata`, not `exists()`: a dangling
+    // `/var/lib/wardnet` symlink (unmounted disk, tree moved) satisfies
+    // neither `exists()` nor `canonicalize`, so `exists()` would call it
+    // `Gone`, free the UID, and announce "now owned by root" over data that is
+    // merely out of reach.
+    let still_there =
+        ops.path_present(data_dir) || ops.path_present(Path::new(inventory::DATA_DIR));
     match classify_retained_data(args.purge, still_there) {
         RetainedData::Gone => return true,
         RetainedData::PurgeIncomplete => {
@@ -601,18 +510,12 @@ fn protect_retained_data(args: &UninstallArgs, data_dir: &Path, report: &mut Rep
         RetainedData::NeedsChown => {}
     }
 
-    // Re-own the whole tree, not just the files we listed as retained. The
-    // directory itself is created `wardnet:wardnet` mode 0750, so leaving it
-    // owned by the departing user would let a later account reusing that UID
-    // unlink or replace the database and `secrets/` even though the files
-    // inside are root-owned. Re-owning the leaves alone would look like it
-    // closed the hazard while leaving the door open.
-    // Present but unresolvable: `/var/lib/wardnet` is a symlink whose target is
-    // gone or unmounted, so `resolved_data_dir` fell back to the literal path.
-    // `chown -R -h` on a symlink operand re-owns the link and exits 0 without
-    // ever traversing, which would look like success and let the account go —
-    // the very hazard this step exists to close.
-    if std::fs::metadata(data_dir).is_err() {
+    // Present but unresolvable: `/var/lib/wardnet` is a symlink whose target
+    // is gone or unmounted, so `resolved_data_dir` fell back to the literal
+    // path. `chown -R -h` on a symlink operand re-owns the link and exits 0
+    // without ever traversing, which would look like success and let the
+    // account go — the very hazard this step exists to close.
+    if !ops.is_reachable(data_dir) {
         let msg = format!(
             "{} exists but its target cannot be reached (unmounted disk or broken \
              symlink); keeping the {SERVICE_USER} user rather than freeing a UID that \
@@ -624,8 +527,14 @@ fn protect_retained_data(args: &UninstallArgs, data_dir: &Path, report: &mut Rep
         return false;
     }
 
+    // Re-own the whole tree, not just the files we listed as retained. The
+    // directory itself is created `wardnet:wardnet` mode 0750, so leaving it
+    // owned by the departing user would let a later account reusing that UID
+    // unlink or replace the database and `secrets/` even though the files
+    // inside are root-owned. Re-owning the leaves alone would look like it
+    // closed the hazard while leaving the door open.
     println!("Re-owning retained data to root...");
-    match chown_root_recursive(data_dir) {
+    match ops.chown_root_recursive(data_dir) {
         Ok(()) => true,
         Err(e) => {
             report.record(&format!("chown {}", data_dir.display()), Err(e));
@@ -639,94 +548,10 @@ fn protect_retained_data(args: &UninstallArgs, data_dir: &Path, report: &mut Rep
     }
 }
 
-fn chown_root_recursive(target: &Path) -> anyhow::Result<()> {
-    // `-h` acts on symlinks themselves and `--` stops the path being read as an
-    // option, so nothing under the tree — which the departing, network-facing
-    // `wardnet` account could write — can redirect the ownership change. The
-    // operand is already symlink-resolved by `resolved_data_dir`, so `-h`
-    // cannot turn the whole traversal into a no-op.
-    let status = std::process::Command::new("chown")
-        .args([
-            std::ffi::OsStr::new("-R"),
-            std::ffi::OsStr::new("-h"),
-            std::ffi::OsStr::new("root:root"),
-            std::ffi::OsStr::new("--"),
-            target.as_os_str(),
-        ])
-        .status()?;
-    if status.success() {
-        Ok(())
-    } else {
-        anyhow::bail!("chown exited with {status}")
-    }
-}
-
-async fn remove_user(report: &mut Report) {
+async fn remove_user(ops: &dyn UninstallOps, report: &mut Report) {
     println!("Removing the {SERVICE_USER} system user...");
-    let output = tokio::process::Command::new("userdel")
-        .arg(SERVICE_USER)
-        .output()
-        .await;
-
-    let result = match output {
-        // userdel exit code 6 means "user does not exist" — idempotent success.
-        Ok(o) if o.status.success() || o.status.code() == Some(6) => Ok(()),
-        Ok(o) => Err(anyhow::anyhow!(
-            "userdel exited with {}: {}",
-            o.status,
-            String::from_utf8_lossy(&o.stderr).trim()
-        )),
-        Err(e) => Err(e.into()),
-    };
+    let result = ops.delete_user(SERVICE_USER).await;
     report.record(&format!("user {SERVICE_USER}"), result);
-}
-
-async fn reload_systemd() {
-    let _ = systemctl(&["daemon-reload"]).await;
-}
-
-/// Why a `systemctl` invocation failed. Typed rather than a flat string so
-/// callers can distinguish "unit not loaded" (exit 5, benign on a re-run) from
-/// a genuine failure.
-#[derive(Debug)]
-enum SystemctlError {
-    Spawn(std::io::Error),
-    Status {
-        args: String,
-        code: Option<i32>,
-        stderr: String,
-    },
-}
-
-impl std::fmt::Display for SystemctlError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::Spawn(e) => write!(f, "failed to run systemctl: {e}"),
-            Self::Status { args, code, stderr } => {
-                let code = code.map_or_else(|| "signal".to_owned(), |c| c.to_string());
-                write!(f, "systemctl {args} exited with {code}: {stderr}")
-            }
-        }
-    }
-}
-
-impl std::error::Error for SystemctlError {}
-
-async fn systemctl(args: &[&str]) -> Result<(), SystemctlError> {
-    let output = tokio::process::Command::new("systemctl")
-        .args(args)
-        .output()
-        .await
-        .map_err(SystemctlError::Spawn)?;
-
-    if output.status.success() {
-        return Ok(());
-    }
-    Err(SystemctlError::Status {
-        args: args.join(" "),
-        code: output.status.code(),
-        stderr: String::from_utf8_lossy(&output.stderr).trim().to_owned(),
-    })
 }
 
 /// Print the closing summary and decide the exit status.

--- a/source/daemon/crates/wardnetd/src/uninstall/mod.rs
+++ b/source/daemon/crates/wardnetd/src/uninstall/mod.rs
@@ -1,0 +1,780 @@
+//! `wardnetd uninstall` — the supported way to remove Wardnet from a host.
+//!
+//! # Why this lives in the daemon rather than in the install script
+//!
+//! ADR 0013 moved nftables management to pure netlink (`rustables`), so the
+//! `nft` CLI is deliberately *not* an install dependency and may not exist on
+//! the box at all. A shell uninstaller therefore cannot be relied on to delete
+//! `table inet wardnet`. The daemon binary can, because it links the same
+//! netlink code that created the table — the uninstaller calls the same
+//! abstraction that installed the state.
+//!
+//! `install.sh` still writes a small `/usr/local/sbin/wardnet-uninstall`
+//! wrapper, which execs this subcommand when the binary works. When it does
+//! not, the wrapper falls back to a deliberately dumb file-removal path: it
+//! still confirms before acting, deletes the table via the `nft` CLI if that
+//! happens to be installed, and otherwise exits non-zero saying firewall state
+//! may remain rather than claiming a clean uninstall.
+//!
+//! # Two tiers
+//!
+//! The default run removes the daemon, units, user, config and kernel state
+//! but **keeps** the `SQLite` database and secret store, printing where they
+//! are. `--purge` destroys them. Retained data is re-owned to root, because
+//! the `wardnet` user is deleted in the same run and an orphaned UID can be
+//! silently reassigned to an unrelated service later.
+//!
+//! # Safety posture
+//!
+//! Inverted relative to `install.sh`: the installer degrades to
+//! non-interactive defaults when there is no tty, because installing is safe.
+//! Uninstalling is not, so with no way to reach a terminal and no `--yes` this
+//! refuses outright. The confirmation is read from `/dev/tty` rather than
+//! stdin, so the piped `curl … | sudo bash -s -- --uninstall` form can still
+//! answer it — see [`confirm`].
+
+use std::io::{BufRead, IsTerminal, Write};
+use std::path::Path;
+use std::sync::Arc;
+
+use clap::Args;
+use wardnetd_services::tunnel::interface::TUNNEL_INTERFACE_PREFIX;
+
+use crate::shutdown::{TunnelTeardown, teardown_runtime_state};
+
+pub mod inventory;
+
+#[cfg(test)]
+mod tests;
+
+use inventory::{Action, Item, Kind, SERVICE_USER, UNITS};
+
+/// Flags for `wardnetd uninstall`.
+#[allow(clippy::struct_excessive_bools)] // four independent CLI flags, not a state machine
+#[derive(Args, Debug, Clone, Default)]
+pub struct UninstallArgs {
+    /// Also delete `/var/lib/wardnet` — the `SQLite` database, `WireGuard`
+    /// private keys, backup passphrase and DDNS credentials. Unrecoverable.
+    #[arg(long)]
+    pub purge: bool,
+
+    /// Print everything that would be removed and exit without touching
+    /// anything.
+    #[arg(long)]
+    pub dry_run: bool,
+
+    /// Skip the confirmation prompt. Required to uninstall non-interactively.
+    #[arg(long, short)]
+    pub yes: bool,
+
+    /// Mirror `install.sh --container-mode`: skip the sysctl, dhcpcd and
+    /// module-load drop-ins the installer never wrote in a container.
+    #[arg(long)]
+    pub container_mode: bool,
+}
+
+/// Outcome of a single removal step, accumulated so the summary can be honest
+/// about partial failure rather than claiming success.
+struct Report {
+    failures: Vec<String>,
+}
+
+impl Report {
+    fn new() -> Self {
+        Self {
+            failures: Vec::new(),
+        }
+    }
+
+    fn record(&mut self, what: &str, result: anyhow::Result<()>) {
+        if let Err(e) = result {
+            eprintln!("  ! failed to remove {what}: {e}");
+            self.failures.push(format!("{what}: {e}"));
+        }
+    }
+
+    /// Record an already-formatted failure (the caller has printed it).
+    fn push_failure(&mut self, failure: String) {
+        self.failures.push(failure);
+    }
+
+    /// Whether some recorded failure already names this exact interface.
+    ///
+    /// The typed teardown and the `ip link` sweep both touch the same
+    /// interfaces, so without this an interface that resisted both would be
+    /// counted twice in the closing summary.
+    ///
+    /// Matching is on whole identifiers, not substrings: `wg_ward1` occurs
+    /// inside `wg_ward10`, and a substring test would treat a still-live
+    /// `wg_ward10` as already reported and drop it from the summary — turning
+    /// a duplicate-reporting nit into the under-reporting this module exists to
+    /// avoid.
+    pub(crate) fn mentions_interface(&self, name: &str) -> bool {
+        self.failures
+            .iter()
+            .any(|failure| mentions_identifier(failure, name))
+    }
+}
+
+/// Run the uninstaller. Returns an error when any step failed, so the process
+/// exits non-zero and a caller (or the wrapper script) can tell.
+pub async fn run(args: &UninstallArgs) -> anyhow::Result<()> {
+    let items = inventory::build_inventory(args.purge, args.container_mode);
+
+    print_warnings(args);
+
+    println!("The following will be touched:\n");
+    print!("{}", inventory::render_plan(&items));
+    println!();
+
+    // Checked after the plan is printed but before anything else, so
+    // `--dry-run` stays usable unprivileged. Without this, an unprivileged run
+    // would prompt for confirmation and then fail every single step with a
+    // wall of permission errors instead of one clear message.
+    if args.dry_run {
+        println!("--dry-run: nothing was changed.");
+        return Ok(());
+    }
+    require_root()?;
+
+    if !confirm(args)? {
+        println!("Aborted; nothing was changed.");
+        return Ok(());
+    }
+
+    let mut report = Report::new();
+
+    // Resolved once, before anything is deleted. A symlinked data directory (a
+    // database moved to another disk) would otherwise make `--purge` unlink
+    // just the symlink while we printed that the keys were destroyed, and make
+    // the retained-data `chown` a no-op on the real tree.
+    let data_dir = resolved_data_dir();
+
+    // Abort rather than continue past a daemon that would not stop. Removing
+    // the binary, units and interfaces out from under a live daemon risks the
+    // forced kill that leaves the hardware watchdog armed and reboots this
+    // host. Nothing has been changed at this point, so bailing is clean.
+    if !stop_service(&mut report).await {
+        anyhow::bail!(
+            "could not confirm wardnetd.service is stopped; refusing to remove anything \
+             while the daemon may still be running (a forced kill would leave the hardware \
+             watchdog armed and reboot this host). Investigate with `systemctl status \
+             wardnetd`, stop it by hand, then re-run. Nothing has been changed."
+        );
+    }
+
+    teardown_kernel_state(&mut report).await;
+    remove_units(&mut report).await;
+    remove_paths(&items, &data_dir, &mut report);
+
+    // Deleting the user is what turns a failed re-own into the orphaned-UID
+    // hazard this step exists to prevent, so if the chown did not succeed the
+    // account stays. A leftover system user is trivially removable by hand; a
+    // recycled UID silently owning the WireGuard keys is not.
+    // `protect_retained_data` prints the specific reason when it declines —
+    // "the purge left the tree behind" and "the chown failed" are different
+    // facts, and reporting one as the other is the kind of small lie this
+    // command must not tell.
+    let data_is_root_owned = protect_retained_data(args, &data_dir, &mut report);
+    if data_is_root_owned {
+        remove_user(&mut report).await;
+    }
+    reload_systemd().await;
+
+    finish(args, &items, &report, data_is_root_owned)
+}
+
+/// The data directory with any symlink resolved.
+///
+/// Operators do relocate the database to another disk by symlinking
+/// `/var/lib/wardnet`. Every destructive step has to act on the real tree:
+/// `remove_dir_all` on a symlink unlinks only the link, and `chown -R -h` on a
+/// symlink operand re-owns the link without traversing into it — both would
+/// report success while the database and secret store sat untouched.
+///
+/// Falls back to the literal path when it does not exist or cannot be resolved.
+fn resolved_data_dir() -> std::path::PathBuf {
+    std::fs::canonicalize(inventory::DATA_DIR)
+        .unwrap_or_else(|_| std::path::PathBuf::from(inventory::DATA_DIR))
+}
+
+/// Whether anything exists at `path`, including a symlink whose target does
+/// not. `Path::exists` follows links and so answers "no" for a dangling one,
+/// which for our purposes is the wrong answer: the link is still there, and
+/// whatever it points at may simply be unmounted.
+fn path_present(path: &Path) -> bool {
+    std::fs::symlink_metadata(path).is_ok()
+}
+
+/// Whether `haystack` contains `name` as a whole identifier rather than as a
+/// substring of a longer one.
+///
+/// Interface names are `[A-Za-z0-9_]`, so splitting on anything else yields the
+/// identifiers in a message and lets `wg_ward1` and `wg_ward10` be told apart.
+pub(crate) fn mentions_identifier(haystack: &str, name: &str) -> bool {
+    haystack
+        .split(|c: char| !(c.is_ascii_alphanumeric() || c == '_'))
+        .any(|token| token == name)
+}
+
+/// Everything past the plan needs `CAP_NET_ADMIN` and write access to `/etc`,
+/// `/usr/local` and `/var/lib`. Fail with one clear message rather than a dozen
+/// permission errors.
+fn require_root() -> anyhow::Result<()> {
+    // SAFETY: `geteuid` is always safe — it takes no arguments, reads
+    // process-local state and cannot fail.
+    let euid = unsafe { libc::geteuid() };
+    if euid == 0 {
+        return Ok(());
+    }
+    anyhow::bail!("uninstall must be run as root (try: sudo wardnet-uninstall)")
+}
+
+/// Everything the operator needs to know *before* deciding, not after.
+fn print_warnings(args: &UninstallArgs) {
+    println!("=== Uninstalling Wardnet ===\n");
+
+    println!(
+        "This host is your network's DHCP and DNS server. Once Wardnet is gone,\n\
+         devices on the LAN will have no addressing and no name resolution until\n\
+         you re-enable DHCP on your router. Do that first if you can.\n"
+    );
+
+    if !args.container_mode {
+        println!(
+            "If you installed with --static-ip, removing /etc/dhcpcd.conf.d/wardnet.conf\n\
+             means this host reverts to DHCP at next boot and may come back on a\n\
+             different address. Note the current one before rebooting.\n"
+        );
+    }
+
+    if args.purge {
+        println!(
+            "--purge DESTROYS /var/lib/wardnet: the SQLite database, your WireGuard\n\
+             private keys, the backup passphrase and any DDNS credentials. There is\n\
+             no way to recover them. Take a backup first if there is any doubt.\n"
+        );
+    } else {
+        println!(
+            "Your database and secrets under /var/lib/wardnet will be KEPT and\n\
+             re-owned to root. Re-run with --purge to destroy them.\n"
+        );
+    }
+}
+
+/// Ask before doing anything destructive.
+///
+/// With no way to ask, this refuses rather than assuming yes — the opposite of
+/// `install.sh`, which safely degrades to defaults when piped.
+///
+/// Reading the answer from `/dev/tty` rather than stdin is what makes the
+/// documented `curl -sSL … | sudo bash -s -- --uninstall` form work. In that
+/// shape the script arrives on stdin, `exec` preserves it, and stdin is a spent
+/// pipe — so a stdin-only prompt would make the advertised command fail every
+/// time. The controlling terminal is still there; we just have to ask it
+/// directly. When there is genuinely no terminal (cron, a CI step), opening
+/// `/dev/tty` fails and we refuse.
+fn confirm(args: &UninstallArgs) -> anyhow::Result<bool> {
+    if args.yes {
+        return Ok(true);
+    }
+
+    // `--purge` is unrecoverable, so a bare "y" is not enough.
+    let (prompt, expected) = if args.purge {
+        ("Type PURGE to destroy all data and uninstall: ", "PURGE")
+    } else {
+        ("Type yes to uninstall: ", "yes")
+    };
+
+    let answer = read_from_terminal(prompt)?;
+    Ok(answer.trim() == expected)
+}
+
+/// Prompt on the controlling terminal and read one line back from it.
+fn read_from_terminal(prompt: &str) -> anyhow::Result<String> {
+    let no_terminal =
+        || anyhow::anyhow!("refusing to uninstall without --yes: no terminal to confirm on");
+
+    // Prefer stdin when it really is a terminal; fall back to /dev/tty for the
+    // piped case.
+    if std::io::stdin().is_terminal() {
+        print!("{prompt}");
+        std::io::stdout().flush()?;
+        let mut answer = String::new();
+        std::io::stdin().read_line(&mut answer)?;
+        return Ok(answer);
+    }
+
+    let tty = std::fs::OpenOptions::new()
+        .read(true)
+        .write(true)
+        .open("/dev/tty")
+        .map_err(|_| no_terminal())?;
+
+    let mut writer = &tty;
+    write!(writer, "{prompt}")?;
+    writer.flush()?;
+
+    let mut answer = String::new();
+    std::io::BufReader::new(&tty).read_line(&mut answer)?;
+    Ok(answer)
+}
+
+/// Stop the unit cleanly.
+///
+/// Never a SIGKILL: the daemon holds `/dev/watchdog` and disarms it via the
+/// kernel magic-close on clean shutdown. Killing it ungracefully leaves the
+/// hardware watchdog armed and reboots the host about fifteen seconds later,
+/// in the middle of the uninstall. `systemctl stop` blocks until the unit is
+/// down, so by the time this returns the daemon's own shutdown path has
+/// already torn most of the kernel state down.
+/// Returns `false` when the unit is demonstrably still running, in which case
+/// the caller must abort rather than delete anything.
+async fn stop_service(report: &mut Report) -> bool {
+    println!("Stopping wardnetd (cleanly, so the hardware watchdog is disarmed)...");
+    match systemctl(&["stop", "wardnetd.service"]).await {
+        Ok(()) => {}
+        // Exit 5 is "unit not loaded" — the normal answer on a re-run or a
+        // partial install, and this module promises to tolerate both.
+        Err(SystemctlError::Status { code: Some(5), .. }) => {
+            println!("  wardnetd.service is not loaded; nothing to stop.");
+        }
+        // No systemd to talk to. Expected in a container or chroot, where
+        // `systemctl` either is absent or exits 1 with "System has not been
+        // booted with systemd". Treating that as a failure would make an
+        // otherwise clean container uninstall report as partial.
+        Err(SystemctlError::Spawn(e)) if e.kind() == std::io::ErrorKind::NotFound => {
+            println!("  systemctl is not available; skipping service stop.");
+        }
+        Err(SystemctlError::Status { stderr, .. }) if is_systemd_not_booted(&stderr) => {
+            println!("  systemd is not running here; skipping service stop.");
+        }
+        Err(e) => report.record("stop wardnetd.service", Err(e.into())),
+    }
+
+    // A stop that timed out escalates to SIGKILL, which leaves the hardware
+    // watchdog armed and reboots this host ~15s later — in the middle of the
+    // uninstall. Only proceed on a *confirmed* stop: an unanswerable probe (a
+    // D-Bus hiccup, an unexpected systemctl failure) says nothing about whether
+    // the daemon is alive, and guessing "down" there is the guess that reboots
+    // the box.
+    match systemctl(&["is-active", "--quiet", "wardnetd.service"]).await {
+        // Exit 0 — still running.
+        Ok(()) => false,
+        // 3 = inactive, 4 = no such unit. Both mean it is genuinely not up.
+        Err(SystemctlError::Status {
+            code: Some(3 | 4), ..
+        }) => true,
+        // No systemd to ask (container, chroot): nothing is supervising the
+        // daemon, so there is no stop to confirm.
+        Err(SystemctlError::Spawn(e)) if e.kind() == std::io::ErrorKind::NotFound => true,
+        Err(SystemctlError::Status { ref stderr, .. }) if is_systemd_not_booted(stderr) => true,
+        Err(e) => {
+            eprintln!("  ! could not confirm wardnetd.service is stopped: {e}");
+            false
+        }
+    }
+}
+
+/// Whether `systemctl` failed because there is no systemd to talk to, rather
+/// than because the stop itself went wrong.
+fn is_systemd_not_booted(stderr: &str) -> bool {
+    stderr.contains("has not been booted with systemd")
+        || stderr.contains("Failed to connect to bus")
+}
+
+/// Re-run the daemon's own teardown as a belt-and-braces sweep.
+///
+/// The clean stop above normally handles this, but if the daemon had
+/// previously been killed ungracefully — or was not running at all — the
+/// nftables table and `wg_ward*` interfaces are still live. Both operations
+/// are idempotent, so repeating them costs nothing.
+async fn teardown_kernel_state(report: &mut Report) {
+    println!("Removing firewall table and wireguard interfaces...");
+
+    let firewall: Arc<dyn wardnetd_services::routing::FirewallManager> =
+        Arc::new(crate::firewall_netlink::NetlinkFirewallManager::new());
+    let tunnels: Arc<dyn wardnetd_services::tunnel::TunnelInterface> =
+        Arc::new(crate::tunnel_interface_wireguard::WireGuardTunnelInterface);
+    let inbound: Arc<dyn wardnetd_services::inbound_wg::InboundWgInterface> =
+        Arc::new(crate::inbound_wg_interface_wireguard::WireGuardInboundInterface);
+
+    // There is no tracing subscriber on this path, so the returned failures are
+    // the only way these reach the operator. Leaving a live firewall table
+    // behind while printing "Wardnet has been removed" is the worst outcome
+    // this command could produce.
+    // Interface-level teardown, not service-level: uninstall has no database
+    // to keep in step, and with `--purge` it is about to delete the one there.
+    for failure in
+        teardown_runtime_state(&firewall, TunnelTeardown::Interface(&tunnels), &inbound).await
+    {
+        eprintln!("  ! {failure}");
+        report.push_failure(failure);
+    }
+
+    // `ip link delete` reaps links the WireGuard netlink family cannot see —
+    // wrong-type or partially-created leftovers from a crash.
+    match wardnet_links().await {
+        Ok(names) => {
+            for name in &names {
+                crate::wireguard_interface::remove_stale_link(name, "wardnet interface").await;
+            }
+            // `remove_stale_link` is best-effort and logs nothing we can see
+            // here, so confirm by re-enumerating. A link we could not delete
+            // must reach the summary rather than being reported as removed.
+            match wardnet_links().await {
+                Ok(remaining) => {
+                    for name in remaining {
+                        // The typed teardown may already have reported this
+                        // interface; counting it again would overstate how much
+                        // is left behind.
+                        if report.mentions_interface(&name) {
+                            continue;
+                        }
+                        let msg = format!("wireguard interface {name} could not be removed");
+                        eprintln!("  ! {msg}");
+                        report.push_failure(msg);
+                    }
+                }
+                Err(e) => {
+                    let msg = format!("could not confirm wireguard interfaces were removed: {e}");
+                    eprintln!("  ! {msg}");
+                    report.push_failure(msg);
+                }
+            }
+        }
+        Err(e) => {
+            let msg = format!("could not enumerate wireguard interfaces: {e}");
+            eprintln!("  ! {msg}");
+            report.push_failure(msg);
+        }
+    }
+}
+
+/// Every `wg_ward*` link currently on the host, per `ip link`.
+///
+/// Enumerated rather than guessed from a fixed range, because the case this
+/// sweep exists for is precisely the one where the typed teardown found nothing
+/// — a failed enumeration, or a link of the wrong type that the `WireGuard`
+/// netlink family cannot see. A hardcoded `wg_ward0..N` would leave anything
+/// above `N` behind with nothing reporting it.
+///
+/// Errors propagate rather than collapsing to an empty list: "no wardnet links"
+/// and "could not ask" must not look the same to the caller, or a failed sweep
+/// would be reported as a clean one.
+async fn wardnet_links() -> anyhow::Result<Vec<String>> {
+    let output = tokio::process::Command::new("ip")
+        .args(["-o", "link", "show"])
+        .output()
+        .await
+        .map_err(|e| anyhow::anyhow!("failed to run `ip link show`: {e}"))?;
+
+    if !output.status.success() {
+        anyhow::bail!(
+            "`ip link show` exited with {}: {}",
+            output.status,
+            String::from_utf8_lossy(&output.stderr).trim()
+        );
+    }
+
+    Ok(String::from_utf8_lossy(&output.stdout)
+        .lines()
+        // `ip -o link show` lines look like `2: eth0: <BROADCAST,...> mtu ...`.
+        .filter_map(|line| line.split(": ").nth(1))
+        // `ip -o link show` renders VLANs and peers as `name@parent`.
+        .map(|name| name.split('@').next().unwrap_or(name).trim().to_owned())
+        .filter(|name| name.starts_with(TUNNEL_INTERFACE_PREFIX))
+        .collect())
+}
+
+async fn remove_units(report: &mut Report) {
+    println!("Disabling systemd units...");
+    for unit in UNITS {
+        // Already-disabled units make this a no-op; a missing unit is fine.
+        let _ = systemctl(&["disable", unit]).await;
+        report.record(
+            &format!("unit file {unit}"),
+            remove_path(Path::new(&format!("/etc/systemd/system/{unit}"))),
+        );
+    }
+}
+
+fn remove_paths(items: &[Item], data_dir: &Path, report: &mut Report) {
+    println!("Removing files...");
+    for item in items {
+        if item.action != Action::Remove {
+            continue;
+        }
+        match item.kind {
+            Kind::File | Kind::Directory => {
+                // `--purge` lists the data directory by its literal path; delete
+                // the resolved tree so a symlinked data dir really is destroyed,
+                // then drop the symlink itself.
+                if item.target == inventory::DATA_DIR {
+                    report.record(&item.target, remove_path(data_dir));
+                    if data_dir != Path::new(inventory::DATA_DIR) {
+                        report.record(
+                            inventory::DATA_DIR,
+                            remove_path(Path::new(inventory::DATA_DIR)),
+                        );
+                    }
+                    continue;
+                }
+                report.record(&item.target, remove_path(Path::new(&item.target)));
+            }
+            // Units are handled by `remove_units`; runtime state and the user
+            // account have their own steps.
+            Kind::Unit | Kind::User | Kind::Runtime => {}
+        }
+    }
+}
+
+/// Delete a file or directory, treating "already absent" as success.
+///
+/// Absence is the normal case on a re-run or a partial install, so it must not
+/// count as a failure — that is what keeps the summary honest.
+fn remove_path(path: &Path) -> anyhow::Result<()> {
+    let metadata = match std::fs::symlink_metadata(path) {
+        Ok(m) => m,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(e) => return Err(e.into()),
+    };
+
+    if metadata.is_dir() {
+        std::fs::remove_dir_all(path)?;
+    } else {
+        std::fs::remove_file(path)?;
+    }
+    Ok(())
+}
+
+/// Re-own retained data to root.
+///
+/// The `wardnet` user is deleted moments later. Left alone, the user's
+/// database and private keys would be owned by a numeric UID with no account
+/// behind it, which a future `useradd` on the same host can silently hand to
+/// an unrelated service.
+/// What the retained tree needs before the `wardnet` account can be deleted.
+///
+/// Split out from the filesystem work so the branch that decides whether the
+/// user survives — the one guarding the orphaned-UID hazard — is testable
+/// without mocking `chown`, `userdel` and the filesystem.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum RetainedData {
+    /// Nothing to protect: purge succeeded, or there was no data directory.
+    Gone,
+    /// Data is being kept and must be re-owned to root first.
+    NeedsChown,
+    /// `--purge` was asked for but the tree is still there, so the account has
+    /// to stay — freeing the UID now would strand the secret store under it.
+    PurgeIncomplete,
+}
+
+pub(crate) fn classify_retained_data(purge: bool, data_dir_exists: bool) -> RetainedData {
+    match (purge, data_dir_exists) {
+        (true, true) => RetainedData::PurgeIncomplete,
+        (false, true) => RetainedData::NeedsChown,
+        (_, false) => RetainedData::Gone,
+    }
+}
+
+/// Returns whether the retained tree is now safely owned by root — `true` when
+/// there was nothing to protect (purge, or no data directory).
+fn protect_retained_data(args: &UninstallArgs, data_dir: &Path, report: &mut Report) -> bool {
+    // `symlink_metadata`, not `exists()`: a dangling `/var/lib/wardnet` symlink
+    // (unmounted disk, tree moved) satisfies neither `exists()` nor
+    // `canonicalize`, so `exists()` would call it `Gone`, free the UID, and
+    // announce "now owned by root" over data that is merely out of reach.
+    let still_there = path_present(data_dir) || path_present(Path::new(inventory::DATA_DIR));
+    match classify_retained_data(args.purge, still_there) {
+        RetainedData::Gone => return true,
+        RetainedData::PurgeIncomplete => {
+            let msg = format!(
+                "{} still exists after --purge; keeping the {SERVICE_USER} user so its \
+                 data is not left owned by an orphaned UID",
+                data_dir.display()
+            );
+            eprintln!("  ! {msg}");
+            report.push_failure(msg);
+            return false;
+        }
+        RetainedData::NeedsChown => {}
+    }
+
+    // Re-own the whole tree, not just the files we listed as retained. The
+    // directory itself is created `wardnet:wardnet` mode 0750, so leaving it
+    // owned by the departing user would let a later account reusing that UID
+    // unlink or replace the database and `secrets/` even though the files
+    // inside are root-owned. Re-owning the leaves alone would look like it
+    // closed the hazard while leaving the door open.
+    // Present but unresolvable: `/var/lib/wardnet` is a symlink whose target is
+    // gone or unmounted, so `resolved_data_dir` fell back to the literal path.
+    // `chown -R -h` on a symlink operand re-owns the link and exits 0 without
+    // ever traversing, which would look like success and let the account go —
+    // the very hazard this step exists to close.
+    if std::fs::metadata(data_dir).is_err() {
+        let msg = format!(
+            "{} exists but its target cannot be reached (unmounted disk or broken \
+             symlink); keeping the {SERVICE_USER} user rather than freeing a UID that \
+             may still own the data",
+            data_dir.display()
+        );
+        eprintln!("  ! {msg}");
+        report.push_failure(msg);
+        return false;
+    }
+
+    println!("Re-owning retained data to root...");
+    match chown_root_recursive(data_dir) {
+        Ok(()) => true,
+        Err(e) => {
+            report.record(&format!("chown {}", data_dir.display()), Err(e));
+            eprintln!(
+                "  ! keeping the {SERVICE_USER} user: {} could not be re-owned to root,\n    \
+                 and removing the account would leave its data owned by an orphaned UID.",
+                data_dir.display()
+            );
+            false
+        }
+    }
+}
+
+fn chown_root_recursive(target: &Path) -> anyhow::Result<()> {
+    // `-h` acts on symlinks themselves and `--` stops the path being read as an
+    // option, so nothing under the tree — which the departing, network-facing
+    // `wardnet` account could write — can redirect the ownership change. The
+    // operand is already symlink-resolved by `resolved_data_dir`, so `-h`
+    // cannot turn the whole traversal into a no-op.
+    let status = std::process::Command::new("chown")
+        .args([
+            std::ffi::OsStr::new("-R"),
+            std::ffi::OsStr::new("-h"),
+            std::ffi::OsStr::new("root:root"),
+            std::ffi::OsStr::new("--"),
+            target.as_os_str(),
+        ])
+        .status()?;
+    if status.success() {
+        Ok(())
+    } else {
+        anyhow::bail!("chown exited with {status}")
+    }
+}
+
+async fn remove_user(report: &mut Report) {
+    println!("Removing the {SERVICE_USER} system user...");
+    let output = tokio::process::Command::new("userdel")
+        .arg(SERVICE_USER)
+        .output()
+        .await;
+
+    let result = match output {
+        // userdel exit code 6 means "user does not exist" — idempotent success.
+        Ok(o) if o.status.success() || o.status.code() == Some(6) => Ok(()),
+        Ok(o) => Err(anyhow::anyhow!(
+            "userdel exited with {}: {}",
+            o.status,
+            String::from_utf8_lossy(&o.stderr).trim()
+        )),
+        Err(e) => Err(e.into()),
+    };
+    report.record(&format!("user {SERVICE_USER}"), result);
+}
+
+async fn reload_systemd() {
+    let _ = systemctl(&["daemon-reload"]).await;
+}
+
+/// Why a `systemctl` invocation failed. Typed rather than a flat string so
+/// callers can distinguish "unit not loaded" (exit 5, benign on a re-run) from
+/// a genuine failure.
+#[derive(Debug)]
+enum SystemctlError {
+    Spawn(std::io::Error),
+    Status {
+        args: String,
+        code: Option<i32>,
+        stderr: String,
+    },
+}
+
+impl std::fmt::Display for SystemctlError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Spawn(e) => write!(f, "failed to run systemctl: {e}"),
+            Self::Status { args, code, stderr } => {
+                let code = code.map_or_else(|| "signal".to_owned(), |c| c.to_string());
+                write!(f, "systemctl {args} exited with {code}: {stderr}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for SystemctlError {}
+
+async fn systemctl(args: &[&str]) -> Result<(), SystemctlError> {
+    let output = tokio::process::Command::new("systemctl")
+        .args(args)
+        .output()
+        .await
+        .map_err(SystemctlError::Spawn)?;
+
+    if output.status.success() {
+        return Ok(());
+    }
+    Err(SystemctlError::Status {
+        args: args.join(" "),
+        code: output.status.code(),
+        stderr: String::from_utf8_lossy(&output.stderr).trim().to_owned(),
+    })
+}
+
+/// Print the closing summary and decide the exit status.
+fn finish(
+    args: &UninstallArgs,
+    items: &[Item],
+    report: &Report,
+    data_is_root_owned: bool,
+) -> anyhow::Result<()> {
+    println!();
+
+    let kept: Vec<&Item> = items.iter().filter(|i| i.action == Action::Keep).collect();
+    if !kept.is_empty() {
+        // Only claim the ownership change when it actually happened — the
+        // whole point of the line is to tell the reader their keys are safe.
+        if data_is_root_owned {
+            println!("Kept (now owned by root):");
+        } else {
+            println!("Kept (STILL OWNED BY THE wardnet UID — re-own these yourself):");
+        }
+        for item in &kept {
+            println!("  {}", item.target);
+        }
+        println!(
+            "\nThese are the default locations. If this host set a custom database,\n\
+             secret-store or log path in /etc/wardnet/wardnet.toml, remove those\n\
+             yourself — uninstall does not read the config."
+        );
+        println!("\nRestore from these with a fresh install, or delete them with:");
+        println!("  sudo rm -rf {}\n", inventory::DATA_DIR);
+    }
+
+    if !args.container_mode {
+        println!(
+            "Note: net.ipv4.ip_forward stays 1 on the running kernel until you reboot.\n\
+             The drop-in that persisted it has been removed.\n"
+        );
+    }
+
+    if report.failures.is_empty() {
+        println!("Wardnet has been removed.");
+        return Ok(());
+    }
+
+    // Netdata's posture: say what is still there rather than claiming success.
+    println!("Wardnet was removed, but some parts may still be present:");
+    for failure in &report.failures {
+        println!("  - {failure}");
+    }
+    anyhow::bail!("{} uninstall step(s) failed", report.failures.len())
+}

--- a/source/daemon/crates/wardnetd/src/uninstall/ops.rs
+++ b/source/daemon/crates/wardnetd/src/uninstall/ops.rs
@@ -1,0 +1,301 @@
+//! The side effects `wardnetd uninstall` performs, behind one trait.
+//!
+//! Everything here shells out, touches the filesystem, or talks to the kernel.
+//! None of it is unit-testable, and all of it is a thin pass-through with no
+//! decisions in it — the decisions live in [`super`], which drives this trait
+//! and is tested against a recording double. That split is what lets the
+//! interesting behaviour (abort when the daemon will not stop, keep the account
+//! when the re-own fails, report honestly on partial failure) be covered
+//! without mocking `systemctl`, `chown` and `userdel` at the process level.
+//!
+//! Same instinct as `FirewallManager` and `WatchdogOps`: the risky, untestable
+//! edge is a trait, and the logic above it is ordinary code.
+
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use async_trait::async_trait;
+
+use crate::shutdown::{TunnelTeardown, teardown_runtime_state};
+use crate::uninstall::inventory::UNITS;
+
+/// Why a `systemctl` invocation failed.
+///
+/// Typed rather than a flat string so callers can tell "unit not loaded"
+/// (exit 5, benign on a re-run) and "inactive" (exit 3) from a real failure.
+#[derive(Debug)]
+pub enum SystemctlError {
+    Spawn(std::io::Error),
+    Status {
+        args: String,
+        code: Option<i32>,
+        stderr: String,
+    },
+}
+
+impl std::fmt::Display for SystemctlError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Spawn(e) => write!(f, "failed to run systemctl: {e}"),
+            Self::Status { args, code, stderr } => {
+                let code = code.map_or_else(|| "signal".to_owned(), |c| c.to_string());
+                write!(f, "systemctl {args} exited with {code}: {stderr}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for SystemctlError {}
+
+/// Every side effect the uninstaller performs.
+#[async_trait]
+pub trait UninstallOps: Send + Sync {
+    /// Resolve symlinks; `None` when the path cannot be resolved.
+    fn canonicalize(&self, path: &Path) -> Option<PathBuf>;
+
+    /// Whether anything exists at `path`, **including a dangling symlink**.
+    fn path_present(&self, path: &Path) -> bool;
+
+    /// Whether `path` resolves to something reachable (follows symlinks).
+    fn is_reachable(&self, path: &Path) -> bool;
+
+    /// Delete a file or directory. Absence is success.
+    fn remove_path(&self, path: &Path) -> anyhow::Result<()>;
+
+    /// `chown -R -h root:root -- <path>`.
+    fn chown_root_recursive(&self, path: &Path) -> anyhow::Result<()>;
+
+    async fn stop_unit(&self, unit: &str) -> Result<(), SystemctlError>;
+    async fn unit_is_active(&self, unit: &str) -> Result<(), SystemctlError>;
+    async fn disable_unit(&self, unit: &str);
+    async fn daemon_reload(&self);
+
+    /// Remove the system user. Absence is success.
+    async fn delete_user(&self, user: &str) -> anyhow::Result<()>;
+
+    /// Delete the nftables table and `WireGuard` interfaces; returns failures.
+    async fn teardown_runtime_state(&self) -> Vec<String>;
+
+    /// Every `wg_ward*` link currently on the host.
+    async fn wardnet_links(&self) -> anyhow::Result<Vec<String>>;
+
+    /// Best-effort `ip link delete`, for links the `WireGuard` family cannot see.
+    async fn delete_link(&self, name: &str);
+
+    fn is_root(&self) -> bool;
+
+    /// Prompt on the controlling terminal and read one line back.
+    fn prompt(&self, prompt: &str) -> anyhow::Result<String>;
+}
+
+/// The real implementation.
+pub struct LinuxUninstallOps;
+
+#[async_trait]
+impl UninstallOps for LinuxUninstallOps {
+    fn canonicalize(&self, path: &Path) -> Option<PathBuf> {
+        std::fs::canonicalize(path).ok()
+    }
+
+    fn path_present(&self, path: &Path) -> bool {
+        std::fs::symlink_metadata(path).is_ok()
+    }
+
+    fn is_reachable(&self, path: &Path) -> bool {
+        std::fs::metadata(path).is_ok()
+    }
+
+    fn remove_path(&self, path: &Path) -> anyhow::Result<()> {
+        let metadata = match std::fs::symlink_metadata(path) {
+            Ok(m) => m,
+            // Absence is the normal case on a re-run or a partial install.
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+            Err(e) => return Err(e.into()),
+        };
+
+        if metadata.is_dir() {
+            std::fs::remove_dir_all(path)?;
+        } else {
+            std::fs::remove_file(path)?;
+        }
+        Ok(())
+    }
+
+    fn chown_root_recursive(&self, target: &Path) -> anyhow::Result<()> {
+        // `-h` acts on symlinks themselves and `--` stops the path being read
+        // as an option, so nothing under the tree — which the departing,
+        // network-facing `wardnet` account could write — can redirect the
+        // ownership change. The operand is symlink-resolved by the caller, so
+        // `-h` cannot turn the whole traversal into a no-op.
+        let status = std::process::Command::new("chown")
+            .args([
+                std::ffi::OsStr::new("-R"),
+                std::ffi::OsStr::new("-h"),
+                std::ffi::OsStr::new("root:root"),
+                std::ffi::OsStr::new("--"),
+                target.as_os_str(),
+            ])
+            .status()?;
+        if status.success() {
+            Ok(())
+        } else {
+            anyhow::bail!("chown exited with {status}")
+        }
+    }
+
+    async fn stop_unit(&self, unit: &str) -> Result<(), SystemctlError> {
+        systemctl(&["stop", unit]).await
+    }
+
+    async fn unit_is_active(&self, unit: &str) -> Result<(), SystemctlError> {
+        systemctl(&["is-active", "--quiet", unit]).await
+    }
+
+    async fn disable_unit(&self, unit: &str) {
+        // Already-disabled or missing units make this a no-op.
+        let _ = systemctl(&["disable", unit]).await;
+    }
+
+    async fn daemon_reload(&self) {
+        let _ = systemctl(&["daemon-reload"]).await;
+    }
+
+    async fn delete_user(&self, user: &str) -> anyhow::Result<()> {
+        let output = tokio::process::Command::new("userdel")
+            .arg(user)
+            .output()
+            .await?;
+
+        // Exit 6 is "user does not exist" — idempotent success.
+        if output.status.success() || output.status.code() == Some(6) {
+            return Ok(());
+        }
+        anyhow::bail!(
+            "userdel exited with {}: {}",
+            output.status,
+            String::from_utf8_lossy(&output.stderr).trim()
+        )
+    }
+
+    async fn teardown_runtime_state(&self) -> Vec<String> {
+        let firewall: Arc<dyn wardnetd_services::routing::FirewallManager> =
+            Arc::new(crate::firewall_netlink::NetlinkFirewallManager::new());
+        let tunnels: Arc<dyn wardnetd_services::tunnel::TunnelInterface> =
+            Arc::new(crate::tunnel_interface_wireguard::WireGuardTunnelInterface);
+        let inbound: Arc<dyn wardnetd_services::inbound_wg::InboundWgInterface> =
+            Arc::new(crate::inbound_wg_interface_wireguard::WireGuardInboundInterface);
+
+        // Interface-level teardown, not service-level: uninstall has no
+        // database to keep in step, and with `--purge` it is about to delete
+        // the one there.
+        teardown_runtime_state(&firewall, TunnelTeardown::Interface(&tunnels), &inbound).await
+    }
+
+    async fn wardnet_links(&self) -> anyhow::Result<Vec<String>> {
+        let output = tokio::process::Command::new("ip")
+            .args(["-o", "link", "show"])
+            .output()
+            .await
+            .map_err(|e| anyhow::anyhow!("failed to run `ip link show`: {e}"))?;
+
+        if !output.status.success() {
+            anyhow::bail!(
+                "`ip link show` exited with {}: {}",
+                output.status,
+                String::from_utf8_lossy(&output.stderr).trim()
+            );
+        }
+
+        Ok(parse_link_names(&String::from_utf8_lossy(&output.stdout)))
+    }
+
+    async fn delete_link(&self, name: &str) {
+        crate::wireguard_interface::remove_stale_link(name, "wardnet interface").await;
+    }
+
+    fn is_root(&self) -> bool {
+        // SAFETY: `geteuid` takes no arguments, reads process-local state and
+        // cannot fail.
+        unsafe { libc::geteuid() == 0 }
+    }
+
+    fn prompt(&self, prompt: &str) -> anyhow::Result<String> {
+        read_from_terminal(prompt)
+    }
+}
+
+/// Pull `wg_ward*` names out of `ip -o link show` output.
+///
+/// Lines look like `2: eth0: <BROADCAST,...> mtu ...`, and VLANs/peers render
+/// as `name@parent`. Split out so the parsing — the one part of this module
+/// with a way to be wrong — is testable without a kernel.
+#[must_use]
+pub fn parse_link_names(stdout: &str) -> Vec<String> {
+    use wardnetd_services::tunnel::interface::TUNNEL_INTERFACE_PREFIX;
+
+    stdout
+        .lines()
+        .filter_map(|line| line.split(": ").nth(1))
+        .map(|name| name.split('@').next().unwrap_or(name).trim().to_owned())
+        .filter(|name| name.starts_with(TUNNEL_INTERFACE_PREFIX))
+        .collect()
+}
+
+/// The units the installer places, in the order it places them.
+#[must_use]
+pub fn installed_units() -> [&'static str; 3] {
+    UNITS
+}
+
+async fn systemctl(args: &[&str]) -> Result<(), SystemctlError> {
+    let output = tokio::process::Command::new("systemctl")
+        .args(args)
+        .output()
+        .await
+        .map_err(SystemctlError::Spawn)?;
+
+    if output.status.success() {
+        return Ok(());
+    }
+    Err(SystemctlError::Status {
+        args: args.join(" "),
+        code: output.status.code(),
+        stderr: String::from_utf8_lossy(&output.stderr).trim().to_owned(),
+    })
+}
+
+/// Prompt on the controlling terminal and read one line back from it.
+///
+/// Reading `/dev/tty` rather than stdin is what makes the documented
+/// `curl -sSL … | sudo bash -s -- --uninstall` form work: there the script
+/// arrives on stdin, `exec` preserves it, and stdin is a spent pipe, so a
+/// stdin-only prompt would make the advertised command fail every time. When
+/// there is genuinely no terminal (cron, CI), opening `/dev/tty` fails and the
+/// caller refuses.
+fn read_from_terminal(prompt: &str) -> anyhow::Result<String> {
+    use std::io::{BufRead, IsTerminal, Write};
+
+    if std::io::stdin().is_terminal() {
+        print!("{prompt}");
+        std::io::stdout().flush()?;
+        let mut answer = String::new();
+        std::io::stdin().read_line(&mut answer)?;
+        return Ok(answer);
+    }
+
+    let tty = std::fs::OpenOptions::new()
+        .read(true)
+        .write(true)
+        .open("/dev/tty")
+        .map_err(|_| {
+            anyhow::anyhow!("refusing to uninstall without --yes: no terminal to confirm on")
+        })?;
+
+    let mut writer = &tty;
+    write!(writer, "{prompt}")?;
+    writer.flush()?;
+
+    let mut answer = String::new();
+    std::io::BufReader::new(&tty).read_line(&mut answer)?;
+    Ok(answer)
+}

--- a/source/daemon/crates/wardnetd/src/uninstall/tests/double.rs
+++ b/source/daemon/crates/wardnetd/src/uninstall/tests/double.rs
@@ -1,0 +1,232 @@
+//! A recording [`UninstallOps`] so the orchestration can be driven without a
+//! host to destroy.
+//!
+//! Mirrors the pattern in `shutdown/tests/doubles.rs`: every call is appended
+//! to an ordered log, and each operation can be told to fail so the
+//! decision branches are reachable.
+
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
+
+use async_trait::async_trait;
+
+use crate::uninstall::ops::{SystemctlError, UninstallOps};
+
+pub type CallLog = Arc<Mutex<Vec<String>>>;
+
+/// How the fake host is configured.
+#[allow(clippy::struct_excessive_bools)] // test toggles, not a domain state machine
+pub struct FakeHost {
+    pub log: CallLog,
+    pub is_root: bool,
+    /// Answer handed back from the confirmation prompt.
+    pub prompt_answer: String,
+    /// When false, `prompt` errors (no terminal).
+    pub prompt_available: bool,
+    /// Outcome of `systemctl stop`.
+    pub stop_result: Option<SystemctlError>,
+    /// Outcome of `systemctl is-active` — `Ok(())` means still running.
+    pub is_active_result: Option<SystemctlError>,
+    /// Paths that exist (as `symlink_metadata` would see them).
+    pub present: Vec<String>,
+    /// Paths that resolve (as `metadata` would see them).
+    pub reachable: Vec<String>,
+    /// `canonicalize` answer for the data directory.
+    pub canonical: Option<PathBuf>,
+    pub chown_fails: bool,
+    pub delete_user_fails: bool,
+    pub remove_path_fails: Vec<String>,
+    /// Failures returned by the typed kernel teardown.
+    pub teardown_failures: Vec<String>,
+    /// Links reported before, and then after, the `ip link` sweep.
+    pub links_before: Vec<String>,
+    pub links_after: Vec<String>,
+    pub links_error: bool,
+}
+
+impl Default for FakeHost {
+    fn default() -> Self {
+        Self {
+            log: Arc::new(Mutex::new(Vec::new())),
+            is_root: true,
+            prompt_answer: "yes".to_owned(),
+            prompt_available: true,
+            // Default: the stop succeeds and the unit is then inactive (3).
+            stop_result: None,
+            is_active_result: Some(inactive()),
+            present: Vec::new(),
+            reachable: Vec::new(),
+            canonical: None,
+            chown_fails: false,
+            delete_user_fails: false,
+            remove_path_fails: Vec::new(),
+            teardown_failures: Vec::new(),
+            links_before: Vec::new(),
+            links_after: Vec::new(),
+            links_error: false,
+        }
+    }
+}
+
+/// `systemctl` exit 3 — unit inactive.
+pub fn inactive() -> SystemctlError {
+    SystemctlError::Status {
+        args: "is-active --quiet wardnetd.service".to_owned(),
+        code: Some(3),
+        stderr: String::new(),
+    }
+}
+
+/// `systemctl` exit 5 — unit not loaded.
+pub fn not_loaded() -> SystemctlError {
+    SystemctlError::Status {
+        args: "stop wardnetd.service".to_owned(),
+        code: Some(5),
+        stderr: String::new(),
+    }
+}
+
+/// A `systemctl` failure that says nothing about liveness.
+pub fn indeterminate() -> SystemctlError {
+    SystemctlError::Status {
+        args: "is-active --quiet wardnetd.service".to_owned(),
+        code: Some(1),
+        stderr: "Failed to get properties: Connection timed out".to_owned(),
+    }
+}
+
+/// systemd is not PID 1 here.
+pub fn not_booted() -> SystemctlError {
+    SystemctlError::Status {
+        args: "is-active --quiet wardnetd.service".to_owned(),
+        code: Some(1),
+        stderr: "System has not been booted with systemd as init system".to_owned(),
+    }
+}
+
+impl FakeHost {
+    pub fn calls(&self) -> Vec<String> {
+        self.log.lock().expect("poisoned").clone()
+    }
+
+    fn record(&self, call: impl Into<String>) {
+        self.log.lock().expect("poisoned").push(call.into());
+    }
+
+    fn clone_err(err: &SystemctlError) -> SystemctlError {
+        match err {
+            SystemctlError::Spawn(e) => SystemctlError::Spawn(std::io::Error::new(e.kind(), "")),
+            SystemctlError::Status { args, code, stderr } => SystemctlError::Status {
+                args: args.clone(),
+                code: *code,
+                stderr: stderr.clone(),
+            },
+        }
+    }
+}
+
+#[async_trait]
+impl UninstallOps for FakeHost {
+    fn canonicalize(&self, _path: &Path) -> Option<PathBuf> {
+        self.canonical.clone()
+    }
+
+    fn path_present(&self, path: &Path) -> bool {
+        self.present.iter().any(|p| Path::new(p) == path)
+    }
+
+    fn is_reachable(&self, path: &Path) -> bool {
+        self.reachable.iter().any(|p| Path::new(p) == path)
+    }
+
+    fn remove_path(&self, path: &Path) -> anyhow::Result<()> {
+        let shown = path.display().to_string();
+        self.record(format!("remove_path:{shown}"));
+        if self.remove_path_fails.contains(&shown) {
+            anyhow::bail!("permission denied");
+        }
+        Ok(())
+    }
+
+    fn chown_root_recursive(&self, path: &Path) -> anyhow::Result<()> {
+        self.record(format!("chown:{}", path.display()));
+        if self.chown_fails {
+            anyhow::bail!("chown exited with 1");
+        }
+        Ok(())
+    }
+
+    async fn stop_unit(&self, unit: &str) -> Result<(), SystemctlError> {
+        self.record(format!("stop:{unit}"));
+        match &self.stop_result {
+            None => Ok(()),
+            Some(e) => Err(Self::clone_err(e)),
+        }
+    }
+
+    async fn unit_is_active(&self, unit: &str) -> Result<(), SystemctlError> {
+        self.record(format!("is_active:{unit}"));
+        match &self.is_active_result {
+            None => Ok(()),
+            Some(e) => Err(Self::clone_err(e)),
+        }
+    }
+
+    async fn disable_unit(&self, unit: &str) {
+        self.record(format!("disable:{unit}"));
+    }
+
+    async fn daemon_reload(&self) {
+        self.record("daemon_reload");
+    }
+
+    async fn delete_user(&self, user: &str) -> anyhow::Result<()> {
+        self.record(format!("delete_user:{user}"));
+        if self.delete_user_fails {
+            anyhow::bail!("userdel exited with 1");
+        }
+        Ok(())
+    }
+
+    async fn teardown_runtime_state(&self) -> Vec<String> {
+        self.record("teardown_runtime_state");
+        self.teardown_failures.clone()
+    }
+
+    async fn wardnet_links(&self) -> anyhow::Result<Vec<String>> {
+        let n = self
+            .log
+            .lock()
+            .expect("poisoned")
+            .iter()
+            .filter(|c| *c == "wardnet_links")
+            .count();
+        self.record("wardnet_links");
+        if self.links_error {
+            anyhow::bail!("`ip link show` exited with 1");
+        }
+        // First call enumerates, second confirms what survived.
+        Ok(if n == 0 {
+            self.links_before.clone()
+        } else {
+            self.links_after.clone()
+        })
+    }
+
+    async fn delete_link(&self, name: &str) {
+        self.record(format!("delete_link:{name}"));
+    }
+
+    fn is_root(&self) -> bool {
+        self.is_root
+    }
+
+    fn prompt(&self, _prompt: &str) -> anyhow::Result<String> {
+        self.record("prompt");
+        if self.prompt_available {
+            Ok(self.prompt_answer.clone())
+        } else {
+            anyhow::bail!("refusing to uninstall without --yes: no terminal to confirm on")
+        }
+    }
+}

--- a/source/daemon/crates/wardnetd/src/uninstall/tests/inventory.rs
+++ b/source/daemon/crates/wardnetd/src/uninstall/tests/inventory.rs
@@ -1,0 +1,186 @@
+//! What each uninstall tier claims it will touch.
+//!
+//! These matter because the inventory is also exactly what `--dry-run` prints:
+//! a dry run that under-reports is worse than no dry run at all.
+
+use crate::uninstall::inventory::{
+    Action, DATA_DIR, Item, Kind, RETAINED_DATA, UNITS, build_inventory, render_plan,
+};
+
+fn targets(items: &[Item]) -> Vec<String> {
+    items.iter().map(|i| i.target.clone()).collect()
+}
+
+fn removed(items: &[Item]) -> Vec<String> {
+    items
+        .iter()
+        .filter(|i| i.action == Action::Remove)
+        .map(|i| i.target.clone())
+        .collect()
+}
+
+fn kept(items: &[Item]) -> Vec<String> {
+    items
+        .iter()
+        .filter(|i| i.action == Action::Keep)
+        .map(|i| i.target.clone())
+        .collect()
+}
+
+#[test]
+fn default_tier_keeps_the_database_and_secret_store() {
+    let items = build_inventory(false, false);
+
+    assert_eq!(kept(&items), RETAINED_DATA.to_vec());
+}
+
+#[test]
+fn retained_secrets_are_labelled_a_directory_not_a_file() {
+    // `secrets/` is a directory and the database entries are files. The plan
+    // prints the kind, so mislabelling misdescribes what will be touched.
+    let items = build_inventory(false, false);
+    for item in items.iter().filter(|i| i.action == Action::Keep) {
+        let expected = if item.target.ends_with("/secrets") {
+            Kind::Directory
+        } else {
+            Kind::File
+        };
+        assert_eq!(item.kind, expected, "wrong kind for {}", item.target);
+    }
+}
+
+#[test]
+fn default_tier_never_removes_the_data_directory_wholesale() {
+    let items = build_inventory(false, false);
+
+    assert!(
+        !removed(&items).contains(&DATA_DIR.to_owned()),
+        "the default tier must not remove {DATA_DIR}"
+    );
+}
+
+#[test]
+fn default_tier_still_removes_daemon_scratch_under_the_data_directory() {
+    // Downloaded release artefacts and the staged post-upgrade binary are not
+    // user data, so they go in both tiers.
+    let removed = removed(&build_inventory(false, false));
+
+    assert!(removed.contains(&"/var/lib/wardnet/updates".to_owned()));
+    assert!(removed.contains(&"/var/lib/wardnet/postupgrade".to_owned()));
+}
+
+#[test]
+fn purge_removes_the_data_directory_and_keeps_nothing() {
+    let items = build_inventory(true, false);
+
+    assert!(kept(&items).is_empty());
+    assert!(removed(&items).contains(&DATA_DIR.to_owned()));
+}
+
+#[test]
+fn every_tier_removes_the_units_the_installer_wrote() {
+    for purge in [false, true] {
+        let removed = removed(&build_inventory(purge, false));
+        for unit in UNITS {
+            assert!(
+                removed.contains(&format!("/etc/systemd/system/{unit}")),
+                "{unit} missing from inventory (purge={purge})"
+            );
+        }
+    }
+}
+
+#[test]
+fn never_touches_the_dev_only_unit() {
+    // `wardnetd-dev.service` exists in deploy/ but install.sh never places it
+    // on a real host, so uninstall must leave it alone.
+    let all = targets(&build_inventory(true, false)).join("\n");
+
+    assert!(!all.contains("wardnetd-dev.service"));
+}
+
+#[test]
+fn bare_metal_removes_the_host_drop_ins() {
+    let removed = removed(&build_inventory(false, false));
+
+    // The issue's inventory missed the sysctl drop-in; install.sh does write it.
+    assert!(removed.contains(&"/etc/sysctl.d/99-wardnet.conf".to_owned()));
+    assert!(removed.contains(&"/etc/dhcpcd.conf.d/wardnet.conf".to_owned()));
+    assert!(removed.contains(&"/etc/modules-load.d/wardnet-watchdog.conf".to_owned()));
+}
+
+#[test]
+fn container_mode_omits_drop_ins_the_installer_never_wrote() {
+    let all = targets(&build_inventory(false, true)).join("\n");
+
+    assert!(!all.contains("/etc/sysctl.d/99-wardnet.conf"));
+    assert!(!all.contains("/etc/dhcpcd.conf.d/wardnet.conf"));
+    assert!(!all.contains("/etc/modules-load.d/wardnet-watchdog.conf"));
+}
+
+#[test]
+fn always_reports_the_kernel_state_it_will_remove() {
+    // This is the whole point of issue #864: a stopped daemon must not still
+    // be filtering traffic, and a dry run must say so.
+    let items = build_inventory(false, false);
+    let runtime: Vec<&Item> = items.iter().filter(|i| i.kind == Kind::Runtime).collect();
+
+    assert_eq!(runtime.len(), 2);
+    assert!(runtime.iter().all(|i| i.action == Action::Remove));
+
+    let plan = render_plan(&items);
+    assert!(plan.contains("inet wardnet"));
+    assert!(plan.contains("wg_ward*"));
+}
+
+#[test]
+fn never_promises_a_conntrack_flush_it_does_not_perform() {
+    // The uninstaller does not flush conntrack: a global `conntrack -F` would
+    // take out every flow on the host (Docker's included), and a targeted
+    // flush needs the device IPs, which means the database this command may
+    // be deleting. Listing it in the plan anyway would make `--dry-run` lie.
+    let plan = render_plan(&build_inventory(false, false));
+
+    assert!(
+        !plan.contains("conntrack"),
+        "plan promises a conntrack flush"
+    );
+}
+
+#[test]
+fn removes_the_service_user_and_both_binaries() {
+    let items = build_inventory(false, false);
+    let removed = removed(&items);
+
+    assert!(removed.contains(&"/usr/local/bin/wardnetd".to_owned()));
+    assert!(removed.contains(&"/usr/local/bin/wardnetd.old".to_owned()));
+    assert!(
+        items
+            .iter()
+            .any(|i| i.kind == Kind::User && i.target == "wardnet")
+    );
+}
+
+#[test]
+fn removes_its_own_escape_hatch_script() {
+    let removed = removed(&build_inventory(false, false));
+
+    assert!(removed.contains(&"/usr/local/sbin/wardnet-uninstall".to_owned()));
+}
+
+#[test]
+fn plan_distinguishes_kept_entries_from_removed_ones() {
+    let plan = render_plan(&build_inventory(false, false));
+
+    assert!(plan.contains("KEEP"));
+    assert!(plan.contains("remove"));
+    // The retained entries must carry the hint that --purge destroys them.
+    assert!(plan.contains("--purge"));
+}
+
+#[test]
+fn purge_plan_warns_that_data_is_destroyed() {
+    let plan = render_plan(&build_inventory(true, false));
+
+    assert!(plan.contains("DESTROYS"));
+}

--- a/source/daemon/crates/wardnetd/src/uninstall/tests/liveness.rs
+++ b/source/daemon/crates/wardnetd/src/uninstall/tests/liveness.rs
@@ -1,0 +1,73 @@
+//! Interpreting `systemctl is-active` after the stop.
+//!
+//! Getting this wrong in the permissive direction is what deletes the binary
+//! out from under a live daemon, forcing a SIGKILL that leaves the hardware
+//! watchdog armed and reboots the host mid-uninstall. Only a confirmed stop
+//! may proceed.
+
+use crate::uninstall::ops::SystemctlError;
+use crate::uninstall::{Liveness, classify_liveness};
+
+fn status(code: Option<i32>, stderr: &str) -> Result<(), SystemctlError> {
+    Err(SystemctlError::Status {
+        args: "is-active --quiet wardnetd.service".to_owned(),
+        code,
+        stderr: stderr.to_owned(),
+    })
+}
+
+#[test]
+fn exit_zero_means_the_unit_is_still_running() {
+    assert_eq!(classify_liveness(&Ok(())), Liveness::NotConfirmed);
+}
+
+#[test]
+fn inactive_and_missing_units_are_confirmed_stopped() {
+    assert_eq!(classify_liveness(&status(Some(3), "")), Liveness::Stopped);
+    assert_eq!(classify_liveness(&status(Some(4), "")), Liveness::Stopped);
+}
+
+#[test]
+fn a_host_without_systemd_counts_as_stopped() {
+    // Container or chroot: nothing is supervising the daemon, so there is no
+    // stop to confirm.
+    assert_eq!(
+        classify_liveness(&status(
+            Some(1),
+            "System has not been booted with systemd as init system"
+        )),
+        Liveness::Stopped
+    );
+    assert_eq!(
+        classify_liveness(&status(Some(1), "Failed to connect to bus: No such file")),
+        Liveness::Stopped
+    );
+    assert_eq!(
+        classify_liveness(&Err(SystemctlError::Spawn(std::io::Error::new(
+            std::io::ErrorKind::NotFound,
+            "no systemctl"
+        )))),
+        Liveness::Stopped
+    );
+}
+
+#[test]
+fn an_unexplained_failure_is_never_read_as_stopped() {
+    // The dangerous default. A probe that failed for an unrelated reason tells
+    // us nothing, and assuming "down" is the assumption that reboots the box.
+    assert_eq!(
+        classify_liveness(&status(Some(1), "Connection timed out")),
+        Liveness::NotConfirmed
+    );
+    assert_eq!(
+        classify_liveness(&status(None, "killed")),
+        Liveness::NotConfirmed
+    );
+    assert_eq!(
+        classify_liveness(&Err(SystemctlError::Spawn(std::io::Error::new(
+            std::io::ErrorKind::PermissionDenied,
+            "denied"
+        )))),
+        Liveness::NotConfirmed
+    );
+}

--- a/source/daemon/crates/wardnetd/src/uninstall/tests/mod.rs
+++ b/source/daemon/crates/wardnetd/src/uninstall/tests/mod.rs
@@ -1,0 +1,2 @@
+mod inventory;
+mod retained_data;

--- a/source/daemon/crates/wardnetd/src/uninstall/tests/mod.rs
+++ b/source/daemon/crates/wardnetd/src/uninstall/tests/mod.rs
@@ -1,2 +1,6 @@
 mod inventory;
+mod liveness;
 mod retained_data;
+mod run;
+
+pub mod double;

--- a/source/daemon/crates/wardnetd/src/uninstall/tests/retained_data.rs
+++ b/source/daemon/crates/wardnetd/src/uninstall/tests/retained_data.rs
@@ -1,0 +1,70 @@
+//! Whether the `wardnet` account survives the uninstall.
+//!
+//! Deleting the account frees its UID for reuse. If the retained database and
+//! secret store are still owned by that UID at that moment, a later `useradd`
+//! on the same host silently inherits the `WireGuard` private keys and the
+//! backup passphrase — so this decision is the whole point of the step, and it
+//! has to hold in the awkward cases as well as the happy one.
+
+use crate::uninstall::{RetainedData, classify_retained_data, mentions_identifier};
+
+#[test]
+fn nothing_to_protect_when_the_data_directory_is_already_gone() {
+    assert_eq!(
+        classify_retained_data(false, false),
+        RetainedData::Gone,
+        "no data directory means the account is safe to remove"
+    );
+}
+
+#[test]
+fn kept_data_must_be_re_owned_before_the_user_goes() {
+    assert_eq!(
+        classify_retained_data(false, true),
+        RetainedData::NeedsChown
+    );
+}
+
+#[test]
+fn a_successful_purge_leaves_nothing_to_protect() {
+    assert_eq!(classify_retained_data(true, false), RetainedData::Gone);
+}
+
+#[test]
+fn an_interface_is_matched_as_a_whole_name_not_a_substring() {
+    // The typed teardown and the `ip link` sweep both report interfaces, and
+    // the second defers to the first. A substring test would let a still-live
+    // `wg_ward10` be swallowed by a report about `wg_ward1`, under-reporting an
+    // interface that is still up.
+    let failure = "tunnel interface wg_ward1: netlink refused the delete";
+
+    assert!(mentions_identifier(failure, "wg_ward1"));
+    assert!(
+        !mentions_identifier(failure, "wg_ward10"),
+        "wg_ward10 must not be considered already-reported by a wg_ward1 failure"
+    );
+}
+
+#[test]
+fn interface_matching_ignores_surrounding_punctuation() {
+    assert!(mentions_identifier(
+        "inbound server wg_wardin0: device busy",
+        "wg_wardin0"
+    ));
+    assert!(mentions_identifier(
+        "wireguard interface wg_ward0 could not be removed",
+        "wg_ward0"
+    ));
+}
+
+#[test]
+fn a_purge_that_did_not_delete_the_tree_keeps_the_user() {
+    // The dangerous case: `--purge` was requested, `remove_dir_all` failed, and
+    // the secret store is still on disk. Removing the account here would free
+    // its UID while it still owns those files.
+    assert_eq!(
+        classify_retained_data(true, true),
+        RetainedData::PurgeIncomplete,
+        "a failed purge must not free the UID that still owns the secret store"
+    );
+}

--- a/source/daemon/crates/wardnetd/src/uninstall/tests/run.rs
+++ b/source/daemon/crates/wardnetd/src/uninstall/tests/run.rs
@@ -1,0 +1,447 @@
+//! End-to-end behaviour of `wardnetd uninstall`, driven against a fake host.
+//!
+//! These cover the decisions that make the command safe: refusing without
+//! privileges or confirmation, refusing to touch anything while the daemon may
+//! still be alive, keeping the `wardnet` account whenever its data could still
+//! be owned by that UID, and never reporting success over a recorded failure.
+
+use crate::uninstall::tests::double::{FakeHost, inactive, indeterminate, not_booted, not_loaded};
+use crate::uninstall::{UninstallArgs, run_with};
+
+fn default_args() -> UninstallArgs {
+    UninstallArgs {
+        yes: true,
+        ..UninstallArgs::default()
+    }
+}
+
+/// A host where the daemon is stopped and nothing is left on disk.
+fn clean_host() -> FakeHost {
+    FakeHost::default()
+}
+
+#[tokio::test]
+async fn dry_run_changes_nothing_and_needs_no_privileges() {
+    let host = FakeHost {
+        is_root: false,
+        ..FakeHost::default()
+    };
+    let args = UninstallArgs {
+        dry_run: true,
+        ..UninstallArgs::default()
+    };
+
+    run_with(&args, &host)
+        .await
+        .expect("dry run should succeed");
+
+    assert!(
+        host.calls().is_empty(),
+        "dry run touched the host: {:?}",
+        host.calls()
+    );
+}
+
+#[tokio::test]
+async fn refuses_without_root() {
+    let host = FakeHost {
+        is_root: false,
+        ..FakeHost::default()
+    };
+
+    let err = run_with(&default_args(), &host)
+        .await
+        .expect_err("should refuse");
+
+    assert!(err.to_string().contains("must be run as root"), "got {err}");
+    assert!(host.calls().is_empty(), "{:?}", host.calls());
+}
+
+#[tokio::test]
+async fn refuses_when_there_is_no_terminal_and_no_yes() {
+    let host = FakeHost {
+        prompt_available: false,
+        ..FakeHost::default()
+    };
+    let args = UninstallArgs::default();
+
+    let err = run_with(&args, &host).await.expect_err("should refuse");
+
+    assert!(err.to_string().contains("no terminal"), "got {err}");
+}
+
+#[tokio::test]
+async fn a_wrong_confirmation_word_aborts_without_touching_anything() {
+    let host = FakeHost {
+        prompt_answer: "y".to_owned(), // not the required "yes"
+        ..FakeHost::default()
+    };
+
+    run_with(&UninstallArgs::default(), &host)
+        .await
+        .expect("abort is not an error");
+
+    assert_eq!(host.calls(), vec!["prompt"]);
+}
+
+#[tokio::test]
+async fn purge_demands_the_word_in_full() {
+    let host = FakeHost {
+        prompt_answer: "yes".to_owned(), // not "PURGE"
+        ..FakeHost::default()
+    };
+    let args = UninstallArgs {
+        purge: true,
+        ..UninstallArgs::default()
+    };
+
+    run_with(&args, &host).await.expect("abort is not an error");
+
+    assert_eq!(host.calls(), vec!["prompt"]);
+}
+
+#[tokio::test]
+async fn aborts_before_removing_anything_when_the_daemon_is_still_running() {
+    // `is-active` exit 0 == still up.
+    let host = FakeHost {
+        is_active_result: None,
+        ..FakeHost::default()
+    };
+
+    let err = run_with(&default_args(), &host)
+        .await
+        .expect_err("should refuse to proceed");
+
+    assert!(err.to_string().contains("could not confirm"), "got {err}");
+    assert!(
+        !host.calls().iter().any(|c| c.starts_with("remove_path")),
+        "removed something despite a live daemon: {:?}",
+        host.calls()
+    );
+}
+
+#[tokio::test]
+async fn aborts_when_liveness_cannot_be_determined() {
+    // A probe that failed for an unrelated reason says nothing about whether
+    // the daemon is alive, and guessing "down" is the guess that reboots the
+    // box via the still-armed watchdog.
+    let host = FakeHost {
+        is_active_result: Some(indeterminate()),
+        ..FakeHost::default()
+    };
+
+    let err = run_with(&default_args(), &host)
+        .await
+        .expect_err("should refuse");
+
+    assert!(err.to_string().contains("could not confirm"), "got {err}");
+    assert!(!host.calls().iter().any(|c| c.starts_with("remove_path")));
+}
+
+#[tokio::test]
+async fn proceeds_when_there_is_no_systemd() {
+    let host = FakeHost {
+        stop_result: Some(not_booted()),
+        is_active_result: Some(not_booted()),
+        ..FakeHost::default()
+    };
+
+    run_with(&default_args(), &host)
+        .await
+        .expect("should proceed");
+
+    assert!(host.calls().iter().any(|c| c.starts_with("remove_path")));
+}
+
+#[tokio::test]
+async fn tolerates_a_unit_that_is_not_loaded() {
+    // The normal answer on a re-run or a partial install.
+    let host = FakeHost {
+        stop_result: Some(not_loaded()),
+        is_active_result: Some(inactive()),
+        ..FakeHost::default()
+    };
+
+    run_with(&default_args(), &host)
+        .await
+        .expect("an absent unit must not fail the uninstall");
+}
+
+#[tokio::test]
+async fn a_clean_run_removes_the_units_and_the_user() {
+    let host = clean_host();
+
+    run_with(&default_args(), &host)
+        .await
+        .expect("should succeed");
+
+    let calls = host.calls();
+    for unit in crate::uninstall::inventory::UNITS {
+        assert!(calls.contains(&format!("disable:{unit}")), "{calls:?}");
+    }
+    assert!(
+        calls.contains(&"delete_user:wardnet".to_owned()),
+        "{calls:?}"
+    );
+    assert!(calls.contains(&"daemon_reload".to_owned()), "{calls:?}");
+}
+
+#[tokio::test]
+async fn retained_data_is_re_owned_before_the_user_is_removed() {
+    let host = FakeHost {
+        present: vec!["/var/lib/wardnet".to_owned()],
+        reachable: vec!["/var/lib/wardnet".to_owned()],
+        ..FakeHost::default()
+    };
+
+    run_with(&default_args(), &host)
+        .await
+        .expect("should succeed");
+
+    let calls = host.calls();
+    let chown = calls
+        .iter()
+        .position(|c| c.starts_with("chown:"))
+        .expect("chowned");
+    let userdel = calls
+        .iter()
+        .position(|c| c.starts_with("delete_user:"))
+        .expect("removed user");
+    assert!(chown < userdel, "user removed before the re-own: {calls:?}");
+}
+
+#[tokio::test]
+async fn a_failed_re_own_keeps_the_user_and_fails_the_run() {
+    let host = FakeHost {
+        present: vec!["/var/lib/wardnet".to_owned()],
+        reachable: vec!["/var/lib/wardnet".to_owned()],
+        chown_fails: true,
+        ..FakeHost::default()
+    };
+
+    let err = run_with(&default_args(), &host)
+        .await
+        .expect_err("should fail");
+
+    assert!(err.to_string().contains("step(s) failed"), "got {err}");
+    assert!(
+        !host.calls().iter().any(|c| c.starts_with("delete_user")),
+        "freed the UID that still owns the data: {:?}",
+        host.calls()
+    );
+}
+
+#[tokio::test]
+async fn an_unreachable_data_directory_keeps_the_user() {
+    // Present as a symlink but its target is unmounted: `chown -R -h` would
+    // re-own the link, exit 0, and traverse nothing.
+    let host = FakeHost {
+        present: vec!["/var/lib/wardnet".to_owned()],
+        reachable: Vec::new(),
+        ..FakeHost::default()
+    };
+
+    let err = run_with(&default_args(), &host)
+        .await
+        .expect_err("should fail");
+
+    assert!(err.to_string().contains("step(s) failed"), "got {err}");
+    let calls = host.calls();
+    assert!(!calls.iter().any(|c| c.starts_with("chown:")), "{calls:?}");
+    assert!(
+        !calls.iter().any(|c| c.starts_with("delete_user")),
+        "{calls:?}"
+    );
+}
+
+#[tokio::test]
+async fn a_purge_that_left_the_tree_behind_keeps_the_user() {
+    let host = FakeHost {
+        present: vec!["/var/lib/wardnet".to_owned()],
+        reachable: vec!["/var/lib/wardnet".to_owned()],
+        ..FakeHost::default()
+    };
+    let args = UninstallArgs {
+        purge: true,
+        yes: true,
+        ..UninstallArgs::default()
+    };
+
+    let err = run_with(&args, &host).await.expect_err("should fail");
+
+    assert!(err.to_string().contains("step(s) failed"), "got {err}");
+    assert!(
+        !host.calls().iter().any(|c| c.starts_with("delete_user")),
+        "freed the UID while the secret store survived: {:?}",
+        host.calls()
+    );
+}
+
+#[tokio::test]
+async fn purge_deletes_the_resolved_tree_and_then_the_symlink() {
+    let host = FakeHost {
+        canonical: Some("/mnt/data/wardnet".into()),
+        ..FakeHost::default()
+    };
+    let args = UninstallArgs {
+        purge: true,
+        yes: true,
+        ..UninstallArgs::default()
+    };
+
+    run_with(&args, &host).await.expect("should succeed");
+
+    let calls = host.calls();
+    assert!(
+        calls.contains(&"remove_path:/mnt/data/wardnet".to_owned()),
+        "did not delete the real tree: {calls:?}"
+    );
+    assert!(
+        calls.contains(&"remove_path:/var/lib/wardnet".to_owned()),
+        "did not drop the symlink: {calls:?}"
+    );
+}
+
+#[tokio::test]
+async fn a_firewall_teardown_failure_fails_the_run() {
+    // The worst possible outcome is reporting success over a live table.
+    let host = FakeHost {
+        teardown_failures: vec!["nftables table `inet wardnet`: permission denied".to_owned()],
+        ..FakeHost::default()
+    };
+
+    let err = run_with(&default_args(), &host)
+        .await
+        .expect_err("should fail");
+
+    assert!(err.to_string().contains("step(s) failed"), "got {err}");
+}
+
+#[tokio::test]
+async fn an_interface_that_survives_the_sweep_is_reported() {
+    let host = FakeHost {
+        links_before: vec!["wg_ward0".to_owned()],
+        links_after: vec!["wg_ward0".to_owned()],
+        ..FakeHost::default()
+    };
+
+    let err = run_with(&default_args(), &host)
+        .await
+        .expect_err("should fail");
+
+    assert!(
+        err.to_string().contains("1 uninstall step(s) failed"),
+        "got {err}"
+    );
+    assert!(host.calls().contains(&"delete_link:wg_ward0".to_owned()));
+}
+
+#[tokio::test]
+async fn an_interface_removed_by_the_sweep_is_not_reported() {
+    let host = FakeHost {
+        links_before: vec!["wg_ward0".to_owned()],
+        links_after: Vec::new(),
+        ..FakeHost::default()
+    };
+
+    run_with(&default_args(), &host)
+        .await
+        .expect("a successfully swept interface is not a failure");
+}
+
+#[tokio::test]
+async fn an_interface_is_not_counted_twice() {
+    // Reported by the typed teardown and still present afterwards; the summary
+    // must name it once, not twice.
+    let host = FakeHost {
+        teardown_failures: vec!["tunnel interface wg_ward0: device busy".to_owned()],
+        links_before: vec!["wg_ward0".to_owned()],
+        links_after: vec!["wg_ward0".to_owned()],
+        ..FakeHost::default()
+    };
+
+    let err = run_with(&default_args(), &host)
+        .await
+        .expect_err("should fail");
+
+    assert!(
+        err.to_string().contains("1 uninstall step(s) failed"),
+        "double-counted: {err}"
+    );
+}
+
+#[tokio::test]
+async fn a_failed_link_enumeration_is_reported_rather_than_ignored() {
+    let host = FakeHost {
+        links_error: true,
+        ..FakeHost::default()
+    };
+
+    let err = run_with(&default_args(), &host)
+        .await
+        .expect_err("should fail");
+
+    assert!(err.to_string().contains("step(s) failed"), "got {err}");
+}
+
+#[tokio::test]
+async fn a_file_that_will_not_delete_fails_the_run() {
+    let host = FakeHost {
+        remove_path_fails: vec!["/usr/local/bin/wardnetd".to_owned()],
+        ..FakeHost::default()
+    };
+
+    let err = run_with(&default_args(), &host)
+        .await
+        .expect_err("should fail");
+
+    assert!(err.to_string().contains("step(s) failed"), "got {err}");
+}
+
+#[tokio::test]
+async fn container_mode_never_touches_the_host_drop_ins() {
+    let host = FakeHost::default();
+    let args = UninstallArgs {
+        yes: true,
+        container_mode: true,
+        ..UninstallArgs::default()
+    };
+
+    run_with(&args, &host).await.expect("should succeed");
+
+    let calls = host.calls().join("\n");
+    assert!(!calls.contains("/etc/sysctl.d/99-wardnet.conf"), "{calls}");
+    assert!(
+        !calls.contains("/etc/dhcpcd.conf.d/wardnet.conf"),
+        "{calls}"
+    );
+    assert!(
+        !calls.contains("/etc/modules-load.d/wardnet-watchdog.conf"),
+        "{calls}"
+    );
+}
+
+#[tokio::test]
+async fn bare_metal_removes_the_host_drop_ins() {
+    let host = clean_host();
+
+    run_with(&default_args(), &host)
+        .await
+        .expect("should succeed");
+
+    let calls = host.calls().join("\n");
+    assert!(calls.contains("/etc/sysctl.d/99-wardnet.conf"), "{calls}");
+    assert!(calls.contains("/etc/dhcpcd.conf.d/wardnet.conf"), "{calls}");
+    assert!(
+        calls.contains("/etc/modules-load.d/wardnet-watchdog.conf"),
+        "{calls}"
+    );
+}
+
+#[tokio::test]
+async fn is_idempotent_on_an_already_clean_host() {
+    let host = clean_host();
+
+    run_with(&default_args(), &host).await.expect("first run");
+    run_with(&default_args(), &host).await.expect("second run");
+}

--- a/source/marketing-site/content/docs.yml
+++ b/source/marketing-site/content/docs.yml
@@ -133,3 +133,8 @@ topics:
     title: SDK reference
     icon: code
     description: JavaScript/TypeScript SDK for integrating with Wardnet programmatically.
+
+  - slug: uninstall
+    title: Uninstall
+    icon: trash-2
+    description: Remove Wardnet cleanly, what it deletes, what it keeps, and what to do about DHCP first.

--- a/source/marketing-site/content/docs/installation.md
+++ b/source/marketing-site/content/docs/installation.md
@@ -284,30 +284,18 @@ fires the `wardnetd-rollback.service` unit after three failures within
 
 ### Uninstall
 
+The installer writes an uninstaller alongside the daemon:
+
 ```bash
-sudo systemctl disable --now wardnetd
-sudo systemctl disable --now wardnet-postupgrade.service
-sudo rm -f /etc/systemd/system/wardnetd.service
-sudo rm -f /etc/systemd/system/wardnetd-rollback.service
-sudo rm -f /etc/systemd/system/wardnet-postupgrade.service
-sudo rm -f /usr/local/bin/wardnetd /usr/local/bin/wardnetd.old
-sudo rm -rf /etc/wardnet /var/lib/wardnet /var/log/wardnet
-sudo rm -rf /usr/local/libexec/wardnet /var/lib/wardnet-postupgrade
-sudo rm -f /etc/sysctl.d/99-wardnet.conf
-sudo rm -f /etc/dhcpcd.conf.d/wardnet.conf
-sudo userdel wardnet
-sudo systemctl daemon-reload
+sudo wardnet-uninstall --dry-run   # see exactly what would go
+sudo wardnet-uninstall             # remove, keeping your data
 ```
 
-This removes everything the installer created. Two notes:
+It removes the daemon, its units, its user, and the firewall and WireGuard
+state it created, while keeping your database and secrets unless you pass
+`--purge`.
 
-- `/etc/dhcpcd.conf.d/wardnet.conf` only exists if you installed with
-  `--static-ip`; the `rm -f` is a harmless no-op otherwise.
-- Removing `/etc/sysctl.d/99-wardnet.conf` stops IP forwarding from
-  persisting across reboots, but the running kernel keeps
-  `net.ipv4.ip_forward=1` until the next reboot. Leave the setting alone
-  if anything else on the host relies on forwarding.
-
-**This deletes your configuration and data** (the SQLite database,
-WireGuard keys, and secrets under `/var/lib/wardnet`). Take an
-[encrypted backup](/docs/backup-restore) first if you might want it back.
+**Re-enable DHCP on your router first.** This host is your LAN's DHCP server
+and DNS resolver, and removing it leaves the network without either. See
+[Uninstall](/docs/uninstall) for the full procedure, what is kept, and the
+static-IP caveat.

--- a/source/marketing-site/content/docs/uninstall.md
+++ b/source/marketing-site/content/docs/uninstall.md
@@ -1,0 +1,176 @@
+# Uninstall
+
+Wardnet installs an uninstaller alongside the daemon, so removing it is one
+command rather than a checklist you have to get right by hand:
+
+```bash
+sudo wardnet-uninstall
+```
+
+That removes the daemon, its systemd units, its configuration, the `wardnet`
+system user, and the firewall and WireGuard state it created in the kernel. It
+**keeps** your database and secrets. Read the two warnings below before you run
+it, because one of them is about your whole network losing DNS.
+
+## Read this first: your LAN loses DHCP and DNS
+
+This host is your network's DHCP server and its DNS resolver. The moment
+Wardnet is gone, devices on the LAN have no way to get an address and no way to
+resolve a name, and they will stay that way until something else takes over.
+
+**Re-enable DHCP on your router before you uninstall,** not after. If you do it
+after, you may find yourself with no working DNS on the very machine you were
+going to use to log into the router. The uninstaller prints this warning too
+and waits for you to confirm, so there is a chance to back out.
+
+## Look before you leap
+
+Every uninstall path supports `--dry-run`, which prints every file, unit,
+nftables table, interface and user it would touch, marked as removed or kept,
+and then exits without changing anything:
+
+```bash
+sudo wardnet-uninstall --dry-run
+```
+
+For something that owns port 53 and rewrites your firewall, it is worth the ten
+seconds.
+
+## What is kept, and how to destroy it
+
+By default your data survives:
+
+| Path | What it holds | Default | `--purge` |
+| --- | --- | --- | --- |
+| `/var/lib/wardnet/wardnet.db` | Devices, rules, zones, history | Kept | Deleted |
+| `/var/lib/wardnet/secrets/` | WireGuard private keys, backup passphrase, DDNS credentials | Kept | Deleted |
+| Everything else | Binary, units, config, logs, firewall state | Deleted | Deleted |
+
+Anything kept is re-owned to `root` on the way out. That matters because the
+`wardnet` user is deleted in the same run, and files left behind owned by a
+user that no longer exists can be silently inherited by whatever service
+happens to be assigned that numeric ID next. If the re-own fails for any
+reason, the uninstaller **keeps** the `wardnet` user rather than creating that
+exact hazard, and tells you so.
+
+One limit worth knowing: these are the default locations. The uninstaller does
+not read `wardnet.toml`, deliberately, so that it still works on a host whose
+config is missing or broken. If you moved the database, secret store, or log
+directory in that file, remove those paths yourself.
+
+To destroy the data as well:
+
+```bash
+sudo wardnet-uninstall --purge
+```
+
+`--purge` asks you to type `PURGE` in full rather than accepting a `y`, because
+the WireGuard private keys and the backup passphrase cannot be recovered once
+they are gone. If there is any doubt, take an
+[encrypted backup](/docs/backup-restore) first, it takes a moment and it
+restores onto a fresh install.
+
+## Running it non-interactively
+
+The installer is happy to run unattended, because installing is safe. The
+uninstaller is the opposite: with no terminal to confirm on and no `--yes`, it
+refuses and exits non-zero rather than guessing that you meant it.
+
+```bash
+sudo wardnet-uninstall --yes
+sudo wardnet-uninstall --purge --yes
+```
+
+## Other ways in
+
+Three entry points, all doing the same thing:
+
+```bash
+# The script the installer wrote (preferred).
+sudo wardnet-uninstall
+
+# The daemon binary directly, if the script is missing.
+sudo wardnetd uninstall
+
+# From the install script, including the piped form.
+curl -sSL https://wardnet.network/install.sh | sudo bash -s -- --uninstall
+```
+
+`wardnet-uninstall` is a thin wrapper that hands over to `wardnetd uninstall`.
+The real work lives in the daemon because Wardnet manages nftables over netlink
+rather than by shelling out to `nft`, so the `nft` command is not something we
+install or can assume exists. The binary can always delete its own firewall
+table; a shell script cannot. If the binary is missing or broken, the wrapper
+falls back to removing files on its own. It still asks for confirmation, and it
+still deletes the firewall table when the `nft` command happens to be installed.
+If it is not, the wrapper says plainly that firewall state may remain and exits
+non-zero, rather than reporting a clean uninstall it did not achieve.
+
+## Never kill the daemon to stop it
+
+Wardnet holds the hardware watchdog on boards that have one, and disarms it as
+part of shutting down cleanly. If you `kill -9` the daemon, that disarm never
+happens and **the board reboots about fifteen seconds later.**
+
+Use `sudo systemctl stop wardnetd`, and let the uninstaller do its own stopping.
+It always stops the service cleanly first, for exactly this reason.
+
+## After a static-IP install
+
+If you installed with `--static-ip`, the address came from a drop-in at
+`/etc/dhcpcd.conf.d/wardnet.conf`. Removing it means this host goes back to
+DHCP at its next boot, and it may come back on a different address than the one
+you have bookmarked. Note the current address before you reboot.
+
+## What gets removed
+
+For reference, the full inventory:
+
+| Item | Purpose |
+| --- | --- |
+| `/usr/local/bin/wardnetd`, `wardnetd.old` | The daemon and its rollback copy |
+| `/usr/local/libexec/wardnet/` | Post-upgrade migration runner |
+| `/etc/wardnet/` | `wardnet.toml` and related config |
+| `/var/log/wardnet/` | Log files |
+| `/var/lib/wardnet/updates/` | Downloaded release artefacts (removed in both tiers) |
+| `/var/lib/wardnet/postupgrade/` | Staged post-upgrade migration binary (removed in both tiers) |
+| `/var/lib/wardnet-postupgrade/` | Root-owned migration state, outside the main tree |
+| `wardnetd.service`, `wardnetd-rollback.service`, `wardnet-postupgrade.service` | systemd units and their enable symlinks |
+| `/etc/sysctl.d/99-wardnet.conf` | Persisted `net.ipv4.ip_forward=1` |
+| `/etc/dhcpcd.conf.d/wardnet.conf` | Static IP drop-in, only if you used `--static-ip` |
+| `/etc/modules-load.d/wardnet-watchdog.conf` | Hardware watchdog module |
+| `wardnet` | The system user the daemon ran as |
+| `table inet wardnet` | The nftables table, deleted by name |
+| `wg_ward*` | Tunnel interfaces and the inbound remote-access server |
+
+Two notes on that list. IP forwarding stays enabled on the *running* kernel
+until you reboot, we only remove the drop-in that made it persist, so nothing
+else on the host that depends on forwarding breaks underneath you. And the
+nftables table is deleted by name, never with a ruleset flush, so Docker's
+rules and any of your own are left exactly as they were.
+
+The uninstaller is safe to re-run. Everything it does tolerates the thing
+already being gone, so a partial or interrupted removal is fixed by running it
+again. If any step does fail, it lists what is still present and exits
+non-zero rather than claiming success.
+
+## What Wardnet never touched
+
+Worth stating, because this is where network tools usually leave a mess:
+
+- **`/etc/resolv.conf` is never modified**, and `systemd-resolved` is never
+  disabled. Wardnet serves DNS on port 53 without rewriting the host's own
+  resolver configuration, so there is nothing to undo and no way for uninstall
+  to leave this machine unable to resolve anything.
+- **The static IP was written as a drop-in file we own**, not as an edit to
+  your `dhcpcd.conf`. Removing it is deleting our file, not unpicking a
+  modification from someone else's.
+
+Both are deliberate. They are the difference between an uninstall that is a
+`rm` and one that is an archaeology exercise.
+
+## Reinstalling later
+
+If you kept your data, a fresh install picks up the existing database and
+secrets at `/var/lib/wardnet` and comes back with your devices, rules and
+tunnels intact. See [Installation](/docs/installation).

--- a/source/marketing-site/src/lib/icons.tsx
+++ b/source/marketing-site/src/lib/icons.tsx
@@ -18,6 +18,7 @@ import {
   Radio,
   Smartphone,
   Bell,
+  Trash2,
   type LucideProps,
 } from "lucide-react";
 import type { ComponentType } from "react";
@@ -42,6 +43,7 @@ const ICON_MAP: Record<string, ComponentType<LucideProps>> = {
   radio: Radio,
   smartphone: Smartphone,
   bell: Bell,
+  "trash-2": Trash2,
 };
 
 /** Resolves a string icon name from YAML content to a Lucide icon component. */

--- a/source/marketing-site/tests/pages/DocsArticle.test.tsx
+++ b/source/marketing-site/tests/pages/DocsArticle.test.tsx
@@ -26,6 +26,16 @@ describe("DocsArticle", () => {
     expect(screen.getAllByRole("heading", { level: 1 }).length).toBeGreaterThan(0);
   });
 
+  it("renders the uninstall doc, which docs.yml links to as a topic", () => {
+    // `content/docs.yml` lists an `uninstall` topic. Nothing in the build
+    // cross-checks that a listed slug has a markdown file behind it, and
+    // `.md` is neither linted nor prettier-formatted here, so a typo in
+    // either place would silently ship a "coming soon" card instead.
+    renderAt("/docs/uninstall");
+    expect(screen.queryByText(/documentation coming soon/i)).not.toBeInTheDocument();
+    expect(screen.getAllByRole("heading", { level: 1 }).length).toBeGreaterThan(0);
+  });
+
   it("renders the ComingSoon placeholder with title and description for a known topic without a doc file", () => {
     // A slug that exists in `content/docs.yml` topics but doesn't have a
     // matching markdown file falls back to ComingSoon with the topic


### PR DESCRIPTION
Closes #864.

## The defect underneath the missing feature

Wardnet shipped `install.sh` with no uninstall path. Underneath that convenience gap sat a real bug: **the daemon never removed the kernel state it created.** The `inet wardnet` nftables table was created at startup and never deleted, so after `systemctl stop wardnetd` every forward/input/NAT rule stayed live until the next reboot. A stopped daemon was still filtering the user's traffic.

`FirewallManager::destroy_wardnet_table()` had existed since the netlink migration, documented as "cleanup on shutdown", implemented idempotently — and called by nothing.

## What changed

**Shutdown tears down its own kernel state, gated on the cause.** `shutdown_signal` previously collapsed all three `select!` arms to `()`. It now returns a `ShutdownCause`, so teardown runs on a signal (`systemctl stop`) but not on the daemon's own restarts (auto-update, rollback, admin Restart). Without that gate, every six-hourly update poll would churn the user's tunnels for nothing.

**Tunnels go through `TunnelService::tear_down_internal`, not the raw interface.** This is the load-bearing part and it is easy to get wrong. Deleting the interface behind the database's back leaves the tunnel recorded `Up` with no interface; the monitor then flips it `Down`, `handle_tunnel_down` strips the routing for every device using it, and *nothing recreates it* — tunnel-routed devices would silently sit on direct WAN after any stop, until an admin brought each tunnel up by hand. Recording `Down` instead lets the next boot's routing reconcile hit the existing on-demand bring-up in `apply_rule`.

**`wardnetd uninstall`** is the front door, with a generated `/usr/local/sbin/wardnet-uninstall` escape hatch. The subcommand owns the implementation because ADR 0013 removed the `nft` CLI dependency — `nft` may not exist on the host, so shell cannot be relied on to delete the table. The wrapper execs the subcommand and otherwise falls back to file removal, exiting non-zero rather than claiming a clean uninstall it did not achieve.

Two tiers: the default keeps the database and secret store and re-owns them to root; `--purge` destroys them. The `wardnet` account is deleted **only once that re-own has actually succeeded** — freeing a UID that still owns the WireGuard keys is the hazard the step exists to close. `--dry-run` prints the full inventory and touches nothing.

## Corrections to the issue

- The issue says `net.ipv4.ip_forward` is "never persisted to `/etc/sysctl.d/`". It **is** — `install.sh` writes `/etc/sysctl.d/99-wardnet.conf`. Now in the inventory.
- The inventory also omitted `/etc/modules-load.d/wardnet-watchdog.conf` and `/usr/local/bin/wardnetd.old`.
- The issue's rationale for the subcommand ("only the daemon knows which tables it created") is weaker than the real one: ADR 0013 means `nft` may simply be absent.

## Review

Five rounds of multi-agent review (`pre-pr-review`), 24 findings, all fixed; round 5 came back clean on both panels. Two were serious enough to call out:

- `destroy_wardnet_table` swallowed **every** error and returned `Ok(())`, so the "report failures honestly" contract was hollow in production. `QueryError::NetlinkError` carries the errno only in `nlmsgerr.error` — no `#[source]`, and a static `Display` — so the fix had to downcast to the concrete error rather than match message text.
- The `--purge` path could delete the account while the tree survived, and a symlinked `/var/lib/wardnet` would make `chown -R -h` a silent no-op and `remove_dir_all` unlink only the link, both while reporting success.

## Testing

- Daemon: `check-inline-tests`, `cargo fmt --check`, `cargo clippy --all-targets -D warnings`, `cargo test --workspace` — all green on this rebase. 30 new tests.
- Site: type-check, lint, format, 145 tests.
- Generated uninstaller exercised in both install modes, both tiers, and the no-root / no-tty / unknown-flag paths.
- **Not run:** the on-Pi sequence (stop-vs-restart behaviour, live uninstall, reinstall). It needs real hardware. The e2e restart spec goes through `POST /api/system/restart`, which is a `Restart` cause and so is unaffected.