### PR TITLE
fix(backup): keep deploy-time-only config keys out of a restore

### DIFF
--- a/.agents/backup.md
+++ b/.agents/backup.md
@@ -56,6 +56,30 @@ On apply, the service:
 3. Sets `backup_restart_pending = "true"` in `system_config`.
 4. Returns the list of snapshots created.
 
+### Deploy-time-only config keys (issue #1112)
+
+Step 2 does **not** write the bundle's `wardnet.toml` verbatim. The
+systemd unit grants `ReadWritePaths=/etc/wardnet` so restore can write
+the config at all, which puts that file within reach of an admin
+session: export a bundle, edit the TOML (the passphrase is the admin's
+own), repack, restore, restart. `[update] allow_edge_channel` is
+exactly what must stay out of that reach — ADR-0023 makes putting a box
+on the edge channel take root *on that box*.
+
+`wardnet_common::config_restore::preserve_deploy_time_keys` therefore
+merges the bundle's config over the live one, taking every key in
+`DEPLOY_TIME_ONLY_KEYS` from the live machine: the update path, the
+filesystem locations the sandbox pins, this box's hardware identity, and
+the test-harness overrides that are never set in production. The merge is
+untyped (`toml::Table`, never `ApplicationConfiguration`) so keys from a
+newer daemon survive, and a bundle that changes none of them is passed
+through byte-for-byte so operator comments are not lost to a
+re-serialisation.
+
+Adding a config field without deciding which side of that line it falls on
+fails `wardnet-common`'s
+`tests::config_restore::every_config_key_is_classified`.
+
 The running SQLite pool still points at the (now renamed) old file
 via its open file descriptor, so writes from the old pool would land
 in the unlinked inode and vanish. That's why the response tells the

--- a/.agents/backup.md
+++ b/.agents/backup.md
@@ -71,14 +71,24 @@ merges the bundle's config over the live one, taking every key in
 `DEPLOY_TIME_ONLY_KEYS` from the live machine: the update path, the
 filesystem locations the sandbox pins, this box's hardware identity, and
 the test-harness overrides that are never set in production. The merge is
-untyped (`toml::Table`, never `ApplicationConfiguration`) so keys from a
-newer daemon survive, and a bundle that changes none of them is passed
-through byte-for-byte so operator comments are not lost to a
-re-serialisation.
+untyped (`toml::Table`, never `ApplicationConfiguration`) so the restored
+file keeps the shape the operator wrote instead of becoming a dump of every
+defaulted field, and a bundle that changes none of those keys is passed
+through byte-for-byte so its comments survive.
+
+Untyped is not unchecked. `ApplicationConfiguration` is
+`deny_unknown_fields` and a restore is followed by a mandatory restart, so a
+bundle carrying an unknown section or a wrongly-typed value would write
+cleanly and then leave the daemon failing to start with no UI left to fix it
+from. `check_bundle_config` runs as part of `check_compat`, so the *preview*
+reports it — the operator finds out before committing, not after — and the
+merged result is re-checked before it is written.
 
 Adding a config field without deciding which side of that line it falls on
 fails `wardnet-common`'s
-`tests::config_restore::every_config_key_is_classified`.
+`tests::config_restore::every_config_key_is_classified`. That guard reads
+serde's own field lists rather than a serialised sample, because `toml`
+omits an `Option` that is `None` and would hide such a field from it.
 
 The running SQLite pool still points at the (now renamed) old file
 via its open file descriptor, so writes from the old pool would land

--- a/docs/adr/0023-edge-release-channel.md
+++ b/docs/adr/0023-edge-release-channel.md
@@ -71,6 +71,11 @@ session is not enough. If the flag is removed from a box already on edge, the
 daemon logs a warning at startup and falls back to `beta`, writing the change
 back so the stored state never contradicts the config.
 
+Backup restore is the one admin-session path that writes `wardnet.toml`, so it
+is explicitly held to the same line: `apply_import` takes this flag (and every
+other deploy-time-only key) from the live machine rather than the bundle. See
+`wardnet_common::config_restore` and issue #1112.
+
 ## Consequences
 
 Edge builds are signed with the production key, so the *channel* remains

--- a/source/daemon/Cargo.lock
+++ b/source/daemon/Cargo.lock
@@ -6345,6 +6345,7 @@ dependencies = [
  "tokio",
  "tokio-tungstenite 0.30.0",
  "tokio-util",
+ "toml 1.1.3+spec-1.1.0",
  "tower",
  "tracing",
  "tracing-subscriber",

--- a/source/daemon/crates/wardnet-common/src/config_restore.rs
+++ b/source/daemon/crates/wardnet-common/src/config_restore.rs
@@ -1,0 +1,232 @@
+//! Which config keys a backup bundle is allowed to change.
+//!
+//! Restoring a bundle replaces `/etc/wardnet/wardnet.toml` wholesale, and
+//! the systemd unit grants `ReadWritePaths=/etc/wardnet` so that write
+//! succeeds. That makes the config file reachable from an admin session:
+//! export a bundle, unpack it with the passphrase you chose, edit the TOML,
+//! repack, restore, restart.
+//!
+//! Some keys must not be reachable that way. `[update] allow_edge_channel`
+//! is the clearest case — ADR-0023 states that putting a box on the edge
+//! channel requires root *on that box*, so an admin session (or a stolen
+//! one) cannot opt it into unvetted builds. `[update] manifest_base_url` is
+//! the same shape and more practically harmful: repoint it at a server that
+//! never publishes a release and the box silently stops patching itself
+//! while the UI still reports a healthy, up-to-date state.
+//!
+//! [`preserve_deploy_time_keys`] closes that off by taking every key in
+//! [`DEPLOY_TIME_ONLY_KEYS`] from the **live** config rather than the
+//! bundle's. Beyond the security property this is the more honest semantic:
+//! a bundle restores your data and your settings, not the deployment posture
+//! of the machine it lands on.
+//!
+//! ### Fidelity
+//!
+//! The merge is untyped — it works on [`toml::Table`], never on
+//! [`ApplicationConfiguration`](crate::config::ApplicationConfiguration) —
+//! so keys this daemon does not know about (a bundle from a newer build)
+//! survive the round trip instead of being silently dropped.
+//!
+//! When nothing needs changing, the bundle's bytes are passed through
+//! **verbatim**, comments and formatting intact. Re-serialising a
+//! `toml::Table` loses both, and that is a real cost on a file
+//! `install.sh` writes with explanatory comments — so it is only paid when
+//! a deploy-time key actually differs, which on the ordinary
+//! restore-onto-the-same-box path it never does.
+
+use toml::{Table, Value};
+
+/// Config keys taken from the live machine on restore, never from the
+/// bundle. Dotted TOML paths; a path naming a table covers its whole
+/// subtree.
+///
+/// Four things land a key here:
+///
+/// 1. **Code provenance and the update path.** Which builds this box will
+///    install, where it fetches them from, and whether it checks at all.
+///    This is the [`allow_edge_channel`](crate::config::UpdateConfig::allow_edge_channel)
+///    gate and everything that can stand in for it — a one-second
+///    `http_timeout_secs` denies patching just as effectively as a dead
+///    `manifest_base_url`.
+/// 2. **Filesystem locations pinned by the systemd sandbox.** The daemon
+///    can only write the paths `wardnetd.service` grants; a bundle that
+///    repoints the database or the log file at somewhere else breaks the
+///    box, and in the log's case does so silently.
+/// 3. **Hardware identity of this box.** Which NIC is the LAN side, which
+///    watchdog device exists, whether the board has one at all. These
+///    describe the machine, not the user's preferences, and a bundle
+///    restored onto different hardware carries the wrong answers.
+/// 4. **Test-harness overrides that are never set in production.** Each
+///    one redirects the daemon at a mock: stubbed tunnel backends, a
+///    stand-in `NordVPN` API, a stand-in wardnet-cloud gateway. Reachable
+///    from a bundle, they are a way to point a live box at a server the
+///    attacker controls.
+///
+/// Adding a field to any config section covered here without deciding which
+/// side of the line it falls on fails
+/// `tests::config_restore::every_config_key_is_classified`.
+pub const DEPLOY_TIME_ONLY_KEYS: &[&str] = &[
+    // 1. Code provenance and the update path.
+    "update.allow_edge_channel",
+    "update.manifest_base_url",
+    "update.check_interval_secs",
+    "update.http_timeout_secs",
+    "update.require_signature",
+    "update.live_binary_path",
+    "update.staging_dir",
+    // 2. Filesystem locations pinned by the systemd sandbox.
+    "database.provider",
+    "database.connection_string",
+    "logging.path",
+    // Whole table: the secret store's location is machine-local, and the
+    // fields under it vary by provider variant. A future provider's
+    // connection settings belong on this side of the line by construction.
+    "secret_store",
+    "pidfile_path",
+    // 3. Hardware identity of this box.
+    "network.lan_interface",
+    "watchdog.enabled",
+    "watchdog.device_path",
+    // 4. Test-harness overrides, never set in production.
+    "test.stub_tunnel_backends",
+    "vpn_providers.nordvpn_api_url",
+    "ddns_wardnet.gateway_url",
+    "ddns_wardnet.region_gateway_url",
+    "ddns_wardnet.region_health_url",
+];
+
+/// Why a restore could not compute the config it should write.
+#[derive(Debug, thiserror::Error)]
+pub enum ConfigRestoreError {
+    /// The live config on disk is not parseable. The daemon parsed it at
+    /// startup, so this means it changed underneath us — and with no live
+    /// values to read, the deploy-time keys cannot be preserved. Refuse
+    /// rather than let the bundle's copy through.
+    #[error("the live config is not valid TOML, so deploy-time keys cannot be preserved: {0}")]
+    LiveConfig(toml::de::Error),
+    /// The config inside the bundle is not parseable. Writing it would
+    /// leave a daemon that cannot start.
+    #[error("the config in the backup bundle is not valid TOML: {0}")]
+    BundleConfig(toml::de::Error),
+    /// Re-serialising the merged table failed.
+    #[error("failed to re-serialise the merged config: {0}")]
+    Serialise(#[from] toml::ser::Error),
+}
+
+/// The config a restore should write, plus what it had to override.
+#[derive(Debug, Clone)]
+pub struct RestoredConfig {
+    /// TOML to write to the live config path.
+    pub toml: String,
+    /// Deploy-time-only keys whose value in the bundle differed from the
+    /// live machine's and were therefore reset to the live value (or
+    /// dropped, where the live config left them at their default).
+    ///
+    /// Empty on every ordinary restore. A non-empty list is worth logging:
+    /// it is either a bundle from a differently-deployed box or somebody
+    /// editing a bundle to change this one's deployment posture.
+    pub overridden: Vec<&'static str>,
+}
+
+/// Merge `bundle` over the live config, keeping [`DEPLOY_TIME_ONLY_KEYS`]
+/// at their live values.
+///
+/// A live key that is absent (left at its compiled-in default) is removed
+/// from the bundle's copy rather than carried across, so the restored file
+/// falls back to the same default. `live` may be empty — that is the
+/// no-config-file case, where every deploy-time key resolves to its default.
+///
+/// # Errors
+///
+/// Returns [`ConfigRestoreError`] when either side is not valid TOML, or
+/// when the merged table cannot be serialised.
+pub fn preserve_deploy_time_keys(
+    live: &str,
+    bundle: &str,
+) -> Result<RestoredConfig, ConfigRestoreError> {
+    let live_table: Table = live.parse().map_err(ConfigRestoreError::LiveConfig)?;
+    let bundle_table: Table = bundle.parse().map_err(ConfigRestoreError::BundleConfig)?;
+
+    let mut merged = bundle_table.clone();
+    let mut overridden = Vec::new();
+
+    for key in DEPLOY_TIME_ONLY_KEYS {
+        let path: Vec<&str> = key.split('.').collect();
+        let live_value = value_at(&live_table, &path);
+        if live_value == value_at(&bundle_table, &path) {
+            continue;
+        }
+        overridden.push(*key);
+        match live_value {
+            Some(value) => set_value(&mut merged, &path, value.clone()),
+            None => remove_value(&mut merged, &path),
+        }
+    }
+
+    // Nothing to change: hand back the bundle's own bytes so its comments
+    // and key order survive a restore untouched.
+    if overridden.is_empty() {
+        return Ok(RestoredConfig {
+            toml: bundle.to_owned(),
+            overridden,
+        });
+    }
+
+    Ok(RestoredConfig {
+        toml: toml::to_string_pretty(&merged)?,
+        overridden,
+    })
+}
+
+/// Resolve a dotted path to the value it names, or `None` if any segment
+/// is missing or is not a table.
+fn value_at<'a>(table: &'a Table, path: &[&str]) -> Option<&'a Value> {
+    let (last, parents) = path.split_last()?;
+    let mut current = table;
+    for segment in parents {
+        current = current.get(*segment)?.as_table()?;
+    }
+    current.get(*last)
+}
+
+/// Write `value` at a dotted path, creating intermediate tables. A
+/// non-table sitting where a parent table belongs is replaced — the bundle
+/// is untrusted input, so `update = "surprise"` must not stop the merge.
+fn set_value(table: &mut Table, path: &[&str], value: Value) {
+    let Some((last, parents)) = path.split_last() else {
+        return;
+    };
+    let mut current = table;
+    for segment in parents {
+        let entry = current
+            .entry((*segment).to_owned())
+            .or_insert_with(|| Value::Table(Table::new()));
+        if !entry.is_table() {
+            *entry = Value::Table(Table::new());
+        }
+        current = entry
+            .as_table_mut()
+            .expect("entry was just coerced to a table");
+    }
+    current.insert((*last).to_owned(), value);
+}
+
+/// Remove the value at a dotted path, pruning any table the removal leaves
+/// empty so a restore does not litter the file with bare `[section]`
+/// headers.
+fn remove_value(table: &mut Table, path: &[&str]) {
+    let Some((head, rest)) = path.split_first() else {
+        return;
+    };
+    if rest.is_empty() {
+        table.remove(*head);
+        return;
+    }
+    let Some(child) = table.get_mut(*head).and_then(Value::as_table_mut) else {
+        return;
+    };
+    remove_value(child, rest);
+    if child.is_empty() {
+        table.remove(*head);
+    }
+}

--- a/source/daemon/crates/wardnet-common/src/config_restore.rs
+++ b/source/daemon/crates/wardnet-common/src/config_restore.rs
@@ -23,9 +23,10 @@
 //! ### Fidelity
 //!
 //! The merge is untyped — it works on [`toml::Table`], never on
-//! [`ApplicationConfiguration`](crate::config::ApplicationConfiguration) —
-//! so keys this daemon does not know about (a bundle from a newer build)
-//! survive the round trip instead of being silently dropped.
+//! [`ApplicationConfiguration`] — so the restored file keeps the shape the
+//! operator wrote. Round-tripping through the typed struct would emit every
+//! defaulted field, turning the small file `install.sh` writes into a full
+//! dump of the config surface.
 //!
 //! When nothing needs changing, the bundle's bytes are passed through
 //! **verbatim**, comments and formatting intact. Re-serialising a
@@ -33,7 +34,27 @@
 //! `install.sh` writes with explanatory comments — so it is only paid when
 //! a deploy-time key actually differs, which on the ordinary
 //! restore-onto-the-same-box path it never does.
+//!
+//! ### Loadability
+//!
+//! Untyped does not mean unchecked. `ApplicationConfiguration` is
+//! `deny_unknown_fields`, and a restore is followed by a mandatory restart —
+//! so a bundle carrying an unknown section or a wrongly-typed value would
+//! write cleanly and then leave the daemon failing to start, with no UI left
+//! to fix it from. Both [`check_bundle_config`] and
+//! [`preserve_deploy_time_keys`] therefore require that what they are handed
+//! (and what they produce) actually deserialises.
+//!
+//! That is a check on *shape*, not on values. A config can deserialise and
+//! still be one the daemon cannot run on — `[health] refresh_interval_secs =
+//! 0` panics the tick loop, `server.host = "nonsense"` fails to parse as a
+//! socket address. Nothing here rules those out, because they are the same
+//! hazard a hand-edited `/etc/wardnet/wardnet.toml` carries and the fix
+//! belongs with the fields themselves, not with restore. What restore
+//! guarantees is narrower and worth stating plainly: it will not write a
+//! file this daemon cannot *parse*.
 
+use crate::config::ApplicationConfiguration;
 use toml::{Table, Value};
 
 /// Config keys taken from the live machine on restore, never from the
@@ -98,19 +119,57 @@ pub const DEPLOY_TIME_ONLY_KEYS: &[&str] = &[
 /// Why a restore could not compute the config it should write.
 #[derive(Debug, thiserror::Error)]
 pub enum ConfigRestoreError {
+    /// The config inside the bundle is not UTF-8, so it is not a config
+    /// file at all.
+    #[error("the config in the backup bundle is not valid UTF-8: {0}")]
+    BundleNotUtf8(std::str::Utf8Error),
+    /// The config inside the bundle is not valid TOML, or is not a config
+    /// this daemon can load — an unknown section, a wrongly-typed value.
+    /// Writing it would leave a daemon that cannot start.
+    #[error("the config in the backup bundle is not one this daemon can load: {0}")]
+    BundleConfig(toml::de::Error),
     /// The live config on disk is not parseable. The daemon parsed it at
     /// startup, so this means it changed underneath us — and with no live
     /// values to read, the deploy-time keys cannot be preserved. Refuse
     /// rather than let the bundle's copy through.
     #[error("the live config is not valid TOML, so deploy-time keys cannot be preserved: {0}")]
     LiveConfig(toml::de::Error),
-    /// The config inside the bundle is not parseable. Writing it would
-    /// leave a daemon that cannot start.
-    #[error("the config in the backup bundle is not valid TOML: {0}")]
-    BundleConfig(toml::de::Error),
+    /// The merge produced something this daemon could not load. Only
+    /// reachable when the live config is itself not a loadable config, since
+    /// the bundle's copy is checked first.
+    #[error("merging the live config's deploy-time keys produced a config that will not load: {0}")]
+    MergedConfig(toml::de::Error),
     /// Re-serialising the merged table failed.
     #[error("failed to re-serialise the merged config: {0}")]
     Serialise(#[from] toml::ser::Error),
+}
+
+impl ConfigRestoreError {
+    /// Whether the bundle is at fault, as opposed to the machine being
+    /// restored onto. Callers surface the first as a rejected bundle and the
+    /// second as an internal failure.
+    #[must_use]
+    pub const fn blames_the_bundle(&self) -> bool {
+        matches!(self, Self::BundleNotUtf8(_) | Self::BundleConfig(_))
+    }
+}
+
+/// Check that a bundle's config is one this daemon could actually load, and
+/// return it as text.
+///
+/// Split out from [`preserve_deploy_time_keys`] so the restore *preview* can
+/// reject an unusable bundle while nothing is at stake, rather than letting
+/// the operator commit to a restore that fails — or worse, one that writes a
+/// config the daemon then cannot start from.
+///
+/// # Errors
+///
+/// [`ConfigRestoreError::BundleNotUtf8`] or
+/// [`ConfigRestoreError::BundleConfig`].
+pub fn check_bundle_config(bundle: &[u8]) -> Result<&str, ConfigRestoreError> {
+    let text = std::str::from_utf8(bundle).map_err(ConfigRestoreError::BundleNotUtf8)?;
+    toml::from_str::<ApplicationConfiguration>(text).map_err(ConfigRestoreError::BundleConfig)?;
+    Ok(text)
 }
 
 /// The config a restore should write, plus what it had to override.
@@ -136,35 +195,64 @@ pub struct RestoredConfig {
 /// falls back to the same default. `live` may be empty — that is the
 /// no-config-file case, where every deploy-time key resolves to its default.
 ///
+/// The result is checked to deserialise before it is returned, so a restore
+/// cannot write a file this daemon would fail to parse. Field *values* are
+/// not validated — see the module docs.
+///
 /// # Errors
 ///
-/// Returns [`ConfigRestoreError`] when either side is not valid TOML, or
-/// when the merged table cannot be serialised.
+/// Returns [`ConfigRestoreError`] when either side is not valid TOML, when
+/// either side (or the merge of them) is not a config this daemon can load,
+/// or when the merged table cannot be serialised.
 pub fn preserve_deploy_time_keys(
     live: &str,
     bundle: &str,
 ) -> Result<RestoredConfig, ConfigRestoreError> {
+    check_bundle_config(bundle.as_bytes())?;
     let live_table: Table = live.parse().map_err(ConfigRestoreError::LiveConfig)?;
     let bundle_table: Table = bundle.parse().map_err(ConfigRestoreError::BundleConfig)?;
 
     let mut merged = bundle_table.clone();
     let mut overridden = Vec::new();
 
+    // An absent key still has a value — its compiled-in default — so the two
+    // sides are compared on what they would *resolve to*, not on whether they
+    // spell it out. Otherwise a bundle that writes `allow_edge_channel =
+    // false` where the live file simply omits it reads as a change: the file
+    // gets re-serialised (losing the operator's comments) and the log accuses
+    // a perfectly ordinary bundle of trying to move the box's posture.
+    //
+    // The mirror case is a deliberate trade, not an oversight: where the live
+    // file spells out a value that equals the default and the bundle omits
+    // it, the restored file omits it too. The box's effective config is
+    // unchanged, which is what this function promises — what is lost is the
+    // record that the operator pinned it, so a later release that changes
+    // that default would move the box with the rest. Keeping the pin would
+    // mean re-serialising (and dropping the bundle's comments) for a restore
+    // that changes nothing, which is the worse of the two.
+    let defaults = default_config_table();
+
     for key in DEPLOY_TIME_ONLY_KEYS {
         let path: Vec<&str> = key.split('.').collect();
+        let default_value = value_at(&defaults, &path);
         let live_value = value_at(&live_table, &path);
-        if live_value == value_at(&bundle_table, &path) {
+        let bundle_value = value_at(&bundle_table, &path);
+        if live_value.or(default_value) == bundle_value.or(default_value) {
             continue;
         }
         overridden.push(*key);
         match live_value {
             Some(value) => set_value(&mut merged, &path, value.clone()),
+            // The live file leaves this key at its default; drop the bundle's
+            // copy rather than writing the default out, so the restored file
+            // stays as small as the one the operator had.
             None => remove_value(&mut merged, &path),
         }
     }
 
     // Nothing to change: hand back the bundle's own bytes so its comments
-    // and key order survive a restore untouched.
+    // and key order survive a restore untouched. Already checked loadable
+    // above, so it needs no second pass.
     if overridden.is_empty() {
         return Ok(RestoredConfig {
             toml: bundle.to_owned(),
@@ -172,10 +260,20 @@ pub fn preserve_deploy_time_keys(
         });
     }
 
-    Ok(RestoredConfig {
-        toml: toml::to_string_pretty(&merged)?,
-        overridden,
-    })
+    let toml = toml::to_string_pretty(&merged)?;
+    toml::from_str::<ApplicationConfiguration>(&toml).map_err(ConfigRestoreError::MergedConfig)?;
+    Ok(RestoredConfig { toml, overridden })
+}
+
+/// The compiled-in defaults as a table, for resolving what an omitted key
+/// would mean. An empty table on the (unreachable) serialisation failure —
+/// that degrades the comparison to "written or not", never to a wrong
+/// preserved value.
+fn default_config_table() -> Table {
+    Value::try_from(ApplicationConfiguration::default())
+        .ok()
+        .and_then(|value| value.as_table().cloned())
+        .unwrap_or_default()
 }
 
 /// Resolve a dotted path to the value it names, or `None` if any segment
@@ -189,9 +287,13 @@ fn value_at<'a>(table: &'a Table, path: &[&str]) -> Option<&'a Value> {
     current.get(*last)
 }
 
-/// Write `value` at a dotted path, creating intermediate tables. A
-/// non-table sitting where a parent table belongs is replaced — the bundle
-/// is untrusted input, so `update = "surprise"` must not stop the merge.
+/// Write `value` at a dotted path, creating intermediate tables.
+///
+/// A non-table sitting where a parent table belongs is replaced rather than
+/// tripping an assertion. Nothing can produce that today — a bundle with
+/// `update = "surprise"` is rejected by [`check_bundle_config`] before it
+/// gets here — but the helper stays total so the merge cannot be turned into
+/// a panic by a future caller that skips the check.
 fn set_value(table: &mut Table, path: &[&str], value: Value) {
     let Some((last, parents)) = path.split_last() else {
         return;

--- a/source/daemon/crates/wardnet-common/src/lib.rs
+++ b/source/daemon/crates/wardnet-common/src/lib.rs
@@ -2,6 +2,7 @@ pub mod api;
 pub mod auth;
 pub mod backup;
 pub mod config;
+pub mod config_restore;
 pub mod device;
 pub mod dhcp;
 pub mod dns;

--- a/source/daemon/crates/wardnet-common/src/tests/config_restore.rs
+++ b/source/daemon/crates/wardnet-common/src/tests/config_restore.rs
@@ -1,0 +1,530 @@
+//! Tests for [`crate::config_restore`].
+//!
+//! Two concerns live here. The merge tests pin the behaviour a restore
+//! relies on: deploy-time keys come from the live machine, everything else
+//! comes from the bundle. The classification test is the guard that keeps
+//! the first set honest as the config grows — see
+//! [`every_config_key_is_classified`].
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+use crate::config::{
+    AdminConfig, ApplicationConfiguration, AuthConfig, DatabaseConfig, DatabaseProvider,
+    DdnsWardnetConfig, DetectionConfig, EnabledMetrics, HealthConfig, LogFormat, LogRotation,
+    LoggingConfig, MdnsConfig, NetworkConfig, OtelConfig, OtelLogsConfig, OtelMetricsConfig,
+    OtelTracesConfig, PyroscopeConfig, SecretStoreConfig, ServerConfig, TestConfig, TunnelConfig,
+    UpdateConfig, VpnProvidersConfig, WatchdogConfig,
+};
+use crate::config_restore::{ConfigRestoreError, DEPLOY_TIME_ONLY_KEYS, preserve_deploy_time_keys};
+
+/// Config keys a backup bundle *may* set: the user's own settings, which
+/// travel with their data. The counterpart to
+/// [`DEPLOY_TIME_ONLY_KEYS`] — between them the two lists must name every
+/// key in the config, which is what
+/// [`every_config_key_is_classified`] checks.
+const RESTORABLE_KEYS: &[&str] = &[
+    "server.host",
+    "server.port",
+    "server.https_port",
+    "server.http_redirect_port",
+    "logging.format",
+    "logging.level",
+    "logging.filters",
+    "logging.rotation",
+    "logging.max_log_files",
+    "logging.max_recent_errors",
+    "logging.broadcast_capacity",
+    "logging.ui_suppressed_targets",
+    "logging.journal_suppressed_targets",
+    "network.default_policy",
+    "auth.session_expiry_hours",
+    "auth.remember_me_expiry_hours",
+    // Bootstrap credentials, used only when the restored database holds no
+    // admin at all. An admin session can already create an admin through
+    // the API, so a bundle carrying these grants nothing it did not have.
+    "admin.username",
+    "admin.password",
+    "tunnel.idle_timeout_secs",
+    "tunnel.health_check_interval_secs",
+    "tunnel.stats_interval_secs",
+    "tunnel.latency_probe_interval_secs",
+    "tunnel.latency_probe_target",
+    "tunnel.test_probe_url",
+    "tunnel.speed_test_url",
+    "tunnel.speed_test_latency_samples",
+    "tunnel.speed_test_parallel_streams",
+    "tunnel.speed_test_warmup_ms",
+    "tunnel.speed_test_measure_ms",
+    "detection.enabled",
+    "detection.departure_timeout_secs",
+    "detection.batch_flush_interval_secs",
+    "detection.departure_scan_interval_secs",
+    "detection.arp_scan_interval_secs",
+    // Telemetry export. Repointing it at a collector of the attacker's
+    // choosing leaks nothing an admin session cannot already read from the
+    // live log stream, so it stays a user setting.
+    "otel.enabled",
+    "otel.endpoint",
+    "otel.service_name",
+    "otel.interval_secs",
+    "otel.traces.enabled",
+    "otel.logs.enabled",
+    "otel.metrics.enabled",
+    "otel.metrics.enabled_metrics.system_cpu_utilization",
+    "otel.metrics.enabled_metrics.system_memory_usage",
+    "otel.metrics.enabled_metrics.system_temperature",
+    "otel.metrics.enabled_metrics.system_network_io",
+    "otel.metrics.enabled_metrics.wardnet_device_count",
+    "otel.metrics.enabled_metrics.wardnet_tunnel_count",
+    "otel.metrics.enabled_metrics.wardnet_tunnel_active_count",
+    "otel.metrics.enabled_metrics.wardnet_uptime_seconds",
+    "otel.metrics.enabled_metrics.wardnet_db_size_bytes",
+    "otel.metrics.enabled_metrics.wardnet_disk_free_bytes",
+    "vpn_providers.enabled",
+    "pyroscope.enabled",
+    "pyroscope.endpoint",
+    "mdns.enabled",
+    "mdns.hostname",
+    "health.refresh_interval_secs",
+    "health.failure_threshold",
+    "health.check_timeout_secs",
+    "watchdog.hardware_timeout_secs",
+    "watchdog.pet_interval_secs",
+    "watchdog.soft_enabled",
+];
+
+/// A config with **every** field written out explicitly and every optional
+/// field populated, so serialising it yields the full set of config keys.
+///
+/// The struct literals are the point: they carry no `..Default::default()`,
+/// so adding a field anywhere in the config tree fails to compile here
+/// before it can slip past [`every_config_key_is_classified`] unclassified.
+/// Open-ended maps (`logging.filters`, `vpn_providers.enabled`) are left
+/// empty — their keys are user data, not config fields.
+#[allow(clippy::too_many_lines)] // One literal per config field — length is the point.
+fn probe_config() -> ApplicationConfiguration {
+    ApplicationConfiguration {
+        server: ServerConfig {
+            host: "0.0.0.0".to_owned(),
+            port: 7411,
+            https_port: 443,
+            http_redirect_port: 80,
+        },
+        database: DatabaseConfig {
+            provider: DatabaseProvider::Sqlite,
+            connection_string: "/var/lib/wardnet/wardnet.db".to_owned(),
+        },
+        logging: LoggingConfig {
+            format: LogFormat::Json,
+            level: "info".to_owned(),
+            filters: HashMap::new(),
+            path: PathBuf::from("/var/log/wardnet/wardnetd.log"),
+            rotation: LogRotation::Daily,
+            max_log_files: 7,
+            max_recent_errors: 15,
+            broadcast_capacity: 256,
+            ui_suppressed_targets: Vec::new(),
+            journal_suppressed_targets: Vec::new(),
+        },
+        network: NetworkConfig {
+            lan_interface: "eth0".to_owned(),
+            default_policy: "direct".to_owned(),
+        },
+        auth: AuthConfig {
+            session_expiry_hours: 24,
+            remember_me_expiry_hours: 720,
+        },
+        admin: Some(AdminConfig {
+            username: "admin".to_owned(),
+            password: "hunter2".to_owned(),
+        }),
+        tunnel: TunnelConfig {
+            idle_timeout_secs: 600,
+            health_check_interval_secs: 10,
+            stats_interval_secs: 5,
+            latency_probe_interval_secs: 60,
+            latency_probe_target: "1.1.1.1".to_owned(),
+            test_probe_url: "https://1.1.1.1/cdn-cgi/trace".to_owned(),
+            speed_test_url: "https://speed.cloudflare.com/__down".to_owned(),
+            speed_test_latency_samples: 5,
+            speed_test_parallel_streams: 4,
+            speed_test_warmup_ms: 1000,
+            speed_test_measure_ms: 4000,
+        },
+        detection: DetectionConfig {
+            enabled: true,
+            departure_timeout_secs: 300,
+            batch_flush_interval_secs: 30,
+            departure_scan_interval_secs: 60,
+            arp_scan_interval_secs: 60,
+        },
+        otel: OtelConfig {
+            enabled: false,
+            endpoint: "http://localhost:4317".to_owned(),
+            service_name: "wardnetd".to_owned(),
+            interval_secs: 10,
+            traces: OtelTracesConfig { enabled: true },
+            logs: OtelLogsConfig { enabled: true },
+            metrics: OtelMetricsConfig {
+                enabled: true,
+                enabled_metrics: EnabledMetrics {
+                    system_cpu_utilization: true,
+                    system_memory_usage: true,
+                    system_temperature: true,
+                    system_network_io: true,
+                    wardnet_device_count: true,
+                    wardnet_tunnel_count: true,
+                    wardnet_tunnel_active_count: true,
+                    wardnet_uptime_seconds: true,
+                    wardnet_db_size_bytes: true,
+                    wardnet_disk_free_bytes: true,
+                },
+            },
+        },
+        vpn_providers: VpnProvidersConfig {
+            enabled: HashMap::new(),
+            nordvpn_api_url: Some("https://api.nordvpn.com".to_owned()),
+        },
+        ddns_wardnet: DdnsWardnetConfig {
+            gateway_url: Some("https://api.wardnet.network".to_owned()),
+            region_gateway_url: Some("https://eu.wardnet.network".to_owned()),
+            region_health_url: Some("https://eu.wardnet.network/health".to_owned()),
+        },
+        pyroscope: PyroscopeConfig {
+            enabled: false,
+            endpoint: "http://localhost:4040".to_owned(),
+        },
+        update: UpdateConfig {
+            manifest_base_url: "https://releases.wardnet.network".to_owned(),
+            check_interval_secs: 21_600,
+            live_binary_path: PathBuf::from("/usr/local/bin/wardnetd"),
+            staging_dir: PathBuf::from("/var/lib/wardnet/updates"),
+            require_signature: true,
+            http_timeout_secs: 60,
+            allow_edge_channel: false,
+        },
+        mdns: MdnsConfig {
+            enabled: true,
+            hostname: Some("wardnet".to_owned()),
+        },
+        health: HealthConfig {
+            refresh_interval_secs: 5,
+            failure_threshold: 3,
+            check_timeout_secs: 2,
+        },
+        watchdog: WatchdogConfig {
+            enabled: true,
+            device_path: PathBuf::from("/dev/watchdog"),
+            hardware_timeout_secs: 15,
+            pet_interval_secs: 5,
+            soft_enabled: true,
+        },
+        test: TestConfig {
+            stub_tunnel_backends: false,
+        },
+        secret_store: Some(SecretStoreConfig::FileSystem {
+            path: PathBuf::from("/var/lib/wardnet/secrets"),
+        }),
+        pidfile_path: PathBuf::from("/run/wardnetd/wardnetd.pid"),
+    }
+}
+
+/// Every dotted path in `value` that holds a scalar, an array, or an empty
+/// table — i.e. the config's leaves, the granularity classification works at.
+fn leaf_paths(value: &toml::Value, prefix: &str, out: &mut Vec<String>) {
+    match value {
+        toml::Value::Table(table) if !table.is_empty() => {
+            for (key, child) in table {
+                let path = if prefix.is_empty() {
+                    key.clone()
+                } else {
+                    format!("{prefix}.{key}")
+                };
+                leaf_paths(child, &path, out);
+            }
+        }
+        _ => out.push(prefix.to_owned()),
+    }
+}
+
+/// Whether `key` names `path` itself or one of its ancestors.
+fn covers(key: &str, path: &str) -> bool {
+    path == key
+        || path
+            .strip_prefix(key)
+            .is_some_and(|rest| rest.starts_with('.'))
+}
+
+fn probe_leaves() -> Vec<String> {
+    let value = toml::Value::try_from(probe_config()).expect("probe config should serialise");
+    let mut leaves = Vec::new();
+    leaf_paths(&value, "", &mut leaves);
+    leaves
+}
+
+// ---------------------------------------------------------------------------
+// Classification coverage
+// ---------------------------------------------------------------------------
+
+#[test]
+fn every_config_key_is_classified() {
+    let unclassified: Vec<String> = probe_leaves()
+        .into_iter()
+        .filter(|path| {
+            !DEPLOY_TIME_ONLY_KEYS
+                .iter()
+                .chain(RESTORABLE_KEYS)
+                .any(|key| covers(key, path))
+        })
+        .collect();
+
+    assert!(
+        unclassified.is_empty(),
+        "config keys with no restore classification: {unclassified:?}\n\
+         Decide whether a backup bundle may set each one. Machine-scoped keys \
+         (update path, sandboxed filesystem locations, hardware identity, \
+         test-harness overrides) go in DEPLOY_TIME_ONLY_KEYS in \
+         config_restore.rs; user settings go in RESTORABLE_KEYS in this file.",
+    );
+}
+
+#[test]
+fn no_key_is_classified_both_ways() {
+    let both: Vec<&&str> = DEPLOY_TIME_ONLY_KEYS
+        .iter()
+        .filter(|key| {
+            RESTORABLE_KEYS
+                .iter()
+                .any(|other| covers(other, key) || covers(key, other))
+        })
+        .collect();
+    assert!(both.is_empty(), "keys classified both ways: {both:?}");
+}
+
+#[test]
+fn no_classified_key_is_stale() {
+    let leaves = probe_leaves();
+    let stale: Vec<&&str> = DEPLOY_TIME_ONLY_KEYS
+        .iter()
+        .chain(RESTORABLE_KEYS)
+        .filter(|key| !leaves.iter().any(|path| covers(key, path)))
+        .collect();
+    assert!(
+        stale.is_empty(),
+        "classified keys that no longer exist in the config (renamed or removed?): {stale:?}",
+    );
+}
+
+// ---------------------------------------------------------------------------
+// The keys the gate exists for
+// ---------------------------------------------------------------------------
+
+#[test]
+fn bundle_cannot_enable_the_edge_channel() {
+    // Live box has never opted into edge: the key is simply absent.
+    let merged = preserve_deploy_time_keys(
+        "[network]\nlan_interface = \"eth0\"\n",
+        "[network]\nlan_interface = \"eth0\"\n\n[update]\nallow_edge_channel = true\n",
+    )
+    .unwrap();
+
+    let table: toml::Table = merged.toml.parse().unwrap();
+    assert!(
+        table.get("update").is_none(),
+        "the bundle's [update] section should be gone entirely: {}",
+        merged.toml,
+    );
+    assert_eq!(merged.overridden, vec!["update.allow_edge_channel"]);
+}
+
+#[test]
+fn bundle_cannot_turn_the_edge_channel_off_either() {
+    // The gate is not one-directional: the live machine's value wins
+    // whichever way it points.
+    let merged = preserve_deploy_time_keys(
+        "[update]\nallow_edge_channel = true\n",
+        "[update]\nallow_edge_channel = false\n",
+    )
+    .unwrap();
+
+    let table: toml::Table = merged.toml.parse().unwrap();
+    assert_eq!(
+        table["update"]["allow_edge_channel"].as_bool(),
+        Some(true),
+        "live value should have been kept: {}",
+        merged.toml,
+    );
+}
+
+#[test]
+fn bundle_cannot_repoint_the_update_source() {
+    let merged = preserve_deploy_time_keys(
+        "[update]\nmanifest_base_url = \"https://releases.wardnet.network\"\n",
+        "[update]\nmanifest_base_url = \"https://attacker.example\"\n",
+    )
+    .unwrap();
+
+    let table: toml::Table = merged.toml.parse().unwrap();
+    assert_eq!(
+        table["update"]["manifest_base_url"].as_str(),
+        Some("https://releases.wardnet.network"),
+    );
+    assert_eq!(merged.overridden, vec!["update.manifest_base_url"]);
+}
+
+#[test]
+fn bundle_cannot_disable_signature_verification() {
+    let merged = preserve_deploy_time_keys("", "[update]\nrequire_signature = false\n").unwrap();
+    let table: toml::Table = merged.toml.parse().unwrap();
+    assert!(
+        table.get("update").is_none(),
+        "require_signature should fall back to its compiled default: {}",
+        merged.toml,
+    );
+}
+
+#[test]
+fn bundle_cannot_point_the_box_at_a_stand_in_cloud() {
+    let merged = preserve_deploy_time_keys(
+        "",
+        "[ddns_wardnet]\ngateway_url = \"https://attacker.example\"\n",
+    )
+    .unwrap();
+    let table: toml::Table = merged.toml.parse().unwrap();
+    assert!(table.get("ddns_wardnet").is_none(), "{}", merged.toml);
+    assert_eq!(merged.overridden, vec!["ddns_wardnet.gateway_url"]);
+}
+
+// ---------------------------------------------------------------------------
+// Everything else still restores
+// ---------------------------------------------------------------------------
+
+#[test]
+fn ordinary_settings_restore_from_the_bundle() {
+    let merged = preserve_deploy_time_keys(
+        "[logging]\nlevel = \"info\"\n\n[detection]\nenabled = true\n",
+        "[logging]\nlevel = \"debug\"\n\n[detection]\nenabled = false\n\n[update]\nallow_edge_channel = true\n",
+    )
+    .unwrap();
+
+    let table: toml::Table = merged.toml.parse().unwrap();
+    assert_eq!(table["logging"]["level"].as_str(), Some("debug"));
+    assert_eq!(table["detection"]["enabled"].as_bool(), Some(false));
+    assert!(table.get("update").is_none());
+}
+
+#[test]
+fn a_bundle_that_changes_nothing_passes_through_verbatim() {
+    // Comments and key order are the operator's, and install.sh writes
+    // several — re-serialising would silently drop them.
+    let config = "# written by install.sh\n[network]\nlan_interface = \"eth0\"\n\n[update]\n# opted in with root\nallow_edge_channel = true\n";
+    let merged = preserve_deploy_time_keys(config, config).unwrap();
+
+    assert_eq!(merged.toml, config);
+    assert!(merged.overridden.is_empty());
+}
+
+#[test]
+fn keys_this_daemon_does_not_know_survive_the_merge() {
+    // A bundle from a newer build carries sections we have no struct for.
+    // The merge is untyped precisely so they are not dropped on the floor.
+    let merged = preserve_deploy_time_keys(
+        "",
+        "[from_the_future]\nknob = 1\n\n[update]\nallow_edge_channel = true\nfuture_knob = 2\n",
+    )
+    .unwrap();
+
+    let table: toml::Table = merged.toml.parse().unwrap();
+    assert_eq!(table["from_the_future"]["knob"].as_integer(), Some(1));
+    assert_eq!(table["update"]["future_knob"].as_integer(), Some(2));
+    assert!(
+        table["update"].get("allow_edge_channel").is_none(),
+        "the gated key should still have been stripped: {}",
+        merged.toml,
+    );
+}
+
+#[test]
+fn the_secret_store_table_is_replaced_wholesale() {
+    let merged = preserve_deploy_time_keys(
+        "[secret_store]\nprovider = \"file_system\"\npath = \"/var/lib/wardnet/secrets\"\n",
+        "[secret_store]\nprovider = \"file_system\"\npath = \"/tmp/attacker\"\n",
+    )
+    .unwrap();
+
+    let table: toml::Table = merged.toml.parse().unwrap();
+    assert_eq!(
+        table["secret_store"]["path"].as_str(),
+        Some("/var/lib/wardnet/secrets"),
+    );
+    assert_eq!(merged.overridden, vec!["secret_store"]);
+}
+
+#[test]
+fn a_non_table_where_a_section_belongs_does_not_stop_the_merge() {
+    // The bundle is untrusted input; `update = "surprise"` must not be a
+    // way to smuggle the section past the merge.
+    let merged = preserve_deploy_time_keys(
+        "[update]\nallow_edge_channel = false\n",
+        "update = \"surprise\"\n",
+    )
+    .unwrap();
+
+    let table: toml::Table = merged.toml.parse().unwrap();
+    assert_eq!(table["update"]["allow_edge_channel"].as_bool(), Some(false));
+}
+
+#[test]
+fn an_empty_live_config_strips_every_deploy_time_key() {
+    let bundle = "[update]\nallow_edge_channel = true\nmanifest_base_url = \"https://attacker.example\"\n\n[test]\nstub_tunnel_backends = true\n";
+    let merged = preserve_deploy_time_keys("", bundle).unwrap();
+
+    let table: toml::Table = merged.toml.parse().unwrap();
+    assert!(
+        table.is_empty(),
+        "expected nothing left, got {}",
+        merged.toml
+    );
+}
+
+#[test]
+fn a_top_level_key_that_sorts_after_a_section_still_round_trips() {
+    // TOML puts every bare key in the table it was last opened under, so a
+    // top-level scalar emitted after a `[section]` header would silently be
+    // re-read as part of that section. `pidfile_path` sorts after
+    // `network`, which is exactly that trap.
+    let merged = preserve_deploy_time_keys(
+        "pidfile_path = \"/run/wardnetd/wardnetd.pid\"\n",
+        "[network]\nlan_interface = \"eth0\"\n",
+    )
+    .unwrap();
+
+    let table: toml::Table = merged.toml.parse().unwrap();
+    assert_eq!(
+        table["pidfile_path"].as_str(),
+        Some("/run/wardnetd/wardnetd.pid"),
+        "pidfile_path was swallowed by a section: {}",
+        merged.toml,
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Failure modes
+// ---------------------------------------------------------------------------
+
+#[test]
+fn an_unparseable_bundle_config_is_rejected() {
+    let err = preserve_deploy_time_keys("", "this is not toml").unwrap_err();
+    assert!(matches!(err, ConfigRestoreError::BundleConfig(_)), "{err}");
+}
+
+#[test]
+fn an_unparseable_live_config_is_rejected() {
+    // Fail closed: with no live values to read, letting the bundle's copy
+    // through would hand it the deploy-time keys.
+    let err =
+        preserve_deploy_time_keys("this is not toml", "[update]\nallow_edge_channel = true\n")
+            .unwrap_err();
+    assert!(matches!(err, ConfigRestoreError::LiveConfig(_)), "{err}");
+}

--- a/source/daemon/crates/wardnet-common/src/tests/config_restore.rs
+++ b/source/daemon/crates/wardnet-common/src/tests/config_restore.rs
@@ -6,17 +6,15 @@
 //! the first set honest as the config grows — see
 //! [`every_config_key_is_classified`].
 
-use std::collections::HashMap;
-use std::path::PathBuf;
-
 use crate::config::{
-    AdminConfig, ApplicationConfiguration, AuthConfig, DatabaseConfig, DatabaseProvider,
-    DdnsWardnetConfig, DetectionConfig, EnabledMetrics, HealthConfig, LogFormat, LogRotation,
-    LoggingConfig, MdnsConfig, NetworkConfig, OtelConfig, OtelLogsConfig, OtelMetricsConfig,
-    OtelTracesConfig, PyroscopeConfig, SecretStoreConfig, ServerConfig, TestConfig, TunnelConfig,
-    UpdateConfig, VpnProvidersConfig, WatchdogConfig,
+    AdminConfig, ApplicationConfiguration, AuthConfig, DatabaseConfig, DdnsWardnetConfig,
+    DetectionConfig, EnabledMetrics, HealthConfig, LoggingConfig, MdnsConfig, NetworkConfig,
+    OtelConfig, OtelLogsConfig, OtelMetricsConfig, OtelTracesConfig, PyroscopeConfig, ServerConfig,
+    TestConfig, TunnelConfig, UpdateConfig, VpnProvidersConfig, WatchdogConfig,
 };
-use crate::config_restore::{ConfigRestoreError, DEPLOY_TIME_ONLY_KEYS, preserve_deploy_time_keys};
+use crate::config_restore::{
+    ConfigRestoreError, DEPLOY_TIME_ONLY_KEYS, check_bundle_config, preserve_deploy_time_keys,
+};
 
 /// Config keys a backup bundle *may* set: the user's own settings, which
 /// travel with their data. The counterpart to
@@ -94,158 +92,103 @@ const RESTORABLE_KEYS: &[&str] = &[
     "watchdog.soft_enabled",
 ];
 
-/// A config with **every** field written out explicitly and every optional
-/// field populated, so serialising it yields the full set of config keys.
+/// The full set of config field paths, taken from **serde's own** field
+/// lists rather than from a serialised value.
 ///
-/// The struct literals are the point: they carry no `..Default::default()`,
-/// so adding a field anywhere in the config tree fails to compile here
-/// before it can slip past [`every_config_key_is_classified`] unclassified.
-/// Open-ended maps (`logging.filters`, `vpn_providers.enabled`) are left
-/// empty — their keys are user data, not config fields.
-#[allow(clippy::too_many_lines)] // One literal per config field — length is the point.
-fn probe_config() -> ApplicationConfiguration {
-    ApplicationConfiguration {
-        server: ServerConfig {
-            host: "0.0.0.0".to_owned(),
-            port: 7411,
-            https_port: 443,
-            http_redirect_port: 80,
-        },
-        database: DatabaseConfig {
-            provider: DatabaseProvider::Sqlite,
-            connection_string: "/var/lib/wardnet/wardnet.db".to_owned(),
-        },
-        logging: LoggingConfig {
-            format: LogFormat::Json,
-            level: "info".to_owned(),
-            filters: HashMap::new(),
-            path: PathBuf::from("/var/log/wardnet/wardnetd.log"),
-            rotation: LogRotation::Daily,
-            max_log_files: 7,
-            max_recent_errors: 15,
-            broadcast_capacity: 256,
-            ui_suppressed_targets: Vec::new(),
-            journal_suppressed_targets: Vec::new(),
-        },
-        network: NetworkConfig {
-            lan_interface: "eth0".to_owned(),
-            default_policy: "direct".to_owned(),
-        },
-        auth: AuthConfig {
-            session_expiry_hours: 24,
-            remember_me_expiry_hours: 720,
-        },
-        admin: Some(AdminConfig {
-            username: "admin".to_owned(),
-            password: "hunter2".to_owned(),
-        }),
-        tunnel: TunnelConfig {
-            idle_timeout_secs: 600,
-            health_check_interval_secs: 10,
-            stats_interval_secs: 5,
-            latency_probe_interval_secs: 60,
-            latency_probe_target: "1.1.1.1".to_owned(),
-            test_probe_url: "https://1.1.1.1/cdn-cgi/trace".to_owned(),
-            speed_test_url: "https://speed.cloudflare.com/__down".to_owned(),
-            speed_test_latency_samples: 5,
-            speed_test_parallel_streams: 4,
-            speed_test_warmup_ms: 1000,
-            speed_test_measure_ms: 4000,
-        },
-        detection: DetectionConfig {
-            enabled: true,
-            departure_timeout_secs: 300,
-            batch_flush_interval_secs: 30,
-            departure_scan_interval_secs: 60,
-            arp_scan_interval_secs: 60,
-        },
-        otel: OtelConfig {
-            enabled: false,
-            endpoint: "http://localhost:4317".to_owned(),
-            service_name: "wardnetd".to_owned(),
-            interval_secs: 10,
-            traces: OtelTracesConfig { enabled: true },
-            logs: OtelLogsConfig { enabled: true },
-            metrics: OtelMetricsConfig {
-                enabled: true,
-                enabled_metrics: EnabledMetrics {
-                    system_cpu_utilization: true,
-                    system_memory_usage: true,
-                    system_temperature: true,
-                    system_network_io: true,
-                    wardnet_device_count: true,
-                    wardnet_tunnel_count: true,
-                    wardnet_tunnel_active_count: true,
-                    wardnet_uptime_seconds: true,
-                    wardnet_db_size_bytes: true,
-                    wardnet_disk_free_bytes: true,
-                },
-            },
-        },
-        vpn_providers: VpnProvidersConfig {
-            enabled: HashMap::new(),
-            nordvpn_api_url: Some("https://api.nordvpn.com".to_owned()),
-        },
-        ddns_wardnet: DdnsWardnetConfig {
-            gateway_url: Some("https://api.wardnet.network".to_owned()),
-            region_gateway_url: Some("https://eu.wardnet.network".to_owned()),
-            region_health_url: Some("https://eu.wardnet.network/health".to_owned()),
-        },
-        pyroscope: PyroscopeConfig {
-            enabled: false,
-            endpoint: "http://localhost:4040".to_owned(),
-        },
-        update: UpdateConfig {
-            manifest_base_url: "https://releases.wardnet.network".to_owned(),
-            check_interval_secs: 21_600,
-            live_binary_path: PathBuf::from("/usr/local/bin/wardnetd"),
-            staging_dir: PathBuf::from("/var/lib/wardnet/updates"),
-            require_signature: true,
-            http_timeout_secs: 60,
-            allow_edge_channel: false,
-        },
-        mdns: MdnsConfig {
-            enabled: true,
-            hostname: Some("wardnet".to_owned()),
-        },
-        health: HealthConfig {
-            refresh_interval_secs: 5,
-            failure_threshold: 3,
-            check_timeout_secs: 2,
-        },
-        watchdog: WatchdogConfig {
-            enabled: true,
-            device_path: PathBuf::from("/dev/watchdog"),
-            hardware_timeout_secs: 15,
-            pet_interval_secs: 5,
-            soft_enabled: true,
-        },
-        test: TestConfig {
-            stub_tunnel_backends: false,
-        },
-        secret_store: Some(SecretStoreConfig::FileSystem {
-            path: PathBuf::from("/var/lib/wardnet/secrets"),
-        }),
-        pidfile_path: PathBuf::from("/run/wardnetd/wardnetd.pid"),
-    }
+/// The distinction matters: `toml` drops an `Option` that is `None`, so
+/// enumerating a sample config would silently omit any optional field left
+/// unset — and five config fields are already `Option`. Asking serde what it
+/// expects, via the `deny_unknown_fields` rejection message, sees every
+/// declared field regardless of the value it would hold.
+///
+/// One entry per struct in the tree. A new *field* is picked up
+/// automatically; a new nested *struct* shows up as an unclassified leaf
+/// until it is either registered here or classified as a whole table.
+fn declared_paths() -> Vec<String> {
+    let mut paths = Vec::new();
+    let mut add = |prefix: &str, names: Vec<String>| {
+        for name in names {
+            paths.push(if prefix.is_empty() {
+                name
+            } else {
+                format!("{prefix}.{name}")
+            });
+        }
+    };
+
+    add("", declared_field_names::<ApplicationConfiguration>());
+    add("server", declared_field_names::<ServerConfig>());
+    add("database", declared_field_names::<DatabaseConfig>());
+    add("logging", declared_field_names::<LoggingConfig>());
+    add("network", declared_field_names::<NetworkConfig>());
+    add("auth", declared_field_names::<AuthConfig>());
+    add("admin", declared_field_names::<AdminConfig>());
+    add("tunnel", declared_field_names::<TunnelConfig>());
+    add("detection", declared_field_names::<DetectionConfig>());
+    add("otel", declared_field_names::<OtelConfig>());
+    add("otel.traces", declared_field_names::<OtelTracesConfig>());
+    add("otel.logs", declared_field_names::<OtelLogsConfig>());
+    add("otel.metrics", declared_field_names::<OtelMetricsConfig>());
+    add(
+        "otel.metrics.enabled_metrics",
+        declared_field_names::<EnabledMetrics>(),
+    );
+    add(
+        "vpn_providers",
+        declared_field_names::<VpnProvidersConfig>(),
+    );
+    add("ddns_wardnet", declared_field_names::<DdnsWardnetConfig>());
+    add("pyroscope", declared_field_names::<PyroscopeConfig>());
+    add("update", declared_field_names::<UpdateConfig>());
+    add("mdns", declared_field_names::<MdnsConfig>());
+    add("health", declared_field_names::<HealthConfig>());
+    add("watchdog", declared_field_names::<WatchdogConfig>());
+    add("test", declared_field_names::<TestConfig>());
+    // `secret_store` is an internally-tagged enum, which serde refuses to
+    // combine with `deny_unknown_fields`, so it has no field list to read.
+    // It is classified as a whole table, which covers every variant's fields
+    // by construction — see DEPLOY_TIME_ONLY_KEYS.
+
+    paths
 }
 
-/// Every dotted path in `value` that holds a scalar, an array, or an empty
-/// table — i.e. the config's leaves, the granularity classification works at.
-fn leaf_paths(value: &toml::Value, prefix: &str, out: &mut Vec<String>) {
-    match value {
-        toml::Value::Table(table) if !table.is_empty() => {
-            for (key, child) in table {
-                let path = if prefix.is_empty() {
-                    key.clone()
-                } else {
-                    format!("{prefix}.{key}")
-                };
-                leaf_paths(child, &path, out);
-            }
-        }
-        _ => out.push(prefix.to_owned()),
-    }
+/// Field names serde declares for `T`, read out of the `deny_unknown_fields`
+/// rejection message.
+///
+/// Serde words the list three ways depending on how many fields there are —
+/// ``expected `a` ``, ``expected `a` or `b` ``, ``expected one of `a`, `b`,
+/// `c` `` — so this takes everything after `expected` and pulls out the
+/// backtick-quoted names rather than matching any one phrasing.
+///
+/// A hack, but a self-checking one: if the message ever stops naming fields
+/// this way the parse fails loudly here rather than quietly returning nothing
+/// and letting [`every_config_key_is_classified`] pass on an empty set.
+fn declared_field_names<T: serde::de::DeserializeOwned>() -> Vec<String> {
+    const PROBE_KEY: &str = "wardnet_unknown_field_probe";
+
+    let message = toml::from_str::<T>(&format!("{PROBE_KEY} = 0"))
+        .err()
+        .expect("a deny_unknown_fields struct must reject an unknown key")
+        .to_string();
+    // Everything before `expected` mentions the probe key itself, in
+    // backticks — start after it so the probe cannot be read as a field.
+    let listed = message
+        .split_once("expected ")
+        .unwrap_or_else(|| {
+            panic!("serde's unknown-field message no longer lists fields: {message}")
+        })
+        .1;
+    let names: Vec<String> = listed
+        .split('`')
+        .skip(1)
+        .step_by(2)
+        .map(ToOwned::to_owned)
+        .collect();
+    assert!(
+        !names.is_empty() && !names.iter().any(String::is_empty),
+        "no field names parsed out of: {message}",
+    );
+    names
 }
 
 /// Whether `key` names `path` itself or one of its ancestors.
@@ -256,11 +199,17 @@ fn covers(key: &str, path: &str) -> bool {
             .is_some_and(|rest| rest.starts_with('.'))
 }
 
-fn probe_leaves() -> Vec<String> {
-    let value = toml::Value::try_from(probe_config()).expect("probe config should serialise");
-    let mut leaves = Vec::new();
-    leaf_paths(&value, "", &mut leaves);
-    leaves
+/// The declared paths that hold a value rather than a nested struct — the
+/// granularity classification works at.
+fn config_leaves() -> Vec<String> {
+    let all = declared_paths();
+    all.iter()
+        .filter(|path| {
+            let prefix = format!("{path}.");
+            !all.iter().any(|other| other.starts_with(&prefix))
+        })
+        .cloned()
+        .collect()
 }
 
 // ---------------------------------------------------------------------------
@@ -269,7 +218,7 @@ fn probe_leaves() -> Vec<String> {
 
 #[test]
 fn every_config_key_is_classified() {
-    let unclassified: Vec<String> = probe_leaves()
+    let unclassified: Vec<String> = config_leaves()
         .into_iter()
         .filter(|path| {
             !DEPLOY_TIME_ONLY_KEYS
@@ -304,7 +253,7 @@ fn no_key_is_classified_both_ways() {
 
 #[test]
 fn no_classified_key_is_stale() {
-    let leaves = probe_leaves();
+    let leaves = config_leaves();
     let stale: Vec<&&str> = DEPLOY_TIME_ONLY_KEYS
         .iter()
         .chain(RESTORABLE_KEYS)
@@ -426,23 +375,51 @@ fn a_bundle_that_changes_nothing_passes_through_verbatim() {
 }
 
 #[test]
-fn keys_this_daemon_does_not_know_survive_the_merge() {
-    // A bundle from a newer build carries sections we have no struct for.
-    // The merge is untyped precisely so they are not dropped on the floor.
+fn the_merge_keeps_the_file_minimal_rather_than_dumping_every_default() {
+    // Round-tripping through `ApplicationConfiguration` would emit all ~80
+    // fields; the operator wrote five lines and should get five back.
     let merged = preserve_deploy_time_keys(
-        "",
-        "[from_the_future]\nknob = 1\n\n[update]\nallow_edge_channel = true\nfuture_knob = 2\n",
+        "[update]\nallow_edge_channel = true\n",
+        "[logging]\nlevel = \"debug\"\n",
     )
     .unwrap();
 
     let table: toml::Table = merged.toml.parse().unwrap();
-    assert_eq!(table["from_the_future"]["knob"].as_integer(), Some(1));
-    assert_eq!(table["update"]["future_knob"].as_integer(), Some(2));
-    assert!(
-        table["update"].get("allow_edge_channel").is_none(),
-        "the gated key should still have been stripped: {}",
+    assert_eq!(
+        table.keys().collect::<Vec<_>>(),
+        vec!["logging", "update"],
+        "only the sections that were written should appear: {}",
         merged.toml,
     );
+    assert_eq!(table["logging"]["level"].as_str(), Some("debug"));
+    assert_eq!(table["update"]["allow_edge_channel"].as_bool(), Some(true));
+}
+
+#[test]
+fn spelling_out_a_default_is_not_treated_as_a_change() {
+    // The live file omits `allow_edge_channel`; the bundle writes it out at
+    // the value omission already means. Nothing has changed, so this must not
+    // re-serialise the file or log the bundle as trying to move the box.
+    let bundle = "# operator notes\n[update]\nallow_edge_channel = false\n";
+    let merged = preserve_deploy_time_keys("[logging]\nlevel = \"info\"\n", bundle).unwrap();
+
+    assert!(
+        merged.overridden.is_empty(),
+        "explicit default reported as an override: {:?}",
+        merged.overridden,
+    );
+    assert_eq!(merged.toml, bundle, "the comment should have survived");
+}
+
+#[test]
+fn omitting_a_key_the_live_file_spells_out_is_not_a_change_either() {
+    // The mirror image: the live file writes the default, the bundle omits
+    // it. Both resolve to the same value, so the bundle passes through.
+    let bundle = "[logging]\nlevel = \"debug\"\n";
+    let merged = preserve_deploy_time_keys("[update]\nrequire_signature = true\n", bundle).unwrap();
+
+    assert!(merged.overridden.is_empty(), "{:?}", merged.overridden);
+    assert_eq!(merged.toml, bundle);
 }
 
 #[test]
@@ -462,17 +439,15 @@ fn the_secret_store_table_is_replaced_wholesale() {
 }
 
 #[test]
-fn a_non_table_where_a_section_belongs_does_not_stop_the_merge() {
-    // The bundle is untrusted input; `update = "surprise"` must not be a
-    // way to smuggle the section past the merge.
-    let merged = preserve_deploy_time_keys(
+fn a_bundle_that_puts_a_scalar_where_a_section_belongs_is_rejected() {
+    // `update = "surprise"` is valid TOML but not a config the daemon can
+    // load, so it never reaches the merge at all.
+    let err = preserve_deploy_time_keys(
         "[update]\nallow_edge_channel = false\n",
         "update = \"surprise\"\n",
     )
-    .unwrap();
-
-    let table: toml::Table = merged.toml.parse().unwrap();
-    assert_eq!(table["update"]["allow_edge_channel"].as_bool(), Some(false));
+    .unwrap_err();
+    assert!(matches!(err, ConfigRestoreError::BundleConfig(_)), "{err}");
 }
 
 #[test]
@@ -494,16 +469,21 @@ fn a_top_level_key_that_sorts_after_a_section_still_round_trips() {
     // top-level scalar emitted after a `[section]` header would silently be
     // re-read as part of that section. `pidfile_path` sorts after
     // `network`, which is exactly that trap.
+    //
+    // The live value is deliberately *not* the default, so the merge has a
+    // real change to make and takes the re-serialising path where the hazard
+    // lives.
     let merged = preserve_deploy_time_keys(
-        "pidfile_path = \"/run/wardnetd/wardnetd.pid\"\n",
+        "pidfile_path = \"/run/wardnetd/custom.pid\"\n",
         "[network]\nlan_interface = \"eth0\"\n",
     )
     .unwrap();
 
+    assert_eq!(merged.overridden, vec!["pidfile_path"]);
     let table: toml::Table = merged.toml.parse().unwrap();
     assert_eq!(
         table["pidfile_path"].as_str(),
-        Some("/run/wardnetd/wardnetd.pid"),
+        Some("/run/wardnetd/custom.pid"),
         "pidfile_path was swallowed by a section: {}",
         merged.toml,
     );
@@ -527,4 +507,46 @@ fn an_unparseable_live_config_is_rejected() {
         preserve_deploy_time_keys("this is not toml", "[update]\nallow_edge_channel = true\n")
             .unwrap_err();
     assert!(matches!(err, ConfigRestoreError::LiveConfig(_)), "{err}");
+}
+
+#[test]
+fn a_bundle_with_a_section_this_daemon_cannot_load_is_rejected() {
+    // `ApplicationConfiguration` is deny_unknown_fields and a restore is
+    // followed by a mandatory restart, so writing this would leave the box
+    // in a systemd restart loop with no UI left to fix it from.
+    let err = preserve_deploy_time_keys("", "[from_the_future]\nknob = 1\n").unwrap_err();
+    assert!(matches!(err, ConfigRestoreError::BundleConfig(_)), "{err}");
+
+    // Same for a known section that grew a key we do not have.
+    let err = preserve_deploy_time_keys("", "[update]\nfuture_knob = 2\n").unwrap_err();
+    assert!(matches!(err, ConfigRestoreError::BundleConfig(_)), "{err}");
+}
+
+#[test]
+fn a_bundle_with_a_wrongly_typed_value_is_rejected() {
+    let err = preserve_deploy_time_keys("", "[server]\nport = \"not a number\"\n").unwrap_err();
+    assert!(matches!(err, ConfigRestoreError::BundleConfig(_)), "{err}");
+}
+
+#[test]
+fn a_bundle_config_that_is_not_utf8_is_rejected() {
+    let err = check_bundle_config(&[0xFF, 0xFE, 0xFD]).unwrap_err();
+    assert!(matches!(err, ConfigRestoreError::BundleNotUtf8(_)), "{err}");
+    assert!(err.blames_the_bundle());
+}
+
+#[test]
+fn a_loadable_bundle_config_passes_the_check() {
+    let text = check_bundle_config(b"[logging]\nlevel = \"debug\"\n").unwrap();
+    assert_eq!(text, "[logging]\nlevel = \"debug\"\n");
+}
+
+#[test]
+fn a_broken_live_config_is_not_blamed_on_the_bundle() {
+    // The caller maps this to an internal error rather than a rejected
+    // upload, because the machine is what is wrong, not the bundle.
+    let err =
+        preserve_deploy_time_keys("this is not toml", "[update]\nallow_edge_channel = true\n")
+            .unwrap_err();
+    assert!(!err.blames_the_bundle(), "{err}");
 }

--- a/source/daemon/crates/wardnet-common/src/tests/mod.rs
+++ b/source/daemon/crates/wardnet-common/src/tests/mod.rs
@@ -1,6 +1,7 @@
 mod api;
 mod auth;
 mod config;
+mod config_restore;
 mod device;
 mod dhcp;
 mod dns;

--- a/source/daemon/crates/wardnetd-services/Cargo.toml
+++ b/source/daemon/crates/wardnetd-services/Cargo.toml
@@ -119,6 +119,9 @@ http.workspace = true
 [dev-dependencies]
 # https://crates.io/crates/tokio
 tokio = { workspace = true, features = ["test-util"] }
+# https://crates.io/crates/toml — parse the config a restore wrote, so the
+# deploy-time-key assertions read keys rather than match on formatting
+toml.workspace = true
 # https://crates.io/crates/minisign — keygen + signing, used by tests that build synthetic signed-tarball fixtures
 minisign.workspace = true
 # https://crates.io/crates/tempfile

--- a/source/daemon/crates/wardnetd-services/src/backup/service.rs
+++ b/source/daemon/crates/wardnetd-services/src/backup/service.rs
@@ -18,6 +18,12 @@
 //! * Every method begins with `auth_context::require_admin()?` — no
 //!   anonymous access to backup operations, same defense-in-depth rule
 //!   as the rest of the service layer.
+//! * The config a restore writes is **not** the bundle's copy verbatim:
+//!   deploy-time-only keys are taken from the live machine first, so a
+//!   bundle cannot change this box's deployment posture (which builds it
+//!   installs, where its files live, what hardware it drives). See
+//!   [`wardnet_common::config_restore`] and
+//!   [`BackupServiceImpl::config_bytes_for_restore`].
 //!
 //! ### What happens to the secret store on restore
 //!
@@ -49,6 +55,7 @@ use wardnet_common::backup::{
     BackupStatus, BundleManifest, CURRENT_BUNDLE_FORMAT_VERSION, LocalSnapshot, MIN_PASSPHRASE_LEN,
     RestorePhase, SnapshotKind,
 };
+use wardnet_common::config_restore::{self, ConfigRestoreError};
 use wardnetd_data::database_dumper::DatabaseDumper;
 use wardnetd_data::db::restore_pending_marker_path;
 use wardnetd_data::repository::SystemConfigRepository;
@@ -319,6 +326,59 @@ impl BackupServiceImpl {
         base.with_file_name(format!(".{name}.pre-restore-{}", Uuid::new_v4()))
     }
 
+    /// The config a restore should actually write: the bundle's, with
+    /// every deploy-time-only key reset to this machine's live value.
+    ///
+    /// Restoring replaces `/etc/wardnet/wardnet.toml` wholesale, and the
+    /// systemd unit grants `ReadWritePaths=/etc/wardnet` so the write
+    /// lands. That puts the file within reach of an admin session — export
+    /// a bundle, edit the TOML, restore it — which is exactly what
+    /// `[update] allow_edge_channel` is supposed to be out of reach of
+    /// (ADR-0023: putting a box on edge takes root *on that box*).
+    /// [`config_restore::preserve_deploy_time_keys`] holds that line; see
+    /// its module docs for what counts as deploy-time and why.
+    ///
+    /// Called before anything on disk is touched, so a bundle carrying an
+    /// unreadable config fails the restore rather than half-applying it.
+    async fn config_bytes_for_restore(&self, bundle_config: &[u8]) -> Result<Vec<u8>, AppError> {
+        let bundle_toml = std::str::from_utf8(bundle_config).map_err(|e| {
+            AppError::BadRequest(format!(
+                "the config in the backup bundle is not valid UTF-8: {e}"
+            ))
+        })?;
+        let live_toml = match tokio::fs::read_to_string(&self.config_path).await {
+            Ok(contents) => contents,
+            // No live config at all: every deploy-time key is at its
+            // compiled-in default, which is what the merge falls back to.
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => String::new(),
+            Err(e) => {
+                return Err(AppError::Internal(anyhow::anyhow!(
+                    "failed to read live config at {}: {e}",
+                    self.config_path.display()
+                )));
+            }
+        };
+
+        let merged = config_restore::preserve_deploy_time_keys(&live_toml, bundle_toml).map_err(
+            |e| match e {
+                // The bundle is caller-supplied, so a broken config in it is
+                // a bad request; a broken *live* config is our own problem.
+                ConfigRestoreError::BundleConfig(_) => AppError::BadRequest(e.to_string()),
+                other => AppError::Internal(anyhow::anyhow!(other)),
+            },
+        )?;
+
+        if !merged.overridden.is_empty() {
+            let keys = merged.overridden.join(", ");
+            tracing::warn!(
+                keys = %keys,
+                "backup restore: bundle would have changed deploy-time-only config keys, live values kept: keys={keys}",
+            );
+        }
+
+        Ok(merged.toml.into_bytes())
+    }
+
     /// Stage the bundle's config bytes as a sibling file so the
     /// eventual `rename` into place is atomic. The staging file is
     /// created with `0600` — the config may carry provider
@@ -353,6 +413,10 @@ impl BackupServiceImpl {
     /// `.bak-<timestamp>`. On any failure after the swap begins,
     /// best-effort rollback renames the holds back into place and
     /// replays the pre-restore secret-store state.
+    // The phases share the rollback state they build up (the two holds, the
+    // staged config, the pre-restore secrets); splitting them into methods
+    // would thread all of it through signatures for no gain in clarity.
+    #[allow(clippy::too_many_lines)]
     async fn run_apply_import(
         &self,
         pending: &PendingImport,
@@ -377,7 +441,10 @@ impl BackupServiceImpl {
             phase: RestorePhase::Validating,
         })
         .await;
-        let staged_config = self.stage_config(&pending.contents.config_bytes).await?;
+        let restored_config = self
+            .config_bytes_for_restore(&pending.contents.config_bytes)
+            .await?;
+        let staged_config = self.stage_config(&restored_config).await?;
 
         // ---- Phase 2: move live files aside ----
         //

--- a/source/daemon/crates/wardnetd-services/src/backup/service.rs
+++ b/source/daemon/crates/wardnetd-services/src/backup/service.rs
@@ -55,7 +55,7 @@ use wardnet_common::backup::{
     BackupStatus, BundleManifest, CURRENT_BUNDLE_FORMAT_VERSION, LocalSnapshot, MIN_PASSPHRASE_LEN,
     RestorePhase, SnapshotKind,
 };
-use wardnet_common::config_restore::{self, ConfigRestoreError};
+use wardnet_common::config_restore;
 use wardnetd_data::database_dumper::DatabaseDumper;
 use wardnetd_data::db::restore_pending_marker_path;
 use wardnetd_data::repository::SystemConfigRepository;
@@ -221,12 +221,20 @@ impl BackupServiceImpl {
         Ok(out)
     }
 
-    /// Decide whether a freshly-unpacked manifest can be restored
-    /// against the running daemon.
+    /// Decide whether a freshly-unpacked bundle can be restored against the
+    /// running daemon.
+    ///
+    /// Covers the config as well as the manifest. A restore is followed by a
+    /// mandatory restart, so a bundle whose config this daemon cannot load
+    /// would take the box down with no UI left to fix it from — and finding
+    /// that out at `apply_import` is too late, because by then the operator
+    /// has already committed. Checking here means the preview says so while
+    /// nothing is at stake.
     async fn check_compat(
         &self,
-        manifest: &BundleManifest,
+        contents: &BundleContents,
     ) -> Result<(bool, Option<String>), AppError> {
+        let manifest = &contents.manifest;
         if !manifest.is_format_supported() {
             return Ok((
                 false,
@@ -247,6 +255,22 @@ impl BackupServiceImpl {
                 Some(format!(
                     "bundle schema version {} is newer than the running daemon's ({}) - upgrade the daemon first, then retry",
                     manifest.schema_version, running_schema
+                )),
+            ));
+        }
+        // Last, so a bundle from a newer build is told to upgrade the daemon
+        // rather than blamed for a config this one happens not to understand.
+        //
+        // That ordering only settles the cases where the newer build also
+        // moved the bundle format or the DB schema. A release that adds a
+        // config field on its own reaches here, and the bare serde message
+        // ("unknown field ...") reads as a corrupt bundle rather than a
+        // version gap — so the remedy is spelled out either way.
+        if let Err(e) = config_restore::check_bundle_config(&contents.config_bytes) {
+            return Ok((
+                false,
+                Some(format!(
+                    "{e} - if the bundle came from a newer Wardnet, upgrade the daemon first, then retry"
                 )),
             ));
         }
@@ -341,11 +365,8 @@ impl BackupServiceImpl {
     /// Called before anything on disk is touched, so a bundle carrying an
     /// unreadable config fails the restore rather than half-applying it.
     async fn config_bytes_for_restore(&self, bundle_config: &[u8]) -> Result<Vec<u8>, AppError> {
-        let bundle_toml = std::str::from_utf8(bundle_config).map_err(|e| {
-            AppError::BadRequest(format!(
-                "the config in the backup bundle is not valid UTF-8: {e}"
-            ))
-        })?;
+        let bundle_toml = config_restore::check_bundle_config(bundle_config)
+            .map_err(|e| AppError::BadRequest(e.to_string()))?;
         let live_toml = match tokio::fs::read_to_string(&self.config_path).await {
             Ok(contents) => contents,
             // No live config at all: every deploy-time key is at its
@@ -359,14 +380,16 @@ impl BackupServiceImpl {
             }
         };
 
-        let merged = config_restore::preserve_deploy_time_keys(&live_toml, bundle_toml).map_err(
-            |e| match e {
+        let merged =
+            config_restore::preserve_deploy_time_keys(&live_toml, bundle_toml).map_err(|e| {
                 // The bundle is caller-supplied, so a broken config in it is
                 // a bad request; a broken *live* config is our own problem.
-                ConfigRestoreError::BundleConfig(_) => AppError::BadRequest(e.to_string()),
-                other => AppError::Internal(anyhow::anyhow!(other)),
-            },
-        )?;
+                if e.blames_the_bundle() {
+                    AppError::BadRequest(e.to_string())
+                } else {
+                    AppError::Internal(anyhow::anyhow!(e))
+                }
+            })?;
 
         if !merged.overridden.is_empty() {
             let keys = merged.overridden.join(", ");
@@ -721,8 +744,7 @@ impl BackupService for BackupServiceImpl {
                 .await
                 .map_err(|e| AppError::BadRequest(format!("bundle could not be decrypted: {e}")))?;
 
-            let (compatible, incompatibility_reason) =
-                self.check_compat(&contents.manifest).await?;
+            let (compatible, incompatibility_reason) = self.check_compat(&contents).await?;
 
             let files_to_replace = vec![
                 self.database_path.display().to_string(),
@@ -786,7 +808,7 @@ impl BackupService for BackupServiceImpl {
             return Err(AppError::BadRequest("preview token has expired".into()));
         }
 
-        let (compatible, reason) = self.check_compat(&pending_entry.contents.manifest).await?;
+        let (compatible, reason) = self.check_compat(&pending_entry.contents).await?;
         if !compatible {
             let reason = reason.unwrap_or_else(|| "bundle is not compatible".into());
             self.set_status(BackupStatus::Failed {

--- a/source/daemon/crates/wardnetd-services/src/backup/tests/service.rs
+++ b/source/daemon/crates/wardnetd-services/src/backup/tests/service.rs
@@ -28,9 +28,28 @@ use wardnetd_data::repository::SystemConfigRepository;
 use wardnetd_data::secret_store::{FileSecretStore, SecretStore};
 
 use crate::auth_context;
-use crate::backup::archiver::{AgeArchiver, BackupArchiver};
+use crate::backup::archiver::{AgeArchiver, BackupArchiver, BundleContents};
 use crate::backup::service::{BACKUP_RESTART_PENDING_KEY, BackupService, BackupServiceImpl};
 use crate::error::AppError;
+
+/// Live config the harness plants on disk.
+///
+/// Real TOML, because `apply_import` parses it to carry deploy-time-only
+/// keys across a restore — and because a fixture that could never exist on
+/// a real box would hide that step from every test here. `allow_edge_channel`
+/// is set the way `install.sh` writes it for a box installed from the edge
+/// channel: opted in, with root, on this machine.
+const LIVE_CONFIG: &str = "\
+[network]
+lan_interface = \"eth0\"
+
+[logging]
+level = \"info\"
+
+[update]
+allow_edge_channel = true
+manifest_base_url = \"https://releases.wardnet.network\"
+";
 
 // ---------------------------------------------------------------------------
 // Mocks
@@ -159,7 +178,7 @@ fn build_harness_at(schema_version: i64, config_location: ConfigLocation) -> Har
     // Pre-populate the live files so apply_import has something to
     // rename — tests that don't touch apply_import don't care.
     std::fs::write(&database_path, b"live db").unwrap();
-    std::fs::write(&config_path, b"live config").unwrap();
+    std::fs::write(&config_path, LIVE_CONFIG).unwrap();
 
     let dumper = Arc::new(MockDumper {
         dump_bytes: b"snapshot bytes".to_vec(),
@@ -309,8 +328,8 @@ async fn round_trip_export_preview_apply() {
 
     // Live files were rewritten.
     assert_eq!(
-        tokio::fs::read(&h.config_path).await.unwrap(),
-        b"live config",
+        tokio::fs::read_to_string(&h.config_path).await.unwrap(),
+        LIVE_CONFIG,
         "config should match the exported content"
     );
     assert!(
@@ -768,7 +787,7 @@ async fn apply_import_rolls_back_and_leaves_no_restore_marker_on_failure() {
     let database_path = tempdir.join("wardnet.db");
     let config_path = tempdir.join("wardnet.toml");
     std::fs::write(&database_path, b"live db").unwrap();
-    std::fs::write(&config_path, b"live config").unwrap();
+    std::fs::write(&config_path, LIVE_CONFIG).unwrap();
 
     let secret_store: Arc<dyn SecretStore> = Arc::new(FileSecretStore::new(tempdir.join("sec")));
     let svc = BackupServiceImpl::new(
@@ -818,6 +837,179 @@ async fn apply_import_rolls_back_and_leaves_no_restore_marker_on_failure() {
     assert!(
         !restore_pending_marker_path(&database_path).exists(),
         "no restore-pending marker should remain after a rolled-back apply"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Deploy-time-only config keys (issue #1112)
+//
+// Restore writes /etc/wardnet/wardnet.toml, and the systemd unit grants
+// ReadWritePaths=/etc/wardnet so the write lands. An admin session can
+// therefore export a bundle, edit the TOML it contains (the passphrase is
+// theirs), and restore it — which would otherwise be a way around the
+// `[update] allow_edge_channel` gate that ADR-0023 says takes root *on the
+// box*. The classification itself is tested in wardnet-common; these tests
+// pin that apply_import actually applies it.
+// ---------------------------------------------------------------------------
+
+/// Pack a bundle whose config is `config` rather than the live machine's —
+/// what an admin gets by unpacking their own export, editing the TOML, and
+/// repacking it.
+async fn bundle_with_config(config: &str, passphrase: &str, schema_version: i64) -> Vec<u8> {
+    AgeArchiver::new()
+        .pack(
+            passphrase,
+            BundleContents {
+                manifest: BundleManifest::new("0.2.0-test", schema_version, "test-host", 0),
+                database_bytes: b"snapshot bytes".to_vec(),
+                config_bytes: config.as_bytes().to_vec(),
+                secrets: Vec::new(),
+            },
+        )
+        .await
+        .unwrap()
+}
+
+/// Preview and apply `bundle`, returning the config left on disk.
+async fn apply_and_read_config(h: &Harness, bundle: Vec<u8>, passphrase: &str) -> String {
+    let preview = auth_context::with_context(
+        admin_ctx(),
+        h.svc.preview_import(bundle, passphrase.to_owned()),
+    )
+    .await
+    .unwrap();
+    auth_context::with_context(
+        admin_ctx(),
+        h.svc.apply_import(ApplyImportRequest {
+            preview_token: preview.preview_token,
+        }),
+    )
+    .await
+    .unwrap();
+    tokio::fs::read_to_string(&h.config_path).await.unwrap()
+}
+
+#[tokio::test]
+async fn apply_import_keeps_the_live_value_of_deploy_time_keys() {
+    let h = build_harness(42);
+    let passphrase = "correct-horse-battery-staple";
+
+    // The live box has the gate open and points at the real release server.
+    // The bundle tries to flip both, plus repoint the secret store.
+    let bundle = bundle_with_config(
+        "[network]\nlan_interface = \"eth0\"\n\n\
+         [update]\nallow_edge_channel = false\nmanifest_base_url = \"https://attacker.example\"\n\n\
+         [secret_store]\nprovider = \"file_system\"\npath = \"/tmp/attacker\"\n",
+        passphrase,
+        42,
+    )
+    .await;
+
+    let written: toml::Table = apply_and_read_config(&h, bundle, passphrase)
+        .await
+        .parse()
+        .unwrap();
+
+    assert_eq!(
+        written["update"]["allow_edge_channel"].as_bool(),
+        Some(true),
+        "a bundle must not change the edge gate",
+    );
+    assert_eq!(
+        written["update"]["manifest_base_url"].as_str(),
+        Some("https://releases.wardnet.network"),
+        "a bundle must not repoint the update source",
+    );
+    assert!(
+        written.get("secret_store").is_none(),
+        "the live machine has no [secret_store], so the bundle's must not survive: {written:?}",
+    );
+}
+
+#[tokio::test]
+async fn apply_import_cannot_open_the_edge_gate_on_a_box_that_never_had_it() {
+    // The direction that matters: the live config leaves the gate at its
+    // default (absent), and the bundle tries to open it.
+    let h = build_harness(42);
+    let passphrase = "correct-horse-battery-staple";
+    tokio::fs::write(&h.config_path, "[logging]\nlevel = \"info\"\n")
+        .await
+        .unwrap();
+
+    let bundle = bundle_with_config(
+        "[logging]\nlevel = \"info\"\n\n[update]\nallow_edge_channel = true\n",
+        passphrase,
+        42,
+    )
+    .await;
+
+    let written: toml::Table = apply_and_read_config(&h, bundle, passphrase)
+        .await
+        .parse()
+        .unwrap();
+    assert!(
+        written.get("update").is_none(),
+        "the bundle's [update] section must not survive the restore: {written:?}",
+    );
+}
+
+#[tokio::test]
+async fn apply_import_still_restores_ordinary_config_from_the_bundle() {
+    let h = build_harness(42);
+    let passphrase = "correct-horse-battery-staple";
+
+    let bundle = bundle_with_config(
+        "[logging]\nlevel = \"debug\"\n\n[detection]\nenabled = false\n",
+        passphrase,
+        42,
+    )
+    .await;
+
+    let written: toml::Table = apply_and_read_config(&h, bundle, passphrase)
+        .await
+        .parse()
+        .unwrap();
+    assert_eq!(written["logging"]["level"].as_str(), Some("debug"));
+    assert_eq!(written["detection"]["enabled"].as_bool(), Some(false));
+}
+
+#[tokio::test]
+async fn apply_import_rejects_a_bundle_whose_config_is_not_toml() {
+    // The merge runs before anything on disk is touched, so an unusable
+    // config fails the restore outright rather than half-applying it.
+    let h = build_harness(42);
+    let passphrase = "correct-horse-battery-staple";
+    let bundle = bundle_with_config("this is not toml", passphrase, 42).await;
+
+    let preview = auth_context::with_context(
+        admin_ctx(),
+        h.svc.preview_import(bundle, passphrase.to_owned()),
+    )
+    .await
+    .unwrap();
+    let err = auth_context::with_context(
+        admin_ctx(),
+        h.svc.apply_import(ApplyImportRequest {
+            preview_token: preview.preview_token,
+        }),
+    )
+    .await
+    .unwrap_err();
+
+    assert!(matches!(err, AppError::BadRequest(_)), "got {err:?}");
+    assert_eq!(
+        tokio::fs::read_to_string(&h.config_path).await.unwrap(),
+        LIVE_CONFIG,
+        "the live config should be untouched",
+    );
+    assert_eq!(
+        tokio::fs::read(&h.database_path).await.unwrap(),
+        b"live db",
+        "the live database should be untouched",
+    );
+    assert!(
+        h.dumper.restored.lock().unwrap().is_none(),
+        "the restore should have failed before touching the database",
     );
 }
 

--- a/source/daemon/crates/wardnetd-services/src/backup/tests/service.rs
+++ b/source/daemon/crates/wardnetd-services/src/backup/tests/service.rs
@@ -974,6 +974,76 @@ async fn apply_import_still_restores_ordinary_config_from_the_bundle() {
 }
 
 #[tokio::test]
+async fn apply_import_onto_a_box_with_no_config_file_falls_back_to_defaults() {
+    // A box that never had a config file has every deploy-time key at its
+    // compiled-in default, and those defaults are what the bundle must be
+    // held to — not the bundle's own values.
+    let h = build_harness(42);
+    let passphrase = "correct-horse-battery-staple";
+    tokio::fs::remove_file(&h.config_path).await.unwrap();
+
+    let bundle = bundle_with_config(
+        "[logging]\nlevel = \"debug\"\n\n[update]\nallow_edge_channel = true\n",
+        passphrase,
+        42,
+    )
+    .await;
+
+    let written: toml::Table = apply_and_read_config(&h, bundle, passphrase)
+        .await
+        .parse()
+        .unwrap();
+    assert!(
+        written.get("update").is_none(),
+        "the gate must stay at its default on a box that never opened it: {written:?}",
+    );
+    assert_eq!(
+        written["logging"]["level"].as_str(),
+        Some("debug"),
+        "ordinary settings should still restore",
+    );
+}
+
+#[tokio::test]
+async fn apply_import_fails_closed_when_the_live_config_is_unreadable() {
+    // With no live values to read, letting the bundle's copy through would
+    // hand it every deploy-time key. The machine is what is wrong here, not
+    // the bundle, so this is an internal error rather than a rejected upload.
+    let h = build_harness(42);
+    let passphrase = "correct-horse-battery-staple";
+    tokio::fs::write(&h.config_path, "this is not toml")
+        .await
+        .unwrap();
+
+    let bundle = bundle_with_config("[update]\nallow_edge_channel = true\n", passphrase, 42).await;
+    let preview = auth_context::with_context(
+        admin_ctx(),
+        h.svc.preview_import(bundle, passphrase.to_owned()),
+    )
+    .await
+    .unwrap();
+    let err = auth_context::with_context(
+        admin_ctx(),
+        h.svc.apply_import(ApplyImportRequest {
+            preview_token: preview.preview_token,
+        }),
+    )
+    .await
+    .unwrap_err();
+
+    assert!(matches!(err, AppError::Internal(_)), "got {err:?}");
+    assert_eq!(
+        tokio::fs::read_to_string(&h.config_path).await.unwrap(),
+        "this is not toml",
+        "the live config should be untouched",
+    );
+    assert!(
+        h.dumper.restored.lock().unwrap().is_none(),
+        "the restore should have failed before touching the database",
+    );
+}
+
+#[tokio::test]
 async fn preview_import_reports_a_config_this_daemon_cannot_load() {
     // A restore is followed by a mandatory restart, so a bundle carrying a
     // config the daemon cannot parse would take the box down with no UI left

--- a/source/daemon/crates/wardnetd-services/src/backup/tests/service.rs
+++ b/source/daemon/crates/wardnetd-services/src/backup/tests/service.rs
@@ -974,8 +974,47 @@ async fn apply_import_still_restores_ordinary_config_from_the_bundle() {
 }
 
 #[tokio::test]
+async fn preview_import_reports_a_config_this_daemon_cannot_load() {
+    // A restore is followed by a mandatory restart, so a bundle carrying a
+    // config the daemon cannot parse would take the box down with no UI left
+    // to fix it from. The operator has to learn that at preview, while
+    // nothing is at stake — not after committing to the apply.
+    let h = build_harness(42);
+    let passphrase = "correct-horse-battery-staple";
+
+    for broken in [
+        "this is not toml",
+        "[from_the_future]\nknob = 1\n",
+        "[server]\nport = \"not a number\"\n",
+    ] {
+        let bundle = bundle_with_config(broken, passphrase, 42).await;
+        let preview = auth_context::with_context(
+            admin_ctx(),
+            h.svc.preview_import(bundle, passphrase.to_owned()),
+        )
+        .await
+        .unwrap();
+
+        assert!(!preview.compatible, "{broken:?} previewed as compatible");
+        let reason = preview.incompatibility_reason.expect("reason populated");
+        assert!(
+            reason.contains("config"),
+            "reason should name the config: {reason}",
+        );
+        // A newer release can add a config field without touching the bundle
+        // format or the DB schema, so this branch also catches version gaps
+        // the manifest checks above cannot see. Say what to do about it.
+        assert!(
+            reason.contains("upgrade the daemon"),
+            "reason should name the remedy: {reason}",
+        );
+    }
+}
+
+#[tokio::test]
 async fn apply_import_rejects_a_bundle_whose_config_is_not_toml() {
-    // The merge runs before anything on disk is touched, so an unusable
+    // Belt and braces behind the preview check: apply re-runs compat, and
+    // the merge runs before anything on disk is touched, so an unusable
     // config fails the restore outright rather than half-applying it.
     let h = build_harness(42);
     let passphrase = "correct-horse-battery-staple";

--- a/source/marketing-site/content/docs/configuration.md
+++ b/source/marketing-site/content/docs/configuration.md
@@ -309,6 +309,11 @@ health — restores from the bundle as you would expect. If a bundle did
 carry different values for any of the keys above, the daemon logs which
 ones it kept at their live values.
 
+A restore also refuses a bundle whose config this daemon cannot read at all
+— an unknown section, a mistyped value — and says so at the preview step,
+before you commit to it. Restoring one would write cleanly and then leave
+the daemon unable to start after the restart a restore requires.
+
 ## Environment variable overrides
 
 Two runtime overrides are honoured independent of the TOML:

--- a/source/marketing-site/content/docs/configuration.md
+++ b/source/marketing-site/content/docs/configuration.md
@@ -285,6 +285,30 @@ pet is never health-gated.
 | --- | --- | --- |
 | `pidfile_path` | `"/run/wardnetd/wardnetd.pid"` | Where the daemon writes its PID file. Not part of any `[section]`. |
 
+## Keys a backup restore will not change
+
+Restoring a backup bundle replaces this file with the copy inside the
+bundle — except for the keys that describe the *machine* rather than your
+settings. Those are always taken from the box you are restoring onto:
+
+- **The update path** — every key in `[update]`. A bundle cannot open
+  `allow_edge_channel`, repoint `manifest_base_url`, or turn off
+  `require_signature`. Opting a box into the edge channel takes root on
+  that box, and a restore is not root.
+- **File locations** — `[database]`, `[secret_store]`, `logging.path`,
+  `pidfile_path`. These are pinned by the systemd sandbox; a bundle from a
+  differently-laid-out box would point the daemon at paths it cannot write.
+- **Hardware** — `network.lan_interface`, `watchdog.enabled`,
+  `watchdog.device_path`. Your NIC is not the same NIC as the box the
+  bundle came from.
+- **Test-harness overrides** — `[test]`, `vpn_providers.nordvpn_api_url`,
+  `[ddns_wardnet]`. Never set on a real deployment.
+
+Everything else — log level, tunnel tuning, detection, telemetry, mDNS,
+health — restores from the bundle as you would expect. If a bundle did
+carry different values for any of the keys above, the daemon logs which
+ones it kept at their live values.
+
 ## Environment variable overrides
 
 Two runtime overrides are honoured independent of the TOML:


### PR DESCRIPTION
Closes #1112.

## The hole

`apply_import` replaces `/etc/wardnet/wardnet.toml` wholesale, and #1111 added `ReadWritePaths=/etc/wardnet` so that write lands on real hardware. That puts the config file within reach of an admin session: export a bundle, unpack it with your own passphrase, edit the TOML, repack, preview, apply, restart.

`[update] allow_edge_channel` is exactly what must stay out of that reach — ADR-0023 makes putting a box on the edge channel take root *on that box*. `manifest_base_url` is the same shape and more practically harmful: repoint it at a server that never publishes a release and the box silently stops patching itself while the UI still reports a healthy, up-to-date state.

## The fix

`wardnet_common::config_restore::preserve_deploy_time_keys` merges the bundle's config over the live one, taking every key in `DEPLOY_TIME_ONLY_KEYS` from the **live machine**. A bundle restores your data and settings, never the deployment posture of the machine it lands on.

Four things put a key on that list, rather than special-casing the edge gate:

| Group | Keys | Why |
| --- | --- | --- |
| Update path | all of `[update]` | Which builds this box installs and whether it checks at all. A one-second `http_timeout_secs` denies patching as effectively as a dead `manifest_base_url`. |
| Sandboxed file locations | `[database]`, `[secret_store]`, `logging.path`, `pidfile_path` | The daemon can only write what `wardnetd.service` grants; repointing the log file fails silently. |
| Hardware identity | `network.lan_interface`, `watchdog.enabled`/`device_path` | Describes the machine, not the user's preferences. |
| Test-harness overrides | `[test]`, `vpn_providers.nordvpn_api_url`, `[ddns_wardnet]` | Each redirects the daemon at a mock — from a bundle, a way to point a live box at a server the attacker controls. |

Two judgement calls: `otel.*` and `[admin]` stay **restorable**. Neither grants anything an admin session doesn't already have — admin can read the live log stream, and can create an admin through the API — so they are user settings, not posture.

### Merge properties

- **Untyped** (`toml::Table`, never `ApplicationConfiguration`) so the restored file keeps the shape the operator wrote, instead of becoming a dump of every defaulted field.
- **Verbatim when nothing changes.** Re-serialising loses comments, and `install.sh` writes several — so that cost is only paid when a deploy-time key actually differs, which on the restore-onto-the-same-box path it never does.
- **Compared on effective values.** An absent key still has a value — its default — so a bundle spelling out `allow_edge_channel = false` where the live file omits it is correctly not a change, rather than a re-serialisation plus a tamper-suggesting log line.
- Runs in phase 1 of `run_apply_import`, before anything on disk is touched. Any key it had to discard is logged by name.

### Loadability

`ApplicationConfiguration` is `deny_unknown_fields` and a restore is followed by a mandatory restart, so a bundle carrying an unknown section would write cleanly and then leave the daemon failing to start with no UI left to fix it from. `check_bundle_config` runs as part of `check_compat`, so the **preview** reports it — before the operator commits — and the merged result is re-checked before it is written.

Scoped honestly: that is a check on shape, not values. A config can deserialise and still hold `[health] refresh_interval_secs = 0`, which panics the tick loop. Nothing here rules that out, because it is the same hazard any hand-edited config carries and the fix belongs with the fields themselves. What restore guarantees is narrower: it will not write a file this daemon cannot **parse**.

## Coverage

24 tests in `wardnet-common`, 40 in `wardnetd-services::backup` (4 new, packing a tampered bundle with `AgeArchiver` directly).

The classification guard — issue acceptance criterion 4 — reads **serde's own field lists** via the `deny_unknown_fields` rejection message rather than enumerating a serialised sample. `toml` omits an `Option` that is `None`, so a sample would hide any optional machine-scoped key; the three `ddns_wardnet` overrides are exactly that shape and are now covered. Adding a config field without classifying it fails `every_config_key_is_classified`; verified by removing a key and watching it fail.

Two changes that weren't strictly required. The service-test fixture moved from `b"live config"` to real TOML — restore parses it now, and a fixture that could never exist on a real box would have hidden that step from every test in the file. And `run_apply_import` picked up `#[allow(clippy::too_many_lines)]`: its phases share the rollback state they build up, so splitting them would thread all of it through signatures for no gain; that matches how the rest of the crate handles the lint.

## Not done

No e2e coverage of "switch to edge after a tampered restore returns 403" — that would mean repacking an age bundle in TypeScript inside the compose stack. The gate itself already has unit coverage, and the config-file assertion is the link this change is responsible for.

`make check-daemon` passes locally.

Docs updated: `.agents/backup.md`, ADR-0023's Gate section, and the public configuration page.

---
_Generated by [Claude Code](https://claude.ai/code/session_01K4UCL36Gbw1GNPeRBayFG5)_