### PR TITLE
fix(release): repair both SDK publish paths and tag-drive the Go SDK

### DIFF
--- a/.agents/skills/release-prep/SKILL.md
+++ b/.agents/skills/release-prep/SKILL.md
@@ -39,13 +39,17 @@ after merge). Everything else is mechanical.
   version of `sync-version` did write this `package.json`, which is
   how it once drifted ahead of what npm actually had.
 - **`source/sdk/wardnet-go/VERSION`** — SemVer for the Go module
-  `wardnet.network/go`. Unlike the JS SDK, this one **publishes off
-  the daemon tag**: `release.yml` calls `release-go-sdk.yml` after
-  `release-daemon`, which mirrors `source/sdk/wardnet-go` to
-  `wardnet/wardnet-go` and tags it `v<that VERSION>`. Stable tags
-  only — prereleases and edge builds are skipped. If the version is
-  already published on the mirror the job no-ops, so a stale VERSION
-  means the release silently ships no new Go SDK.
+  `wardnet.network/go`. Same shape as the JS SDK: published by
+  pushing a **`wardnet-go@x.y.z`** tag (`release-go-sdk.yml`), *not*
+  by the daemon tag. The job asserts the tag matches this file, and
+  refuses a version already on the mirror — those tags are immutable,
+  because the Go checksum database pins a version's hash the first
+  time anyone fetches it.
+
+**Neither SDK rides the daemon tag.** `v<CALVER>` publishes the
+daemon, its image and the site; each SDK needs its own tag push. A
+release PR that bumps an SDK without saying so leaves a package
+unpublished with nobody tracking it.
 
 For a typical point release: bump `CALVER` to the next free counter
 slot in the current month (e.g. `2026.05.00` → `2026.05.01`) and
@@ -63,8 +67,9 @@ npm view @wardnet/js version                         # what npm actually has
 ```
 
 **Go SDK** — if the diff has user-visible changes, bump
-`source/sdk/wardnet-go/VERSION` *in this PR*. The daemon tag will
-publish whatever is in that file, so this is the last chance.
+`source/sdk/wardnet-go/VERSION` in this PR, then push a matching
+`wardnet-go@x.y.z` tag after merge (Step 7b). Bumping the file alone
+publishes nothing.
 
 **JS SDK** — if `source/.changeset/` holds unconsumed changesets, the
 package is due a release. Consuming them is `yarn changeset version`
@@ -269,9 +274,8 @@ PR body should:
   release-notes doc.
 - Surface any action-required upgrade note prominently, so reviewers
   don't miss it during review.
-- State what each SDK does on merge: the Go SDK version this tag will
-  publish (or that it will no-op), and whether a separate
-  `@wardnet/js@x.y.z` tag push is still owed.
+- State which SDK tags are still owed after merge, and at what
+  versions. Neither SDK is published by the daemon tag.
 - List the test plan: `make check-version`, `make check-openapi`,
   `make check-sdk-openapi`, `make check-go-openapi`, `make check-daemon`
   all green.
@@ -304,28 +308,40 @@ What the tag triggers (`.github/workflows/release.yml` watches
 - `deploy-site.yml` regenerates `releases/stable.json` and
   `releases/beta.json` so auto-update clients pick up the new
   version on their next manifest poll.
-- `release-go-sdk.yml` (stable tags only, after `release-daemon`)
-  mirrors `source/sdk/wardnet-go` to `wardnet/wardnet-go` and tags it
-  `v<source/sdk/wardnet-go/VERSION>`. Mirror tags are immutable and
-  `main` there is force-pushed — never commit to the mirror.
+Neither SDK is published here — see Step 7b.
 
 Watch the workflow run; if any step fails, do not retry blindly — a
 failed publish can land partial assets that auto-update will then
 try to verify and reject.
 
-### Step 7b — the JS SDK tag, if one is owed
+### Step 7b — the SDK tags, for whichever are owed
 
-`@wardnet/js` is **not** published by the daemon tag. If this release
-consumed changesets, push its tag after the daemon release is green:
+Each SDK publishes on its own tag, after the daemon release is green.
+Both jobs verify the tag against the committed version and refuse a
+version that is already published, so a mismatch fails loudly rather
+than shipping the wrong thing.
 
 ```sh
+# npm — must match source/sdk/wardnet-js/package.json on main
 git tag -s '@wardnet/js@<x.y.z>' -m '@wardnet/js@<x.y.z>'
 git push origin '@wardnet/js@<x.y.z>'
+
+# Go — must match source/sdk/wardnet-go/VERSION on main
+git tag -s 'wardnet-go@<x.y.z>' -m 'wardnet-go@<x.y.z>'
+git push origin 'wardnet-go@<x.y.z>'
 ```
 
-The version in the tag must match `source/sdk/wardnet-js/package.json`
-on `main`. `release-sdk.yml` publishes to npmjs.org via OIDC trusted
-publishing — there is no token to supply.
+`release-sdk.yml` publishes to npmjs.org via OIDC trusted publishing —
+no token to supply. `release-go-sdk.yml` mirrors `source/sdk/wardnet-go`
+to `wardnet/wardnet-go` and tags it `v<x.y.z>` there (Go requires that
+shape at the module root). Mirror tags are immutable and its `main` is
+force-pushed — never commit to the mirror.
+
+Both publish paths are only ever exercised by a real tag push. Watch
+each run to completion rather than assuming: a failed npm publish still
+writes a permanent entry to the public sigstore transparency log, and a
+failed mirror push can leave the module unpublished while the daemon
+release looks entirely green.
 
 ## Common pitfalls
 
@@ -347,10 +363,16 @@ publishing — there is no token to supply.
 - **Regenerating the spec but not the two clients that are generated
   from it.** `check-sdk-openapi` and `check-go-openapi` are separate
   CI gates on separate files, and each fails on its own.
-- **Assuming the daemon tag publishes both SDKs.** It publishes the Go
-  module and nothing else. `@wardnet/js` needs its own tag, and a
-  release PR that bumps it without saying so leaves the npm package
-  unpublished with no one tracking it.
+- **Assuming the daemon tag publishes an SDK.** It publishes neither.
+  Each needs its own tag push, and a release PR that bumps an SDK
+  version without saying so leaves a package unpublished with nobody
+  tracking it. `v2026.08.00` shipped with both SDKs unpublished for
+  exactly this reason.
+- **Calling a release done because the daemon release is green.** The
+  SDK publish jobs run on separate tags, so their failures are not
+  visible from the release run at all. Check what actually landed:
+  `npm view @wardnet/js version` and
+  `gh api repos/wardnet/wardnet-go/tags --jq '.[].name'`.
 - **Hand-editing `source/sdk/wardnet-js/package.json`.** Changesets
   owns it. A hand bump produces a version with no changelog entry and
   no published tag behind it, and the *next* `changeset version` builds

--- a/.github/workflows/release-go-sdk.yml
+++ b/.github/workflows/release-go-sdk.yml
@@ -17,18 +17,39 @@ name: Release Go SDK
 # and pull requests are all disabled on it, and `main` is force-pushed here on
 # every release. Never commit to it directly.
 #
-# Stable releases only. Prereleases (beta, edge) are skipped deliberately —
-# publishing them would put versions into the module space that consumers can
-# select, and edge tags are cut from arbitrary branches.
-
-# Takes no version input on purpose: the SDK is versioned by
-# source/sdk/wardnet-go/VERSION, independently of the daemon's CalVer. Passing
-# the daemon tag in is what produced a module version Go cannot resolve.
+# Driven by its own tag namespace, mirroring how @wardnet/js publishes on
+# `@wardnet/js@x.y.z`. NOT `v*.*.*` — that is the daemon's namespace, and a
+# CalVer tag like v2026.08.00 is major 2026, which Go would require the module
+# path to end in `/v2026` to resolve. The SDK's version is its own semver and
+# has to stay that way; a separate namespace is what keeps the two apart.
+#
+# This used to hang off the daemon's release as a `workflow_call`, reading the
+# version from source/sdk/wardnet-go/VERSION with no tag of its own. That
+# conflated "a daemon release happened" with "the SDK has something to ship":
+# forgetting to bump VERSION published nothing while the release still went
+# green (a ::notice:: in a job log is not a gate), an SDK-only fix could not
+# ship without cutting a daemon release, and a VERSION bump merged today
+# detonated at whatever the next daemon tag turned out to be. A tag is the
+# deliberate act that authorising a publish deserves.
+#
+# Stable releases only. There is no prerelease path: publishing one would put a
+# version into the module space that consumers can select, and Go's checksum
+# database pins it permanently on first fetch.
+#
+# `workflow_dispatch` validates everything except the publish itself.
 on:
-  workflow_call:
+  push:
+    tags:
+      - "wardnet-go@*.*.*"
+  workflow_dispatch:
 
 permissions:
   contents: read
+
+# Mirror pushes are force-pushes and tags are immutable; never run two at once.
+concurrency:
+  group: release-go-sdk-publish
+  cancel-in-progress: false
 
 jobs:
   mirror:
@@ -107,12 +128,29 @@ jobs:
             exit 1
           fi
 
+          # VERSION stays the source of truth (it is what the major-suffix
+          # tripwire above reads); the tag has to agree with it, exactly as
+          # @wardnet/js requires its tag to match package.json. Checking rather
+          # than deriving means the tag cannot quietly publish a version the
+          # committed tree does not claim.
+          if [[ "${GITHUB_REF}" == refs/tags/* ]]; then
+            TAG_VERSION="${GITHUB_REF#refs/tags/wardnet-go@}"
+            if [[ "${TAG_VERSION}" != "${SDK_VERSION}" ]]; then
+              echo "::error::tag is wardnet-go@${TAG_VERSION} but source/sdk/wardnet-go/VERSION says ${SDK_VERSION}. Bump the file and re-tag."
+              exit 1
+            fi
+          fi
+
           echo "version=${SDK_VERSION}" >> "$GITHUB_OUTPUT"
           echo "tag=v${SDK_VERSION}" >> "$GITHUB_OUTPUT"
           echo "publishing wardnet.network/go@v${SDK_VERSION} (module ${MODULE})"
 
+      # Everything above runs on workflow_dispatch as a dry validation — build,
+      # tests, version and module-path checks. Only this step needs a tag,
+      # mirroring release-sdk.yml's gate on the npm publish.
       - name: Split, push, and tag
         id: publish
+        if: startsWith(github.ref, 'refs/tags/wardnet-go@')
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           SDK_TAG: ${{ steps.sdk.outputs.tag }}
@@ -137,9 +175,14 @@ jobs:
           set -e
           case "${LS_STATUS}" in
             0)
-              echo "::notice::${SDK_TAG} is already published — source/sdk/wardnet-go/VERSION was not bumped, so this release ships no new SDK version."
-              echo "published=false" >> "$GITHUB_OUTPUT"
-              exit 0
+              # A hard failure now that a tag is what triggers this. Under the
+              # old daemon-release trigger, re-seeing a published version was
+              # the ordinary case (every release re-ran the job) and a notice
+              # was right. Pushing wardnet-go@x.y.z for a version already on
+              # the mirror is instead a mistake, and one that cannot be
+              # satisfied: the tag is immutable.
+              echo "::error::${SDK_TAG} is already published on the mirror and release tags are immutable. Bump source/sdk/wardnet-go/VERSION and tag the new version."
+              exit 1
               ;;
             2) ;;  # reachable, tag absent — proceed to publish
             *)

--- a/.github/workflows/release-go-sdk.yml
+++ b/.github/workflows/release-go-sdk.yml
@@ -43,9 +43,19 @@ jobs:
 
       # Full history: `git subtree split` has to walk every commit that
       # touched the prefix, and a shallow clone silently truncates it.
+      #
+      # `persist-credentials: false` because checkout otherwise writes
+      # `http.https://github.com/.extraheader` with an Authorization header
+      # for GITHUB_TOKEN, and that header wins over the userinfo in a push
+      # URL. The mirror push below embeds an app token in its URL, so with
+      # credentials persisted it authenticated as github-actions[bot] —
+      # which has no access to wardnet-go — and 403'd. Nothing in this job
+      # needs the checkout's credentials: `git subtree split` is entirely
+      # local, and every remote operation supplies its own token.
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       # GITHUB_TOKEN is scoped to this repository and cannot push to another
       # one. wardnet-infra-bot is installed org-wide with contents:write.
@@ -114,11 +124,29 @@ jobs:
           # Go checksum database pins a version's hash on first fetch, so
           # re-tagging breaks verification for every consumer instead of
           # updating them. A ruleset on the mirror enforces this too.
-          if git ls-remote --exit-code --tags "${MIRROR}" "refs/tags/${SDK_TAG}" >/dev/null 2>&1; then
-            echo "::notice::${SDK_TAG} is already published — source/sdk/wardnet-go/VERSION was not bumped, so this release ships no new SDK version."
-            echo "published=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
+          #
+          # Exit codes are separated rather than collapsed with `if`. Both a
+          # missing tag and an auth failure are non-zero, so treating any
+          # non-zero as "not published yet" turns a 403 into a green light —
+          # which is exactly how the auth bug above stayed invisible until
+          # the push failed. 0 = tag exists, 2 = ran fine and found nothing,
+          # anything else = the query itself failed and we must not guess.
+          set +e
+          git ls-remote --exit-code --tags "${MIRROR}" "refs/tags/${SDK_TAG}" >/dev/null
+          LS_STATUS=$?
+          set -e
+          case "${LS_STATUS}" in
+            0)
+              echo "::notice::${SDK_TAG} is already published — source/sdk/wardnet-go/VERSION was not bumped, so this release ships no new SDK version."
+              echo "published=false" >> "$GITHUB_OUTPUT"
+              exit 0
+              ;;
+            2) ;;  # reachable, tag absent — proceed to publish
+            *)
+              echo "::error::Could not query the mirror for ${SDK_TAG} (git ls-remote exit ${LS_STATUS}). Refusing to publish without knowing whether the tag already exists."
+              exit 1
+              ;;
+          esac
 
           # Rewrites the subdirectory's history into commits rooted at the SDK.
           SPLIT=$(git subtree split --prefix=source/sdk/wardnet-go)

--- a/.github/workflows/release-sdk.yml
+++ b/.github/workflows/release-sdk.yml
@@ -66,6 +66,29 @@ jobs:
         working-directory: source
         run: yarn workspace @wardnet/js build
 
+      # Deliberately not gated on the tag ref: workflow_dispatch is meant to
+      # validate a publish without performing one, and this is exactly the
+      # kind of thing it should catch.
+      #
+      # `--provenance` makes the registry cross-check the attestation against
+      # the package, and npm rejects the upload with E422 unless
+      # `repository.url` matches the repository the build came from. That
+      # check happens registry-side, AFTER npm has signed the provenance
+      # statement and written it to the public Rekor transparency log — so a
+      # missing field costs a permanent public log entry for a version that
+      # never published. Fail before anything is signed instead.
+      - name: Verify the metadata npm will check the provenance against
+        working-directory: source/sdk/wardnet-js
+        run: |
+          set -euo pipefail
+          URL="$(node -p "require('./package.json').repository?.url ?? ''")"
+          EXPECTED="git+https://github.com/${GITHUB_REPOSITORY}.git"
+          if [[ "${URL}" != "${EXPECTED}" ]]; then
+            echo "::error::package.json repository.url is '${URL}', expected '${EXPECTED}'. npm publish --provenance would fail with E422."
+            exit 1
+          fi
+          echo "repository.url = ${URL}"
+
       - name: Publish to npmjs.org
         if: startsWith(github.ref, 'refs/tags/@wardnet/js@')
         working-directory: source/sdk/wardnet-js

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -264,22 +264,12 @@ jobs:
       prerelease: ${{ fromJSON(needs.resolve.outputs.prerelease) }}
     secrets: inherit
 
-  release-go-sdk:
-    name: Release Go SDK
-    # After release-daemon: if publishing the release itself fails, the SDK
-    # mirror should not carry a version that has no release behind it. Tags on
-    # the mirror are immutable, so an over-eager publish cannot be undone.
-    needs: [resolve, release-daemon]
-    # Stable tags only. Prereleases would occupy versions in the module space
-    # that consumers can resolve, and edge builds are cut from arbitrary
-    # branches (ADR-0023).
-    if: >
-      startsWith(github.ref, 'refs/tags/v') &&
-      needs.resolve.outputs.prerelease != 'true'
-    permissions:
-      contents: read
-    uses: ./.github/workflows/release-go-sdk.yml
-    secrets: inherit
+  # The Go SDK is NOT released from here. It publishes on its own
+  # `wardnet-go@x.y.z` tag (.github/workflows/release-go-sdk.yml), the same
+  # shape as @wardnet/js. Hanging it off this workflow conflated "a daemon
+  # release happened" with "the SDK has something to ship": an unbumped
+  # VERSION published nothing while the release still went green, and an
+  # SDK-only fix could not ship without cutting a daemon release.
 
   release-image:
     name: Release Image

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -187,7 +187,7 @@ root-path from the module path, so a module named `wardnet.network/go` has to
 sit at the *root* of the repository it is fetched from — a subdirectory of this
 monorepo cannot be named. So `release-go-sdk.yml` force-pushes
 `source/sdk/wardnet-go` to [wardnet/wardnet-go](https://github.com/wardnet/wardnet-go)
-with `git subtree split` on every stable release, and
+with `git subtree split` on every SDK release, and
 `source/marketing-site/public/go/index.html` serves the meta tag pointing there.
 
 That mirror is generated and read-only — issues, wiki, projects, discussions,
@@ -195,9 +195,14 @@ and pull requests are all disabled on it, and its `main` is overwritten on
 every release. Never commit to it; edit `source/sdk/wardnet-go` here.
 
 **The SDK carries its own version**, in `source/sdk/wardnet-go/VERSION`, and it
-is *not* the daemon's CalVer. Bump that file to cut an SDK release; a release
-whose VERSION is unchanged republishes `main` but publishes no new module
-version. This is not bookkeeping preference — Go's semantic import versioning
+is *not* the daemon's CalVer. It also releases on its own cadence: bump that
+file, merge, then push a `wardnet-go@x.y.z` tag matching it — the same shape as
+`@wardnet/js@x.y.z`. The daemon's `v<CalVer>` tag does not publish the SDK, so
+an SDK-only fix ships without waiting for a daemon release. The publish job
+fails if the tag and the VERSION file disagree, and fails if that version is
+already on the mirror.
+
+Keeping the SDK off CalVer is not bookkeeping preference — Go's semantic import versioning
 requires any module at major ≥ 2 to end its path in `/vN`, so a CalVer version
 like `2026.08.00` (major 2026) would demand `module wardnet.network/go/v2026`,
 an import path that changes every January. Staying on `0.x` keeps the path

--- a/source/sdk/wardnet-js/package.json
+++ b/source/sdk/wardnet-js/package.json
@@ -3,6 +3,15 @@
   "version": "0.5.0",
   "description": "TypeScript SDK for the Wardnet network privacy gateway",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/wardnet/wardnet.git",
+    "directory": "source/sdk/wardnet-js"
+  },
+  "homepage": "https://github.com/wardnet/wardnet/tree/main/source/sdk/wardnet-js#readme",
+  "bugs": {
+    "url": "https://github.com/wardnet/wardnet/issues"
+  },
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
yupThe `v2026.08.00` release published the daemon cleanly — release, assets, GHCR
image, site and update manifest all green — and then failed on **both** SDKs,
each for a different reason.

Neither path had ever run against a real stable tag before: the Go mirror was
added in #1049 after the last release, and npm provenance postdates the 0.4.0
publish. Both were first exercised in production, which is where they broke.

**Nothing was published by either failure.** The mirror has zero tags and npm
still serves 0.4.0, so there is no partial state to unwind.

## 1. Go SDK mirror — pushed as the wrong identity

```
remote: Permission to wardnet/wardnet-go.git denied to github-actions[bot].
fatal: ... The requested URL returned error: 403
```

`release-go-sdk.yml` builds its push URL with the minted app token
(`https://x-access-token:${GH_TOKEN}@github.com/...`), but `actions/checkout`
persists `http.https://github.com/.extraheader` carrying an `Authorization`
header for the default `GITHUB_TOKEN` — and that header takes precedence over
userinfo in the URL. The app token minted correctly and was then never used.

Fixed with `persist-credentials: false` on that job's checkout. `git subtree
split` is entirely local, and every remote operation in the job supplies its
own token, so the checkout's credentials are dead weight.

### The guard that hid it

The same step's "is this tag already published?" check was:

```sh
if git ls-remote --exit-code --tags "${MIRROR}" "refs/tags/${SDK_TAG}" >/dev/null 2>&1; then
```

`--exit-code` returns 2 for "no such ref" and 128 for "auth failed", and `if`
collapses both to "not published yet" while `2>/dev/null` throws away the
message. **An auth failure read as a green light to publish.** It gave the
right answer here only by luck.

Exit codes are now separated: `0` published, `2` reachable-and-absent, anything
else is a hard error rather than a guess.

## 2. npm publish — E422 on provenance

```
npm error code E422
422 Unprocessable Entity - PUT https://registry.npmjs.org/@wardnet%2fjs -
Error verifying sigstore provenance bundle: Failed to validate repository
information: package.json: "repository.url" is "", expected to match
"https://github.com/wardnet/wardnet" from provenance
```

`source/sdk/wardnet-js/package.json` has no `repository` field, and
`--provenance` makes the registry cross-check the attestation against it.
Added `repository` (with `directory` for the monorepo path), plus `homepage`
and `bugs` while there.

### Why this needs a pre-publish guard, not just the field

That validation is **registry-side**, and it runs *after* npm has signed the
provenance statement and written it to the public Rekor transparency log:

```
npm notice publish Signed provenance statement with source and build information from GitHub Actions
npm notice publish Provenance statement published to transparency log: https://search.sigstore.dev/?logIndex=2396954001
npm error code E422
```

So the failed publish still cost a permanent public log entry for a version
that does not exist. A new step asserts `repository.url` matches the building
repository before anything is signed. It is deliberately **not** gated on the
tag ref, so `workflow_dispatch` — whose stated purpose is validating a publish
without performing one — actually catches this class of problem.


## 3. The Go SDK now publishes on its own tag

Reviewing the above raised a fair question: why is the Go SDK release not tied
to a tag at all?

`release-go-sdk.yml` was a `workflow_call` hanging off the daemon's release,
taking no tag and reading its version from `source/sdk/wardnet-go/VERSION`. Its
header explains the no-version-input decision: passing the daemon's CalVer in
produced a module version Go cannot resolve, because `v2026.08.00` is major
2026 and Go would demand the path end in `/v2026`. That reasoning is correct —
but it argues against reusing *the daemon's* tag, not against having a tag.
The conclusion went one step too far.

What that cost:

- **A release could ship nothing.** An unbumped `VERSION` emitted
  `::notice:: this release ships no new SDK version` and passed. A notice in a
  job log is not a gate — this is why the release-prep skill had to grow a
  manual "check the mirror's tags" step.
- **The SDK could only ship at daemon cadence.** An SDK-only fix waited for the
  next daemon release.
- **Delayed detonation.** A `VERSION` bump merged today published at whatever
  the next daemon tag turned out to be, bundled with whatever else had landed.
- **Two SDKs, two mental models**, for no reason either one required.

Now `wardnet-go@x.y.z` triggers it, matching `@wardnet/js@x.y.z`. Its own
namespace keeps the module version as the SDK's semver, well away from the
daemon's `v*.*.*`. `VERSION` stays the source of truth — it is what the
major-suffix tripwire reads — and the job fails if the tag disagrees with it.

Two behaviours change with the trigger:

- **Already-published is now an error, not a notice.** Under the old trigger
  every release re-ran the job, so re-seeing a published version was the
  ordinary case. Pushing a tag for an already-published version is instead a
  mistake, and an unsatisfiable one — mirror tags are immutable.
- **The publish step is gated on the tag ref**, so `workflow_dispatch`
  validates the build, tests, version and module path without publishing.

Also adds a concurrency group: the job force-pushes a mirror branch and creates
immutable tags, and two at once was never safe.

Docs updated to match: `docs/DEVELOPMENT.md` and the release-prep skill, whose
Step 7b now covers both SDK tags instead of just npm.

## After merge

The `@wardnet/js@0.5.0` tag currently points at `cf6459db`, which lacks the
metadata fix. It needs deleting and re-pointing at the merge commit. That is
safe precisely because nothing published — unlike a daemon tag, no consumer has
resolved it.

The Go SDK's `v0.1.0` now needs a `wardnet-go@0.1.0` tag rather than a job
re-run — the old trigger no longer exists.

## Test plan

- `actionlint` clean on all three release workflows (it caught a stray `exit 0`
  I left behind in the reworked `case`)
- `make check-sdk` — prettier clean, 34 tests pass, `yarn install --immutable`
  unaffected (metadata-only fields, `yarn.lock` unchanged)
- The new guard asserted locally against the fixed `package.json`
- Neither fix is verifiable end-to-end without a real tag push, which is what
  produced both bugs — hence the guard, which fails on `workflow_dispatch`