### PR TITLE
refactor(admin-site): hoist TanStack Query hooks out of compound/ and features/ components into pages

### DIFF
--- a/.agents/code-conventions.md
+++ b/.agents/code-conventions.md
@@ -29,14 +29,29 @@
   - `compound/` — compositions of core components, data via props only, no API calls
   - `features/` — use-case views, data via props + callbacks, no direct API/service calls
   - `layouts/` — page shells, navigation/routing, no business logic
-    - **Carve-out — shell-wide status/auth.** The `AppLayout` shells may call
-      `useDaemonStatus()` (admin-app, user-app) and `useAuth()` (admin-site)
-      directly. These two hooks feed the shell chrome itself — the header
-      version/connection pill and the admin-gated navigation — which live above
-      every route and have no owning `page` to hoist them into. The carve-out is
-      limited to these two read hooks; layouts still perform no mutations and
-      wire no other queries.
+    - **Carve-out — shell-wide status/auth.** The `AppLayout` shells wire the
+      hooks that feed the shell chrome itself — the header version/connection
+      pill, the admin-gated navigation, and the shell banners — which live
+      above every route and have no owning `page` to hoist them into. In the
+      admin-app and user-app that is `useDaemonStatus()`; in the admin-site
+      `AppLayout` additionally wires `useAuth()`, `useUpdateStatus()`,
+      `useSystemStatus()`, and the `useAcknowledgeShutdown()` mutation, and
+      passes data + callbacks down so the shell compounds (`Sidebar`,
+      `ConnectionStatus`, `ConnectionBanner`, `UncleanShutdownBanner`) stay
+      pure presentation. The carve-out is limited to these shell-chrome hooks;
+      layouts wire no other queries or mutations.
   - `pages/` — route-level, wire TanStack Query hooks → feature/compound components
+  - **Carve-out — self-contained creation flows.** The tunnel-creation flow
+    (`CreateTunnelInline` → `ManualTunnelTab` / `ProviderTunnelTab`) keeps its
+    `useCreateTunnel` / provider hooks (`useProviders`, `useValidateCredentials`,
+    `useProviderServers`, `useProviderCountries`, `useProviderSetup`) internal.
+    It is a multi-step wizard whose queries are parameterised on flow-internal
+    state (selected provider, entered credentials), it is mounted by two owners
+    (`pages/Tunnels.tsx` and the setup wizard's `StepTunnel`), and nothing
+    outside the flow shares its data or in-flight state — hoisting would
+    duplicate a large stateful wiring block in both owners for no
+    de-duplication or mutation-sharing benefit. Anything reusable outside the
+    flow (e.g. the tunnels list itself) still belongs to the page.
 - **All business logic in `@wardnet/js`** — components are pure presentation.
 - **Hooks** bridge SDK and React: wrap SDK service calls in TanStack Query for caching/loading/error.
 - **Dark/light mode**: System preference via `prefers-color-scheme`, toggles `.dark` class on `<html>`.

--- a/source/admin-site/src/components/compound/ConnectionBanner.tsx
+++ b/source/admin-site/src/components/compound/ConnectionBanner.tsx
@@ -1,19 +1,23 @@
 import { AlertTriangle } from "lucide-react";
 import { Banner } from "@wardnet/web";
-import { useDaemonStatus } from "@wardnet/web";
+
+interface ConnectionBannerProps {
+  /** Whether the daemon answered the last status probe; `undefined` while
+   *  the shell layout's status query is still unresolved (banner hidden). */
+  reachable: boolean | undefined;
+}
 
 /**
  * Full-width red banner shown at the top of all pages when the daemon is unreachable.
- * Uses the same unauthenticated /api/info endpoint as the sidebar connection indicator.
+ * Fed by the same unauthenticated /api/info endpoint as the sidebar connection indicator.
  *
- * Thin data-coupled wrapper over the Forge `<Banner>` primitive — visual
- * shape lives in the `.banner` recipe (styles.css §05); this component only
- * decides whether to show the strip and what to put inside it.
+ * Thin wrapper over the Forge `<Banner>` primitive — visual shape lives in
+ * the `.banner` recipe (styles.css §05); this component only decides whether
+ * to show the strip and what to put inside it. Pure presentation — the shell
+ * layout wires the status hook and passes the state in.
  */
-export function ConnectionBanner() {
-  const { data } = useDaemonStatus();
-
-  if (!data || data.reachable) return null;
+export function ConnectionBanner({ reachable }: ConnectionBannerProps) {
+  if (reachable !== false) return null;
 
   return (
     <Banner tone="down" icon={<AlertTriangle />} role="alert">

--- a/source/admin-site/src/components/compound/ConnectionStatus.tsx
+++ b/source/admin-site/src/components/compound/ConnectionStatus.tsx
@@ -1,12 +1,20 @@
-import { useDaemonStatus, Text } from "@wardnet/web";
+import { Text } from "@wardnet/web";
+
+interface ConnectionStatusProps {
+  /** True while the daemon status is still being fetched. */
+  isLoading: boolean;
+  /** Whether the daemon answered the last status probe. */
+  reachable: boolean;
+}
 
 /** Traffic-light status indicator shown in the sidebar footer. The
  *  daemon version is rendered separately under the brand mark (see
- *  Sidebar), so this row stays a single line. */
-export function ConnectionStatus() {
-  const { data, isLoading } = useDaemonStatus();
-
-  const reachable = data?.reachable ?? false;
+ *  Sidebar), so this row stays a single line. Pure presentation — the
+ *  shell layout wires the status hook and passes the state in. */
+export function ConnectionStatus({
+  isLoading,
+  reachable,
+}: ConnectionStatusProps) {
   const color = isLoading ? "bg-warn" : reachable ? "bg-accent" : "bg-danger";
   const label = isLoading
     ? "Connecting…"

--- a/source/admin-site/src/components/compound/DeviceTable.tsx
+++ b/source/admin-site/src/components/compound/DeviceTable.tsx
@@ -8,10 +8,6 @@ import {
 import { DeviceIcon } from "@wardnet/web";
 import { HostCell } from "@/components/compound/HostCell";
 import { StatusBadge } from "@/components/compound/StatusBadge";
-import {
-  useDeviceFilterSettingsList,
-  useDnsFilterProfiles,
-} from "@wardnet/web";
 import { deviceTypeLabel, manufacturerDisplay } from "@wardnet/web";
 import { timeAgo } from "@wardnet/web";
 import type {
@@ -146,9 +142,17 @@ interface DeviceTableProps {
   action?: ReactNode;
   /** Shown when the table has no rows; a node so callers can explain why. */
   emptyMessage?: ReactNode;
+  /** Per-device DNS filter settings for the Filtering column, from the
+   *  owning page's `useDeviceFilterSettingsList()`. */
+  filterSettings: DeviceDnsFilterSettings[] | undefined;
+  /** All DNS filter profiles, for resolving profile names, from the owning
+   *  page's `useDnsFilterProfiles()`. */
+  filterProfiles: DnsFilterProfile[] | undefined;
 }
 
-/** Table listing network devices. Receives pre-filtered, pre-sorted data. */
+/** Table listing network devices. Receives pre-filtered, pre-sorted data.
+ *  Pure presentation — the owning page wires the query hooks and passes
+ *  data + callbacks in. */
 export function DeviceTable({
   devices,
   onDeviceClick,
@@ -160,21 +164,20 @@ export function DeviceTable({
   searchPlaceholder,
   action,
   emptyMessage,
+  filterSettings,
+  filterProfiles,
 }: DeviceTableProps) {
-  const { data: settingsData } = useDeviceFilterSettingsList();
-  const { data: profilesData } = useDnsFilterProfiles();
-
   const settingsByDevice = useMemo(() => {
     const map = new Map<string, DeviceDnsFilterSettings>();
-    for (const s of settingsData?.devices ?? []) map.set(s.device_id, s);
+    for (const s of filterSettings ?? []) map.set(s.device_id, s);
     return map;
-  }, [settingsData]);
+  }, [filterSettings]);
 
   const profilesById = useMemo(() => {
     const map = new Map<string, DnsFilterProfile>();
-    for (const p of profilesData?.profiles ?? []) map.set(p.id, p);
+    for (const p of filterProfiles ?? []) map.set(p.id, p);
     return map;
-  }, [profilesData]);
+  }, [filterProfiles]);
 
   const columns = useMemo(
     () => buildColumns(settingsByDevice, profilesById),

--- a/source/admin-site/src/components/compound/DhcpConfigCard.tsx
+++ b/source/admin-site/src/components/compound/DhcpConfigCard.tsx
@@ -17,9 +17,14 @@ import { Ipv4Input } from "@wardnet/web";
 import { isPrivateIpv4 } from "@wardnet/web";
 import { isCompleteIpv4, ipv4ToInt } from "@wardnet/js";
 import { ApiErrorAlert } from "@wardnet/web";
-import { useUpdateDhcpConfig, usePreviewDhcpConfig } from "@wardnet/web";
-import { useDnsConfig } from "@wardnet/web";
-import type { DhcpConfig, DhcpLease } from "@wardnet/js";
+import type {
+  DhcpConfig,
+  DhcpLease,
+  PreviewDhcpConfigRequest,
+  PreviewDhcpConfigResponse,
+  UpdateDhcpConfigRequest,
+} from "@wardnet/js";
+import type { MutationHandle } from "@/lib/mutationHandle";
 import { ConfirmDialog } from "@/components/compound/ConfirmDialog";
 
 function formatDuration(secs: number): string {
@@ -44,23 +49,38 @@ function affectedDescription(leases: DhcpLease[]): string {
 
 interface DhcpConfigCardProps {
   config: DhcpConfig;
+  /** Whether the Wardnet DNS server is enabled. Tri-state on purpose:
+   *  `undefined` means the page's DNS query hasn't resolved (loading or
+   *  errored). Falling back to `false` would show the raw upstream list as
+   *  the effective client DNS while the daemon is actually advertising the
+   *  Pi — the exact misread this card exists to prevent. */
+  dnsEnabled: boolean | undefined;
+  /** The page's hoisted config-update mutation. */
+  updateConfig: MutationHandle<UpdateDhcpConfigRequest>;
+  /** The page's hoisted pool-change dry-run mutation. Typed separately from
+   *  `MutationHandle` because the card consumes its resolved value (the
+   *  affected leases). */
+  previewConfig: {
+    mutateAsync: (
+      body: PreviewDhcpConfigRequest,
+    ) => Promise<PreviewDhcpConfigResponse>;
+    isPending: boolean;
+  };
 }
 
 /** Card displaying the DHCP pool configuration with inline edit-mode.
  *  When the Wardnet DNS server is enabled, the upstream-DNS field
  *  collapses: the daemon will advertise Wardnet's own IP to clients
  *  regardless of what's saved here, so we hide the field in edit mode
- *  and show "Wardnet DNS" in the read view to match reality. */
-export function DhcpConfigCard({ config }: DhcpConfigCardProps) {
-  const updateConfig = useUpdateDhcpConfig();
-  const previewConfig = usePreviewDhcpConfig();
-  const { data: dnsConfigData } = useDnsConfig();
-  // Tri-state on purpose: `undefined` means the DNS query hasn't resolved
-  // (loading or errored). Falling back to `false` here would show the raw
-  // upstream list as the effective client DNS while the daemon is actually
-  // advertising the Pi — the exact misread this card exists to prevent.
-  const dnsEnabled: boolean | undefined = dnsConfigData?.config.enabled;
-
+ *  and show "Wardnet DNS" in the read view to match reality.
+ *  Pure presentation — the owning page wires the query/mutation hooks and
+ *  passes data + callbacks in. */
+export function DhcpConfigCard({
+  config,
+  dnsEnabled,
+  updateConfig,
+  previewConfig,
+}: DhcpConfigCardProps) {
   const [editing, setEditing] = useState(false);
   const [confirmOpen, setConfirmOpen] = useState(false);
   const [affected, setAffected] = useState<DhcpLease[]>([]);

--- a/source/admin-site/src/components/compound/DhcpConfigCard.tsx
+++ b/source/admin-site/src/components/compound/DhcpConfigCard.tsx
@@ -57,15 +57,12 @@ interface DhcpConfigCardProps {
   dnsEnabled: boolean | undefined;
   /** The page's hoisted config-update mutation. */
   updateConfig: MutationHandle<UpdateDhcpConfigRequest>;
-  /** The page's hoisted pool-change dry-run mutation. Typed separately from
-   *  `MutationHandle` because the card consumes its resolved value (the
-   *  affected leases). */
-  previewConfig: {
-    mutateAsync: (
-      body: PreviewDhcpConfigRequest,
-    ) => Promise<PreviewDhcpConfigResponse>;
-    isPending: boolean;
-  };
+  /** The page's hoisted pool-change dry-run mutation; the card consumes its
+   *  resolved value (the affected leases). */
+  previewConfig: MutationHandle<
+    PreviewDhcpConfigRequest,
+    PreviewDhcpConfigResponse
+  >;
 }
 
 /** Card displaying the DHCP pool configuration with inline edit-mode.

--- a/source/admin-site/src/components/compound/MobileMenu.tsx
+++ b/source/admin-site/src/components/compound/MobileMenu.tsx
@@ -6,10 +6,14 @@ import {
   DrawerTitle,
   DrawerTrigger,
 } from "@wardnet/web";
-import { Sidebar } from "./Sidebar";
+import { Sidebar, type SidebarProps } from "./Sidebar";
+
+/** The sidebar's data props, forwarded verbatim — the drawer only adds the
+ *  open/close state and the on-navigate auto-close. */
+type MobileMenuProps = Omit<SidebarProps, "onNavigate">;
 
 /** Hamburger menu with slide-in sidebar for mobile viewports. */
-export function MobileMenu() {
+export function MobileMenu(props: MobileMenuProps) {
   const [open, setOpen] = useState(false);
 
   return (
@@ -41,7 +45,7 @@ export function MobileMenu() {
       </DrawerTrigger>
       <DrawerContent side="left">
         <DrawerTitle className="sr-only">Navigation</DrawerTitle>
-        <Sidebar onNavigate={() => setOpen(false)} />
+        <Sidebar {...props} onNavigate={() => setOpen(false)} />
       </DrawerContent>
     </Drawer>
   );

--- a/source/admin-site/src/components/compound/Sidebar.tsx
+++ b/source/admin-site/src/components/compound/Sidebar.tsx
@@ -16,16 +16,25 @@ import {
   Split,
 } from "lucide-react";
 import { ShieldWifi, GlobeFilter } from "@wardnet/web";
-import { useAuth } from "@wardnet/web";
-import { useDaemonStatus } from "@wardnet/web";
-import { useUpdateStatus } from "@wardnet/web";
 import { Logo } from "@wardnet/web";
 import { Text } from "@wardnet/web";
 import { ConnectionStatus } from "./ConnectionStatus";
 import { UpdateBanner } from "./UpdateBanner";
 
-interface SidebarProps {
+export interface SidebarProps {
   onNavigate?: () => void;
+  /** Whether the current session is an admin (drives nav + footer links). */
+  isAdmin: boolean;
+  /** Revoke the server session; resolves even when the network call fails. */
+  onLogout: () => Promise<unknown>;
+  /** Daemon version for the caption under the brand mark, if known. */
+  version: string | null | undefined;
+  /** Connection-indicator state, from the shell layout's daemon-status query. */
+  connectionLoading: boolean;
+  connected: boolean;
+  /** Update-banner state, from the shell layout's update-status query. */
+  updateAvailable: boolean;
+  latestVersion: string | null;
 }
 
 type Icon = ComponentType<SVGProps<SVGSVGElement>>;
@@ -134,23 +143,28 @@ const adminSections: NavSection[] = [
  * itself per the slice 0a sweep, so no variant prop is needed.
  *
  * `<UpdateBanner />` stays mounted as a child — it's a separate compound
- * already on Forge accent tokens.
+ * already on Forge accent tokens. Pure presentation — the shell layout wires
+ * the auth/status hooks and passes data + callbacks in.
  */
-export function Sidebar({ onNavigate }: SidebarProps) {
-  const { isAdmin, logout } = useAuth();
+export function Sidebar({
+  onNavigate,
+  isAdmin,
+  onLogout,
+  version,
+  connectionLoading,
+  connected,
+  updateAvailable,
+  latestVersion,
+}: SidebarProps) {
   const navigate = useNavigate();
-  // Only admins see update state — self-service users don't have the perms
-  // to trigger installs, so we don't bother them with the banner.
-  const { data: updateStatus } = useUpdateStatus();
-  const { data: daemonStatus } = useDaemonStatus();
 
   const sections = isAdmin ? adminSections : [];
 
   function handleLogout() {
-    // Revoke the server session before leaving the page. logout() clears
+    // Revoke the server session before leaving the page. onLogout() clears
     // local auth state even when the network call fails, so the redirect
     // always happens.
-    void logout().then(() => {
+    void onLogout().then(() => {
       onNavigate?.();
       navigate("/");
     });
@@ -161,7 +175,7 @@ export function Sidebar({ onNavigate }: SidebarProps) {
       <div className="side__brand">
         <Logo height={28} variant="dark" />
       </div>
-      {daemonStatus?.version && (
+      {version && (
         // -mt absorbs the version into `.side__brand`'s bottom padding so it
         // sits as a tight caption right under the logo lockup. pl-[50px] lines
         // the "v" up under the start of the "WARDNET" wordmark at this height.
@@ -171,7 +185,7 @@ export function Sidebar({ onNavigate }: SidebarProps) {
           weight="normal"
           className="-mt-6 pb-2 pl-[50px] text-side-ink/40"
         >
-          v{daemonStatus.version}
+          v{version}
         </Text>
       )}
 
@@ -205,12 +219,15 @@ export function Sidebar({ onNavigate }: SidebarProps) {
       <div className="side__foot">
         {isAdmin && (
           <UpdateBanner
-            updateAvailable={updateStatus?.status.update_available ?? false}
-            latestVersion={updateStatus?.status.latest_version ?? null}
+            updateAvailable={updateAvailable}
+            latestVersion={latestVersion}
           />
         )}
         <div className="side__status">
-          <ConnectionStatus />
+          <ConnectionStatus
+            isLoading={connectionLoading}
+            reachable={connected}
+          />
         </div>
         <div className="side__links">
           {isAdmin ? (

--- a/source/admin-site/src/components/compound/UncleanShutdownBanner.tsx
+++ b/source/admin-site/src/components/compound/UncleanShutdownBanner.tsx
@@ -2,8 +2,17 @@ import { CircleAlertIcon, X } from "lucide-react";
 import { Banner } from "@wardnet/web";
 import { Button } from "@wardnet/web";
 import { Text } from "@wardnet/web";
-import { useAcknowledgeShutdown, useSystemStatus } from "@wardnet/web";
 import { timeAgo } from "@wardnet/web";
+import type { SystemStatusResponse } from "@wardnet/js";
+
+interface UncleanShutdownBannerProps {
+  /** The system status, from the shell layout's `useSystemStatus()`. */
+  status: SystemStatusResponse | undefined;
+  /** Acknowledge the shutdown (records `acknowledged_at` server-side). */
+  onDismiss: () => void;
+  /** True while the acknowledgement mutation is in flight. */
+  dismissPending: boolean;
+}
 
 /**
  * Full-width banner that calls out the previous unclean daemon
@@ -17,15 +26,17 @@ import { timeAgo } from "@wardnet/web";
  * the new event timestamp is newer than the stored ack — no explicit
  * "reset on event" coupling is required.
  *
- * Thin data-coupled wrapper over the Forge `<Banner>` primitive — visual
- * shape (full-width danger-soft strip) lives in the `.banner` recipe
+ * Thin wrapper over the Forge `<Banner>` primitive — visual shape
+ * (full-width danger-soft strip) lives in the `.banner` recipe
  * (styles.css §05); this component owns the visibility predicate and the
- * Dismiss action.
+ * Dismiss action. Pure presentation — the shell layout wires the
+ * query/mutation hooks and passes data + callbacks in.
  */
-export function UncleanShutdownBanner() {
-  const { data: status } = useSystemStatus();
-  const ack = useAcknowledgeShutdown();
-
+export function UncleanShutdownBanner({
+  status,
+  onDismiss,
+  dismissPending,
+}: UncleanShutdownBannerProps) {
   if (!status) return null;
 
   const { last_shutdown: shutdown } = status;
@@ -45,8 +56,8 @@ export function UncleanShutdownBanner() {
         <Button
           size="sm"
           variant="ghost"
-          onClick={() => ack.mutate()}
-          disabled={ack.isPending}
+          onClick={onDismiss}
+          disabled={dismissPending}
           aria-label="Dismiss unclean shutdown banner"
         >
           <X className="mr-1 size-3.5" />

--- a/source/admin-site/src/components/features/ConditionalForwardingCard.tsx
+++ b/source/admin-site/src/components/features/ConditionalForwardingCard.tsx
@@ -16,31 +16,51 @@ import { Input } from "@wardnet/web";
 import { Toggle } from "@wardnet/web";
 import { DataTable, RowAction } from "@/components/core/ui/data-table";
 import { ConfirmDialog } from "@/components/compound/ConfirmDialog";
-import {
-  useForwardingRules,
-  useCreateForwardingRule,
-  useUpdateForwardingRule,
-  useDeleteForwardingRule,
-} from "@wardnet/web";
-import type { ConditionalForwardingRule } from "@wardnet/js";
+import type {
+  ConditionalForwardingRule,
+  CreateForwardingRuleRequest,
+  UpdateForwardingRuleRequest,
+} from "@wardnet/js";
+
+interface ConditionalForwardingCardProps {
+  rules: ConditionalForwardingRule[];
+  /** True while the page's create or update mutation is in flight. */
+  isSaving: boolean;
+  /** True while the page's update mutation is in flight (gates the per-row
+   *  enable toggles without also locking them during a create). */
+  updatePending: boolean;
+  /** The optional callbacks match TanStack's `mutate` signature so the page
+   *  can pass the mutation's `mutate` straight through; the card uses
+   *  `onSuccess` to close its inline form. */
+  onCreateRule: (
+    body: CreateForwardingRuleRequest,
+    callbacks?: { onSuccess?: () => void },
+  ) => void;
+  onUpdateRule: (
+    change: { id: string; body: UpdateForwardingRuleRequest },
+    callbacks?: { onSuccess?: () => void },
+  ) => void;
+  onDeleteRule: (id: string) => void;
+}
 
 /** Conditional forwarding — send a specific domain to a chosen upstream
  *  resolver instead of the default. An explicit rule overrides authoritative
- *  zone handling for the same name. */
-export function ConditionalForwardingCard() {
-  const { data } = useForwardingRules();
-  const createRule = useCreateForwardingRule();
-  const updateRule = useUpdateForwardingRule();
-  const deleteRule = useDeleteForwardingRule();
-
+ *  zone handling for the same name. Pure presentation — the owning page wires
+ *  the query/mutation hooks and passes data + callbacks in. */
+export function ConditionalForwardingCard({
+  rules,
+  isSaving,
+  updatePending,
+  onCreateRule,
+  onUpdateRule,
+  onDeleteRule,
+}: ConditionalForwardingCardProps) {
   const [formOpen, setFormOpen] = useState(false);
   const [editing, setEditing] = useState<ConditionalForwardingRule | null>(
     null,
   );
   const [deleteId, setDeleteId] = useState<string | null>(null);
 
-  const rules = useMemo(() => data?.rules ?? [], [data]);
-  const isSaving = createRule.isPending || updateRule.isPending;
   const ruleToDelete = rules.find((r) => r.id === deleteId);
 
   function openCreate() {
@@ -85,14 +105,14 @@ export function ConditionalForwardingCard() {
             aria-label={`Toggle rule for ${row.original.domain}`}
             checked={row.original.enabled}
             onCheckedChange={(enabled) =>
-              updateRule.mutate({ id: row.original.id, body: { enabled } })
+              onUpdateRule({ id: row.original.id, body: { enabled } })
             }
-            disabled={updateRule.isPending}
+            disabled={updatePending}
           />
         ),
       },
     ],
-    [updateRule],
+    [onUpdateRule, updatePending],
   );
 
   return (
@@ -112,11 +132,9 @@ export function ConditionalForwardingCard() {
             rule={editing}
             isSaving={isSaving}
             onCancel={closeForm}
-            onCreate={(body) =>
-              createRule.mutate(body, { onSuccess: closeForm })
-            }
+            onCreate={(body) => onCreateRule(body, { onSuccess: closeForm })}
             onUpdate={(id, body) =>
-              updateRule.mutate({ id, body }, { onSuccess: closeForm })
+              onUpdateRule({ id, body }, { onSuccess: closeForm })
             }
           />
         )}
@@ -160,7 +178,7 @@ export function ConditionalForwardingCard() {
         description={`Delete the forwarding rule for ${ruleToDelete?.domain ?? "this domain"}? Queries will fall back to the default upstream.`}
         confirmLabel="Delete"
         onConfirm={() => {
-          if (deleteId) deleteRule.mutate(deleteId);
+          if (deleteId) onDeleteRule(deleteId);
           setDeleteId(null);
         }}
       />

--- a/source/admin-site/src/components/features/ConditionalForwardingCard.tsx
+++ b/source/admin-site/src/components/features/ConditionalForwardingCard.tsx
@@ -16,6 +16,7 @@ import { Input } from "@wardnet/web";
 import { Toggle } from "@wardnet/web";
 import { DataTable, RowAction } from "@/components/core/ui/data-table";
 import { ConfirmDialog } from "@/components/compound/ConfirmDialog";
+import type { MutateFn } from "@/lib/mutationHandle";
 import type {
   ConditionalForwardingRule,
   CreateForwardingRuleRequest,
@@ -29,17 +30,8 @@ interface ConditionalForwardingCardProps {
   /** True while the page's update mutation is in flight (gates the per-row
    *  enable toggles without also locking them during a create). */
   updatePending: boolean;
-  /** The optional callbacks match TanStack's `mutate` signature so the page
-   *  can pass the mutation's `mutate` straight through; the card uses
-   *  `onSuccess` to close its inline form. */
-  onCreateRule: (
-    body: CreateForwardingRuleRequest,
-    callbacks?: { onSuccess?: () => void },
-  ) => void;
-  onUpdateRule: (
-    change: { id: string; body: UpdateForwardingRuleRequest },
-    callbacks?: { onSuccess?: () => void },
-  ) => void;
+  onCreateRule: MutateFn<CreateForwardingRuleRequest>;
+  onUpdateRule: MutateFn<{ id: string; body: UpdateForwardingRuleRequest }>;
   onDeleteRule: (id: string) => void;
 }
 

--- a/source/admin-site/src/components/features/CreateReservationInline.tsx
+++ b/source/admin-site/src/components/features/CreateReservationInline.tsx
@@ -6,8 +6,9 @@ import { Input } from "@wardnet/web";
 import { Ipv4Input } from "@wardnet/web";
 import { MacInput } from "@/components/core/ui/mac-input";
 import { ApiErrorAlert } from "@wardnet/web";
-import { useCreateReservation, suggestHostnameForMac } from "@wardnet/web";
-import type { Device } from "@wardnet/js";
+import { suggestHostnameForMac } from "@wardnet/web";
+import type { MutationHandle } from "@/lib/mutationHandle";
+import type { CreateDhcpReservationRequest, Device } from "@wardnet/js";
 
 /** Optional pre-filled values for the reservation form. */
 export interface ReservationDefaults {
@@ -31,6 +32,8 @@ interface CreateReservationInlineProps {
    *  (issue #85). Sourced from the parent's `useDevices()` — passed in
    *  rather than fetched here so the component stays presentational. */
   devices?: Device[];
+  /** The page's hoisted create-reservation mutation. */
+  createReservation: MutationHandle<CreateDhcpReservationRequest>;
 }
 
 /**
@@ -51,9 +54,8 @@ export function CreateReservationInline({
   onSuccess,
   defaults,
   devices = [],
+  createReservation,
 }: CreateReservationInlineProps) {
-  const createReservation = useCreateReservation();
-
   // Auto-suggest a hostname from a matching managed device (issue #85).
   // An explicit `defaults.hostname` (e.g. carried over from a lease on
   // "Make static") is respected as-is; we only suggest into an empty

--- a/source/admin-site/src/components/features/DashboardRemoteAccessBanner.tsx
+++ b/source/admin-site/src/components/features/DashboardRemoteAccessBanner.tsx
@@ -1,5 +1,10 @@
-import { useTlsStatus } from "@wardnet/web";
+import type { TlsStatusResponse } from "@wardnet/js";
 import { RemoteAccessStatus } from "@/components/features/RemoteAccessStatus";
+
+interface DashboardRemoteAccessBannerProps {
+  /** The TLS provisioning status, from the owning page's `useTlsStatus()`. */
+  status: TlsStatusResponse | undefined;
+}
 
 /**
  * Persistent dashboard indicator for remote-access provisioning. Surfaces the
@@ -11,12 +16,13 @@ import { RemoteAccessStatus } from "@/components/features/RemoteAccessStatus";
  * suppressed here: a permanent "remote access is live" card would clutter every
  * dashboard load forever, and the steady-state certificate panel (with manual
  * retry) is owned by Settings (C10). The wizard's own step still shows the
- * issued confirmation inline. Renders nothing while idle. Polls only while
- * issuance is in flight (the hook stops once a terminal phase is reached).
+ * issued confirmation inline. Renders nothing while idle. Pure presentation —
+ * the owning page wires the status query (which polls only while issuance is
+ * in flight) and passes the data in.
  */
-export function DashboardRemoteAccessBanner() {
-  const { data: status } = useTlsStatus();
-
+export function DashboardRemoteAccessBanner({
+  status,
+}: DashboardRemoteAccessBannerProps) {
   if (!status || status.phase === "idle" || status.phase === "issued")
     return null;
 

--- a/source/admin-site/src/components/features/DeviceDnsCaptureCard.tsx
+++ b/source/admin-site/src/components/features/DeviceDnsCaptureCard.tsx
@@ -12,14 +12,20 @@ import {
 import { Input } from "@wardnet/web";
 import { Toggle } from "@wardnet/web";
 import { ApiErrorAlert } from "@wardnet/web";
-import {
-  useDnsCaptureSettings,
-  useUpdateDnsCaptureSettings,
-} from "@wardnet/web";
 import { formatBytes } from "@wardnet/web";
+import type { MutationHandle } from "@/lib/mutationHandle";
+import type {
+  DnsCaptureSettingsRequest,
+  DnsCaptureSettingsResponse,
+} from "@wardnet/js";
 
 interface DeviceDnsCaptureCardProps {
-  deviceId: string;
+  /** The device's capture settings, or `undefined` while loading. */
+  settings: DnsCaptureSettingsResponse | undefined;
+  isLoading: boolean;
+  /** The page's hoisted capture-settings update mutation (already bound to
+   *  this device). */
+  update: MutationHandle<DnsCaptureSettingsRequest>;
 }
 
 function StorageBar({ value, max }: { value: number; max: number }) {
@@ -35,10 +41,14 @@ function StorageBar({ value, max }: { value: number; max: number }) {
   );
 }
 
-export function DeviceDnsCaptureCard({ deviceId }: DeviceDnsCaptureCardProps) {
-  const { data, isLoading } = useDnsCaptureSettings(deviceId);
-  const update = useUpdateDnsCaptureSettings(deviceId);
-
+/** Editable DNS-capture settings card for the device detail page. Pure
+ *  presentation — the owning page wires the query/mutation hooks and passes
+ *  data + callbacks in. */
+export function DeviceDnsCaptureCard({
+  settings: data,
+  isLoading,
+  update,
+}: DeviceDnsCaptureCardProps) {
   const [editing, setEditing] = useState(false);
   const [enabled, setEnabled] = useState(false);
   const [capCount, setCapCount] = useState(1000);

--- a/source/admin-site/src/components/features/DeviceDnsFilterCard.tsx
+++ b/source/admin-site/src/components/features/DeviceDnsFilterCard.tsx
@@ -30,8 +30,6 @@ interface DeviceDnsFilterCardProps {
   profiles: DnsFilterProfile[] | undefined;
   /** The global filter config, or `undefined` while loading. */
   config: DnsFilterConfig | undefined;
-  /** True while any of the three queries above is still loading. */
-  isLoading: boolean;
   /** The page's hoisted filter-settings update mutation. */
   update: MutationHandle<{
     id: string;
@@ -50,7 +48,6 @@ export function DeviceDnsFilterCard({
   settings,
   profiles,
   config,
-  isLoading,
   update,
 }: DeviceDnsFilterCardProps) {
   const [editing, setEditing] = useState(false);
@@ -80,8 +77,10 @@ export function DeviceDnsFilterCard({
 
   // All three queries must settle before rendering — otherwise the
   // read-only summary line resolves `defaultProfiles`/`assignedProfiles`
-  // against an empty profiles cache and falsely reports "None".
-  const ready = !isLoading && settings && profiles && config;
+  // against an empty profiles cache and falsely reports "None". Defined
+  // data implies the query is no longer loading, so the data props are the
+  // whole predicate.
+  const ready = settings && profiles && config;
 
   if (!ready) {
     return (

--- a/source/admin-site/src/components/features/DeviceDnsFilterCard.tsx
+++ b/source/admin-site/src/components/features/DeviceDnsFilterCard.tsx
@@ -13,35 +13,46 @@ import { Field } from "@wardnet/web";
 import { Toggle } from "@wardnet/web";
 import { ApiErrorAlert } from "@wardnet/web";
 import { ProfileToggleList } from "@/components/compound/ProfileToggleList";
-import {
-  useDeviceFilterSettings,
-  useDnsFilterConfig,
-  useDnsFilterProfiles,
-  useUpdateDeviceFilterSettings,
-} from "@wardnet/web";
-import type { Device, DnsFilterProfile } from "@wardnet/js";
+import type { MutationHandle } from "@/lib/mutationHandle";
+import type {
+  Device,
+  DeviceDnsFilterSettings,
+  DnsFilterConfig,
+  DnsFilterProfile,
+  UpdateDeviceFilterSettingsRequest,
+} from "@wardnet/js";
 
 interface DeviceDnsFilterCardProps {
   device: Device;
+  /** The device's filter settings, or `undefined` while loading. */
+  settings: DeviceDnsFilterSettings | undefined;
+  /** All filter profiles, or `undefined` while loading. */
+  profiles: DnsFilterProfile[] | undefined;
+  /** The global filter config, or `undefined` while loading. */
+  config: DnsFilterConfig | undefined;
+  /** True while any of the three queries above is still loading. */
+  isLoading: boolean;
+  /** The page's hoisted filter-settings update mutation. */
+  update: MutationHandle<{
+    id: string;
+    body: UpdateDeviceFilterSettingsRequest;
+  }>;
 }
 
 const PROFILES_LABEL_ID = "device-dns-filter-profiles-label";
 
 /** Editable DNS filter settings card for the device detail page —
  *  edit-mode card protocol per DhcpConfigCard / DeviceSettingsCard
- *  (folded edit form, hook-coupled via `useUpdateDeviceFilterSettings`). */
-export function DeviceDnsFilterCard({ device }: DeviceDnsFilterCardProps) {
-  const { data: settingsData, isLoading: settingsLoading } =
-    useDeviceFilterSettings(device.id);
-  const { data: profilesData, isLoading: profilesLoading } =
-    useDnsFilterProfiles();
-  const { data: configData, isLoading: configLoading } = useDnsFilterConfig();
-  const update = useUpdateDeviceFilterSettings();
-
-  const profiles = profilesData?.profiles;
-  const settings = settingsData?.settings;
-  const config = configData?.config;
-
+ *  (folded edit form). Pure presentation — the owning page wires the
+ *  query/mutation hooks and passes data + callbacks in. */
+export function DeviceDnsFilterCard({
+  device,
+  settings,
+  profiles,
+  config,
+  isLoading,
+  update,
+}: DeviceDnsFilterCardProps) {
   const [editing, setEditing] = useState(false);
   const [enabled, setEnabled] = useState(true);
   const [profileIds, setProfileIds] = useState<string[]>([]);
@@ -70,13 +81,7 @@ export function DeviceDnsFilterCard({ device }: DeviceDnsFilterCardProps) {
   // All three queries must settle before rendering — otherwise the
   // read-only summary line resolves `defaultProfiles`/`assignedProfiles`
   // against an empty profiles cache and falsely reports "None".
-  const ready =
-    !settingsLoading &&
-    !profilesLoading &&
-    !configLoading &&
-    settings &&
-    profiles &&
-    config;
+  const ready = !isLoading && settings && profiles && config;
 
   if (!ready) {
     return (

--- a/source/admin-site/src/components/features/DeviceNetworkCard.tsx
+++ b/source/admin-site/src/components/features/DeviceNetworkCard.tsx
@@ -13,15 +13,26 @@ import { Field } from "@wardnet/web";
 import { Ipv4Input } from "@wardnet/web";
 import { ApiErrorAlert } from "@wardnet/web";
 import { StatusBadge } from "@/components/compound/StatusBadge";
-import {
-  useCreateReservation,
-  useDeleteReservation,
-  useDhcpReservations,
-} from "@wardnet/web";
-import type { Device, DhcpReservation, DhcpStatus } from "@wardnet/js";
+import type { MutationHandle } from "@/lib/mutationHandle";
+import type {
+  CreateDhcpReservationRequest,
+  Device,
+  DhcpReservation,
+  DhcpStatus,
+} from "@wardnet/js";
 
 interface DeviceNetworkCardProps {
   device: Device;
+  /** All DHCP reservations — the card resolves this device's by MAC. */
+  reservations: DhcpReservation[] | undefined;
+  /** The page's hoisted create-reservation mutation. */
+  createReservation: MutationHandle<CreateDhcpReservationRequest>;
+  /** Dedicated silent create instance for the rollback recreate: it must not
+   *  pop a "Reservation created" toast that would contradict the failure the
+   *  admin is being shown for their actual edit. */
+  restoreReservation: MutationHandle<CreateDhcpReservationRequest>;
+  /** The page's hoisted delete-reservation mutation. */
+  deleteReservation: MutationHandle<string>;
 }
 
 function statusBadge(status: DhcpStatus) {
@@ -44,20 +55,17 @@ function findReservation(
   return reservations?.find((r) => r.mac_address === mac);
 }
 
-/** Editable network card: current IP, DHCP status, reservation create/update/remove. */
-export function DeviceNetworkCard({ device }: DeviceNetworkCardProps) {
-  const { data: reservationsData } = useDhcpReservations();
-  const reservation = findReservation(
-    reservationsData?.reservations,
-    device.mac,
-  );
-
-  const createReservation = useCreateReservation();
-  // Dedicated silent instance for the rollback recreate below: it must not
-  // pop a "Reservation created" toast that would contradict the failure the
-  // admin is being shown for their actual edit.
-  const restoreReservation = useCreateReservation({ silent: true });
-  const deleteReservation = useDeleteReservation();
+/** Editable network card: current IP, DHCP status, reservation
+ *  create/update/remove. Pure presentation — the owning page wires the
+ *  query/mutation hooks and passes data + callbacks in. */
+export function DeviceNetworkCard({
+  device,
+  reservations,
+  createReservation,
+  restoreReservation,
+  deleteReservation,
+}: DeviceNetworkCardProps) {
+  const reservation = findReservation(reservations, device.mac);
 
   const [editing, setEditing] = useState(false);
   const [ip, setIp] = useState(reservation?.ip_address ?? device.last_ip);

--- a/source/admin-site/src/components/features/DeviceRoutingProfilesCard.tsx
+++ b/source/admin-site/src/components/features/DeviceRoutingProfilesCard.tsx
@@ -19,15 +19,17 @@ import {
 import { Text } from "@wardnet/web";
 import { ApiErrorAlert } from "@wardnet/web";
 import { FormActions } from "@wardnet/web";
-import {
-  useRoutingProfiles,
-  useDeviceRoutingProfiles,
-  useSetDeviceRoutingProfiles,
-} from "@wardnet/web";
+import type { MutationHandle } from "@/lib/mutationHandle";
 import type { Device, RoutingProfile } from "@wardnet/js";
 
 interface DeviceRoutingProfilesCardProps {
   device: Device;
+  /** All routing profiles. */
+  allProfiles: RoutingProfile[];
+  /** This device's assigned profile ids, in priority order. */
+  assignedIds: string[];
+  /** The page's hoisted assignment-save mutation. */
+  save: MutationHandle<{ deviceId: string; profileIds: string[] }>;
 }
 
 /**
@@ -35,18 +37,15 @@ interface DeviceRoutingProfilesCardProps {
  * profiles are consulted in priority order — the first profile whose rule
  * matches a resolved domain wins — so the list order matters. Editing mirrors
  * the upstream-DNS reorder idiom: move up/down + remove, add from the
- * unassigned set, then save the whole ordered list.
+ * unassigned set, then save the whole ordered list. Pure presentation — the
+ * owning page wires the query/mutation hooks and passes data + callbacks in.
  */
 export function DeviceRoutingProfilesCard({
   device,
+  allProfiles,
+  assignedIds,
+  save,
 }: DeviceRoutingProfilesCardProps) {
-  const { data: profilesData } = useRoutingProfiles();
-  const { data: assignedData } = useDeviceRoutingProfiles(device.id);
-  const save = useSetDeviceRoutingProfiles();
-
-  const allProfiles = profilesData?.profiles ?? [];
-  const assignedIds = assignedData?.profile_ids ?? [];
-
   const [editing, setEditing] = useState(false);
   const [draft, setDraft] = useState<string[]>([]);
 

--- a/source/admin-site/src/components/features/DeviceSettingsCard.tsx
+++ b/source/admin-site/src/components/features/DeviceSettingsCard.tsx
@@ -22,11 +22,16 @@ import { Toggle } from "@wardnet/web";
 import { ApiErrorAlert } from "@wardnet/web";
 import { DeviceIcon } from "@wardnet/web";
 import { RoutingSelector } from "@wardnet/web";
-import { useUpdateDevice } from "@wardnet/web";
-import { useTunnels } from "@wardnet/web";
 import { countryFlag } from "@wardnet/web";
 import { DEVICE_TYPE_OPTIONS, deviceTypeLabel } from "@wardnet/web";
-import type { Device, DeviceType, RoutingTarget, Tunnel } from "@wardnet/js";
+import type { MutationHandle } from "@/lib/mutationHandle";
+import type {
+  Device,
+  DeviceType,
+  RoutingTarget,
+  Tunnel,
+  UpdateDeviceRequest,
+} from "@wardnet/js";
 
 function routingLabel(
   target: RoutingTarget | null,
@@ -52,17 +57,21 @@ function routingLabel(
 interface DeviceSettingsCardProps {
   device: Device;
   currentRule: RoutingTarget | null;
+  tunnels: Tunnel[];
+  /** The page's hoisted device-update mutation. */
+  updateDevice: MutationHandle<{ id: string; body: UpdateDeviceRequest }>;
 }
 
-/** Editable settings card: friendly name, type, routing, admin lock. */
+/** Editable settings card: friendly name, type, routing, admin lock. Pure
+ *  presentation — the owning page wires the query/mutation hooks and passes
+ *  data + callbacks in. */
 export function DeviceSettingsCard({
   device,
   currentRule,
+  tunnels,
+  updateDevice,
 }: DeviceSettingsCardProps) {
   const isManaged = device.name != null;
-  const { data: tunnelData } = useTunnels();
-  const tunnels = tunnelData?.tunnels ?? [];
-  const updateDevice = useUpdateDevice();
 
   const [editing, setEditing] = useState(false);
   const [name, setName] = useState(device.name ?? "");

--- a/source/admin-site/src/components/features/DeviceZoneCard.tsx
+++ b/source/admin-site/src/components/features/DeviceZoneCard.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useState } from "react";
 import { Button } from "@wardnet/web";
 import { FormActions } from "@wardnet/web";
 import { Text } from "@wardnet/web";
@@ -18,25 +18,29 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@wardnet/web";
-import { useNetworkZones, useAssignDeviceZone } from "@wardnet/web";
 import { IsolationDisclaimer } from "./IsolationDisclaimer";
-import type { Device } from "@wardnet/js";
+import type { MutationHandle } from "@/lib/mutationHandle";
+import type { Device, NetworkZoneView } from "@wardnet/js";
 
 interface DeviceZoneCardProps {
   device: Device;
+  zones: NetworkZoneView[];
+  /** The page's hoisted zone-assignment mutation. */
+  assignZone: MutationHandle<{ deviceId: string; zoneId: string }>;
 }
 
 /**
  * Zone selector card for the device editor. A device belongs to exactly one
  * Network Zone; changing it here re-runs the daemon's per-device egress /
  * admin-UI enforcement. The isolation disclaimer is mandatory wherever
- * isolation is implied (issue #739).
+ * isolation is implied (issue #739). Pure presentation — the owning page
+ * wires the query/mutation hooks and passes data + callbacks in.
  */
-export function DeviceZoneCard({ device }: DeviceZoneCardProps) {
-  const { data: zoneData } = useNetworkZones();
-  const assignZone = useAssignDeviceZone({ successMessage: "Zone updated" });
-  const zones = useMemo(() => zoneData?.zones ?? [], [zoneData]);
-
+export function DeviceZoneCard({
+  device,
+  zones,
+  assignZone,
+}: DeviceZoneCardProps) {
   const [editing, setEditing] = useState(false);
   const [zoneId, setZoneId] = useState(device.zone_id);
 

--- a/source/admin-site/src/components/features/DhcpLanInfoCard.tsx
+++ b/source/admin-site/src/components/features/DhcpLanInfoCard.tsx
@@ -1,4 +1,3 @@
-import { useMemo } from "react";
 import { Link } from "react-router";
 import {
   Card,
@@ -10,19 +9,18 @@ import {
 import { Button } from "@wardnet/web";
 import { Text } from "@wardnet/web";
 import { Pill } from "@wardnet/web";
-import { useDnsRecords } from "@wardnet/web";
 
-/** Read-only explainer for the DHCP `.lan` integration. Owns its own data —
- *  counts the DHCP-sourced records ({hostname}.lan, auto-registered into the
- *  seeded `lan` zone). These are managed automatically and don't appear in the
- *  editable Records table. */
-export function DhcpLanInfoCard() {
-  const { data } = useDnsRecords();
-  const dhcpRecordCount = useMemo(
-    () => (data?.records ?? []).filter((r) => r.source === "dhcp").length,
-    [data],
-  );
+interface DhcpLanInfoCardProps {
+  /** Count of DHCP-sourced records ({hostname}.lan, auto-registered into the
+   *  seeded `lan` zone), derived by the owning page from the shared records
+   *  query. */
+  dhcpRecordCount: number;
+}
 
+/** Read-only explainer for the DHCP `.lan` integration. The auto-registered
+ *  records are managed automatically and don't appear in the editable Records
+ *  table. Pure presentation — the owning page passes the derived count in. */
+export function DhcpLanInfoCard({ dhcpRecordCount }: DhcpLanInfoCardProps) {
   return (
     <Card>
       <CardHeader>

--- a/source/admin-site/src/components/features/DnsAnalyticsSection.tsx
+++ b/source/admin-site/src/components/features/DnsAnalyticsSection.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useMemo } from "react";
 import {
   CartesianGrid,
   Line,
@@ -20,16 +20,14 @@ import {
   SelectItem,
   SelectTrigger,
   SelectValue,
-  useDevices,
-  useDnsPeriodComparison,
-  useDnsPerDeviceStats,
-  useDnsTopTrackers,
   deviceDisplayName,
   parseLabels,
   RANGE_HOURS,
+  type DevicePoint,
+  type DnsPeriodComparison,
   type StatsRange,
 } from "@wardnet/web";
-import type { StatsTopEntry } from "@wardnet/js";
+import type { Device, StatsTopEntry, StatsTopResponse } from "@wardnet/js";
 
 const perDeviceConfig: ChartConfig = {
   total: { label: "Queries", color: "var(--chart-1)" },
@@ -71,30 +69,37 @@ function formatXAxis(tsMs: number, range: StatsRange): string {
 
 interface Props {
   range: StatsRange;
+  /** The page's `useDnsPeriodComparison` data. */
+  comparison: DnsPeriodComparison | undefined;
+  /** The page's `useDnsTopTrackers` data. */
+  trackers: StatsTopResponse | undefined;
+  devices: Device[];
+  /** The device the per-device chart is showing (the page defaults it to the
+   *  first device once the list loads). */
+  selectedDeviceId: string;
+  onSelectDevice: (deviceId: string) => void;
+  /** The page's `useDnsPerDeviceStats` series for the selected device. */
+  deviceSeries: DevicePoint[] | undefined;
+  deviceSeriesLoading: boolean;
 }
 
 /**
  * Deeper DNS analytics for the DNS page, rendered under the same range
  * selector as {@link DnsStatsSection}: period-over-period comparison, top
  * trackers blocked (categorised by operating company), and a per-device
- * query timeseries.
+ * query timeseries. Pure presentation — the owning page wires the query
+ * hooks and passes data + callbacks in.
  */
-export function DnsAnalyticsSection({ range }: Props) {
-  const { data: comparison } = useDnsPeriodComparison(range);
-  const { data: trackers } = useDnsTopTrackers(range);
-  const { data: devicesData } = useDevices();
-
-  const devices = devicesData?.devices ?? [];
-  const [selectedDevice, setSelectedDevice] = useState<string>("");
-  // Default to the first device once the list loads, so the chart shows
-  // something without the user having to pick.
-  const effectiveDevice =
-    selectedDevice || (devices.length > 0 ? devices[0].id : "");
-  const { data: deviceSeries, isLoading: deviceLoading } = useDnsPerDeviceStats(
-    effectiveDevice || null,
-    range,
-  );
-
+export function DnsAnalyticsSection({
+  range,
+  comparison,
+  trackers,
+  devices,
+  selectedDeviceId: effectiveDevice,
+  onSelectDevice: setSelectedDevice,
+  deviceSeries,
+  deviceSeriesLoading: deviceLoading,
+}: Props) {
   const chartSeries = useMemo(
     () =>
       (deviceSeries ?? []).map((p) => ({

--- a/source/admin-site/src/components/features/DnsStatsSection.tsx
+++ b/source/admin-site/src/components/features/DnsStatsSection.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useMemo } from "react";
 import { Link } from "react-router";
 import {
   CartesianGrid,
@@ -20,10 +20,9 @@ import { DashboardStatCard } from "@/components/compound/DashboardStatCard";
 import { HostCell } from "@/components/compound/HostCell";
 import { useChartZoom, type ZoomRange } from "@/hooks/useChartZoom";
 import {
-  useDevices,
-  useDnsStatsDashboard,
   deviceDisplayName,
   RANGE_HOURS,
+  type DnsStatsDashboardData,
   type StatsRange,
 } from "@wardnet/web";
 import type { Device, StatsTopEntry } from "@wardnet/js";
@@ -50,34 +49,34 @@ function formatXAxis(tsMs: number, range: StatsRange): string {
 
 interface Props {
   range: StatsRange;
+  /** The committed chart-zoom window, owned by the page because it also
+   *  drives the dashboard query's top-N window. */
+  zoom: ZoomRange | null;
+  onZoomChange: (zoom: ZoomRange | null) => void;
+  /** The page's `useDnsStatsDashboard` result. */
+  data: DnsStatsDashboardData | undefined;
+  isLoading: boolean;
+  isError: boolean;
+  error: unknown;
+  /** Device list for resolving top-client entries' `device_id` labels to
+   *  names. Lookup is by immutable device id — never by IP, which DHCP may
+   *  have reassigned since the stats were recorded. */
+  devices: Device[] | undefined;
 }
 
-/** Stats panel for the DNS page: top cards, time series, top tables. */
-export function DnsStatsSection({ range }: Props) {
-  // Device list for resolving top-client entries' `device_id` labels to
-  // names. Lookup is by immutable device id — never by IP, which DHCP may
-  // have reassigned since the stats were recorded.
-  const { data: devicesData } = useDevices();
-  // Tag zoom with the range it was committed for so it auto-invalidates
-  // when the parent changes range without needing a useEffect reset.
-  const [storedZoom, setStoredZoom] = useState<{
-    range: StatsRange;
-    zoom: ZoomRange;
-  } | null>(null);
-  const zoom = storedZoom?.range === range ? storedZoom.zoom : null;
-  const setZoom = (z: ZoomRange | null) =>
-    setStoredZoom(z ? { range, zoom: z } : null);
-  const topOverride = zoom
-    ? {
-        from: new Date(Number(zoom.start)).toISOString(),
-        to: new Date(Number(zoom.end)).toISOString(),
-      }
-    : undefined;
-  const { data, isLoading, isError, error } = useDnsStatsDashboard(
-    range,
-    topOverride,
-  );
-
+/** Stats panel for the DNS page: top cards, time series, top tables.
+ *  Pure presentation — the owning page wires the query hooks and passes
+ *  data + callbacks in. */
+export function DnsStatsSection({
+  range,
+  zoom,
+  onZoomChange: setZoom,
+  data,
+  isLoading,
+  isError,
+  error,
+  devices,
+}: Props) {
   // Numeric-timestamp chart data lets Recharts XAxis use type="number"
   // so the domain can be constrained to the zoom window, same pattern as
   // TunnelThroughputChart.
@@ -280,7 +279,7 @@ export function DnsStatsSection({ range }: Props) {
         <TopClientsList
           title={`Top clients (${zoomLabel ?? range})`}
           entries={data?.topClients.entries}
-          devices={devicesData?.devices}
+          devices={devices}
         />
       </div>
     </div>

--- a/source/admin-site/src/components/features/DnsStatsSection.tsx
+++ b/source/admin-site/src/components/features/DnsStatsSection.tsx
@@ -61,7 +61,7 @@ interface Props {
   /** Device list for resolving top-client entries' `device_id` labels to
    *  names. Lookup is by immutable device id — never by IP, which DHCP may
    *  have reassigned since the stats were recorded. */
-  devices: Device[] | undefined;
+  devices: Device[];
 }
 
 /** Stats panel for the DNS page: top cards, time series, top tables.

--- a/source/admin-site/src/components/features/DnsZonesCard.tsx
+++ b/source/admin-site/src/components/features/DnsZonesCard.tsx
@@ -10,6 +10,7 @@ import { Toggle } from "@wardnet/web";
 import { Text } from "@wardnet/web";
 import { DataTable, RowAction } from "@/components/core/ui/data-table";
 import { ConfirmDialog } from "@/components/compound/ConfirmDialog";
+import type { MutateFn } from "@/lib/mutationHandle";
 import type {
   CreateZoneRequest,
   CustomDnsRecord,
@@ -31,17 +32,8 @@ interface DnsZonesCardProps {
   /** True while the page's update mutation is in flight (gates the per-row
    *  enable toggles without also locking them during a create). */
   updatePending: boolean;
-  /** The optional callbacks match TanStack's `mutate` signature so the page
-   *  can pass the mutation's `mutate` straight through; the card uses
-   *  `onSuccess` to close its inline form. */
-  onCreateZone: (
-    body: CreateZoneRequest,
-    callbacks?: { onSuccess?: () => void },
-  ) => void;
-  onUpdateZone: (
-    change: { id: string; body: UpdateZoneRequest },
-    callbacks?: { onSuccess?: () => void },
-  ) => void;
+  onCreateZone: MutateFn<CreateZoneRequest>;
+  onUpdateZone: MutateFn<{ id: string; body: UpdateZoneRequest }>;
   onDeleteZone: (id: string) => void;
 }
 

--- a/source/admin-site/src/components/features/DnsZonesCard.tsx
+++ b/source/admin-site/src/components/features/DnsZonesCard.tsx
@@ -10,46 +10,66 @@ import { Toggle } from "@wardnet/web";
 import { Text } from "@wardnet/web";
 import { DataTable, RowAction } from "@/components/core/ui/data-table";
 import { ConfirmDialog } from "@/components/compound/ConfirmDialog";
-import {
-  useDnsZones,
-  useDnsRecords,
-  useCreateDnsZone,
-  useUpdateDnsZone,
-  useDeleteDnsZone,
-} from "@wardnet/web";
-import type { DnsZone } from "@wardnet/js";
+import type {
+  CreateZoneRequest,
+  CustomDnsRecord,
+  DnsZone,
+  UpdateZoneRequest,
+} from "@wardnet/js";
 
 /** Public-suffix-looking single label or known TLD — making the gateway
  *  authoritative for such a zone would blackhole the real public domain, so
  *  the form warns (without blocking — `.lan` / `home` are perfectly valid). */
 const PUBLIC_TLD = /\.(com|net|org|io|dev|app|co|gov|edu)$/i;
 
+interface DnsZonesCardProps {
+  zones: DnsZone[];
+  /** All local records — the card derives per-zone record counts from them. */
+  records: CustomDnsRecord[];
+  /** True while the page's create or update mutation is in flight. */
+  isSaving: boolean;
+  /** True while the page's update mutation is in flight (gates the per-row
+   *  enable toggles without also locking them during a create). */
+  updatePending: boolean;
+  /** The optional callbacks match TanStack's `mutate` signature so the page
+   *  can pass the mutation's `mutate` straight through; the card uses
+   *  `onSuccess` to close its inline form. */
+  onCreateZone: (
+    body: CreateZoneRequest,
+    callbacks?: { onSuccess?: () => void },
+  ) => void;
+  onUpdateZone: (
+    change: { id: string; body: UpdateZoneRequest },
+    callbacks?: { onSuccess?: () => void },
+  ) => void;
+  onDeleteZone: (id: string) => void;
+}
+
 /** Authoritative local zones. An enabled zone makes the gateway own the whole
  *  `*.zone` namespace (unknown names answered NXDOMAIN, never forwarded) and
- *  acts as a master switch over its records. */
-export function DnsZonesCard() {
-  const { data: zoneData } = useDnsZones();
-  const { data: recordData } = useDnsRecords();
-  const createZone = useCreateDnsZone();
-  const updateZone = useUpdateDnsZone();
-  const deleteZone = useDeleteDnsZone();
-
+ *  acts as a master switch over its records. Pure presentation — the owning
+ *  page wires the query/mutation hooks and passes data + callbacks in. */
+export function DnsZonesCard({
+  zones,
+  records,
+  isSaving,
+  updatePending,
+  onCreateZone,
+  onUpdateZone,
+  onDeleteZone,
+}: DnsZonesCardProps) {
   const [formOpen, setFormOpen] = useState(false);
   const [editing, setEditing] = useState<DnsZone | null>(null);
   const [deleteId, setDeleteId] = useState<string | null>(null);
 
-  const zones = useMemo(() => zoneData?.zones ?? [], [zoneData]);
-
   // Per-zone record count, derived from the already-loaded records list.
   const recordCount = useMemo(() => {
     const counts = new Map<string, number>();
-    for (const r of recordData?.records ?? []) {
+    for (const r of records) {
       if (r.zone_id) counts.set(r.zone_id, (counts.get(r.zone_id) ?? 0) + 1);
     }
     return counts;
-  }, [recordData]);
-
-  const isSaving = createZone.isPending || updateZone.isPending;
+  }, [records]);
   const zoneToDelete = zones.find((z) => z.id === deleteId);
   const deleteCount = zoneToDelete
     ? (recordCount.get(zoneToDelete.id) ?? 0)
@@ -98,14 +118,14 @@ export function DnsZonesCard() {
             aria-label={`Toggle zone ${row.original.name}`}
             checked={row.original.enabled}
             onCheckedChange={(enabled) =>
-              updateZone.mutate({ id: row.original.id, body: { enabled } })
+              onUpdateZone({ id: row.original.id, body: { enabled } })
             }
-            disabled={updateZone.isPending}
+            disabled={updatePending}
           />
         ),
       },
     ],
-    [recordCount, updateZone],
+    [recordCount, onUpdateZone, updatePending],
   );
 
   return (
@@ -121,11 +141,9 @@ export function DnsZonesCard() {
             zone={editing}
             isSaving={isSaving}
             onCancel={closeForm}
-            onCreate={(body) =>
-              createZone.mutate(body, { onSuccess: closeForm })
-            }
+            onCreate={(body) => onCreateZone(body, { onSuccess: closeForm })}
             onUpdate={(id, body) =>
-              updateZone.mutate({ id, body }, { onSuccess: closeForm })
+              onUpdateZone({ id, body }, { onSuccess: closeForm })
             }
           />
         )}
@@ -173,7 +191,7 @@ export function DnsZonesCard() {
         description={`Delete zone "${zoneToDelete?.name ?? ""}"? Its ${deleteCount} record(s) are kept (they become unzoned), but the gateway stops being authoritative for *.${zoneToDelete?.name ?? ""} - unknown names under it will be forwarded upstream again.`}
         confirmLabel="Delete"
         onConfirm={() => {
-          if (deleteId) deleteZone.mutate(deleteId);
+          if (deleteId) onDeleteZone(deleteId);
           setDeleteId(null);
         }}
       />

--- a/source/admin-site/src/components/features/LocalRecordsCard.tsx
+++ b/source/admin-site/src/components/features/LocalRecordsCard.tsx
@@ -18,14 +18,13 @@ import {
 } from "@wardnet/web";
 import { DataTable, RowAction } from "@/components/core/ui/data-table";
 import { ConfirmDialog } from "@/components/compound/ConfirmDialog";
-import {
-  useDnsRecords,
-  useDnsZones,
-  useCreateDnsRecord,
-  useUpdateDnsRecord,
-  useDeleteDnsRecord,
-} from "@wardnet/web";
-import type { CustomDnsRecord, DnsRecordType } from "@wardnet/js";
+import type {
+  CreateRecordRequest,
+  CustomDnsRecord,
+  DnsRecordType,
+  DnsZone,
+  UpdateRecordRequest,
+} from "@wardnet/js";
 
 const RECORD_TYPES: DnsRecordType[] = [
   "A",
@@ -39,32 +38,57 @@ const RECORD_TYPES: DnsRecordType[] = [
  *  empty string value, so we map this to `zone_id: null` on submit. */
 const NO_ZONE = "__none__";
 
+interface LocalRecordsCardProps {
+  /** All local records — the card shows only the editable `manual` ones. */
+  records: CustomDnsRecord[];
+  zones: DnsZone[];
+  /** True while the page's create or update mutation is in flight. */
+  isSaving: boolean;
+  /** True while the page's update mutation is in flight (gates the per-row
+   *  enable toggles without also locking them during a create). */
+  updatePending: boolean;
+  /** The optional callbacks match TanStack's `mutate` signature so the page
+   *  can pass the mutation's `mutate` straight through; the card uses
+   *  `onSuccess` to close its inline form. */
+  onCreateRecord: (
+    body: CreateRecordRequest,
+    callbacks?: { onSuccess?: () => void },
+  ) => void;
+  onUpdateRecord: (
+    change: { id: string; body: UpdateRecordRequest },
+    callbacks?: { onSuccess?: () => void },
+  ) => void;
+  onDeleteRecord: (id: string) => void;
+}
+
 /** Custom local DNS records — the manual CRUD surface. DHCP/system records
  *  are intentionally excluded here (they're surfaced in the DHCP `.lan`
- *  info card); only `source === "manual"` records are editable. */
-export function LocalRecordsCard() {
-  const { data: recordData } = useDnsRecords();
-  const { data: zoneData } = useDnsZones();
-  const createRecord = useCreateDnsRecord();
-  const updateRecord = useUpdateDnsRecord();
-  const deleteRecord = useDeleteDnsRecord();
-
+ *  info card); only `source === "manual"` records are editable. Pure
+ *  presentation — the owning page wires the query/mutation hooks and passes
+ *  data + callbacks in. */
+export function LocalRecordsCard({
+  records: allRecords,
+  zones,
+  isSaving,
+  updatePending,
+  onCreateRecord,
+  onUpdateRecord,
+  onDeleteRecord,
+}: LocalRecordsCardProps) {
   const [formOpen, setFormOpen] = useState(false);
   const [editing, setEditing] = useState<CustomDnsRecord | null>(null);
   const [deleteId, setDeleteId] = useState<string | null>(null);
 
-  const zones = useMemo(() => zoneData?.zones ?? [], [zoneData]);
   const zoneName = useMemo(() => {
     const map = new Map(zones.map((z) => [z.id, z.name]));
     return (id?: string | null) => (id ? (map.get(id) ?? "-") : "-");
   }, [zones]);
 
   const records = useMemo(
-    () => (recordData?.records ?? []).filter((r) => r.source === "manual"),
-    [recordData],
+    () => allRecords.filter((r) => r.source === "manual"),
+    [allRecords],
   );
 
-  const isSaving = createRecord.isPending || updateRecord.isPending;
   const recordToDelete = records.find((r) => r.id === deleteId);
 
   function openCreate() {
@@ -137,14 +161,14 @@ export function LocalRecordsCard() {
             aria-label={`Toggle ${row.original.domain}`}
             checked={row.original.enabled}
             onCheckedChange={(enabled) =>
-              updateRecord.mutate({ id: row.original.id, body: { enabled } })
+              onUpdateRecord({ id: row.original.id, body: { enabled } })
             }
-            disabled={updateRecord.isPending}
+            disabled={updatePending}
           />
         ),
       },
     ],
-    [zoneName, updateRecord],
+    [zoneName, onUpdateRecord, updatePending],
   );
 
   return (
@@ -162,11 +186,9 @@ export function LocalRecordsCard() {
             zones={zones}
             isSaving={isSaving}
             onCancel={closeForm}
-            onCreate={(body) =>
-              createRecord.mutate(body, { onSuccess: closeForm })
-            }
+            onCreate={(body) => onCreateRecord(body, { onSuccess: closeForm })}
             onUpdate={(id, body) =>
-              updateRecord.mutate({ id, body }, { onSuccess: closeForm })
+              onUpdateRecord({ id, body }, { onSuccess: closeForm })
             }
           />
         )}
@@ -210,7 +232,7 @@ export function LocalRecordsCard() {
         description={`Delete ${recordToDelete?.record_type ?? ""} record for ${recordToDelete?.domain ?? "this name"}? Clients will stop resolving it locally.`}
         confirmLabel="Delete"
         onConfirm={() => {
-          if (deleteId) deleteRecord.mutate(deleteId);
+          if (deleteId) onDeleteRecord(deleteId);
           setDeleteId(null);
         }}
       />

--- a/source/admin-site/src/components/features/LocalRecordsCard.tsx
+++ b/source/admin-site/src/components/features/LocalRecordsCard.tsx
@@ -18,6 +18,7 @@ import {
 } from "@wardnet/web";
 import { DataTable, RowAction } from "@/components/core/ui/data-table";
 import { ConfirmDialog } from "@/components/compound/ConfirmDialog";
+import type { MutateFn } from "@/lib/mutationHandle";
 import type {
   CreateRecordRequest,
   CustomDnsRecord,
@@ -47,17 +48,8 @@ interface LocalRecordsCardProps {
   /** True while the page's update mutation is in flight (gates the per-row
    *  enable toggles without also locking them during a create). */
   updatePending: boolean;
-  /** The optional callbacks match TanStack's `mutate` signature so the page
-   *  can pass the mutation's `mutate` straight through; the card uses
-   *  `onSuccess` to close its inline form. */
-  onCreateRecord: (
-    body: CreateRecordRequest,
-    callbacks?: { onSuccess?: () => void },
-  ) => void;
-  onUpdateRecord: (
-    change: { id: string; body: UpdateRecordRequest },
-    callbacks?: { onSuccess?: () => void },
-  ) => void;
+  onCreateRecord: MutateFn<CreateRecordRequest>;
+  onUpdateRecord: MutateFn<{ id: string; body: UpdateRecordRequest }>;
   onDeleteRecord: (id: string) => void;
 }
 

--- a/source/admin-site/src/components/features/PrivateDnsCard.tsx
+++ b/source/admin-site/src/components/features/PrivateDnsCard.tsx
@@ -17,6 +17,7 @@ import type {
   PrivateDnsPrerequisites,
   PrivateDnsStatusResponse,
 } from "@wardnet/js";
+import type { MutationHandle } from "@/lib/mutationHandle";
 import { ConfirmDialog } from "@/components/compound/ConfirmDialog";
 import { DeviceSelect } from "@/components/compound/DeviceSelect";
 import { PrivateDnsGrantsTable } from "@/components/compound/PrivateDnsGrantsTable";
@@ -31,11 +32,8 @@ interface PrivateDnsCardProps {
   /** True while the page's enable/disable mutation is in flight. */
   setEnabledPending: boolean;
   /** The page's hoisted grant mutation. The card consumes the resolved grant
-   *  to open the setup-link modal, so it needs `mutateAsync`. */
-  grantDevice: {
-    mutateAsync: (deviceId: string) => Promise<PrivateDnsGrantSummary>;
-    isPending: boolean;
-  };
+   *  to open the setup-link modal. */
+  grantDevice: MutationHandle<string, PrivateDnsGrantSummary>;
   onRevokeDevice: (deviceId: string) => void;
   onSendToDevice: (deviceId: string) => void;
   /** True while the page's send-to-device mutation is in flight. */

--- a/source/admin-site/src/components/features/PrivateDnsCard.tsx
+++ b/source/admin-site/src/components/features/PrivateDnsCard.tsx
@@ -10,21 +10,37 @@ import {
   Text,
   Toggle,
   deviceDisplayName,
-  useDevices,
-  usePrivateDnsStatus,
-  useSetPrivateDnsEnabled,
-  useGrantPrivateDnsDevice,
-  useRevokePrivateDnsDevice,
-  useSendPrivateDnsToDevice,
 } from "@wardnet/web";
 import type {
+  Device,
   PrivateDnsGrantSummary,
   PrivateDnsPrerequisites,
+  PrivateDnsStatusResponse,
 } from "@wardnet/js";
 import { ConfirmDialog } from "@/components/compound/ConfirmDialog";
 import { DeviceSelect } from "@/components/compound/DeviceSelect";
 import { PrivateDnsGrantsTable } from "@/components/compound/PrivateDnsGrantsTable";
 import { PrivateDnsGrantedModal } from "@/components/features/PrivateDnsGrantedModal";
+
+interface PrivateDnsCardProps {
+  /** The Private DNS status, or `undefined` while the page's query loads. */
+  status: PrivateDnsStatusResponse | undefined;
+  isLoading: boolean;
+  devices: Device[];
+  onSetEnabled: (enabled: boolean) => void;
+  /** True while the page's enable/disable mutation is in flight. */
+  setEnabledPending: boolean;
+  /** The page's hoisted grant mutation. The card consumes the resolved grant
+   *  to open the setup-link modal, so it needs `mutateAsync`. */
+  grantDevice: {
+    mutateAsync: (deviceId: string) => Promise<PrivateDnsGrantSummary>;
+    isPending: boolean;
+  };
+  onRevokeDevice: (deviceId: string) => void;
+  onSendToDevice: (deviceId: string) => void;
+  /** True while the page's send-to-device mutation is in flight. */
+  sendPending: boolean;
+}
 
 /**
  * Private DNS (issue #915) — always mounted on the Remote Access page so the
@@ -32,20 +48,20 @@ import { PrivateDnsGrantedModal } from "@/components/features/PrivateDnsGrantedM
  * exists. Enabling is gated on three hard prerequisites (wardnet provider, live
  * certificate, Premium entitlement); the reverse tunnel is informational only.
  * Once enabled the admin grants managed devices and can push a setup link to
- * each granted device.
+ * each granted device. Pure presentation — the owning page wires the
+ * query/mutation hooks and passes data + callbacks in.
  */
-export function PrivateDnsCard() {
-  const { data: status, isLoading } = usePrivateDnsStatus();
-  const setEnabled = useSetPrivateDnsEnabled();
-  const grantDevice = useGrantPrivateDnsDevice();
-  const revokeDevice = useRevokePrivateDnsDevice();
-  const sendToDevice = useSendPrivateDnsToDevice();
-  const { data: devicesData } = useDevices();
-
-  const devices = useMemo(
-    () => devicesData?.devices ?? [],
-    [devicesData?.devices],
-  );
+export function PrivateDnsCard({
+  status,
+  isLoading,
+  devices,
+  onSetEnabled,
+  setEnabledPending,
+  grantDevice,
+  onRevokeDevice,
+  onSendToDevice,
+  sendPending,
+}: PrivateDnsCardProps) {
   const deviceById = useMemo(
     () => new Map(devices.map((d) => [d.id, d])),
     [devices],
@@ -107,10 +123,8 @@ export function PrivateDnsCard() {
             checked={enabled}
             // Enabling needs every hard prerequisite; disabling is always
             // allowed.
-            disabled={
-              isLoading || setEnabled.isPending || (!enabled && !hardMet)
-            }
-            onCheckedChange={(next) => setEnabled.mutate(next)}
+            disabled={isLoading || setEnabledPending || (!enabled && !hardMet)}
+            onCheckedChange={onSetEnabled}
           />
         </CardAction>
       </CardHeader>
@@ -190,7 +204,7 @@ export function PrivateDnsCard() {
             <PrivateDnsGrantsTable
               grants={grants}
               deviceName={deviceName}
-              onSendToDevice={(grant) => sendToDevice.mutate(grant.device_id)}
+              onSendToDevice={(grant) => onSendToDevice(grant.device_id)}
               onRevoke={setRevokeTarget}
             />
           </div>
@@ -200,8 +214,8 @@ export function PrivateDnsCard() {
       <PrivateDnsGrantedModal
         grant={granted}
         deviceName={granted ? deviceName(granted.device_id) : ""}
-        onSendToDevice={(grant) => sendToDevice.mutate(grant.device_id)}
-        sending={sendToDevice.isPending}
+        onSendToDevice={(grant) => onSendToDevice(grant.device_id)}
+        sending={sendPending}
         onDismiss={() => setGranted(null)}
       />
 
@@ -216,7 +230,7 @@ export function PrivateDnsCard() {
         } and deletes its hostname. Re-granting later mints a new one.`}
         confirmLabel="Revoke"
         onConfirm={() => {
-          if (revokeTarget) revokeDevice.mutate(revokeTarget.device_id);
+          if (revokeTarget) onRevokeDevice(revokeTarget.device_id);
           setRevokeTarget(null);
         }}
       />

--- a/source/admin-site/src/components/features/QuarantineSettingsCard.tsx
+++ b/source/admin-site/src/components/features/QuarantineSettingsCard.tsx
@@ -31,9 +31,10 @@ interface QuarantineSettingsCardProps {
   zones: NetworkZoneView[];
   /** Approve a pending device into a zone. */
   onApprove: (deviceId: string, zoneId: string) => void;
-  /** Device id whose approval is mid-flight, or `null`. Derived by the page
-   *  from the single hoisted mutation's `isPending` + `variables`. */
-  approvingDeviceId: string | null;
+  /** Device ids whose approvals are mid-flight. A list, not the shared
+   *  mutation's latest `variables`: with concurrent approvals every
+   *  in-flight row must stay disabled, not just the most recent one. */
+  approvingDeviceIds: string[];
 }
 
 /**
@@ -55,7 +56,7 @@ export function QuarantineSettingsCard({
   homeZone,
   zones,
   onApprove,
-  approvingDeviceId,
+  approvingDeviceIds,
 }: QuarantineSettingsCardProps) {
   return (
     <Card>
@@ -124,7 +125,7 @@ export function QuarantineSettingsCard({
                   zones={zones}
                   defaultTargetZoneId={homeZone?.id}
                   onApprove={onApprove}
-                  approving={approvingDeviceId === device.id}
+                  approving={approvingDeviceIds.includes(device.id)}
                 />
               ))}
             </div>

--- a/source/admin-site/src/components/features/QuarantineSettingsCard.tsx
+++ b/source/admin-site/src/components/features/QuarantineSettingsCard.tsx
@@ -11,16 +11,30 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@wardnet/web";
-import {
-  usePendingDevices,
-  useUpdateNetworkZone,
-  useAssignDeviceZone,
-  useQuarantineNewDevices,
-  useSetQuarantineNewDevices,
-  deviceDisplayName,
-  timeAgo,
-} from "@wardnet/web";
+import { deviceDisplayName, timeAgo } from "@wardnet/web";
 import type { Device, NetworkZoneView } from "@wardnet/js";
+
+interface QuarantineSettingsCardProps {
+  /** Whether new-device notifications are enabled. */
+  notifyEnabled: boolean;
+  /** True while the page's notify-toggle mutation is in flight. */
+  notifyPending: boolean;
+  onSetNotify: (enabled: boolean) => void;
+  /** Flag a zone as the landing spot for newly-discovered devices. */
+  onSetDefaultForNew: (id: string) => void;
+  /** Devices sitting in the default-for-new zone, most-recent-first. */
+  pending: Device[];
+  /** The zone new devices land in, if one is flagged. */
+  defaultForNew: NetworkZoneView | undefined;
+  /** The anchor "home" zone (the usual approve target). */
+  homeZone: NetworkZoneView | undefined;
+  zones: NetworkZoneView[];
+  /** Approve a pending device into a zone. */
+  onApprove: (deviceId: string, zoneId: string) => void;
+  /** Device id whose approval is mid-flight, or `null`. Derived by the page
+   *  from the single hoisted mutation's `isPending` + `variables`. */
+  approvingDeviceId: string | null;
+}
 
 /**
  * New-device quarantine settings (issue #738). Quarantine is **notification
@@ -28,16 +42,21 @@ import type { Device, NetworkZoneView } from "@wardnet/js";
  * the toggle just controls whether admins get a push when one appears. The
  * "pending approvals" list is derived — devices currently sitting in the
  * default-for-new zone, most-recent-first — and "Approve" simply reassigns the
- * device to a real zone.
+ * device to a real zone. Pure presentation — the owning page wires the
+ * query/mutation hooks and passes data + callbacks in.
  */
-export function QuarantineSettingsCard() {
-  const { data: quarantine } = useQuarantineNewDevices();
-  const setQuarantine = useSetQuarantineNewDevices();
-  const setDefaultForNew = useUpdateNetworkZone({
-    successMessage: "Default-for-new zone updated",
-  });
-  const { pending, defaultForNew, homeZone, zones } = usePendingDevices();
-
+export function QuarantineSettingsCard({
+  notifyEnabled,
+  notifyPending,
+  onSetNotify,
+  onSetDefaultForNew,
+  pending,
+  defaultForNew,
+  homeZone,
+  zones,
+  onApprove,
+  approvingDeviceId,
+}: QuarantineSettingsCardProps) {
   return (
     <Card>
       <CardHeader>
@@ -56,9 +75,9 @@ export function QuarantineSettingsCard() {
           <Toggle
             aria-label="Notify admins about new devices"
             data-testid="quarantine-toggle"
-            checked={quarantine?.enabled ?? false}
-            onCheckedChange={(enabled) => setQuarantine.mutate(enabled)}
-            disabled={setQuarantine.isPending}
+            checked={notifyEnabled}
+            onCheckedChange={onSetNotify}
+            disabled={notifyPending}
           />
         </label>
 
@@ -69,12 +88,7 @@ export function QuarantineSettingsCard() {
         >
           <Select
             value={defaultForNew?.id ?? ""}
-            onValueChange={(id) =>
-              setDefaultForNew.mutate({
-                id,
-                body: { is_default_for_new: true },
-              })
-            }
+            onValueChange={onSetDefaultForNew}
           >
             <SelectTrigger
               id="default-for-new"
@@ -109,6 +123,8 @@ export function QuarantineSettingsCard() {
                   device={device}
                   zones={zones}
                   defaultTargetZoneId={homeZone?.id}
+                  onApprove={onApprove}
+                  approving={approvingDeviceId === device.id}
                 />
               ))}
             </div>
@@ -123,14 +139,18 @@ interface PendingDeviceRowProps {
   device: Device;
   zones: NetworkZoneView[];
   defaultTargetZoneId: string | undefined;
+  onApprove: (deviceId: string, zoneId: string) => void;
+  /** Whether this row's approval is mid-flight. */
+  approving: boolean;
 }
 
 function PendingDeviceRow({
   device,
   zones,
   defaultTargetZoneId,
+  onApprove,
+  approving,
 }: PendingDeviceRowProps) {
-  const assignZone = useAssignDeviceZone({ successMessage: "Device approved" });
   // Default the approve target to the home zone; fall back to the first zone.
   const [targetZoneId, setTargetZoneId] = useState(
     defaultTargetZoneId ?? zones[0]?.id ?? "",
@@ -165,10 +185,8 @@ function PendingDeviceRow({
         <Button
           size="sm"
           data-testid="quarantine-approve"
-          disabled={assignZone.isPending || !targetZoneId}
-          onClick={() =>
-            assignZone.mutate({ deviceId: device.id, zoneId: targetZoneId })
-          }
+          disabled={approving || !targetZoneId}
+          onClick={() => onApprove(device.id, targetZoneId)}
         >
           Approve
         </Button>

--- a/source/admin-site/src/components/features/SecuritySettingsCard.tsx
+++ b/source/admin-site/src/components/features/SecuritySettingsCard.tsx
@@ -9,19 +9,35 @@ import {
   FormActions,
   Input,
   Toggle,
-  useDnsConfig,
-  useUpdateDnsConfig,
 } from "@wardnet/web";
+import type { DnsConfig, UpdateDnsConfigRequest } from "@wardnet/js";
+
+interface SecuritySettingsCardProps {
+  /** The DNS config, or `undefined` while the page's query loads. */
+  config: DnsConfig | undefined;
+  isLoading: boolean;
+  /** Matches TanStack's `mutate` signature so the page can pass the
+   *  mutation's `mutate` straight through; the card uses `onSuccess` to
+   *  clear its rate-limit edit buffer. */
+  onUpdate: (
+    body: UpdateDnsConfigRequest,
+    callbacks?: { onSuccess?: () => void },
+  ) => void;
+  /** True while the page's update mutation is in flight. */
+  updatePending: boolean;
+}
 
 /** DNS security settings (Stage 4): DNSSEC validation, rebinding
  *  protection, and per-client rate limiting. Toggles save immediately;
  *  the rate limit uses an explicit Save so transient keystrokes don't
- *  thrash the config. */
-export function SecuritySettingsCard() {
-  const { data, isLoading } = useDnsConfig();
-  const update = useUpdateDnsConfig();
-  const config = data?.config;
-
+ *  thrash the config. Pure presentation — the owning page wires the
+ *  query/mutation hooks and passes data + callbacks in. */
+export function SecuritySettingsCard({
+  config,
+  isLoading,
+  onUpdate,
+  updatePending,
+}: SecuritySettingsCardProps) {
   const dnssec = config?.dnssec_enabled ?? false;
   const rebinding = config?.rebinding_protection ?? true;
   const currentRate = config?.rate_limit_per_second ?? 0;
@@ -34,7 +50,7 @@ export function SecuritySettingsCard() {
   const rateValid =
     rateValue.trim() !== "" && Number.isInteger(rateParsed) && rateParsed >= 0;
   const rateDirty = rate !== null && rateParsed !== currentRate;
-  const busy = isLoading || update.isPending;
+  const busy = isLoading || updatePending;
 
   return (
     <Card>
@@ -53,7 +69,7 @@ export function SecuritySettingsCard() {
             aria-label="Enable DNSSEC validation"
             checked={dnssec}
             disabled={busy}
-            onCheckedChange={(next) => update.mutate({ dnssec_enabled: next })}
+            onCheckedChange={(next) => onUpdate({ dnssec_enabled: next })}
           />
         </Field>
 
@@ -68,9 +84,7 @@ export function SecuritySettingsCard() {
             aria-label="Enable DNS rebinding protection"
             checked={rebinding}
             disabled={busy}
-            onCheckedChange={(next) =>
-              update.mutate({ rebinding_protection: next })
-            }
+            onCheckedChange={(next) => onUpdate({ rebinding_protection: next })}
           />
         </Field>
 
@@ -102,7 +116,7 @@ export function SecuritySettingsCard() {
           primaryProps={{
             disabled: busy || !rateValid,
             onClick: () =>
-              update.mutate(
+              onUpdate(
                 { rate_limit_per_second: rateParsed },
                 { onSuccess: () => setRate(null) },
               ),

--- a/source/admin-site/src/components/features/SecuritySettingsCard.tsx
+++ b/source/admin-site/src/components/features/SecuritySettingsCard.tsx
@@ -10,20 +10,17 @@ import {
   Input,
   Toggle,
 } from "@wardnet/web";
+import type { MutateFn } from "@/lib/mutationHandle";
 import type { DnsConfig, UpdateDnsConfigRequest } from "@wardnet/js";
 
 interface SecuritySettingsCardProps {
   /** The DNS config, or `undefined` while the page's query loads. */
   config: DnsConfig | undefined;
   isLoading: boolean;
-  /** Matches TanStack's `mutate` signature so the page can pass the
-   *  mutation's `mutate` straight through; the card uses `onSuccess` to
-   *  clear its rate-limit edit buffer. */
-  onUpdate: (
-    body: UpdateDnsConfigRequest,
-    callbacks?: { onSuccess?: () => void },
-  ) => void;
-  /** True while the page's update mutation is in flight. */
+  onUpdate: MutateFn<UpdateDnsConfigRequest>;
+  /** True while the page's dedicated security-settings update mutation is in
+   *  flight — its own instance, so unrelated config saves elsewhere on the
+   *  page don't lock this card's controls. */
   updatePending: boolean;
 }
 

--- a/source/admin-site/src/components/features/TunnelDevicesTable.tsx
+++ b/source/admin-site/src/components/features/TunnelDevicesTable.tsx
@@ -13,11 +13,14 @@ import {
 import { DataTable } from "@/components/core/ui/data-table";
 import { DeviceIcon } from "@wardnet/web";
 import { HostCell } from "@/components/compound/HostCell";
-import { useTunnelDevices } from "@wardnet/web";
 import type { Device } from "@wardnet/js";
 
 interface Props {
-  tunnelId: string;
+  /** Devices routed through the tunnel, from the owning page's
+   *  `useTunnelDevices(tunnelId)`. */
+  devices: Device[] | undefined;
+  isLoading: boolean;
+  isError: boolean;
 }
 
 function buildColumns(): ColumnDef<Device>[] {
@@ -49,12 +52,17 @@ function buildColumns(): ColumnDef<Device>[] {
   ];
 }
 
-export function TunnelDevicesTable({ tunnelId }: Props) {
+/** Devices routed through a tunnel. Pure presentation — the owning page
+ *  wires the query hook and passes data in. */
+export function TunnelDevicesTable({
+  devices: rawDevices,
+  isLoading,
+  isError,
+}: Props) {
   const navigate = useNavigate();
-  const { data, isLoading, isError } = useTunnelDevices(tunnelId);
   const devices = useMemo(
-    () => sortByLabel(data?.devices ?? [], deviceDisplayName),
-    [data?.devices],
+    () => sortByLabel(rawDevices ?? [], deviceDisplayName),
+    [rawDevices],
   );
   const columns = useMemo(() => buildColumns(), []);
 

--- a/source/admin-site/src/components/features/ZoneExceptionsCard.tsx
+++ b/source/admin-site/src/components/features/ZoneExceptionsCard.tsx
@@ -18,17 +18,12 @@ import {
 } from "@wardnet/web";
 import { DataTable, RowAction } from "@/components/core/ui/data-table";
 import { ConfirmDialog } from "@/components/compound/ConfirmDialog";
-import {
-  useDevices,
-  useNetworkZones,
-  useZoneExceptions,
-  useCreateZoneException,
-  useDeleteZoneException,
-  deviceDisplayName,
-} from "@wardnet/web";
+import { deviceDisplayName } from "@wardnet/web";
 import type {
+  Device,
   ExceptionEndpoint,
   ExceptionEndpointKind,
+  NetworkZoneView,
   PortSpec,
   Proto,
   ServiceSpec,
@@ -54,28 +49,48 @@ function serviceLabel(service: ServiceSpec): string {
   return `${count} port${count === 1 ? "" : "s"}`;
 }
 
+/** The body the card's inline form submits when adding an exception. */
+export interface ZoneExceptionBody {
+  from: ExceptionEndpoint;
+  to: ExceptionEndpoint;
+  service: ServiceSpec;
+  bidirectional: boolean;
+}
+
+interface ZoneExceptionsCardProps {
+  exceptions: ZoneException[];
+  zones: NetworkZoneView[];
+  devices: Device[];
+  /** True while the page's create mutation is in flight. */
+  isSaving: boolean;
+  /** Matches TanStack's `mutate` signature so the page can pass the
+   *  mutation's `mutate` straight through; the card uses `onSuccess` to
+   *  close its inline form. */
+  onCreateException: (
+    body: ZoneExceptionBody,
+    callbacks?: { onSuccess?: () => void },
+  ) => void;
+  onDeleteException: (id: string) => void;
+}
+
 /**
  * Cross-zone exceptions manager (issue #737). Grants one endpoint access to
  * another across an otherwise-isolated zone boundary. The headline case is the
  * one-click **casting** preset (mDNS + SSDP/DLNA + Chromecast + AirPlay,
  * bidirectional), e.g. a phone in Trusted casting to a TV in IoT.
+ * Pure presentation — the owning page wires the query/mutation hooks and
+ * passes data + callbacks in.
  */
-export function ZoneExceptionsCard() {
-  const { data: exceptionData } = useZoneExceptions();
-  const { data: zoneData } = useNetworkZones();
-  const { data: deviceData } = useDevices();
-  const createException = useCreateZoneException();
-  const deleteException = useDeleteZoneException();
-
+export function ZoneExceptionsCard({
+  exceptions,
+  zones,
+  devices,
+  isSaving,
+  onCreateException,
+  onDeleteException,
+}: ZoneExceptionsCardProps) {
   const [formOpen, setFormOpen] = useState(false);
   const [deleteId, setDeleteId] = useState<string | null>(null);
-
-  const zones = useMemo(() => zoneData?.zones ?? [], [zoneData]);
-  const devices = useMemo(() => deviceData?.devices ?? [], [deviceData]);
-  const exceptions = useMemo(
-    () => exceptionData?.exceptions ?? [],
-    [exceptionData],
-  );
 
   /** Resolve an endpoint to a display label. */
   const endpointLabel = useMemo(() => {
@@ -148,10 +163,10 @@ export function ZoneExceptionsCard() {
               id: d.id,
               name: deviceDisplayName(d),
             }))}
-            isSaving={createException.isPending}
+            isSaving={isSaving}
             onCancel={() => setFormOpen(false)}
             onCreate={(body) =>
-              createException.mutate(body, {
+              onCreateException(body, {
                 onSuccess: () => setFormOpen(false),
               })
             }
@@ -188,7 +203,7 @@ export function ZoneExceptionsCard() {
         description="Remove this cross-zone exception? The allowance is revoked immediately."
         confirmLabel="Remove"
         onConfirm={() => {
-          if (deleteId) deleteException.mutate(deleteId);
+          if (deleteId) onDeleteException(deleteId);
           setDeleteId(null);
         }}
       />

--- a/source/admin-site/src/components/features/ZoneExceptionsCard.tsx
+++ b/source/admin-site/src/components/features/ZoneExceptionsCard.tsx
@@ -18,6 +18,7 @@ import {
 } from "@wardnet/web";
 import { DataTable, RowAction } from "@/components/core/ui/data-table";
 import { ConfirmDialog } from "@/components/compound/ConfirmDialog";
+import type { MutateFn } from "@/lib/mutationHandle";
 import { deviceDisplayName } from "@wardnet/web";
 import type {
   Device,
@@ -50,7 +51,7 @@ function serviceLabel(service: ServiceSpec): string {
 }
 
 /** The body the card's inline form submits when adding an exception. */
-export interface ZoneExceptionBody {
+interface ZoneExceptionBody {
   from: ExceptionEndpoint;
   to: ExceptionEndpoint;
   service: ServiceSpec;
@@ -63,13 +64,7 @@ interface ZoneExceptionsCardProps {
   devices: Device[];
   /** True while the page's create mutation is in flight. */
   isSaving: boolean;
-  /** Matches TanStack's `mutate` signature so the page can pass the
-   *  mutation's `mutate` straight through; the card uses `onSuccess` to
-   *  close its inline form. */
-  onCreateException: (
-    body: ZoneExceptionBody,
-    callbacks?: { onSuccess?: () => void },
-  ) => void;
+  onCreateException: MutateFn<ZoneExceptionBody>;
   onDeleteException: (id: string) => void;
 }
 

--- a/source/admin-site/src/components/features/ZonesCard.tsx
+++ b/source/admin-site/src/components/features/ZonesCard.tsx
@@ -19,6 +19,7 @@ import {
 } from "@wardnet/web";
 import { DataTable, RowAction } from "@/components/core/ui/data-table";
 import { ConfirmDialog } from "@/components/compound/ConfirmDialog";
+import type { MutateFn } from "@/lib/mutationHandle";
 import type {
   AllowedTargetKind,
   NetworkZoneView,
@@ -33,7 +34,7 @@ const STANCE_LABEL: Record<ZoneStance, string> = {
 
 /** The full zone shape the card's form submits. Assignable to the SDK's
  *  create/update request bodies. */
-export interface ZoneFormBody {
+interface ZoneFormBody {
   name: string;
   isolation_stance: ZoneStance;
   allowed_targets: AllowedTargetKind[];
@@ -46,17 +47,8 @@ interface ZonesCardProps {
   zones: NetworkZoneView[];
   /** True while the page's create or update mutation is in flight. */
   isSaving: boolean;
-  /** The optional callbacks match TanStack's `mutate` signature so the page
-   *  can pass the mutation's `mutate` straight through; the card uses
-   *  `onSuccess` to close its inline form. */
-  onCreateZone: (
-    body: ZoneFormBody,
-    callbacks?: { onSuccess?: () => void },
-  ) => void;
-  onUpdateZone: (
-    change: { id: string; body: ZoneFormBody },
-    callbacks?: { onSuccess?: () => void },
-  ) => void;
+  onCreateZone: MutateFn<ZoneFormBody>;
+  onUpdateZone: MutateFn<{ id: string; body: ZoneFormBody }>;
   /** Promote a zone to the home (default) zone. */
   onSetHome: (id: string) => void;
   /** Flag a zone as the landing spot for newly-discovered devices. */

--- a/source/admin-site/src/components/features/ZonesCard.tsx
+++ b/source/admin-site/src/components/features/ZonesCard.tsx
@@ -19,12 +19,6 @@ import {
 } from "@wardnet/web";
 import { DataTable, RowAction } from "@/components/core/ui/data-table";
 import { ConfirmDialog } from "@/components/compound/ConfirmDialog";
-import {
-  useNetworkZones,
-  useCreateNetworkZone,
-  useUpdateNetworkZone,
-  useDeleteNetworkZone,
-} from "@wardnet/web";
 import type {
   AllowedTargetKind,
   NetworkZoneView,
@@ -37,23 +31,55 @@ const STANCE_LABEL: Record<ZoneStance, string> = {
   isolate_members: "Isolate members",
 };
 
-/** The Network Zones management surface: full lifecycle + promotion. */
-export function ZonesCard() {
-  const { data } = useNetworkZones();
-  const createZone = useCreateNetworkZone();
-  const updateZone = useUpdateNetworkZone();
-  const setHome = useUpdateNetworkZone({ successMessage: "Home zone updated" });
-  const setDefaultForNew = useUpdateNetworkZone({
-    successMessage: "Default-for-new zone updated",
-  });
-  const deleteZone = useDeleteNetworkZone();
+/** The full zone shape the card's form submits. Assignable to the SDK's
+ *  create/update request bodies. */
+export interface ZoneFormBody {
+  name: string;
+  isolation_stance: ZoneStance;
+  allowed_targets: AllowedTargetKind[];
+  member_isolation: boolean;
+  admin_ui_reachable: boolean;
+  subnet: { cidr: string } | null;
+}
 
+interface ZonesCardProps {
+  zones: NetworkZoneView[];
+  /** True while the page's create or update mutation is in flight. */
+  isSaving: boolean;
+  /** The optional callbacks match TanStack's `mutate` signature so the page
+   *  can pass the mutation's `mutate` straight through; the card uses
+   *  `onSuccess` to close its inline form. */
+  onCreateZone: (
+    body: ZoneFormBody,
+    callbacks?: { onSuccess?: () => void },
+  ) => void;
+  onUpdateZone: (
+    change: { id: string; body: ZoneFormBody },
+    callbacks?: { onSuccess?: () => void },
+  ) => void;
+  /** Promote a zone to the home (default) zone. */
+  onSetHome: (id: string) => void;
+  /** Flag a zone as the landing spot for newly-discovered devices. */
+  onSetDefaultForNew: (id: string) => void;
+  onDeleteZone: (id: string) => void;
+}
+
+/** The Network Zones management surface: full lifecycle + promotion. Pure
+ *  presentation — the owning page wires the query/mutation hooks and passes
+ *  data + callbacks in. */
+export function ZonesCard({
+  zones,
+  isSaving,
+  onCreateZone,
+  onUpdateZone,
+  onSetHome,
+  onSetDefaultForNew,
+  onDeleteZone,
+}: ZonesCardProps) {
   const [formOpen, setFormOpen] = useState(false);
   const [editing, setEditing] = useState<NetworkZoneView | null>(null);
   const [deleteId, setDeleteId] = useState<string | null>(null);
 
-  const zones = useMemo(() => data?.zones ?? [], [data]);
-  const isSaving = createZone.isPending || updateZone.isPending;
   const zoneToDelete = zones.find((z) => z.id === deleteId);
 
   function openCreate() {
@@ -159,11 +185,9 @@ export function ZonesCard() {
             zone={editing}
             isSaving={isSaving}
             onCancel={closeForm}
-            onCreate={(body) =>
-              createZone.mutate(body, { onSuccess: closeForm })
-            }
+            onCreate={(body) => onCreateZone(body, { onSuccess: closeForm })}
             onUpdate={(id, body) =>
-              updateZone.mutate({ id, body }, { onSuccess: closeForm })
+              onUpdateZone({ id, body }, { onSuccess: closeForm })
             }
           />
         )}
@@ -187,9 +211,7 @@ export function ZonesCard() {
               </RowAction>
               {!row.is_default && (
                 <RowAction
-                  onSelect={() =>
-                    setHome.mutate({ id: row.id, body: { is_default: true } })
-                  }
+                  onSelect={() => onSetHome(row.id)}
                   icon={<Home aria-hidden />}
                   testId="zone-set-home"
                 >
@@ -198,12 +220,7 @@ export function ZonesCard() {
               )}
               {!row.is_default_for_new && (
                 <RowAction
-                  onSelect={() =>
-                    setDefaultForNew.mutate({
-                      id: row.id,
-                      body: { is_default_for_new: true },
-                    })
-                  }
+                  onSelect={() => onSetDefaultForNew(row.id)}
                   icon={<UserPlus aria-hidden />}
                   testId="zone-set-default-for-new"
                 >
@@ -236,21 +253,12 @@ export function ZonesCard() {
         description={`Delete the "${zoneToDelete?.name ?? "this"}" zone? This can't be undone.`}
         confirmLabel="Delete"
         onConfirm={() => {
-          if (deleteId) deleteZone.mutate(deleteId);
+          if (deleteId) onDeleteZone(deleteId);
           setDeleteId(null);
         }}
       />
     </Card>
   );
-}
-
-interface ZoneFormBody {
-  name: string;
-  isolation_stance: ZoneStance;
-  allowed_targets: AllowedTargetKind[];
-  member_isolation: boolean;
-  admin_ui_reachable: boolean;
-  subnet: { cidr: string } | null;
 }
 
 interface ZoneFormProps {

--- a/source/admin-site/src/components/layouts/AppLayout.tsx
+++ b/source/admin-site/src/components/layouts/AppLayout.tsx
@@ -31,8 +31,6 @@ export function AppLayout() {
   // Only admins see update state — self-service users don't have the perms
   // to trigger installs, so we don't bother them with the banner.
   const { data: updateStatus } = useUpdateStatus();
-  const { data: systemStatus } = useSystemStatus();
-  const acknowledgeShutdown = useAcknowledgeShutdown();
   const location = useLocation();
   const crumb = crumbFromPath(location.pathname);
 
@@ -71,19 +69,30 @@ export function AppLayout() {
         </header>
 
         <ConnectionBanner reachable={daemonStatus?.reachable} />
-        {isAdmin && (
-          <UncleanShutdownBanner
-            status={systemStatus}
-            onDismiss={acknowledgeShutdown.mutate}
-            dismissPending={acknowledgeShutdown.isPending}
-          />
-        )}
+        {isAdmin && <AdminUncleanShutdownBanner />}
 
         <div className="scroll">
           <Outlet />
         </div>
       </main>
     </div>
+  );
+}
+
+/** Wires the admin-only shutdown-state query + acknowledgement mutation.
+ *  A separate component so the shell only subscribes to the admin-gated
+ *  `/api/system/status` poll when an admin session is actually present —
+ *  mounting it unconditionally would leave non-admin sessions issuing a
+ *  failing request every poll interval. */
+function AdminUncleanShutdownBanner() {
+  const { data: systemStatus } = useSystemStatus();
+  const acknowledgeShutdown = useAcknowledgeShutdown();
+  return (
+    <UncleanShutdownBanner
+      status={systemStatus}
+      onDismiss={acknowledgeShutdown.mutate}
+      dismissPending={acknowledgeShutdown.isPending}
+    />
   );
 }
 

--- a/source/admin-site/src/components/layouts/AppLayout.tsx
+++ b/source/admin-site/src/components/layouts/AppLayout.tsx
@@ -3,7 +3,13 @@ import { Sidebar } from "@/components/compound/Sidebar";
 import { MobileMenu } from "@/components/compound/MobileMenu";
 import { ConnectionBanner } from "@/components/compound/ConnectionBanner";
 import { UncleanShutdownBanner } from "@/components/compound/UncleanShutdownBanner";
-import { useAuth } from "@wardnet/web";
+import {
+  useAuth,
+  useDaemonStatus,
+  useUpdateStatus,
+  useSystemStatus,
+  useAcknowledgeShutdown,
+} from "@wardnet/web";
 
 /**
  * Main application layout.
@@ -12,22 +18,44 @@ import { useAuth } from "@wardnet/web";
  * to a `.main` content card. The `.main` card carries a `.topbar` header
  * (breadcrumbs on the left, chrome controls on the right) above the
  * connection / shutdown banners and the scrollable `<Outlet />` content.
+ *
+ * The shell chrome lives above every route and has no owning page, so this
+ * layout wires the shell-wide auth/status hooks itself (the documented
+ * layouts carve-out in `.agents/code-conventions.md`) and passes data +
+ * callbacks down so the shell compounds stay pure presentation.
  */
 export function AppLayout() {
-  const { isAdmin } = useAuth();
+  const { isAdmin, logout } = useAuth();
+  const { data: daemonStatus, isLoading: daemonStatusLoading } =
+    useDaemonStatus();
+  // Only admins see update state — self-service users don't have the perms
+  // to trigger installs, so we don't bother them with the banner.
+  const { data: updateStatus } = useUpdateStatus();
+  const { data: systemStatus } = useSystemStatus();
+  const acknowledgeShutdown = useAcknowledgeShutdown();
   const location = useLocation();
   const crumb = crumbFromPath(location.pathname);
 
+  const sidebarProps = {
+    isAdmin,
+    onLogout: logout,
+    version: daemonStatus?.version,
+    connectionLoading: daemonStatusLoading,
+    connected: daemonStatus?.reachable ?? false,
+    updateAvailable: updateStatus?.status.update_available ?? false,
+    latestVersion: updateStatus?.status.latest_version ?? null,
+  };
+
   return (
     <div className="app">
-      <Sidebar />
+      <Sidebar {...sidebarProps} />
 
       <main className="main">
         <header className="topbar">
           {/* Mobile drawer trigger — Sidebar is always visible at desktop
               widths via the `.app` grid; MobileMenu hosts the same Sidebar
               inside a Drawer for narrow viewports (admin-only). */}
-          {isAdmin && <MobileMenu />}
+          {isAdmin && <MobileMenu {...sidebarProps} />}
 
           <div className="topbar__crumbs">
             <span>Wardnet</span>
@@ -42,8 +70,14 @@ export function AppLayout() {
               out-of-scope for this slice (no existing palette to port). */}
         </header>
 
-        <ConnectionBanner />
-        {isAdmin && <UncleanShutdownBanner />}
+        <ConnectionBanner reachable={daemonStatus?.reachable} />
+        {isAdmin && (
+          <UncleanShutdownBanner
+            status={systemStatus}
+            onDismiss={acknowledgeShutdown.mutate}
+            dismissPending={acknowledgeShutdown.isPending}
+          />
+        )}
 
         <div className="scroll">
           <Outlet />

--- a/source/admin-site/src/lib/mutationHandle.ts
+++ b/source/admin-site/src/lib/mutationHandle.ts
@@ -4,12 +4,25 @@
  * component-layer rule in `.agents/code-conventions.md`). A page passes the
  * mutation result straight through — `UseMutationResult` is structurally
  * assignable to this — while tests can satisfy it with plain `vi.fn()`s
- * instead of stubbing whole hook shapes.
+ * instead of stubbing whole hook shapes. `TData` types the resolved value
+ * for cards that consume it (e.g. a dry-run preview's response); leave it
+ * defaulted when the card only awaits completion.
  */
-export interface MutationHandle<TVariables> {
-  mutateAsync: (variables: TVariables) => Promise<unknown>;
+export interface MutationHandle<TVariables, TData = unknown> {
+  mutateAsync: (variables: TVariables) => Promise<TData>;
   reset: () => void;
   isPending: boolean;
   isError: boolean;
   error: Error | null;
 }
+
+/**
+ * A hoisted mutation's fire-and-forget entry point. Matches TanStack's
+ * `mutate` signature so the page can pass `mutation.mutate` straight
+ * through; cards use the optional `onSuccess` to close inline forms on a
+ * successful save.
+ */
+export type MutateFn<TVariables> = (
+  variables: TVariables,
+  callbacks?: { onSuccess?: () => void },
+) => void;

--- a/source/admin-site/src/lib/mutationHandle.ts
+++ b/source/admin-site/src/lib/mutationHandle.ts
@@ -1,0 +1,15 @@
+/**
+ * The narrow slice of a TanStack `useMutation` result that a presentation
+ * card receives as a prop once the owning page hoists the mutation (the
+ * component-layer rule in `.agents/code-conventions.md`). A page passes the
+ * mutation result straight through — `UseMutationResult` is structurally
+ * assignable to this — while tests can satisfy it with plain `vi.fn()`s
+ * instead of stubbing whole hook shapes.
+ */
+export interface MutationHandle<TVariables> {
+  mutateAsync: (variables: TVariables) => Promise<unknown>;
+  reset: () => void;
+  isPending: boolean;
+  isError: boolean;
+  error: Error | null;
+}

--- a/source/admin-site/src/pages/Dashboard.tsx
+++ b/source/admin-site/src/pages/Dashboard.tsx
@@ -4,7 +4,7 @@ import { DhcpSummaryCard } from "@/components/compound/DhcpSummaryCard";
 import { RecentErrorsCard } from "@/components/compound/RecentErrorsCard";
 import { DashboardLogWidget } from "@/components/features/DashboardLogWidget";
 import { DashboardRemoteAccessBanner } from "@/components/features/DashboardRemoteAccessBanner";
-import { useSystemStatus, useRecentErrors } from "@wardnet/web";
+import { useSystemStatus, useRecentErrors, useTlsStatus } from "@wardnet/web";
 import { useDevices } from "@wardnet/web";
 import { useTunnels } from "@wardnet/web";
 import { useDhcpStatus } from "@wardnet/web";
@@ -14,6 +14,7 @@ import { formatBytes, formatUptime } from "@wardnet/web";
 /** Admin dashboard with system overview stats. */
 export default function Dashboard() {
   const { data: status } = useSystemStatus();
+  const { data: tlsStatus } = useTlsStatus();
   const { data: devicesData } = useDevices();
   const { data: tunnelsData } = useTunnels();
   const { data: dhcpStatus } = useDhcpStatus();
@@ -44,7 +45,7 @@ export default function Dashboard() {
       <PageHeader title="Dashboard" description="Live overview" />
 
       <div className="col gap-20">
-        <DashboardRemoteAccessBanner />
+        <DashboardRemoteAccessBanner status={tlsStatus} />
 
         {/* Stat cards */}
         <div className="grid grid-cols-1 gap-3.5 sm:grid-cols-2 lg:grid-cols-3">

--- a/source/admin-site/src/pages/DeviceDetail.tsx
+++ b/source/admin-site/src/pages/DeviceDetail.tsx
@@ -127,12 +127,9 @@ function DeviceDetailLoaded({
   const assignZone = useAssignDeviceZone({ successMessage: "Zone updated" });
 
   // DNS filter card.
-  const { data: filterSettingsData, isLoading: filterSettingsLoading } =
-    useDeviceFilterSettings(device.id);
-  const { data: filterProfilesData, isLoading: filterProfilesLoading } =
-    useDnsFilterProfiles();
-  const { data: filterConfigData, isLoading: filterConfigLoading } =
-    useDnsFilterConfig();
+  const { data: filterSettingsData } = useDeviceFilterSettings(device.id);
+  const { data: filterProfilesData } = useDnsFilterProfiles();
+  const { data: filterConfigData } = useDnsFilterConfig();
   const updateFilterSettings = useUpdateDeviceFilterSettings();
 
   // DNS capture card.
@@ -199,9 +196,6 @@ function DeviceDetailLoaded({
         settings={filterSettingsData?.settings}
         profiles={filterProfilesData?.profiles}
         config={filterConfigData?.config}
-        isLoading={
-          filterSettingsLoading || filterProfilesLoading || filterConfigLoading
-        }
         update={updateFilterSettings}
       />
       <DeviceDnsCaptureCard

--- a/source/admin-site/src/pages/DeviceDetail.tsx
+++ b/source/admin-site/src/pages/DeviceDetail.tsx
@@ -11,10 +11,28 @@ import { DeviceNetworkCard } from "@/components/features/DeviceNetworkCard";
 import { DeviceSettingsCard } from "@/components/features/DeviceSettingsCard";
 import { DeviceRoutingProfilesCard } from "@/components/features/DeviceRoutingProfilesCard";
 import { DeviceZoneCard } from "@/components/features/DeviceZoneCard";
-import { useDevice } from "@wardnet/web";
+import {
+  useDevice,
+  useTunnels,
+  useUpdateDevice,
+  useRoutingProfiles,
+  useDeviceRoutingProfiles,
+  useSetDeviceRoutingProfiles,
+  useNetworkZones,
+  useAssignDeviceZone,
+  useDeviceFilterSettings,
+  useDnsFilterProfiles,
+  useDnsFilterConfig,
+  useUpdateDeviceFilterSettings,
+  useDnsCaptureSettings,
+  useUpdateDnsCaptureSettings,
+  useDhcpReservations,
+  useCreateReservation,
+  useDeleteReservation,
+} from "@wardnet/web";
 import { deviceTypeLabel } from "@wardnet/web";
 import { timeAgo } from "@wardnet/web";
-import type { Device } from "@wardnet/js";
+import type { Device, DeviceSignal, RoutingTarget } from "@wardnet/js";
 
 const ONLINE_THRESHOLD_MS = 5 * 60 * 1000;
 
@@ -68,7 +86,66 @@ export default function DeviceDetail() {
     );
   }
 
-  const device = data.device;
+  return (
+    <DeviceDetailLoaded
+      device={data.device}
+      // `?? []` guards a browser holding a cached bundle newer than the
+      // daemon it is talking to: a missing field must render the empty
+      // state, not throw out the whole detail page.
+      signals={data.signals ?? []}
+      currentRule={data.current_rule}
+    />
+  );
+}
+
+interface DeviceDetailLoadedProps {
+  device: Device;
+  signals: DeviceSignal[];
+  currentRule: RoutingTarget | null;
+}
+
+/** The loaded detail view. Split from the route component so the card
+ *  queries/mutations mount only once the device itself has resolved — this
+ *  is still the pages layer, and it owns every hook the cards need, passing
+ *  data + callbacks down so the cards stay pure presentation. */
+function DeviceDetailLoaded({
+  device,
+  signals,
+  currentRule,
+}: DeviceDetailLoadedProps) {
+  // Settings card.
+  const { data: tunnelData } = useTunnels();
+  const updateDevice = useUpdateDevice();
+
+  // Routing profiles card.
+  const { data: profilesData } = useRoutingProfiles();
+  const { data: assignedData } = useDeviceRoutingProfiles(device.id);
+  const saveRoutingProfiles = useSetDeviceRoutingProfiles();
+
+  // Zone card.
+  const { data: zoneData } = useNetworkZones();
+  const assignZone = useAssignDeviceZone({ successMessage: "Zone updated" });
+
+  // DNS filter card.
+  const { data: filterSettingsData, isLoading: filterSettingsLoading } =
+    useDeviceFilterSettings(device.id);
+  const { data: filterProfilesData, isLoading: filterProfilesLoading } =
+    useDnsFilterProfiles();
+  const { data: filterConfigData, isLoading: filterConfigLoading } =
+    useDnsFilterConfig();
+  const updateFilterSettings = useUpdateDeviceFilterSettings();
+
+  // DNS capture card.
+  const { data: captureSettings, isLoading: captureLoading } =
+    useDnsCaptureSettings(device.id);
+  const updateCaptureSettings = useUpdateDnsCaptureSettings(device.id);
+
+  // Network card.
+  const { data: reservationsData } = useDhcpReservations();
+  const createReservation = useCreateReservation();
+  const restoreReservation = useCreateReservation({ silent: true });
+  const deleteReservation = useDeleteReservation();
+
   const managed = device.name != null;
   const online = managed && isOnline(device.last_seen);
 
@@ -99,16 +176,46 @@ export default function DeviceDetail() {
       />
 
       <DeviceIdentityCard device={device} />
-      {/* `?? []` guards a browser holding a cached bundle newer than the
-          daemon it is talking to: a missing field must render the empty
-          state, not throw out the whole detail page. */}
-      <DeviceIdentificationCard signals={data.signals ?? []} />
-      <DeviceSettingsCard device={device} currentRule={data.current_rule} />
-      <DeviceRoutingProfilesCard device={device} />
-      <DeviceZoneCard device={device} />
-      <DeviceDnsFilterCard device={device} />
-      <DeviceDnsCaptureCard deviceId={device.id} />
-      <DeviceNetworkCard device={device} />
+      <DeviceIdentificationCard signals={signals} />
+      <DeviceSettingsCard
+        device={device}
+        currentRule={currentRule}
+        tunnels={tunnelData?.tunnels ?? []}
+        updateDevice={updateDevice}
+      />
+      <DeviceRoutingProfilesCard
+        device={device}
+        allProfiles={profilesData?.profiles ?? []}
+        assignedIds={assignedData?.profile_ids ?? []}
+        save={saveRoutingProfiles}
+      />
+      <DeviceZoneCard
+        device={device}
+        zones={zoneData?.zones ?? []}
+        assignZone={assignZone}
+      />
+      <DeviceDnsFilterCard
+        device={device}
+        settings={filterSettingsData?.settings}
+        profiles={filterProfilesData?.profiles}
+        config={filterConfigData?.config}
+        isLoading={
+          filterSettingsLoading || filterProfilesLoading || filterConfigLoading
+        }
+        update={updateFilterSettings}
+      />
+      <DeviceDnsCaptureCard
+        settings={captureSettings}
+        isLoading={captureLoading}
+        update={updateCaptureSettings}
+      />
+      <DeviceNetworkCard
+        device={device}
+        reservations={reservationsData?.reservations}
+        createReservation={createReservation}
+        restoreReservation={restoreReservation}
+        deleteReservation={deleteReservation}
+      />
     </div>
   );
 }

--- a/source/admin-site/src/pages/Devices.tsx
+++ b/source/admin-site/src/pages/Devices.tsx
@@ -11,6 +11,8 @@ import {
   Button,
   Text,
   useDevices,
+  useDeviceFilterSettingsList,
+  useDnsFilterProfiles,
 } from "@wardnet/web";
 import type { Device } from "@wardnet/js";
 
@@ -29,9 +31,13 @@ function isRecent(d: Device, now: number): boolean {
   return now - t < RECENT_WINDOW_MS;
 }
 
-/** Devices page with grouped, searchable device table. */
+/** Devices page with grouped, searchable device table. Owns the queries the
+ *  table's Filtering column needs, passing data down so the table stays pure
+ *  presentation. */
 export default function Devices() {
   const { data, isLoading, isError } = useDevices();
+  const { data: filterSettingsData } = useDeviceFilterSettingsList();
+  const { data: filterProfilesData } = useDnsFilterProfiles();
   const navigate = useNavigate();
   const allDevices = useMemo(() => data?.devices ?? [], [data]);
 
@@ -130,6 +136,8 @@ export default function Devices() {
         searchValue={query}
         onSearchChange={setQuery}
         searchPlaceholder="Search by name, MAC, hostname, manufacturer or IP"
+        filterSettings={filterSettingsData?.devices}
+        filterProfiles={filterProfilesData?.profiles}
         emptyMessage={
           <NoDevicesFound
             neighbours={neighbours}

--- a/source/admin-site/src/pages/Dhcp.tsx
+++ b/source/admin-site/src/pages/Dhcp.tsx
@@ -71,11 +71,16 @@ export default function Dhcp() {
   // change the active group. We only switch to "reservations" after
   // the user confirms and the daemon creates the reservation, via
   // CreateReservationInline.onSuccess below.
+  // Opening resets the page-lifetime mutation: without it a previous
+  // attempt's failure (isError/error) would greet the fresh form with a
+  // stale API error alert.
   function openReservationFromLease(defaults: ReservationDefaults) {
+    createReservation.reset();
     setReservationCreate({ open: true, defaults });
   }
 
   function openReservationCreate() {
+    createReservation.reset();
     setReservationCreate({ open: true });
   }
 

--- a/source/admin-site/src/pages/Dhcp.tsx
+++ b/source/admin-site/src/pages/Dhcp.tsx
@@ -19,10 +19,16 @@ import {
   useToggleDhcp,
   useRevokeLease,
   useDeleteReservation,
+  useCreateReservation,
+  useUpdateDhcpConfig,
+  usePreviewDhcpConfig,
+  useDnsConfig,
 } from "@wardnet/web";
 import { useDevices } from "@wardnet/web";
 
-/** DHCP management page (admin only). */
+/** DHCP management page (admin only). Owns every query and mutation for the
+ *  cards below, passing data + callbacks down so they stay pure
+ *  presentation. */
 export default function Dhcp() {
   const navigate = useNavigate();
   const { data: statusData, isLoading: statusLoading } = useDhcpStatus();
@@ -30,10 +36,14 @@ export default function Dhcp() {
   const { data: leaseData } = useDhcpLeases();
   const { data: reservationData } = useDhcpReservations();
   const { data: deviceData } = useDevices();
+  const { data: dnsConfigData } = useDnsConfig();
 
   const toggleDhcp = useToggleDhcp();
   const revokeLease = useRevokeLease();
   const deleteReservation = useDeleteReservation();
+  const createReservation = useCreateReservation();
+  const updateConfig = useUpdateDhcpConfig();
+  const previewConfig = usePreviewDhcpConfig();
 
   const [group, setGroup] = useState<DhcpGroupId>("all");
   const [query, setQuery] = useState("");
@@ -92,7 +102,12 @@ export default function Dhcp() {
               onToggle={(enabled) => toggleDhcp.mutate(enabled)}
               isPending={toggleDhcp.isPending}
             />
-            <DhcpConfigCard config={config} />
+            <DhcpConfigCard
+              config={config}
+              dnsEnabled={dnsConfigData?.config.enabled}
+              updateConfig={updateConfig}
+              previewConfig={previewConfig}
+            />
           </div>
 
           {reservationCreate.open && (
@@ -102,6 +117,7 @@ export default function Dhcp() {
               key={JSON.stringify(reservationCreate.defaults ?? {})}
               defaults={reservationCreate.defaults}
               devices={devices}
+              createReservation={createReservation}
               onClose={() => setReservationCreate({ open: false })}
               onSuccess={() => setGroup("reservations")}
             />

--- a/source/admin-site/src/pages/Dns.tsx
+++ b/source/admin-site/src/pages/Dns.tsx
@@ -55,42 +55,13 @@ export default function Dns() {
   const toggleDns = useToggleDns();
   const flushCache = useFlushDnsCache();
   const updateConfig = useUpdateDnsConfig();
+  // Dedicated instance for the security card so its controls only lock for
+  // its own saves, not for query-log/upstream edits elsewhere on the page
+  // (and vice versa).
+  const updateSecurityConfig = useUpdateDnsConfig();
 
   const status = statusData;
   const config = configData?.config;
-
-  // ---- Stats + analytics wiring (range, zoom, per-device selection). ----
-  const [range, setRange] = useState<StatsRange>("24h");
-  // Tag zoom with the range it was committed for so it auto-invalidates
-  // when the range changes without needing a useEffect reset.
-  const [storedZoom, setStoredZoom] = useState<{
-    range: StatsRange;
-    zoom: ZoomRange;
-  } | null>(null);
-  const zoom = storedZoom?.range === range ? storedZoom.zoom : null;
-  const setZoom = (z: ZoomRange | null) =>
-    setStoredZoom(z ? { range, zoom: z } : null);
-  // A committed zoom narrows the dashboard's top-N window so all four stat
-  // cards reflect the same time slice.
-  const topOverride = zoom
-    ? {
-        from: new Date(Number(zoom.start)).toISOString(),
-        to: new Date(Number(zoom.end)).toISOString(),
-      }
-    : undefined;
-  const { data: devicesData } = useDevices();
-  const dashboard = useDnsStatsDashboard(range, topOverride);
-  const { data: comparison } = useDnsPeriodComparison(range);
-  const { data: trackers } = useDnsTopTrackers(range);
-
-  const devices = devicesData?.devices ?? [];
-  const [selectedDevice, setSelectedDevice] = useState<string>("");
-  // Default to the first device once the list loads, so the per-device chart
-  // shows something without the user having to pick.
-  const effectiveDevice =
-    selectedDevice || (devices.length > 0 ? devices[0].id : "");
-  const { data: deviceSeries, isLoading: deviceSeriesLoading } =
-    useDnsPerDeviceStats(effectiveDevice || null, range);
 
   // Stable callbacks so UpstreamServersCard's `columns` memo isn't rebuilt on
   // every render (e.g. the 15s status poll). `updateConfig.mutate` is stable.
@@ -261,8 +232,8 @@ export default function Dns() {
           <SecuritySettingsCard
             config={config}
             isLoading={configLoading}
-            onUpdate={updateConfig.mutate}
-            updatePending={updateConfig.isPending}
+            onUpdate={updateSecurityConfig.mutate}
+            updatePending={updateSecurityConfig.isPending}
           />
 
           {/* Query log card — Pill + Toggle in header (matches DHCP
@@ -371,46 +342,88 @@ export default function Dns() {
             onSelectServer={handleSelectServer}
           />
 
-          {/* DNS query stats — range tabs above the section; state lifted
-              here because the range controls cards, chart, and top lists. */}
-          <div className="col gap-4">
-            <div className="flex justify-end">
-              <Tabs
-                value={range}
-                onValueChange={(v) => setRange(v as StatsRange)}
-              >
-                <TabsList>
-                  {RANGES.map((r) => (
-                    <TabsTrigger key={r.value} value={r.value}>
-                      {r.label}
-                    </TabsTrigger>
-                  ))}
-                </TabsList>
-              </Tabs>
-            </div>
-            <DnsStatsSection
-              range={range}
-              zoom={zoom}
-              onZoomChange={setZoom}
-              data={dashboard.data}
-              isLoading={dashboard.isLoading}
-              isError={dashboard.isError}
-              error={dashboard.error}
-              devices={devicesData?.devices}
-            />
-            <DnsAnalyticsSection
-              range={range}
-              comparison={comparison}
-              trackers={trackers}
-              devices={devices}
-              selectedDeviceId={effectiveDevice}
-              onSelectDevice={setSelectedDevice}
-              deviceSeries={deviceSeries}
-              deviceSeriesLoading={deviceSeriesLoading}
-            />
-          </div>
+          {/* DNS query stats — the insights wrapper below owns the range /
+              zoom / device-selection state and the stats queries, and is
+              mounted only inside this `status && config` gate so no stats
+              request fires while the resolver status is unresolved. */}
+          <DnsInsights />
         </div>
       )}
+    </div>
+  );
+}
+
+/** Stats + analytics block for the DNS page. Still the pages layer — split
+ *  from the route component so its query bundle (dashboard, comparison,
+ *  trackers, per-device series; all polling) mounts only once the page's
+ *  `status && config` gate opens, matching the pre-hoist behaviour where the
+ *  sections owned these hooks and never rendered while the gate was closed. */
+function DnsInsights() {
+  const [range, setRange] = useState<StatsRange>("24h");
+  // Tag zoom with the range it was committed for so it auto-invalidates
+  // when the range changes without needing a useEffect reset.
+  const [storedZoom, setStoredZoom] = useState<{
+    range: StatsRange;
+    zoom: ZoomRange;
+  } | null>(null);
+  const zoom = storedZoom?.range === range ? storedZoom.zoom : null;
+  const setZoom = (z: ZoomRange | null) =>
+    setStoredZoom(z ? { range, zoom: z } : null);
+  // A committed zoom narrows the dashboard's top-N window so all four stat
+  // cards reflect the same time slice.
+  const topOverride = zoom
+    ? {
+        from: new Date(Number(zoom.start)).toISOString(),
+        to: new Date(Number(zoom.end)).toISOString(),
+      }
+    : undefined;
+  const { data: devicesData } = useDevices();
+  const dashboard = useDnsStatsDashboard(range, topOverride);
+  const { data: comparison } = useDnsPeriodComparison(range);
+  const { data: trackers } = useDnsTopTrackers(range);
+
+  const devices = devicesData?.devices ?? [];
+  const [selectedDevice, setSelectedDevice] = useState<string>("");
+  // Default to the first device once the list loads, so the per-device chart
+  // shows something without the user having to pick.
+  const effectiveDevice =
+    selectedDevice || (devices.length > 0 ? devices[0].id : "");
+  const { data: deviceSeries, isLoading: deviceSeriesLoading } =
+    useDnsPerDeviceStats(effectiveDevice || null, range);
+
+  return (
+    <div className="col gap-4">
+      <div className="flex justify-end">
+        <Tabs value={range} onValueChange={(v) => setRange(v as StatsRange)}>
+          <TabsList>
+            {RANGES.map((r) => (
+              <TabsTrigger key={r.value} value={r.value}>
+                {r.label}
+              </TabsTrigger>
+            ))}
+          </TabsList>
+        </Tabs>
+      </div>
+      <DnsStatsSection
+        range={range}
+        zoom={zoom}
+        onZoomChange={setZoom}
+        data={dashboard.data}
+        isLoading={dashboard.isLoading}
+        isError={dashboard.isError}
+        error={dashboard.error}
+        devices={devices}
+      />
+      <DnsAnalyticsSection
+        range={range}
+        comparison={comparison}
+        trackers={trackers}
+        devices={devices}
+        selectedDeviceId={effectiveDevice}
+        onSelectDevice={setSelectedDevice}
+        deviceSeries={deviceSeries}
+        deviceSeriesLoading={deviceSeriesLoading}
+      />
     </div>
   );
 }

--- a/source/admin-site/src/pages/Dns.tsx
+++ b/source/admin-site/src/pages/Dns.tsx
@@ -34,14 +34,23 @@ import {
   useToggleDns,
   useFlushDnsCache,
   useUpdateDnsConfig,
+  useDevices,
+  useDnsStatsDashboard,
+  useDnsPeriodComparison,
+  useDnsTopTrackers,
+  useDnsPerDeviceStats,
 } from "@wardnet/web";
 import { RANGES, type StatsRange } from "@wardnet/web";
+import type { ZoomRange } from "@/hooks/useChartZoom";
 import type { DnsResolutionMode, ForwarderSelectionMode } from "@wardnet/js";
 
-/** DNS server configuration page (admin only). */
+/** DNS server configuration page (admin only). Owns every query and mutation
+ *  for the cards and stats sections below, fetching the shared device/config
+ *  queries once and passing data + callbacks down so they stay pure
+ *  presentation. */
 export default function Dns() {
   const { data: statusData, isLoading: statusLoading } = useDnsStatus();
-  const { data: configData } = useDnsConfig();
+  const { data: configData, isLoading: configLoading } = useDnsConfig();
 
   const toggleDns = useToggleDns();
   const flushCache = useFlushDnsCache();
@@ -49,6 +58,39 @@ export default function Dns() {
 
   const status = statusData;
   const config = configData?.config;
+
+  // ---- Stats + analytics wiring (range, zoom, per-device selection). ----
+  const [range, setRange] = useState<StatsRange>("24h");
+  // Tag zoom with the range it was committed for so it auto-invalidates
+  // when the range changes without needing a useEffect reset.
+  const [storedZoom, setStoredZoom] = useState<{
+    range: StatsRange;
+    zoom: ZoomRange;
+  } | null>(null);
+  const zoom = storedZoom?.range === range ? storedZoom.zoom : null;
+  const setZoom = (z: ZoomRange | null) =>
+    setStoredZoom(z ? { range, zoom: z } : null);
+  // A committed zoom narrows the dashboard's top-N window so all four stat
+  // cards reflect the same time slice.
+  const topOverride = zoom
+    ? {
+        from: new Date(Number(zoom.start)).toISOString(),
+        to: new Date(Number(zoom.end)).toISOString(),
+      }
+    : undefined;
+  const { data: devicesData } = useDevices();
+  const dashboard = useDnsStatsDashboard(range, topOverride);
+  const { data: comparison } = useDnsPeriodComparison(range);
+  const { data: trackers } = useDnsTopTrackers(range);
+
+  const devices = devicesData?.devices ?? [];
+  const [selectedDevice, setSelectedDevice] = useState<string>("");
+  // Default to the first device once the list loads, so the per-device chart
+  // shows something without the user having to pick.
+  const effectiveDevice =
+    selectedDevice || (devices.length > 0 ? devices[0].id : "");
+  const { data: deviceSeries, isLoading: deviceSeriesLoading } =
+    useDnsPerDeviceStats(effectiveDevice || null, range);
 
   // Stable callbacks so UpstreamServersCard's `columns` memo isn't rebuilt on
   // every render (e.g. the 15s status poll). `updateConfig.mutate` is stable.
@@ -74,7 +116,6 @@ export default function Dns() {
   // Retention edit-mode state — follows DhcpConfigCard pattern. The
   // draft is reset when leaving edit mode so subsequent edits start
   // from the latest server value.
-  const [range, setRange] = useState<StatsRange>("24h");
   const [editingRetention, setEditingRetention] = useState(false);
   const [retentionDraft, setRetentionDraft] = useState<number>(7);
 
@@ -217,7 +258,12 @@ export default function Dns() {
 
           {/* Security settings — DNSSEC, rebinding protection, rate limit
               (Stage 4). */}
-          <SecuritySettingsCard />
+          <SecuritySettingsCard
+            config={config}
+            isLoading={configLoading}
+            onUpdate={updateConfig.mutate}
+            updatePending={updateConfig.isPending}
+          />
 
           {/* Query log card — Pill + Toggle in header (matches DHCP
               status card); retention follows the Edit/Save pattern
@@ -342,8 +388,26 @@ export default function Dns() {
                 </TabsList>
               </Tabs>
             </div>
-            <DnsStatsSection range={range} />
-            <DnsAnalyticsSection range={range} />
+            <DnsStatsSection
+              range={range}
+              zoom={zoom}
+              onZoomChange={setZoom}
+              data={dashboard.data}
+              isLoading={dashboard.isLoading}
+              isError={dashboard.isError}
+              error={dashboard.error}
+              devices={devicesData?.devices}
+            />
+            <DnsAnalyticsSection
+              range={range}
+              comparison={comparison}
+              trackers={trackers}
+              devices={devices}
+              selectedDeviceId={effectiveDevice}
+              onSelectDevice={setSelectedDevice}
+              deviceSeries={deviceSeries}
+              deviceSeriesLoading={deviceSeriesLoading}
+            />
           </div>
         </div>
       )}

--- a/source/admin-site/src/pages/DnsLocal.tsx
+++ b/source/admin-site/src/pages/DnsLocal.tsx
@@ -1,13 +1,54 @@
+import { useMemo } from "react";
 import { PageHeader } from "@/components/compound/PageHeader";
 import { LocalRecordsCard } from "@/components/features/LocalRecordsCard";
 import { DnsZonesCard } from "@/components/features/DnsZonesCard";
 import { ConditionalForwardingCard } from "@/components/features/ConditionalForwardingCard";
 import { DhcpLanInfoCard } from "@/components/features/DhcpLanInfoCard";
+import {
+  useDnsRecords,
+  useDnsZones,
+  useForwardingRules,
+  useCreateDnsRecord,
+  useUpdateDnsRecord,
+  useDeleteDnsRecord,
+  useCreateDnsZone,
+  useUpdateDnsZone,
+  useDeleteDnsZone,
+  useCreateForwardingRule,
+  useUpdateForwardingRule,
+  useDeleteForwardingRule,
+} from "@wardnet/web";
 
 /** Local DNS page (admin only) — authoritative zones, custom records, and
  *  conditional forwarding. Distinct from the resolver page (`/dns`), which
- *  owns cache, upstreams, and the query log. */
+ *  owns cache, upstreams, and the query log. Owns every query and mutation
+ *  for the cards below, fetching the shared records/zones queries once and
+ *  passing data + callbacks down so the cards stay pure presentation. */
 export default function DnsLocal() {
+  const { data: recordData } = useDnsRecords();
+  const { data: zoneData } = useDnsZones();
+  const { data: ruleData } = useForwardingRules();
+
+  const createRecord = useCreateDnsRecord();
+  const updateRecord = useUpdateDnsRecord();
+  const deleteRecord = useDeleteDnsRecord();
+
+  const createZone = useCreateDnsZone();
+  const updateZone = useUpdateDnsZone();
+  const deleteZone = useDeleteDnsZone();
+
+  const createRule = useCreateForwardingRule();
+  const updateRule = useUpdateForwardingRule();
+  const deleteRule = useDeleteForwardingRule();
+
+  const records = useMemo(() => recordData?.records ?? [], [recordData]);
+  const zones = useMemo(() => zoneData?.zones ?? [], [zoneData]);
+  const rules = useMemo(() => ruleData?.rules ?? [], [ruleData]);
+  const dhcpRecordCount = useMemo(
+    () => records.filter((r) => r.source === "dhcp").length,
+    [records],
+  );
+
   return (
     <div className="col gap-20">
       <PageHeader
@@ -16,10 +57,33 @@ export default function DnsLocal() {
       />
 
       <div className="col gap-20">
-        <LocalRecordsCard />
-        <DnsZonesCard />
-        <ConditionalForwardingCard />
-        <DhcpLanInfoCard />
+        <LocalRecordsCard
+          records={records}
+          zones={zones}
+          isSaving={createRecord.isPending || updateRecord.isPending}
+          updatePending={updateRecord.isPending}
+          onCreateRecord={createRecord.mutate}
+          onUpdateRecord={updateRecord.mutate}
+          onDeleteRecord={deleteRecord.mutate}
+        />
+        <DnsZonesCard
+          zones={zones}
+          records={records}
+          isSaving={createZone.isPending || updateZone.isPending}
+          updatePending={updateZone.isPending}
+          onCreateZone={createZone.mutate}
+          onUpdateZone={updateZone.mutate}
+          onDeleteZone={deleteZone.mutate}
+        />
+        <ConditionalForwardingCard
+          rules={rules}
+          isSaving={createRule.isPending || updateRule.isPending}
+          updatePending={updateRule.isPending}
+          onCreateRule={createRule.mutate}
+          onUpdateRule={updateRule.mutate}
+          onDeleteRule={deleteRule.mutate}
+        />
+        <DhcpLanInfoCard dhcpRecordCount={dhcpRecordCount} />
       </div>
     </div>
   );

--- a/source/admin-site/src/pages/RemoteAccess.tsx
+++ b/source/admin-site/src/pages/RemoteAccess.tsx
@@ -22,8 +22,14 @@ import { WardnetApiError } from "@wardnet/js";
 import {
   useDdnsStatus,
   useDeleteDdns,
+  useDevices,
   useResolutionCheck,
   useTlsStatus,
+  usePrivateDnsStatus,
+  useSetPrivateDnsEnabled,
+  useGrantPrivateDnsDevice,
+  useRevokePrivateDnsDevice,
+  useSendPrivateDnsToDevice,
 } from "@wardnet/web";
 import { PageHeader } from "@/components/compound/PageHeader";
 import { PrivateDnsCard } from "@/components/features/PrivateDnsCard";
@@ -56,6 +62,15 @@ import { suggestName } from "@/lib/suggestName";
 export default function RemoteAccess() {
   const { data: ddns } = useDdnsStatus();
   const { data: tls } = useTlsStatus();
+  // Private DNS card wiring — the page owns the queries/mutations so the
+  // card stays pure presentation.
+  const { data: privateDnsStatus, isLoading: privateDnsLoading } =
+    usePrivateDnsStatus();
+  const setPrivateDnsEnabled = useSetPrivateDnsEnabled();
+  const grantPrivateDnsDevice = useGrantPrivateDnsDevice();
+  const revokePrivateDnsDevice = useRevokePrivateDnsDevice();
+  const sendPrivateDnsToDevice = useSendPrivateDnsToDevice();
+  const { data: devicesData } = useDevices();
   const configured = !!ddns?.provider;
   const resolution = useResolutionCheck(configured);
 
@@ -310,7 +325,17 @@ export default function RemoteAccess() {
         </Card>
       )}
 
-      <PrivateDnsCard />
+      <PrivateDnsCard
+        status={privateDnsStatus}
+        isLoading={privateDnsLoading}
+        devices={devicesData?.devices ?? []}
+        onSetEnabled={setPrivateDnsEnabled.mutate}
+        setEnabledPending={setPrivateDnsEnabled.isPending}
+        grantDevice={grantPrivateDnsDevice}
+        onRevokeDevice={revokePrivateDnsDevice.mutate}
+        onSendToDevice={sendPrivateDnsToDevice.mutate}
+        sendPending={sendPrivateDnsToDevice.isPending}
+      />
 
       {configured && (
         <Card style={{ background: "var(--danger-soft)" }}>

--- a/source/admin-site/src/pages/TunnelDetail.tsx
+++ b/source/admin-site/src/pages/TunnelDetail.tsx
@@ -13,6 +13,7 @@ import { TunnelThroughputChart } from "@/components/features/TunnelThroughputCha
 import { TunnelLatencyChart } from "@/components/features/TunnelLatencyChart";
 import {
   useTunnel,
+  useTunnelDevices,
   useDeleteTunnel,
   useSetTunnelDnsOverride,
   useRebuildTunnel,
@@ -121,6 +122,11 @@ export default function TunnelDetail() {
     isLoading: statsLoading,
     isError: statsError,
   } = useTunnelStats(id, range);
+  const {
+    data: tunnelDevicesData,
+    isLoading: tunnelDevicesLoading,
+    isError: tunnelDevicesError,
+  } = useTunnelDevices(id);
 
   if (isLoading) {
     return (
@@ -273,7 +279,11 @@ export default function TunnelDetail() {
         />
       </div>
 
-      <TunnelDevicesTable tunnelId={tunnel.id} />
+      <TunnelDevicesTable
+        devices={tunnelDevicesData?.devices}
+        isLoading={tunnelDevicesLoading}
+        isError={tunnelDevicesError}
+      />
 
       <SpeedTestHistory tunnelId={tunnel.id} />
 

--- a/source/admin-site/src/pages/TunnelDetail.tsx
+++ b/source/admin-site/src/pages/TunnelDetail.tsx
@@ -122,11 +122,14 @@ export default function TunnelDetail() {
     isLoading: statsLoading,
     isError: statsError,
   } = useTunnelStats(id, range);
+  // Gate the devices query (30s poll) on the tunnel itself having resolved:
+  // an empty id disables the query, so a deleted/bad tunnel URL renders the
+  // not-found branch without endlessly re-polling /tunnels/:id/devices.
   const {
     data: tunnelDevicesData,
     isLoading: tunnelDevicesLoading,
     isError: tunnelDevicesError,
-  } = useTunnelDevices(id);
+  } = useTunnelDevices(data?.tunnel ? id : "");
 
   if (isLoading) {
     return (

--- a/source/admin-site/src/pages/Zones.tsx
+++ b/source/admin-site/src/pages/Zones.tsx
@@ -1,11 +1,58 @@
+import { useMemo } from "react";
 import { PageHeader } from "@/components/compound/PageHeader";
 import { ZonesCard } from "@/components/features/ZonesCard";
 import { QuarantineSettingsCard } from "@/components/features/QuarantineSettingsCard";
 import { ZoneExceptionsCard } from "@/components/features/ZoneExceptionsCard";
+import {
+  useDevices,
+  usePendingDevices,
+  useZoneExceptions,
+  useCreateNetworkZone,
+  useUpdateNetworkZone,
+  useDeleteNetworkZone,
+  useCreateZoneException,
+  useDeleteZoneException,
+  useQuarantineNewDevices,
+  useSetQuarantineNewDevices,
+  useAssignDeviceZone,
+} from "@wardnet/web";
 
 /** Network Zones page (admin only) — device policy buckets, cross-zone
- *  exceptions/casting, and new-device quarantine. Epic #244. */
+ *  exceptions/casting, and new-device quarantine. Epic #244.
+ *  Owns every query and mutation for the three cards below, passing data +
+ *  callbacks down so the cards stay pure presentation and the zone/device
+ *  queries are fetched once for the whole page. */
 export default function Zones() {
+  // Zone lifecycle. `usePendingDevices` composes the zone + device queries the
+  // whole page shares (TanStack dedupes them by query key).
+  const { pending, defaultForNew, homeZone, zones } = usePendingDevices();
+  const createZone = useCreateNetworkZone();
+  const updateZone = useUpdateNetworkZone();
+  const setHome = useUpdateNetworkZone({ successMessage: "Home zone updated" });
+  const setDefaultForNew = useUpdateNetworkZone({
+    successMessage: "Default-for-new zone updated",
+  });
+  const deleteZone = useDeleteNetworkZone();
+
+  // Cross-zone exceptions.
+  const { data: exceptionData } = useZoneExceptions();
+  const { data: deviceData } = useDevices();
+  const createException = useCreateZoneException();
+  const deleteException = useDeleteZoneException();
+
+  // New-device quarantine.
+  const { data: quarantine } = useQuarantineNewDevices();
+  const setQuarantine = useSetQuarantineNewDevices();
+  const approveDevice = useAssignDeviceZone({
+    successMessage: "Device approved",
+  });
+
+  const devices = useMemo(() => deviceData?.devices ?? [], [deviceData]);
+  const exceptions = useMemo(
+    () => exceptionData?.exceptions ?? [],
+    [exceptionData],
+  );
+
   return (
     <div className="col gap-20">
       <PageHeader
@@ -14,9 +61,45 @@ export default function Zones() {
       />
 
       <div className="col gap-20">
-        <ZonesCard />
-        <ZoneExceptionsCard />
-        <QuarantineSettingsCard />
+        <ZonesCard
+          zones={zones}
+          isSaving={createZone.isPending || updateZone.isPending}
+          onCreateZone={createZone.mutate}
+          onUpdateZone={updateZone.mutate}
+          onSetHome={(id) => setHome.mutate({ id, body: { is_default: true } })}
+          onSetDefaultForNew={(id) =>
+            setDefaultForNew.mutate({ id, body: { is_default_for_new: true } })
+          }
+          onDeleteZone={deleteZone.mutate}
+        />
+        <ZoneExceptionsCard
+          exceptions={exceptions}
+          zones={zones}
+          devices={devices}
+          isSaving={createException.isPending}
+          onCreateException={createException.mutate}
+          onDeleteException={deleteException.mutate}
+        />
+        <QuarantineSettingsCard
+          notifyEnabled={quarantine?.enabled ?? false}
+          notifyPending={setQuarantine.isPending}
+          onSetNotify={setQuarantine.mutate}
+          onSetDefaultForNew={(id) =>
+            setDefaultForNew.mutate({ id, body: { is_default_for_new: true } })
+          }
+          pending={pending}
+          defaultForNew={defaultForNew}
+          homeZone={homeZone}
+          zones={zones}
+          onApprove={(deviceId, zoneId) =>
+            approveDevice.mutate({ deviceId, zoneId })
+          }
+          approvingDeviceId={
+            approveDevice.isPending
+              ? (approveDevice.variables?.deviceId ?? null)
+              : null
+          }
+        />
       </div>
     </div>
   );

--- a/source/admin-site/src/pages/Zones.tsx
+++ b/source/admin-site/src/pages/Zones.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
 import { PageHeader } from "@/components/compound/PageHeader";
 import { ZonesCard } from "@/components/features/ZonesCard";
 import { QuarantineSettingsCard } from "@/components/features/QuarantineSettingsCard";
@@ -53,6 +53,25 @@ export default function Zones() {
     [exceptionData],
   );
 
+  // Every approval currently in flight, not just the shared mutation's
+  // latest `variables` — with concurrent approvals the latest-call view
+  // would re-enable an earlier row's button while its request is still
+  // pending, allowing a duplicate submit.
+  const [approvingIds, setApprovingIds] = useState<string[]>([]);
+  function handleApprove(deviceId: string, zoneId: string) {
+    setApprovingIds((prev) => [...prev, deviceId]);
+    approveDevice.mutate(
+      { deviceId, zoneId },
+      {
+        onSettled: () =>
+          setApprovingIds((prev) => prev.filter((id) => id !== deviceId)),
+      },
+    );
+  }
+
+  const handleSetDefaultForNew = (id: string) =>
+    setDefaultForNew.mutate({ id, body: { is_default_for_new: true } });
+
   return (
     <div className="col gap-20">
       <PageHeader
@@ -67,9 +86,7 @@ export default function Zones() {
           onCreateZone={createZone.mutate}
           onUpdateZone={updateZone.mutate}
           onSetHome={(id) => setHome.mutate({ id, body: { is_default: true } })}
-          onSetDefaultForNew={(id) =>
-            setDefaultForNew.mutate({ id, body: { is_default_for_new: true } })
-          }
+          onSetDefaultForNew={handleSetDefaultForNew}
           onDeleteZone={deleteZone.mutate}
         />
         <ZoneExceptionsCard
@@ -84,21 +101,13 @@ export default function Zones() {
           notifyEnabled={quarantine?.enabled ?? false}
           notifyPending={setQuarantine.isPending}
           onSetNotify={setQuarantine.mutate}
-          onSetDefaultForNew={(id) =>
-            setDefaultForNew.mutate({ id, body: { is_default_for_new: true } })
-          }
+          onSetDefaultForNew={handleSetDefaultForNew}
           pending={pending}
           defaultForNew={defaultForNew}
           homeZone={homeZone}
           zones={zones}
-          onApprove={(deviceId, zoneId) =>
-            approveDevice.mutate({ deviceId, zoneId })
-          }
-          approvingDeviceId={
-            approveDevice.isPending
-              ? (approveDevice.variables?.deviceId ?? null)
-              : null
-          }
+          onApprove={handleApprove}
+          approvingDeviceIds={approvingIds}
         />
       </div>
     </div>

--- a/source/admin-site/tests/components/compound/ConnectionBanner.test.tsx
+++ b/source/admin-site/tests/components/compound/ConnectionBanner.test.tsx
@@ -1,38 +1,23 @@
-import { describe, expect, it, vi, beforeEach } from "vitest";
+import { describe, expect, it } from "vitest";
 import { screen } from "@testing-library/react";
-import { useDaemonStatus } from "@wardnet/web";
 import { ConnectionBanner } from "@/components/compound/ConnectionBanner";
 import { renderWithProviders } from "../../test-utils";
 
-vi.mock("@wardnet/web", async (importOriginal) => {
-  const actual = await importOriginal<Record<string, unknown>>();
-  return { ...actual, useDaemonStatus: vi.fn() };
-});
-
-const mockUseDaemonStatus = vi.mocked(useDaemonStatus);
-
 describe("ConnectionBanner", () => {
-  beforeEach(() => vi.clearAllMocks());
-
-  it("renders nothing when there is no data", () => {
-    mockUseDaemonStatus.mockReturnValue({ data: undefined } as never);
-    const { container } = renderWithProviders(<ConnectionBanner />);
+  it("renders nothing while the status is unknown", () => {
+    const { container } = renderWithProviders(
+      <ConnectionBanner reachable={undefined} />,
+    );
     expect(container).toBeEmptyDOMElement();
   });
 
   it("renders nothing when the daemon is reachable", () => {
-    mockUseDaemonStatus.mockReturnValue({
-      data: { reachable: true },
-    } as never);
-    const { container } = renderWithProviders(<ConnectionBanner />);
+    const { container } = renderWithProviders(<ConnectionBanner reachable />);
     expect(container).toBeEmptyDOMElement();
   });
 
   it("shows the alert banner when the daemon is unreachable", () => {
-    mockUseDaemonStatus.mockReturnValue({
-      data: { reachable: false },
-    } as never);
-    renderWithProviders(<ConnectionBanner />);
+    renderWithProviders(<ConnectionBanner reachable={false} />);
     expect(screen.getByRole("alert")).toBeInTheDocument();
     expect(
       screen.getByText(/Unable to connect to the Wardnet daemon/),

--- a/source/admin-site/tests/components/compound/ConnectionStatus.test.tsx
+++ b/source/admin-site/tests/components/compound/ConnectionStatus.test.tsx
@@ -1,59 +1,30 @@
-import { describe, expect, it, vi, beforeEach } from "vitest";
+import { describe, expect, it } from "vitest";
 import { screen } from "@testing-library/react";
-import { useDaemonStatus } from "@wardnet/web";
 import { ConnectionStatus } from "@/components/compound/ConnectionStatus";
 import { renderWithProviders } from "../../test-utils";
-
-vi.mock("@wardnet/web", async (importOriginal) => {
-  const actual = await importOriginal<Record<string, unknown>>();
-  return { ...actual, useDaemonStatus: vi.fn() };
-});
-
-const mockUseDaemonStatus = vi.mocked(useDaemonStatus);
 
 function dot(): HTMLElement {
   return document.querySelector("span.inline-block") as HTMLElement;
 }
 
 describe("ConnectionStatus", () => {
-  beforeEach(() => vi.clearAllMocks());
-
   it("shows Connecting while loading", () => {
-    mockUseDaemonStatus.mockReturnValue({
-      data: undefined,
-      isLoading: true,
-    } as never);
-    renderWithProviders(<ConnectionStatus />);
+    renderWithProviders(<ConnectionStatus isLoading reachable={false} />);
     expect(screen.getByText("Connecting…")).toBeInTheDocument();
     expect(dot().className).toContain("bg-warn");
   });
 
   it("shows Connected when reachable", () => {
-    mockUseDaemonStatus.mockReturnValue({
-      data: { reachable: true },
-      isLoading: false,
-    } as never);
-    renderWithProviders(<ConnectionStatus />);
+    renderWithProviders(<ConnectionStatus isLoading={false} reachable />);
     expect(screen.getByText("Connected")).toBeInTheDocument();
     expect(dot().className).toContain("bg-accent");
   });
 
   it("shows Disconnected when not reachable", () => {
-    mockUseDaemonStatus.mockReturnValue({
-      data: { reachable: false },
-      isLoading: false,
-    } as never);
-    renderWithProviders(<ConnectionStatus />);
+    renderWithProviders(
+      <ConnectionStatus isLoading={false} reachable={false} />,
+    );
     expect(screen.getByText("Disconnected")).toBeInTheDocument();
     expect(dot().className).toContain("bg-danger");
-  });
-
-  it("defaults to Disconnected when data is absent and not loading", () => {
-    mockUseDaemonStatus.mockReturnValue({
-      data: undefined,
-      isLoading: false,
-    } as never);
-    renderWithProviders(<ConnectionStatus />);
-    expect(screen.getByText("Disconnected")).toBeInTheDocument();
   });
 });

--- a/source/admin-site/tests/components/compound/DeviceTable.test.tsx
+++ b/source/admin-site/tests/components/compound/DeviceTable.test.tsx
@@ -1,30 +1,9 @@
 import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { DeviceTable } from "@/components/compound/DeviceTable";
 import { makeDevice, renderWithProviders } from "../../test-utils";
-
-vi.mock("@wardnet/web", async (importOriginal) => {
-  const actual = await importOriginal<Record<string, unknown>>();
-  return {
-    ...actual,
-    useDeviceFilterSettingsList: vi.fn(),
-    useDnsFilterProfiles: vi.fn(),
-  };
-});
-
-import {
-  useDeviceFilterSettingsList,
-  useDnsFilterProfiles,
-} from "@wardnet/web";
-
-const mockSettings = vi.mocked(useDeviceFilterSettingsList);
-const mockProfiles = vi.mocked(useDnsFilterProfiles);
-
-beforeEach(() => {
-  mockSettings.mockReturnValue({ data: undefined } as never);
-  mockProfiles.mockReturnValue({ data: undefined } as never);
-});
+import type { DeviceDnsFilterSettings, DnsFilterProfile } from "@wardnet/js";
 
 describe("DeviceTable", () => {
   it("renders device rows with name, IP, type, and manufacturer fallback", () => {
@@ -47,6 +26,8 @@ describe("DeviceTable", () => {
           }),
         ]}
         onDeviceClick={vi.fn()}
+        filterSettings={undefined}
+        filterProfiles={undefined}
       />,
     );
     expect(screen.getByText("Laptop")).toBeInTheDocument();
@@ -64,30 +45,24 @@ describe("DeviceTable", () => {
       <DeviceTable
         devices={[makeDevice({ id: "d1", dhcp_status: "external" })]}
         onDeviceClick={vi.fn()}
+        filterSettings={undefined}
+        filterProfiles={undefined}
       />,
     );
     expect(screen.getByText("External")).toBeInTheDocument();
   });
 
   it("renders the DNS-filter column across its branches", () => {
-    mockProfiles.mockReturnValue({
-      data: {
-        profiles: [
-          { id: "p1", name: "Ads" },
-          { id: "p2", name: "Malware" },
-        ],
-      },
-    } as never);
-    mockSettings.mockReturnValue({
-      data: {
-        devices: [
-          { device_id: "d-off", enabled: false, profile_ids: [] },
-          { device_id: "d-empty", enabled: true, profile_ids: [] },
-          { device_id: "d-named", enabled: true, profile_ids: ["p1", "p2"] },
-          { device_id: "d-unknown", enabled: true, profile_ids: ["nope"] },
-        ],
-      },
-    } as never);
+    const filterProfiles = [
+      { id: "p1", name: "Ads" },
+      { id: "p2", name: "Malware" },
+    ] as DnsFilterProfile[];
+    const filterSettings = [
+      { device_id: "d-off", enabled: false, profile_ids: [] },
+      { device_id: "d-empty", enabled: true, profile_ids: [] },
+      { device_id: "d-named", enabled: true, profile_ids: ["p1", "p2"] },
+      { device_id: "d-unknown", enabled: true, profile_ids: ["nope"] },
+    ] as DeviceDnsFilterSettings[];
 
     renderWithProviders(
       <DeviceTable
@@ -99,6 +74,8 @@ describe("DeviceTable", () => {
           makeDevice({ id: "d-default", name: "NoRow" }),
         ]}
         onDeviceClick={vi.fn()}
+        filterSettings={filterSettings}
+        filterProfiles={filterProfiles}
       />,
     );
     expect(screen.getByText("Filtering off")).toBeInTheDocument();
@@ -117,6 +94,8 @@ describe("DeviceTable", () => {
       <DeviceTable
         devices={[makeDevice({ id: "d1", name: "Laptop" })]}
         onDeviceClick={onDeviceClick}
+        filterSettings={undefined}
+        filterProfiles={undefined}
       />,
     );
     await user.click(screen.getByText("Laptop"));

--- a/source/admin-site/tests/components/compound/DhcpConfigCard.test.tsx
+++ b/source/admin-site/tests/components/compound/DhcpConfigCard.test.tsx
@@ -5,26 +5,6 @@ import type { DhcpConfig } from "@wardnet/js";
 import { DhcpConfigCard } from "@/components/compound/DhcpConfigCard";
 import { renderWithProviders } from "../../test-utils";
 
-vi.mock("@wardnet/web", async (importOriginal) => {
-  const actual = await importOriginal<Record<string, unknown>>();
-  return {
-    ...actual,
-    useUpdateDhcpConfig: vi.fn(),
-    usePreviewDhcpConfig: vi.fn(),
-    useDnsConfig: vi.fn(),
-  };
-});
-
-import {
-  useUpdateDhcpConfig,
-  usePreviewDhcpConfig,
-  useDnsConfig,
-} from "@wardnet/web";
-
-const mockUpdate = vi.mocked(useUpdateDhcpConfig);
-const mockPreview = vi.mocked(usePreviewDhcpConfig);
-const mockDns = vi.mocked(useDnsConfig);
-
 const updateMutateAsync = vi.fn();
 const previewMutateAsync = vi.fn();
 const updateReset = vi.fn();
@@ -43,27 +23,46 @@ function makeConfig(overrides: Partial<DhcpConfig> = {}): DhcpConfig {
   };
 }
 
+function cardProps({
+  config = makeConfig(),
+  dnsEnabled = false as boolean | undefined,
+  update = {},
+}: {
+  config?: DhcpConfig;
+  dnsEnabled?: boolean | undefined;
+  update?: Partial<{
+    isPending: boolean;
+    isError: boolean;
+    error: Error | null;
+  }>;
+} = {}) {
+  return {
+    config,
+    dnsEnabled,
+    updateConfig: {
+      mutateAsync: updateMutateAsync,
+      reset: updateReset,
+      isPending: false,
+      isError: false,
+      error: null,
+      ...update,
+    },
+    previewConfig: {
+      mutateAsync: previewMutateAsync,
+      isPending: false,
+    },
+  };
+}
+
 beforeEach(() => {
   updateMutateAsync.mockReset().mockResolvedValue(undefined);
   previewMutateAsync.mockReset().mockResolvedValue({ affected: [] });
   updateReset.mockReset();
-  mockUpdate.mockReturnValue({
-    mutateAsync: updateMutateAsync,
-    reset: updateReset,
-    isPending: false,
-    isError: false,
-    error: null,
-  } as never);
-  mockPreview.mockReturnValue({
-    mutateAsync: previewMutateAsync,
-    isPending: false,
-  } as never);
-  mockDns.mockReturnValue({ data: { config: { enabled: false } } } as never);
 });
 
 describe("DhcpConfigCard", () => {
   it("renders the read view with pool range and upstream DNS", () => {
-    renderWithProviders(<DhcpConfigCard config={makeConfig()} />);
+    renderWithProviders(<DhcpConfigCard {...cardProps()} />);
     expect(screen.getByTestId("dhcp-config-pool-range")).toHaveTextContent(
       "10.232.1.100",
     );
@@ -73,18 +72,23 @@ describe("DhcpConfigCard", () => {
 
   it("formats sub-hour and sub-day lease durations", () => {
     const { rerender } = renderWithProviders(
-      <DhcpConfigCard config={makeConfig({ lease_duration_secs: 1800 })} />,
+      <DhcpConfigCard
+        {...cardProps({ config: makeConfig({ lease_duration_secs: 1800 }) })}
+      />,
     );
     expect(screen.getByText("30m")).toBeInTheDocument();
     rerender(
-      <DhcpConfigCard config={makeConfig({ lease_duration_secs: 7200 })} />,
+      <DhcpConfigCard
+        {...cardProps({ config: makeConfig({ lease_duration_secs: 7200 }) })}
+      />,
     );
     expect(screen.getByText("2h")).toBeInTheDocument();
   });
 
   it("shows 'Wardnet DNS' in the read view when the DNS server is enabled", () => {
-    mockDns.mockReturnValue({ data: { config: { enabled: true } } } as never);
-    renderWithProviders(<DhcpConfigCard config={makeConfig()} />);
+    renderWithProviders(
+      <DhcpConfigCard {...cardProps({ dnsEnabled: true })} />,
+    );
     expect(screen.getByText("Wardnet DNS")).toBeInTheDocument();
   });
 
@@ -95,25 +99,28 @@ describe("DhcpConfigCard", () => {
   // assert on the accessible name: that is both what a screen reader announces
   // and the only copy a sighted user can surface by hovering.
   it("warns that already-leased devices keep their old DNS until they reconnect", () => {
-    mockDns.mockReturnValue({ data: { config: { enabled: true } } } as never);
-    renderWithProviders(<DhcpConfigCard config={makeConfig()} />);
+    renderWithProviders(
+      <DhcpConfigCard {...cardProps({ dnsEnabled: true })} />,
+    );
     expect(screen.getByTestId("dhcp-dns-lease-note")).toHaveAccessibleName(
       /reconnect a device/i,
     );
   });
 
   it("omits the lease note when the DNS server is off", () => {
-    mockDns.mockReturnValue({ data: { config: { enabled: false } } } as never);
-    renderWithProviders(<DhcpConfigCard config={makeConfig()} />);
+    renderWithProviders(
+      <DhcpConfigCard {...cardProps({ dnsEnabled: false })} />,
+    );
     expect(screen.queryByTestId("dhcp-dns-lease-note")).not.toBeInTheDocument();
   });
 
   it("shows a placeholder, not the upstream list, while the DNS query is unresolved", () => {
-    // While the ["dns"] query is loading (or errored) the effective client
-    // DNS is unknown — rendering the raw upstream list would claim clients
-    // bypass the Pi when the daemon may actually be advertising it.
-    mockDns.mockReturnValue({ data: undefined } as never);
-    renderWithProviders(<DhcpConfigCard config={makeConfig()} />);
+    // While the page's ["dns"] query is loading (or errored) the effective
+    // client DNS is unknown — rendering the raw upstream list would claim
+    // clients bypass the Pi when the daemon may actually be advertising it.
+    renderWithProviders(
+      <DhcpConfigCard {...cardProps()} dnsEnabled={undefined} />,
+    );
     expect(screen.getByText("…")).toBeInTheDocument();
     expect(screen.queryByText(/1\.1\.1\.1/)).not.toBeInTheDocument();
     expect(screen.queryByText("Wardnet DNS")).not.toBeInTheDocument();
@@ -121,8 +128,9 @@ describe("DhcpConfigCard", () => {
 
   it("enters edit mode and hides the upstream DNS field when DNS is enabled", async () => {
     const user = userEvent.setup();
-    mockDns.mockReturnValue({ data: { config: { enabled: true } } } as never);
-    renderWithProviders(<DhcpConfigCard config={makeConfig()} />);
+    renderWithProviders(
+      <DhcpConfigCard {...cardProps({ dnsEnabled: true })} />,
+    );
     await user.click(screen.getByTestId("dhcp-config-edit"));
     expect(screen.getByTestId("dhcp-pool-start")).toBeInTheDocument();
     expect(screen.queryByLabelText(/Upstream DNS/)).not.toBeInTheDocument();
@@ -132,9 +140,11 @@ describe("DhcpConfigCard", () => {
     const user = userEvent.setup();
     renderWithProviders(
       <DhcpConfigCard
-        config={makeConfig({
-          pool_start: "10.232.1.200",
-          pool_end: "10.232.1.100",
+        {...cardProps({
+          config: makeConfig({
+            pool_start: "10.232.1.200",
+            pool_end: "10.232.1.100",
+          }),
         })}
       />,
     );
@@ -149,9 +159,11 @@ describe("DhcpConfigCard", () => {
     const user = userEvent.setup();
     renderWithProviders(
       <DhcpConfigCard
-        config={makeConfig({
-          pool_start: "8.8.8.100",
-          pool_end: "8.8.8.200",
+        {...cardProps({
+          config: makeConfig({
+            pool_start: "8.8.8.100",
+            pool_end: "8.8.8.200",
+          }),
         })}
       />,
     );
@@ -164,7 +176,7 @@ describe("DhcpConfigCard", () => {
 
   it("cancels back to the read view", async () => {
     const user = userEvent.setup();
-    renderWithProviders(<DhcpConfigCard config={makeConfig()} />);
+    renderWithProviders(<DhcpConfigCard {...cardProps()} />);
     await user.click(screen.getByTestId("dhcp-config-edit"));
     await user.click(screen.getByTestId("dhcp-config-cancel"));
     expect(screen.queryByTestId("dhcp-pool-start")).not.toBeInTheDocument();
@@ -173,7 +185,7 @@ describe("DhcpConfigCard", () => {
 
   it("saves directly when the pool range is unchanged", async () => {
     const user = userEvent.setup();
-    renderWithProviders(<DhcpConfigCard config={makeConfig()} />);
+    renderWithProviders(<DhcpConfigCard {...cardProps()} />);
     await user.click(screen.getByTestId("dhcp-config-edit"));
     await user.click(screen.getByTestId("dhcp-config-save"));
     expect(previewMutateAsync).not.toHaveBeenCalled();
@@ -192,7 +204,7 @@ describe("DhcpConfigCard", () => {
         },
       ],
     });
-    renderWithProviders(<DhcpConfigCard config={makeConfig()} />);
+    renderWithProviders(<DhcpConfigCard {...cardProps()} />);
     await user.click(screen.getByTestId("dhcp-config-edit"));
 
     // Change the pool-start octets so the range differs from the config.
@@ -217,7 +229,7 @@ describe("DhcpConfigCard", () => {
   // field that triggers it.
   it("rejects an incomplete pool start", async () => {
     const user = userEvent.setup();
-    renderWithProviders(<DhcpConfigCard config={makeConfig()} />);
+    renderWithProviders(<DhcpConfigCard {...cardProps()} />);
     await user.click(screen.getByTestId("dhcp-config-edit"));
     const input = screen
       .getByTestId("dhcp-pool-start")
@@ -235,7 +247,7 @@ describe("DhcpConfigCard", () => {
   // would leave the field valid.
   it("rejects an incomplete fallback router address", async () => {
     const user = userEvent.setup();
-    renderWithProviders(<DhcpConfigCard config={makeConfig()} />);
+    renderWithProviders(<DhcpConfigCard {...cardProps()} />);
     await user.click(screen.getByTestId("dhcp-config-edit"));
     const octets = screen.getByTestId("dhcp-router").querySelectorAll("input");
     await user.click(octets[3]);
@@ -248,7 +260,7 @@ describe("DhcpConfigCard", () => {
   // A public router address would hand every client a gateway off the LAN.
   it("rejects a non-private fallback router address", async () => {
     const user = userEvent.setup();
-    renderWithProviders(<DhcpConfigCard config={makeConfig()} />);
+    renderWithProviders(<DhcpConfigCard {...cardProps()} />);
     await user.click(screen.getByTestId("dhcp-config-edit"));
     const router = screen
       .getByTestId("dhcp-router")
@@ -262,7 +274,7 @@ describe("DhcpConfigCard", () => {
 
   it("edits the lease duration and upstream DNS fields", async () => {
     const user = userEvent.setup();
-    renderWithProviders(<DhcpConfigCard config={makeConfig()} />);
+    renderWithProviders(<DhcpConfigCard {...cardProps()} />);
     await user.click(screen.getByTestId("dhcp-config-edit"));
 
     const lease = screen.getByLabelText(/Lease duration/i);
@@ -278,14 +290,13 @@ describe("DhcpConfigCard", () => {
 
   it("renders an API error alert in edit mode when the update failed", async () => {
     const user = userEvent.setup();
-    mockUpdate.mockReturnValue({
-      mutateAsync: updateMutateAsync,
-      reset: updateReset,
-      isPending: false,
-      isError: true,
-      error: new Error("nope"),
-    } as never);
-    renderWithProviders(<DhcpConfigCard config={makeConfig()} />);
+    renderWithProviders(
+      <DhcpConfigCard
+        {...cardProps({
+          update: { isError: true, error: new Error("nope") },
+        })}
+      />,
+    );
     await user.click(screen.getByTestId("dhcp-config-edit"));
     // Edit mode is active and the isError branch renders the alert.
     expect(screen.getByTestId("dhcp-pool-start")).toBeInTheDocument();

--- a/source/admin-site/tests/components/compound/DhcpConfigCard.test.tsx
+++ b/source/admin-site/tests/components/compound/DhcpConfigCard.test.tsx
@@ -49,7 +49,10 @@ function cardProps({
     },
     previewConfig: {
       mutateAsync: previewMutateAsync,
+      reset: vi.fn(),
       isPending: false,
+      isError: false,
+      error: null,
     },
   };
 }

--- a/source/admin-site/tests/components/compound/MobileMenu.test.tsx
+++ b/source/admin-site/tests/components/compound/MobileMenu.test.tsx
@@ -1,40 +1,38 @@
 import { describe, expect, it, vi, beforeEach } from "vitest";
 import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { useAuth, useDaemonStatus, useUpdateStatus } from "@wardnet/web";
 import { MobileMenu } from "@/components/compound/MobileMenu";
 import { renderWithProviders } from "../../test-utils";
 
-vi.mock("@wardnet/web", async (importOriginal) => {
-  const actual = await importOriginal<Record<string, unknown>>();
+const onLogout = vi.fn();
+
+function menuProps() {
   return {
-    ...actual,
-    useAuth: vi.fn(),
-    useDaemonStatus: vi.fn(),
-    useUpdateStatus: vi.fn(),
+    isAdmin: true,
+    onLogout,
+    version: undefined,
+    connectionLoading: false,
+    connected: false,
+    updateAvailable: false,
+    latestVersion: null,
   };
-});
+}
 
 beforeEach(() => {
   vi.clearAllMocks();
-  vi.mocked(useAuth).mockReturnValue({
-    isAdmin: true,
-    logout: vi.fn(),
-  } as never);
-  vi.mocked(useDaemonStatus).mockReturnValue({ data: undefined } as never);
-  vi.mocked(useUpdateStatus).mockReturnValue({ data: undefined } as never);
+  onLogout.mockResolvedValue(true);
 });
 
 describe("MobileMenu", () => {
   it("renders the trigger button", () => {
-    renderWithProviders(<MobileMenu />);
+    renderWithProviders(<MobileMenu {...menuProps()} />);
     expect(screen.getByTestId("mobile-menu-trigger")).toBeInTheDocument();
     expect(screen.getByText("Toggle menu")).toBeInTheDocument();
   });
 
   it("opens the drawer with the sidebar when the trigger is clicked", async () => {
     const user = userEvent.setup();
-    renderWithProviders(<MobileMenu />);
+    renderWithProviders(<MobileMenu {...menuProps()} />);
     await user.click(screen.getByTestId("mobile-menu-trigger"));
     await waitFor(() => {
       expect(screen.getByText("Navigation")).toBeInTheDocument();
@@ -45,7 +43,7 @@ describe("MobileMenu", () => {
 
   it("closes the drawer when a sidebar nav item is clicked", async () => {
     const user = userEvent.setup();
-    renderWithProviders(<MobileMenu />);
+    renderWithProviders(<MobileMenu {...menuProps()} />);
     await user.click(screen.getByTestId("mobile-menu-trigger"));
     const navItem = await screen.findByTestId("nav-devices");
     // Clicking a nav link fires Sidebar's onNavigate → setOpen(false).

--- a/source/admin-site/tests/components/compound/Sidebar.test.tsx
+++ b/source/admin-site/tests/components/compound/Sidebar.test.tsx
@@ -4,38 +4,29 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { Sidebar } from "@/components/compound/Sidebar";
 import { renderWithProviders } from "../../test-utils";
 
-vi.mock("@wardnet/web", async (importOriginal) => {
-  const actual = await importOriginal<Record<string, unknown>>();
+const onLogout = vi.fn();
+
+function sidebarProps(over: Partial<Parameters<typeof Sidebar>[0]> = {}) {
   return {
-    ...actual,
-    useAuth: vi.fn(),
-    useDaemonStatus: vi.fn(),
-    useUpdateStatus: vi.fn(),
+    isAdmin: true,
+    onLogout,
+    version: "1.2.3" as string | undefined,
+    connectionLoading: false,
+    connected: true,
+    updateAvailable: false,
+    latestVersion: null as string | null,
+    ...over,
   };
-});
-
-import { useAuth, useDaemonStatus, useUpdateStatus } from "@wardnet/web";
-
-const mockAuth = vi.mocked(useAuth);
-const mockDaemon = vi.mocked(useDaemonStatus);
-const mockUpdate = vi.mocked(useUpdateStatus);
-const logout = vi.fn();
+}
 
 beforeEach(() => {
-  logout.mockReset();
-  logout.mockResolvedValue(true);
-  mockAuth.mockReturnValue({ isAdmin: true, logout } as never);
-  mockDaemon.mockReturnValue({
-    data: { version: "1.2.3", reachable: true },
-  } as never);
-  mockUpdate.mockReturnValue({
-    data: { status: { update_available: false, latest_version: null } },
-  } as never);
+  onLogout.mockReset();
+  onLogout.mockResolvedValue(true);
 });
 
 describe("Sidebar", () => {
   it("renders admin navigation, version, and admin footer links", () => {
-    renderWithProviders(<Sidebar />);
+    renderWithProviders(<Sidebar {...sidebarProps()} />);
     expect(screen.getByTestId("nav-dashboard")).toBeInTheDocument();
     expect(screen.getByTestId("nav-devices")).toBeInTheDocument();
     expect(screen.getByTestId("nav-power")).toBeInTheDocument();
@@ -45,32 +36,35 @@ describe("Sidebar", () => {
   });
 
   it("shows the update banner when an update is available", () => {
-    mockUpdate.mockReturnValue({
-      data: { status: { update_available: true, latest_version: "9.9.9" } },
-    } as never);
-    renderWithProviders(<Sidebar />);
+    renderWithProviders(
+      <Sidebar
+        {...sidebarProps({ updateAvailable: true, latestVersion: "9.9.9" })}
+      />,
+    );
     expect(screen.getByText("Update available: v9.9.9")).toBeInTheDocument();
   });
 
   it("logs out and navigates when Sign out is clicked", async () => {
     const user = userEvent.setup();
     const onNavigate = vi.fn();
-    renderWithProviders(<Sidebar onNavigate={onNavigate} />);
+    renderWithProviders(
+      <Sidebar {...sidebarProps()} onNavigate={onNavigate} />,
+    );
     await user.click(screen.getByText("Sign out"));
-    expect(logout).toHaveBeenCalledOnce();
+    expect(onLogout).toHaveBeenCalledOnce();
     await waitFor(() => expect(onNavigate).toHaveBeenCalledOnce());
   });
 
   it("renders the sign-in link and no nav for non-admins", () => {
-    mockAuth.mockReturnValue({ isAdmin: false, logout } as never);
-    renderWithProviders(<Sidebar />);
+    renderWithProviders(<Sidebar {...sidebarProps({ isAdmin: false })} />);
     expect(screen.getByText("Sign in as admin")).toBeInTheDocument();
     expect(screen.queryByTestId("nav-dashboard")).not.toBeInTheDocument();
   });
 
   it("omits the version caption when the daemon reports none", () => {
-    mockDaemon.mockReturnValue({ data: { reachable: false } } as never);
-    renderWithProviders(<Sidebar />);
+    renderWithProviders(
+      <Sidebar {...sidebarProps({ version: undefined, connected: false })} />,
+    );
     expect(screen.queryByText(/^v/)).not.toBeInTheDocument();
   });
 });

--- a/source/admin-site/tests/components/compound/UncleanShutdownBanner.test.tsx
+++ b/source/admin-site/tests/components/compound/UncleanShutdownBanner.test.tsx
@@ -1,83 +1,75 @@
 import { describe, expect, it, vi, beforeEach } from "vitest";
 import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { useSystemStatus, useAcknowledgeShutdown } from "@wardnet/web";
 import { UncleanShutdownBanner } from "@/components/compound/UncleanShutdownBanner";
 import { renderWithProviders } from "../../test-utils";
+import type { SystemStatusResponse } from "@wardnet/js";
 
-vi.mock("@wardnet/web", async (importOriginal) => {
-  const actual = await importOriginal<Record<string, unknown>>();
-  return {
-    ...actual,
-    useSystemStatus: vi.fn(),
-    useAcknowledgeShutdown: vi.fn(),
-  };
-});
-
-const mutate = vi.fn();
+const onDismiss = vi.fn();
 
 beforeEach(() => {
   vi.clearAllMocks();
-  vi.mocked(useAcknowledgeShutdown).mockReturnValue({
-    mutate,
-    isPending: false,
-  } as never);
 });
 
-function setStatus(last_shutdown: unknown) {
-  vi.mocked(useSystemStatus).mockReturnValue({
-    data: { last_shutdown },
-  } as never);
+function renderBanner(last_shutdown: unknown) {
+  const status =
+    last_shutdown === null
+      ? undefined
+      : ({ last_shutdown } as unknown as SystemStatusResponse);
+  return renderWithProviders(
+    <UncleanShutdownBanner
+      status={status}
+      onDismiss={onDismiss}
+      dismissPending={false}
+    />,
+  );
 }
 
 describe("UncleanShutdownBanner", () => {
   it("renders nothing when status is missing", () => {
-    vi.mocked(useSystemStatus).mockReturnValue({ data: undefined } as never);
-    const { container } = renderWithProviders(<UncleanShutdownBanner />);
+    const { container } = renderBanner(null);
     expect(container).toBeEmptyDOMElement();
   });
 
   it("renders nothing when the last shutdown was clean", () => {
-    setStatus({ state: "clean", at: "2026-01-01T00:00:00Z" });
-    const { container } = renderWithProviders(<UncleanShutdownBanner />);
+    const { container } = renderBanner({
+      state: "clean",
+      at: "2026-01-01T00:00:00Z",
+    });
     expect(container).toBeEmptyDOMElement();
   });
 
   it("renders nothing when unclean but no timestamp", () => {
-    setStatus({ state: "unclean", at: null });
-    const { container } = renderWithProviders(<UncleanShutdownBanner />);
+    const { container } = renderBanner({ state: "unclean", at: null });
     expect(container).toBeEmptyDOMElement();
   });
 
   it("renders nothing when acknowledged at-or-after the event", () => {
-    setStatus({
+    const { container } = renderBanner({
       state: "unclean",
       at: "2026-01-01T00:00:00Z",
       acknowledged_at: "2026-01-02T00:00:00Z",
     });
-    const { container } = renderWithProviders(<UncleanShutdownBanner />);
     expect(container).toBeEmptyDOMElement();
   });
 
   it("shows the banner for an unacknowledged unclean shutdown", () => {
-    setStatus({
+    renderBanner({
       state: "unclean",
       at: "2026-01-01T00:00:00Z",
       acknowledged_at: null,
     });
-    renderWithProviders(<UncleanShutdownBanner />);
     expect(
       screen.getByText("Wardnet did not shut down cleanly"),
     ).toBeInTheDocument();
   });
 
   it("shows the banner when the ack predates the event", () => {
-    setStatus({
+    renderBanner({
       state: "unclean",
       at: "2026-01-02T00:00:00Z",
       acknowledged_at: "2026-01-01T00:00:00Z",
     });
-    renderWithProviders(<UncleanShutdownBanner />);
     expect(
       screen.getByText("Wardnet did not shut down cleanly"),
     ).toBeInTheDocument();
@@ -85,15 +77,14 @@ describe("UncleanShutdownBanner", () => {
 
   it("acknowledges when Dismiss is clicked", async () => {
     const user = userEvent.setup();
-    setStatus({
+    renderBanner({
       state: "unclean",
       at: "2026-01-01T00:00:00Z",
       acknowledged_at: null,
     });
-    renderWithProviders(<UncleanShutdownBanner />);
     await user.click(
       screen.getByRole("button", { name: "Dismiss unclean shutdown banner" }),
     );
-    expect(mutate).toHaveBeenCalledTimes(1);
+    expect(onDismiss).toHaveBeenCalledTimes(1);
   });
 });

--- a/source/admin-site/tests/components/features/ConditionalForwardingCard.test.tsx
+++ b/source/admin-site/tests/components/features/ConditionalForwardingCard.test.tsx
@@ -1,14 +1,9 @@
 import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import {
-  useForwardingRules,
-  useCreateForwardingRule,
-  useUpdateForwardingRule,
-  useDeleteForwardingRule,
-} from "@wardnet/web";
 import { ConditionalForwardingCard } from "@/components/features/ConditionalForwardingCard";
 import { renderWithProviders } from "../../test-utils";
+import type { ConditionalForwardingRule } from "@wardnet/js";
 
 Element.prototype.hasPointerCapture ??= () => false;
 Element.prototype.setPointerCapture ??= () => {};
@@ -23,66 +18,48 @@ vi.stubGlobal(
   },
 );
 
-vi.mock("@wardnet/web", async (importOriginal) => {
-  const actual = await importOriginal<Record<string, unknown>>();
-  return {
-    ...actual,
-    useForwardingRules: vi.fn(),
-    useCreateForwardingRule: vi.fn(),
-    useUpdateForwardingRule: vi.fn(),
-    useDeleteForwardingRule: vi.fn(),
-  };
-});
+const onCreateRule = vi.fn();
+const onUpdateRule = vi.fn();
+const onDeleteRule = vi.fn();
 
-const createMutate = vi.fn();
-const updateMutate = vi.fn();
-const deleteMutate = vi.fn();
+const rules = [
+  {
+    id: "r1",
+    domain: "corp.internal",
+    upstream: "10.0.0.1",
+    enabled: true,
+  },
+] as ConditionalForwardingRule[];
 
-function mutation<T>(mutate: ReturnType<typeof vi.fn>): T {
-  return {
-    mutate,
-    mutateAsync: vi.fn(),
-    isPending: false,
-  } as unknown as T;
+function renderCard() {
+  return renderWithProviders(
+    <ConditionalForwardingCard
+      rules={rules}
+      isSaving={false}
+      updatePending={false}
+      onCreateRule={onCreateRule}
+      onUpdateRule={onUpdateRule}
+      onDeleteRule={onDeleteRule}
+    />,
+  );
 }
 
 beforeEach(() => {
   vi.clearAllMocks();
-  vi.mocked(useForwardingRules).mockReturnValue({
-    data: {
-      rules: [
-        {
-          id: "r1",
-          domain: "corp.internal",
-          upstream: "10.0.0.1",
-          enabled: true,
-        },
-      ],
-    },
-  } as unknown as ReturnType<typeof useForwardingRules>);
-  vi.mocked(useCreateForwardingRule).mockReturnValue(
-    mutation<ReturnType<typeof useCreateForwardingRule>>(createMutate),
-  );
-  vi.mocked(useUpdateForwardingRule).mockReturnValue(
-    mutation<ReturnType<typeof useUpdateForwardingRule>>(updateMutate),
-  );
-  vi.mocked(useDeleteForwardingRule).mockReturnValue(
-    mutation<ReturnType<typeof useDeleteForwardingRule>>(deleteMutate),
-  );
 });
 
 describe("ConditionalForwardingCard", () => {
   it("renders existing rules", () => {
-    renderWithProviders(<ConditionalForwardingCard />);
+    renderCard();
     expect(screen.getByText("corp.internal")).toBeInTheDocument();
     expect(screen.getByText("10.0.0.1")).toBeInTheDocument();
   });
 
-  it("toggling a rule calls updateRule.mutate", async () => {
+  it("toggling a rule calls the update callback", async () => {
     const user = userEvent.setup();
-    renderWithProviders(<ConditionalForwardingCard />);
+    renderCard();
     await user.click(screen.getByLabelText("Toggle rule for corp.internal"));
-    expect(updateMutate).toHaveBeenCalledWith({
+    expect(onUpdateRule).toHaveBeenCalledWith({
       id: "r1",
       body: { enabled: false },
     });
@@ -90,12 +67,12 @@ describe("ConditionalForwardingCard", () => {
 
   it("creates a rule through the add form", async () => {
     const user = userEvent.setup();
-    renderWithProviders(<ConditionalForwardingCard />);
+    renderCard();
     await user.click(screen.getByTestId("fwd-add"));
     await user.type(screen.getByTestId("fwd-domain"), "lab.internal");
     await user.type(screen.getByTestId("fwd-upstream"), "10.1.1.1");
     await user.click(screen.getByTestId("fwd-submit"));
-    expect(createMutate).toHaveBeenCalledWith(
+    expect(onCreateRule).toHaveBeenCalledWith(
       { domain: "lab.internal", upstream: "10.1.1.1", enabled: true },
       expect.objectContaining({ onSuccess: expect.any(Function) }),
     );
@@ -103,7 +80,7 @@ describe("ConditionalForwardingCard", () => {
 
   it("cancelling closes the form", async () => {
     const user = userEvent.setup();
-    renderWithProviders(<ConditionalForwardingCard />);
+    renderCard();
     await user.click(screen.getByTestId("fwd-add"));
     await user.click(screen.getByRole("button", { name: "Cancel" }));
     expect(screen.queryByTestId("fwd-domain")).not.toBeInTheDocument();
@@ -111,7 +88,7 @@ describe("ConditionalForwardingCard", () => {
 
   it("edits a rule via the row menu", async () => {
     const user = userEvent.setup({ pointerEventsCheck: 0 });
-    renderWithProviders(<ConditionalForwardingCard />);
+    renderCard();
     await user.click(screen.getByTestId("fwd-row-menu"));
     await user.click(await screen.findByTestId("fwd-edit"));
     const domain = screen.getByTestId("fwd-domain") as HTMLInputElement;
@@ -119,7 +96,7 @@ describe("ConditionalForwardingCard", () => {
     await user.clear(domain);
     await user.type(domain, "corp.local");
     await user.click(screen.getByTestId("fwd-submit"));
-    expect(updateMutate).toHaveBeenCalledWith(
+    expect(onUpdateRule).toHaveBeenCalledWith(
       { id: "r1", body: { domain: "corp.local", upstream: "10.0.0.1" } },
       expect.objectContaining({ onSuccess: expect.any(Function) }),
     );
@@ -127,10 +104,10 @@ describe("ConditionalForwardingCard", () => {
 
   it("deletes a rule after confirming", async () => {
     const user = userEvent.setup({ pointerEventsCheck: 0 });
-    renderWithProviders(<ConditionalForwardingCard />);
+    renderCard();
     await user.click(screen.getByTestId("fwd-row-menu"));
     await user.click(await screen.findByTestId("fwd-delete"));
     await user.click(await screen.findByTestId("confirm-dialog-confirm"));
-    expect(deleteMutate).toHaveBeenCalledWith("r1");
+    expect(onDeleteRule).toHaveBeenCalledWith("r1");
   });
 });

--- a/source/admin-site/tests/components/features/CreateReservationInline.test.tsx
+++ b/source/admin-site/tests/components/features/CreateReservationInline.test.tsx
@@ -1,10 +1,22 @@
-import { screen, within } from "@testing-library/react";
+import { screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { CreateReservationInline } from "@/components/features/CreateReservationInline";
 import { makeDevice, renderWithProviders } from "../../test-utils";
 
 const HELP = "Suggested from device name";
+
+const mutateAsync = vi.fn();
+
+function createReservationHandle() {
+  return {
+    mutateAsync,
+    reset: vi.fn(),
+    isPending: false,
+    isError: false,
+    error: null,
+  };
+}
 
 function hostnameInput(): HTMLInputElement {
   return screen.getByTestId("dhcp-reservation-hostname") as HTMLInputElement;
@@ -24,6 +36,11 @@ async function typeMac(user: ReturnType<typeof userEvent.setup>, mac: string) {
   }
 }
 
+beforeEach(() => {
+  vi.clearAllMocks();
+  mutateAsync.mockResolvedValue(undefined);
+});
+
 describe("CreateReservationInline hostname suggestion (issue #85)", () => {
   it("pre-fills and marks the hostname when the fixed MAC matches a device", () => {
     renderWithProviders(
@@ -33,6 +50,7 @@ describe("CreateReservationInline hostname suggestion (issue #85)", () => {
         devices={[
           makeDevice({ mac: "AA:BB:CC:DD:EE:FF", name: "Office printer" }),
         ]}
+        createReservation={createReservationHandle()}
       />,
     );
 
@@ -48,6 +66,7 @@ describe("CreateReservationInline hostname suggestion (issue #85)", () => {
         devices={[
           makeDevice({ mac: "AA:BB:CC:DD:EE:FF", name: "Office printer" }),
         ]}
+        createReservation={createReservationHandle()}
       />,
     );
 
@@ -63,6 +82,7 @@ describe("CreateReservationInline hostname suggestion (issue #85)", () => {
         devices={[
           makeDevice({ mac: "AA:BB:CC:DD:EE:FF", name: "Office printer" }),
         ]}
+        createReservation={createReservationHandle()}
       />,
     );
 
@@ -78,6 +98,7 @@ describe("CreateReservationInline hostname suggestion (issue #85)", () => {
         devices={[
           makeDevice({ mac: "AA:BB:CC:DD:EE:FF", name: "Living-room TV" }),
         ]}
+        createReservation={createReservationHandle()}
       />,
     );
 
@@ -96,6 +117,7 @@ describe("CreateReservationInline hostname suggestion (issue #85)", () => {
         devices={[
           makeDevice({ mac: "AA:BB:CC:DD:EE:FF", name: "Living-room TV" }),
         ]}
+        createReservation={createReservationHandle()}
       />,
     );
 
@@ -104,5 +126,32 @@ describe("CreateReservationInline hostname suggestion (issue #85)", () => {
 
     expect(hostnameInput().value).toBe("my-own-name");
     expect(screen.queryByText(HELP)).not.toBeInTheDocument();
+  });
+});
+
+describe("CreateReservationInline create", () => {
+  it("submits the reservation through the hoisted mutation and closes", async () => {
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+    const onSuccess = vi.fn();
+    renderWithProviders(
+      <CreateReservationInline
+        onClose={onClose}
+        onSuccess={onSuccess}
+        defaults={{ mac: "AA:BB:CC:DD:EE:FF", ip: "10.232.1.50" }}
+        createReservation={createReservationHandle()}
+      />,
+    );
+
+    await user.click(screen.getByTestId("dhcp-reservation-submit"));
+    await waitFor(() => expect(mutateAsync).toHaveBeenCalled());
+    expect(mutateAsync).toHaveBeenCalledWith({
+      mac_address: "AA:BB:CC:DD:EE:FF",
+      ip_address: "10.232.1.50",
+      hostname: undefined,
+      description: undefined,
+    });
+    expect(onSuccess).toHaveBeenCalled();
+    expect(onClose).toHaveBeenCalled();
   });
 });

--- a/source/admin-site/tests/components/features/DashboardRemoteAccessBanner.test.tsx
+++ b/source/admin-site/tests/components/features/DashboardRemoteAccessBanner.test.tsx
@@ -1,54 +1,43 @@
 import { screen } from "@testing-library/react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
-import { useTlsStatus } from "@wardnet/web";
+import { describe, expect, it } from "vitest";
 import { DashboardRemoteAccessBanner } from "@/components/features/DashboardRemoteAccessBanner";
 import { renderWithProviders } from "../../test-utils";
+import type { TlsStatusResponse } from "@wardnet/js";
 
-vi.mock("@wardnet/web", async (importOriginal) => {
-  const actual = await importOriginal<Record<string, unknown>>();
-  return { ...actual, useTlsStatus: vi.fn() };
-});
-
-const mockUseTlsStatus = vi.mocked(useTlsStatus);
-
-function setStatus(status: unknown) {
-  mockUseTlsStatus.mockReturnValue({
-    data: status,
-  } as unknown as ReturnType<typeof useTlsStatus>);
+function renderBanner(status: unknown) {
+  return renderWithProviders(
+    <DashboardRemoteAccessBanner
+      status={status as TlsStatusResponse | undefined}
+    />,
+  );
 }
 
 describe("DashboardRemoteAccessBanner", () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-  });
-
   it("renders nothing when status is undefined", () => {
-    setStatus(undefined);
-    const { container } = renderWithProviders(<DashboardRemoteAccessBanner />);
+    const { container } = renderBanner(undefined);
     expect(container).toBeEmptyDOMElement();
   });
 
   it("renders nothing while idle", () => {
-    setStatus({ phase: "idle" });
-    const { container } = renderWithProviders(<DashboardRemoteAccessBanner />);
+    const { container } = renderBanner({ phase: "idle" });
     expect(container).toBeEmptyDOMElement();
   });
 
   it("renders nothing once issued", () => {
-    setStatus({ phase: "issued", domain: "home.example.com" });
-    const { container } = renderWithProviders(<DashboardRemoteAccessBanner />);
+    const { container } = renderBanner({
+      phase: "issued",
+      domain: "home.example.com",
+    });
     expect(container).toBeEmptyDOMElement();
   });
 
   it("renders the progress banner while issuing", () => {
-    setStatus({ phase: "issuing", domain: "home.example.com" });
-    renderWithProviders(<DashboardRemoteAccessBanner />);
+    renderBanner({ phase: "issuing", domain: "home.example.com" });
     expect(screen.getByText("Issuing certificate…")).toBeInTheDocument();
   });
 
   it("renders the failure banner when failed", () => {
-    setStatus({ phase: "failed", error: "boom" });
-    renderWithProviders(<DashboardRemoteAccessBanner />);
+    renderBanner({ phase: "failed", error: "boom" });
     expect(screen.getByText("Certificate issuance failed")).toBeInTheDocument();
   });
 });

--- a/source/admin-site/tests/components/features/DeviceDnsCaptureCard.test.tsx
+++ b/source/admin-site/tests/components/features/DeviceDnsCaptureCard.test.tsx
@@ -3,25 +3,12 @@ import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { DeviceDnsCaptureCard } from "@/components/features/DeviceDnsCaptureCard";
 import { renderWithProviders } from "../../test-utils";
-
-vi.mock("@wardnet/web", async (importOriginal) => {
-  const actual = await importOriginal<Record<string, unknown>>();
-  return {
-    ...actual,
-    useDnsCaptureSettings: vi.fn(),
-    useUpdateDnsCaptureSettings: vi.fn(),
-  };
-});
-
-import {
-  useDnsCaptureSettings,
-  useUpdateDnsCaptureSettings,
-} from "@wardnet/web";
+import type { DnsCaptureSettingsResponse } from "@wardnet/js";
 
 const mutateAsync = vi.fn();
 const reset = vi.fn();
 
-const defaultData = {
+const defaultData: DnsCaptureSettingsResponse = {
   enabled: true,
   cap_count: 1000,
   cap_days: 7,
@@ -29,58 +16,69 @@ const defaultData = {
   size_bytes: 4096,
 };
 
-function setup({
-  data = defaultData,
+function cardProps({
+  settings = defaultData,
   isLoading = false,
   update = {},
 }: {
-  data?: Record<string, unknown> | undefined;
+  settings?: DnsCaptureSettingsResponse | undefined;
   isLoading?: boolean;
-  update?: Record<string, unknown>;
+  update?: Partial<{
+    isPending: boolean;
+    isError: boolean;
+    error: Error | null;
+  }>;
 } = {}) {
-  vi.mocked(useDnsCaptureSettings).mockReturnValue({
-    data,
+  return {
+    settings,
     isLoading,
-  } as unknown as ReturnType<typeof useDnsCaptureSettings>);
-  vi.mocked(useUpdateDnsCaptureSettings).mockReturnValue({
-    mutateAsync,
-    reset,
-    isPending: false,
-    isError: false,
-    error: null,
-    ...update,
-  } as unknown as ReturnType<typeof useUpdateDnsCaptureSettings>);
+    update: {
+      mutateAsync,
+      reset,
+      isPending: false,
+      isError: false,
+      error: null,
+      ...update,
+    },
+  };
 }
 
 beforeEach(() => {
   vi.clearAllMocks();
   mutateAsync.mockResolvedValue(undefined);
-  setup();
 });
 
 describe("DeviceDnsCaptureCard", () => {
   it("shows the loading placeholder", () => {
-    setup({ data: undefined, isLoading: true });
-    renderWithProviders(<DeviceDnsCaptureCard deviceId="dev-1" />);
+    renderWithProviders(
+      <DeviceDnsCaptureCard
+        {...cardProps({ settings: undefined, isLoading: true })}
+      />,
+    );
     expect(screen.getByText("Loading…")).toBeInTheDocument();
   });
 
   it("renders the read-only summary (near-full storage bar branch)", () => {
-    renderWithProviders(<DeviceDnsCaptureCard deviceId="dev-1" />);
+    renderWithProviders(<DeviceDnsCaptureCard {...cardProps()} />);
     expect(screen.getByText("Enabled")).toBeInTheDocument();
     expect(screen.getByText(/1,000 records · 7 days/)).toBeInTheDocument();
     expect(screen.getByText(/950 records/)).toBeInTheDocument();
   });
 
   it("shows Disabled when capture is off", () => {
-    setup({ data: { ...defaultData, enabled: false, row_count: 10 } });
-    renderWithProviders(<DeviceDnsCaptureCard deviceId="dev-1" />);
+    renderWithProviders(
+      <DeviceDnsCaptureCard
+        {...cardProps({
+          settings: { ...defaultData, enabled: false, row_count: 10 },
+        })}
+      />,
+    );
     expect(screen.getByText("Disabled")).toBeInTheDocument();
   });
 
   it("enters edit mode, edits fields, and saves", async () => {
     const user = userEvent.setup();
-    renderWithProviders(<DeviceDnsCaptureCard deviceId="dev-1" />);
+    renderWithProviders(<DeviceDnsCaptureCard {...cardProps()} />);
     await user.click(screen.getByRole("button", { name: "Edit" }));
 
     const numbers = screen.getAllByRole("spinbutton");
@@ -100,7 +98,7 @@ describe("DeviceDnsCaptureCard", () => {
 
   it("cancels editing", async () => {
     const user = userEvent.setup();
-    renderWithProviders(<DeviceDnsCaptureCard deviceId="dev-1" />);
+    renderWithProviders(<DeviceDnsCaptureCard {...cardProps()} />);
     await user.click(screen.getByRole("button", { name: "Edit" }));
     await user.click(screen.getByRole("button", { name: "Cancel" }));
     expect(screen.getByRole("button", { name: "Edit" })).toBeInTheDocument();
@@ -109,13 +107,17 @@ describe("DeviceDnsCaptureCard", () => {
 
   it("shows a saving label and error alert while updating", async () => {
     const user = userEvent.setup();
-    renderWithProviders(<DeviceDnsCaptureCard deviceId="dev-1" />);
+    const { rerender } = renderWithProviders(
+      <DeviceDnsCaptureCard {...cardProps()} />,
+    );
     await user.click(screen.getByRole("button", { name: "Edit" }));
-    setup({
-      update: { isPending: true, isError: true, error: new Error("x") },
-    });
-    // re-render by toggling the enable switch which triggers state update
-    await user.click(screen.getByRole("switch"));
+    rerender(
+      <DeviceDnsCaptureCard
+        {...cardProps({
+          update: { isPending: true, isError: true, error: new Error("x") },
+        })}
+      />,
+    );
     expect(screen.getByRole("button", { name: "Saving…" })).toBeInTheDocument();
     expect(screen.getByRole("alert")).toBeInTheDocument();
   });

--- a/source/admin-site/tests/components/features/DeviceDnsFilterCard.test.tsx
+++ b/source/admin-site/tests/components/features/DeviceDnsFilterCard.test.tsx
@@ -3,25 +3,11 @@ import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { DeviceDnsFilterCard } from "@/components/features/DeviceDnsFilterCard";
 import { makeDevice, renderWithProviders } from "../../test-utils";
-import type { DnsFilterProfile } from "@wardnet/js";
-
-vi.mock("@wardnet/web", async (importOriginal) => {
-  const actual = await importOriginal<Record<string, unknown>>();
-  return {
-    ...actual,
-    useDeviceFilterSettings: vi.fn(),
-    useDnsFilterProfiles: vi.fn(),
-    useDnsFilterConfig: vi.fn(),
-    useUpdateDeviceFilterSettings: vi.fn(),
-  };
-});
-
-import {
-  useDeviceFilterSettings,
-  useDnsFilterConfig,
-  useDnsFilterProfiles,
-  useUpdateDeviceFilterSettings,
-} from "@wardnet/web";
+import type {
+  DeviceDnsFilterSettings,
+  DnsFilterConfig,
+  DnsFilterProfile,
+} from "@wardnet/js";
 
 const mutateAsync = vi.fn();
 const reset = vi.fn();
@@ -39,7 +25,7 @@ function profile(id: string, name: string): DnsFilterProfile {
 
 const profiles = [profile("p1", "Ads"), profile("p2", "Malware")];
 
-function setup({
+function cardProps({
   settings = { enabled: true, profile_ids: [] as string[] },
   defaultIds = [] as string[],
   loading = false,
@@ -48,70 +34,89 @@ function setup({
   settings?: { enabled: boolean; profile_ids: string[] } | undefined;
   defaultIds?: string[];
   loading?: boolean;
-  update?: Record<string, unknown>;
+  update?: Partial<{
+    isPending: boolean;
+    isError: boolean;
+    error: Error | null;
+  }>;
 } = {}) {
-  vi.mocked(useDeviceFilterSettings).mockReturnValue({
-    data: settings ? { settings } : undefined,
+  return {
+    device: makeDevice(),
+    settings: settings as DeviceDnsFilterSettings | undefined,
+    profiles,
+    config: {
+      enabled: true,
+      default_profile_ids: defaultIds,
+    } as DnsFilterConfig,
     isLoading: loading,
-  } as unknown as ReturnType<typeof useDeviceFilterSettings>);
-  vi.mocked(useDnsFilterProfiles).mockReturnValue({
-    data: { profiles },
-    isLoading: loading,
-  } as unknown as ReturnType<typeof useDnsFilterProfiles>);
-  vi.mocked(useDnsFilterConfig).mockReturnValue({
-    data: { config: { enabled: true, default_profile_ids: defaultIds } },
-    isLoading: loading,
-  } as unknown as ReturnType<typeof useDnsFilterConfig>);
-  vi.mocked(useUpdateDeviceFilterSettings).mockReturnValue({
-    mutateAsync,
-    reset,
-    isPending: false,
-    isError: false,
-    error: null,
-    ...update,
-  } as unknown as ReturnType<typeof useUpdateDeviceFilterSettings>);
+    update: {
+      mutateAsync,
+      reset,
+      isPending: false,
+      isError: false,
+      error: null,
+      ...update,
+    },
+  };
 }
 
 beforeEach(() => {
   vi.clearAllMocks();
   mutateAsync.mockResolvedValue(undefined);
-  setup();
 });
 
 describe("DeviceDnsFilterCard read view", () => {
   it("shows a loading placeholder until every query settles", () => {
-    setup({ settings: undefined, loading: true });
-    renderWithProviders(<DeviceDnsFilterCard device={makeDevice()} />);
+    renderWithProviders(
+      <DeviceDnsFilterCard
+        {...cardProps({ settings: undefined, loading: true })}
+      />,
+    );
     expect(screen.getByText("Loading…")).toBeInTheDocument();
   });
 
   it("lists assigned profiles by name", () => {
-    setup({ settings: { enabled: true, profile_ids: ["p1"] } });
-    renderWithProviders(<DeviceDnsFilterCard device={makeDevice()} />);
+    renderWithProviders(
+      <DeviceDnsFilterCard
+        {...cardProps({ settings: { enabled: true, profile_ids: ["p1"] } })}
+      />,
+    );
     expect(screen.getByText("Filtering on")).toBeInTheDocument();
     expect(screen.getByText("Ads")).toBeInTheDocument();
   });
 
   it("shows the default profile hint when none are assigned", () => {
-    setup({
-      settings: { enabled: true, profile_ids: [] },
-      defaultIds: ["p2"],
-    });
-    renderWithProviders(<DeviceDnsFilterCard device={makeDevice()} />);
+    renderWithProviders(
+      <DeviceDnsFilterCard
+        {...cardProps({
+          settings: { enabled: true, profile_ids: [] },
+          defaultIds: ["p2"],
+        })}
+      />,
+    );
     expect(screen.getByText("Malware (default)")).toBeInTheDocument();
   });
 
   it("shows the no-default message", () => {
-    setup({ settings: { enabled: true, profile_ids: [] }, defaultIds: [] });
-    renderWithProviders(<DeviceDnsFilterCard device={makeDevice()} />);
+    renderWithProviders(
+      <DeviceDnsFilterCard
+        {...cardProps({
+          settings: { enabled: true, profile_ids: [] },
+          defaultIds: [],
+        })}
+      />,
+    );
     expect(
       screen.getByText("None (no default profile set)"),
     ).toBeInTheDocument();
   });
 
   it("shows a dash when filtering is off", () => {
-    setup({ settings: { enabled: false, profile_ids: [] } });
-    renderWithProviders(<DeviceDnsFilterCard device={makeDevice()} />);
+    renderWithProviders(
+      <DeviceDnsFilterCard
+        {...cardProps({ settings: { enabled: false, profile_ids: [] } })}
+      />,
+    );
     expect(screen.getByText("Filtering off")).toBeInTheDocument();
   });
 });
@@ -119,8 +124,11 @@ describe("DeviceDnsFilterCard read view", () => {
 describe("DeviceDnsFilterCard editing", () => {
   it("saves updated settings", async () => {
     const user = userEvent.setup();
-    setup({ settings: { enabled: true, profile_ids: ["p1"] } });
-    renderWithProviders(<DeviceDnsFilterCard device={makeDevice()} />);
+    renderWithProviders(
+      <DeviceDnsFilterCard
+        {...cardProps({ settings: { enabled: true, profile_ids: ["p1"] } })}
+      />,
+    );
     await user.click(screen.getByRole("button", { name: "Edit" }));
     // hasExplicit hint (profile already selected)
     expect(
@@ -136,8 +144,14 @@ describe("DeviceDnsFilterCard editing", () => {
 
   it("shows the global-default hint when nothing is selected", async () => {
     const user = userEvent.setup();
-    setup({ settings: { enabled: true, profile_ids: [] }, defaultIds: ["p1"] });
-    renderWithProviders(<DeviceDnsFilterCard device={makeDevice()} />);
+    renderWithProviders(
+      <DeviceDnsFilterCard
+        {...cardProps({
+          settings: { enabled: true, profile_ids: [] },
+          defaultIds: ["p1"],
+        })}
+      />,
+    );
     await user.click(screen.getByRole("button", { name: "Edit" }));
     expect(
       screen.getByText(/follows the global default profile/),
@@ -146,8 +160,14 @@ describe("DeviceDnsFilterCard editing", () => {
 
   it("shows the unfiltered hint when no default and nothing selected", async () => {
     const user = userEvent.setup();
-    setup({ settings: { enabled: true, profile_ids: [] }, defaultIds: [] });
-    renderWithProviders(<DeviceDnsFilterCard device={makeDevice()} />);
+    renderWithProviders(
+      <DeviceDnsFilterCard
+        {...cardProps({
+          settings: { enabled: true, profile_ids: [] },
+          defaultIds: [],
+        })}
+      />,
+    );
     await user.click(screen.getByRole("button", { name: "Edit" }));
     expect(
       screen.getByText(/this device's traffic\s+isn't filtered/),
@@ -156,8 +176,14 @@ describe("DeviceDnsFilterCard editing", () => {
 
   it("shows the filtering-off hint after disabling the toggle", async () => {
     const user = userEvent.setup();
-    setup({ settings: { enabled: true, profile_ids: [] }, defaultIds: [] });
-    renderWithProviders(<DeviceDnsFilterCard device={makeDevice()} />);
+    renderWithProviders(
+      <DeviceDnsFilterCard
+        {...cardProps({
+          settings: { enabled: true, profile_ids: [] },
+          defaultIds: [],
+        })}
+      />,
+    );
     await user.click(screen.getByRole("button", { name: "Edit" }));
     await user.click(screen.getByRole("switch", { name: /DNS filtering/i }));
     expect(screen.getByText(/skip every profile/)).toBeInTheDocument();
@@ -165,7 +191,7 @@ describe("DeviceDnsFilterCard editing", () => {
 
   it("cancels editing", async () => {
     const user = userEvent.setup();
-    renderWithProviders(<DeviceDnsFilterCard device={makeDevice()} />);
+    renderWithProviders(<DeviceDnsFilterCard {...cardProps()} />);
     await user.click(screen.getByRole("button", { name: "Edit" }));
     await user.click(screen.getByRole("button", { name: "Cancel" }));
     expect(screen.getByRole("button", { name: "Edit" })).toBeInTheDocument();
@@ -174,12 +200,17 @@ describe("DeviceDnsFilterCard editing", () => {
 
   it("renders an error alert while pending", async () => {
     const user = userEvent.setup();
-    renderWithProviders(<DeviceDnsFilterCard device={makeDevice()} />);
+    const { rerender } = renderWithProviders(
+      <DeviceDnsFilterCard {...cardProps()} />,
+    );
     await user.click(screen.getByRole("button", { name: "Edit" }));
-    setup({
-      update: { isPending: true, isError: true, error: new Error("x") },
-    });
-    await user.click(screen.getByRole("switch", { name: /DNS filtering/i }));
+    rerender(
+      <DeviceDnsFilterCard
+        {...cardProps({
+          update: { isPending: true, isError: true, error: new Error("x") },
+        })}
+      />,
+    );
     expect(screen.getByRole("alert")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Saving…" })).toBeInTheDocument();
   });

--- a/source/admin-site/tests/components/features/DeviceDnsFilterCard.test.tsx
+++ b/source/admin-site/tests/components/features/DeviceDnsFilterCard.test.tsx
@@ -28,12 +28,10 @@ const profiles = [profile("p1", "Ads"), profile("p2", "Malware")];
 function cardProps({
   settings = { enabled: true, profile_ids: [] as string[] },
   defaultIds = [] as string[],
-  loading = false,
   update = {},
 }: {
   settings?: { enabled: boolean; profile_ids: string[] } | undefined;
   defaultIds?: string[];
-  loading?: boolean;
   update?: Partial<{
     isPending: boolean;
     isError: boolean;
@@ -48,7 +46,6 @@ function cardProps({
       enabled: true,
       default_profile_ids: defaultIds,
     } as DnsFilterConfig,
-    isLoading: loading,
     update: {
       mutateAsync,
       reset,
@@ -68,9 +65,7 @@ beforeEach(() => {
 describe("DeviceDnsFilterCard read view", () => {
   it("shows a loading placeholder until every query settles", () => {
     renderWithProviders(
-      <DeviceDnsFilterCard
-        {...cardProps({ settings: undefined, loading: true })}
-      />,
+      <DeviceDnsFilterCard {...cardProps()} settings={undefined} />,
     );
     expect(screen.getByText("Loading…")).toBeInTheDocument();
   });

--- a/source/admin-site/tests/components/features/DeviceNetworkCard.test.tsx
+++ b/source/admin-site/tests/components/features/DeviceNetworkCard.test.tsx
@@ -3,23 +3,7 @@ import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { DeviceNetworkCard } from "@/components/features/DeviceNetworkCard";
 import { makeDevice, renderWithProviders } from "../../test-utils";
-import type { DhcpReservation } from "@wardnet/js";
-
-vi.mock("@wardnet/web", async (importOriginal) => {
-  const actual = await importOriginal<Record<string, unknown>>();
-  return {
-    ...actual,
-    useDhcpReservations: vi.fn(),
-    useCreateReservation: vi.fn(),
-    useDeleteReservation: vi.fn(),
-  };
-});
-
-import {
-  useCreateReservation,
-  useDeleteReservation,
-  useDhcpReservations,
-} from "@wardnet/web";
+import type { Device, DhcpReservation } from "@wardnet/js";
 
 const createAsync = vi.fn();
 const deleteAsync = vi.fn();
@@ -39,41 +23,51 @@ function makeReservation(over: Partial<DhcpReservation> = {}): DhcpReservation {
   };
 }
 
-function setup({
-  reservations = [],
+function cardProps({
+  device = makeDevice(),
+  reservations = [] as DhcpReservation[],
   create = {},
   del = {},
 }: {
+  device?: Device;
   reservations?: DhcpReservation[];
-  create?: Record<string, unknown>;
-  del?: Record<string, unknown>;
+  create?: Partial<{
+    isPending: boolean;
+    isError: boolean;
+    error: Error | null;
+  }>;
+  del?: Partial<{ isPending: boolean; isError: boolean; error: Error | null }>;
 } = {}) {
-  vi.mocked(useDhcpReservations).mockReturnValue({
-    data: { reservations },
-  } as unknown as ReturnType<typeof useDhcpReservations>);
-  vi.mocked(useCreateReservation).mockReturnValue({
+  // Both create instances share the same spy, mirroring the sequence the card
+  // drives: first the edit's create, then (on failure) the silent restore.
+  const createHandle = {
     mutateAsync: createAsync,
     reset: createReset,
     isPending: false,
     isError: false,
     error: null,
     ...create,
-  } as unknown as ReturnType<typeof useCreateReservation>);
-  vi.mocked(useDeleteReservation).mockReturnValue({
-    mutateAsync: deleteAsync,
-    reset: deleteReset,
-    isPending: false,
-    isError: false,
-    error: null,
-    ...del,
-  } as unknown as ReturnType<typeof useDeleteReservation>);
+  };
+  return {
+    device,
+    reservations,
+    createReservation: createHandle,
+    restoreReservation: createHandle,
+    deleteReservation: {
+      mutateAsync: deleteAsync,
+      reset: deleteReset,
+      isPending: false,
+      isError: false,
+      error: null,
+      ...del,
+    },
+  };
 }
 
 beforeEach(() => {
   vi.clearAllMocks();
   createAsync.mockResolvedValue(undefined);
   deleteAsync.mockResolvedValue(undefined);
-  setup();
 });
 
 async function setLastOctet(
@@ -89,7 +83,9 @@ async function setLastOctet(
 describe("DeviceNetworkCard", () => {
   it("renders the read-only IP and lease status badge", () => {
     renderWithProviders(
-      <DeviceNetworkCard device={makeDevice({ dhcp_status: "lease" })} />,
+      <DeviceNetworkCard
+        {...cardProps({ device: makeDevice({ dhcp_status: "lease" }) })}
+      />,
     );
     expect(screen.getByText("10.232.1.10")).toBeInTheDocument();
     expect(screen.getByText("Lease")).toBeInTheDocument();
@@ -97,14 +93,18 @@ describe("DeviceNetworkCard", () => {
 
   it("shows the reservation badge", () => {
     renderWithProviders(
-      <DeviceNetworkCard device={makeDevice({ dhcp_status: "reservation" })} />,
+      <DeviceNetworkCard
+        {...cardProps({ device: makeDevice({ dhcp_status: "reservation" }) })}
+      />,
     );
     expect(screen.getByText("Reserved")).toBeInTheDocument();
   });
 
   it("shows the external badge", () => {
     renderWithProviders(
-      <DeviceNetworkCard device={makeDevice({ dhcp_status: "external" })} />,
+      <DeviceNetworkCard
+        {...cardProps({ device: makeDevice({ dhcp_status: "external" }) })}
+      />,
     );
     expect(screen.getByText("External")).toBeInTheDocument();
   });
@@ -113,7 +113,9 @@ describe("DeviceNetworkCard", () => {
     const user = userEvent.setup();
     renderWithProviders(
       <DeviceNetworkCard
-        device={makeDevice({ name: "TV", hostname: "tv-host" })}
+        {...cardProps({
+          device: makeDevice({ name: "TV", hostname: "tv-host" }),
+        })}
       />,
     );
     await user.click(screen.getByRole("button", { name: "Edit" }));
@@ -131,8 +133,13 @@ describe("DeviceNetworkCard", () => {
 
   it("closes without mutating when IP is unchanged for an existing reservation", async () => {
     const user = userEvent.setup();
-    setup({ reservations: [makeReservation({ ip_address: "10.232.1.10" })] });
-    renderWithProviders(<DeviceNetworkCard device={makeDevice()} />);
+    renderWithProviders(
+      <DeviceNetworkCard
+        {...cardProps({
+          reservations: [makeReservation({ ip_address: "10.232.1.10" })],
+        })}
+      />,
+    );
 
     await user.click(screen.getByRole("button", { name: "Edit" }));
     await user.click(screen.getByRole("button", { name: "Save" }));
@@ -146,8 +153,13 @@ describe("DeviceNetworkCard", () => {
 
   it("deletes then creates when the IP changes for an existing reservation", async () => {
     const user = userEvent.setup();
-    setup({ reservations: [makeReservation({ ip_address: "10.232.1.10" })] });
-    renderWithProviders(<DeviceNetworkCard device={makeDevice()} />);
+    renderWithProviders(
+      <DeviceNetworkCard
+        {...cardProps({
+          reservations: [makeReservation({ ip_address: "10.232.1.10" })],
+        })}
+      />,
+    );
 
     await user.click(screen.getByRole("button", { name: "Edit" }));
     await setLastOctet(user, "20");
@@ -161,12 +173,17 @@ describe("DeviceNetworkCard", () => {
 
   it("restores the original reservation when the replacement create fails", async () => {
     const user = userEvent.setup();
-    setup({ reservations: [makeReservation({ ip_address: "10.232.1.10" })] });
     // First create (the new IP) is rejected; the rollback recreate succeeds.
     createAsync
       .mockRejectedValueOnce(new Error("409"))
       .mockResolvedValueOnce(undefined);
-    renderWithProviders(<DeviceNetworkCard device={makeDevice()} />);
+    renderWithProviders(
+      <DeviceNetworkCard
+        {...cardProps({
+          reservations: [makeReservation({ ip_address: "10.232.1.10" })],
+        })}
+      />,
+    );
 
     await user.click(screen.getByRole("button", { name: "Edit" }));
     await setLastOctet(user, "20");
@@ -193,10 +210,15 @@ describe("DeviceNetworkCard", () => {
 
   it("warns that the reservation is lost when the rollback recreate also fails", async () => {
     const user = userEvent.setup();
-    setup({ reservations: [makeReservation({ ip_address: "10.232.1.10" })] });
     // Both the new-IP create and the rollback recreate fail.
     createAsync.mockRejectedValue(new Error("409"));
-    renderWithProviders(<DeviceNetworkCard device={makeDevice()} />);
+    renderWithProviders(
+      <DeviceNetworkCard
+        {...cardProps({
+          reservations: [makeReservation({ ip_address: "10.232.1.10" })],
+        })}
+      />,
+    );
 
     await user.click(screen.getByRole("button", { name: "Edit" }));
     await setLastOctet(user, "20");
@@ -213,8 +235,11 @@ describe("DeviceNetworkCard", () => {
 
   it("removes an existing reservation", async () => {
     const user = userEvent.setup();
-    setup({ reservations: [makeReservation()] });
-    renderWithProviders(<DeviceNetworkCard device={makeDevice()} />);
+    renderWithProviders(
+      <DeviceNetworkCard
+        {...cardProps({ reservations: [makeReservation()] })}
+      />,
+    );
 
     await user.click(screen.getByRole("button", { name: "Edit" }));
     await user.click(
@@ -226,7 +251,7 @@ describe("DeviceNetworkCard", () => {
 
   it("cancels edit mode", async () => {
     const user = userEvent.setup();
-    renderWithProviders(<DeviceNetworkCard device={makeDevice()} />);
+    renderWithProviders(<DeviceNetworkCard {...cardProps()} />);
     await user.click(screen.getByRole("button", { name: "Edit" }));
     await user.click(screen.getByRole("button", { name: "Cancel" }));
     expect(screen.getByRole("button", { name: "Edit" })).toBeInTheDocument();
@@ -235,10 +260,13 @@ describe("DeviceNetworkCard", () => {
 
   it("shows a busy label and error alert", async () => {
     const user = userEvent.setup();
-    setup({
-      create: { isPending: true, isError: true, error: new Error("x") },
-    });
-    renderWithProviders(<DeviceNetworkCard device={makeDevice()} />);
+    renderWithProviders(
+      <DeviceNetworkCard
+        {...cardProps({
+          create: { isPending: true, isError: true, error: new Error("x") },
+        })}
+      />,
+    );
     await user.click(screen.getByRole("button", { name: "Edit" }));
     expect(screen.getByRole("button", { name: "Saving…" })).toBeInTheDocument();
     expect(screen.getByRole("alert")).toBeInTheDocument();

--- a/source/admin-site/tests/components/features/DeviceRoutingProfilesCard.test.tsx
+++ b/source/admin-site/tests/components/features/DeviceRoutingProfilesCard.test.tsx
@@ -15,53 +15,41 @@ vi.stubGlobal(
   },
 );
 
-const {
-  useRoutingProfiles,
-  useDeviceRoutingProfiles,
-  useSetDeviceRoutingProfiles,
-} = vi.hoisted(() => ({
-  useRoutingProfiles: vi.fn(),
-  useDeviceRoutingProfiles: vi.fn(),
-  useSetDeviceRoutingProfiles: vi.fn(),
-}));
-
-vi.mock("@wardnet/web", async (importOriginal) => {
-  const actual = await importOriginal<Record<string, unknown>>();
-  return {
-    ...actual,
-    useRoutingProfiles,
-    useDeviceRoutingProfiles,
-    useSetDeviceRoutingProfiles,
-  };
-});
-
 import { DeviceRoutingProfilesCard } from "@/components/features/DeviceRoutingProfilesCard";
 import { renderWithProviders, makeDevice } from "../../test-utils";
+import type { RoutingProfile } from "@wardnet/js";
 
 const profiles = [
   { id: "p1", name: "Streaming" },
   { id: "p2", name: "Work" },
   { id: "p3", name: "Kids" },
-];
+] as RoutingProfile[];
 
-const saveMutateAsync = vi.fn().mockResolvedValue({ message: "ok" });
+const saveMutateAsync = vi.fn();
+const saveReset = vi.fn();
 
 function setup(assigned: string[] = ["p1", "p2"]) {
-  useRoutingProfiles.mockReturnValue({ data: { profiles } });
-  useDeviceRoutingProfiles.mockReturnValue({ data: { profile_ids: assigned } });
-  useSetDeviceRoutingProfiles.mockReturnValue({
-    mutate: vi.fn(),
-    mutateAsync: saveMutateAsync,
-    reset: vi.fn(),
-    isPending: false,
-    isError: false,
-    error: null,
-  });
-  renderWithProviders(<DeviceRoutingProfilesCard device={makeDevice()} />);
+  renderWithProviders(
+    <DeviceRoutingProfilesCard
+      device={makeDevice()}
+      allProfiles={profiles}
+      assignedIds={assigned}
+      save={{
+        mutateAsync: saveMutateAsync,
+        reset: saveReset,
+        isPending: false,
+        isError: false,
+        error: null,
+      }}
+    />,
+  );
 }
 
 describe("DeviceRoutingProfilesCard", () => {
-  beforeEach(() => vi.clearAllMocks());
+  beforeEach(() => {
+    vi.clearAllMocks();
+    saveMutateAsync.mockResolvedValue({ message: "ok" });
+  });
 
   it("shows the assigned profiles in priority order", () => {
     setup();

--- a/source/admin-site/tests/components/features/DeviceSettingsCard.test.tsx
+++ b/source/admin-site/tests/components/features/DeviceSettingsCard.test.tsx
@@ -3,7 +3,7 @@ import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { DeviceSettingsCard } from "@/components/features/DeviceSettingsCard";
 import { makeDevice, renderWithProviders } from "../../test-utils";
-import type { RoutingTarget, Tunnel } from "@wardnet/js";
+import type { Device, RoutingTarget, Tunnel } from "@wardnet/js";
 
 // Radix primitives (Select) measure their trigger in a layout effect; jsdom has
 // no ResizeObserver / pointer-capture, so stub them as elsewhere in the suite.
@@ -19,13 +19,6 @@ vi.stubGlobal(
     disconnect() {}
   },
 );
-
-vi.mock("@wardnet/web", async (importOriginal) => {
-  const actual = await importOriginal<Record<string, unknown>>();
-  return { ...actual, useTunnels: vi.fn(), useUpdateDevice: vi.fn() };
-});
-
-import { useTunnels, useUpdateDevice } from "@wardnet/web";
 
 const mutateAsync = vi.fn();
 const reset = vi.fn();
@@ -51,37 +44,44 @@ function makeTunnel(over: Partial<Tunnel> = {}): Tunnel {
   } as Tunnel;
 }
 
-function setup({
+function cardProps({
+  device = makeDevice({ name: "TV" }),
+  currentRule = null as RoutingTarget | null,
   tunnels = [] as Tunnel[],
   update = {},
-}: { tunnels?: Tunnel[]; update?: Record<string, unknown> } = {}) {
-  vi.mocked(useTunnels).mockReturnValue({
-    data: { tunnels },
-  } as unknown as ReturnType<typeof useTunnels>);
-  vi.mocked(useUpdateDevice).mockReturnValue({
-    mutateAsync,
-    reset,
-    isPending: false,
-    isError: false,
-    error: null,
-    ...update,
-  } as unknown as ReturnType<typeof useUpdateDevice>);
+}: {
+  device?: Device;
+  currentRule?: RoutingTarget | null;
+  tunnels?: Tunnel[];
+  update?: Partial<{
+    isPending: boolean;
+    isError: boolean;
+    error: Error | null;
+  }>;
+} = {}) {
+  return {
+    device,
+    currentRule,
+    tunnels,
+    updateDevice: {
+      mutateAsync,
+      reset,
+      isPending: false,
+      isError: false,
+      error: null,
+      ...update,
+    },
+  };
 }
 
 beforeEach(() => {
   vi.clearAllMocks();
   mutateAsync.mockResolvedValue(undefined);
-  setup();
 });
 
 describe("DeviceSettingsCard routing label", () => {
   it("shows Direct when there is no rule", () => {
-    renderWithProviders(
-      <DeviceSettingsCard
-        device={makeDevice({ name: "TV" })}
-        currentRule={null}
-      />,
-    );
+    renderWithProviders(<DeviceSettingsCard {...cardProps()} />);
     expect(
       screen.getByTestId("device-settings-routing-value"),
     ).toHaveTextContent("Direct (no VPN)");
@@ -90,8 +90,7 @@ describe("DeviceSettingsCard routing label", () => {
   it("shows Direct for an explicit direct rule", () => {
     renderWithProviders(
       <DeviceSettingsCard
-        device={makeDevice({ name: "TV" })}
-        currentRule={{ type: "direct" } as RoutingTarget}
+        {...cardProps({ currentRule: { type: "direct" } as RoutingTarget })}
       />,
     );
     expect(
@@ -100,11 +99,12 @@ describe("DeviceSettingsCard routing label", () => {
   });
 
   it("shows the tunnel label for a matched tunnel", () => {
-    setup({ tunnels: [makeTunnel({ id: "tun-1", label: "US West" })] });
     renderWithProviders(
       <DeviceSettingsCard
-        device={makeDevice({ name: "TV" })}
-        currentRule={{ type: "tunnel", tunnel_id: "tun-1" }}
+        {...cardProps({
+          tunnels: [makeTunnel({ id: "tun-1", label: "US West" })],
+          currentRule: { type: "tunnel", tunnel_id: "tun-1" },
+        })}
       />,
     );
     expect(
@@ -115,8 +115,9 @@ describe("DeviceSettingsCard routing label", () => {
   it("falls back to 'Via tunnel' when the tunnel is unknown", () => {
     renderWithProviders(
       <DeviceSettingsCard
-        device={makeDevice({ name: "TV" })}
-        currentRule={{ type: "tunnel", tunnel_id: "missing" }}
+        {...cardProps({
+          currentRule: { type: "tunnel", tunnel_id: "missing" },
+        })}
       />,
     );
     expect(
@@ -129,8 +130,9 @@ describe("DeviceSettingsCard editing", () => {
   it("shows read-only fields for a managed device", () => {
     renderWithProviders(
       <DeviceSettingsCard
-        device={makeDevice({ name: "Laptop", admin_locked: true })}
-        currentRule={null}
+        {...cardProps({
+          device: makeDevice({ name: "Laptop", admin_locked: true }),
+        })}
       />,
     );
     expect(screen.getByText("Laptop")).toBeInTheDocument();
@@ -139,12 +141,7 @@ describe("DeviceSettingsCard editing", () => {
 
   it("saves edits for a managed device", async () => {
     const user = userEvent.setup();
-    renderWithProviders(
-      <DeviceSettingsCard
-        device={makeDevice({ name: "TV" })}
-        currentRule={null}
-      />,
-    );
+    renderWithProviders(<DeviceSettingsCard {...cardProps()} />);
     await user.click(screen.getByTestId("device-settings-edit"));
     const nameInput = screen.getByLabelText("Friendly name");
     await user.clear(nameInput);
@@ -167,8 +164,7 @@ describe("DeviceSettingsCard editing", () => {
     const user = userEvent.setup();
     renderWithProviders(
       <DeviceSettingsCard
-        device={makeDevice({ name: null })}
-        currentRule={null}
+        {...cardProps({ device: makeDevice({ name: null }) })}
       />,
     );
     await user.click(screen.getByTestId("device-settings-edit"));
@@ -187,8 +183,7 @@ describe("DeviceSettingsCard editing", () => {
     const user = userEvent.setup();
     renderWithProviders(
       <DeviceSettingsCard
-        device={makeDevice({ name: null })}
-        currentRule={null}
+        {...cardProps({ device: makeDevice({ name: null }) })}
       />,
     );
     await user.click(screen.getByTestId("device-settings-edit"));
@@ -208,8 +203,7 @@ describe("DeviceSettingsCard editing", () => {
     const user = userEvent.setup();
     renderWithProviders(
       <DeviceSettingsCard
-        device={makeDevice({ name: null })}
-        currentRule={null}
+        {...cardProps({ device: makeDevice({ name: null }) })}
       />,
     );
     await user.click(screen.getByTestId("device-settings-edit"));
@@ -226,29 +220,24 @@ describe("DeviceSettingsCard editing", () => {
 
   it("shows the saving label and error alert while pending", async () => {
     const user = userEvent.setup();
-    renderWithProviders(
-      <DeviceSettingsCard
-        device={makeDevice({ name: "TV" })}
-        currentRule={null}
-      />,
+    const { rerender } = renderWithProviders(
+      <DeviceSettingsCard {...cardProps()} />,
     );
     await user.click(screen.getByTestId("device-settings-edit"));
-    setup({
-      update: { isPending: true, isError: true, error: new Error("x") },
-    });
-    await user.type(screen.getByLabelText("Friendly name"), "x");
+    rerender(
+      <DeviceSettingsCard
+        {...cardProps({
+          update: { isPending: true, isError: true, error: new Error("x") },
+        })}
+      />,
+    );
     expect(screen.getByRole("button", { name: "Saving…" })).toBeInTheDocument();
     expect(screen.getByRole("alert")).toBeInTheDocument();
   });
 
   it("cancels editing", async () => {
     const user = userEvent.setup();
-    renderWithProviders(
-      <DeviceSettingsCard
-        device={makeDevice({ name: "TV" })}
-        currentRule={null}
-      />,
-    );
+    renderWithProviders(<DeviceSettingsCard {...cardProps()} />);
     await user.click(screen.getByTestId("device-settings-edit"));
     await user.click(screen.getByRole("button", { name: "Cancel" }));
     expect(screen.getByTestId("device-settings-edit")).toBeInTheDocument();

--- a/source/admin-site/tests/components/features/DeviceZoneCard.test.tsx
+++ b/source/admin-site/tests/components/features/DeviceZoneCard.test.tsx
@@ -3,14 +3,7 @@ import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { DeviceZoneCard } from "@/components/features/DeviceZoneCard";
 import { makeDevice, renderWithProviders } from "../../test-utils";
-import type { NetworkZoneView } from "@wardnet/js";
-
-vi.mock("@wardnet/web", async (importOriginal) => {
-  const actual = await importOriginal<Record<string, unknown>>();
-  return { ...actual, useNetworkZones: vi.fn(), useAssignDeviceZone: vi.fn() };
-});
-
-import { useNetworkZones, useAssignDeviceZone } from "@wardnet/web";
+import type { Device, NetworkZoneView } from "@wardnet/js";
 
 const mutateAsync = vi.fn();
 const reset = vi.fn();
@@ -39,28 +32,30 @@ const zones = [
   makeZone({ id: "zone-2", name: "Guest", is_default: false }),
 ];
 
-function setup() {
-  vi.mocked(useNetworkZones).mockReturnValue({
-    data: { zones },
-  } as unknown as ReturnType<typeof useNetworkZones>);
-  vi.mocked(useAssignDeviceZone).mockReturnValue({
-    mutateAsync,
-    reset,
-    isPending: false,
-  } as unknown as ReturnType<typeof useAssignDeviceZone>);
+function renderCard(device: Device) {
+  return renderWithProviders(
+    <DeviceZoneCard
+      device={device}
+      zones={zones}
+      assignZone={{
+        mutateAsync,
+        reset,
+        isPending: false,
+        isError: false,
+        error: null,
+      }}
+    />,
+  );
 }
 
 beforeEach(() => {
   vi.clearAllMocks();
   mutateAsync.mockResolvedValue(undefined);
-  setup();
 });
 
 describe("DeviceZoneCard", () => {
   it("shows the device's current zone with a Home pill and the disclaimer", () => {
-    renderWithProviders(
-      <DeviceZoneCard device={makeDevice({ zone_id: "zone-1" })} />,
-    );
+    renderCard(makeDevice({ zone_id: "zone-1" }));
     expect(screen.getByTestId("device-zone-value")).toHaveTextContent(
       "Trusted",
     );
@@ -69,28 +64,20 @@ describe("DeviceZoneCard", () => {
   });
 
   it("shows a dash when the device's zone is not in the list", () => {
-    renderWithProviders(
-      <DeviceZoneCard device={makeDevice({ zone_id: "gone" })} />,
-    );
+    renderCard(makeDevice({ zone_id: "gone" }));
     expect(screen.getByTestId("device-zone-value")).toHaveTextContent("-");
     expect(screen.queryByText("Home")).not.toBeInTheDocument();
   });
 
   it("omits the Home pill for a non-default zone", () => {
-    renderWithProviders(
-      <DeviceZoneCard device={makeDevice({ zone_id: "zone-2" })} />,
-    );
+    renderCard(makeDevice({ zone_id: "zone-2" }));
     expect(screen.getByTestId("device-zone-value")).toHaveTextContent("Guest");
     expect(screen.queryByText("Home")).not.toBeInTheDocument();
   });
 
   it("enters edit mode and saves the (unchanged) zone", async () => {
     const user = userEvent.setup();
-    renderWithProviders(
-      <DeviceZoneCard
-        device={makeDevice({ id: "dev-1", zone_id: "zone-1" })}
-      />,
-    );
+    renderCard(makeDevice({ id: "dev-1", zone_id: "zone-1" }));
     await user.click(screen.getByTestId("device-zone-edit"));
     expect(reset).toHaveBeenCalled();
     await user.click(screen.getByTestId("device-zone-save"));

--- a/source/admin-site/tests/components/features/DhcpLanInfoCard.test.tsx
+++ b/source/admin-site/tests/components/features/DhcpLanInfoCard.test.tsx
@@ -1,29 +1,11 @@
 import { screen } from "@testing-library/react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
-import { useDnsRecords } from "@wardnet/web";
+import { describe, expect, it } from "vitest";
 import { DhcpLanInfoCard } from "@/components/features/DhcpLanInfoCard";
 import { renderWithProviders } from "../../test-utils";
 
-vi.mock("@wardnet/web", async (importOriginal) => {
-  const actual = await importOriginal<Record<string, unknown>>();
-  return { ...actual, useDnsRecords: vi.fn() };
-});
-
-const mockUseDnsRecords = vi.mocked(useDnsRecords);
-
 describe("DhcpLanInfoCard", () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-  });
-
-  it("counts only DHCP-sourced records", () => {
-    mockUseDnsRecords.mockReturnValue({
-      data: {
-        records: [{ source: "dhcp" }, { source: "dhcp" }, { source: "manual" }],
-      },
-    } as unknown as ReturnType<typeof useDnsRecords>);
-
-    renderWithProviders(<DhcpLanInfoCard />);
+  it("renders the count of DHCP-sourced records", () => {
+    renderWithProviders(<DhcpLanInfoCard dhcpRecordCount={2} />);
 
     expect(screen.getByText("2 auto-registered")).toBeInTheDocument();
     expect(screen.getByText("DHCP .lan names")).toBeInTheDocument();
@@ -33,12 +15,8 @@ describe("DhcpLanInfoCard", () => {
     );
   });
 
-  it("renders zero when there is no data", () => {
-    mockUseDnsRecords.mockReturnValue({
-      data: undefined,
-    } as unknown as ReturnType<typeof useDnsRecords>);
-
-    renderWithProviders(<DhcpLanInfoCard />);
+  it("renders zero when there are no DHCP records", () => {
+    renderWithProviders(<DhcpLanInfoCard dhcpRecordCount={0} />);
 
     expect(screen.getByText("0 auto-registered")).toBeInTheDocument();
   });

--- a/source/admin-site/tests/components/features/DnsAnalyticsSection.test.tsx
+++ b/source/admin-site/tests/components/features/DnsAnalyticsSection.test.tsx
@@ -1,13 +1,9 @@
 import { screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import {
-  useDevices,
-  useDnsPeriodComparison,
-  useDnsPerDeviceStats,
-  useDnsTopTrackers,
-} from "@wardnet/web";
 import { DnsAnalyticsSection } from "@/components/features/DnsAnalyticsSection";
 import { renderWithProviders } from "../../test-utils";
+import type { DevicePoint, DnsPeriodComparison } from "@wardnet/web";
+import type { Device, StatsTopResponse } from "@wardnet/js";
 
 // recharts needs a real container size and ResizeObserver under jsdom.
 vi.stubGlobal(
@@ -32,53 +28,39 @@ Element.prototype.getBoundingClientRect = () =>
     toJSON() {},
   }) as DOMRect;
 
-vi.mock("@wardnet/web", async (importOriginal) => {
-  const actual = await importOriginal<Record<string, unknown>>();
-  return {
-    ...actual,
-    useDevices: vi.fn(),
-    useDnsPeriodComparison: vi.fn(),
-    useDnsPerDeviceStats: vi.fn(),
-    useDnsTopTrackers: vi.fn(),
-  };
-});
+const onSelectDevice = vi.fn();
 
-const mockDevices = vi.mocked(useDevices);
-const mockComparison = vi.mocked(useDnsPeriodComparison);
-const mockPerDevice = vi.mocked(useDnsPerDeviceStats);
-const mockTrackers = vi.mocked(useDnsTopTrackers);
-
-function setup(
+function renderSection(
   opts: {
+    range?: "1h" | "12h" | "24h" | "7d" | "12mo";
     devices?: { id: string; name?: string; device_type?: string }[];
     comparison?: unknown;
     trackers?: unknown;
     perDevice?: unknown;
+    perDeviceLoading?: boolean;
   } = {},
 ) {
-  mockDevices.mockReturnValue({
-    data: { devices: opts.devices ?? [] },
-  } as never);
-  mockComparison.mockReturnValue({
-    data: opts.comparison,
-    isLoading: false,
-    isError: false,
-    error: null,
-  } as never);
-  mockTrackers.mockReturnValue({ data: opts.trackers } as never);
-  mockPerDevice.mockReturnValue({
-    data: opts.perDevice,
-    isLoading: false,
-    isError: false,
-    error: null,
-  } as never);
+  const devices = (opts.devices ?? []) as Device[];
+  return renderWithProviders(
+    <DnsAnalyticsSection
+      range={opts.range ?? "24h"}
+      comparison={opts.comparison as DnsPeriodComparison | undefined}
+      trackers={opts.trackers as StatsTopResponse | undefined}
+      devices={devices}
+      selectedDeviceId={devices[0]?.id ?? ""}
+      onSelectDevice={onSelectDevice}
+      deviceSeries={opts.perDevice as DevicePoint[] | undefined}
+      deviceSeriesLoading={opts.perDeviceLoading ?? false}
+    />,
+  );
 }
 
 beforeEach(() => vi.clearAllMocks());
 
 describe("DnsAnalyticsSection", () => {
   it("renders period-over-period comparison with signed deltas", () => {
-    setup({
+    renderSection({
+      range: "7d",
       comparison: {
         current: { total: 100, blocked: 40, blockedPercent: 40 },
         previous: { total: 50, blocked: 10, blockedPercent: 20 },
@@ -86,7 +68,6 @@ describe("DnsAnalyticsSection", () => {
         blockedChangePercent: 300,
       },
     });
-    renderWithProviders(<DnsAnalyticsSection range="7d" />);
     // Period noun for 7d.
     expect(screen.getByText("Compared to previous week")).toBeInTheDocument();
     expect(screen.getByTestId("dns-comparison-queries")).toHaveTextContent(
@@ -101,7 +82,7 @@ describe("DnsAnalyticsSection", () => {
   });
 
   it("renders a null change as 'new' rather than a percentage", () => {
-    setup({
+    renderSection({
       comparison: {
         current: { total: 5000, blocked: 200, blockedPercent: 4 },
         previous: { total: 0, blocked: 0, blockedPercent: 0 },
@@ -110,7 +91,6 @@ describe("DnsAnalyticsSection", () => {
         previousPartial: false,
       },
     });
-    renderWithProviders(<DnsAnalyticsSection range="24h" />);
     expect(screen.getByTestId("dns-comparison-queries")).toHaveTextContent(
       "new",
     );
@@ -120,7 +100,7 @@ describe("DnsAnalyticsSection", () => {
   });
 
   it("lists top trackers by company", () => {
-    setup({
+    renderSection({
       trackers: {
         metric: "dns.blocked.by_tracker",
         entries: [
@@ -129,7 +109,6 @@ describe("DnsAnalyticsSection", () => {
         ],
       },
     });
-    renderWithProviders(<DnsAnalyticsSection range="24h" />);
     const card = screen.getByTestId("dns-top-trackers");
     expect(card).toHaveTextContent("Google");
     expect(card).toHaveTextContent("120 blocks");
@@ -137,16 +116,14 @@ describe("DnsAnalyticsSection", () => {
   });
 
   it("shows the tracker empty state when nothing recognised was blocked", () => {
-    setup({ trackers: { metric: "m", entries: [] } });
-    renderWithProviders(<DnsAnalyticsSection range="24h" />);
+    renderSection({ trackers: { metric: "m", entries: [] } });
     expect(
       screen.getByText("No recognised trackers blocked yet."),
     ).toBeInTheDocument();
   });
 
   it("shows the no-devices state for the per-device chart", () => {
-    setup({ devices: [] });
-    renderWithProviders(<DnsAnalyticsSection range="24h" />);
+    renderSection({ devices: [] });
     expect(screen.getByText("No devices yet.")).toBeInTheDocument();
     // With no devices there is no device selector.
     expect(
@@ -155,45 +132,38 @@ describe("DnsAnalyticsSection", () => {
   });
 
   it("renders the per-device selector and chart when a device has data", () => {
-    setup({
+    renderSection({
       devices: [{ id: "dev-1", name: "Laptop", device_type: "computer" }],
       perDevice: [
         { ts: "2026-01-01T00:00:00Z", total: 10 },
         { ts: "2026-01-01T01:00:00Z", total: 20 },
       ],
     });
-    renderWithProviders(<DnsAnalyticsSection range="24h" />);
     expect(screen.getByTestId("dns-per-device-select")).toBeInTheDocument();
     expect(screen.getByText("Per-device queries")).toBeInTheDocument();
   });
 
   it("shows a loading state while the per-device series loads", () => {
-    setup({
+    renderSection({
       devices: [{ id: "dev-1", name: "Laptop", device_type: "computer" }],
+      perDeviceLoading: true,
     });
-    mockPerDevice.mockReturnValue({
-      data: undefined,
-      isLoading: true,
-      isError: false,
-      error: null,
-    } as never);
-    renderWithProviders(<DnsAnalyticsSection range="24h" />);
     expect(screen.getByText("Loading…")).toBeInTheDocument();
   });
 
   it("shows an empty state when the selected device has no queries", () => {
-    setup({
+    renderSection({
       devices: [{ id: "dev-1", name: "Laptop", device_type: "computer" }],
       perDevice: [],
     });
-    renderWithProviders(<DnsAnalyticsSection range="24h" />);
     expect(
       screen.getByText("No queries recorded for this device yet."),
     ).toBeInTheDocument();
   });
 
   it("flags an approximate comparison when the previous period is partial", () => {
-    setup({
+    renderSection({
+      range: "12mo",
       comparison: {
         current: { total: 100, blocked: 10, blockedPercent: 10 },
         previous: { total: 40, blocked: 5, blockedPercent: 12.5 },
@@ -202,7 +172,6 @@ describe("DnsAnalyticsSection", () => {
         previousPartial: true,
       },
     });
-    renderWithProviders(<DnsAnalyticsSection range="12mo" />);
     // Partial-period note plus the 12mo period noun ("year").
     expect(screen.getByText(/predates stored history/)).toBeInTheDocument();
     expect(screen.getByText("Compared to previous year")).toBeInTheDocument();
@@ -214,7 +183,8 @@ describe("DnsAnalyticsSection", () => {
       ["12h", "Compared to previous 12 hours"],
     ] as const;
     for (const [range, text] of cases) {
-      setup({
+      const { unmount } = renderSection({
+        range,
         comparison: {
           current: { total: 1, blocked: 0, blockedPercent: 0 },
           previous: { total: 1, blocked: 0, blockedPercent: 0 },
@@ -223,9 +193,6 @@ describe("DnsAnalyticsSection", () => {
           previousPartial: false,
         },
       });
-      const { unmount } = renderWithProviders(
-        <DnsAnalyticsSection range={range} />,
-      );
       expect(screen.getByText(text)).toBeInTheDocument();
       unmount();
     }

--- a/source/admin-site/tests/components/features/DnsStatsSection.test.tsx
+++ b/source/admin-site/tests/components/features/DnsStatsSection.test.tsx
@@ -111,7 +111,7 @@ function Harness({
       isLoading={isLoading}
       isError={isError}
       error={error}
-      devices={undefined}
+      devices={[]}
     />
   );
 }

--- a/source/admin-site/tests/components/features/DnsStatsSection.test.tsx
+++ b/source/admin-site/tests/components/features/DnsStatsSection.test.tsx
@@ -1,8 +1,10 @@
 import { act, screen } from "@testing-library/react";
+import { useState } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { useDnsStatsDashboard } from "@wardnet/web";
 import { DnsStatsSection } from "@/components/features/DnsStatsSection";
+import type { ZoomRange } from "@/hooks/useChartZoom";
 import { renderWithProviders } from "../../test-utils";
+import type { DnsStatsDashboardData, StatsRange } from "@wardnet/web";
 
 // Drag-to-zoom is driven by useChartZoom, whose recharts mouse plumbing does
 // not compute an activeLabel under jsdom. Mock the hook so we can deterministically
@@ -11,28 +13,32 @@ import { renderWithProviders } from "../../test-utils";
 const zoomState = vi.hoisted(() => ({
   commit: null as null | ((z: { start: number; end: number } | null) => void),
 }));
-vi.mock("@/hooks/useChartZoom", () => ({
-  useChartZoom: ({
-    zoom,
-    onZoomChange,
-  }: {
-    zoom: unknown;
-    onZoomChange: (z: { start: number; end: number } | null) => void;
-  }) => {
-    zoomState.commit = onZoomChange;
-    return {
-      chartProps: {
-        onMouseDown() {},
-        onMouseMove() {},
-        onMouseUp() {},
-        onMouseLeave() {},
-      },
-      previewRange: null,
-      isZoomed: zoom != null,
-      reset: () => onZoomChange(null),
-    };
-  },
-}));
+vi.mock("@/hooks/useChartZoom", async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return {
+    ...actual,
+    useChartZoom: ({
+      zoom,
+      onZoomChange,
+    }: {
+      zoom: unknown;
+      onZoomChange: (z: { start: number; end: number } | null) => void;
+    }) => {
+      zoomState.commit = onZoomChange;
+      return {
+        chartProps: {
+          onMouseDown() {},
+          onMouseMove() {},
+          onMouseUp() {},
+          onMouseLeave() {},
+        },
+        previewRange: null,
+        isZoomed: zoom != null,
+        reset: () => onZoomChange(null),
+      };
+    },
+  };
+});
 
 vi.stubGlobal(
   "ResizeObserver",
@@ -57,25 +63,6 @@ Element.prototype.getBoundingClientRect = () =>
     toJSON() {},
   }) as DOMRect;
 
-vi.mock("@wardnet/web", async (importOriginal) => {
-  const actual = await importOriginal<Record<string, unknown>>();
-  return { ...actual, useDnsStatsDashboard: vi.fn() };
-});
-
-const mockDashboard = vi.mocked(useDnsStatsDashboard);
-
-function dashboardResult(
-  overrides: Partial<ReturnType<typeof useDnsStatsDashboard>> = {},
-) {
-  return {
-    data: undefined,
-    isLoading: false,
-    isError: false,
-    error: null,
-    ...overrides,
-  } as unknown as ReturnType<typeof useDnsStatsDashboard>;
-}
-
 const fullData = {
   series: [
     { ts: "2026-01-01T00:00:00Z", total: 100, blocked: 40 },
@@ -94,7 +81,40 @@ const fullData = {
   topClients: {
     entries: [{ labels: JSON.stringify({ client: "10.0.0.5" }), total: 120 }],
   },
-};
+} as unknown as DnsStatsDashboardData;
+
+interface HarnessProps {
+  range: StatsRange;
+  data?: DnsStatsDashboardData;
+  isLoading?: boolean;
+  isError?: boolean;
+  error?: unknown;
+}
+
+/** Stateful harness standing in for the page: owns the committed zoom the
+ *  way pages/Dns.tsx does, so zoom commits from the chart re-render the
+ *  section with the new window. */
+function Harness({
+  range,
+  data,
+  isLoading = false,
+  isError = false,
+  error = null,
+}: HarnessProps) {
+  const [zoom, setZoom] = useState<ZoomRange | null>(null);
+  return (
+    <DnsStatsSection
+      range={range}
+      zoom={zoom}
+      onZoomChange={setZoom}
+      data={data}
+      isLoading={isLoading}
+      isError={isError}
+      error={error}
+      devices={undefined}
+    />
+  );
+}
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -102,45 +122,33 @@ beforeEach(() => {
 
 describe("DnsStatsSection", () => {
   it("renders an error card with the error message", () => {
-    mockDashboard.mockReturnValue(
-      dashboardResult({ isError: true, error: new Error("stats down") }),
+    renderWithProviders(
+      <Harness range="24h" isError error={new Error("stats down")} />,
     );
-    renderWithProviders(<DnsStatsSection range="24h" />);
     expect(screen.getByText("stats down")).toBeInTheDocument();
   });
 
   it("renders a generic error card for a non-Error rejection", () => {
-    mockDashboard.mockReturnValue(
-      dashboardResult({ isError: true, error: "weird" as unknown as Error }),
-    );
-    renderWithProviders(<DnsStatsSection range="24h" />);
+    renderWithProviders(<Harness range="24h" isError error="weird" />);
     expect(screen.getByText("Failed to load DNS stats")).toBeInTheDocument();
   });
 
   it("shows the loading state in the chart area", () => {
-    mockDashboard.mockReturnValue(dashboardResult({ isLoading: true }));
-    renderWithProviders(<DnsStatsSection range="1h" />);
+    renderWithProviders(<Harness range="1h" isLoading />);
     expect(screen.getByText("Loading…")).toBeInTheDocument();
     // Stat cards fall back to em dashes with no data.
     expect(screen.getAllByText("-").length).toBeGreaterThanOrEqual(1);
   });
 
   it("shows an empty chart message when the series is empty", () => {
-    mockDashboard.mockReturnValue(
-      dashboardResult({
-        data: {
-          ...fullData,
-          series: [],
-        } as unknown as typeof fullData,
-      } as never),
+    renderWithProviders(
+      <Harness range="7d" data={{ ...fullData, series: [] }} />,
     );
-    renderWithProviders(<DnsStatsSection range="7d" />);
     expect(screen.getByText("No data yet.")).toBeInTheDocument();
   });
 
   it("renders stat cards, chart and top lists from full data", () => {
-    mockDashboard.mockReturnValue(dashboardResult({ data: fullData as never }));
-    renderWithProviders(<DnsStatsSection range="12h" />);
+    renderWithProviders(<Harness range="12h" data={fullData} />);
     expect(screen.getByText("Queries (12h)")).toBeInTheDocument();
     expect(screen.getByText("300")).toBeInTheDocument();
     expect(screen.getByText("33.3%")).toBeInTheDocument();
@@ -156,20 +164,17 @@ describe("DnsStatsSection", () => {
   });
 
   it("renders the chart with a multi-day x-axis (7d range)", () => {
-    mockDashboard.mockReturnValue(dashboardResult({ data: fullData as never }));
-    renderWithProviders(<DnsStatsSection range="7d" />);
+    renderWithProviders(<Harness range="7d" data={fullData} />);
     expect(screen.getByText("Queries over time")).toBeInTheDocument();
   });
 
   it("renders the chart with a monthly x-axis (12mo range)", () => {
-    mockDashboard.mockReturnValue(dashboardResult({ data: fullData as never }));
-    renderWithProviders(<DnsStatsSection range="12mo" />);
+    renderWithProviders(<Harness range="12mo" data={fullData} />);
     expect(screen.getByText("Queries over time")).toBeInTheDocument();
   });
 
   it("commits a zoom (relabelling cards) then resets it", () => {
-    mockDashboard.mockReturnValue(dashboardResult({ data: fullData as never }));
-    renderWithProviders(<DnsStatsSection range="24h" />);
+    renderWithProviders(<Harness range="24h" data={fullData} />);
     const t0 = new Date("2026-01-01T00:00:00Z").getTime();
     const t1 = new Date("2026-01-01T01:00:00Z").getTime();
     // Commit a 1-hour zoom window through the hook's onZoomChange.
@@ -184,16 +189,18 @@ describe("DnsStatsSection", () => {
   });
 
   it("renders top-list empty states when entries are missing", () => {
-    mockDashboard.mockReturnValue(
-      dashboardResult({
-        data: {
-          ...fullData,
-          topDomains: { entries: [] },
-          topClients: { entries: [] },
-        } as never,
-      }),
+    renderWithProviders(
+      <Harness
+        range="12mo"
+        data={
+          {
+            ...fullData,
+            topDomains: { entries: [] },
+            topClients: { entries: [] },
+          } as unknown as DnsStatsDashboardData
+        }
+      />,
     );
-    renderWithProviders(<DnsStatsSection range="12mo" />);
     // Both top lists show the empty message.
     expect(screen.getAllByText("No data yet.").length).toBeGreaterThanOrEqual(
       2,

--- a/source/admin-site/tests/components/features/DnsZonesCard.test.tsx
+++ b/source/admin-site/tests/components/features/DnsZonesCard.test.tsx
@@ -1,15 +1,9 @@
 import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import {
-  useDnsZones,
-  useDnsRecords,
-  useCreateDnsZone,
-  useUpdateDnsZone,
-  useDeleteDnsZone,
-} from "@wardnet/web";
 import { DnsZonesCard } from "@/components/features/DnsZonesCard";
 import { renderWithProviders } from "../../test-utils";
+import type { CustomDnsRecord, DnsZone } from "@wardnet/js";
 
 // Radix DropdownMenu / Toggle need these DOM APIs that jsdom lacks.
 Element.prototype.hasPointerCapture ??= () => false;
@@ -25,66 +19,53 @@ vi.stubGlobal(
   },
 );
 
-vi.mock("@wardnet/web", async (importOriginal) => {
-  const actual = await importOriginal<Record<string, unknown>>();
-  return {
-    ...actual,
-    useDnsZones: vi.fn(),
-    useDnsRecords: vi.fn(),
-    useCreateDnsZone: vi.fn(),
-    useUpdateDnsZone: vi.fn(),
-    useDeleteDnsZone: vi.fn(),
-  };
-});
+const onCreateZone = vi.fn();
+const onUpdateZone = vi.fn();
+const onDeleteZone = vi.fn();
 
-const createMutate = vi.fn();
-const updateMutate = vi.fn();
-const deleteMutate = vi.fn();
+const zones = [
+  { id: "z1", name: "home", enabled: true, source: "user" },
+  { id: "z2", name: "lan", enabled: false, source: "system" },
+] as DnsZone[];
 
-function mutation<T>(mutate: ReturnType<typeof vi.fn>, isPending = false): T {
-  return { mutate, mutateAsync: vi.fn(), isPending } as unknown as T;
+const records = [
+  { zone_id: "z1" },
+  { zone_id: "z1" },
+  { zone_id: null },
+] as CustomDnsRecord[];
+
+function renderCard() {
+  return renderWithProviders(
+    <DnsZonesCard
+      zones={zones}
+      records={records}
+      isSaving={false}
+      updatePending={false}
+      onCreateZone={onCreateZone}
+      onUpdateZone={onUpdateZone}
+      onDeleteZone={onDeleteZone}
+    />,
+  );
 }
 
 beforeEach(() => {
   vi.clearAllMocks();
-  vi.mocked(useDnsZones).mockReturnValue({
-    data: {
-      zones: [
-        { id: "z1", name: "home", enabled: true, source: "user" },
-        { id: "z2", name: "lan", enabled: false, source: "system" },
-      ],
-    },
-  } as unknown as ReturnType<typeof useDnsZones>);
-  vi.mocked(useDnsRecords).mockReturnValue({
-    data: {
-      records: [{ zone_id: "z1" }, { zone_id: "z1" }, { zone_id: null }],
-    },
-  } as unknown as ReturnType<typeof useDnsRecords>);
-  vi.mocked(useCreateDnsZone).mockReturnValue(
-    mutation<ReturnType<typeof useCreateDnsZone>>(createMutate),
-  );
-  vi.mocked(useUpdateDnsZone).mockReturnValue(
-    mutation<ReturnType<typeof useUpdateDnsZone>>(updateMutate),
-  );
-  vi.mocked(useDeleteDnsZone).mockReturnValue(
-    mutation<ReturnType<typeof useDeleteDnsZone>>(deleteMutate),
-  );
 });
 
 describe("DnsZonesCard", () => {
   it("renders zones with their derived record counts", () => {
-    renderWithProviders(<DnsZonesCard />);
+    renderCard();
     expect(screen.getByText("home")).toBeInTheDocument();
     expect(screen.getByText("lan")).toBeInTheDocument();
     // z1 has 2 records; z2 (lan) has 0.
     expect(screen.getByText("2")).toBeInTheDocument();
   });
 
-  it("toggling a zone's enabled switch calls updateZone.mutate", async () => {
+  it("toggling a zone's enabled switch calls the update callback", async () => {
     const user = userEvent.setup();
-    renderWithProviders(<DnsZonesCard />);
+    renderCard();
     await user.click(screen.getByLabelText("Toggle zone home"));
-    expect(updateMutate).toHaveBeenCalledWith({
+    expect(onUpdateZone).toHaveBeenCalledWith({
       id: "z1",
       body: { enabled: false },
     });
@@ -92,11 +73,11 @@ describe("DnsZonesCard", () => {
 
   it("creates a zone through the add form", async () => {
     const user = userEvent.setup();
-    renderWithProviders(<DnsZonesCard />);
+    renderCard();
     await user.click(screen.getByTestId("zone-add"));
     await user.type(screen.getByTestId("zone-name"), "office");
     await user.click(screen.getByTestId("zone-submit"));
-    expect(createMutate).toHaveBeenCalledWith(
+    expect(onCreateZone).toHaveBeenCalledWith(
       { name: "office", enabled: true },
       expect.objectContaining({ onSuccess: expect.any(Function) }),
     );
@@ -104,7 +85,7 @@ describe("DnsZonesCard", () => {
 
   it("warns when the zone name looks like a public domain", async () => {
     const user = userEvent.setup();
-    renderWithProviders(<DnsZonesCard />);
+    renderCard();
     await user.click(screen.getByTestId("zone-add"));
     await user.type(screen.getByTestId("zone-name"), "example.com");
     expect(screen.getByText(/looks like a public domain/i)).toBeInTheDocument();
@@ -112,7 +93,7 @@ describe("DnsZonesCard", () => {
 
   it("cancelling the form closes it", async () => {
     const user = userEvent.setup();
-    renderWithProviders(<DnsZonesCard />);
+    renderCard();
     await user.click(screen.getByTestId("zone-add"));
     expect(screen.getByTestId("zone-name")).toBeInTheDocument();
     await user.click(screen.getByRole("button", { name: "Cancel" }));
@@ -121,7 +102,7 @@ describe("DnsZonesCard", () => {
 
   it("edits an existing zone via the row menu", async () => {
     const user = userEvent.setup({ pointerEventsCheck: 0 });
-    renderWithProviders(<DnsZonesCard />);
+    renderCard();
     // The first row (home) is a non-system zone with edit + delete.
     const menus = screen.getAllByTestId("zone-row-menu");
     await user.click(menus[0]);
@@ -131,7 +112,7 @@ describe("DnsZonesCard", () => {
     await user.clear(input);
     await user.type(input, "casa");
     await user.click(screen.getByTestId("zone-submit"));
-    expect(updateMutate).toHaveBeenCalledWith(
+    expect(onUpdateZone).toHaveBeenCalledWith(
       { id: "z1", body: { name: "casa" } },
       expect.objectContaining({ onSuccess: expect.any(Function) }),
     );
@@ -139,17 +120,17 @@ describe("DnsZonesCard", () => {
 
   it("deletes a zone after confirming", async () => {
     const user = userEvent.setup({ pointerEventsCheck: 0 });
-    renderWithProviders(<DnsZonesCard />);
+    renderCard();
     const menus = screen.getAllByTestId("zone-row-menu");
     await user.click(menus[0]);
     await user.click(await screen.findByTestId("zone-delete"));
     await user.click(await screen.findByTestId("confirm-dialog-confirm"));
-    expect(deleteMutate).toHaveBeenCalledWith("z1");
+    expect(onDeleteZone).toHaveBeenCalledWith("z1");
   });
 
   it("hides the delete action for system zones", async () => {
     const user = userEvent.setup({ pointerEventsCheck: 0 });
-    renderWithProviders(<DnsZonesCard />);
+    renderCard();
     const menus = screen.getAllByTestId("zone-row-menu");
     // Second row is the system 'lan' zone — only Edit is offered.
     await user.click(menus[1]);

--- a/source/admin-site/tests/components/features/LocalRecordsCard.test.tsx
+++ b/source/admin-site/tests/components/features/LocalRecordsCard.test.tsx
@@ -1,15 +1,9 @@
 import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import {
-  useDnsRecords,
-  useDnsZones,
-  useCreateDnsRecord,
-  useUpdateDnsRecord,
-  useDeleteDnsRecord,
-} from "@wardnet/web";
 import { LocalRecordsCard } from "@/components/features/LocalRecordsCard";
 import { renderWithProviders } from "../../test-utils";
+import type { CustomDnsRecord, DnsZone } from "@wardnet/js";
 
 Element.prototype.hasPointerCapture ??= () => false;
 Element.prototype.setPointerCapture ??= () => {};
@@ -24,86 +18,67 @@ vi.stubGlobal(
   },
 );
 
-vi.mock("@wardnet/web", async (importOriginal) => {
-  const actual = await importOriginal<Record<string, unknown>>();
-  return {
-    ...actual,
-    useDnsRecords: vi.fn(),
-    useDnsZones: vi.fn(),
-    useCreateDnsRecord: vi.fn(),
-    useUpdateDnsRecord: vi.fn(),
-    useDeleteDnsRecord: vi.fn(),
-  };
-});
+const onCreateRecord = vi.fn();
+const onUpdateRecord = vi.fn();
+const onDeleteRecord = vi.fn();
 
-const createMutate = vi.fn();
-const updateMutate = vi.fn();
-const deleteMutate = vi.fn();
+const records = [
+  {
+    id: "rec1",
+    source: "manual",
+    domain: "printer.lan",
+    record_type: "A",
+    value: "192.168.1.50",
+    ttl: 300,
+    zone_id: "z1",
+    enabled: true,
+  },
+  // DHCP-sourced record is filtered out.
+  {
+    id: "rec2",
+    source: "dhcp",
+    domain: "tv.lan",
+    record_type: "A",
+    value: "192.168.1.60",
+    ttl: 300,
+    zone_id: null,
+    enabled: true,
+  },
+] as CustomDnsRecord[];
 
-function mutation<T>(mutate: ReturnType<typeof vi.fn>): T {
-  return {
-    mutate,
-    mutateAsync: vi.fn(),
-    isPending: false,
-  } as unknown as T;
+const zones = [{ id: "z1", name: "home" }] as DnsZone[];
+
+function renderCard() {
+  return renderWithProviders(
+    <LocalRecordsCard
+      records={records}
+      zones={zones}
+      isSaving={false}
+      updatePending={false}
+      onCreateRecord={onCreateRecord}
+      onUpdateRecord={onUpdateRecord}
+      onDeleteRecord={onDeleteRecord}
+    />,
+  );
 }
 
 beforeEach(() => {
   vi.clearAllMocks();
-  vi.mocked(useDnsRecords).mockReturnValue({
-    data: {
-      records: [
-        {
-          id: "rec1",
-          source: "manual",
-          domain: "printer.lan",
-          record_type: "A",
-          value: "192.168.1.50",
-          ttl: 300,
-          zone_id: "z1",
-          enabled: true,
-        },
-        // DHCP-sourced record is filtered out.
-        {
-          id: "rec2",
-          source: "dhcp",
-          domain: "tv.lan",
-          record_type: "A",
-          value: "192.168.1.60",
-          ttl: 300,
-          zone_id: null,
-          enabled: true,
-        },
-      ],
-    },
-  } as unknown as ReturnType<typeof useDnsRecords>);
-  vi.mocked(useDnsZones).mockReturnValue({
-    data: { zones: [{ id: "z1", name: "home" }] },
-  } as unknown as ReturnType<typeof useDnsZones>);
-  vi.mocked(useCreateDnsRecord).mockReturnValue(
-    mutation<ReturnType<typeof useCreateDnsRecord>>(createMutate),
-  );
-  vi.mocked(useUpdateDnsRecord).mockReturnValue(
-    mutation<ReturnType<typeof useUpdateDnsRecord>>(updateMutate),
-  );
-  vi.mocked(useDeleteDnsRecord).mockReturnValue(
-    mutation<ReturnType<typeof useDeleteDnsRecord>>(deleteMutate),
-  );
 });
 
 describe("LocalRecordsCard", () => {
   it("renders only manual records with their zone name", () => {
-    renderWithProviders(<LocalRecordsCard />);
+    renderCard();
     expect(screen.getByText("printer.lan")).toBeInTheDocument();
     expect(screen.queryByText("tv.lan")).not.toBeInTheDocument();
     expect(screen.getByText("home")).toBeInTheDocument();
   });
 
-  it("toggling a record calls updateRecord.mutate", async () => {
+  it("toggling a record calls the update callback", async () => {
     const user = userEvent.setup();
-    renderWithProviders(<LocalRecordsCard />);
+    renderCard();
     await user.click(screen.getByLabelText("Toggle printer.lan"));
-    expect(updateMutate).toHaveBeenCalledWith({
+    expect(onUpdateRecord).toHaveBeenCalledWith({
       id: "rec1",
       body: { enabled: false },
     });
@@ -111,12 +86,12 @@ describe("LocalRecordsCard", () => {
 
   it("creates a record through the add form", async () => {
     const user = userEvent.setup();
-    renderWithProviders(<LocalRecordsCard />);
+    renderCard();
     await user.click(screen.getByTestId("local-record-add"));
     await user.type(screen.getByTestId("local-record-domain"), "nas.lan");
     await user.type(screen.getByTestId("local-record-value"), "10.0.0.5");
     await user.click(screen.getByTestId("local-record-submit"));
-    expect(createMutate).toHaveBeenCalledWith(
+    expect(onCreateRecord).toHaveBeenCalledWith(
       {
         zone_id: null,
         domain: "nas.lan",
@@ -131,7 +106,7 @@ describe("LocalRecordsCard", () => {
 
   it("cancelling closes the form", async () => {
     const user = userEvent.setup();
-    renderWithProviders(<LocalRecordsCard />);
+    renderCard();
     await user.click(screen.getByTestId("local-record-add"));
     await user.click(screen.getByRole("button", { name: "Cancel" }));
     expect(screen.queryByTestId("local-record-domain")).not.toBeInTheDocument();
@@ -139,7 +114,7 @@ describe("LocalRecordsCard", () => {
 
   it("edits a record via the row menu, preserving its zone", async () => {
     const user = userEvent.setup({ pointerEventsCheck: 0 });
-    renderWithProviders(<LocalRecordsCard />);
+    renderCard();
     await user.click(screen.getByTestId("local-record-row-menu"));
     await user.click(await screen.findByTestId("local-record-edit"));
     const domain = screen.getByTestId(
@@ -149,7 +124,7 @@ describe("LocalRecordsCard", () => {
     await user.clear(domain);
     await user.type(domain, "printer2.lan");
     await user.click(screen.getByTestId("local-record-submit"));
-    expect(updateMutate).toHaveBeenCalledWith(
+    expect(onUpdateRecord).toHaveBeenCalledWith(
       {
         id: "rec1",
         body: {
@@ -166,10 +141,10 @@ describe("LocalRecordsCard", () => {
 
   it("deletes a record after confirming", async () => {
     const user = userEvent.setup({ pointerEventsCheck: 0 });
-    renderWithProviders(<LocalRecordsCard />);
+    renderCard();
     await user.click(screen.getByTestId("local-record-row-menu"));
     await user.click(await screen.findByTestId("local-record-delete"));
     await user.click(await screen.findByTestId("confirm-dialog-confirm"));
-    expect(deleteMutate).toHaveBeenCalledWith("rec1");
+    expect(onDeleteRecord).toHaveBeenCalledWith("rec1");
   });
 });

--- a/source/admin-site/tests/components/features/PrivateDnsCard.test.tsx
+++ b/source/admin-site/tests/components/features/PrivateDnsCard.test.tsx
@@ -1,16 +1,9 @@
 import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import {
-  useDevices,
-  usePrivateDnsStatus,
-  useSetPrivateDnsEnabled,
-  useGrantPrivateDnsDevice,
-  useRevokePrivateDnsDevice,
-  useSendPrivateDnsToDevice,
-} from "@wardnet/web";
 import { PrivateDnsCard } from "@/components/features/PrivateDnsCard";
 import { makeDevice, renderWithProviders } from "../../test-utils";
+import type { PrivateDnsStatusResponse } from "@wardnet/js";
 
 // The grant panel's DeviceSelect is a Radix Select, which measures its trigger
 // in a layout effect; jsdom has no ResizeObserver / pointer-capture, so stub
@@ -28,23 +21,10 @@ vi.stubGlobal(
   },
 );
 
-vi.mock("@wardnet/web", async (importOriginal) => {
-  const actual = await importOriginal<Record<string, unknown>>();
-  return {
-    ...actual,
-    useDevices: vi.fn(),
-    usePrivateDnsStatus: vi.fn(),
-    useSetPrivateDnsEnabled: vi.fn(),
-    useGrantPrivateDnsDevice: vi.fn(),
-    useRevokePrivateDnsDevice: vi.fn(),
-    useSendPrivateDnsToDevice: vi.fn(),
-  };
-});
-
-const setEnabledMutate = vi.fn();
+const onSetEnabled = vi.fn();
 const grantMutateAsync = vi.fn();
-const revokeMutate = vi.fn();
-const sendMutate = vi.fn();
+const onRevokeDevice = vi.fn();
+const onSendToDevice = vi.fn();
 
 type Prereqs = {
   wardnet_provider: boolean;
@@ -59,7 +39,7 @@ type Grant = {
   created_at: string;
 };
 
-function setup({
+function renderCard({
   enabled = false,
   prerequisites,
   grants = [] as Grant[],
@@ -70,27 +50,25 @@ function setup({
   grants?: Grant[];
   devices?: ReturnType<typeof makeDevice>[];
 }) {
-  vi.mocked(usePrivateDnsStatus).mockReturnValue({
-    data: { enabled, domain: "abc.my.wardnet.services", prerequisites, grants },
-    isLoading: false,
-  } as never);
-  vi.mocked(useDevices).mockReturnValue({ data: { devices } } as never);
-  vi.mocked(useSetPrivateDnsEnabled).mockReturnValue({
-    mutate: setEnabledMutate,
-    isPending: false,
-  } as never);
-  vi.mocked(useGrantPrivateDnsDevice).mockReturnValue({
-    mutateAsync: grantMutateAsync,
-    isPending: false,
-  } as never);
-  vi.mocked(useRevokePrivateDnsDevice).mockReturnValue({
-    mutate: revokeMutate,
-    isPending: false,
-  } as never);
-  vi.mocked(useSendPrivateDnsToDevice).mockReturnValue({
-    mutate: sendMutate,
-    isPending: false,
-  } as never);
+  const status = {
+    enabled,
+    domain: "abc.my.wardnet.services",
+    prerequisites,
+    grants,
+  } as unknown as PrivateDnsStatusResponse;
+  return renderWithProviders(
+    <PrivateDnsCard
+      status={status}
+      isLoading={false}
+      devices={devices}
+      onSetEnabled={onSetEnabled}
+      setEnabledPending={false}
+      grantDevice={{ mutateAsync: grantMutateAsync, isPending: false }}
+      onRevokeDevice={onRevokeDevice}
+      onSendToDevice={onSendToDevice}
+      sendPending={false}
+    />,
+  );
 }
 
 const ALL_MET: Prereqs = {
@@ -110,8 +88,7 @@ describe("PrivateDnsCard", () => {
   beforeEach(() => vi.clearAllMocks());
 
   it("renders the prerequisite checklist and disables the toggle when a hard gate is unmet", () => {
-    setup({ prerequisites: { ...ALL_MET, entitled: false } });
-    renderWithProviders(<PrivateDnsCard />);
+    renderCard({ prerequisites: { ...ALL_MET, entitled: false } });
 
     expect(screen.getByTestId("private-dns-prerequisites")).toBeInTheDocument();
     expect(screen.getByText(/Premium feature/)).toBeInTheDocument();
@@ -121,23 +98,21 @@ describe("PrivateDnsCard", () => {
   });
 
   it("allows enabling once every hard gate is met", async () => {
-    setup({ prerequisites: ALL_MET });
-    renderWithProviders(<PrivateDnsCard />);
+    renderCard({ prerequisites: ALL_MET });
 
     const toggle = screen.getByRole("switch", { name: "Enable Private DNS" });
     expect(toggle).toBeEnabled();
     await userEvent.click(toggle);
-    expect(setEnabledMutate).toHaveBeenCalledWith(true);
+    expect(onSetEnabled).toHaveBeenCalledWith(true);
   });
 
   it("lists granted devices with their hostname once enabled", () => {
-    setup({
+    renderCard({
       enabled: true,
       prerequisites: ALL_MET,
       devices: [makeDevice({ id: "d1", name: "Alice phone" })],
       grants: [GRANT],
     });
-    renderWithProviders(<PrivateDnsCard />);
 
     expect(screen.getByText("Alice phone")).toBeInTheDocument();
     expect(screen.getByText("tok.abc.my.wardnet.services")).toBeInTheDocument();
@@ -148,13 +123,12 @@ describe("PrivateDnsCard", () => {
   it("grants a device, then the granted modal wires send + dismiss", async () => {
     const user = userEvent.setup();
     grantMutateAsync.mockResolvedValue(GRANT);
-    setup({
+    renderCard({
       enabled: true,
       prerequisites: ALL_MET,
       devices: [makeDevice({ id: "d1", name: "Alice phone" })],
       grants: [],
     });
-    renderWithProviders(<PrivateDnsCard />);
 
     await user.click(screen.getByRole("button", { name: "Grant access" }));
     // Choose the device in the DeviceSelect combobox, then grant.
@@ -165,18 +139,17 @@ describe("PrivateDnsCard", () => {
     await waitFor(() => expect(grantMutateAsync).toHaveBeenCalledWith("d1"));
     // The granted modal opens; its actions route through the card.
     await user.click(await screen.findByTestId("private-dns-modal-send"));
-    expect(sendMutate).toHaveBeenCalledWith("d1");
+    expect(onSendToDevice).toHaveBeenCalledWith("d1");
     await user.click(screen.getByRole("button", { name: "Done" }));
   });
 
   it("cancels the grant panel", async () => {
     const user = userEvent.setup();
-    setup({
+    renderCard({
       enabled: true,
       prerequisites: ALL_MET,
       devices: [makeDevice({ id: "d1", name: "Alice phone" })],
     });
-    renderWithProviders(<PrivateDnsCard />);
 
     await user.click(screen.getByRole("button", { name: "Grant access" }));
     await user.click(screen.getByRole("button", { name: "Cancel" }));
@@ -187,33 +160,31 @@ describe("PrivateDnsCard", () => {
 
   it("sends to a granted device from the table row", async () => {
     const user = userEvent.setup();
-    setup({
+    renderCard({
       enabled: true,
       prerequisites: ALL_MET,
       devices: [makeDevice({ id: "d1", name: "Alice phone" })],
       grants: [GRANT],
     });
-    renderWithProviders(<PrivateDnsCard />);
 
     await user.click(screen.getByTestId("private-dns-grant-menu"));
     await user.click(await screen.findByTestId("private-dns-grant-send"));
-    expect(sendMutate).toHaveBeenCalledWith("d1");
+    expect(onSendToDevice).toHaveBeenCalledWith("d1");
   });
 
   it("revokes a granted device after confirmation", async () => {
     const user = userEvent.setup();
-    setup({
+    renderCard({
       enabled: true,
       prerequisites: ALL_MET,
       devices: [makeDevice({ id: "d1", name: "Alice phone" })],
       grants: [GRANT],
     });
-    renderWithProviders(<PrivateDnsCard />);
 
     await user.click(screen.getByTestId("private-dns-grant-menu"));
     await user.click(await screen.findByTestId("private-dns-grant-revoke"));
     // ConfirmDialog opens — confirm the revoke.
     await user.click(await screen.findByRole("button", { name: "Revoke" }));
-    expect(revokeMutate).toHaveBeenCalledWith("d1");
+    expect(onRevokeDevice).toHaveBeenCalledWith("d1");
   });
 });

--- a/source/admin-site/tests/components/features/PrivateDnsCard.test.tsx
+++ b/source/admin-site/tests/components/features/PrivateDnsCard.test.tsx
@@ -63,7 +63,13 @@ function renderCard({
       devices={devices}
       onSetEnabled={onSetEnabled}
       setEnabledPending={false}
-      grantDevice={{ mutateAsync: grantMutateAsync, isPending: false }}
+      grantDevice={{
+        mutateAsync: grantMutateAsync,
+        reset: vi.fn(),
+        isPending: false,
+        isError: false,
+        error: null,
+      }}
       onRevokeDevice={onRevokeDevice}
       onSendToDevice={onSendToDevice}
       sendPending={false}

--- a/source/admin-site/tests/components/features/QuarantineSettingsCard.test.tsx
+++ b/source/admin-site/tests/components/features/QuarantineSettingsCard.test.tsx
@@ -41,7 +41,7 @@ const zones = [
 function renderCard({
   enabled = false,
   pending = [] as Device[],
-  approvingDeviceId = null as string | null,
+  approvingDeviceIds = [] as string[],
 } = {}) {
   return renderWithProviders(
     <QuarantineSettingsCard
@@ -54,7 +54,7 @@ function renderCard({
       homeZone={zones[0]}
       zones={zones}
       onApprove={onApprove}
-      approvingDeviceId={approvingDeviceId}
+      approvingDeviceIds={approvingDeviceIds}
     />,
   );
 }
@@ -108,16 +108,18 @@ describe("QuarantineSettingsCard", () => {
     expect(onApprove).toHaveBeenCalledWith("new-1", "zone-1");
   });
 
-  it("disables the approve button for the row whose approval is mid-flight", () => {
+  it("disables every row whose approval is mid-flight, not just the latest", () => {
     renderCard({
       pending: [
         makeDevice({ id: "new-1", name: "Phone A", zone_id: "zone-guest" }),
         makeDevice({ id: "new-2", name: "Phone B", zone_id: "zone-guest" }),
+        makeDevice({ id: "new-3", name: "Phone C", zone_id: "zone-guest" }),
       ],
-      approvingDeviceId: "new-1",
+      approvingDeviceIds: ["new-1", "new-2"],
     });
     const buttons = screen.getAllByTestId("quarantine-approve");
     expect(buttons[0]).toBeDisabled();
-    expect(buttons[1]).toBeEnabled();
+    expect(buttons[1]).toBeDisabled();
+    expect(buttons[2]).toBeEnabled();
   });
 });

--- a/source/admin-site/tests/components/features/QuarantineSettingsCard.test.tsx
+++ b/source/admin-site/tests/components/features/QuarantineSettingsCard.test.tsx
@@ -1,33 +1,13 @@
-import { screen, waitFor } from "@testing-library/react";
+import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { QuarantineSettingsCard } from "@/components/features/QuarantineSettingsCard";
 import { makeDevice, renderWithProviders } from "../../test-utils";
-import type { NetworkZoneView } from "@wardnet/js";
+import type { Device, NetworkZoneView } from "@wardnet/js";
 
-vi.mock("@wardnet/web", async (importOriginal) => {
-  const actual = await importOriginal<Record<string, unknown>>();
-  return {
-    ...actual,
-    useQuarantineNewDevices: vi.fn(),
-    useSetQuarantineNewDevices: vi.fn(),
-    usePendingDevices: vi.fn(),
-    useUpdateNetworkZone: vi.fn(),
-    useAssignDeviceZone: vi.fn(),
-  };
-});
-
-import {
-  useQuarantineNewDevices,
-  useSetQuarantineNewDevices,
-  usePendingDevices,
-  useUpdateNetworkZone,
-  useAssignDeviceZone,
-} from "@wardnet/web";
-
-const setQuarantine = vi.fn();
-const setDefaultForNew = vi.fn();
-const assign = vi.fn();
+const onSetNotify = vi.fn();
+const onSetDefaultForNew = vi.fn();
+const onApprove = vi.fn();
 
 function makeZone(over: Partial<NetworkZoneView> = {}): NetworkZoneView {
   return {
@@ -58,66 +38,51 @@ const zones = [
   }),
 ];
 
-function setup({
+function renderCard({
   enabled = false,
-  devices = [] as ReturnType<typeof makeDevice>[],
+  pending = [] as Device[],
+  approvingDeviceId = null as string | null,
 } = {}) {
-  vi.mocked(useQuarantineNewDevices).mockReturnValue({
-    data: { enabled },
-  } as unknown as ReturnType<typeof useQuarantineNewDevices>);
-  vi.mocked(useSetQuarantineNewDevices).mockReturnValue({
-    mutate: setQuarantine,
-    isPending: false,
-  } as unknown as ReturnType<typeof useSetQuarantineNewDevices>);
-  const pending = devices
-    .filter((d) => d.zone_id === "zone-guest")
-    .sort(
-      (a, b) =>
-        new Date(b.first_seen).getTime() - new Date(a.first_seen).getTime(),
-    );
-  vi.mocked(usePendingDevices).mockReturnValue({
-    pending,
-    defaultForNew: zones[1],
-    homeZone: zones[0],
-    zones,
-  });
-  vi.mocked(useUpdateNetworkZone).mockReturnValue({
-    mutate: setDefaultForNew,
-  } as unknown as ReturnType<typeof useUpdateNetworkZone>);
-  vi.mocked(useAssignDeviceZone).mockReturnValue({
-    mutate: assign,
-    isPending: false,
-  } as unknown as ReturnType<typeof useAssignDeviceZone>);
+  return renderWithProviders(
+    <QuarantineSettingsCard
+      notifyEnabled={enabled}
+      notifyPending={false}
+      onSetNotify={onSetNotify}
+      onSetDefaultForNew={onSetDefaultForNew}
+      pending={pending}
+      defaultForNew={zones[1]}
+      homeZone={zones[0]}
+      zones={zones}
+      onApprove={onApprove}
+      approvingDeviceId={approvingDeviceId}
+    />,
+  );
 }
 
 beforeEach(() => {
   vi.clearAllMocks();
-  setup();
 });
 
 describe("QuarantineSettingsCard", () => {
   it("toggles the new-device notification setting", async () => {
     const user = userEvent.setup();
-    renderWithProviders(<QuarantineSettingsCard />);
+    renderCard();
     await user.click(screen.getByTestId("quarantine-toggle"));
-    expect(setQuarantine).toHaveBeenCalledWith(true);
+    expect(onSetNotify).toHaveBeenCalledWith(true);
   });
 
   it("changes the default-for-new zone via the picker", async () => {
     const user = userEvent.setup({ pointerEventsCheck: 0 });
     Element.prototype.hasPointerCapture ??= () => false;
     Element.prototype.scrollIntoView ??= () => {};
-    renderWithProviders(<QuarantineSettingsCard />);
+    renderCard();
     await user.click(screen.getByRole("combobox"));
     await user.click(await screen.findByRole("option", { name: "Trusted" }));
-    expect(setDefaultForNew).toHaveBeenCalledWith({
-      id: "zone-1",
-      body: { is_default_for_new: true },
-    });
+    expect(onSetDefaultForNew).toHaveBeenCalledWith("zone-1");
   });
 
   it("shows an empty review queue when no device sits in the default-for-new zone", () => {
-    renderWithProviders(<QuarantineSettingsCard />);
+    renderCard();
     expect(screen.getByText(/Awaiting review \(0\)/)).toBeInTheDocument();
     expect(
       screen.getByText(/No new devices awaiting review/i),
@@ -126,27 +91,33 @@ describe("QuarantineSettingsCard", () => {
 
   it("lists pending devices and approves one to the home zone", async () => {
     const user = userEvent.setup();
-    setup({
-      devices: [
+    renderCard({
+      pending: [
         makeDevice({
           id: "new-1",
           name: "Unknown phone",
           zone_id: "zone-guest",
         }),
-        makeDevice({ id: "old-1", name: "Laptop", zone_id: "zone-1" }),
       ],
     });
-    renderWithProviders(<QuarantineSettingsCard />);
     expect(screen.getByText(/Awaiting review \(1\)/)).toBeInTheDocument();
     expect(screen.getByText("Unknown phone")).toBeInTheDocument();
-    expect(screen.queryByText("Laptop")).not.toBeInTheDocument();
 
     await user.click(screen.getByTestId("quarantine-approve"));
-    await waitFor(() => expect(assign).toHaveBeenCalled());
     // Approve target defaults to the home (is_default) zone.
-    expect(assign).toHaveBeenCalledWith({
-      deviceId: "new-1",
-      zoneId: "zone-1",
+    expect(onApprove).toHaveBeenCalledWith("new-1", "zone-1");
+  });
+
+  it("disables the approve button for the row whose approval is mid-flight", () => {
+    renderCard({
+      pending: [
+        makeDevice({ id: "new-1", name: "Phone A", zone_id: "zone-guest" }),
+        makeDevice({ id: "new-2", name: "Phone B", zone_id: "zone-guest" }),
+      ],
+      approvingDeviceId: "new-1",
     });
+    const buttons = screen.getAllByTestId("quarantine-approve");
+    expect(buttons[0]).toBeDisabled();
+    expect(buttons[1]).toBeEnabled();
   });
 });

--- a/source/admin-site/tests/components/features/SecuritySettingsCard.test.tsx
+++ b/source/admin-site/tests/components/features/SecuritySettingsCard.test.tsx
@@ -1,54 +1,37 @@
 import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { useDnsConfig, useUpdateDnsConfig } from "@wardnet/web";
 import { SecuritySettingsCard } from "@/components/features/SecuritySettingsCard";
 import { renderWithProviders } from "../../test-utils";
+import type { DnsConfig } from "@wardnet/js";
 
-vi.mock("@wardnet/web", async (importOriginal) => {
-  const actual = await importOriginal<Record<string, unknown>>();
-  return {
-    ...actual,
-    useDnsConfig: vi.fn(),
-    useUpdateDnsConfig: vi.fn(),
-  };
-});
+const onUpdate = vi.fn();
 
-vi.mock("@wardnet/ui", async (importOriginal) => {
-  const actual = await importOriginal<Record<string, unknown>>();
-  return { ...actual, toast: { success: vi.fn(), error: vi.fn() } };
-});
-
-const mockConfig = vi.mocked(useDnsConfig);
-const mockUpdate = vi.mocked(useUpdateDnsConfig);
-const mutate = vi.fn();
-
-function setConfig(
+function renderCard(
   config: Record<string, unknown> | undefined,
   isLoading = false,
 ) {
-  mockConfig.mockReturnValue({
-    data: config ? { config } : undefined,
-    isLoading,
-  } as unknown as ReturnType<typeof useDnsConfig>);
+  return renderWithProviders(
+    <SecuritySettingsCard
+      config={config as DnsConfig | undefined}
+      isLoading={isLoading}
+      onUpdate={onUpdate}
+      updatePending={false}
+    />,
+  );
 }
 
 describe("SecuritySettingsCard", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockUpdate.mockReturnValue({
-      mutate,
-      isPending: false,
-    } as unknown as ReturnType<typeof useUpdateDnsConfig>);
   });
 
   it("reflects the loaded config in the toggles", () => {
-    setConfig({
+    renderCard({
       dnssec_enabled: true,
       rebinding_protection: false,
       rate_limit_per_second: 50,
     });
-    renderWithProviders(<SecuritySettingsCard />);
 
     expect(screen.getByLabelText("Enable DNSSEC validation")).toBeChecked();
     expect(
@@ -57,22 +40,20 @@ describe("SecuritySettingsCard", () => {
     expect(screen.getByRole("spinbutton")).toHaveValue(50);
   });
 
-  it("mutates when DNSSEC and rebinding toggles change", async () => {
-    setConfig({ dnssec_enabled: false, rebinding_protection: true });
-    renderWithProviders(<SecuritySettingsCard />);
+  it("calls the update callback when DNSSEC and rebinding toggles change", async () => {
+    renderCard({ dnssec_enabled: false, rebinding_protection: true });
 
     await userEvent.click(screen.getByLabelText("Enable DNSSEC validation"));
-    expect(mutate).toHaveBeenCalledWith({ dnssec_enabled: true });
+    expect(onUpdate).toHaveBeenCalledWith({ dnssec_enabled: true });
 
     await userEvent.click(
       screen.getByLabelText("Enable DNS rebinding protection"),
     );
-    expect(mutate).toHaveBeenCalledWith({ rebinding_protection: false });
+    expect(onUpdate).toHaveBeenCalledWith({ rebinding_protection: false });
   });
 
   it("shows Save when the rate limit is dirty and saves the parsed value", async () => {
-    setConfig({ rate_limit_per_second: 0 });
-    renderWithProviders(<SecuritySettingsCard />);
+    renderCard({ rate_limit_per_second: 0 });
 
     // No Save button until the rate is edited to a new value.
     expect(
@@ -84,15 +65,14 @@ describe("SecuritySettingsCard", () => {
     await userEvent.type(input, "25");
 
     await userEvent.click(screen.getByRole("button", { name: "Save" }));
-    expect(mutate).toHaveBeenCalledWith(
+    expect(onUpdate).toHaveBeenCalledWith(
       { rate_limit_per_second: 25 },
       expect.objectContaining({ onSuccess: expect.any(Function) }),
     );
   });
 
   it("shows a validation error and disables Save for a bad value", async () => {
-    setConfig({ rate_limit_per_second: 0 });
-    renderWithProviders(<SecuritySettingsCard />);
+    renderCard({ rate_limit_per_second: 0 });
 
     const input = screen.getByRole("spinbutton");
     await userEvent.clear(input);
@@ -103,8 +83,7 @@ describe("SecuritySettingsCard", () => {
   });
 
   it("cancel resets the rate edit buffer", async () => {
-    setConfig({ rate_limit_per_second: 10 });
-    renderWithProviders(<SecuritySettingsCard />);
+    renderCard({ rate_limit_per_second: 10 });
 
     const input = screen.getByRole("spinbutton");
     await userEvent.clear(input);
@@ -116,5 +95,11 @@ describe("SecuritySettingsCard", () => {
     expect(
       screen.queryByRole("button", { name: "Save" }),
     ).not.toBeInTheDocument();
+  });
+
+  it("disables the controls while the config loads or an update is pending", () => {
+    renderCard({ rate_limit_per_second: 0 }, true);
+    expect(screen.getByLabelText("Enable DNSSEC validation")).toBeDisabled();
+    expect(screen.getByRole("spinbutton")).toBeDisabled();
   });
 });

--- a/source/admin-site/tests/components/features/TunnelDevicesTable.test.tsx
+++ b/source/admin-site/tests/components/features/TunnelDevicesTable.test.tsx
@@ -1,9 +1,9 @@
 import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { useTunnelDevices } from "@wardnet/web";
 import { TunnelDevicesTable } from "@/components/features/TunnelDevicesTable";
 import { makeDevice, renderWithProviders } from "../../test-utils";
+import type { Device } from "@wardnet/js";
 
 const navigate = vi.fn();
 
@@ -12,20 +12,18 @@ vi.mock("react-router", async (importOriginal) => {
   return { ...actual, useNavigate: () => navigate };
 });
 
-vi.mock("@wardnet/web", async (importOriginal) => {
-  const actual = await importOriginal<Record<string, unknown>>();
-  return { ...actual, useTunnelDevices: vi.fn() };
-});
-
-const mockUseTunnelDevices = vi.mocked(useTunnelDevices);
-
-function setState(over: Record<string, unknown>) {
-  mockUseTunnelDevices.mockReturnValue({
-    data: undefined,
-    isLoading: false,
-    isError: false,
-    ...over,
-  } as unknown as ReturnType<typeof useTunnelDevices>);
+function renderTable({
+  devices = undefined as Device[] | undefined,
+  isLoading = false,
+  isError = false,
+} = {}) {
+  return renderWithProviders(
+    <TunnelDevicesTable
+      devices={devices}
+      isLoading={isLoading}
+      isError={isError}
+    />,
+  );
 }
 
 describe("TunnelDevicesTable", () => {
@@ -34,22 +32,19 @@ describe("TunnelDevicesTable", () => {
   });
 
   it("renders the loading state", () => {
-    setState({ isLoading: true });
-    renderWithProviders(<TunnelDevicesTable tunnelId="t1" />);
+    renderTable({ isLoading: true });
     expect(screen.getByText("Loading…")).toBeInTheDocument();
   });
 
   it("renders the error state", () => {
-    setState({ isError: true });
-    renderWithProviders(<TunnelDevicesTable tunnelId="t1" />);
+    renderTable({ isError: true });
     expect(
       screen.getByText("Failed to load devices for this tunnel."),
     ).toBeInTheDocument();
   });
 
   it("renders an empty message when no devices route through the tunnel", () => {
-    setState({ data: { devices: [] } });
-    renderWithProviders(<TunnelDevicesTable tunnelId="t1" />);
+    renderTable({ devices: [] });
     expect(
       screen.getByText("No devices are currently routed through this tunnel."),
     ).toBeInTheDocument();
@@ -63,8 +58,7 @@ describe("TunnelDevicesTable", () => {
       name: "Laptop",
       last_ip: "10.0.0.9",
     });
-    setState({ data: { devices: [device] } });
-    renderWithProviders(<TunnelDevicesTable tunnelId="t1" />);
+    renderTable({ devices: [device] });
 
     expect(screen.getByText("Laptop")).toBeInTheDocument();
     expect(screen.getByText("10.0.0.9")).toBeInTheDocument();

--- a/source/admin-site/tests/components/features/ZoneExceptionsCard.test.tsx
+++ b/source/admin-site/tests/components/features/ZoneExceptionsCard.test.tsx
@@ -1,13 +1,6 @@
 import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import {
-  useZoneExceptions,
-  useNetworkZones,
-  useDevices,
-  useCreateZoneException,
-  useDeleteZoneException,
-} from "@wardnet/web";
 import { ZoneExceptionsCard } from "@/components/features/ZoneExceptionsCard";
 import { makeDevice, renderWithProviders } from "../../test-utils";
 import type { NetworkZoneView, ZoneException } from "@wardnet/js";
@@ -26,24 +19,8 @@ vi.stubGlobal(
   },
 );
 
-vi.mock("@wardnet/web", async (importOriginal) => {
-  const actual = await importOriginal<Record<string, unknown>>();
-  return {
-    ...actual,
-    useZoneExceptions: vi.fn(),
-    useNetworkZones: vi.fn(),
-    useDevices: vi.fn(),
-    useCreateZoneException: vi.fn(),
-    useDeleteZoneException: vi.fn(),
-  };
-});
-
-const createMutate = vi.fn();
-const deleteMutate = vi.fn();
-
-function mutation<T>(mutate: ReturnType<typeof vi.fn>): T {
-  return { mutate, mutateAsync: vi.fn(), isPending: false } as unknown as T;
-}
+const onCreateException = vi.fn();
+const onDeleteException = vi.fn();
 
 function makeZone(over: Partial<NetworkZoneView> = {}): NetworkZoneView {
   return {
@@ -74,33 +51,26 @@ const casting: ZoneException = {
   updated_at: "2026-01-01T00:00:00Z",
 };
 
-function setup({ exceptions = [] as ZoneException[] } = {}) {
-  vi.mocked(useZoneExceptions).mockReturnValue({
-    data: { exceptions },
-  } as unknown as ReturnType<typeof useZoneExceptions>);
-  vi.mocked(useNetworkZones).mockReturnValue({
-    data: { zones: [makeZone()] },
-  } as unknown as ReturnType<typeof useNetworkZones>);
-  vi.mocked(useDevices).mockReturnValue({
-    data: { devices: [makeDevice({ id: "d1", name: "Phone" })] },
-  } as unknown as ReturnType<typeof useDevices>);
-  vi.mocked(useCreateZoneException).mockReturnValue(
-    mutation<ReturnType<typeof useCreateZoneException>>(createMutate),
-  );
-  vi.mocked(useDeleteZoneException).mockReturnValue(
-    mutation<ReturnType<typeof useDeleteZoneException>>(deleteMutate),
+function renderCard({ exceptions = [] as ZoneException[] } = {}) {
+  return renderWithProviders(
+    <ZoneExceptionsCard
+      exceptions={exceptions}
+      zones={[makeZone()]}
+      devices={[makeDevice({ id: "d1", name: "Phone" })]}
+      isSaving={false}
+      onCreateException={onCreateException}
+      onDeleteException={onDeleteException}
+    />,
   );
 }
 
 beforeEach(() => {
   vi.clearAllMocks();
-  setup();
 });
 
 describe("ZoneExceptionsCard", () => {
   it("resolves endpoint labels and the casting service for an exception", () => {
-    setup({ exceptions: [casting] });
-    renderWithProviders(<ZoneExceptionsCard />);
+    renderCard({ exceptions: [casting] });
     expect(screen.getByText("Phone")).toBeInTheDocument();
     expect(screen.getByText("Guest")).toBeInTheDocument();
     expect(screen.getByText("Casting")).toBeInTheDocument();
@@ -110,7 +80,7 @@ describe("ZoneExceptionsCard", () => {
 
   it("shows the empty state and opens the add-exception form", async () => {
     const user = userEvent.setup();
-    renderWithProviders(<ZoneExceptionsCard />);
+    renderCard();
     expect(
       screen.getByText(/No cross-zone exceptions yet/i),
     ).toBeInTheDocument();
@@ -121,7 +91,7 @@ describe("ZoneExceptionsCard", () => {
   });
 
   it("labels a custom-port service by its port count", () => {
-    setup({
+    renderCard({
       exceptions: [
         {
           ...casting,
@@ -137,7 +107,6 @@ describe("ZoneExceptionsCard", () => {
         },
       ],
     });
-    renderWithProviders(<ZoneExceptionsCard />);
     expect(screen.getByText("2 ports")).toBeInTheDocument();
     // one-directional renders the → glyph.
     expect(screen.getByText("→")).toBeInTheDocument();
@@ -145,7 +114,7 @@ describe("ZoneExceptionsCard", () => {
 
   it("creates a casting exception between two chosen endpoints", async () => {
     const user = userEvent.setup({ pointerEventsCheck: 0 });
-    renderWithProviders(<ZoneExceptionsCard />);
+    renderCard();
     await user.click(screen.getByTestId("exception-add"));
 
     const combos = screen.getAllByRole("combobox");
@@ -161,7 +130,7 @@ describe("ZoneExceptionsCard", () => {
     const submit = screen.getByTestId("exception-submit");
     expect(submit).toBeEnabled();
     await user.click(submit);
-    expect(createMutate).toHaveBeenCalledWith(
+    expect(onCreateException).toHaveBeenCalledWith(
       {
         from: { kind: "device", id: "d1" },
         to: { kind: "zone", id: "z-guest" },
@@ -176,7 +145,7 @@ describe("ZoneExceptionsCard", () => {
     // The preset the casting one was silently failing to cover: it must reach
     // the daemon as a real backend preset, not as an expanded port list.
     const user = userEvent.setup({ pointerEventsCheck: 0 });
-    renderWithProviders(<ZoneExceptionsCard />);
+    renderCard();
     await user.click(screen.getByTestId("exception-add"));
     const combos = screen.getAllByRole("combobox");
     await user.click(combos[0]);
@@ -190,7 +159,7 @@ describe("ZoneExceptionsCard", () => {
     await user.click(screen.getByTestId("exception-service"));
     await user.click(await screen.findByRole("option", { name: /Smart home/ }));
     await user.click(screen.getByTestId("exception-submit"));
-    expect(createMutate).toHaveBeenCalledWith(
+    expect(onCreateException).toHaveBeenCalledWith(
       expect.objectContaining({
         service: { type: "preset", set: "smart_home" },
         // The device->client leg is a fresh flow, so this must be bidirectional.
@@ -202,7 +171,7 @@ describe("ZoneExceptionsCard", () => {
 
   it("creates an exception for a curated service bundle (SSH)", async () => {
     const user = userEvent.setup({ pointerEventsCheck: 0 });
-    renderWithProviders(<ZoneExceptionsCard />);
+    renderCard();
     await user.click(screen.getByTestId("exception-add"));
     const combos = screen.getAllByRole("combobox");
     await user.click(combos[0]);
@@ -216,7 +185,7 @@ describe("ZoneExceptionsCard", () => {
     await user.click(screen.getByTestId("exception-service"));
     await user.click(await screen.findByRole("option", { name: "SSH" }));
     await user.click(screen.getByTestId("exception-submit"));
-    expect(createMutate).toHaveBeenCalledWith(
+    expect(onCreateException).toHaveBeenCalledWith(
       expect.objectContaining({
         service: { type: "ports", ports: [{ proto: "tcp", from: 22, to: 22 }] },
         bidirectional: true,
@@ -227,7 +196,7 @@ describe("ZoneExceptionsCard", () => {
 
   it("creates a custom-ports exception", async () => {
     const user = userEvent.setup({ pointerEventsCheck: 0 });
-    renderWithProviders(<ZoneExceptionsCard />);
+    renderCard();
     await user.click(screen.getByTestId("exception-add"));
     const combos = screen.getAllByRole("combobox");
     await user.click(combos[0]);
@@ -246,7 +215,7 @@ describe("ZoneExceptionsCard", () => {
     expect(screen.getByTestId("exception-submit")).toBeDisabled();
     await user.type(screen.getByTestId("exception-port-from-0"), "8080");
     await user.click(screen.getByTestId("exception-submit"));
-    expect(createMutate).toHaveBeenCalledWith(
+    expect(onCreateException).toHaveBeenCalledWith(
       expect.objectContaining({
         service: {
           type: "ports",
@@ -258,7 +227,7 @@ describe("ZoneExceptionsCard", () => {
   });
 
   it("labels a known service bundle by name in the list", () => {
-    setup({
+    renderCard({
       exceptions: [
         {
           ...casting,
@@ -270,13 +239,12 @@ describe("ZoneExceptionsCard", () => {
         },
       ],
     });
-    renderWithProviders(<ZoneExceptionsCard />);
     expect(screen.getByText("SSH")).toBeInTheDocument();
   });
 
   it("shows an error and blocks submit for an out-of-range custom port", async () => {
     const user = userEvent.setup({ pointerEventsCheck: 0 });
-    renderWithProviders(<ZoneExceptionsCard />);
+    renderCard();
     await user.click(screen.getByTestId("exception-add"));
     await user.click(screen.getByTestId("exception-service"));
     await user.click(
@@ -292,7 +260,7 @@ describe("ZoneExceptionsCard", () => {
 
   it("adds and removes custom port rows", async () => {
     const user = userEvent.setup({ pointerEventsCheck: 0 });
-    renderWithProviders(<ZoneExceptionsCard />);
+    renderCard();
     await user.click(screen.getByTestId("exception-add"));
     await user.click(screen.getByTestId("exception-service"));
     await user.click(
@@ -313,7 +281,7 @@ describe("ZoneExceptionsCard", () => {
 
   it("rejects picking the same endpoint for both sides", async () => {
     const user = userEvent.setup({ pointerEventsCheck: 0 });
-    renderWithProviders(<ZoneExceptionsCard />);
+    renderCard();
     await user.click(screen.getByTestId("exception-add"));
 
     const combos = screen.getAllByRole("combobox");
@@ -336,11 +304,10 @@ describe("ZoneExceptionsCard", () => {
 
   it("deletes an exception after confirming", async () => {
     const user = userEvent.setup({ pointerEventsCheck: 0 });
-    setup({ exceptions: [casting] });
-    renderWithProviders(<ZoneExceptionsCard />);
+    renderCard({ exceptions: [casting] });
     await user.click(screen.getByTestId("exception-row-menu"));
     await user.click(await screen.findByTestId("exception-delete"));
     await user.click(await screen.findByTestId("confirm-dialog-confirm"));
-    expect(deleteMutate).toHaveBeenCalledWith("e1");
+    expect(onDeleteException).toHaveBeenCalledWith("e1");
   });
 });

--- a/source/admin-site/tests/components/features/ZonesCard.test.tsx
+++ b/source/admin-site/tests/components/features/ZonesCard.test.tsx
@@ -1,12 +1,6 @@
 import { screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import {
-  useNetworkZones,
-  useCreateNetworkZone,
-  useUpdateNetworkZone,
-  useDeleteNetworkZone,
-} from "@wardnet/web";
 import { ZonesCard } from "@/components/features/ZonesCard";
 import { renderWithProviders } from "../../test-utils";
 import type { NetworkZoneView } from "@wardnet/js";
@@ -25,24 +19,11 @@ vi.stubGlobal(
   },
 );
 
-vi.mock("@wardnet/web", async (importOriginal) => {
-  const actual = await importOriginal<Record<string, unknown>>();
-  return {
-    ...actual,
-    useNetworkZones: vi.fn(),
-    useCreateNetworkZone: vi.fn(),
-    useUpdateNetworkZone: vi.fn(),
-    useDeleteNetworkZone: vi.fn(),
-  };
-});
-
-const createMutate = vi.fn();
-const updateMutate = vi.fn();
-const deleteMutate = vi.fn();
-
-function mutation<T>(mutate: ReturnType<typeof vi.fn>): T {
-  return { mutate, mutateAsync: vi.fn(), isPending: false } as unknown as T;
-}
+const onCreateZone = vi.fn();
+const onUpdateZone = vi.fn();
+const onSetHome = vi.fn();
+const onSetDefaultForNew = vi.fn();
+const onDeleteZone = vi.fn();
 
 function makeZone(over: Partial<NetworkZoneView> = {}): NetworkZoneView {
   return {
@@ -63,37 +44,39 @@ function makeZone(over: Partial<NetworkZoneView> = {}): NetworkZoneView {
   };
 }
 
+const zones = [
+  makeZone(),
+  makeZone({
+    id: "z-iot",
+    name: "IoT",
+    provenance: "manual",
+    is_default: false,
+    is_default_for_new: false,
+    member_count: 0,
+  }),
+];
+
+function renderCard() {
+  return renderWithProviders(
+    <ZonesCard
+      zones={zones}
+      isSaving={false}
+      onCreateZone={onCreateZone}
+      onUpdateZone={onUpdateZone}
+      onSetHome={onSetHome}
+      onSetDefaultForNew={onSetDefaultForNew}
+      onDeleteZone={onDeleteZone}
+    />,
+  );
+}
+
 beforeEach(() => {
   vi.clearAllMocks();
-  vi.mocked(useNetworkZones).mockReturnValue({
-    data: {
-      zones: [
-        makeZone(),
-        makeZone({
-          id: "z-iot",
-          name: "IoT",
-          provenance: "manual",
-          is_default: false,
-          is_default_for_new: false,
-          member_count: 0,
-        }),
-      ],
-    },
-  } as unknown as ReturnType<typeof useNetworkZones>);
-  vi.mocked(useCreateNetworkZone).mockReturnValue(
-    mutation<ReturnType<typeof useCreateNetworkZone>>(createMutate),
-  );
-  vi.mocked(useUpdateNetworkZone).mockReturnValue(
-    mutation<ReturnType<typeof useUpdateNetworkZone>>(updateMutate),
-  );
-  vi.mocked(useDeleteNetworkZone).mockReturnValue(
-    mutation<ReturnType<typeof useDeleteNetworkZone>>(deleteMutate),
-  );
 });
 
 describe("ZonesCard", () => {
   it("renders zones with their status pills", () => {
-    renderWithProviders(<ZonesCard />);
+    renderCard();
     expect(screen.getByText("Trusted")).toBeInTheDocument();
     expect(screen.getByText("IoT")).toBeInTheDocument();
     expect(screen.getByText("Home")).toBeInTheDocument();
@@ -102,11 +85,11 @@ describe("ZonesCard", () => {
 
   it("creates a zone with the form defaults", async () => {
     const user = userEvent.setup();
-    renderWithProviders(<ZonesCard />);
+    renderCard();
     await user.click(screen.getByTestId("zone-add"));
     await user.type(screen.getByTestId("zone-name"), "Cameras");
     await user.click(screen.getByTestId("zone-submit"));
-    expect(createMutate).toHaveBeenCalledWith(
+    expect(onCreateZone).toHaveBeenCalledWith(
       {
         name: "Cameras",
         isolation_stance: "shared_subnet",
@@ -121,7 +104,7 @@ describe("ZonesCard", () => {
 
   it("creates a zone with edited fields (stance, targets, subnet, toggles)", async () => {
     const user = userEvent.setup({ pointerEventsCheck: 0 });
-    renderWithProviders(<ZonesCard />);
+    renderCard();
     await user.click(screen.getByTestId("zone-add"));
     await user.type(screen.getByTestId("zone-name"), "Cameras");
 
@@ -145,7 +128,7 @@ describe("ZonesCard", () => {
     await user.click(screen.getByLabelText("Member isolation"));
 
     await user.click(screen.getByTestId("zone-submit"));
-    expect(createMutate).toHaveBeenCalledWith(
+    expect(onCreateZone).toHaveBeenCalledWith(
       {
         name: "Cameras",
         isolation_stance: "isolate_members",
@@ -160,7 +143,7 @@ describe("ZonesCard", () => {
 
   it("blocks submit when no routing target is allowed", async () => {
     const user = userEvent.setup({ pointerEventsCheck: 0 });
-    renderWithProviders(<ZonesCard />);
+    renderCard();
     await user.click(screen.getByTestId("zone-add"));
     await user.type(screen.getByTestId("zone-name"), "Nowhere");
     await user.click(screen.getByLabelText("Allow direct routing"));
@@ -173,7 +156,7 @@ describe("ZonesCard", () => {
 
   it("gates member isolation on a zone subnet", async () => {
     const user = userEvent.setup({ pointerEventsCheck: 0 });
-    renderWithProviders(<ZonesCard />);
+    renderCard();
     await user.click(screen.getByTestId("zone-add"));
     // No subnet yet → the toggle is disabled.
     expect(screen.getByLabelText("Member isolation")).toBeDisabled();
@@ -187,7 +170,7 @@ describe("ZonesCard", () => {
 
   it("edits an existing zone via the row menu", async () => {
     const user = userEvent.setup({ pointerEventsCheck: 0 });
-    renderWithProviders(<ZonesCard />);
+    renderCard();
     await user.click(screen.getAllByTestId("zone-row-menu")[1]);
     await user.click(await screen.findByTestId("zone-edit"));
     const name = screen.getByTestId("zone-name") as HTMLInputElement;
@@ -195,7 +178,7 @@ describe("ZonesCard", () => {
     await user.clear(name);
     await user.type(name, "Sensors");
     await user.click(screen.getByTestId("zone-submit"));
-    expect(updateMutate).toHaveBeenCalledWith(
+    expect(onUpdateZone).toHaveBeenCalledWith(
       expect.objectContaining({ id: "z-iot" }),
       expect.objectContaining({ onSuccess: expect.any(Function) }),
     );
@@ -203,18 +186,15 @@ describe("ZonesCard", () => {
 
   it("sets a zone as the default for new devices via the row menu", async () => {
     const user = userEvent.setup({ pointerEventsCheck: 0 });
-    renderWithProviders(<ZonesCard />);
+    renderCard();
     await user.click(screen.getAllByTestId("zone-row-menu")[1]);
     await user.click(await screen.findByTestId("zone-set-default-for-new"));
-    expect(updateMutate).toHaveBeenCalledWith({
-      id: "z-iot",
-      body: { is_default_for_new: true },
-    });
+    expect(onSetDefaultForNew).toHaveBeenCalledWith("z-iot");
   });
 
   it("cancels the add form", async () => {
     const user = userEvent.setup();
-    renderWithProviders(<ZonesCard />);
+    renderCard();
     await user.click(screen.getByTestId("zone-add"));
     expect(screen.getByTestId("zone-name")).toBeInTheDocument();
     await user.click(screen.getByRole("button", { name: "Cancel" }));
@@ -223,28 +203,25 @@ describe("ZonesCard", () => {
 
   it("promotes a zone to home via the row menu", async () => {
     const user = userEvent.setup({ pointerEventsCheck: 0 });
-    renderWithProviders(<ZonesCard />);
+    renderCard();
     // Second row (IoT) is a non-default manual zone.
     await user.click(screen.getAllByTestId("zone-row-menu")[1]);
     await user.click(await screen.findByTestId("zone-set-home"));
-    expect(updateMutate).toHaveBeenCalledWith({
-      id: "z-iot",
-      body: { is_default: true },
-    });
+    expect(onSetHome).toHaveBeenCalledWith("z-iot");
   });
 
   it("deletes an empty manual zone after confirming", async () => {
     const user = userEvent.setup({ pointerEventsCheck: 0 });
-    renderWithProviders(<ZonesCard />);
+    renderCard();
     await user.click(screen.getAllByTestId("zone-row-menu")[1]);
     await user.click(await screen.findByTestId("zone-delete"));
     await user.click(await screen.findByTestId("confirm-dialog-confirm"));
-    expect(deleteMutate).toHaveBeenCalledWith("z-iot");
+    expect(onDeleteZone).toHaveBeenCalledWith("z-iot");
   });
 
   it("hides delete for the protected default/system zone", async () => {
     const user = userEvent.setup({ pointerEventsCheck: 0 });
-    renderWithProviders(<ZonesCard />);
+    renderCard();
     // First row (Trusted) is system + is_default + has members → no delete.
     await user.click(screen.getAllByTestId("zone-row-menu")[0]);
     expect(await screen.findByTestId("zone-edit")).toBeInTheDocument();

--- a/source/admin-site/tests/components/layouts/AppLayout.test.tsx
+++ b/source/admin-site/tests/components/layouts/AppLayout.test.tsx
@@ -114,6 +114,10 @@ describe("AppLayout", () => {
     expect(screen.getByText("Dashboard")).toBeInTheDocument();
     expect(screen.queryByText("menu")).not.toBeInTheDocument();
     expect(screen.queryByText("shutdown-banner")).not.toBeInTheDocument();
+    // The admin-only /system/status poll must not be subscribed for
+    // non-admin sessions — it would fail every interval forever.
+    expect(useSystemStatus).not.toHaveBeenCalled();
+    expect(useAcknowledgeShutdown).not.toHaveBeenCalled();
   });
 
   it("passes the shell status data down to the sidebar and banners", () => {

--- a/source/admin-site/tests/components/layouts/AppLayout.test.tsx
+++ b/source/admin-site/tests/components/layouts/AppLayout.test.tsx
@@ -129,6 +129,21 @@ describe("AppLayout", () => {
     );
   });
 
+  it("falls back to safe defaults while the status queries are unresolved", () => {
+    useAuth.mockReturnValue({ isAdmin: true, logout: vi.fn() });
+    useDaemonStatus.mockReturnValue({ data: undefined, isLoading: true });
+    useUpdateStatus.mockReturnValue({ data: undefined });
+    renderAt("/devices");
+    const sidebar = screen.getByText("sidebar");
+    expect(sidebar).toHaveAttribute("data-version", "-");
+    expect(sidebar).toHaveAttribute("data-connected", "false");
+    expect(sidebar).toHaveAttribute("data-update", "false");
+    expect(screen.getByTestId("connection-banner")).toHaveAttribute(
+      "data-reachable",
+      "undefined",
+    );
+  });
+
   it("wires the shutdown acknowledgement mutation to the banner", async () => {
     useAuth.mockReturnValue({ isAdmin: true, logout: vi.fn() });
     renderAt("/devices");

--- a/source/admin-site/tests/components/layouts/AppLayout.test.tsx
+++ b/source/admin-site/tests/components/layouts/AppLayout.test.tsx
@@ -2,29 +2,73 @@ import { render, screen } from "@testing-library/react";
 import { MemoryRouter, Route, Routes } from "react-router";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { useAuth } = vi.hoisted(() => ({ useAuth: vi.fn() }));
+const {
+  useAuth,
+  useDaemonStatus,
+  useUpdateStatus,
+  useSystemStatus,
+  useAcknowledgeShutdown,
+} = vi.hoisted(() => ({
+  useAuth: vi.fn(),
+  useDaemonStatus: vi.fn(),
+  useUpdateStatus: vi.fn(),
+  useSystemStatus: vi.fn(),
+  useAcknowledgeShutdown: vi.fn(),
+}));
 
 vi.mock("@wardnet/web", async (importOriginal) => {
   const actual = await importOriginal<Record<string, unknown>>();
-  return { ...actual, useAuth };
+  return {
+    ...actual,
+    useAuth,
+    useDaemonStatus,
+    useUpdateStatus,
+    useSystemStatus,
+    useAcknowledgeShutdown,
+  };
 });
 
 // Stub the compound children (owned/tested elsewhere) so this test isolates
-// the layout shell.
+// the layout shell — the harnesses surface the props the layout wired.
 vi.mock("@/components/compound/Sidebar", () => ({
-  Sidebar: () => <nav>sidebar</nav>,
+  Sidebar: ({
+    version,
+    connected,
+    updateAvailable,
+  }: {
+    version?: string;
+    connected: boolean;
+    updateAvailable: boolean;
+  }) => (
+    <nav
+      data-version={version ?? "-"}
+      data-connected={String(connected)}
+      data-update={String(updateAvailable)}
+    >
+      sidebar
+    </nav>
+  ),
 }));
 vi.mock("@/components/compound/MobileMenu", () => ({
   MobileMenu: () => <button>menu</button>,
 }));
 vi.mock("@/components/compound/ConnectionBanner", () => ({
-  ConnectionBanner: () => <div>connection-banner</div>,
+  ConnectionBanner: ({ reachable }: { reachable: boolean | undefined }) => (
+    <div data-testid="connection-banner" data-reachable={String(reachable)} />
+  ),
 }));
 vi.mock("@/components/compound/UncleanShutdownBanner", () => ({
-  UncleanShutdownBanner: () => <div>shutdown-banner</div>,
+  UncleanShutdownBanner: ({ onDismiss }: { onDismiss: () => void }) => (
+    <div>
+      shutdown-banner
+      <button onClick={() => onDismiss()}>dismiss-shutdown</button>
+    </div>
+  ),
 }));
 
 import { AppLayout } from "@/components/layouts/AppLayout";
+
+const ackMutate = vi.fn();
 
 function renderAt(path: string) {
   return render(
@@ -39,10 +83,24 @@ function renderAt(path: string) {
 }
 
 describe("AppLayout", () => {
-  beforeEach(() => vi.clearAllMocks());
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useDaemonStatus.mockReturnValue({
+      data: { version: "1.2.3", reachable: true },
+      isLoading: false,
+    });
+    useUpdateStatus.mockReturnValue({
+      data: { status: { update_available: true, latest_version: "9.9.9" } },
+    });
+    useSystemStatus.mockReturnValue({ data: undefined });
+    useAcknowledgeShutdown.mockReturnValue({
+      mutate: ackMutate,
+      isPending: false,
+    });
+  });
 
   it("derives the breadcrumb from the path and renders admin chrome", () => {
-    useAuth.mockReturnValue({ isAdmin: true });
+    useAuth.mockReturnValue({ isAdmin: true, logout: vi.fn() });
     renderAt("/devices");
     expect(screen.getByText("Devices")).toBeInTheDocument();
     expect(screen.getByText("menu")).toBeInTheDocument();
@@ -51,10 +109,30 @@ describe("AppLayout", () => {
   });
 
   it("shows the Dashboard crumb at root and hides admin-only chrome for non-admins", () => {
-    useAuth.mockReturnValue({ isAdmin: false });
+    useAuth.mockReturnValue({ isAdmin: false, logout: vi.fn() });
     renderAt("/");
     expect(screen.getByText("Dashboard")).toBeInTheDocument();
     expect(screen.queryByText("menu")).not.toBeInTheDocument();
     expect(screen.queryByText("shutdown-banner")).not.toBeInTheDocument();
+  });
+
+  it("passes the shell status data down to the sidebar and banners", () => {
+    useAuth.mockReturnValue({ isAdmin: true, logout: vi.fn() });
+    renderAt("/devices");
+    const sidebar = screen.getByText("sidebar");
+    expect(sidebar).toHaveAttribute("data-version", "1.2.3");
+    expect(sidebar).toHaveAttribute("data-connected", "true");
+    expect(sidebar).toHaveAttribute("data-update", "true");
+    expect(screen.getByTestId("connection-banner")).toHaveAttribute(
+      "data-reachable",
+      "true",
+    );
+  });
+
+  it("wires the shutdown acknowledgement mutation to the banner", async () => {
+    useAuth.mockReturnValue({ isAdmin: true, logout: vi.fn() });
+    renderAt("/devices");
+    screen.getByText("dismiss-shutdown").click();
+    expect(ackMutate).toHaveBeenCalled();
   });
 });

--- a/source/admin-site/tests/pages/Dashboard.test.tsx
+++ b/source/admin-site/tests/pages/Dashboard.test.tsx
@@ -9,6 +9,7 @@ const {
   useDhcpStatus,
   useRecentErrors,
   useDnsStatSummary,
+  useTlsStatus,
 } = vi.hoisted(() => ({
   useSystemStatus: vi.fn(),
   useDevices: vi.fn(),
@@ -16,6 +17,7 @@ const {
   useDhcpStatus: vi.fn(),
   useRecentErrors: vi.fn(),
   useDnsStatSummary: vi.fn(),
+  useTlsStatus: vi.fn(),
 }));
 
 vi.mock("@wardnet/web", async (importOriginal) => {
@@ -28,6 +30,7 @@ vi.mock("@wardnet/web", async (importOriginal) => {
     useDhcpStatus,
     useRecentErrors,
     useDnsStatSummary,
+    useTlsStatus,
   };
 });
 
@@ -97,6 +100,7 @@ beforeEach(() => {
   useTunnels.mockReturnValue({ data: undefined });
   useDhcpStatus.mockReturnValue({ data: undefined });
   useRecentErrors.mockReturnValue({ data: undefined });
+  useTlsStatus.mockReturnValue({ data: undefined });
   useDnsStatSummary.mockReturnValue({
     data: undefined,
     isError: false,

--- a/source/admin-site/tests/pages/DeviceDetail.test.tsx
+++ b/source/admin-site/tests/pages/DeviceDetail.test.tsx
@@ -102,17 +102,17 @@ vi.mock("@/components/features/DeviceDnsFilterCard", () => ({
   DeviceDnsFilterCard: ({
     settings,
     profiles,
-    isLoading,
+    config,
   }: {
     settings?: { enabled: boolean };
     profiles?: unknown[];
-    isLoading: boolean;
+    config?: unknown;
   }) => (
     <div
       data-testid="dns-filter-card"
       data-enabled={String(settings?.enabled)}
       data-profiles={profiles?.length ?? "none"}
-      data-loading={String(isLoading)}
+      data-config={String(config != null)}
     />
   ),
 }));
@@ -309,13 +309,13 @@ describe("DeviceDetail", () => {
     );
   });
 
-  it("marks the filter card loading until every filter query settles", () => {
+  it("passes no config to the filter card until its query settles", () => {
     loadDevice({ name: "My Laptop" });
     useDnsFilterConfig.mockReturnValue({ data: undefined, isLoading: true });
     renderWithProviders(<DeviceDetail />);
     expect(screen.getByTestId("dns-filter-card")).toHaveAttribute(
-      "data-loading",
-      "true",
+      "data-config",
+      "false",
     );
   });
 

--- a/source/admin-site/tests/pages/DeviceDetail.test.tsx
+++ b/source/admin-site/tests/pages/DeviceDetail.test.tsx
@@ -2,7 +2,43 @@ import { screen } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { useDevice } = vi.hoisted(() => ({ useDevice: vi.fn() }));
+const {
+  useDevice,
+  useTunnels,
+  useUpdateDevice,
+  useRoutingProfiles,
+  useDeviceRoutingProfiles,
+  useSetDeviceRoutingProfiles,
+  useNetworkZones,
+  useAssignDeviceZone,
+  useDeviceFilterSettings,
+  useDnsFilterProfiles,
+  useDnsFilterConfig,
+  useUpdateDeviceFilterSettings,
+  useDnsCaptureSettings,
+  useUpdateDnsCaptureSettings,
+  useDhcpReservations,
+  useCreateReservation,
+  useDeleteReservation,
+} = vi.hoisted(() => ({
+  useDevice: vi.fn(),
+  useTunnels: vi.fn(),
+  useUpdateDevice: vi.fn(),
+  useRoutingProfiles: vi.fn(),
+  useDeviceRoutingProfiles: vi.fn(),
+  useSetDeviceRoutingProfiles: vi.fn(),
+  useNetworkZones: vi.fn(),
+  useAssignDeviceZone: vi.fn(),
+  useDeviceFilterSettings: vi.fn(),
+  useDnsFilterProfiles: vi.fn(),
+  useDnsFilterConfig: vi.fn(),
+  useUpdateDeviceFilterSettings: vi.fn(),
+  useDnsCaptureSettings: vi.fn(),
+  useUpdateDnsCaptureSettings: vi.fn(),
+  useDhcpReservations: vi.fn(),
+  useCreateReservation: vi.fn(),
+  useDeleteReservation: vi.fn(),
+}));
 
 vi.mock("react-router", async (io) => {
   const actual = await io<typeof import("react-router")>();
@@ -14,6 +50,22 @@ vi.mock("@wardnet/web", async (importOriginal) => {
   return {
     ...actual,
     useDevice,
+    useTunnels,
+    useUpdateDevice,
+    useRoutingProfiles,
+    useDeviceRoutingProfiles,
+    useSetDeviceRoutingProfiles,
+    useNetworkZones,
+    useAssignDeviceZone,
+    useDeviceFilterSettings,
+    useDnsFilterProfiles,
+    useDnsFilterConfig,
+    useUpdateDeviceFilterSettings,
+    useDnsCaptureSettings,
+    useUpdateDnsCaptureSettings,
+    useDhcpReservations,
+    useCreateReservation,
+    useDeleteReservation,
     DeviceIcon: ({ type }: { type: string }) => (
       <span data-testid="device-icon">{type}</span>
     ),
@@ -44,11 +96,37 @@ vi.mock("@/components/compound/StatusBadge", () => ({
     </span>
   ),
 }));
+// The cards are mocked to thin harnesses that surface the page's wiring so
+// the tests assert what the page hoisted, not the cards' own rendering.
 vi.mock("@/components/features/DeviceDnsFilterCard", () => ({
-  DeviceDnsFilterCard: () => <div data-testid="dns-filter-card" />,
+  DeviceDnsFilterCard: ({
+    settings,
+    profiles,
+    isLoading,
+  }: {
+    settings?: { enabled: boolean };
+    profiles?: unknown[];
+    isLoading: boolean;
+  }) => (
+    <div
+      data-testid="dns-filter-card"
+      data-enabled={String(settings?.enabled)}
+      data-profiles={profiles?.length ?? "none"}
+      data-loading={String(isLoading)}
+    />
+  ),
 }));
 vi.mock("@/components/features/DeviceDnsCaptureCard", () => ({
-  DeviceDnsCaptureCard: () => <div data-testid="dns-capture-card" />,
+  DeviceDnsCaptureCard: ({
+    settings,
+  }: {
+    settings?: { cap_count: number };
+  }) => (
+    <div
+      data-testid="dns-capture-card"
+      data-cap={settings?.cap_count ?? "none"}
+    />
+  ),
 }));
 vi.mock("@/components/features/DeviceIdentityCard", () => ({
   DeviceIdentityCard: () => <div data-testid="identity-card" />,
@@ -59,18 +137,103 @@ vi.mock("@/components/features/DeviceIdentificationCard", () => ({
   ),
 }));
 vi.mock("@/components/features/DeviceNetworkCard", () => ({
-  DeviceNetworkCard: () => <div data-testid="network-card" />,
+  DeviceNetworkCard: ({
+    reservations,
+  }: {
+    reservations?: Array<{ id: string }>;
+  }) => (
+    <div
+      data-testid="network-card"
+      data-reservations={reservations?.length ?? "none"}
+    />
+  ),
 }));
 vi.mock("@/components/features/DeviceSettingsCard", () => ({
-  DeviceSettingsCard: () => <div data-testid="settings-card" />,
+  DeviceSettingsCard: ({ tunnels }: { tunnels: Array<{ id: string }> }) => (
+    <div data-testid="settings-card" data-tunnels={tunnels.length} />
+  ),
+}));
+vi.mock("@/components/features/DeviceZoneCard", () => ({
+  DeviceZoneCard: ({ zones }: { zones: Array<{ id: string }> }) => (
+    <div data-testid="zone-card" data-zones={zones.length} />
+  ),
+}));
+vi.mock("@/components/features/DeviceRoutingProfilesCard", () => ({
+  DeviceRoutingProfilesCard: ({
+    allProfiles,
+    assignedIds,
+  }: {
+    allProfiles: Array<{ id: string }>;
+    assignedIds: string[];
+  }) => (
+    <div
+      data-testid="routing-profiles-card"
+      data-profiles={allProfiles.length}
+      data-assigned={assignedIds.join(",")}
+    />
+  ),
 }));
 
 import DeviceDetail from "@/pages/DeviceDetail";
 import { makeDevice, renderWithProviders } from "../test-utils";
 
+function mutationHandle() {
+  return {
+    mutateAsync: vi.fn(),
+    reset: vi.fn(),
+    isPending: false,
+    isError: false,
+    error: null,
+  };
+}
+
 beforeEach(() => {
   vi.clearAllMocks();
+  useTunnels.mockReturnValue({ data: { tunnels: [{ id: "tun-1" }] } });
+  useUpdateDevice.mockReturnValue(mutationHandle());
+  useRoutingProfiles.mockReturnValue({ data: { profiles: [{ id: "p1" }] } });
+  useDeviceRoutingProfiles.mockReturnValue({
+    data: { profile_ids: ["p1"] },
+  });
+  useSetDeviceRoutingProfiles.mockReturnValue(mutationHandle());
+  useNetworkZones.mockReturnValue({ data: { zones: [{ id: "z1" }] } });
+  useAssignDeviceZone.mockReturnValue(mutationHandle());
+  useDeviceFilterSettings.mockReturnValue({
+    data: { settings: { enabled: true, profile_ids: [] } },
+    isLoading: false,
+  });
+  useDnsFilterProfiles.mockReturnValue({
+    data: { profiles: [{ id: "fp1" }] },
+    isLoading: false,
+  });
+  useDnsFilterConfig.mockReturnValue({
+    data: { config: { enabled: true, default_profile_ids: [] } },
+    isLoading: false,
+  });
+  useUpdateDeviceFilterSettings.mockReturnValue(mutationHandle());
+  useDnsCaptureSettings.mockReturnValue({
+    data: { enabled: true, cap_count: 1000, cap_days: 7 },
+    isLoading: false,
+  });
+  useUpdateDnsCaptureSettings.mockReturnValue(mutationHandle());
+  useDhcpReservations.mockReturnValue({
+    data: { reservations: [{ id: "res-1" }] },
+  });
+  useCreateReservation.mockReturnValue(mutationHandle());
+  useDeleteReservation.mockReturnValue(mutationHandle());
 });
+
+function loadDevice(overrides = {}) {
+  useDevice.mockReturnValue({
+    data: {
+      device: makeDevice(overrides),
+      current_rule: null,
+      signals: [],
+    },
+    isLoading: false,
+    isError: false,
+  });
+}
 
 describe("DeviceDetail", () => {
   it("shows loading state", () => {
@@ -105,22 +268,55 @@ describe("DeviceDetail", () => {
   });
 
   it("renders an online managed device", () => {
-    useDevice.mockReturnValue({
-      data: {
-        device: makeDevice({
-          name: "My Laptop",
-          last_seen: new Date().toISOString(),
-        }),
-        current_rule: null,
-        signals: [],
-      },
-      isLoading: false,
-      isError: false,
-    });
+    loadDevice({ name: "My Laptop", last_seen: new Date().toISOString() });
     renderWithProviders(<DeviceDetail />);
     expect(screen.getByTestId("item-label")).toHaveTextContent("My Laptop");
     expect(screen.getByTestId("status-badge")).toHaveTextContent("Online");
     expect(screen.getByTestId("identity-card")).toBeInTheDocument();
+  });
+
+  it("hands each card the data its hoisted queries resolved", () => {
+    loadDevice({ name: "My Laptop" });
+    renderWithProviders(<DeviceDetail />);
+    expect(screen.getByTestId("settings-card")).toHaveAttribute(
+      "data-tunnels",
+      "1",
+    );
+    expect(screen.getByTestId("routing-profiles-card")).toHaveAttribute(
+      "data-profiles",
+      "1",
+    );
+    expect(screen.getByTestId("routing-profiles-card")).toHaveAttribute(
+      "data-assigned",
+      "p1",
+    );
+    expect(screen.getByTestId("zone-card")).toHaveAttribute("data-zones", "1");
+    expect(screen.getByTestId("dns-filter-card")).toHaveAttribute(
+      "data-enabled",
+      "true",
+    );
+    expect(screen.getByTestId("dns-filter-card")).toHaveAttribute(
+      "data-profiles",
+      "1",
+    );
+    expect(screen.getByTestId("dns-capture-card")).toHaveAttribute(
+      "data-cap",
+      "1000",
+    );
+    expect(screen.getByTestId("network-card")).toHaveAttribute(
+      "data-reservations",
+      "1",
+    );
+  });
+
+  it("marks the filter card loading until every filter query settles", () => {
+    loadDevice({ name: "My Laptop" });
+    useDnsFilterConfig.mockReturnValue({ data: undefined, isLoading: true });
+    renderWithProviders(<DeviceDetail />);
+    expect(screen.getByTestId("dns-filter-card")).toHaveAttribute(
+      "data-loading",
+      "true",
+    );
   });
 
   it("passes the device's identification signals to the identification card", () => {
@@ -150,32 +346,13 @@ describe("DeviceDetail", () => {
   });
 
   it("renders an offline managed device", () => {
-    useDevice.mockReturnValue({
-      data: {
-        device: makeDevice({
-          name: "Old Device",
-          last_seen: "2000-01-01T00:00:00Z",
-        }),
-        current_rule: null,
-        signals: [],
-      },
-      isLoading: false,
-      isError: false,
-    });
+    loadDevice({ name: "Old Device", last_seen: "2000-01-01T00:00:00Z" });
     renderWithProviders(<DeviceDetail />);
     expect(screen.getByTestId("status-badge")).toHaveTextContent("Offline");
   });
 
   it("renders a discovered (unmanaged) device and falls back to hostname label", () => {
-    useDevice.mockReturnValue({
-      data: {
-        device: makeDevice({ name: null, hostname: "living-room-tv" }),
-        current_rule: null,
-        signals: [],
-      },
-      isLoading: false,
-      isError: false,
-    });
+    loadDevice({ name: null, hostname: "living-room-tv" });
     renderWithProviders(<DeviceDetail />);
     expect(screen.getByTestId("status-badge")).toHaveTextContent("Discovered");
     expect(screen.getByTestId("item-label")).toHaveTextContent(
@@ -187,20 +364,12 @@ describe("DeviceDetail", () => {
     // A curated-catalog match is an inference, not a registered fact. Titling
     // the page "Govee device" would state it as fact — exactly the hedge the
     // rest of the UI applies via manufacturerDisplay (issue #1099).
-    useDevice.mockReturnValue({
-      data: {
-        device: makeDevice({
-          name: null,
-          hostname: null,
-          manufacturer: "Govee",
-          manufacturer_source: "catalog",
-          mac: "5c:e7:53:4e:ec:d9",
-        }),
-        current_rule: null,
-        signals: [],
-      },
-      isLoading: false,
-      isError: false,
+    loadDevice({
+      name: null,
+      hostname: null,
+      manufacturer: "Govee",
+      manufacturer_source: "catalog",
+      mac: "5c:e7:53:4e:ec:d9",
     });
     renderWithProviders(<DeviceDetail />);
     expect(screen.getByTestId("item-label")).toHaveTextContent(
@@ -212,38 +381,22 @@ describe("DeviceDetail", () => {
   });
 
   it("falls back to manufacturer label for an IEEE registrant", () => {
-    useDevice.mockReturnValue({
-      data: {
-        device: makeDevice({
-          name: null,
-          hostname: null,
-          manufacturer: "Acme",
-          manufacturer_source: "ieee",
-        }),
-        current_rule: null,
-        signals: [],
-      },
-      isLoading: false,
-      isError: false,
+    loadDevice({
+      name: null,
+      hostname: null,
+      manufacturer: "Acme",
+      manufacturer_source: "ieee",
     });
     renderWithProviders(<DeviceDetail />);
     expect(screen.getByTestId("item-label")).toHaveTextContent("Acme device");
   });
 
   it("falls back to MAC label", () => {
-    useDevice.mockReturnValue({
-      data: {
-        device: makeDevice({
-          name: null,
-          hostname: null,
-          manufacturer: null,
-          mac: "AA:BB:CC:00:11:22",
-        }),
-        current_rule: null,
-        signals: [],
-      },
-      isLoading: false,
-      isError: false,
+    loadDevice({
+      name: null,
+      hostname: null,
+      manufacturer: null,
+      mac: "AA:BB:CC:00:11:22",
     });
     renderWithProviders(<DeviceDetail />);
     expect(screen.getByTestId("item-label")).toHaveTextContent(
@@ -252,15 +405,7 @@ describe("DeviceDetail", () => {
   });
 
   it("treats an invalid last_seen as offline for managed devices", () => {
-    useDevice.mockReturnValue({
-      data: {
-        device: makeDevice({ name: "Weird", last_seen: "not-a-date" }),
-        current_rule: null,
-        signals: [],
-      },
-      isLoading: false,
-      isError: false,
-    });
+    loadDevice({ name: "Weird", last_seen: "not-a-date" });
     renderWithProviders(<DeviceDetail />);
     expect(screen.getByTestId("status-badge")).toHaveTextContent("Offline");
   });

--- a/source/admin-site/tests/pages/Devices.test.tsx
+++ b/source/admin-site/tests/pages/Devices.test.tsx
@@ -3,11 +3,21 @@ import userEvent from "@testing-library/user-event";
 import type { ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { useDevices } = vi.hoisted(() => ({ useDevices: vi.fn() }));
+const { useDevices, useDeviceFilterSettingsList, useDnsFilterProfiles } =
+  vi.hoisted(() => ({
+    useDevices: vi.fn(),
+    useDeviceFilterSettingsList: vi.fn(),
+    useDnsFilterProfiles: vi.fn(),
+  }));
 
 vi.mock("@wardnet/web", async (importOriginal) => {
   const actual = await importOriginal<Record<string, unknown>>();
-  return { ...actual, useDevices };
+  return {
+    ...actual,
+    useDevices,
+    useDeviceFilterSettingsList,
+    useDnsFilterProfiles,
+  };
 });
 
 vi.mock("@/components/compound/PageHeader", () => ({
@@ -75,6 +85,8 @@ beforeEach(() => {
     isLoading: false,
     isError: false,
   });
+  useDeviceFilterSettingsList.mockReturnValue({ data: undefined });
+  useDnsFilterProfiles.mockReturnValue({ data: undefined });
 });
 
 describe("Devices", () => {

--- a/source/admin-site/tests/pages/Dhcp.test.tsx
+++ b/source/admin-site/tests/pages/Dhcp.test.tsx
@@ -206,6 +206,7 @@ import { renderWithProviders } from "../test-utils";
 const toggleMutate = vi.fn();
 const revokeMutate = vi.fn();
 const deleteMutate = vi.fn();
+const createReservationReset = vi.fn();
 
 function populated() {
   useDhcpStatus.mockReturnValue({
@@ -251,7 +252,8 @@ beforeEach(() => {
   useDeleteReservation.mockReturnValue({ mutate: deleteMutate });
   useCreateReservation.mockReturnValue({
     mutateAsync: vi.fn(),
-    reset: vi.fn(),
+    mutate: vi.fn(),
+    reset: createReservationReset,
     isPending: false,
     isError: false,
     error: null,
@@ -320,6 +322,18 @@ describe("Dhcp", () => {
       "data-has-create",
       "true",
     );
+  });
+
+  it("resets the create mutation whenever the form opens, clearing stale errors", async () => {
+    populated();
+    const user = userEvent.setup();
+    renderWithProviders(<Dhcp />);
+    await user.click(screen.getByText("add-res"));
+    expect(createReservationReset).toHaveBeenCalledTimes(1);
+    await user.click(screen.getByText("close-res"));
+    // Reopening from a lease must also start from a clean mutation.
+    await user.click(screen.getByText("make-static"));
+    expect(createReservationReset).toHaveBeenCalledTimes(2);
   });
 
   it("toggles DHCP, changes group and search", async () => {

--- a/source/admin-site/tests/pages/Dhcp.test.tsx
+++ b/source/admin-site/tests/pages/Dhcp.test.tsx
@@ -11,6 +11,10 @@ const {
   useToggleDhcp,
   useRevokeLease,
   useDeleteReservation,
+  useCreateReservation,
+  useUpdateDhcpConfig,
+  usePreviewDhcpConfig,
+  useDnsConfig,
   useDevices,
   navigate,
 } = vi.hoisted(() => ({
@@ -21,6 +25,10 @@ const {
   useToggleDhcp: vi.fn(),
   useRevokeLease: vi.fn(),
   useDeleteReservation: vi.fn(),
+  useCreateReservation: vi.fn(),
+  useUpdateDhcpConfig: vi.fn(),
+  usePreviewDhcpConfig: vi.fn(),
+  useDnsConfig: vi.fn(),
   useDevices: vi.fn(),
   navigate: vi.fn(),
 }));
@@ -41,6 +49,10 @@ vi.mock("@wardnet/web", async (importOriginal) => {
     useToggleDhcp,
     useRevokeLease,
     useDeleteReservation,
+    useCreateReservation,
+    useUpdateDhcpConfig,
+    usePreviewDhcpConfig,
+    useDnsConfig,
     useDevices,
   };
 });
@@ -64,7 +76,22 @@ vi.mock("@/components/compound/DhcpStatusCard", () => ({
   ),
 }));
 vi.mock("@/components/compound/DhcpConfigCard", () => ({
-  DhcpConfigCard: () => <div data-testid="dhcp-config-card" />,
+  DhcpConfigCard: ({
+    dnsEnabled,
+    updateConfig,
+    previewConfig,
+  }: {
+    dnsEnabled: boolean | undefined;
+    updateConfig: { mutateAsync: unknown };
+    previewConfig: { mutateAsync: unknown };
+  }) => (
+    <div
+      data-testid="dhcp-config-card"
+      data-dns-enabled={String(dnsEnabled)}
+      data-has-update={String(typeof updateConfig.mutateAsync === "function")}
+      data-has-preview={String(typeof previewConfig.mutateAsync === "function")}
+    />
+  ),
 }));
 vi.mock("@/components/compound/DhcpEntryTable", () => ({
   DhcpEntryTable: ({
@@ -153,12 +180,19 @@ vi.mock("@/components/features/CreateReservationInline", () => ({
     onClose,
     onSuccess,
     defaults,
+    createReservation,
   }: {
     onClose: () => void;
     onSuccess: () => void;
     defaults?: unknown;
+    createReservation: { mutateAsync: unknown };
   }) => (
-    <div data-testid="create-reservation">
+    <div
+      data-testid="create-reservation"
+      data-has-create={String(
+        typeof createReservation.mutateAsync === "function",
+      )}
+    >
       <span data-testid="defaults">{JSON.stringify(defaults ?? null)}</span>
       <button onClick={() => onClose()}>close-res</button>
       <button onClick={() => onSuccess()}>success-res</button>
@@ -215,6 +249,25 @@ beforeEach(() => {
   useToggleDhcp.mockReturnValue({ mutate: toggleMutate, isPending: false });
   useRevokeLease.mockReturnValue({ mutate: revokeMutate });
   useDeleteReservation.mockReturnValue({ mutate: deleteMutate });
+  useCreateReservation.mockReturnValue({
+    mutateAsync: vi.fn(),
+    reset: vi.fn(),
+    isPending: false,
+    isError: false,
+    error: null,
+  });
+  useUpdateDhcpConfig.mockReturnValue({
+    mutateAsync: vi.fn(),
+    reset: vi.fn(),
+    isPending: false,
+    isError: false,
+    error: null,
+  });
+  usePreviewDhcpConfig.mockReturnValue({
+    mutateAsync: vi.fn(),
+    isPending: false,
+  });
+  useDnsConfig.mockReturnValue({ data: { config: { enabled: true } } });
   useDhcpStatus.mockReturnValue({ data: undefined, isLoading: false });
   useDhcpConfig.mockReturnValue({ data: undefined });
   useDhcpLeases.mockReturnValue({ data: undefined });
@@ -237,6 +290,36 @@ describe("Dhcp", () => {
     expect(screen.getByTestId("dhcp-config-card")).toBeInTheDocument();
     expect(screen.getByTestId("lease-count")).toHaveTextContent("2");
     expect(screen.getByTestId("reservation-count")).toHaveTextContent("2");
+  });
+
+  it("wires the hoisted config mutations and DNS state into the config card", () => {
+    populated();
+    renderWithProviders(<Dhcp />);
+    const card = screen.getByTestId("dhcp-config-card");
+    expect(card).toHaveAttribute("data-dns-enabled", "true");
+    expect(card).toHaveAttribute("data-has-update", "true");
+    expect(card).toHaveAttribute("data-has-preview", "true");
+  });
+
+  it("keeps the config card's DNS state tri-state while the DNS query is unresolved", () => {
+    populated();
+    useDnsConfig.mockReturnValue({ data: undefined });
+    renderWithProviders(<Dhcp />);
+    expect(screen.getByTestId("dhcp-config-card")).toHaveAttribute(
+      "data-dns-enabled",
+      "undefined",
+    );
+  });
+
+  it("hands the hoisted create-reservation mutation to the inline form", async () => {
+    populated();
+    const user = userEvent.setup();
+    renderWithProviders(<Dhcp />);
+    await user.click(screen.getByText("add-res"));
+    expect(screen.getByTestId("create-reservation")).toHaveAttribute(
+      "data-has-create",
+      "true",
+    );
   });
 
   it("toggles DHCP, changes group and search", async () => {

--- a/source/admin-site/tests/pages/Dns.test.tsx
+++ b/source/admin-site/tests/pages/Dns.test.tsx
@@ -191,6 +191,18 @@ describe("Dns", () => {
     expect(screen.getByText("Loading DNS status...")).toBeInTheDocument();
   });
 
+  it("does not mount the stats queries while the status/config gate is closed", () => {
+    useDnsStatus.mockReturnValue({ data: undefined, isLoading: true });
+    useDnsConfig.mockReturnValue({ data: undefined });
+    renderWithProviders(<Dns />);
+    // The insights block owns these hooks and only mounts inside the gate,
+    // so no stats request fires while the resolver status is unresolved.
+    expect(useDnsStatsDashboard).not.toHaveBeenCalled();
+    expect(useDnsPeriodComparison).not.toHaveBeenCalled();
+    expect(useDnsTopTrackers).not.toHaveBeenCalled();
+    expect(useDnsPerDeviceStats).not.toHaveBeenCalled();
+  });
+
   it("renders the populated resolver page", () => {
     renderWithProviders(<Dns />);
     expect(screen.getByRole("heading", { name: "DNS" })).toBeInTheDocument();

--- a/source/admin-site/tests/pages/Dns.test.tsx
+++ b/source/admin-site/tests/pages/Dns.test.tsx
@@ -22,12 +22,22 @@ const {
   useToggleDns,
   useFlushDnsCache,
   useUpdateDnsConfig,
+  useDevices,
+  useDnsStatsDashboard,
+  useDnsPeriodComparison,
+  useDnsTopTrackers,
+  useDnsPerDeviceStats,
 } = vi.hoisted(() => ({
   useDnsStatus: vi.fn(),
   useDnsConfig: vi.fn(),
   useToggleDns: vi.fn(),
   useFlushDnsCache: vi.fn(),
   useUpdateDnsConfig: vi.fn(),
+  useDevices: vi.fn(),
+  useDnsStatsDashboard: vi.fn(),
+  useDnsPeriodComparison: vi.fn(),
+  useDnsTopTrackers: vi.fn(),
+  useDnsPerDeviceStats: vi.fn(),
 }));
 
 vi.mock("@wardnet/web", async (importOriginal) => {
@@ -39,6 +49,11 @@ vi.mock("@wardnet/web", async (importOriginal) => {
     useToggleDns,
     useFlushDnsCache,
     useUpdateDnsConfig,
+    useDevices,
+    useDnsStatsDashboard,
+    useDnsPeriodComparison,
+    useDnsTopTrackers,
+    useDnsPerDeviceStats,
   };
 });
 
@@ -71,7 +86,46 @@ vi.mock("@/components/features/SecuritySettingsCard", () => ({
   SecuritySettingsCard: () => <div>security-card</div>,
 }));
 vi.mock("@/components/features/DnsStatsSection", () => ({
-  DnsStatsSection: ({ range }: { range: string }) => <div>stats:{range}</div>,
+  DnsStatsSection: ({
+    range,
+    zoom,
+    onZoomChange,
+    data,
+  }: {
+    range: string;
+    zoom: { start: number; end: number } | null;
+    onZoomChange: (z: { start: number; end: number } | null) => void;
+    data?: { total: number };
+  }) => (
+    <div>
+      <div>stats:{range}</div>
+      <div data-testid="stats-zoom">{zoom ? "zoomed" : "full"}</div>
+      <div data-testid="stats-total">{data?.total ?? "-"}</div>
+      <button onClick={() => onZoomChange({ start: 0, end: 3_600_000 })}>
+        commit-zoom
+      </button>
+    </div>
+  ),
+}));
+vi.mock("@/components/features/DnsAnalyticsSection", () => ({
+  DnsAnalyticsSection: ({
+    range,
+    selectedDeviceId,
+    onSelectDevice,
+    devices,
+  }: {
+    range: string;
+    selectedDeviceId: string;
+    onSelectDevice: (id: string) => void;
+    devices: Array<{ id: string }>;
+  }) => (
+    <div>
+      <div>analytics:{range}</div>
+      <div data-testid="analytics-selected">{selectedDeviceId || "-"}</div>
+      <div data-testid="analytics-devices">{devices.length}</div>
+      <button onClick={() => onSelectDevice("dev-2")}>pick-device</button>
+    </div>
+  ),
 }));
 
 import Dns from "@/pages/Dns";
@@ -104,6 +158,18 @@ beforeEach(() => {
     mutate: updateMutate,
     isPending: false,
   });
+  useDevices.mockReturnValue({
+    data: { devices: [{ id: "dev-1" }, { id: "dev-2" }] },
+  });
+  useDnsStatsDashboard.mockReturnValue({
+    data: { total: 300 },
+    isLoading: false,
+    isError: false,
+    error: null,
+  });
+  useDnsPeriodComparison.mockReturnValue({ data: undefined });
+  useDnsTopTrackers.mockReturnValue({ data: undefined });
+  useDnsPerDeviceStats.mockReturnValue({ data: undefined, isLoading: false });
   useDnsStatus.mockReturnValue({
     data: {
       running: true,
@@ -212,6 +278,41 @@ describe("Dns", () => {
     const sevenDay = screen.getByRole("tab", { name: "7d" });
     await user.click(sevenDay);
     expect(screen.getByText("stats:7d")).toBeInTheDocument();
+    expect(screen.getByText("analytics:7d")).toBeInTheDocument();
+  });
+
+  it("passes the hoisted dashboard data and device list to the sections", () => {
+    renderWithProviders(<Dns />);
+    expect(screen.getByTestId("stats-total")).toHaveTextContent("300");
+    expect(screen.getByTestId("analytics-devices")).toHaveTextContent("2");
+    // The per-device selection defaults to the first device.
+    expect(screen.getByTestId("analytics-selected")).toHaveTextContent("dev-1");
+  });
+
+  it("owns the committed zoom, narrows the dashboard window, and invalidates it on range change", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<Dns />);
+    expect(screen.getByTestId("stats-zoom")).toHaveTextContent("full");
+    await user.click(screen.getByText("commit-zoom"));
+    expect(screen.getByTestId("stats-zoom")).toHaveTextContent("zoomed");
+    // The dashboard's top-N window now follows the zoom.
+    expect(useDnsStatsDashboard).toHaveBeenLastCalledWith(
+      "24h",
+      expect.objectContaining({ from: expect.any(String) }),
+    );
+    // Switching range drops the stale zoom rather than applying it to the
+    // new window.
+    await user.click(screen.getByRole("tab", { name: "7d" }));
+    expect(screen.getByTestId("stats-zoom")).toHaveTextContent("full");
+    expect(useDnsStatsDashboard).toHaveBeenLastCalledWith("7d", undefined);
+  });
+
+  it("switches the per-device series to a user-picked device", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<Dns />);
+    await user.click(screen.getByText("pick-device"));
+    expect(screen.getByTestId("analytics-selected")).toHaveTextContent("dev-2");
+    expect(useDnsPerDeviceStats).toHaveBeenLastCalledWith("dev-2", "24h");
   });
 
   it("shows a Stopped pill when the resolver is down", () => {

--- a/source/admin-site/tests/pages/DnsLocal.test.tsx
+++ b/source/admin-site/tests/pages/DnsLocal.test.tsx
@@ -1,6 +1,54 @@
 import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import type { ReactNode } from "react";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  useDnsRecords,
+  useDnsZones,
+  useForwardingRules,
+  useCreateDnsRecord,
+  useUpdateDnsRecord,
+  useDeleteDnsRecord,
+  useCreateDnsZone,
+  useUpdateDnsZone,
+  useDeleteDnsZone,
+  useCreateForwardingRule,
+  useUpdateForwardingRule,
+  useDeleteForwardingRule,
+} = vi.hoisted(() => ({
+  useDnsRecords: vi.fn(),
+  useDnsZones: vi.fn(),
+  useForwardingRules: vi.fn(),
+  useCreateDnsRecord: vi.fn(),
+  useUpdateDnsRecord: vi.fn(),
+  useDeleteDnsRecord: vi.fn(),
+  useCreateDnsZone: vi.fn(),
+  useUpdateDnsZone: vi.fn(),
+  useDeleteDnsZone: vi.fn(),
+  useCreateForwardingRule: vi.fn(),
+  useUpdateForwardingRule: vi.fn(),
+  useDeleteForwardingRule: vi.fn(),
+}));
+
+vi.mock("@wardnet/web", async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return {
+    ...actual,
+    useDnsRecords,
+    useDnsZones,
+    useForwardingRules,
+    useCreateDnsRecord,
+    useUpdateDnsRecord,
+    useDeleteDnsRecord,
+    useCreateDnsZone,
+    useUpdateDnsZone,
+    useDeleteDnsZone,
+    useCreateForwardingRule,
+    useUpdateForwardingRule,
+    useDeleteForwardingRule,
+  };
+});
 
 vi.mock("@/components/compound/PageHeader", () => ({
   PageHeader: ({
@@ -16,21 +64,151 @@ vi.mock("@/components/compound/PageHeader", () => ({
     </div>
   ),
 }));
+
+// The cards are mocked to thin harnesses that surface the page's wiring: they
+// expose the hoisted callbacks and derived flags so the tests assert what the
+// page wired, not the cards' own rendering.
 vi.mock("@/components/features/LocalRecordsCard", () => ({
-  LocalRecordsCard: () => <div>local-records</div>,
+  LocalRecordsCard: ({
+    records,
+    zones,
+    isSaving,
+    onCreateRecord,
+    onUpdateRecord,
+    onDeleteRecord,
+  }: {
+    records: Array<{ id: string }>;
+    zones: Array<{ id: string }>;
+    isSaving: boolean;
+    onCreateRecord: (body: unknown, cb?: unknown) => void;
+    onUpdateRecord: (change: unknown, cb?: unknown) => void;
+    onDeleteRecord: (id: string) => void;
+  }) => (
+    <div data-testid="local-records">
+      <span data-testid="records-count">{records.length}</span>
+      <span data-testid="records-zones">{zones.length}</span>
+      <span data-testid="records-saving">{String(isSaving)}</span>
+      <button onClick={() => onCreateRecord({ domain: "nas.lan" })}>
+        create-record
+      </button>
+      <button onClick={() => onUpdateRecord({ id: "rec1", body: {} })}>
+        update-record
+      </button>
+      <button onClick={() => onDeleteRecord("rec1")}>delete-record</button>
+    </div>
+  ),
 }));
 vi.mock("@/components/features/DnsZonesCard", () => ({
-  DnsZonesCard: () => <div>dns-zones</div>,
+  DnsZonesCard: ({
+    zones,
+    records,
+    onCreateZone,
+    onUpdateZone,
+    onDeleteZone,
+  }: {
+    zones: Array<{ id: string }>;
+    records: Array<{ id: string }>;
+    onCreateZone: (body: unknown, cb?: unknown) => void;
+    onUpdateZone: (change: unknown, cb?: unknown) => void;
+    onDeleteZone: (id: string) => void;
+  }) => (
+    <div data-testid="dns-zones">
+      <span data-testid="zones-count">{zones.length}</span>
+      <span data-testid="zones-records">{records.length}</span>
+      <button onClick={() => onCreateZone({ name: "office" })}>
+        create-zone
+      </button>
+      <button onClick={() => onUpdateZone({ id: "z1", body: {} })}>
+        update-zone
+      </button>
+      <button onClick={() => onDeleteZone("z1")}>delete-zone</button>
+    </div>
+  ),
 }));
 vi.mock("@/components/features/ConditionalForwardingCard", () => ({
-  ConditionalForwardingCard: () => <div>conditional-forwarding</div>,
+  ConditionalForwardingCard: ({
+    rules,
+    onCreateRule,
+    onUpdateRule,
+    onDeleteRule,
+  }: {
+    rules: Array<{ id: string }>;
+    onCreateRule: (body: unknown, cb?: unknown) => void;
+    onUpdateRule: (change: unknown, cb?: unknown) => void;
+    onDeleteRule: (id: string) => void;
+  }) => (
+    <div data-testid="conditional-forwarding">
+      <span data-testid="rules-count">{rules.length}</span>
+      <button onClick={() => onCreateRule({ domain: "lab.internal" })}>
+        create-rule
+      </button>
+      <button onClick={() => onUpdateRule({ id: "r1", body: {} })}>
+        update-rule
+      </button>
+      <button onClick={() => onDeleteRule("r1")}>delete-rule</button>
+    </div>
+  ),
 }));
 vi.mock("@/components/features/DhcpLanInfoCard", () => ({
-  DhcpLanInfoCard: () => <div>dhcp-lan-info</div>,
+  DhcpLanInfoCard: ({ dhcpRecordCount }: { dhcpRecordCount: number }) => (
+    <div data-testid="dhcp-lan-info">{dhcpRecordCount}</div>
+  ),
 }));
 
 import DnsLocal from "@/pages/DnsLocal";
 import { renderWithProviders } from "../test-utils";
+
+const createRecordMutate = vi.fn();
+const updateRecordMutate = vi.fn();
+const deleteRecordMutate = vi.fn();
+const createZoneMutate = vi.fn();
+const updateZoneMutate = vi.fn();
+const deleteZoneMutate = vi.fn();
+const createRuleMutate = vi.fn();
+const updateRuleMutate = vi.fn();
+const deleteRuleMutate = vi.fn();
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  useDnsRecords.mockReturnValue({
+    data: {
+      records: [
+        { id: "rec1", source: "manual" },
+        { id: "rec2", source: "dhcp" },
+        { id: "rec3", source: "dhcp" },
+      ],
+    },
+  });
+  useDnsZones.mockReturnValue({ data: { zones: [{ id: "z1" }] } });
+  useForwardingRules.mockReturnValue({ data: { rules: [{ id: "r1" }] } });
+  useCreateDnsRecord.mockReturnValue({
+    mutate: createRecordMutate,
+    isPending: false,
+  });
+  useUpdateDnsRecord.mockReturnValue({
+    mutate: updateRecordMutate,
+    isPending: false,
+  });
+  useDeleteDnsRecord.mockReturnValue({ mutate: deleteRecordMutate });
+  useCreateDnsZone.mockReturnValue({
+    mutate: createZoneMutate,
+    isPending: false,
+  });
+  useUpdateDnsZone.mockReturnValue({
+    mutate: updateZoneMutate,
+    isPending: false,
+  });
+  useDeleteDnsZone.mockReturnValue({ mutate: deleteZoneMutate });
+  useCreateForwardingRule.mockReturnValue({
+    mutate: createRuleMutate,
+    isPending: false,
+  });
+  useUpdateForwardingRule.mockReturnValue({
+    mutate: updateRuleMutate,
+    isPending: false,
+  });
+  useDeleteForwardingRule.mockReturnValue({ mutate: deleteRuleMutate });
+});
 
 describe("DnsLocal", () => {
   it("renders the header and composes every child card", () => {
@@ -38,9 +216,61 @@ describe("DnsLocal", () => {
     expect(
       screen.getByRole("heading", { name: "Local DNS" }),
     ).toBeInTheDocument();
-    expect(screen.getByText("local-records")).toBeInTheDocument();
-    expect(screen.getByText("dns-zones")).toBeInTheDocument();
-    expect(screen.getByText("conditional-forwarding")).toBeInTheDocument();
-    expect(screen.getByText("dhcp-lan-info")).toBeInTheDocument();
+    expect(screen.getByTestId("local-records")).toBeInTheDocument();
+    expect(screen.getByTestId("dns-zones")).toBeInTheDocument();
+    expect(screen.getByTestId("conditional-forwarding")).toBeInTheDocument();
+    expect(screen.getByTestId("dhcp-lan-info")).toBeInTheDocument();
+  });
+
+  it("shares the records and zones queries across the cards", () => {
+    renderWithProviders(<DnsLocal />);
+    // Full record list goes to both cards; the DHCP count is derived once.
+    expect(screen.getByTestId("records-count")).toHaveTextContent("3");
+    expect(screen.getByTestId("zones-records")).toHaveTextContent("3");
+    expect(screen.getByTestId("records-zones")).toHaveTextContent("1");
+    expect(screen.getByTestId("zones-count")).toHaveTextContent("1");
+    expect(screen.getByTestId("dhcp-lan-info")).toHaveTextContent("2");
+  });
+
+  it("wires the record mutations to the LocalRecordsCard callbacks", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<DnsLocal />);
+    await user.click(screen.getByText("create-record"));
+    expect(createRecordMutate).toHaveBeenCalledWith({ domain: "nas.lan" });
+    await user.click(screen.getByText("update-record"));
+    expect(updateRecordMutate).toHaveBeenCalledWith({ id: "rec1", body: {} });
+    await user.click(screen.getByText("delete-record"));
+    expect(deleteRecordMutate).toHaveBeenCalledWith("rec1");
+  });
+
+  it("wires the zone mutations to the DnsZonesCard callbacks", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<DnsLocal />);
+    await user.click(screen.getByText("create-zone"));
+    expect(createZoneMutate).toHaveBeenCalledWith({ name: "office" });
+    await user.click(screen.getByText("update-zone"));
+    expect(updateZoneMutate).toHaveBeenCalledWith({ id: "z1", body: {} });
+    await user.click(screen.getByText("delete-zone"));
+    expect(deleteZoneMutate).toHaveBeenCalledWith("z1");
+  });
+
+  it("wires the forwarding-rule mutations to the card callbacks", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<DnsLocal />);
+    await user.click(screen.getByText("create-rule"));
+    expect(createRuleMutate).toHaveBeenCalledWith({ domain: "lab.internal" });
+    await user.click(screen.getByText("update-rule"));
+    expect(updateRuleMutate).toHaveBeenCalledWith({ id: "r1", body: {} });
+    await user.click(screen.getByText("delete-rule"));
+    expect(deleteRuleMutate).toHaveBeenCalledWith("r1");
+  });
+
+  it("derives isSaving from the create/update record mutations", () => {
+    useCreateDnsRecord.mockReturnValue({
+      mutate: createRecordMutate,
+      isPending: true,
+    });
+    renderWithProviders(<DnsLocal />);
+    expect(screen.getByTestId("records-saving")).toHaveTextContent("true");
   });
 });

--- a/source/admin-site/tests/pages/DnsLocal.test.tsx
+++ b/source/admin-site/tests/pages/DnsLocal.test.tsx
@@ -265,6 +265,17 @@ describe("DnsLocal", () => {
     expect(deleteRuleMutate).toHaveBeenCalledWith("r1");
   });
 
+  it("falls back to empty data while the queries are unresolved", () => {
+    useDnsRecords.mockReturnValue({ data: undefined });
+    useDnsZones.mockReturnValue({ data: undefined });
+    useForwardingRules.mockReturnValue({ data: undefined });
+    renderWithProviders(<DnsLocal />);
+    expect(screen.getByTestId("records-count")).toHaveTextContent("0");
+    expect(screen.getByTestId("zones-count")).toHaveTextContent("0");
+    expect(screen.getByTestId("rules-count")).toHaveTextContent("0");
+    expect(screen.getByTestId("dhcp-lan-info")).toHaveTextContent("0");
+  });
+
   it("derives isSaving from the create/update record mutations", () => {
     useCreateDnsRecord.mockReturnValue({
       mutate: createRecordMutate,

--- a/source/admin-site/tests/pages/RemoteAccess.test.tsx
+++ b/source/admin-site/tests/pages/RemoteAccess.test.tsx
@@ -8,6 +8,12 @@ const {
   useTlsStatus,
   useResolutionCheck,
   useDeleteDdns,
+  useDevices,
+  usePrivateDnsStatus,
+  useSetPrivateDnsEnabled,
+  useGrantPrivateDnsDevice,
+  useRevokePrivateDnsDevice,
+  useSendPrivateDnsToDevice,
   useWardnetEnrollment,
   toast,
 } = vi.hoisted(() => ({
@@ -15,6 +21,12 @@ const {
   useTlsStatus: vi.fn(),
   useResolutionCheck: vi.fn(),
   useDeleteDdns: vi.fn(),
+  useDevices: vi.fn(),
+  usePrivateDnsStatus: vi.fn(),
+  useSetPrivateDnsEnabled: vi.fn(),
+  useGrantPrivateDnsDevice: vi.fn(),
+  useRevokePrivateDnsDevice: vi.fn(),
+  useSendPrivateDnsToDevice: vi.fn(),
   useWardnetEnrollment: vi.fn(),
   toast: Object.assign(vi.fn(), {
     success: vi.fn(),
@@ -31,8 +43,36 @@ vi.mock("@wardnet/web", async (importOriginal) => {
     useTlsStatus,
     useResolutionCheck,
     useDeleteDdns,
+    useDevices,
+    usePrivateDnsStatus,
+    useSetPrivateDnsEnabled,
+    useGrantPrivateDnsDevice,
+    useRevokePrivateDnsDevice,
+    useSendPrivateDnsToDevice,
   };
 });
+
+// Mocked to a harness that surfaces the page's wiring: the card's own
+// behaviour is covered by its prop-driven component test.
+vi.mock("@/components/features/PrivateDnsCard", () => ({
+  PrivateDnsCard: ({
+    status,
+    devices,
+    onSetEnabled,
+  }: {
+    status?: { enabled: boolean };
+    devices: Array<{ id: string }>;
+    onSetEnabled: (enabled: boolean) => void;
+  }) => (
+    <div
+      data-testid="private-dns-card"
+      data-enabled={String(status?.enabled)}
+      data-devices={devices.length}
+    >
+      <button onClick={() => onSetEnabled(true)}>pdns-enable</button>
+    </div>
+  ),
+}));
 
 vi.mock("@wardnet/ui", async (importOriginal) => {
   const actual = await importOriginal<Record<string, unknown>>();
@@ -126,6 +166,21 @@ beforeEach(() => {
   refetch.mockResolvedValue({ data: { verdict: "match" } });
   useDdnsStatus.mockReturnValue({ data: undefined });
   useTlsStatus.mockReturnValue({ data: undefined });
+  useDevices.mockReturnValue({ data: undefined });
+  usePrivateDnsStatus.mockReturnValue({ data: undefined, isLoading: false });
+  useSetPrivateDnsEnabled.mockReturnValue({
+    mutate: vi.fn(),
+    isPending: false,
+  });
+  useGrantPrivateDnsDevice.mockReturnValue({
+    mutateAsync: vi.fn(),
+    isPending: false,
+  });
+  useRevokePrivateDnsDevice.mockReturnValue({ mutate: vi.fn() });
+  useSendPrivateDnsToDevice.mockReturnValue({
+    mutate: vi.fn(),
+    isPending: false,
+  });
   useResolutionCheck.mockReturnValue({
     data: undefined,
     isFetching: false,

--- a/source/admin-site/tests/pages/TunnelDetail.test.tsx
+++ b/source/admin-site/tests/pages/TunnelDetail.test.tsx
@@ -10,6 +10,7 @@ const {
   useRebuildTunnel,
   useSpeedTestResults,
   useTunnelStats,
+  useTunnelDevices,
   navigate,
 } = vi.hoisted(() => ({
   useTunnel: vi.fn(),
@@ -18,6 +19,7 @@ const {
   useRebuildTunnel: vi.fn(),
   useSpeedTestResults: vi.fn(),
   useTunnelStats: vi.fn(),
+  useTunnelDevices: vi.fn(),
   navigate: vi.fn(),
 }));
 
@@ -40,6 +42,7 @@ vi.mock("@wardnet/web", async (importOriginal) => {
     useRebuildTunnel,
     useSpeedTestResults,
     useTunnelStats,
+    useTunnelDevices,
   };
 });
 
@@ -122,6 +125,11 @@ beforeEach(() => {
   });
   useSpeedTestResults.mockReturnValue({ data: { results: [] } });
   useTunnelStats.mockReturnValue({
+    data: undefined,
+    isLoading: false,
+    isError: false,
+  });
+  useTunnelDevices.mockReturnValue({
     data: undefined,
     isLoading: false,
     isError: false,

--- a/source/admin-site/tests/pages/Zones.test.tsx
+++ b/source/admin-site/tests/pages/Zones.test.tsx
@@ -259,6 +259,29 @@ describe("Zones", () => {
     });
   });
 
+  it("falls back to empty data while the queries are unresolved", () => {
+    usePendingDevices.mockReturnValue({
+      pending: [],
+      defaultForNew: undefined,
+      homeZone: undefined,
+      zones: [],
+    });
+    useDevices.mockReturnValue({ data: undefined });
+    useZoneExceptions.mockReturnValue({ data: undefined });
+    useQuarantineNewDevices.mockReturnValue({ data: undefined });
+    useAssignDeviceZone.mockReturnValue({
+      mutate: assignMutate,
+      isPending: true,
+      variables: undefined,
+    });
+    renderWithProviders(<Zones />);
+    expect(screen.getByTestId("exceptions-count")).toHaveTextContent("0");
+    expect(screen.getByTestId("exceptions-devices")).toHaveTextContent("0");
+    expect(screen.getByTestId("notify-enabled")).toHaveTextContent("false");
+    // Pending with no variables yet must not claim any row is approving.
+    expect(screen.getByTestId("approving-id")).toHaveTextContent("-");
+  });
+
   it("derives the mid-flight approval device id from the shared mutation", () => {
     useAssignDeviceZone.mockReturnValue({
       mutate: assignMutate,

--- a/source/admin-site/tests/pages/Zones.test.tsx
+++ b/source/admin-site/tests/pages/Zones.test.tsx
@@ -1,4 +1,4 @@
-import { screen } from "@testing-library/react";
+import { act, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -116,24 +116,27 @@ vi.mock("@/components/features/QuarantineSettingsCard", () => ({
     onSetDefaultForNew,
     pending,
     onApprove,
-    approvingDeviceId,
+    approvingDeviceIds,
   }: {
     notifyEnabled: boolean;
     onSetNotify: (enabled: boolean) => void;
     onSetDefaultForNew: (id: string) => void;
     pending: Array<{ id: string }>;
     onApprove: (deviceId: string, zoneId: string) => void;
-    approvingDeviceId: string | null;
+    approvingDeviceIds: string[];
   }) => (
     <div data-testid="quarantine-card">
       <span data-testid="notify-enabled">{String(notifyEnabled)}</span>
       <span data-testid="pending-count">{pending.length}</span>
-      <span data-testid="approving-id">{approvingDeviceId ?? "-"}</span>
+      <span data-testid="approving-ids">
+        {approvingDeviceIds.join(",") || "-"}
+      </span>
       <button onClick={() => onSetNotify(true)}>set-notify</button>
       <button onClick={() => onSetDefaultForNew("z2")}>
         quarantine-set-dfn
       </button>
       <button onClick={() => onApprove("d1", "z1")}>approve</button>
+      <button onClick={() => onApprove("d2", "z1")}>approve-2</button>
     </div>
   ),
 }));
@@ -253,10 +256,10 @@ describe("Zones", () => {
       body: { is_default_for_new: true },
     });
     await user.click(screen.getByText("approve"));
-    expect(assignMutate).toHaveBeenCalledWith({
-      deviceId: "d1",
-      zoneId: "z1",
-    });
+    expect(assignMutate).toHaveBeenCalledWith(
+      { deviceId: "d1", zoneId: "z1" },
+      expect.objectContaining({ onSettled: expect.any(Function) }),
+    );
   });
 
   it("falls back to empty data while the queries are unresolved", () => {
@@ -269,26 +272,31 @@ describe("Zones", () => {
     useDevices.mockReturnValue({ data: undefined });
     useZoneExceptions.mockReturnValue({ data: undefined });
     useQuarantineNewDevices.mockReturnValue({ data: undefined });
-    useAssignDeviceZone.mockReturnValue({
-      mutate: assignMutate,
-      isPending: true,
-      variables: undefined,
-    });
     renderWithProviders(<Zones />);
     expect(screen.getByTestId("exceptions-count")).toHaveTextContent("0");
     expect(screen.getByTestId("exceptions-devices")).toHaveTextContent("0");
     expect(screen.getByTestId("notify-enabled")).toHaveTextContent("false");
-    // Pending with no variables yet must not claim any row is approving.
-    expect(screen.getByTestId("approving-id")).toHaveTextContent("-");
+    expect(screen.getByTestId("approving-ids")).toHaveTextContent("-");
   });
 
-  it("derives the mid-flight approval device id from the shared mutation", () => {
-    useAssignDeviceZone.mockReturnValue({
-      mutate: assignMutate,
-      isPending: true,
-      variables: { deviceId: "d-new", zoneId: "z1" },
-    });
+  it("keeps every in-flight approval marked until its own request settles", async () => {
+    const user = userEvent.setup();
+    // Capture each call's onSettled so the test can settle them out of order.
+    const settlers: Array<() => void> = [];
+    assignMutate.mockImplementation(
+      (_vars: unknown, opts: { onSettled: () => void }) => {
+        settlers.push(opts.onSettled);
+      },
+    );
     renderWithProviders(<Zones />);
-    expect(screen.getByTestId("approving-id")).toHaveTextContent("d-new");
+    await user.click(screen.getByText("approve"));
+    await user.click(screen.getByText("approve-2"));
+    // Both approvals are in flight — the first must NOT be un-marked by the
+    // second click (the latest-variables race this state exists to prevent).
+    expect(screen.getByTestId("approving-ids")).toHaveTextContent("d1,d2");
+    act(() => settlers[0]());
+    expect(screen.getByTestId("approving-ids")).toHaveTextContent("d2");
+    act(() => settlers[1]());
+    expect(screen.getByTestId("approving-ids")).toHaveTextContent("-");
   });
 });

--- a/source/admin-site/tests/pages/Zones.test.tsx
+++ b/source/admin-site/tests/pages/Zones.test.tsx
@@ -1,0 +1,271 @@
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  usePendingDevices,
+  useDevices,
+  useZoneExceptions,
+  useCreateNetworkZone,
+  useUpdateNetworkZone,
+  useDeleteNetworkZone,
+  useCreateZoneException,
+  useDeleteZoneException,
+  useQuarantineNewDevices,
+  useSetQuarantineNewDevices,
+  useAssignDeviceZone,
+} = vi.hoisted(() => ({
+  usePendingDevices: vi.fn(),
+  useDevices: vi.fn(),
+  useZoneExceptions: vi.fn(),
+  useCreateNetworkZone: vi.fn(),
+  useUpdateNetworkZone: vi.fn(),
+  useDeleteNetworkZone: vi.fn(),
+  useCreateZoneException: vi.fn(),
+  useDeleteZoneException: vi.fn(),
+  useQuarantineNewDevices: vi.fn(),
+  useSetQuarantineNewDevices: vi.fn(),
+  useAssignDeviceZone: vi.fn(),
+}));
+
+vi.mock("@wardnet/web", async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return {
+    ...actual,
+    usePendingDevices,
+    useDevices,
+    useZoneExceptions,
+    useCreateNetworkZone,
+    useUpdateNetworkZone,
+    useDeleteNetworkZone,
+    useCreateZoneException,
+    useDeleteZoneException,
+    useQuarantineNewDevices,
+    useSetQuarantineNewDevices,
+    useAssignDeviceZone,
+  };
+});
+
+// The cards are mocked to thin harnesses that surface the page's wiring: they
+// expose the hoisted callbacks and derived flags so the tests assert what the
+// page wired, not the cards' own rendering.
+vi.mock("@/components/features/ZonesCard", () => ({
+  ZonesCard: ({
+    zones,
+    isSaving,
+    onCreateZone,
+    onUpdateZone,
+    onSetHome,
+    onSetDefaultForNew,
+    onDeleteZone,
+  }: {
+    zones: Array<{ id: string }>;
+    isSaving: boolean;
+    onCreateZone: (body: unknown, cb?: unknown) => void;
+    onUpdateZone: (change: unknown, cb?: unknown) => void;
+    onSetHome: (id: string) => void;
+    onSetDefaultForNew: (id: string) => void;
+    onDeleteZone: (id: string) => void;
+  }) => (
+    <div data-testid="zones-card">
+      <span data-testid="zones-count">{zones.length}</span>
+      <span data-testid="zones-saving">{String(isSaving)}</span>
+      <button onClick={() => onCreateZone({ name: "Cameras" })}>
+        create-zone
+      </button>
+      <button onClick={() => onUpdateZone({ id: "z1", body: {} })}>
+        update-zone
+      </button>
+      <button onClick={() => onSetHome("z1")}>set-home</button>
+      <button onClick={() => onSetDefaultForNew("z1")}>set-dfn</button>
+      <button onClick={() => onDeleteZone("z1")}>delete-zone</button>
+    </div>
+  ),
+}));
+
+vi.mock("@/components/features/ZoneExceptionsCard", () => ({
+  ZoneExceptionsCard: ({
+    exceptions,
+    zones,
+    devices,
+    onCreateException,
+    onDeleteException,
+  }: {
+    exceptions: Array<{ id: string }>;
+    zones: Array<{ id: string }>;
+    devices: Array<{ id: string }>;
+    onCreateException: (body: unknown, cb?: unknown) => void;
+    onDeleteException: (id: string) => void;
+  }) => (
+    <div data-testid="exceptions-card">
+      <span data-testid="exceptions-count">{exceptions.length}</span>
+      <span data-testid="exceptions-zones">{zones.length}</span>
+      <span data-testid="exceptions-devices">{devices.length}</span>
+      <button onClick={() => onCreateException({ bidirectional: true })}>
+        create-exception
+      </button>
+      <button onClick={() => onDeleteException("e1")}>delete-exception</button>
+    </div>
+  ),
+}));
+
+vi.mock("@/components/features/QuarantineSettingsCard", () => ({
+  QuarantineSettingsCard: ({
+    notifyEnabled,
+    onSetNotify,
+    onSetDefaultForNew,
+    pending,
+    onApprove,
+    approvingDeviceId,
+  }: {
+    notifyEnabled: boolean;
+    onSetNotify: (enabled: boolean) => void;
+    onSetDefaultForNew: (id: string) => void;
+    pending: Array<{ id: string }>;
+    onApprove: (deviceId: string, zoneId: string) => void;
+    approvingDeviceId: string | null;
+  }) => (
+    <div data-testid="quarantine-card">
+      <span data-testid="notify-enabled">{String(notifyEnabled)}</span>
+      <span data-testid="pending-count">{pending.length}</span>
+      <span data-testid="approving-id">{approvingDeviceId ?? "-"}</span>
+      <button onClick={() => onSetNotify(true)}>set-notify</button>
+      <button onClick={() => onSetDefaultForNew("z2")}>
+        quarantine-set-dfn
+      </button>
+      <button onClick={() => onApprove("d1", "z1")}>approve</button>
+    </div>
+  ),
+}));
+
+import Zones from "@/pages/Zones";
+import { renderWithProviders } from "../test-utils";
+
+const createZoneMutate = vi.fn();
+const updateZoneMutate = vi.fn();
+const deleteZoneMutate = vi.fn();
+const createExceptionMutate = vi.fn();
+const deleteExceptionMutate = vi.fn();
+const setQuarantineMutate = vi.fn();
+const assignMutate = vi.fn();
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  usePendingDevices.mockReturnValue({
+    pending: [{ id: "d-new" }],
+    defaultForNew: { id: "z2" },
+    homeZone: { id: "z1" },
+    zones: [{ id: "z1" }, { id: "z2" }],
+  });
+  useDevices.mockReturnValue({ data: { devices: [{ id: "d1" }] } });
+  useZoneExceptions.mockReturnValue({ data: { exceptions: [{ id: "e1" }] } });
+  useCreateNetworkZone.mockReturnValue({
+    mutate: createZoneMutate,
+    isPending: false,
+  });
+  useUpdateNetworkZone.mockReturnValue({
+    mutate: updateZoneMutate,
+    isPending: false,
+  });
+  useDeleteNetworkZone.mockReturnValue({ mutate: deleteZoneMutate });
+  useCreateZoneException.mockReturnValue({
+    mutate: createExceptionMutate,
+    isPending: false,
+  });
+  useDeleteZoneException.mockReturnValue({ mutate: deleteExceptionMutate });
+  useQuarantineNewDevices.mockReturnValue({ data: { enabled: true } });
+  useSetQuarantineNewDevices.mockReturnValue({
+    mutate: setQuarantineMutate,
+    isPending: false,
+  });
+  useAssignDeviceZone.mockReturnValue({
+    mutate: assignMutate,
+    isPending: false,
+    variables: undefined,
+  });
+});
+
+describe("Zones", () => {
+  it("passes the shared zone/device/exception data down to the cards", () => {
+    renderWithProviders(<Zones />);
+    expect(screen.getByTestId("zones-count")).toHaveTextContent("2");
+    expect(screen.getByTestId("exceptions-count")).toHaveTextContent("1");
+    expect(screen.getByTestId("exceptions-zones")).toHaveTextContent("2");
+    expect(screen.getByTestId("exceptions-devices")).toHaveTextContent("1");
+    expect(screen.getByTestId("notify-enabled")).toHaveTextContent("true");
+    expect(screen.getByTestId("pending-count")).toHaveTextContent("1");
+  });
+
+  it("wires the zone lifecycle mutations to the ZonesCard callbacks", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<Zones />);
+    await user.click(screen.getByText("create-zone"));
+    expect(createZoneMutate).toHaveBeenCalledWith({ name: "Cameras" });
+    await user.click(screen.getByText("update-zone"));
+    expect(updateZoneMutate).toHaveBeenCalledWith({ id: "z1", body: {} });
+    await user.click(screen.getByText("delete-zone"));
+    expect(deleteZoneMutate).toHaveBeenCalledWith("z1");
+  });
+
+  it("promotes zones via dedicated update mutations with promotion bodies", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<Zones />);
+    await user.click(screen.getByText("set-home"));
+    expect(updateZoneMutate).toHaveBeenCalledWith({
+      id: "z1",
+      body: { is_default: true },
+    });
+    await user.click(screen.getByText("set-dfn"));
+    expect(updateZoneMutate).toHaveBeenCalledWith({
+      id: "z1",
+      body: { is_default_for_new: true },
+    });
+  });
+
+  it("derives isSaving for ZonesCard from the create/update mutations", () => {
+    useCreateNetworkZone.mockReturnValue({
+      mutate: createZoneMutate,
+      isPending: true,
+    });
+    renderWithProviders(<Zones />);
+    expect(screen.getByTestId("zones-saving")).toHaveTextContent("true");
+  });
+
+  it("wires the exception mutations to the ZoneExceptionsCard callbacks", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<Zones />);
+    await user.click(screen.getByText("create-exception"));
+    expect(createExceptionMutate).toHaveBeenCalledWith({
+      bidirectional: true,
+    });
+    await user.click(screen.getByText("delete-exception"));
+    expect(deleteExceptionMutate).toHaveBeenCalledWith("e1");
+  });
+
+  it("wires the quarantine toggle, promotion, and approval mutations", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<Zones />);
+    await user.click(screen.getByText("set-notify"));
+    expect(setQuarantineMutate).toHaveBeenCalledWith(true);
+    await user.click(screen.getByText("quarantine-set-dfn"));
+    expect(updateZoneMutate).toHaveBeenCalledWith({
+      id: "z2",
+      body: { is_default_for_new: true },
+    });
+    await user.click(screen.getByText("approve"));
+    expect(assignMutate).toHaveBeenCalledWith({
+      deviceId: "d1",
+      zoneId: "z1",
+    });
+  });
+
+  it("derives the mid-flight approval device id from the shared mutation", () => {
+    useAssignDeviceZone.mockReturnValue({
+      mutate: assignMutate,
+      isPending: true,
+      variables: { deviceId: "d-new", zoneId: "z1" },
+    });
+    renderWithProviders(<Zones />);
+    expect(screen.getByTestId("approving-id")).toHaveTextContent("d-new");
+  });
+});


### PR DESCRIPTION
Closes #849.

Brings the admin-site into compliance with the component-layer rule in `.agents/code-conventions.md`: `pages/` is now the only layer that wires TanStack Query hooks, and every `compound/`/`features/` component receives data and mutation callbacks via props. One commit per migration group so review stays tractable.

## What changed

- **Zones** — `ZonesCard`, `ZoneExceptionsCard`, `QuarantineSettingsCard` are prop-driven; the page fetches the shared zone/device queries once and owns a single `useAssignDeviceZone` for approvals (with an in-flight id list so concurrent approvals can't double-submit).
- **Local DNS** — `DnsZonesCard`, `LocalRecordsCard`, `ConditionalForwardingCard`, `DhcpLanInfoCard`; the records/zones queries are fetched once instead of three times.
- **DeviceDetail** — all six device cards receive data plus a narrow `MutationHandle` (new `src/lib/mutationHandle.ts`, generic over variables and result). The page keeps its loading/not-found gate via a `DeviceDetailLoaded` body so card queries still mount only after the device resolves.
- **DHCP** — `DhcpConfigCard` (tri-state `dnsEnabled`, update + preview mutations) and `CreateReservationInline`; the page resets the create mutation on every form open so a failed attempt can't leave a stale error.
- **DNS** — `SecuritySettingsCard` (own dedicated update instance, so unrelated config saves don't cross-disable it), `DnsStatsSection`, `DnsAnalyticsSection`; the stats/analytics bundle lives in a `DnsInsights` pages-layer child mounted inside the `status && config` gate, and the page owns the chart-zoom window + per-device selection because both feed query parameters.
- **Devices / TunnelDetail** — `DeviceTable` and `TunnelDevicesTable` take their query data as props; the tunnel-devices query is disabled until the tunnel itself resolves.
- **RemoteAccess / Dashboard** — `PrivateDnsCard` and `DashboardRemoteAccessBanner` are prop-driven.
- **Shell** — `Sidebar`, `ConnectionStatus`, `ConnectionBanner`, `UncleanShutdownBanner` are pure presentation; `AppLayout` wires the shell-wide hooks, with the admin-only `/system/status` poll gated behind an admin-only child so non-admin sessions never hit it.

## Documented carve-outs (doc + code now agree)

- `.agents/code-conventions.md`'s layouts carve-out now states exactly which shell hooks `AppLayout` wires and why (no owning page above the routes).
- A new carve-out covers the self-contained tunnel-creation flow: `CreateTunnelInline`'s `ManualTunnelTab`/`ProviderTunnelTab` keep their creation hooks (queries parameterised on flow-internal state, two owners, nothing shared outside the flow). These are the only remaining `use*` data-hook imports under `compound/` + `features/`.

## Acceptance criteria from #849

- [x] No `compound/`/`features/` component imports `use*` data/mutation hooks from `@wardnet/web`, except the documented tunnel-creation-flow exception.
- [x] Migrated card tests render with plain props — no more `vi.mock("@wardnet/web")` hook-shape stubbing (`DhcpConfigCard.test.tsx` included); page tests assert the wiring.
- [x] Tunnels group was already hoisted on `main` (the repo moved past the issue's snapshot); the shared-mutation in-flight pattern is preserved.
- [x] Coverage is above the `main` baseline on all four metrics (lines 95.92 vs 95.81, statements 94.76 vs 94.66, branches 88.13 vs 88.12, functions 92.87 vs 92.68).
- [x] One commit per migration group.

The final `fix` commit addresses the findings of a post-hoist code review: query subscriptions that would have fired on pages/sessions where their components previously never mounted, stale/shared mutation state, and shared-type cleanups.