### PR TITLE
feat(devices): observe mDNS service advertisements as an identification signal

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ LINUX_TARGET := $(CURDIR)/.target-linux
 
 # Coverage: files excluded from cargo-llvm-cov.  Single source of truth —
 # CI calls `make coverage-daemon` with COV_FMT overridden for LCOV output.
-COV_IGNORE := (main\.rs|noop_.*\.rs|db\.rs|web\.rs|api/mod\.rs|auth_context\.rs|command\.rs|policy_router_netlink\.rs|firewall_netlink\.rs|uninstall/ops\.rs|route_monitor\.rs|mdns_advertiser\.rs|pnet_network_probe\.rs|garp_pnet\.rs|tunnel_exit_probe\.rs|tunnel_throughput_tester\.rs|tunnel_latency_prober\.rs|inbound_wg_peer_monitor\.rs|linux_watchdog\.rs|wardnet-test-agent/.*|wardnet-test-support/.*|wardnetd-mock/src/events\.rs|wardnetd-data/src/lib\.rs)
+COV_IGNORE := (main\.rs|noop_.*\.rs|db\.rs|web\.rs|api/mod\.rs|auth_context\.rs|command\.rs|policy_router_netlink\.rs|firewall_netlink\.rs|uninstall/ops\.rs|route_monitor\.rs|mdns_advertiser\.rs|mdns_observer\.rs|pnet_network_probe\.rs|garp_pnet\.rs|tunnel_exit_probe\.rs|tunnel_throughput_tester\.rs|tunnel_latency_prober\.rs|inbound_wg_peer_monitor\.rs|linux_watchdog\.rs|wardnet-test-agent/.*|wardnet-test-support/.*|wardnetd-mock/src/events\.rs|wardnetd-data/src/lib\.rs)
 # Default: human-readable summary.  CI overrides:
 #   make coverage-daemon COV_FMT="--lcov --output-path ../../coverage/daemon-lcov.info"
 COV_FMT    ?= --summary-only

--- a/source/daemon/crates/wardnetd-api/src/api/tests/devices.rs
+++ b/source/daemon/crates/wardnetd-api/src/api/tests/devices.rs
@@ -642,6 +642,14 @@ impl DeviceIdentificationService for MockIdentificationService {
     ) -> Result<(), AppError> {
         Ok(())
     }
+    async fn record_signal_for_ip(
+        &self,
+        _ip: std::net::IpAddr,
+        _kind: DeviceSignalKind,
+        _value: &str,
+    ) -> Result<(), AppError> {
+        Ok(())
+    }
     async fn signals_for(&self, _device_id: &str) -> Result<Vec<DeviceSignal>, AppError> {
         self.signals_for
             .clone()

--- a/source/daemon/crates/wardnetd-api/src/state.rs
+++ b/source/daemon/crates/wardnetd-api/src/state.rs
@@ -653,6 +653,14 @@ impl DeviceIdentificationService for NoopDeviceIdentificationService {
     ) -> Result<(), wardnetd_services::error::AppError> {
         Ok(())
     }
+    async fn record_signal_for_ip(
+        &self,
+        _ip: std::net::IpAddr,
+        _kind: wardnet_common::device::DeviceSignalKind,
+        _value: &str,
+    ) -> Result<(), wardnetd_services::error::AppError> {
+        Ok(())
+    }
     async fn signals_for(
         &self,
         _device_id: &str,

--- a/source/daemon/crates/wardnetd-api/src/tests/state.rs
+++ b/source/daemon/crates/wardnetd-api/src/tests/state.rs
@@ -48,6 +48,15 @@ async fn default_identification_service_is_a_silent_no_op() {
         .await
         .is_ok()
     );
+    assert!(
+        svc.record_signal_for_ip(
+            "192.168.1.10".parse().unwrap(),
+            DeviceSignalKind::MdnsService,
+            "_googlecast._tcp.local."
+        )
+        .await
+        .is_ok()
+    );
     assert_eq!(svc.reconcile_from_catalog().await.unwrap(), 0);
     assert!(svc.signals_for("dev-1").await.unwrap().is_empty());
 }

--- a/source/daemon/crates/wardnetd-data/src/repository/device.rs
+++ b/source/daemon/crates/wardnetd-data/src/repository/device.rs
@@ -49,7 +49,7 @@ pub trait DeviceRepository: Send + Sync {
     /// an empty set, never the departed rows that share it.
     ///
     /// The default implementation filters [`find_all`](Self::find_all); the
-    /// SQLite implementation overrides it with an indexed `last_ip` lookup.
+    /// `SQLite` implementation overrides it with an indexed `last_ip` lookup.
     async fn find_all_by_ip(&self, ip: &str) -> anyhow::Result<Vec<Device>> {
         if ip.is_empty() {
             return Ok(Vec::new());

--- a/source/daemon/crates/wardnetd-data/src/repository/device.rs
+++ b/source/daemon/crates/wardnetd-data/src/repository/device.rs
@@ -35,6 +35,33 @@ pub trait DeviceRepository: Send + Sync {
     /// Find a device by its most recently observed IP address.
     async fn find_by_ip(&self, ip: &str) -> anyhow::Result<Option<Device>>;
 
+    /// Find **every** device whose `last_ip` equals `ip`.
+    ///
+    /// Unlike [`find_by_ip`](Self::find_by_ip), which resolves a shared address
+    /// to the most-recently-seen claimant, this exposes the full set so a caller
+    /// can detect an ambiguous mapping. `last_ip` is not unique — a departed
+    /// device keeps its row until discovery clears it — so a recycled address
+    /// can transiently belong to more than one row. The mDNS observer uses this
+    /// to skip attributing a vendor when zero or more than one device claims an
+    /// address (issue #1115).
+    ///
+    /// An empty `ip` (the "no known address" sentinel of departed rows) returns
+    /// an empty set, never the departed rows that share it.
+    ///
+    /// The default implementation filters [`find_all`](Self::find_all); the
+    /// SQLite implementation overrides it with an indexed `last_ip` lookup.
+    async fn find_all_by_ip(&self, ip: &str) -> anyhow::Result<Vec<Device>> {
+        if ip.is_empty() {
+            return Ok(Vec::new());
+        }
+        Ok(self
+            .find_all()
+            .await?
+            .into_iter()
+            .filter(|d| d.last_ip == ip)
+            .collect())
+    }
+
     /// Find a device by its primary key.
     async fn find_by_id(&self, id: &str) -> anyhow::Result<Option<Device>>;
 

--- a/source/daemon/crates/wardnetd-data/src/repository/sqlite/device.rs
+++ b/source/daemon/crates/wardnetd-data/src/repository/sqlite/device.rs
@@ -122,6 +122,8 @@ struct RuleRow {
 // further down (JOIN/LIKE against routing_rules) keep their own literals.
 const FIND_BY_IP_SQL: &str = "SELECT id, mac, name, hostname, manufacturer, manufacturer_source, is_randomized, device_type, first_seen, last_seen, last_ip, admin_locked, zone_id, dns_capture_enabled, dns_capture_cap_count, dns_capture_cap_days, connection_mode \
      FROM devices WHERE last_ip = ? ORDER BY last_seen DESC LIMIT 1";
+const FIND_ALL_BY_IP_SQL: &str = "SELECT id, mac, name, hostname, manufacturer, manufacturer_source, is_randomized, device_type, first_seen, last_seen, last_ip, admin_locked, zone_id, dns_capture_enabled, dns_capture_cap_count, dns_capture_cap_days, connection_mode \
+     FROM devices WHERE last_ip = ? ORDER BY last_seen DESC";
 const FIND_BY_ID_SQL: &str = "SELECT id, mac, name, hostname, manufacturer, manufacturer_source, is_randomized, device_type, first_seen, last_seen, last_ip, admin_locked, zone_id, dns_capture_enabled, dns_capture_cap_count, dns_capture_cap_days, connection_mode \
      FROM devices WHERE id = ?";
 const FIND_BY_MAC_SQL: &str = "SELECT id, mac, name, hostname, manufacturer, manufacturer_source, is_randomized, device_type, first_seen, last_seen, last_ip, admin_locked, zone_id, dns_capture_enabled, dns_capture_cap_count, dns_capture_cap_days, connection_mode \
@@ -154,6 +156,21 @@ impl DeviceRepository for SqliteDeviceRepository {
             .fetch_optional(&self.pools.read)
             .await?;
         row.map(DeviceRow::into_device).transpose()
+    }
+
+    async fn find_all_by_ip(&self, ip: &str) -> anyhow::Result<Vec<Device>> {
+        // Empty string is the departed-device sentinel (see `find_by_ip`); never
+        // match it, or every departed row would resolve to one address.
+        if ip.is_empty() {
+            return Ok(Vec::new());
+        }
+        // Indexed `last_ip` lookup rather than the trait's default full-table
+        // scan: the mDNS observer resolves against this on every advertisement.
+        let rows = sqlx::query_as::<_, DeviceRow>(FIND_ALL_BY_IP_SQL)
+            .bind(ip)
+            .fetch_all(&self.pools.read)
+            .await?;
+        rows.into_iter().map(DeviceRow::into_device).collect()
     }
 
     async fn find_by_id(&self, id: &str) -> anyhow::Result<Option<Device>> {

--- a/source/daemon/crates/wardnetd-data/src/repository/tests/device.rs
+++ b/source/daemon/crates/wardnetd-data/src/repository/tests/device.rs
@@ -109,6 +109,60 @@ async fn find_by_ip_returns_most_recently_seen_on_collision() {
     );
 }
 
+// The mDNS observer (issue #1115) needs the *full* set of devices on an address,
+// not just the most-recently-seen one, so it can skip attributing a vendor when
+// the mapping is ambiguous. `find_all_by_ip` returns every row sharing the IP.
+#[tokio::test]
+async fn find_all_by_ip_returns_every_device_on_a_shared_address() {
+    let pool = test_pool().await;
+    insert_device_seen_at(
+        &pool,
+        DEV1,
+        "aa:bb:cc:dd:ee:01",
+        "192.168.1.10",
+        "2026-03-07T00:00:00Z",
+    )
+    .await;
+    insert_device_seen_at(
+        &pool,
+        DEV2,
+        "aa:bb:cc:dd:ee:02",
+        "192.168.1.10",
+        "2026-03-08T00:00:00Z",
+    )
+    .await;
+    insert_device(&pool, DEV3, "aa:bb:cc:dd:ee:03", "192.168.1.20").await;
+    let repo = SqliteDeviceRepository::new(pool);
+
+    let shared = repo.find_all_by_ip("192.168.1.10").await.unwrap();
+    assert_eq!(
+        shared.len(),
+        2,
+        "both claimants of the address are returned"
+    );
+
+    let lone = repo.find_all_by_ip("192.168.1.20").await.unwrap();
+    assert_eq!(lone.len(), 1);
+    assert_eq!(lone[0].id.to_string(), DEV3);
+
+    assert!(
+        repo.find_all_by_ip("10.0.0.99").await.unwrap().is_empty(),
+        "an unclaimed address matches nothing"
+    );
+}
+
+// The empty-string sentinel of departed rows must never match, exactly as in
+// `find_by_ip` — otherwise every departed device would resolve to one address.
+#[tokio::test]
+async fn find_all_by_ip_empty_returns_none() {
+    let pool = test_pool().await;
+    insert_device_seen_at(&pool, DEV1, "aa:bb:cc:dd:ee:01", "", "2026-03-07T00:00:00Z").await;
+    insert_device_seen_at(&pool, DEV2, "aa:bb:cc:dd:ee:02", "", "2026-03-08T00:00:00Z").await;
+    let repo = SqliteDeviceRepository::new(pool);
+
+    assert!(repo.find_all_by_ip("").await.unwrap().is_empty());
+}
+
 // Regression for issue #831: clearing a departed device's `last_ip` must make
 // its row unresolvable by that IP so it can never again be returned for a live
 // device's source address.

--- a/source/daemon/crates/wardnetd-data/src/tests/vendor_catalog.rs
+++ b/source/daemon/crates/wardnetd-data/src/tests/vendor_catalog.rs
@@ -1,6 +1,6 @@
 use crate::vendor_catalog::{
-    lookup_mdns_service, lookup_oui_override, lookup_tcp_port, lookup_vendor_class, probe_ports,
-    vendors,
+    lookup_mdns_service, lookup_oui_override, lookup_tcp_port, lookup_vendor_class,
+    mdns_service_types, probe_ports, vendors,
 };
 
 #[test]
@@ -120,6 +120,34 @@ fn probe_ports_are_sorted_and_bounded() {
         ports.len() < 20,
         "probe surface grew unexpectedly large: {ports:?}"
     );
+}
+
+#[test]
+fn mdns_service_types_are_sorted_bounded_and_resolvable() {
+    let types = mdns_service_types();
+    let mut sorted = types.clone();
+    sorted.sort_unstable();
+    assert_eq!(types, sorted, "browse set must be deterministic");
+
+    // The observer issues one browse per entry, so the set is a passive-traffic
+    // commitment the same way `probe_ports` bounds the active-probe surface.
+    assert!(
+        !types.is_empty(),
+        "catalog declares mDNS services but the browse set is empty"
+    );
+    assert!(
+        types.len() < 40,
+        "mDNS browse surface grew unexpectedly large: {types:?}"
+    );
+
+    // Every type the observer browses must resolve back to a vendor — otherwise
+    // the observation is recorded but never names anyone.
+    for ty in types {
+        assert!(
+            lookup_mdns_service(ty).is_some(),
+            "browsed service type {ty} does not resolve to a vendor"
+        );
+    }
 }
 
 #[test]

--- a/source/daemon/crates/wardnetd-data/src/vendor_catalog.rs
+++ b/source/daemon/crates/wardnetd-data/src/vendor_catalog.rs
@@ -198,3 +198,16 @@ pub fn probe_ports() -> Vec<u16> {
     ports.sort_unstable();
     ports
 }
+
+/// Every mDNS service type the catalog can attribute — the complete set the
+/// passive observer browses for, and by construction its upper bound.
+///
+/// Returned lowercased and without the `.local.` domain (e.g. `_govee._tcp`),
+/// exactly as declared in `vendors.toml`; the observer appends the domain the
+/// mDNS browse query expects. Sorted so the browse set is deterministic.
+#[must_use]
+pub fn mdns_service_types() -> Vec<&'static str> {
+    let mut types: Vec<&'static str> = CATALOG.by_mdns.keys().map(String::as_str).collect();
+    types.sort_unstable();
+    types
+}

--- a/source/daemon/crates/wardnetd-services/src/device/identification.rs
+++ b/source/daemon/crates/wardnetd-services/src/device/identification.rs
@@ -7,6 +7,7 @@
 //! that talks to [`DeviceIdentificationRepository`], so background components follow
 //! the "runners call services, not repositories" rule in `.agents/architecture.md`.
 
+use std::net::IpAddr;
 use std::sync::Arc;
 
 use async_trait::async_trait;
@@ -44,6 +45,23 @@ pub trait DeviceIdentificationService: Send + Sync {
     async fn record_signal_for_mac(
         &self,
         mac: &str,
+        kind: DeviceSignalKind,
+        value: &str,
+    ) -> Result<(), AppError>;
+
+    /// Record a signal against whichever device currently holds `ip`.
+    ///
+    /// The mDNS observer resolves a browse result to a device by its last
+    /// observed IP, since a service advertisement carries an address, not a
+    /// MAC. `last_ip` is not unique across the devices table — a departed
+    /// device keeps its row until discovery clears it — so an address can
+    /// transiently map to more than one device. Rather than guess (ADR 0025,
+    /// decision on mDNS: a wrong attribution is worse than no signal), an IP
+    /// that resolves to zero or to more than one device is skipped with a debug
+    /// log and `Ok(())` is returned.
+    async fn record_signal_for_ip(
+        &self,
+        ip: IpAddr,
         kind: DeviceSignalKind,
         value: &str,
     ) -> Result<(), AppError>;
@@ -170,6 +188,47 @@ impl DeviceIdentificationService for DeviceIdentificationServiceImpl {
             .map_err(AppError::Internal)?
         else {
             tracing::debug!(%mac, ?kind, "identification: no device for MAC yet, dropping signal");
+            return Ok(());
+        };
+
+        self.record_signal(&device.id.to_string(), kind, value)
+            .await
+    }
+
+    async fn record_signal_for_ip(
+        &self,
+        ip: IpAddr,
+        kind: DeviceSignalKind,
+        value: &str,
+    ) -> Result<(), AppError> {
+        auth_context::require_admin()?;
+
+        // `last_ip` is not unique: a departed device keeps its row until
+        // discovery clears the address, so DHCP recycling an IP to a new device
+        // leaves two rows sharing it. `find_by_ip` resolves that by taking the
+        // most-recently-seen row — a reasonable guess for the DNS attribution
+        // path, but the wrong call here. An mDNS advertisement that names a
+        // vendor would stamp that name on whichever device won the tie, and a
+        // confident-but-wrong manufacturer is the exact failure #1099 was filed
+        // about. So resolve the full set and attribute only when exactly one
+        // device claims the address; zero or many is ambiguous and skipped.
+        let matches: Vec<_> = self
+            .devices
+            .find_all()
+            .await
+            .map_err(AppError::Internal)?
+            .into_iter()
+            .filter(|d| d.last_ip.parse::<IpAddr>().is_ok_and(|parsed| parsed == ip))
+            .collect();
+
+        let [device] = matches.as_slice() else {
+            tracing::debug!(
+                %ip,
+                ?kind,
+                match_count = matches.len(),
+                "identification: IP maps to {} devices, skipping ambiguous mDNS attribution",
+                matches.len()
+            );
             return Ok(());
         };
 

--- a/source/daemon/crates/wardnetd-services/src/device/identification.rs
+++ b/source/daemon/crates/wardnetd-services/src/device/identification.rs
@@ -210,24 +210,22 @@ impl DeviceIdentificationService for DeviceIdentificationServiceImpl {
         // path, but the wrong call here. An mDNS advertisement that names a
         // vendor would stamp that name on whichever device won the tie, and a
         // confident-but-wrong manufacturer is the exact failure #1099 was filed
-        // about. So resolve the full set and attribute only when exactly one
-        // device claims the address; zero or many is ambiguous and skipped.
-        let matches: Vec<_> = self
+        // about. So resolve the full set (an indexed `last_ip` lookup) and
+        // attribute only when exactly one device claims the address; zero or
+        // many is ambiguous and skipped.
+        let matches = self
             .devices
-            .find_all()
+            .find_all_by_ip(&ip.to_string())
             .await
-            .map_err(AppError::Internal)?
-            .into_iter()
-            .filter(|d| d.last_ip.parse::<IpAddr>().is_ok_and(|parsed| parsed == ip))
-            .collect();
+            .map_err(AppError::Internal)?;
 
         let [device] = matches.as_slice() else {
+            let match_count = matches.len();
             tracing::debug!(
                 %ip,
                 ?kind,
-                match_count = matches.len(),
-                "identification: IP maps to {} devices, skipping ambiguous mDNS attribution",
-                matches.len()
+                match_count,
+                "identification: IP {ip} maps to {match_count} devices, skipping ambiguous mDNS {kind:?} attribution",
             );
             return Ok(());
         };

--- a/source/daemon/crates/wardnetd-services/src/device/tests/identification.rs
+++ b/source/daemon/crates/wardnetd-services/src/device/tests/identification.rs
@@ -51,6 +51,16 @@ async fn build() -> Harness {
 
 /// Insert a device with no manufacturer, returning its id.
 async fn insert_device(devices: &Arc<dyn DeviceRepository>, mac: &str) -> String {
+    insert_device_with_ip(devices, mac, "192.168.1.10").await
+}
+
+/// Insert a device with no manufacturer at a specific `last_ip`, returning its
+/// id. The IP is what the mDNS observer resolves against.
+async fn insert_device_with_ip(
+    devices: &Arc<dyn DeviceRepository>,
+    mac: &str,
+    last_ip: &str,
+) -> String {
     let id = uuid::Uuid::new_v4().to_string();
     devices
         .insert(&DeviceRow {
@@ -63,7 +73,7 @@ async fn insert_device(devices: &Arc<dyn DeviceRepository>, mac: &str) -> String
             device_type: "unknown".to_owned(),
             first_seen: "2026-03-07T00:00:00Z".to_owned(),
             last_seen: "2026-03-07T00:00:00Z".to_owned(),
-            last_ip: "192.168.1.10".to_owned(),
+            last_ip: last_ip.to_owned(),
             zone_id: ZONE.to_owned(),
             connection_mode: DeviceConnectionMode::Lan,
         })
@@ -303,6 +313,94 @@ async fn record_for_mac_is_case_insensitive() {
     .unwrap();
 
     assert_eq!(as_admin(h.svc.signals_for(&id)).await.unwrap().len(), 1);
+}
+
+#[tokio::test]
+async fn an_mdns_signal_names_the_single_device_holding_an_ip() {
+    // The happy path: an IP that resolves to exactly one device attributes the
+    // observed service type to it, just like the MAC path.
+    let h = build().await;
+    let id = insert_device_with_ip(&h.devices, "aa:bb:cc:dd:ee:01", "192.168.1.42").await;
+
+    as_admin(h.svc.record_signal_for_ip(
+        "192.168.1.42".parse().unwrap(),
+        DeviceSignalKind::MdnsService,
+        "_googlecast._tcp.local.",
+    ))
+    .await
+    .unwrap();
+
+    let device = h.devices.find_by_id(&id).await.unwrap().unwrap();
+    assert_eq!(device.manufacturer.as_deref(), Some("Google"));
+    assert_eq!(as_admin(h.svc.signals_for(&id)).await.unwrap().len(), 1);
+}
+
+#[tokio::test]
+async fn an_ip_with_no_device_is_skipped() {
+    // A browse result for an address no device currently holds is dropped
+    // rather than failing — an observability side-effect must never error out
+    // the passive observer.
+    let h = build().await;
+    let id = insert_device_with_ip(&h.devices, "aa:bb:cc:dd:ee:01", "192.168.1.42").await;
+
+    as_admin(h.svc.record_signal_for_ip(
+        "192.168.1.99".parse().unwrap(),
+        DeviceSignalKind::MdnsService,
+        "_googlecast._tcp.local.",
+    ))
+    .await
+    .unwrap();
+
+    let device = h.devices.find_by_id(&id).await.unwrap().unwrap();
+    assert_eq!(device.manufacturer, None);
+    assert!(as_admin(h.svc.signals_for(&id)).await.unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn an_ip_shared_by_two_devices_is_skipped() {
+    // The core of the ADR's mDNS decision: `last_ip` is not unique (a departed
+    // row can still hold a recycled address), and a wrong attribution is worse
+    // than no signal. When an IP maps to more than one device, neither is
+    // named and nothing is recorded.
+    let h = build().await;
+    let a = insert_device_with_ip(&h.devices, "aa:bb:cc:dd:ee:01", "192.168.1.42").await;
+    let b = insert_device_with_ip(&h.devices, "aa:bb:cc:dd:ee:02", "192.168.1.42").await;
+
+    as_admin(h.svc.record_signal_for_ip(
+        "192.168.1.42".parse().unwrap(),
+        DeviceSignalKind::MdnsService,
+        "_googlecast._tcp.local.",
+    ))
+    .await
+    .unwrap();
+
+    for id in [&a, &b] {
+        let device = h.devices.find_by_id(id).await.unwrap().unwrap();
+        assert_eq!(device.manufacturer, None, "no device may be named on a tie");
+        assert!(
+            as_admin(h.svc.signals_for(id)).await.unwrap().is_empty(),
+            "no signal may be recorded on a tie"
+        );
+    }
+}
+
+#[tokio::test]
+async fn record_signal_for_ip_is_admin_gated() {
+    // The observer is a background component and must supply an admin context,
+    // exactly like the DHCP producer.
+    let h = build().await;
+    insert_device_with_ip(&h.devices, "aa:bb:cc:dd:ee:01", "192.168.1.42").await;
+
+    let result = h
+        .svc
+        .record_signal_for_ip(
+            "192.168.1.42".parse().unwrap(),
+            DeviceSignalKind::MdnsService,
+            "_googlecast._tcp.local.",
+        )
+        .await;
+
+    assert!(result.is_err(), "no ambient context must be refused");
 }
 
 #[tokio::test]

--- a/source/daemon/crates/wardnetd-services/src/device/tests/ip_snapshot.rs
+++ b/source/daemon/crates/wardnetd-services/src/device/tests/ip_snapshot.rs
@@ -163,6 +163,34 @@ fn sample_device(id: &str, ip: &str, last_seen: &str) -> Device {
 
 // -- Tests --------------------------------------------------------------
 
+// Exercises the `DeviceRepository::find_all_by_ip` *default* implementation
+// (issue #1115). `MockDeviceRepo` does not override it, so it runs the trait's
+// find_all-and-filter fallback — the path the SQLite repository overrides for
+// production and that its own tests therefore never touch.
+#[tokio::test]
+async fn find_all_by_ip_default_filters_and_skips_the_empty_sentinel() {
+    let a = Uuid::new_v4();
+    let b = Uuid::new_v4();
+    let repo = MockDeviceRepo::new(vec![
+        sample_device(&a.to_string(), "192.168.1.50", "2026-03-07T00:00:00Z"),
+        sample_device(&b.to_string(), "192.168.1.50", "2026-03-08T00:00:00Z"),
+        sample_device(
+            &Uuid::new_v4().to_string(),
+            "192.168.1.60",
+            "2026-03-07T00:00:00Z",
+        ),
+        // A departed device carrying the empty sentinel must never match.
+        sample_device(&Uuid::new_v4().to_string(), "", "2026-03-07T00:00:00Z"),
+    ]);
+
+    assert_eq!(repo.find_all_by_ip("192.168.1.50").await.unwrap().len(), 2);
+    assert_eq!(repo.find_all_by_ip("192.168.1.60").await.unwrap().len(), 1);
+    assert!(repo.find_all_by_ip("10.0.0.1").await.unwrap().is_empty());
+    // The empty-string guard returns before scanning, so it never matches the
+    // departed row above.
+    assert!(repo.find_all_by_ip("").await.unwrap().is_empty());
+}
+
 #[tokio::test]
 async fn new_snapshot_is_empty_before_rebuild() {
     let repo = Arc::new(MockDeviceRepo::new(vec![]));

--- a/source/daemon/crates/wardnetd/src/dhcp/tests/server.rs
+++ b/source/daemon/crates/wardnetd/src/dhcp/tests/server.rs
@@ -2091,6 +2091,15 @@ impl wardnetd_services::device::DeviceIdentificationService for RecordingIdentif
         Ok(())
     }
 
+    async fn record_signal_for_ip(
+        &self,
+        _ip: std::net::IpAddr,
+        _kind: DeviceSignalKind,
+        _value: &str,
+    ) -> Result<(), AppError> {
+        unimplemented!("the DHCP path records by MAC")
+    }
+
     async fn signals_for(
         &self,
         _device_id: &str,

--- a/source/daemon/crates/wardnetd/src/lib.rs
+++ b/source/daemon/crates/wardnetd/src/lib.rs
@@ -47,6 +47,7 @@ pub mod health_runner;
 pub mod heartbeat;
 pub mod inbound_wg_peer_monitor;
 pub mod mdns_advertiser;
+pub mod mdns_observer;
 pub mod metrics_collector;
 pub mod profiling;
 pub mod route_monitor;

--- a/source/daemon/crates/wardnetd/src/main.rs
+++ b/source/daemon/crates/wardnetd/src/main.rs
@@ -721,11 +721,15 @@ async fn run(
         None
     };
 
-    // Start the mDNS observer alongside the advertiser: it browses the LAN for
-    // catalogued service advertisements and records them as device
-    // identification signals (issue #1115). Passive and non-fatal — a failure
-    // here just drops one identification signal, so we log and continue.
-    let mdns_observer = if config.mdns.enabled {
+    // Start the mDNS observer: it browses the LAN for catalogued service
+    // advertisements and records them as device identification signals (issue
+    // #1115). It is gated on `detection.enabled`, not `mdns.enabled`: the mDNS
+    // flag governs whether the daemon *advertises* its own hostname, an
+    // independent concern from passively *observing* other devices. Observation
+    // is an identification signal source alongside the packet-capture detector,
+    // so it lives and dies with device detection. Passive and non-fatal — a
+    // failure here just drops one identification signal, so we log and continue.
+    let mdns_observer = if config.detection.enabled {
         match MdnsObserver::start(
             services.device_identification.clone(),
             &config.network.lan_interface,
@@ -738,7 +742,7 @@ async fn run(
             }
         }
     } else {
-        tracing::info!("mDNS observer disabled");
+        tracing::info!("mDNS observer disabled (device detection off)");
         None
     };
 

--- a/source/daemon/crates/wardnetd/src/main.rs
+++ b/source/daemon/crates/wardnetd/src/main.rs
@@ -36,6 +36,7 @@ use wardnetd::hostname_resolver::SystemHostnameResolver;
 use wardnetd::inbound_wg_interface_wireguard::WireGuardInboundInterface;
 use wardnetd::inbound_wg_peer_monitor::InboundWgPeerMonitor;
 use wardnetd::mdns_advertiser::MdnsAdvertiser;
+use wardnetd::mdns_observer::MdnsObserver;
 use wardnetd::metrics_collector::MetricsCollector;
 use wardnetd::noop_tunnel_backends::{
     NoopExitProbe, NoopLatencyProber, NoopThroughputTester, NoopTunnelInterface,
@@ -720,6 +721,27 @@ async fn run(
         None
     };
 
+    // Start the mDNS observer alongside the advertiser: it browses the LAN for
+    // catalogued service advertisements and records them as device
+    // identification signals (issue #1115). Passive and non-fatal — a failure
+    // here just drops one identification signal, so we log and continue.
+    let mdns_observer = if config.mdns.enabled {
+        match MdnsObserver::start(
+            services.device_identification.clone(),
+            &config.network.lan_interface,
+            &root_span,
+        ) {
+            Ok(observer) => Some(observer),
+            Err(e) => {
+                tracing::warn!(error = %e, "failed to start mDNS observer; continuing without it: {e}");
+                None
+            }
+        }
+    } else {
+        tracing::info!("mDNS observer disabled");
+        None
+    };
+
     // Start device detector (conditionally).
     let device_detector = if config.detection.enabled {
         Some(DeviceDetector::start(
@@ -1293,6 +1315,9 @@ async fn run(
     heartbeat_runner.shutdown().await;
     if let Some(advertiser) = mdns_advertiser {
         advertiser.shutdown().await;
+    }
+    if let Some(observer) = mdns_observer {
+        observer.shutdown().await;
     }
     if let Some(detector) = device_detector {
         detector.shutdown().await;

--- a/source/daemon/crates/wardnetd/src/mdns_observer.rs
+++ b/source/daemon/crates/wardnetd/src/mdns_observer.rs
@@ -1,0 +1,198 @@
+//! mDNS observer — passively watches the LAN for service advertisements and
+//! records them as device identification signals (issue #1115).
+//!
+//! mDNS is the signal that names most smart-home gear outright: `_googlecast._tcp`,
+//! `_hap._tcp` and `_esphomelib._tcp` are unambiguous vendor tells. Observing
+//! them costs nothing beyond a passive listener joined to the standard mDNS
+//! multicast group — no unicast traffic is directed at the admin's own devices,
+//! so this sits on the right side of ADR 0025's "no background probing"
+//! invariant (decision 5), which is about active per-device probes.
+//!
+//! The observer browses **only** the service types the curated catalog can
+//! attribute ([`vendor_catalog::mdns_service_types`]). That keeps the
+//! observation surface bounded by the catalog — the same commitment
+//! `probe_ports` makes for the admin-triggered probe — and asserted small by
+//! test.
+//!
+//! ## IP → device
+//!
+//! A browse result yields an IP address, not a MAC. Resolution to a device
+//! happens in [`DeviceIdentificationService::record_signal_for_ip`], which maps
+//! the address through the devices table's `last_ip` and **skips ambiguous
+//! mappings rather than guessing** (0 or >1 match). ADR 0025 records why: a
+//! wrong attribution would put a confident vendor name on the wrong device,
+//! which is exactly the failure mode issue #1099 was filed about.
+//!
+//! The observer is a background component, so it calls the *service*, never the
+//! repository (`.agents/architecture.md`), under an explicit admin context (the
+//! browse loop has no ambient one), mirroring the DHCP identification producer.
+//!
+//! Like the advertiser, the observer is a Linux-production concern: the mock
+//! binary does not start it, and a startup failure is non-fatal — identification
+//! simply loses one of several signals.
+
+use std::sync::Arc;
+
+use futures::StreamExt;
+use futures::stream::select_all;
+use mdns_sd::{IfKind, ResolvedService, ServiceDaemon, ServiceEvent};
+use tokio_util::sync::CancellationToken;
+use tracing::Instrument;
+use uuid::Uuid;
+
+use wardnet_common::auth::AuthContext;
+use wardnet_common::device::DeviceSignalKind;
+use wardnetd_data::vendor_catalog;
+use wardnetd_services::auth_context;
+use wardnetd_services::device::DeviceIdentificationService;
+
+/// Background runner that owns the browsing [`ServiceDaemon`] for the lifetime
+/// of the daemon and tears it down on shutdown.
+///
+/// Mirrors [`crate::mdns_advertiser::MdnsAdvertiser`]: a self-contained runner
+/// with `start`/`shutdown` methods and no service-layer trait.
+pub struct MdnsObserver {
+    daemon: ServiceDaemon,
+    cancel: CancellationToken,
+    handle: tokio::task::JoinHandle<()>,
+}
+
+impl MdnsObserver {
+    /// Start the observer.
+    ///
+    /// Joins the LAN interface's mDNS group, opens a browse per catalogued
+    /// service type, and spawns a background task that records each resolved
+    /// service against the device holding its address.
+    ///
+    /// Returns `Err` only if the daemon thread cannot be created or the LAN
+    /// interface cannot be enabled. Individual browse failures are logged and
+    /// skipped. Callers should log a start error and continue — identification
+    /// keeps working from its other signals.
+    pub fn start(
+        identification: Arc<dyn DeviceIdentificationService>,
+        lan_interface: &str,
+        parent: &tracing::Span,
+    ) -> anyhow::Result<Self> {
+        let span = tracing::info_span!(parent: parent, "mdns_observer");
+        let _enter = span.enter();
+
+        let daemon = ServiceDaemon::new()
+            .map_err(|e| anyhow::anyhow!("failed to create mDNS observer daemon: {e}"))?;
+
+        // Confine browsing to the LAN interface. `wg_ward*` tunnels and loopback
+        // must never carry these queries — the same restriction the advertiser
+        // applies. `disable_interface(All)` first so only the explicit LAN
+        // interface is enabled.
+        if let Err(e) = daemon.disable_interface(IfKind::All) {
+            tracing::warn!(error = %e, "mDNS observer: failed to disable default interfaces; continuing");
+        }
+        daemon
+            .enable_interface(IfKind::Name(lan_interface.to_owned()))
+            .map_err(|e| {
+                anyhow::anyhow!("failed to enable mDNS observer on interface {lan_interface}: {e}")
+            })?;
+
+        // Browse exactly the service types the catalog can attribute. The
+        // catalog stores them without the domain (`_govee._tcp`); the browse
+        // query wants it fully qualified.
+        let service_types = vendor_catalog::mdns_service_types();
+        let mut streams = Vec::with_capacity(service_types.len());
+        for ty in &service_types {
+            let query = browse_query(ty);
+            match daemon.browse(&query) {
+                Ok(rx) => streams.push(rx.into_stream().boxed()),
+                Err(e) => {
+                    tracing::warn!(service_type = %query, error = %e, "mDNS observer: failed to browse {query}; continuing");
+                }
+            }
+        }
+
+        tracing::info!(
+            interface = %lan_interface,
+            browsed = streams.len(),
+            "mDNS observer started: interface={lan_interface}, browsing {} service type(s)",
+            streams.len(),
+        );
+
+        let cancel = CancellationToken::new();
+        let cancel_clone = cancel.clone();
+        let observer_span = tracing::Span::current();
+        let handle = tokio::spawn(
+            async move {
+                // Merge every per-type browse stream into one. An empty set (all
+                // browses failed) yields `None` immediately and drops straight to
+                // waiting for shutdown — no busy loop, no panic.
+                let mut events = select_all(streams);
+                loop {
+                    tokio::select! {
+                        () = cancel_clone.cancelled() => break,
+                        event = events.next() => match event {
+                            Some(ServiceEvent::ServiceResolved(info)) => {
+                                record_resolved(identification.as_ref(), info.as_ref()).await;
+                            }
+                            // SearchStarted / ServiceFound / ServiceRemoved /
+                            // SearchStopped carry no address to attribute.
+                            Some(_) => {}
+                            None => {
+                                cancel_clone.cancelled().await;
+                                break;
+                            }
+                        },
+                    }
+                }
+            }
+            .instrument(observer_span),
+        );
+
+        Ok(Self {
+            daemon,
+            cancel,
+            handle,
+        })
+    }
+
+    /// Tear down the observer: stop the browse loop and shut the daemon down.
+    pub async fn shutdown(self) {
+        self.cancel.cancel();
+        let _ = self.handle.await;
+        if let Err(e) = self.daemon.shutdown() {
+            tracing::warn!(error = %e, "mDNS observer daemon shutdown failed: {e}");
+        }
+        tracing::info!("mDNS observer shut down");
+    }
+}
+
+/// The fully-qualified browse query for a catalogued service type.
+///
+/// The catalog stores service types without a domain (`_govee._tcp`), while an
+/// mDNS browse query wants it terminated with the local domain
+/// (`_govee._tcp.local.`).
+pub(crate) fn browse_query(service_type: &str) -> String {
+    format!("{service_type}.local.")
+}
+
+/// Record every address a resolved service advertised as an [`MdnsService`]
+/// signal for the device holding that address.
+///
+/// A resolved service can carry several addresses (IPv4 plus IPv6); each is
+/// resolved independently, and the service's ambiguity skip means an address no
+/// single device claims is simply dropped. Runs under an explicit admin context
+/// because the identification service is auth-gated and this browse loop is a
+/// background task with no ambient context of its own.
+///
+/// [`MdnsService`]: DeviceSignalKind::MdnsService
+async fn record_resolved(identification: &dyn DeviceIdentificationService, info: &ResolvedService) {
+    for scoped in &info.addresses {
+        let ip = scoped.to_ip_addr();
+        let result = auth_context::with_context(
+            AuthContext::Admin {
+                admin_id: Uuid::nil(),
+            },
+            identification.record_signal_for_ip(ip, DeviceSignalKind::MdnsService, &info.ty_domain),
+        )
+        .await;
+        if let Err(error) = result {
+            tracing::debug!(%ip, service_type = %info.ty_domain, %error, "mDNS observer: failed to record signal");
+        }
+    }
+}

--- a/source/daemon/crates/wardnetd/src/mdns_observer.rs
+++ b/source/daemon/crates/wardnetd/src/mdns_observer.rs
@@ -134,6 +134,14 @@ impl MdnsObserver {
                             // SearchStopped carry no address to attribute.
                             Some(_) => {}
                             None => {
+                                // Every browse stream ended without a shutdown
+                                // request — the daemon's channels closed under us
+                                // (internal failure, all senders dropped). No more
+                                // observations will arrive; surface it rather than
+                                // parking indistinguishably from a healthy idle.
+                                tracing::warn!(
+                                    "mDNS observer: all browse streams ended unexpectedly; no further service advertisements will be observed"
+                                );
                                 cancel_clone.cancelled().await;
                                 break;
                             }
@@ -192,7 +200,16 @@ async fn record_resolved(identification: &dyn DeviceIdentificationService, info:
         )
         .await;
         if let Err(error) = result {
-            tracing::debug!(%ip, service_type = %info.ty_domain, %error, "mDNS observer: failed to record signal");
+            // The service returns Ok for the ambiguous/zero-match skips, so an
+            // Err here is a genuine backend failure (e.g. a write error), not a
+            // dropped attribution — warn so a sustained outage is visible.
+            let service_type = &info.ty_domain;
+            tracing::warn!(
+                %ip,
+                %service_type,
+                %error,
+                "mDNS observer: failed to record {service_type} signal for {ip}: {error}"
+            );
         }
     }
 }

--- a/source/daemon/crates/wardnetd/src/tests/mdns_observer.rs
+++ b/source/daemon/crates/wardnetd/src/tests/mdns_observer.rs
@@ -1,0 +1,29 @@
+use wardnetd_data::vendor_catalog::{lookup_mdns_service, mdns_service_types};
+
+use crate::mdns_observer::browse_query;
+
+#[test]
+fn browse_query_appends_the_local_domain() {
+    // The catalog stores bare service types; the mDNS browse query wants them
+    // fully qualified. Building the daemon and binding multicast is out of scope
+    // for a unit test (see `mdns_advertiser` tests), so the query construction
+    // is what we lock down here.
+    assert_eq!(browse_query("_govee._tcp"), "_govee._tcp.local.");
+}
+
+#[test]
+fn every_browsed_type_round_trips_to_a_vendor() {
+    // The observer browses exactly the catalogued service types and records the
+    // fully-qualified `ty_domain` it gets back. That value must resolve to a
+    // vendor through the same catalog, or the observation would be stored yet
+    // name nobody — pin the whole loop end to end.
+    let types = mdns_service_types();
+    assert!(!types.is_empty(), "nothing to browse for");
+    for ty in types {
+        let query = browse_query(ty);
+        assert!(
+            lookup_mdns_service(&query).is_some(),
+            "browse query {query} does not resolve back to a vendor",
+        );
+    }
+}

--- a/source/daemon/crates/wardnetd/src/tests/mod.rs
+++ b/source/daemon/crates/wardnetd/src/tests/mod.rs
@@ -9,6 +9,7 @@ mod hostname_resolver;
 mod inbound_wg_interface_wireguard;
 mod linux_watchdog;
 mod mdns_advertiser;
+mod mdns_observer;
 mod metrics_collector;
 mod packet_capture;
 mod pidfile;


### PR DESCRIPTION
Closes #1115.

## Summary

Adds a passive mDNS observer that names smart-home gear from the service types it advertises, wired into the daemon next to the existing advertiser. `vendors.toml` already declared `mdns_services` per vendor and the identification service already handled `DeviceSignalKind::MdnsService` — nothing ever observed one. This closes that gap.

## What changed

- **New `wardnetd/src/mdns_observer.rs`** — browses the LAN with `mdns_sd::ServiceDaemon::browse`, confined to the LAN interface (same restriction as the advertiser). It browses **only the service types the vendor catalog can attribute** (`_googlecast._tcp`, `_hap._tcp`, `_esphomelib._tcp`, …), so the observation surface is bounded by the catalog — the same commitment `probe_ports` makes for the admin-triggered probe, asserted small by test. Each resolved service's addresses are recorded under an explicit admin context (the browse loop has no ambient one), mirroring the DHCP identification producer.

- **IP → device resolution** — a browse result carries an IP, not a MAC. New `DeviceIdentificationService::record_signal_for_ip` resolves the address through the devices table and **skips ambiguous mappings rather than guessing**: `last_ip` is not unique (a departed row can still hold a recycled address), so an IP resolving to zero *or more than one* device is dropped with a debug log. A wrong attribution would stamp a confident vendor name on the wrong device — the exact failure mode #1099 was filed about (ADR 0025). Resolution goes through a new indexed `DeviceRepository::find_all_by_ip` (`WHERE last_ip = ?`) rather than a full-table scan.

- **Naming rules preserved** — a catalogued service type fills in a device's manufacturer only when it has none; an IEEE-sourced manufacturer is never overwritten (existing `set_manufacturer_if_absent` first-writer-wins).

- **Wiring** — started in `main.rs`, gated on `detection.enabled` (an identification-signal concern, independent of the advertiser's hostname-publish switch), non-fatal on failure, shuts down cleanly. The mock binary does not start it. Follows the `mdns_observer` tracing span under the root span.

## Non-goals (per the issue)

No SSDP, no mDNS *instance* names (service types only — instance names can carry personal information), no change to the advertiser.

## Testing

- Ambiguity skip (0 / 1 / >1 match), admin-gating, and catalogued-type naming covered at the service layer; `find_all_by_ip` covered at the repository layer; bounded browse surface and end-to-end catalog round-trip covered in the observer/catalog tests.
- `cargo fmt --all --check` clean, `cargo clippy --workspace --all-targets -- -D warnings` clean, full daemon test suite passes.