### PR TITLE
feat(devices): explicit managed flag, Stop managing, and 30-day retention

### DIFF
--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -164,7 +164,8 @@ Eviction is **subtree-scoped**, not exact-name (issue #1184). Every form of loca
 ### Background runners call auth-gated services, never repositories
 
 Background runners (`DnsRunner`, `DnsFilterRunner`, `DnsQueryLogRunner`,
-`DbMaintenanceRunner`, `DhcpLanRunner`) hold `Arc<dyn *Service>` trait
+`DbMaintenanceRunner`, `DeviceRetentionRunner`, `DhcpLanRunner`) hold
+`Arc<dyn *Service>` trait
 objects, **not** repository handles. Each runs its service calls under an
 admin auth context:
 
@@ -448,7 +449,7 @@ path — so idempotent by construction) publishes a dedicated
 existing `PUT /api/devices/{id}/zone`. Note `DeviceDiscovered` is **not** a
 valid first-ever signal (it also fires on every reconnect).
 
-## Managed devices subsystem (issue #1181)
+## Managed devices + retention subsystem (issue #1181)
 
 See [ADR 0032](../docs/adr/0032-managed-devices-and-retention.md) for the
 reasoning; this is the shape.
@@ -459,8 +460,8 @@ explicit release. That gives the invariant everything else rests on:
 
 > `managed = 0` implies no admin artefacts exist for this device.
 
-which is what a future retention prune will rely on to delete an unmanaged
-row without checking anything else.
+which is why `DeviceRetentionRunner` can delete an unmanaged row without
+checking anything else.
 
 ### Promotion
 
@@ -479,8 +480,8 @@ the auth context, not on the write succeeding:
 would make every guest device permanently exempt from retention.
 
 **Adding a new per-device table? Decide whether it promotes.** If an admin
-creates the row, it must — otherwise device retention will cascade it away 30
-days after the device was last seen, silently.
+creates the row, it must — otherwise the prune will cascade it away 30 days
+after the device was last seen, silently.
 
 ### Release (`POST /api/devices/{id}/release`)
 
@@ -494,5 +495,17 @@ leaves the device still managed — never half-released with a live credential i
 is no longer recorded as owning. Every step is idempotent, so a retry
 completes.
 
+### Prune (`DeviceDiscoveryService::prune_unmanaged_devices`)
+
+Lives on the *discovery* service because deleting the row is only half the job.
+**Delete first, then evict from memory, holding `lock_for_mac(mac)` across
+both.** Skipping the eviction leaves the pruned MAC in `state` with
+`gone = true`, so the next observation takes the `Reappear` arm with a dangling
+`device_id`; `update_last_seen_and_ip` then matches zero rows and returns
+`Ok(())` silently, `handle_unknown_mac` is never reached, and the device is
+invisible in the UI while its traffic flows unattributed until restart.
+Evicting first is wrong the other way — an observation in the window re-inserts
+from the not-yet-deleted row. Also evicts `ip_history` and `device_locks`,
+which nothing bounded before.
 
 [`NetworkZone`]: ../source/daemon/crates/wardnet-common/src/network_zone.rs

--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -448,4 +448,51 @@ path — so idempotent by construction) publishes a dedicated
 existing `PUT /api/devices/{id}/zone`. Note `DeviceDiscovered` is **not** a
 valid first-ever signal (it also fires on every reconnect).
 
+## Managed devices subsystem (issue #1181)
+
+See [ADR 0032](../docs/adr/0032-managed-devices-and-retention.md) for the
+reasoning; this is the shape.
+
+`devices.managed` is an explicit, latching column — **never** derived from
+`name`. It is promoted by any *admin* configuration act and cleared only by an
+explicit release. That gives the invariant everything else rests on:
+
+> `managed = 0` implies no admin artefacts exist for this device.
+
+which is what a future retention prune will rely on to delete an unmanaged
+row without checking anything else.
+
+### Promotion
+
+Routed through `DeviceService::mark_managed` (per the
+single-service-per-repository rule) from `PrivateDnsService::grant_device`,
+`InboundWgService::add_peer`, and `RoutingProfileService::set_device_profiles`.
+Services that already hold `DeviceRepository` directly — `dhcp`,
+`network_zone`, `zone_exception`, `dns_filter` — call `set_managed` on it
+rather than acquiring a second handle; do not extend those holdings to new
+services.
+
+Two call sites are reachable by a **non-admin** caller and gate promotion on
+the auth context, not on the write succeeding:
+`DeviceDiscoveryService::update_device` (a device may rename itself) and
+`DeviceService::set_rule` (a device may set its own routing). Promoting there
+would make every guest device permanently exempt from retention.
+
+**Adding a new per-device table? Decide whether it promotes.** If an admin
+creates the row, it must — otherwise device retention will cascade it away 30
+days after the device was last seen, silently.
+
+### Release (`POST /api/devices/{id}/release`)
+
+Lives in `wardnetd-api/src/api/devices.rs`, **not** in `DeviceService`, and
+that is forced: `InboundWgServiceImpl` and `PrivateDnsServiceImpl` both hold
+`Arc<dyn DeviceService>`, so the reverse edge would be an `Arc` cycle and a
+construction-order deadlock.
+
+It reverts every artefact and sets `managed = 0` **last**, so a partial failure
+leaves the device still managed — never half-released with a live credential it
+is no longer recorded as owning. Every step is idempotent, so a retry
+completes.
+
+
 [`NetworkZone`]: ../source/daemon/crates/wardnet-common/src/network_zone.rs

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -123,6 +123,14 @@ you're about to make, rather than the whole set.
   session**; the **Admin role** + **Local admin** break-glass pair; and why
   a forward-auth gate breaks native mobile clients while app-native OIDC
   does not.
+- **[Managed devices](.agents/architecture.md#managed-devices-subsystem-issue-1181)** —
+  `devices.managed` as an explicit **latching** column (never derived from
+  `name`), promoted by any *admin* configuration act and cleared only by an
+  explicit **release**; and why the release orchestration lives in the API
+  handler (an `Arc` cycle with `InboundWgService` / `PrivateDnsService`).
+  Invariant: **`managed = 0` implies no admin artefacts exist**, which is what
+  makes device retention safe. A new per-device table must decide whether it
+  promotes. See [ADR 0032](docs/adr/0032-managed-devices-and-retention.md).
 - **[Auth model](.agents/auth.md)** — setup wizard,
   unauthenticated vs admin endpoints, and the HARD REQUIREMENT
   that every service method opens with

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -123,13 +123,15 @@ you're about to make, rather than the whole set.
   session**; the **Admin role** + **Local admin** break-glass pair; and why
   a forward-auth gate breaks native mobile clients while app-native OIDC
   does not.
-- **[Managed devices](.agents/architecture.md#managed-devices-subsystem-issue-1181)** —
+- **[Managed devices + retention](.agents/architecture.md#managed-devices--retention-subsystem-issue-1181)** —
   `devices.managed` as an explicit **latching** column (never derived from
   `name`), promoted by any *admin* configuration act and cleared only by an
-  explicit **release**; and why the release orchestration lives in the API
-  handler (an `Arc` cycle with `InboundWgService` / `PrivateDnsService`).
-  Invariant: **`managed = 0` implies no admin artefacts exist**, which is what
-  makes device retention safe. A new per-device table must decide whether it
+  explicit **release**; the `DeviceRetentionRunner` that deletes unmanaged
+  devices absent over 30 days; why the release orchestration lives in the API
+  handler (an `Arc` cycle with `InboundWgService` / `PrivateDnsService`); and
+  why the prune must **delete then evict** the MAC from discovery's in-memory
+  maps. Invariant: **`managed = 0` implies no admin artefacts exist**, which is
+  what makes the prune safe. A new per-device table must decide whether it
   promotes. See [ADR 0032](docs/adr/0032-managed-devices-and-retention.md).
 - **[Auth model](.agents/auth.md)** — setup wizard,
   unauthenticated vs admin endpoints, and the HARD REQUIREMENT

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -88,6 +88,14 @@
 
 **Derived MAC** (neighbour MAC) — One of the several addresses a single chipset derives from one base MAC. Espressif assigns Wi-Fi STA, Wi-Fi AP, Bluetooth and Ethernet as base+0/+1/+2/+3. This is why the MAC printed in a vendor's mobile app — often the **Bluetooth** one — is not the address the device associated with over Wi-Fi, and why an admin comparing the two is unknowingly comparing different identifiers. Wardnet's device search answers this by offering devices within ±4 of a missed exact MAC search as clearly-labelled *possible* matches.
 
+## Managed devices and retention (issue #1181)
+
+**Managed device** — A `Device` whose configuration an admin has decided to control. Promotion is automatic on *any* admin configuration act — naming, locking, a routing rule or profile, DNS filter settings, DNS capture, a **Private-DNS grant**, a **Remote peer** credential, a DHCP reservation, a **Cross-zone exception**, or an explicit zone reassignment. It is deliberately *not* inferred from the name alone. A device's own self-service acts never promote it — that is the device asking, not the admin deciding. Managed is **latching**: it never demotes automatically, only through an explicit **release**. Only unmanaged devices are subject to **device retention**. See [0032-managed-devices-and-retention.md](docs/adr/0032-managed-devices-and-retention.md).
+
+**Release** ("Stop managing") — The admin action that reverts every managed configuration to default and returns the device to unmanaged. Destructive and confirmed: it revokes remote access.
+
+**Device retention** — Unmanaged devices absent longer than 30 days are deleted. Managed devices are never auto-deleted at any age.
+
 ## Remote access (inbound WireGuard + published access)
 
 **Remote peer** — A `Device`, previously discovered on the LAN, that an admin has explicitly granted an inbound WireGuard credential (issue #810). Not a separate identity: the credential (`inbound_wg_peers.device_id`, one per device) attaches to the device's existing row, so it participates in **Routing rule**, **Network Zone** enforcement, and DNS capture exactly like any LAN device — there is deliberately no separate device concept for it. There is no way to grant remote access to a device that has never connected to the LAN; the MAC needed to link the credential can't be known in advance, since modern OSes randomize the MAC presented to a network the device hasn't associated with before. Distinguished from a device currently on the LAN only by its live `connection_mode` (`lan` | `remote`), which flips with whichever path — LAN or tunnel — most recently observed the device; it is not a permanent record of how the device was first discovered.

--- a/docs/adr/0032-managed-devices-and-retention.md
+++ b/docs/adr/0032-managed-devices-and-retention.md
@@ -1,0 +1,221 @@
+---
+status: accepted
+date: 2026-08-10
+issue: "#1181 (devices table has no retention policy)"
+---
+
+# ADR: `managed` becomes an explicit latching column, and only unmanaged devices are ever pruned
+
+---
+
+## Context
+
+The `devices` table has no retention policy. A row is created on discovery and
+never deleted. On a live box with 23 days of uptime: 42 devices, 19 named, 23
+unnamed, arriving at roughly one a day and never leaving.
+
+MAC randomization sharpens this into a real problem rather than a slow leak. A
+phone that re-randomizes its address on each join mints a **new** row every
+time — so the rows that will never return under the same MAC are precisely the
+ones accumulating fastest. Left alone the table grows without bound, and the
+device list becomes a graveyard the admin has to read past.
+
+The obvious fix — delete devices not seen for N days — is where it stops being
+simple. Something has to distinguish "a guest's phone that visited once" from
+"the TV I configured six months ago and haven't power-cycled since". Today the
+UI answers that with `name != null` (`Devices.tsx`, `DeviceDetail.tsx`), and
+that inference is **wrong in both directions**:
+
+- Granting a device Private DNS, pinning a DHCP reservation, or issuing it a
+  Remote peer credential leaves it rendered as "Discovered" — it is configured,
+  extensively, and the UI says it is not.
+- A bare name, typed once and never followed by any actual configuration, makes
+  a device "Managed".
+
+Pruning on `name IS NULL` therefore does not merely mislabel things. It
+**silently revokes remote access**: a roaming phone with a Private-DNS grant is
+exactly the device most likely to be off the LAN for 30 days, and deleting its
+row cascades the grant away. It would also orphan admin-authored MAC-keyed rows
+that have no foreign key to clean them up.
+
+So retention could not be built until the modelling bug underneath it was
+fixed.
+
+## Decision
+
+### 1. `managed` is a stored, explicit, latching column — not a derived one
+
+`devices.managed INTEGER NOT NULL DEFAULT 0`, promoted by any **admin**
+configuration act and cleared only by an explicit release.
+
+It cannot be derived. Any derivation is a disjunction over "does this device
+have any admin artefact", which means the answer changes the moment an artefact
+is deleted — so clearing a device's name, or removing one of its two DNS-filter
+profiles, would silently demote it and re-expose it to the prune. Latching is
+the point: a device an admin has taken responsibility for stays that way until
+the admin says otherwise.
+
+This buys the invariant the whole feature rests on:
+
+> **`managed = 0` implies no admin artefacts exist for this device.**
+
+Which is why the prune can delete an unmanaged row without checking anything
+else, and can never orphan or revoke anything.
+
+### 2. Only ADMIN acts promote; self-service acts deliberately do not
+
+Promoting: naming, admin-locking, an admin-set routing rule, a routing profile
+assignment, DNS-filter settings or profiles, enabling DNS capture, a
+Private-DNS grant, a Remote peer credential, a DHCP reservation, a zone
+exception naming the device, an explicit zone reassignment.
+
+Not promoting: a self-service routing rule (`created_by = 'user'`), a device
+rule request, a push subscription, the zone assigned at discovery, quarantine,
+and every machine-derived identification signal.
+
+A guest tapping a toggle in the user PWA is **the device asking, not the admin
+deciding**. If self-service promoted, every guest phone would become
+permanently exempt — and guest phones are the exact population the issue is
+about. The gate is the auth context at the call site, not the stored row:
+`update_device` and `set_rule` are both reachable by an
+`AuthContext::Device` and promote only under `AuthContext::Admin`.
+
+### 3. Demotion is an explicit "Stop managing" release that reverts everything
+
+`POST /api/devices/{id}/release` reverts every managed setting to default and
+*then* sets `managed = 0`, in that order. It is destructive and confirmed: it
+revokes the device's Private-DNS grant and its Remote peer credential,
+disconnecting it.
+
+Reverting **everything** — including the two credentials — is the part worth
+stating. A release that left a credential in place would hand back an unmanaged
+device still holding live remote access, which the prune would then delete 30
+days later with nothing but a log line. Partial release is how you build the
+bug this ADR exists to remove.
+
+`managed = 0` being **last** makes a partial failure safe: the device is left
+still managed, never half-released, and every step is idempotent so a retry
+completes.
+
+### 4. The TTL is hard-coded at 30 days
+
+`DEVICE_RETENTION_DAYS: i64 = 30`, matching the `INTRADAY_RETENTION` /
+`NOTIFICATION_RETENTION_CAP` precedent.
+
+**This deviates from the issue**, which asks for a configurable TTL. Deliberate:
+a setting needs a UI, a migration, a validation story and a support answer for
+"why did my device vanish", and none of that is worth shipping before we know
+anyone wants a number other than 30. Revisitable without a data migration —
+the column and the prune predicate do not change.
+
+## Rejected
+
+### Testing the device's zone in the prune predicate
+
+Tempting: "a device still sitting in the default-for-new zone was never touched
+by an admin, so it is prunable." Rejected, and it is the sharpest trap here.
+
+Zone membership is **sticky** (`CONTEXT.md`) — set once at discovery from the
+default-for-new flag and never re-resolved. So `zone_id = <default-for-new>` is
+not "this device was never moved"; it is "this device was discovered while that
+flag pointed here". The instant an admin promotes a different zone to
+default-for-new, every existing device's `zone_id` stops matching and the
+predicate matches nothing. Retention would silently switch itself off — no
+error, no log line, just a table that quietly resumes growing.
+
+### Backfilling `managed` from a past zone reassignment
+
+The migration backfills from every admin artefact **except** zone membership,
+for the mirror image of the reason above: `zone_id != <default-for-new>` cannot
+distinguish "an admin moved this device" from "the default-for-new flag was
+later re-pointed at a different zone".
+
+Guessing inclusively would mark essentially every existing device managed on
+any box whose default-for-new flag has ever moved — disabling retention on
+exactly the boxes that need it, and doing so invisibly. Guessing exclusively
+would be a lie in the other direction, but a harmless one: a device that really
+was moved by an admin, and has no other artefact and no name, stays unmanaged
+until the next admin act. Going forward `assign_device` promotes explicitly.
+This is an accepted, bounded gap in one-shot backfill accuracy, taken in
+exchange for the feature actually working.
+
+### A `CREATE TRIGGER` to promote automatically
+
+No trigger exists anywhere in the migrations, and promotion is not a
+row-shape fact — it depends on the **auth context** of the caller, which SQL
+cannot see. A trigger on `routing_rules` could not tell an admin-set rule from
+a self-service one. Promotion is explicit code at each call site.
+
+### Putting the release orchestration in `DeviceService`
+
+Forced out by an `Arc` cycle, not by taste. `InboundWgServiceImpl` and
+`PrivateDnsServiceImpl` both hold `Arc<dyn DeviceService>` — they call
+`mark_managed` — so a `DeviceService` that reached back into them to revoke a
+peer or a grant would be a construction-order deadlock.
+
+The release therefore lives in the API handler (`api/devices.rs`), which
+already orchestrates several services and is the established home for exactly
+this shape. Promotion still goes through `DeviceService::mark_managed` rather
+than scattered `DeviceRepository` writes, per the single-service-per-repository
+rule.
+
+## Consequences
+
+- **Unmanaged devices absent over 30 days are deleted**, hourly-ticked and
+  once per calendar day, by a new `DeviceRetentionRunner`. Kept separate from
+  `DbMaintenanceRunner`, which is database-level (vacuum, checkpoint, optimize)
+  and takes only a `MaintenanceService`; this is domain policy over one table.
+
+- **The prune must evict the pruned MAC from the discovery service's in-memory
+  maps, and must delete the row first.** This is not bookkeeping. A pruned MAC
+  left in `state` takes the `gone` arm on its next observation →
+  `ObsAction::Reappear` with a now-dangling `device_id` →
+  `update_last_seen_and_ip` matches zero rows and returns `Ok(())` **silently**
+  → `handle_unknown_mac` is never reached, so the device is never re-inserted.
+  The result is a device invisible in the UI while its traffic flows
+  unattributed, until the daemon restarts. Evicting *before* deleting is wrong
+  in the other direction: an observation in the window finds the row still
+  present and re-populates `state`. Delete, then evict, holding
+  `lock_for_mac(mac)` across both. This also bounds `ip_history` and
+  `device_locks`, which nothing pruned before.
+
+- **No event is published on prune.** No subscriber exists; the device departed
+  at least 30 days ago and every listener tore down long before.
+
+- **Rows deliberately left dangling.** `push_subscriptions` — by existing
+  design, stated in its own migration: a forgotten-then-rediscovered device
+  keeps its MAC and its subscription stays valid, and stale rows are pruned on
+  404/410 from the push service. `dns_query_log` self-expires within the same
+  window. `stats_*` and `notifications` are historical truth and are kept.
+  `dhcp_leases.device_id` is already `ON DELETE SET NULL`.
+
+- **The release *deletes* the routing rule rather than setting it to
+  `Direct`.** Two reasons, and the second is a hard blocker. "No rule" is the
+  state a never-configured device is in — it follows the gateway's global
+  default policy — whereas a `Direct` rule is an explicit persisted choice that
+  *overrides* that default, so writing one is not a revert. And `set_rule` is
+  validated against the device's zone allow-list, so on a tunnel-only zone
+  `Direct` is rejected outright and the device could never be released at all.
+  Deleting cannot conflict with a zone. The new `DeviceService::clear_rule`
+  publishes `RoutingRuleChanged` carrying the *global default policy* as the
+  target — the routing listener applies whatever the event says, so publishing
+  the deleted rule would re-install it.
+
+- **`routing_rules.created_by` is not a usable promotion signal today.**
+  `upsert_user_rule` hard-codes `'user'` regardless of caller, so an admin-set
+  rule is indistinguishable in the row. The migration's `created_by = 'admin'`
+  clause is the correct predicate and matches nothing at present; it is kept
+  for the day rules record their true author. Promotion keys off the auth
+  context instead.
+
+- **An empty device name now clears the name to `NULL`** rather than storing
+  `""`. An empty-string name renders as no label while still counting as named
+  — precisely the ambiguity this ADR removes — and the release needs a way to
+  actually unname a device.
+
+- **"Managed" and "named" are now separate everywhere.** Two places that
+  conflated them were corrected rather than left: the inbound-WireGuard
+  `add_peer` gate and the Private-DNS grant picker both still require a *name*
+  (a credential needs a human-readable label) but no longer describe that as a
+  managed-state requirement — which would now be circular, since granting is
+  itself one of the acts that makes a device managed.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -46,3 +46,4 @@ edge-release-channel one.
 | [0029](0029-private-dns-dot.md) | Private DNS is a closed `DoT` resolver keyed by a per-device secret hostname | 2026-08-09 | Accepted |
 | [0030](0030-published-apps.md) | A published app is a name, a reach ladder, and a policy — not a port forward | 2026-08-10 | Accepted — supersedes §2 of [ADR-0022](0022-inbound-wireguard-and-published-access.md) |
 | [0031](0031-household-identity.md) | Household identity is box-local; the cloud never vouches, and device affinity never authenticates | 2026-08-10 | Accepted |
+| [0032](0032-managed-devices-and-retention.md) | `managed` is an explicit latching column; only unmanaged devices are pruned | 2026-08-10 | Accepted |

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -2990,6 +2990,199 @@
         }
       }
     },
+    "/api/devices/{id}/release": {
+      "post": {
+        "tags": [
+          "devices"
+        ],
+        "description": "Stop managing a device (issue #1181). Reverts every admin-set configuration to default and returns the device to unmanaged, after which it becomes subject to device retention and is deleted once it has been absent for 30 days. Destructive: this revokes the device's Private-DNS grant and its Remote peer credential, disconnecting it. Idempotent — each step is a no-op when there is nothing to revert, so a retry after a partial failure completes. Admin only.",
+        "operationId": "release_device",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Device ID",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Updated device detail",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DeviceDetailResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Malformed or invalid request body",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "description": "Standard API error response.",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "detail": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "error": {
+                      "type": "string"
+                    },
+                    "request_id": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "description": "Request ID for correlation with server logs."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthenticated - session cookie or API key missing/invalid",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "description": "Standard API error response.",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "detail": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "error": {
+                      "type": "string"
+                    },
+                    "request_id": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "description": "Request ID for correlation with server logs."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden - caller is not an admin",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "description": "Standard API error response.",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "detail": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "error": {
+                      "type": "string"
+                    },
+                    "request_id": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "description": "Request ID for correlation with server logs."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Resource not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "description": "Standard API error response.",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "detail": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "error": {
+                      "type": "string"
+                    },
+                    "request_id": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "description": "Request ID for correlation with server logs."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "description": "Standard API error response.",
+                  "required": [
+                    "error"
+                  ],
+                  "properties": {
+                    "detail": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "error": {
+                      "type": "string"
+                    },
+                    "request_id": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "description": "Request ID for correlation with server logs."
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/devices/{id}/zone": {
       "put": {
         "tags": [
@@ -25608,7 +25801,8 @@
           "dns_capture_enabled",
           "dns_capture_cap_count",
           "dns_capture_cap_days",
-          "connection_mode"
+          "connection_mode",
+          "managed"
         ],
         "properties": {
           "admin_locked": {
@@ -25659,6 +25853,10 @@
           },
           "mac": {
             "type": "string"
+          },
+          "managed": {
+            "type": "boolean",
+            "description": "Whether an admin has decided to control this device's configuration.\n\nSet by *any* admin configuration act (naming, locking, a routing rule or\nprofile, DNS filter settings, DNS capture, a Private-DNS grant, a Remote\npeer credential, a DHCP reservation, a zone exception, an explicit zone\nreassignment) and deliberately **not** inferred from `name` — a device\ncan be configured without ever being named, and clearing a name must not\nsilently revoke its remote access.\n\nLatching: never demotes automatically, only through an explicit release\n(`POST /api/devices/{id}/release`), which first reverts every managed\nsetting to default. That upholds the invariant device retention depends\non — `managed = false` implies no admin artefacts exist — so pruning a\nlong-absent unmanaged device can never orphan a row. See issue #1181 and\n`docs/adr/0032-managed-devices-and-retention.md`."
           },
           "manufacturer": {
             "type": [

--- a/source/admin-app/tests/test-utils.tsx
+++ b/source/admin-app/tests/test-utils.tsx
@@ -69,6 +69,9 @@ export function makeDevice(overrides: Partial<Device> = {}): Device {
     dhcp_status: "lease",
     current_rule: null,
     connection_mode: "lan",
+    // Unmanaged by default: that is what a freshly discovered device is, and
+    // it keeps `managed: true` an explicit opt-in in the tests that need it.
+    managed: false,
     ...overrides,
   };
 }

--- a/source/admin-site/src/components/features/DeviceReleaseCard.tsx
+++ b/source/admin-site/src/components/features/DeviceReleaseCard.tsx
@@ -1,0 +1,131 @@
+import { useState } from "react";
+import { Button } from "@wardnet/web";
+import { Text } from "@wardnet/web";
+import {
+  Card,
+  CardAction,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@wardnet/web";
+import { ConfirmDialog } from "@/components/compound/ConfirmDialog";
+import type { MutationHandle } from "@/lib/mutationHandle";
+import type { Device } from "@wardnet/js";
+
+interface DeviceReleaseCardProps {
+  device: Device;
+  /** The page's hoisted release mutation. */
+  release: MutationHandle<string>;
+}
+
+/**
+ * "Stop managing" — the explicit release that reverts every admin-set setting
+ * on a device and returns it to unmanaged (issue #1181).
+ *
+ * Rendered only for managed devices: there is nothing to release otherwise.
+ *
+ * The reverts are enumerated in the card body rather than hidden behind the
+ * confirm dialog. Two of them disconnect the device, and one of them
+ * (retention) is a delayed deletion — an admin should be able to read the full
+ * consequence before clicking anything, not discover it in a modal.
+ */
+export function DeviceReleaseCard({ device, release }: DeviceReleaseCardProps) {
+  const [confirming, setConfirming] = useState(false);
+
+  if (!device.managed) return null;
+
+  async function handleRelease() {
+    setConfirming(false);
+    await release.mutateAsync(device.id);
+  }
+
+  return (
+    <Card data-testid="device-release-card">
+      <CardHeader>
+        <CardTitle>Stop managing</CardTitle>
+        <CardAction>
+          <Button
+            variant="destructive"
+            size="sm"
+            disabled={release.isPending}
+            onClick={() => setConfirming(true)}
+            data-testid="device-release-button"
+          >
+            {release.isPending ? "Releasing…" : "Stop managing"}
+          </Button>
+        </CardAction>
+      </CardHeader>
+      <CardContent className="col gap-12">
+        <Text as="p" size="sm" className="text-ink-3">
+          Reverts every setting below to its default and returns this device to
+          Discovered. It keeps working on the network — it just stops being
+          configured.
+        </Text>
+        <ul
+          className="col gap-4 pl-16 list-disc"
+          data-testid="device-release-effects"
+        >
+          <li>
+            <Text size="sm" weight="medium">
+              Revokes Private DNS access — this disconnects the device
+            </Text>
+          </li>
+          <li>
+            <Text size="sm" weight="medium">
+              Deletes its remote-access credential — this disconnects the device
+            </Text>
+          </li>
+          <li>
+            <Text size="sm" className="text-ink-3">
+              Deletes its DHCP reservation, so its IP can change
+            </Text>
+          </li>
+          <li>
+            <Text size="sm" className="text-ink-3">
+              Removes any zone exceptions naming it
+            </Text>
+          </li>
+          <li>
+            <Text size="sm" className="text-ink-3">
+              Resets its routing rule and routing profiles
+            </Text>
+          </li>
+          <li>
+            <Text size="sm" className="text-ink-3">
+              Resets its DNS filter settings and turns off DNS capture
+            </Text>
+          </li>
+          <li>
+            <Text size="sm" className="text-ink-3">
+              Clears its name and admin lock
+            </Text>
+          </li>
+          <li>
+            <Text size="sm" className="text-ink-3">
+              Returns it to the default zone for new devices
+            </Text>
+          </li>
+          <li>
+            <Text size="sm" className="text-ink-3">
+              Once released, the device is forgotten after 30 days away
+            </Text>
+          </li>
+        </ul>
+      </CardContent>
+
+      <ConfirmDialog
+        open={confirming}
+        onOpenChange={setConfirming}
+        title="Stop managing this device?"
+        description={
+          "This revokes its Private DNS access and its remote-access credential, " +
+          "disconnecting the device, and reverts every other setting to default. " +
+          "It will be forgotten after 30 days away. Re-granting later mints new " +
+          "credentials — the old ones cannot be restored."
+        }
+        confirmLabel="Stop managing"
+        onConfirm={() => void handleRelease()}
+      />
+    </Card>
+  );
+}

--- a/source/admin-site/src/components/features/DeviceSettingsCard.tsx
+++ b/source/admin-site/src/components/features/DeviceSettingsCard.tsx
@@ -71,7 +71,8 @@ export function DeviceSettingsCard({
   tunnels,
   updateDevice,
 }: DeviceSettingsCardProps) {
-  const isManaged = device.name != null;
+  // Server-owned flag (#1181), not inferred from the name.
+  const isManaged = device.managed;
 
   const [editing, setEditing] = useState(false);
   const [name, setName] = useState(device.name ?? "");
@@ -113,12 +114,9 @@ export function DeviceSettingsCard({
     setEditing(false);
   }
 
-  // Only claim "To Managed Device" when a name will actually make it managed;
-  // otherwise the save just persists settings (the old label promised a
-  // promotion an empty name never delivered).
-  const willPromote = !isManaged && trimmedName !== "";
-  const saveLabel = willPromote ? "To Managed Device" : "Save";
-  const savingLabel = willPromote ? "Promoting…" : "Saving…";
+  // Always just "Save". Since #1181, saving ANY admin setting here promotes
+  // the device to managed — not only a name — so a label that singled out
+  // naming would be describing the wrong thing on most of these saves.
 
   return (
     <Card>
@@ -145,7 +143,9 @@ export function DeviceSettingsCard({
               label="Friendly name"
               htmlFor="device-name"
               help={
-                isManaged ? undefined : "Give the device a name to manage it."
+                isManaged
+                  ? undefined
+                  : "Optional. Saving any setting here will manage this device."
               }
             >
               <Input
@@ -215,7 +215,7 @@ export function DeviceSettingsCard({
               onClick: cancelEdit,
               disabled: updateDevice.isPending,
             }}
-            primaryLabel={updateDevice.isPending ? savingLabel : saveLabel}
+            primaryLabel={updateDevice.isPending ? "Saving…" : "Save"}
             primaryProps={{
               onClick: handleSave,
               disabled: updateDevice.isPending,

--- a/source/admin-site/src/components/features/PrivateDnsCard.tsx
+++ b/source/admin-site/src/components/features/PrivateDnsCard.tsx
@@ -45,8 +45,10 @@ interface PrivateDnsCardProps {
  * prerequisite checklist explains what's missing even before a Wardnet hostname
  * exists. Enabling is gated on three hard prerequisites (wardnet provider, live
  * certificate, Premium entitlement); the reverse tunnel is informational only.
- * Once enabled the admin grants managed devices and can push a setup link to
- * each granted device. Pure presentation — the owning page wires the
+ * Once enabled the admin grants named devices and can push a setup link to
+ * each granted device. Granting makes a device managed (#1181), so it is no
+ * longer forgotten after 30 days away — which is what keeps a roaming phone's
+ * grant alive while it is off the LAN. Pure presentation — the owning page wires the
  * query/mutation hooks and passes data + callbacks in.
  */
 export function PrivateDnsCard({
@@ -79,8 +81,12 @@ export function PrivateDnsCard({
   const grants = useMemo(() => status?.grants ?? [], [status?.grants]);
   const enabled = status?.enabled ?? false;
 
-  // Only managed (admin-named) devices can be granted; a granted device drops
-  // out of the picker so the one-grant-per-device guard is never hit.
+  // Only NAMED devices are offered: a grant is listed and pushed to by the
+  // device's name, so an unnamed one has nothing to identify it by. This is a
+  // naming requirement, not a managed-state one — since #1181 those are
+  // separate, and granting is itself one of the acts that MAKES a device
+  // managed, so gating on `managed` here would be circular. A granted device
+  // drops out of the picker so the one-grant-per-device guard is never hit.
   const grantable = useMemo(() => {
     const grantedIds = new Set(grants.map((g) => g.device_id));
     return devices.filter((d) => d.name != null && !grantedIds.has(d.id));
@@ -152,8 +158,8 @@ export function PrivateDnsCard({
 
             {devices.every((d) => d.name == null) && (
               <Text as="p" size="sm" className="text-ink-3">
-                Only managed devices can be granted. Name a device on the
-                Devices page, then grant it access here.
+                Only named devices can be granted. Name a device on the Devices
+                page, then grant it access here.
               </Text>
             )}
 
@@ -196,6 +202,10 @@ export function PrivateDnsCard({
                     {grantDevice.isPending ? "Granting…" : "Grant"}
                   </Button>
                 </div>
+                <Text as="p" size="xs" className="text-ink-3">
+                  Granting makes this device managed, so it won't be forgotten
+                  while it's away.
+                </Text>
               </div>
             )}
 

--- a/source/admin-site/src/pages/DeviceDetail.tsx
+++ b/source/admin-site/src/pages/DeviceDetail.tsx
@@ -8,6 +8,7 @@ import { DeviceDnsCaptureCard } from "@/components/features/DeviceDnsCaptureCard
 import { DeviceIdentityCard } from "@/components/features/DeviceIdentityCard";
 import { DeviceIdentificationCard } from "@/components/features/DeviceIdentificationCard";
 import { DeviceNetworkCard } from "@/components/features/DeviceNetworkCard";
+import { DeviceReleaseCard } from "@/components/features/DeviceReleaseCard";
 import { DeviceSettingsCard } from "@/components/features/DeviceSettingsCard";
 import { DeviceRoutingProfilesCard } from "@/components/features/DeviceRoutingProfilesCard";
 import { DeviceZoneCard } from "@/components/features/DeviceZoneCard";
@@ -15,6 +16,7 @@ import {
   useDevice,
   useTunnels,
   useUpdateDevice,
+  useReleaseDevice,
   useRoutingProfiles,
   useDeviceRoutingProfiles,
   useSetDeviceRoutingProfiles,
@@ -116,6 +118,7 @@ function DeviceDetailLoaded({
   // Settings card.
   const { data: tunnelData } = useTunnels();
   const updateDevice = useUpdateDevice();
+  const releaseDevice = useReleaseDevice();
 
   // Routing profiles card.
   const { data: profilesData } = useRoutingProfiles();
@@ -143,7 +146,8 @@ function DeviceDetailLoaded({
   const restoreReservation = useCreateReservation({ silent: true });
   const deleteReservation = useDeleteReservation();
 
-  const managed = device.name != null;
+  // Server-owned flag (#1181), not inferred from the name — see Devices.tsx.
+  const managed = device.managed;
   const online = managed && isOnline(device.last_seen);
 
   const status = managed ? (
@@ -210,6 +214,7 @@ function DeviceDetailLoaded({
         restoreReservation={restoreReservation}
         deleteReservation={deleteReservation}
       />
+      <DeviceReleaseCard device={device} release={releaseDevice} />
     </div>
   );
 }

--- a/source/admin-site/src/pages/Devices.tsx
+++ b/source/admin-site/src/pages/Devices.tsx
@@ -20,8 +20,13 @@ type GroupId = "all" | "managed" | "unmanaged" | "recent";
 
 const RECENT_WINDOW_MS = 60 * 60 * 1000; // 1 hour
 
+// Managed is an explicit, server-owned flag (issue #1181), not something the
+// UI infers. It used to be `d.name != null`, which was wrong in both
+// directions: a device granted Private DNS or a Remote peer credential without
+// ever being named rendered as "Discovered", while a bare name alone made a
+// device look configured.
 function isManaged(d: Device): boolean {
-  return d.name != null;
+  return d.managed;
 }
 
 function isRecent(d: Device, now: number): boolean {

--- a/source/admin-site/tests/components/features/DeviceReleaseCard.test.tsx
+++ b/source/admin-site/tests/components/features/DeviceReleaseCard.test.tsx
@@ -1,0 +1,110 @@
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { DeviceReleaseCard } from "@/components/features/DeviceReleaseCard";
+import { makeDevice, renderWithProviders } from "../../test-utils";
+import type { Device } from "@wardnet/js";
+
+const mutateAsync = vi.fn();
+const reset = vi.fn();
+
+function renderCard(device: Device, isPending = false) {
+  return renderWithProviders(
+    <DeviceReleaseCard
+      device={device}
+      release={{
+        mutateAsync,
+        reset,
+        isPending,
+        isError: false,
+        error: null,
+      }}
+    />,
+  );
+}
+
+describe("DeviceReleaseCard", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mutateAsync.mockResolvedValue(undefined);
+  });
+
+  it("renders nothing for an unmanaged device", () => {
+    // There is nothing to release — offering the action would imply the device
+    // is configured when it isn't.
+    const { container } = renderCard(makeDevice({ managed: false }));
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders for a managed device even when it has no name", () => {
+    // The #1181 regression in miniature: managed is the server's flag, not
+    // `name != null`. A device granted Private DNS but never named is managed
+    // and must be releasable.
+    renderCard(makeDevice({ managed: true, name: null }));
+    expect(screen.getByTestId("device-release-card")).toBeInTheDocument();
+  });
+
+  it("enumerates every revert, flagging the two that disconnect the device", () => {
+    renderCard(makeDevice({ managed: true }));
+    const effects = screen.getByTestId("device-release-effects");
+
+    // The two destructive ones are called out as disconnecting.
+    expect(effects).toHaveTextContent(
+      /Revokes Private DNS access — this disconnects the device/,
+    );
+    expect(effects).toHaveTextContent(
+      /Deletes its remote-access credential — this disconnects the device/,
+    );
+    // And the rest of the sweep is stated, not implied.
+    expect(effects).toHaveTextContent(/DHCP reservation/);
+    expect(effects).toHaveTextContent(/zone exceptions/);
+    expect(effects).toHaveTextContent(/routing rule and routing profiles/);
+    expect(effects).toHaveTextContent(/DNS filter settings/);
+    expect(effects).toHaveTextContent(/name and admin lock/);
+    expect(effects).toHaveTextContent(/default zone for new devices/);
+    // Including the delayed consequence, which is the whole point of the flag.
+    expect(effects).toHaveTextContent(/forgotten after 30 days away/);
+  });
+
+  it("confirms before releasing, and does not fire on the first click", async () => {
+    const user = userEvent.setup();
+    renderCard(makeDevice({ managed: true }));
+
+    await user.click(screen.getByTestId("device-release-button"));
+    expect(mutateAsync).not.toHaveBeenCalled();
+    expect(
+      screen.getByText(/Stop managing this device\?/i),
+    ).toBeInTheDocument();
+
+    await user.click(screen.getByTestId("confirm-dialog-confirm"));
+    await waitFor(() => expect(mutateAsync).toHaveBeenCalledWith("dev-1"));
+  });
+
+  it("does not release when the confirmation is cancelled", async () => {
+    const user = userEvent.setup();
+    renderCard(makeDevice({ managed: true }));
+
+    await user.click(screen.getByTestId("device-release-button"));
+    await user.click(screen.getByTestId("confirm-dialog-cancel"));
+
+    expect(mutateAsync).not.toHaveBeenCalled();
+  });
+
+  it("names the irreversible part in the confirmation", async () => {
+    const user = userEvent.setup();
+    renderCard(makeDevice({ managed: true }));
+
+    await user.click(screen.getByTestId("device-release-button"));
+    // Re-granting mints new credentials; the old ones are gone. An admin
+    // should read that before confirming, not discover it afterwards.
+    expect(
+      screen.getByText(/old ones cannot be restored/i),
+    ).toBeInTheDocument();
+  });
+
+  it("disables the button while the release is in flight", () => {
+    renderCard(makeDevice({ managed: true }), true);
+    expect(screen.getByTestId("device-release-button")).toBeDisabled();
+    expect(screen.getByText("Releasing…")).toBeInTheDocument();
+  });
+});

--- a/source/admin-site/tests/components/features/DeviceSettingsCard.test.tsx
+++ b/source/admin-site/tests/components/features/DeviceSettingsCard.test.tsx
@@ -160,23 +160,40 @@ describe("DeviceSettingsCard editing", () => {
     });
   });
 
-  it("labels the save 'Save' until a name will actually promote the device", async () => {
+  it("always labels the save 'Save', named or not (#1181)", async () => {
     const user = userEvent.setup();
     renderWithProviders(
       <DeviceSettingsCard
-        {...cardProps({ device: makeDevice({ name: null }) })}
+        {...cardProps({ device: makeDevice({ name: null, managed: false }) })}
       />,
     );
     await user.click(screen.getByTestId("device-settings-edit"));
-    // No name yet — saving just persists settings, so it isn't a "promotion",
-    // and the form hints how to manage the device.
+    // Since #1181, saving ANY admin setting here promotes the device — not
+    // only a name — so a label that singled out naming would describe the
+    // wrong thing on most saves.
     expect(screen.getByRole("button", { name: "Save" })).toBeInTheDocument();
-    expect(screen.getByText(/name to manage it/i)).toBeInTheDocument();
-    // Entering a name turns the save into an actual promotion.
+    expect(screen.getByText(/will manage this device/i)).toBeInTheDocument();
+
     await user.type(screen.getByLabelText("Friendly name"), "Alice phone");
+    expect(screen.getByRole("button", { name: "Save" })).toBeInTheDocument();
     expect(
-      screen.getByRole("button", { name: "To Managed Device" }),
-    ).toBeInTheDocument();
+      screen.queryByRole("button", { name: "To Managed Device" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("drops the manage hint once the device is already managed", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(
+      <DeviceSettingsCard
+        {...cardProps({ device: makeDevice({ name: null, managed: true }) })}
+      />,
+    );
+    await user.click(screen.getByTestId("device-settings-edit"));
+    // Managed is the server's flag, not `name != null` — this device has no
+    // name and is still managed (e.g. it holds a Private-DNS grant).
+    expect(
+      screen.queryByText(/will manage this device/i),
+    ).not.toBeInTheDocument();
   });
 
   it("saves an unnamed device's settings without forcing a name", async () => {
@@ -199,7 +216,7 @@ describe("DeviceSettingsCard editing", () => {
     );
   });
 
-  it("promotes and sends the name once one is entered", async () => {
+  it("sends the name once one is entered", async () => {
     const user = userEvent.setup();
     renderWithProviders(
       <DeviceSettingsCard
@@ -208,7 +225,7 @@ describe("DeviceSettingsCard editing", () => {
     );
     await user.click(screen.getByTestId("device-settings-edit"));
     await user.type(screen.getByLabelText("Friendly name"), "Alice phone");
-    await user.click(screen.getByRole("button", { name: "To Managed Device" }));
+    await user.click(screen.getByTestId("device-settings-save"));
     await waitFor(() => expect(mutateAsync).toHaveBeenCalled());
     expect(mutateAsync).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/source/admin-site/tests/pages/DeviceDetail.test.tsx
+++ b/source/admin-site/tests/pages/DeviceDetail.test.tsx
@@ -268,7 +268,11 @@ describe("DeviceDetail", () => {
   });
 
   it("renders an online managed device", () => {
-    loadDevice({ name: "My Laptop", last_seen: new Date().toISOString() });
+    loadDevice({
+      name: "My Laptop",
+      managed: true,
+      last_seen: new Date().toISOString(),
+    });
     renderWithProviders(<DeviceDetail />);
     expect(screen.getByTestId("item-label")).toHaveTextContent("My Laptop");
     expect(screen.getByTestId("status-badge")).toHaveTextContent("Online");
@@ -346,13 +350,17 @@ describe("DeviceDetail", () => {
   });
 
   it("renders an offline managed device", () => {
-    loadDevice({ name: "Old Device", last_seen: "2000-01-01T00:00:00Z" });
+    loadDevice({
+      name: "Old Device",
+      managed: true,
+      last_seen: "2000-01-01T00:00:00Z",
+    });
     renderWithProviders(<DeviceDetail />);
     expect(screen.getByTestId("status-badge")).toHaveTextContent("Offline");
   });
 
   it("renders a discovered (unmanaged) device and falls back to hostname label", () => {
-    loadDevice({ name: null, hostname: "living-room-tv" });
+    loadDevice({ name: null, managed: false, hostname: "living-room-tv" });
     renderWithProviders(<DeviceDetail />);
     expect(screen.getByTestId("status-badge")).toHaveTextContent("Discovered");
     expect(screen.getByTestId("item-label")).toHaveTextContent(
@@ -405,7 +413,7 @@ describe("DeviceDetail", () => {
   });
 
   it("treats an invalid last_seen as offline for managed devices", () => {
-    loadDevice({ name: "Weird", last_seen: "not-a-date" });
+    loadDevice({ name: "Weird", managed: true, last_seen: "not-a-date" });
     renderWithProviders(<DeviceDetail />);
     expect(screen.getByTestId("status-badge")).toHaveTextContent("Offline");
   });

--- a/source/admin-site/tests/pages/Devices.test.tsx
+++ b/source/admin-site/tests/pages/Devices.test.tsx
@@ -126,7 +126,12 @@ describe("Devices", () => {
     useDevices.mockReturnValue({
       data: {
         devices: [
-          makeDevice({ id: "d1", name: "Managed", last_seen: recent }),
+          makeDevice({
+            id: "d1",
+            name: "Managed",
+            managed: true,
+            last_seen: recent,
+          }),
           makeDevice({ id: "d2", name: null, last_seen: "not-a-date" }),
           makeDevice({ id: "d3", name: null, last_seen: undefined }),
         ],
@@ -179,6 +184,7 @@ describe("Devices", () => {
           makeDevice({
             id: "d1",
             name: "Alpha",
+            managed: true,
             hostname: "alpha",
             last_ip: "10.0.0.1",
             last_seen: recent,
@@ -186,6 +192,7 @@ describe("Devices", () => {
           makeDevice({
             id: "d2",
             name: null,
+            managed: false,
             hostname: "beta",
             mac: "11:22:33:44:55:66",
             last_ip: "10.0.0.2",
@@ -272,8 +279,14 @@ describe("Devices — the dead-end help must not fire on a present device", () =
     useDevices.mockReturnValue({
       data: {
         devices: [
-          // Unmanaged: name is null, so the "managed" group excludes it.
-          makeDevice({ id: "d0", mac: "5c:e7:53:4e:ec:db", name: null }),
+          // Unmanaged, so the "managed" group excludes it. Since #1181 that
+          // is the server's `managed` flag, not an inference from `name`.
+          makeDevice({
+            id: "d0",
+            mac: "5c:e7:53:4e:ec:db",
+            name: null,
+            managed: false,
+          }),
         ],
       },
       isLoading: false,
@@ -295,13 +308,15 @@ describe("Devices — the dead-end help must not fire on a present device", () =
 
   it("shows the plain filter message when nothing is searched", async () => {
     useDevices.mockReturnValue({
-      data: { devices: [makeDevice({ id: "d0", name: "Named" })] },
+      data: {
+        devices: [makeDevice({ id: "d0", name: "Named", managed: true })],
+      },
       isLoading: false,
       isError: false,
     });
     renderWithProviders(<Devices />);
 
-    // "Unmanaged" excludes the only (named) device, with no search active.
+    // "Unmanaged" excludes the only (managed) device, with no search active.
     await userEvent.click(screen.getByText("group-unmanaged-0"));
 
     expect(

--- a/source/admin-site/tests/test-utils.tsx
+++ b/source/admin-site/tests/test-utils.tsx
@@ -48,6 +48,9 @@ export function makeDevice(overrides: Partial<Device> = {}): Device {
     dhcp_status: "lease",
     current_rule: null,
     connection_mode: "lan",
+    // Unmanaged by default: that is what a freshly discovered device is, and
+    // it keeps `managed: true` an explicit opt-in in the tests that need it.
+    managed: false,
     ...overrides,
   };
 }

--- a/source/daemon/crates/wardnet-common/src/device.rs
+++ b/source/daemon/crates/wardnet-common/src/device.rs
@@ -108,6 +108,11 @@ pub enum DeviceSignalKind {
 }
 
 /// A discovered network device.
+// The bools are independent, orthogonal facts about one device — randomized
+// MAC, admin lock, DNS capture, managed — not a state machine hiding in a
+// struct. Grouping them into sub-structs would change the wire format for no
+// gain, since this type is serialized straight onto the API.
+#[allow(clippy::struct_excessive_bools)]
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, utoipa::ToSchema)]
 pub struct Device {
     pub id: Uuid,
@@ -137,4 +142,20 @@ pub struct Device {
     /// How the device is currently reachable (LAN vs. inbound `WireGuard`).
     /// Live status, last-observation-wins — see [`DeviceConnectionMode`].
     pub connection_mode: DeviceConnectionMode,
+    /// Whether an admin has decided to control this device's configuration.
+    ///
+    /// Set by *any* admin configuration act (naming, locking, a routing rule or
+    /// profile, DNS filter settings, DNS capture, a Private-DNS grant, a Remote
+    /// peer credential, a DHCP reservation, a zone exception, an explicit zone
+    /// reassignment) and deliberately **not** inferred from `name` — a device
+    /// can be configured without ever being named, and clearing a name must not
+    /// silently revoke its remote access.
+    ///
+    /// Latching: never demotes automatically, only through an explicit release
+    /// (`POST /api/devices/{id}/release`), which first reverts every managed
+    /// setting to default. That upholds the invariant device retention depends
+    /// on — `managed = false` implies no admin artefacts exist — so pruning a
+    /// long-absent unmanaged device can never orphan a row. See issue #1181 and
+    /// `docs/adr/0032-managed-devices-and-retention.md`.
+    pub managed: bool,
 }

--- a/source/daemon/crates/wardnet-common/src/tests/device.rs
+++ b/source/daemon/crates/wardnet-common/src/tests/device.rs
@@ -47,6 +47,7 @@ fn device_round_trip() {
         dns_capture_cap_count: 1000,
         dns_capture_cap_days: 7,
         connection_mode: DeviceConnectionMode::Lan,
+        managed: false,
     };
     let json = serde_json::to_string(&device).unwrap();
     let back: Device = serde_json::from_str(&json).unwrap();

--- a/source/daemon/crates/wardnetd-api/src/api/devices.rs
+++ b/source/daemon/crates/wardnetd-api/src/api/devices.rs
@@ -26,6 +26,7 @@ pub fn register(router: OpenApiRouter<AppState>) -> OpenApiRouter<AppState> {
         .routes(routes!(set_my_rule))
         .routes(routes!(get_device, update_device))
         .routes(routes!(assign_device_zone))
+        .routes(routes!(release_device))
 }
 
 const TAG: &str = "devices";
@@ -413,6 +414,240 @@ pub async fn assign_device_zone(
         .network_zone_service()
         .assign_device(uuid, body.zone_id)
         .await?;
+
+    let device = state.discovery_service().get_device_by_id(uuid).await?;
+    // Mutation path — see `device_detail`.
+    Ok(Json(device_detail(&state, device, false).await?))
+}
+
+/// Run one step of the release sequence, tagging any failure with the step's
+/// name so a 500 says which revert did not land.
+///
+/// The device is left **managed** on any failure — `clear_managed` is the last
+/// step and never runs — so a partial release is always recoverable by
+/// retrying, never a half-released device carrying live credentials it is no
+/// longer recorded as owning.
+fn releasing(step: &'static str, result: Result<(), AppError>) -> Result<(), AppError> {
+    result.map_err(|e| match e {
+        // A guard rejection is about the caller, not the step; keep its status.
+        e @ (AppError::Unauthorized(_) | AppError::Forbidden(_)) => e,
+        e => AppError::Internal(anyhow::anyhow!("release failed at step '{step}': {e}")),
+    })
+}
+
+/// Revoke the release steps that live in collections which must be scanned for
+/// the device: its Private-DNS grant, Remote peer credential, DHCP reservation,
+/// and zone exceptions.
+///
+/// Split out of [`release_device`] for length only; it is the first half of
+/// that function's ordered sequence and must not be reordered against it.
+///
+/// The Private-DNS grant goes first because revoking publishes
+/// `PrivateDnsGrantRevoked`, which tears down the device's already-established
+/// `DoT` sessions — the token is otherwise only checked at handshake, so a
+/// revoked device would keep resolving until it happened to reconnect.
+async fn release_credentials_and_scoped_rules(
+    state: &AppState,
+    device_id: Uuid,
+    mac: &str,
+) -> Result<(), AppError> {
+    if let Some(grant) = state.private_dns_service().device_grant(device_id).await? {
+        releasing(
+            "revoke private-DNS grant",
+            state.private_dns_service().revoke_grant(grant.id).await,
+        )?;
+    }
+
+    let peers = state.inbound_wg_service().list_peers().await?;
+    for peer in peers.iter().filter(|p| p.device_id == Some(device_id)) {
+        releasing(
+            "remove remote peer",
+            state.inbound_wg_service().remove_peer(peer.id).await,
+        )?;
+    }
+
+    // Reservations are keyed by MAC, not device id — the one artefact that
+    // would otherwise survive the device row entirely.
+    let reservations = state.dhcp_service().list_reservations().await?;
+    for reservation in reservations
+        .reservations
+        .iter()
+        .filter(|r| r.mac_address.eq_ignore_ascii_case(mac))
+    {
+        releasing(
+            "delete DHCP reservation",
+            state
+                .dhcp_service()
+                .delete_reservation(reservation.id)
+                .await
+                .map(|_| ()),
+        )?;
+    }
+
+    // Exceptions naming this device on either side.
+    let exceptions = state.zone_exception_service().list_exceptions().await?;
+    for exception in exceptions.iter().filter(|e| {
+        [&e.from, &e.to].iter().any(|endpoint| {
+            endpoint.kind == wardnet_common::zone_exception::ExceptionEndpointKind::Device
+                && endpoint.id == device_id
+        })
+    }) {
+        releasing(
+            "delete zone exception",
+            state
+                .zone_exception_service()
+                .delete_exception(exception.id)
+                .await,
+        )?;
+    }
+
+    Ok(())
+}
+
+#[utoipa::path(
+    post,
+    path = "/api/devices/{id}/release",
+    tag = TAG,
+    description = "Stop managing a device (issue #1181). Reverts every \
+                   admin-set configuration to default and returns the device to \
+                   unmanaged, after which it becomes subject to device \
+                   retention and is deleted once it has been absent for 30 \
+                   days. Destructive: this revokes the device's Private-DNS \
+                   grant and its Remote peer credential, disconnecting it. \
+                   Idempotent — each step is a no-op when there is nothing to \
+                   revert, so a retry after a partial failure completes. \
+                   Admin only.",
+    params(("id" = Uuid, Path, description = "Device ID")),
+    responses(
+        (status = 200, description = "Updated device detail", body = DeviceDetailResponse),
+        AuthErrors,
+        NotFound,
+        BadRequest,
+    ),
+)]
+pub async fn release_device(
+    State(state): State<AppState>,
+    _auth: AdminAuth,
+    Path(id): Path<String>,
+) -> Result<Json<DeviceDetailResponse>, AppError> {
+    let uuid: Uuid = id
+        .parse()
+        .map_err(|_| AppError::BadRequest("invalid device ID".to_owned()))?;
+    let device_id = uuid.to_string();
+
+    // 404 up front rather than silently "releasing" a device that isn't there:
+    // every step below is individually tolerant of a missing device, so without
+    // this the whole sequence would succeed against nothing.
+    let device = state.discovery_service().get_device_by_id(uuid).await?;
+
+    // This orchestration lives in the handler, not in `DeviceService`, and that
+    // is forced rather than stylistic: `InboundWgServiceImpl` and
+    // `PrivateDnsServiceImpl` both hold `Arc<dyn DeviceService>` (they call
+    // `mark_managed`), so a `DeviceService` that reached back into them would
+    // be an `Arc` cycle and a construction-order deadlock. This handler already
+    // orchestrates several services, so it is the established home.
+    //
+    // Order matters. `clear_managed` is LAST, so the invariant device retention
+    // depends on — `managed = false` implies no admin artefacts exist — is only
+    // asserted once every artefact is actually gone. Reversed, a failure
+    // midway would leave an unmanaged device still holding a live Private-DNS
+    // grant, which the prune would then delete 30 days later with nothing but a
+    // log line to show for it.
+
+    // 1-4. The artefacts held in collections that have to be scanned for this
+    //      device. Split out only to keep this function readable — the ordering
+    //      inside it is part of the same sequence.
+    release_credentials_and_scoped_rules(&state, uuid, &device.mac).await?;
+
+    // 5. Routing rule + routing-profile assignments. The rule is *deleted*, not
+    //    set to `Direct`: "no rule" is the state a never-configured device is
+    //    in (it follows the gateway's global default policy), whereas a
+    //    `Direct` rule is an explicit choice that overrides that default — and
+    //    is validated against the device's zone, so a tunnel-only zone would
+    //    reject it and make such a device impossible to release.
+    releasing(
+        "clear routing rule",
+        state.device_service().clear_rule(&device_id).await,
+    )?;
+    releasing(
+        "clear routing profiles",
+        state
+            .routing_profile_service()
+            .set_device_profiles(uuid, &[])
+            .await,
+    )?;
+
+    // 6. DNS-filter settings and profile assignments, back to `default_for`:
+    //    filtering enabled, no profiles.
+    releasing(
+        "reset DNS filter settings",
+        state
+            .dns_filter_service()
+            .update_device_settings(
+                uuid,
+                wardnet_common::api::UpdateDeviceFilterSettingsRequest {
+                    enabled: true,
+                    profile_ids: Vec::new(),
+                },
+            )
+            .await
+            .map(|_| ()),
+    )?;
+
+    // 7. DNS capture off, admin lock cleared, name cleared.
+    releasing(
+        "disable DNS capture",
+        state
+            .device_service()
+            .update_dns_capture_settings(&device_id, Some(false), None, None)
+            .await,
+    )?;
+    releasing(
+        "clear admin lock",
+        state
+            .device_service()
+            .update_admin_locked(&device_id, false)
+            .await,
+    )?;
+    releasing(
+        "clear device name",
+        state
+            .discovery_service()
+            .update_device(uuid, Some(""), None)
+            .await
+            .map(|_| ()),
+    )?;
+
+    // 8. Zone back to the current default-for-new — the zone a freshly
+    //    discovered device would land in. Membership is sticky, so nothing else
+    //    would ever move it back.
+    let zones = state.network_zone_service().list_zones().await?;
+    if let Some(default_zone) = zones.iter().find(|z| z.zone.is_default_for_new)
+        && default_zone.zone.id != device.zone_id
+    {
+        releasing(
+            "reset network zone",
+            state
+                .network_zone_service()
+                .assign_device(uuid, default_zone.zone.id)
+                .await,
+        )?;
+    }
+
+    // 9. Finally unmanaged. Every step above that promotes on write (the
+    //    routing rule, the filter settings, the zone) has already run, so this
+    //    lands last and stays.
+    releasing(
+        "clear managed flag",
+        state.device_service().clear_managed(&device_id).await,
+    )?;
+
+    tracing::info!(
+        device_id = %uuid,
+        mac = %device.mac,
+        "released device {uuid} (mac {mac}): configuration reverted to default, now unmanaged",
+        mac = device.mac,
+    );
 
     let device = state.discovery_service().get_device_by_id(uuid).await?;
     // Mutation path — see `device_detail`.

--- a/source/daemon/crates/wardnetd-api/src/api/tests/devices.rs
+++ b/source/daemon/crates/wardnetd-api/src/api/tests/devices.rs
@@ -86,6 +86,13 @@ impl AuthService for MockAuthService {
 }
 
 /// Mock `DeviceService` returning configurable responses.
+/// Ordered record of the service calls a request made, shared between the
+/// device and discovery mocks so a test can assert *sequence*, not just
+/// occurrence. The release handler's correctness is an ordering property —
+/// `clear_managed` must be last — so occurrence alone would not catch the bug
+/// that matters (issue #1181).
+type AuditLog = Arc<std::sync::Mutex<Vec<&'static str>>>;
+
 struct MockDeviceService {
     device: Option<Device>,
     rule: Option<RoutingTarget>,
@@ -93,6 +100,10 @@ struct MockDeviceService {
     set_rule_error: Option<String>,
     /// Batched routing rules returned by `current_rules` (used by the list path).
     current_rules: std::collections::HashMap<Uuid, RoutingTarget>,
+    audit: AuditLog,
+    /// When set, `update_admin_locked` fails — standing in for any mid-sequence
+    /// step of the release blowing up.
+    fail_admin_locked: bool,
 }
 
 impl MockDeviceService {
@@ -104,6 +115,8 @@ impl MockDeviceService {
             admin_locked,
             set_rule_error: None,
             current_rules: std::collections::HashMap::new(),
+            audit: AuditLog::default(),
+            fail_admin_locked: false,
         }
     }
 
@@ -114,6 +127,8 @@ impl MockDeviceService {
             admin_locked: false,
             set_rule_error: Some("not_found".to_owned()),
             current_rules: std::collections::HashMap::new(),
+            audit: AuditLog::default(),
+            fail_admin_locked: false,
         }
     }
 
@@ -124,6 +139,8 @@ impl MockDeviceService {
             admin_locked: true,
             set_rule_error: Some("forbidden".to_owned()),
             current_rules: std::collections::HashMap::new(),
+            audit: AuditLog::default(),
+            fail_admin_locked: false,
         }
     }
 
@@ -223,6 +240,21 @@ impl TunnelService for MockTunnelService {
 
 #[async_trait]
 impl DeviceService for MockDeviceService {
+    async fn clear_rule(&self, _device_id: &str) -> Result<(), AppError> {
+        self.audit.lock().unwrap().push("clear_rule");
+        Ok(())
+    }
+
+    async fn mark_managed(&self, _device_id: &str) -> Result<(), AppError> {
+        self.audit.lock().unwrap().push("mark_managed");
+        Ok(())
+    }
+
+    async fn clear_managed(&self, _device_id: &str) -> Result<(), AppError> {
+        self.audit.lock().unwrap().push("clear_managed");
+        Ok(())
+    }
+
     async fn get_device(
         &self,
         _device_id: &str,
@@ -278,6 +310,12 @@ impl DeviceService for MockDeviceService {
     }
 
     async fn update_admin_locked(&self, _id: &str, _locked: bool) -> Result<(), AppError> {
+        self.audit.lock().unwrap().push("update_admin_locked");
+        if self.fail_admin_locked {
+            return Err(AppError::Internal(anyhow::anyhow!(
+                "synthetic lock failure"
+            )));
+        }
         Ok(())
     }
     async fn get_dns_capture_settings(
@@ -293,7 +331,11 @@ impl DeviceService for MockDeviceService {
         _cap_count: Option<i64>,
         _cap_days: Option<i64>,
     ) -> Result<(), AppError> {
-        unimplemented!()
+        self.audit
+            .lock()
+            .unwrap()
+            .push("update_dns_capture_settings");
+        Ok(())
     }
     async fn set_my_capture_enabled(
         &self,
@@ -431,6 +473,7 @@ impl DhcpService for MockDhcpService {
 /// Mock `DeviceDiscoveryService` for admin device endpoints.
 struct MockDiscoveryService {
     devices: Vec<Device>,
+    audit: AuditLog,
 }
 
 #[async_trait]
@@ -489,10 +532,15 @@ impl DeviceDiscoveryService for MockDiscoveryService {
         name: Option<&str>,
         _device_type: Option<DeviceType>,
     ) -> Result<Device, AppError> {
+        self.audit.lock().unwrap().push("update_device");
         let mut device = self.get_device_by_id(id).await?;
-        if let Some(n) = name {
-            device.name = Some(n.to_owned());
-        }
+        // Mirrors the service: a blank name clears it to `None` rather than
+        // storing an empty string (#1181).
+        device.name = name
+            .map(str::trim)
+            .filter(|n| !n.is_empty())
+            .map(str::to_owned)
+            .or(if name.is_some() { None } else { device.name });
         Ok(device)
     }
 }
@@ -520,6 +568,7 @@ fn sample_device() -> Device {
         dns_capture_cap_count: 1000,
         dns_capture_cap_days: 7,
         connection_mode: wardnet_common::device::DeviceConnectionMode::Lan,
+        managed: false,
     }
 }
 
@@ -669,6 +718,7 @@ fn build_state_with_identification(
         MockDeviceService::found(device.clone(), Some(RoutingTarget::Direct)),
         MockDiscoveryService {
             devices: vec![device],
+            audit: AuditLog::default(),
         },
         MockDhcpService::empty(),
     )
@@ -690,6 +740,10 @@ fn device_router(state: AppState) -> Router {
         .route(
             "/api/devices/{id}/zone",
             put(crate::api::devices::assign_device_zone),
+        )
+        .route(
+            "/api/devices/{id}/release",
+            axum::routing::post(crate::api::devices::release_device),
         )
         .with_state(state)
 }
@@ -736,6 +790,27 @@ async fn put_json(app: Router, uri: &str, json_body: &str) -> (StatusCode, serde
     (status, json)
 }
 
+/// Send an authenticated POST with no body.
+async fn post_json(app: Router, uri: &str) -> (StatusCode, serde_json::Value) {
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(uri)
+                .header("Cookie", "wardnet_session=valid-token")
+                .extension(connect_info())
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    let status = resp.status();
+    let body = axum::body::to_bytes(resp.into_body(), 16384).await.unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap_or(serde_json::Value::Null);
+    (status, json)
+}
+
 // ---------------------------------------------------------------------------
 // GET /api/devices/me
 // ---------------------------------------------------------------------------
@@ -745,7 +820,10 @@ async fn get_me_returns_device_when_found() {
     let device = sample_device();
     let state = build_state(
         MockDeviceService::found(device, Some(RoutingTarget::Direct)),
-        MockDiscoveryService { devices: vec![] },
+        MockDiscoveryService {
+            devices: vec![],
+            audit: AuditLog::default(),
+        },
     );
     let app = device_router(state);
 
@@ -764,7 +842,10 @@ async fn get_me_returns_device_when_found() {
 async fn get_me_returns_null_device_when_unknown_ip() {
     let state = build_state(
         MockDeviceService::not_found(),
-        MockDiscoveryService { devices: vec![] },
+        MockDiscoveryService {
+            devices: vec![],
+            audit: AuditLog::default(),
+        },
     );
     let app = device_router(state);
 
@@ -819,12 +900,16 @@ async fn get_me_includes_assigned_routing_profiles() {
     let routing_svc = Arc::new(RoutingProfileServiceImpl::new(
         repo,
         Arc::new(StubTunnelService),
+        Arc::new(crate::tests::stubs::StubDeviceService),
         tx,
     ));
 
     let state = build_state(
         MockDeviceService::found(device, None),
-        MockDiscoveryService { devices: vec![] },
+        MockDiscoveryService {
+            devices: vec![],
+            audit: AuditLog::default(),
+        },
     )
     .with_routing_profile_service(routing_svc);
     let app = device_router(state);
@@ -858,7 +943,10 @@ async fn get_me_includes_tunnel_status_and_last_handshake() {
     };
     let state = build_state_with_tunnel_svc(
         MockDeviceService::found(sample_device(), None),
-        MockDiscoveryService { devices: vec![] },
+        MockDiscoveryService {
+            devices: vec![],
+            audit: AuditLog::default(),
+        },
         MockTunnelService {
             tunnels: vec![tunnel],
         },
@@ -879,7 +967,10 @@ async fn get_me_includes_tunnel_status_and_last_handshake() {
 async fn set_my_rule_success() {
     let state = build_state(
         MockDeviceService::found(sample_device(), None),
-        MockDiscoveryService { devices: vec![] },
+        MockDiscoveryService {
+            devices: vec![],
+            audit: AuditLog::default(),
+        },
     );
     let app = device_router(state);
 
@@ -899,7 +990,10 @@ async fn set_my_rule_with_tunnel_target() {
     let tunnel_id = "00000000-0000-0000-0000-000000000010";
     let state = build_state(
         MockDeviceService::found(sample_device(), None),
-        MockDiscoveryService { devices: vec![] },
+        MockDiscoveryService {
+            devices: vec![],
+            audit: AuditLog::default(),
+        },
     );
     let app = device_router(state);
 
@@ -914,7 +1008,10 @@ async fn set_my_rule_with_tunnel_target() {
 async fn set_my_rule_device_not_found() {
     let state = build_state(
         MockDeviceService::not_found(),
-        MockDiscoveryService { devices: vec![] },
+        MockDiscoveryService {
+            devices: vec![],
+            audit: AuditLog::default(),
+        },
     );
     let app = device_router(state);
 
@@ -934,7 +1031,13 @@ async fn set_my_rule_forbidden_when_locked() {
     device.admin_locked = true;
 
     let svc = MockDeviceService::forbidden(device);
-    let state = build_state(svc, MockDiscoveryService { devices: vec![] });
+    let state = build_state(
+        svc,
+        MockDiscoveryService {
+            devices: vec![],
+            audit: AuditLog::default(),
+        },
+    );
     let app = device_router(state);
 
     let (status, json) = put_json(
@@ -951,7 +1054,10 @@ async fn set_my_rule_forbidden_when_locked() {
 async fn set_my_rule_bad_json_returns_error() {
     let state = build_state(
         MockDeviceService::found(sample_device(), None),
-        MockDiscoveryService { devices: vec![] },
+        MockDiscoveryService {
+            devices: vec![],
+            audit: AuditLog::default(),
+        },
     );
     let app = device_router(state);
 
@@ -988,6 +1094,7 @@ async fn list_devices_returns_all() {
         MockDeviceService::not_found(),
         MockDiscoveryService {
             devices: vec![device],
+            audit: AuditLog::default(),
         },
         MockDhcpService::empty(),
     );
@@ -1023,6 +1130,7 @@ async fn list_devices_includes_routing_target() {
         MockDeviceService::not_found().with_current_rules(rules),
         MockDiscoveryService {
             devices: vec![tunnel_device, default_device],
+            audit: AuditLog::default(),
         },
         MockDhcpService::empty(),
     );
@@ -1055,7 +1163,10 @@ async fn list_devices_includes_routing_target() {
 async fn list_devices_returns_empty() {
     let state = build_state_with_dhcp(
         MockDeviceService::not_found(),
-        MockDiscoveryService { devices: vec![] },
+        MockDiscoveryService {
+            devices: vec![],
+            audit: AuditLog::default(),
+        },
         MockDhcpService::empty(),
     );
     let app = device_router(state);
@@ -1069,7 +1180,10 @@ async fn list_devices_returns_empty() {
 async fn list_devices_unauthorized_without_session() {
     let state = build_state_with_dhcp(
         MockDeviceService::not_found(),
-        MockDiscoveryService { devices: vec![] },
+        MockDiscoveryService {
+            devices: vec![],
+            audit: AuditLog::default(),
+        },
         MockDhcpService::empty(),
     );
     let app = device_router(state);
@@ -1099,6 +1213,7 @@ async fn get_device_by_id_success() {
         MockDeviceService::found(device.clone(), Some(RoutingTarget::Direct)),
         MockDiscoveryService {
             devices: vec![device],
+            audit: AuditLog::default(),
         },
         MockDhcpService::empty(),
     );
@@ -1174,7 +1289,10 @@ async fn update_device_degrades_when_signals_cannot_be_read() {
 async fn get_device_by_id_not_found() {
     let state = build_state_with_dhcp(
         MockDeviceService::not_found(),
-        MockDiscoveryService { devices: vec![] },
+        MockDiscoveryService {
+            devices: vec![],
+            audit: AuditLog::default(),
+        },
         MockDhcpService::empty(),
     );
     let app = device_router(state);
@@ -1188,7 +1306,10 @@ async fn get_device_by_id_not_found() {
 async fn get_device_by_id_invalid_uuid() {
     let state = build_state_with_dhcp(
         MockDeviceService::not_found(),
-        MockDiscoveryService { devices: vec![] },
+        MockDiscoveryService {
+            devices: vec![],
+            audit: AuditLog::default(),
+        },
         MockDhcpService::empty(),
     );
     let app = device_router(state);
@@ -1209,6 +1330,7 @@ async fn assign_device_zone_success() {
         MockDeviceService::found(device.clone(), Some(RoutingTarget::Direct)),
         MockDiscoveryService {
             devices: vec![device],
+            audit: AuditLog::default(),
         },
         MockDhcpService::empty(),
     );
@@ -1235,6 +1357,7 @@ async fn update_device_success() {
         MockDeviceService::found(device.clone(), None),
         MockDiscoveryService {
             devices: vec![device],
+            audit: AuditLog::default(),
         },
         MockDhcpService::empty(),
     );
@@ -1257,6 +1380,7 @@ async fn update_device_with_type() {
         MockDeviceService::found(device.clone(), None),
         MockDiscoveryService {
             devices: vec![device],
+            audit: AuditLog::default(),
         },
         MockDhcpService::empty(),
     );
@@ -1276,7 +1400,10 @@ async fn update_device_with_type() {
 async fn update_device_invalid_uuid() {
     let state = build_state_with_dhcp(
         MockDeviceService::not_found(),
-        MockDiscoveryService { devices: vec![] },
+        MockDiscoveryService {
+            devices: vec![],
+            audit: AuditLog::default(),
+        },
         MockDhcpService::empty(),
     );
     let app = device_router(state);
@@ -1290,7 +1417,10 @@ async fn update_device_invalid_uuid() {
 async fn update_device_not_found() {
     let state = build_state_with_dhcp(
         MockDeviceService::not_found(),
-        MockDiscoveryService { devices: vec![] },
+        MockDiscoveryService {
+            devices: vec![],
+            audit: AuditLog::default(),
+        },
         MockDhcpService::empty(),
     );
     let app = device_router(state);
@@ -1316,6 +1446,7 @@ async fn update_device_with_routing_target() {
         MockDeviceService::found(device.clone(), None),
         MockDiscoveryService {
             devices: vec![device],
+            audit: AuditLog::default(),
         },
         MockDhcpService::empty(),
     );
@@ -1337,6 +1468,7 @@ async fn update_device_with_admin_locked() {
         MockDeviceService::found(device.clone(), None),
         MockDiscoveryService {
             devices: vec![device],
+            audit: AuditLog::default(),
         },
         MockDhcpService::empty(),
     );
@@ -1380,6 +1512,7 @@ async fn list_devices_with_dhcp_lease_shows_lease_status() {
         MockDeviceService::not_found(),
         MockDiscoveryService {
             devices: vec![device],
+            audit: AuditLog::default(),
         },
         dhcp,
     );
@@ -1412,6 +1545,7 @@ async fn list_devices_with_dhcp_reservation_shows_reservation_status() {
         MockDeviceService::not_found(),
         MockDiscoveryService {
             devices: vec![device],
+            audit: AuditLog::default(),
         },
         dhcp,
     );
@@ -1457,6 +1591,7 @@ async fn list_devices_reservation_overrides_lease() {
         MockDeviceService::not_found(),
         MockDiscoveryService {
             devices: vec![device],
+            audit: AuditLog::default(),
         },
         dhcp,
     );
@@ -1495,6 +1630,7 @@ async fn get_device_by_id_includes_dhcp_status() {
         MockDeviceService::found(device.clone(), Some(RoutingTarget::Direct)),
         MockDiscoveryService {
             devices: vec![device],
+            audit: AuditLog::default(),
         },
         dhcp,
     );
@@ -1503,4 +1639,138 @@ async fn get_device_by_id_includes_dhcp_status() {
     let (status, json) = get_json(app, "/api/devices/00000000-0000-0000-0000-000000000001").await;
     assert_eq!(status, StatusCode::OK);
     assert_eq!(json["device"]["dhcp_status"], "lease");
+}
+
+// ---------------------------------------------------------------------------
+// POST /api/devices/{id}/release  (issue #1181)
+// ---------------------------------------------------------------------------
+
+/// Build a state for the release path, returning the shared audit log so the
+/// test can assert the *order* the handler called things in.
+fn build_release_state_with(
+    device_svc: MockDeviceService,
+    device: Device,
+    audit: AuditLog,
+) -> AppState {
+    build_state_with_dhcp(
+        device_svc,
+        MockDiscoveryService {
+            devices: vec![device],
+            audit,
+        },
+        MockDhcpService::empty(),
+    )
+    .with_routing_profile_service(Arc::new(crate::tests::stubs::StubRoutingProfileService))
+}
+
+fn build_release_state(managed: bool) -> (AppState, AuditLog) {
+    let mut device = sample_device();
+    device.managed = managed;
+    device.name = Some("Living Room TV".to_owned());
+
+    let audit = AuditLog::default();
+    let mut device_svc = MockDeviceService::found(device.clone(), Some(RoutingTarget::Direct));
+    device_svc.audit = audit.clone();
+
+    let state = build_release_state_with(device_svc, device, audit.clone());
+    (state, audit)
+}
+
+#[tokio::test]
+async fn release_clears_managed_last() {
+    // The ordering IS the safety property: `clear_managed` asserts the
+    // invariant "no admin artefacts exist", so it must only run once every
+    // revert has landed. If it moved earlier, a later failure would leave an
+    // unmanaged device still holding a live credential — which the retention
+    // prune would then delete 30 days later.
+    let (state, audit) = build_release_state(true);
+    let app = device_router(state);
+
+    let (status, _json) = post_json(
+        app,
+        "/api/devices/00000000-0000-0000-0000-000000000001/release",
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+
+    let calls = audit.lock().unwrap().clone();
+    assert!(
+        calls.contains(&"clear_managed"),
+        "release must clear the managed flag; calls={calls:?}"
+    );
+    assert_eq!(
+        calls.last(),
+        Some(&"clear_managed"),
+        "clear_managed must be the LAST call; calls={calls:?}"
+    );
+    // And it really did revert things on the way — not just flip the flag.
+    assert!(
+        calls.contains(&"update_admin_locked") && calls.contains(&"update_device"),
+        "release must revert configuration, not merely unmanage; calls={calls:?}"
+    );
+}
+
+#[tokio::test]
+async fn release_leaves_the_device_managed_when_a_step_fails() {
+    // A partial release must be recoverable by retrying, never a half-released
+    // device carrying a credential it is no longer recorded as owning.
+    let mut device = sample_device();
+    device.managed = true;
+
+    let audit = AuditLog::default();
+    let mut device_svc = MockDeviceService::found(device.clone(), Some(RoutingTarget::Direct));
+    device_svc.audit = audit.clone();
+    device_svc.fail_admin_locked = true;
+
+    let state = build_release_state_with(device_svc, device, audit.clone());
+    let app = device_router(state);
+
+    let (status, json) = post_json(
+        app,
+        "/api/devices/00000000-0000-0000-0000-000000000001/release",
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::INTERNAL_SERVER_ERROR);
+    // The response body is deliberately generic — the step name goes to the
+    // log, not to the client.
+    assert_eq!(json["error"], "internal server error");
+
+    let calls = audit.lock().unwrap().clone();
+    assert!(
+        !calls.contains(&"clear_managed"),
+        "a failed release must leave the device managed; calls={calls:?}"
+    );
+}
+
+#[tokio::test]
+async fn release_is_404_for_an_unknown_device() {
+    // Every step below is individually tolerant of a missing device, so without
+    // an up-front lookup the whole sequence would "succeed" against nothing.
+    let state = build_state_with_dhcp(
+        MockDeviceService::not_found(),
+        MockDiscoveryService {
+            devices: vec![],
+            audit: AuditLog::default(),
+        },
+        MockDhcpService::empty(),
+    )
+    .with_routing_profile_service(Arc::new(crate::tests::stubs::StubRoutingProfileService));
+    let app = device_router(state);
+
+    let (status, _json) = post_json(
+        app,
+        "/api/devices/00000000-0000-0000-0000-000000000099/release",
+    )
+    .await;
+    assert_eq!(status, StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn release_rejects_a_malformed_device_id() {
+    let (state, _audit) = build_release_state(true);
+    let app = device_router(state);
+
+    let (status, _json) = post_json(app, "/api/devices/not-a-uuid/release").await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
 }

--- a/source/daemon/crates/wardnetd-api/src/api/tests/devices.rs
+++ b/source/daemon/crates/wardnetd-api/src/api/tests/devices.rs
@@ -373,6 +373,7 @@ impl DeviceService for MockDeviceService {
 struct MockDhcpService {
     leases: Vec<wardnet_common::dhcp::DhcpLease>,
     reservations: Vec<wardnet_common::dhcp::DhcpReservation>,
+    audit: AuditLog,
 }
 
 impl MockDhcpService {
@@ -380,6 +381,28 @@ impl MockDhcpService {
         Self {
             leases: vec![],
             reservations: vec![],
+            audit: AuditLog::default(),
+        }
+    }
+
+    /// One reservation pinned to `mac`, so the release's MAC-keyed lookup has
+    /// something to find (#1181).
+    fn with_reservation_for(mac: &str, audit: AuditLog) -> Self {
+        let now = chrono::Utc::now();
+        Self {
+            leases: vec![],
+            reservations: vec![wardnet_common::dhcp::DhcpReservation {
+                id: Uuid::parse_str("00000000-0000-0000-0000-0000000000d1").unwrap(),
+                // Deliberately uppercase: the handler matches case-insensitively
+                // because reservation MACs are not guaranteed canonical.
+                mac_address: mac.to_uppercase(),
+                ip_address: "192.168.1.42".parse().unwrap(),
+                hostname: None,
+                description: None,
+                created_at: now,
+                updated_at: now,
+            }],
+            audit,
         }
     }
 }
@@ -437,7 +460,10 @@ impl DhcpService for MockDhcpService {
         &self,
         _id: Uuid,
     ) -> Result<wardnet_common::api::DeleteDhcpReservationResponse, AppError> {
-        unimplemented!()
+        self.audit.lock().unwrap().push("delete_reservation");
+        Ok(wardnet_common::api::DeleteDhcpReservationResponse {
+            message: "reservation deleted".to_owned(),
+        })
     }
     async fn status(&self) -> Result<wardnet_common::api::DhcpStatusResponse, AppError> {
         unimplemented!()
@@ -1510,6 +1536,7 @@ async fn list_devices_with_dhcp_lease_shows_lease_status() {
     let dhcp = MockDhcpService {
         leases: vec![lease],
         reservations: vec![],
+        audit: AuditLog::default(),
     };
 
     let state = build_state_with_dhcp(
@@ -1543,6 +1570,7 @@ async fn list_devices_with_dhcp_reservation_shows_reservation_status() {
     let dhcp = MockDhcpService {
         leases: vec![],
         reservations: vec![reservation],
+        audit: AuditLog::default(),
     };
 
     let state = build_state_with_dhcp(
@@ -1589,6 +1617,7 @@ async fn list_devices_reservation_overrides_lease() {
     let dhcp = MockDhcpService {
         leases: vec![lease],
         reservations: vec![reservation],
+        audit: AuditLog::default(),
     };
 
     let state = build_state_with_dhcp(
@@ -1628,6 +1657,7 @@ async fn get_device_by_id_includes_dhcp_status() {
     let dhcp = MockDhcpService {
         leases: vec![lease],
         reservations: vec![],
+        audit: AuditLog::default(),
     };
 
     let state = build_state_with_dhcp(
@@ -1777,4 +1807,353 @@ async fn release_rejects_a_malformed_device_id() {
 
     let (status, _json) = post_json(app, "/api/devices/not-a-uuid/release").await;
     assert_eq!(status, StatusCode::BAD_REQUEST);
+}
+
+// ---------------------------------------------------------------------------
+// Release with artefacts actually present (issue #1181)
+// ---------------------------------------------------------------------------
+//
+// The release tests above run against empty collections, which proves the
+// ordering but never executes a single revoke. These populate every artefact
+// the release is supposed to tear down, so the destructive path — the one that
+// disconnects a device — is actually exercised.
+
+const RELEASE_DEVICE_ID: &str = "00000000-0000-0000-0000-000000000001";
+const RELEASE_MAC: &str = "aa:bb:cc:dd:ee:01";
+
+/// `PrivateDnsService` holding one grant for the device under test.
+struct GrantingPrivateDns {
+    audit: AuditLog,
+}
+
+#[async_trait]
+impl wardnetd_services::private_dns::PrivateDnsService for GrantingPrivateDns {
+    async fn list_grants(
+        &self,
+    ) -> Result<Vec<wardnetd_services::private_dns::PrivateDnsGrant>, AppError> {
+        // `device_grant` is a provided method over this one, so seeding here is
+        // enough to drive the handler's lookup.
+        Ok(vec![wardnetd_services::private_dns::PrivateDnsGrant {
+            id: Uuid::parse_str("00000000-0000-0000-0000-0000000000a1").unwrap(),
+            device_id: Uuid::parse_str(RELEASE_DEVICE_ID).unwrap(),
+            token: "secrettoken".to_owned(),
+            created_at: "2026-01-01T00:00:00Z".to_owned(),
+        }])
+    }
+    /// Overridden, not inherited: the trait's default `device_grant` returns
+    /// `Ok(None)` unconditionally and is meant to be replaced by the impl (as
+    /// `PrivateDnsServiceImpl` does). A double that inherited it would report
+    /// "no grant" and quietly skip the revoke this test exists to check.
+    async fn device_grant(
+        &self,
+        device_id: Uuid,
+    ) -> Result<Option<wardnetd_services::private_dns::PrivateDnsGrant>, AppError> {
+        Ok(self
+            .list_grants()
+            .await?
+            .into_iter()
+            .find(|g| g.device_id == device_id))
+    }
+
+    async fn revoke_grant(&self, _grant_id: Uuid) -> Result<(), AppError> {
+        self.audit.lock().unwrap().push("revoke_grant");
+        Ok(())
+    }
+    async fn status(&self) -> Result<wardnetd_services::private_dns::PrivateDnsStatus, AppError> {
+        unimplemented!()
+    }
+    async fn is_enabled(&self) -> Result<bool, AppError> {
+        Ok(true)
+    }
+    async fn set_enabled(
+        &self,
+        _enabled: bool,
+    ) -> Result<wardnetd_services::private_dns::PrivateDnsStatus, AppError> {
+        unimplemented!()
+    }
+    async fn grant_device(
+        &self,
+        _device_id: Uuid,
+    ) -> Result<wardnetd_services::private_dns::PrivateDnsGrant, AppError> {
+        unimplemented!()
+    }
+    async fn resolve_token(
+        &self,
+        _token: &str,
+    ) -> Result<Option<wardnetd_services::private_dns::PrivateDnsGrant>, AppError> {
+        unimplemented!()
+    }
+    async fn reconcile(&self) -> Result<(), AppError> {
+        unimplemented!()
+    }
+}
+
+/// `InboundWgService` holding one peer bound to the device under test.
+struct PeeredInboundWg {
+    audit: AuditLog,
+}
+
+#[async_trait]
+impl wardnetd_services::InboundWgService for PeeredInboundWg {
+    async fn list_peers(&self) -> Result<Vec<wardnet_common::api::InboundWgPeerSummary>, AppError> {
+        Ok(vec![wardnet_common::api::InboundWgPeerSummary {
+            id: Uuid::parse_str("00000000-0000-0000-0000-0000000000b1").unwrap(),
+            name: "alice-phone".to_owned(),
+            public_key: "pk".to_owned(),
+            allowed_ip: "10.100.64.2/32".to_owned(),
+            enabled: true,
+            created_at: chrono::Utc::now(),
+            device_id: Some(Uuid::parse_str(RELEASE_DEVICE_ID).unwrap()),
+        }])
+    }
+    async fn remove_peer(&self, _id: Uuid) -> Result<(), AppError> {
+        self.audit.lock().unwrap().push("remove_peer");
+        Ok(())
+    }
+    async fn get_config(&self) -> Result<wardnet_common::api::InboundWgConfigResponse, AppError> {
+        unimplemented!()
+    }
+    async fn set_config(
+        &self,
+        _enabled: bool,
+        _listen_port: u16,
+    ) -> Result<wardnet_common::api::InboundWgConfigResponse, AppError> {
+        unimplemented!()
+    }
+    async fn add_peer(
+        &self,
+        _device_id: Uuid,
+        _endpoint: Option<String>,
+    ) -> Result<wardnet_common::api::AddInboundWgPeerResponse, AppError> {
+        unimplemented!()
+    }
+    async fn set_peer_enabled(
+        &self,
+        _id: Uuid,
+        _enabled: bool,
+    ) -> Result<wardnet_common::api::InboundWgPeerSummary, AppError> {
+        unimplemented!()
+    }
+    async fn list_peers_for_monitor(
+        &self,
+    ) -> Result<Vec<wardnetd_services::inbound_wg::InboundWgMonitorPeer>, AppError> {
+        unimplemented!()
+    }
+    async fn reconcile(&self) -> Result<(), AppError> {
+        unimplemented!()
+    }
+}
+
+/// `ZoneExceptionService` holding one exception naming the device.
+struct ExceptioningZones {
+    audit: AuditLog,
+}
+
+impl ExceptioningZones {
+    fn exception() -> wardnet_common::zone_exception::ZoneException {
+        use wardnet_common::zone_exception::{
+            ExceptionEndpoint, ExceptionEndpointKind, ServiceSet, ServiceSpec, ZoneException,
+        };
+        let now = chrono::Utc::now();
+        ZoneException {
+            id: Uuid::parse_str("00000000-0000-0000-0000-0000000000c1").unwrap(),
+            // Device on the `to` side, so the handler's both-endpoints check is
+            // exercised rather than only its first arm.
+            from: ExceptionEndpoint {
+                kind: ExceptionEndpointKind::Zone,
+                id: Uuid::parse_str("00000000-0000-0000-0000-000000000202").unwrap(),
+            },
+            to: ExceptionEndpoint {
+                kind: ExceptionEndpointKind::Device,
+                id: Uuid::parse_str(RELEASE_DEVICE_ID).unwrap(),
+            },
+            service: ServiceSpec::Preset {
+                set: ServiceSet::Casting,
+            },
+            bidirectional: true,
+            created_at: now,
+            updated_at: now,
+        }
+    }
+}
+
+#[async_trait]
+impl wardnetd_services::ZoneExceptionService for ExceptioningZones {
+    async fn list_exceptions(
+        &self,
+    ) -> Result<Vec<wardnet_common::zone_exception::ZoneException>, AppError> {
+        Ok(vec![Self::exception()])
+    }
+    async fn delete_exception(&self, _id: Uuid) -> Result<(), AppError> {
+        self.audit.lock().unwrap().push("delete_exception");
+        Ok(())
+    }
+    async fn get_exception(
+        &self,
+        _id: Uuid,
+    ) -> Result<wardnet_common::zone_exception::ZoneException, AppError> {
+        unimplemented!()
+    }
+    async fn create_exception(
+        &self,
+        _req: wardnet_common::api::CreateZoneExceptionRequest,
+    ) -> Result<wardnet_common::zone_exception::ZoneException, AppError> {
+        unimplemented!()
+    }
+    async fn update_exception(
+        &self,
+        _id: Uuid,
+        _req: wardnet_common::api::UpdateZoneExceptionRequest,
+    ) -> Result<wardnet_common::zone_exception::ZoneException, AppError> {
+        unimplemented!()
+    }
+}
+
+/// A zone catalogue whose default-for-new zone is NOT the device's, so the
+/// release's zone-reset step actually fires.
+struct RezoningNetworkZones {
+    audit: AuditLog,
+}
+
+const RELEASE_DEFAULT_ZONE: &str = "00000000-0000-0000-0000-0000000000e1";
+
+#[async_trait]
+impl wardnetd_services::NetworkZoneService for RezoningNetworkZones {
+    async fn list_zones(&self) -> Result<Vec<wardnet_common::api::NetworkZoneView>, AppError> {
+        let mut zone = crate::tests::stubs::StubNetworkZoneService::stub_zone();
+        zone.id = Uuid::parse_str(RELEASE_DEFAULT_ZONE).unwrap();
+        zone.is_default_for_new = true;
+        Ok(vec![wardnet_common::api::NetworkZoneView {
+            zone,
+            member_count: 0,
+        }])
+    }
+    async fn assign_device(&self, _device_id: Uuid, _zone_id: Uuid) -> Result<(), AppError> {
+        self.audit.lock().unwrap().push("assign_device");
+        Ok(())
+    }
+    async fn get_zone(&self, _id: Uuid) -> Result<wardnet_common::api::NetworkZoneView, AppError> {
+        unimplemented!()
+    }
+    async fn create_zone(
+        &self,
+        _req: wardnet_common::api::CreateNetworkZoneRequest,
+    ) -> Result<wardnet_common::network_zone::NetworkZone, AppError> {
+        unimplemented!()
+    }
+    async fn update_zone(
+        &self,
+        _id: Uuid,
+        _req: wardnet_common::api::UpdateNetworkZoneRequest,
+    ) -> Result<wardnet_common::network_zone::NetworkZone, AppError> {
+        unimplemented!()
+    }
+    async fn delete_zone(&self, _id: Uuid) -> Result<(), AppError> {
+        unimplemented!()
+    }
+    async fn set_default(&self, _id: Uuid) -> Result<(), AppError> {
+        unimplemented!()
+    }
+    async fn set_default_for_new(&self, _id: Uuid) -> Result<(), AppError> {
+        unimplemented!()
+    }
+    async fn get_quarantine_new_devices(&self) -> Result<bool, AppError> {
+        Ok(false)
+    }
+    async fn set_quarantine_new_devices(&self, _enabled: bool) -> Result<(), AppError> {
+        unimplemented!()
+    }
+}
+
+#[tokio::test]
+async fn release_revokes_every_artefact_the_device_actually_has() {
+    // The load-bearing release test. Every prior one runs against empty
+    // collections, so the four revoke paths — the ones that disconnect a
+    // device — never execute. This seeds a Private-DNS grant, a Remote peer,
+    // a DHCP reservation, a zone exception and a differing default-for-new
+    // zone, and asserts each is torn down, in order, with `clear_managed` last.
+    let mut device = sample_device();
+    device.managed = true;
+    device.name = Some("Living Room TV".to_owned());
+
+    let audit = AuditLog::default();
+    let mut device_svc = MockDeviceService::found(device.clone(), Some(RoutingTarget::Direct));
+    device_svc.audit = audit.clone();
+
+    // `zone_exception` and `network_zone` are constructor params, not `with_`
+    // builders, so this test assembles the state directly.
+    let state = AppState::new(
+        Arc::new(MockAuthService),
+        Arc::new(crate::tests::stubs::StubBackupService),
+        Arc::new(device_svc),
+        Arc::new(MockDhcpService::with_reservation_for(
+            RELEASE_MAC,
+            audit.clone(),
+        )),
+        Arc::new(StubDnsService),
+        Arc::new(StubDnsFilterService),
+        Arc::new(StubDnsLocalService),
+        Arc::new(crate::tests::stubs::StubDdnsService),
+        Arc::new(crate::tests::stubs::StubTlsService),
+        Arc::new(MockDiscoveryService {
+            devices: vec![device],
+            audit: audit.clone(),
+        }),
+        Arc::new(StubLogService) as Arc<dyn LogService>,
+        Arc::new(StubProviderService),
+        Arc::new(StubRoutingService),
+        Arc::new(RezoningNetworkZones {
+            audit: audit.clone(),
+        }),
+        Arc::new(StubSystemService),
+        Arc::new(StubTunnelService),
+        Arc::new(crate::tests::stubs::StubUpdateService),
+        Arc::new(StubDhcpServer),
+        Arc::new(StubDnsServer),
+        Arc::new(StubEventPublisher),
+        crate::tests::stubs::StubJobService::new_arc(),
+        Arc::new(crate::tests::stubs::StubStatsService),
+        Arc::new(crate::tests::stubs::StubRuleRequestService),
+        Arc::new(ExceptioningZones {
+            audit: audit.clone(),
+        }),
+    )
+    .with_routing_profile_service(Arc::new(crate::tests::stubs::StubRoutingProfileService))
+    .with_private_dns_service(Arc::new(GrantingPrivateDns {
+        audit: audit.clone(),
+    }))
+    .with_inbound_wg_service(Arc::new(PeeredInboundWg {
+        audit: audit.clone(),
+    }));
+    let app = device_router(state);
+
+    let (status, _json) =
+        post_json(app, &format!("/api/devices/{RELEASE_DEVICE_ID}/release")).await;
+    assert_eq!(status, StatusCode::OK);
+
+    let calls = audit.lock().unwrap().clone();
+    for expected in [
+        "revoke_grant",
+        "remove_peer",
+        "delete_reservation",
+        "delete_exception",
+        "clear_rule",
+        "update_dns_capture_settings",
+        "update_admin_locked",
+        "update_device",
+        "assign_device",
+        "clear_managed",
+    ] {
+        assert!(
+            calls.contains(&expected),
+            "release did not perform '{expected}'; calls={calls:?}"
+        );
+    }
+
+    // The grant is revoked FIRST — it publishes `PrivateDnsGrantRevoked`, which
+    // tears down the device's live DoT sessions.
+    assert_eq!(calls.first(), Some(&"revoke_grant"), "calls={calls:?}");
+    // And `clear_managed` is LAST, so the "no admin artefacts exist" invariant
+    // is only asserted once every artefact above is actually gone.
+    assert_eq!(calls.last(), Some(&"clear_managed"), "calls={calls:?}");
 }

--- a/source/daemon/crates/wardnetd-api/src/api/tests/devices.rs
+++ b/source/daemon/crates/wardnetd-api/src/api/tests/devices.rs
@@ -478,6 +478,10 @@ struct MockDiscoveryService {
 
 #[async_trait]
 impl DeviceDiscoveryService for MockDiscoveryService {
+    async fn prune_unmanaged_devices(&self) -> Result<u64, wardnetd_services::error::AppError> {
+        Ok(0)
+    }
+
     async fn process_peer_observation(
         &self,
         _device_id: uuid::Uuid,

--- a/source/daemon/crates/wardnetd-api/src/api/tests/dns_capture.rs
+++ b/source/daemon/crates/wardnetd-api/src/api/tests/dns_capture.rs
@@ -123,6 +123,24 @@ impl MockDnsDeviceService {
 
 #[async_trait]
 impl DeviceService for MockDnsDeviceService {
+    async fn clear_rule(&self, _device_id: &str) -> Result<(), wardnetd_services::error::AppError> {
+        Ok(())
+    }
+
+    async fn mark_managed(
+        &self,
+        _device_id: &str,
+    ) -> Result<(), wardnetd_services::error::AppError> {
+        Ok(())
+    }
+
+    async fn clear_managed(
+        &self,
+        _device_id: &str,
+    ) -> Result<(), wardnetd_services::error::AppError> {
+        Ok(())
+    }
+
     async fn get_device(
         &self,
         _device_id: &str,

--- a/source/daemon/crates/wardnetd-api/src/api/tests/dns_events.rs
+++ b/source/daemon/crates/wardnetd-api/src/api/tests/dns_events.rs
@@ -129,6 +129,7 @@ fn sample_device() -> Device {
         dns_capture_cap_count: 500,
         dns_capture_cap_days: 14,
         connection_mode: wardnet_common::device::DeviceConnectionMode::Lan,
+        managed: false,
     }
 }
 
@@ -181,6 +182,24 @@ impl MockDnsEventsDeviceService {
 
 #[async_trait]
 impl DeviceService for MockDnsEventsDeviceService {
+    async fn clear_rule(&self, _device_id: &str) -> Result<(), wardnetd_services::error::AppError> {
+        Ok(())
+    }
+
+    async fn mark_managed(
+        &self,
+        _device_id: &str,
+    ) -> Result<(), wardnetd_services::error::AppError> {
+        Ok(())
+    }
+
+    async fn clear_managed(
+        &self,
+        _device_id: &str,
+    ) -> Result<(), wardnetd_services::error::AppError> {
+        Ok(())
+    }
+
     async fn get_device(
         &self,
         _device_id: &str,

--- a/source/daemon/crates/wardnetd-api/src/api/tests/middleware.rs
+++ b/source/daemon/crates/wardnetd-api/src/api/tests/middleware.rs
@@ -412,6 +412,24 @@ struct MockDeviceService {
 
 #[async_trait]
 impl DeviceService for MockDeviceService {
+    async fn clear_rule(&self, _device_id: &str) -> Result<(), wardnetd_services::error::AppError> {
+        Ok(())
+    }
+
+    async fn mark_managed(
+        &self,
+        _device_id: &str,
+    ) -> Result<(), wardnetd_services::error::AppError> {
+        Ok(())
+    }
+
+    async fn clear_managed(
+        &self,
+        _device_id: &str,
+    ) -> Result<(), wardnetd_services::error::AppError> {
+        Ok(())
+    }
+
     async fn get_device(
         &self,
         _device_id: &str,
@@ -705,6 +723,7 @@ async fn resolve_auth_context_known_device_ip() {
         dns_capture_cap_count: 1000,
         dns_capture_cap_days: 7,
         connection_mode: wardnet_common::device::DeviceConnectionMode::Lan,
+        managed: false,
     };
     let state = make_state_with_device(
         MockAuthService {

--- a/source/daemon/crates/wardnetd-api/src/api/tests/private_dns.rs
+++ b/source/daemon/crates/wardnetd-api/src/api/tests/private_dns.rs
@@ -179,11 +179,30 @@ fn me_device() -> Device {
         dns_capture_cap_count: 0,
         dns_capture_cap_days: 0,
         connection_mode: DeviceConnectionMode::Lan,
+        managed: false,
     }
 }
 
 #[async_trait]
 impl DeviceService for MeDeviceService {
+    async fn clear_rule(&self, _device_id: &str) -> Result<(), wardnetd_services::error::AppError> {
+        Ok(())
+    }
+
+    async fn mark_managed(
+        &self,
+        _device_id: &str,
+    ) -> Result<(), wardnetd_services::error::AppError> {
+        Ok(())
+    }
+
+    async fn clear_managed(
+        &self,
+        _device_id: &str,
+    ) -> Result<(), wardnetd_services::error::AppError> {
+        Ok(())
+    }
+
     async fn get_device_for_ip(&self, _ip: &str) -> Result<DeviceMeResponse, AppError> {
         Ok(DeviceMeResponse {
             device: self.known.then(me_device),

--- a/source/daemon/crates/wardnetd-api/src/api/tests/routing_profiles.rs
+++ b/source/daemon/crates/wardnetd-api/src/api/tests/routing_profiles.rs
@@ -65,6 +65,7 @@ async fn app() -> Router {
     let service = Arc::new(RoutingProfileServiceImpl::new(
         repo,
         Arc::new(StubTunnelService),
+        Arc::new(crate::tests::stubs::StubDeviceService),
         tx,
     ));
 

--- a/source/daemon/crates/wardnetd-api/src/tests/stubs.rs
+++ b/source/daemon/crates/wardnetd-api/src/tests/stubs.rs
@@ -135,6 +135,24 @@ impl AuthService for AlwaysAdminAuth {
 pub struct StubDeviceService;
 #[async_trait]
 impl DeviceService for StubDeviceService {
+    async fn clear_rule(&self, _device_id: &str) -> Result<(), wardnetd_services::error::AppError> {
+        Ok(())
+    }
+
+    async fn mark_managed(
+        &self,
+        _device_id: &str,
+    ) -> Result<(), wardnetd_services::error::AppError> {
+        Ok(())
+    }
+
+    async fn clear_managed(
+        &self,
+        _device_id: &str,
+    ) -> Result<(), wardnetd_services::error::AppError> {
+        Ok(())
+    }
+
     async fn get_device(
         &self,
         _device_id: &str,
@@ -470,10 +488,21 @@ impl wardnetd_services::DnsFilterService for StubDnsFilterService {
     }
     async fn update_device_settings(
         &self,
-        _device_id: Uuid,
-        _r: UpdateDeviceFilterSettingsRequest,
+        device_id: Uuid,
+        r: UpdateDeviceFilterSettingsRequest,
     ) -> Result<UpdateDeviceFilterSettingsResponse, AppError> {
-        unimplemented!()
+        // Echoes the request back rather than `unimplemented!()`: the release
+        // handler resets a device's filter settings as one of its steps
+        // (#1181), so a panicking stub would make that whole path untestable.
+        Ok(UpdateDeviceFilterSettingsResponse {
+            settings: wardnet_common::dns_filter::DeviceDnsFilterSettings {
+                device_id,
+                enabled: r.enabled,
+                profile_ids: r.profile_ids,
+                updated_at: chrono::Utc::now(),
+            },
+            message: "device filter settings updated".to_owned(),
+        })
     }
     async fn get_filter_config(&self) -> Result<DnsFilterConfigResponse, AppError> {
         unimplemented!()
@@ -1406,4 +1435,95 @@ pub fn test_app_state() -> AppState {
         Arc::new(StubRuleRequestService),
         Arc::new(StubZoneExceptionService),
     )
+}
+
+/// A permissive `RoutingProfileService` for handler tests.
+///
+/// `AppState`'s default is a `Noop` that reports "not configured", and the real
+/// impl is `require_admin`-guarded — neither works in a handler test, which
+/// establishes no ambient auth context. This one just succeeds, so a handler
+/// that resets a device's profiles (the release flow, #1181) can be exercised.
+pub struct StubRoutingProfileService;
+
+#[async_trait]
+impl wardnetd_services::routing_profile::RoutingProfileService for StubRoutingProfileService {
+    async fn list_profiles(
+        &self,
+    ) -> Result<Vec<wardnet_common::routing_profile::RoutingProfile>, AppError> {
+        Ok(Vec::new())
+    }
+    async fn get_profile(
+        &self,
+        _id: Uuid,
+    ) -> Result<wardnet_common::routing_profile::RoutingProfile, AppError> {
+        Err(AppError::NotFound("profile not found".to_owned()))
+    }
+    async fn create_profile(
+        &self,
+        _name: &str,
+    ) -> Result<wardnet_common::routing_profile::RoutingProfile, AppError> {
+        unimplemented!()
+    }
+    async fn rename_profile(
+        &self,
+        _id: Uuid,
+        _name: &str,
+    ) -> Result<wardnet_common::routing_profile::RoutingProfile, AppError> {
+        unimplemented!()
+    }
+    async fn delete_profile(&self, _id: Uuid) -> Result<(), AppError> {
+        unimplemented!()
+    }
+    async fn list_rules(
+        &self,
+        _profile_id: Uuid,
+    ) -> Result<Vec<wardnet_common::routing_profile::DomainRoutingRule>, AppError> {
+        Ok(Vec::new())
+    }
+    async fn create_rule(
+        &self,
+        _profile_id: Uuid,
+        _pattern: &str,
+        _target: wardnet_common::routing_profile::DomainRoutingTarget,
+        _enabled: bool,
+    ) -> Result<wardnet_common::routing_profile::DomainRoutingRule, AppError> {
+        unimplemented!()
+    }
+    async fn update_rule(
+        &self,
+        _id: Uuid,
+        _pattern: Option<String>,
+        _target: Option<wardnet_common::routing_profile::DomainRoutingTarget>,
+        _enabled: Option<bool>,
+    ) -> Result<wardnet_common::routing_profile::DomainRoutingRule, AppError> {
+        unimplemented!()
+    }
+    async fn delete_rule(&self, _id: Uuid) -> Result<(), AppError> {
+        unimplemented!()
+    }
+    async fn get_device_profiles(&self, _device_id: Uuid) -> Result<Vec<Uuid>, AppError> {
+        Ok(Vec::new())
+    }
+    async fn set_device_profiles(
+        &self,
+        _device_id: Uuid,
+        _profile_ids: &[Uuid],
+    ) -> Result<(), AppError> {
+        Ok(())
+    }
+    async fn list_profile_devices(&self, _profile_id: Uuid) -> Result<Vec<Uuid>, AppError> {
+        Ok(Vec::new())
+    }
+    async fn refresh_view(&self) -> Result<(), AppError> {
+        Ok(())
+    }
+    fn note_resolution(
+        &self,
+        _device_id: Uuid,
+        _device_ip: std::net::IpAddr,
+        _name: &str,
+        _answer_ips: &[std::net::IpAddr],
+        _ttl_secs: u32,
+    ) {
+    }
 }

--- a/source/daemon/crates/wardnetd-api/src/tests/stubs.rs
+++ b/source/daemon/crates/wardnetd-api/src/tests/stubs.rs
@@ -618,6 +618,10 @@ impl wardnetd_services::DnsLocalService for StubDnsLocalService {
 pub struct StubDiscoveryService;
 #[async_trait]
 impl DeviceDiscoveryService for StubDiscoveryService {
+    async fn prune_unmanaged_devices(&self) -> Result<u64, wardnetd_services::error::AppError> {
+        Ok(0)
+    }
+
     async fn process_peer_observation(
         &self,
         _device_id: uuid::Uuid,

--- a/source/daemon/crates/wardnetd-api/src/tests/stubs.rs
+++ b/source/daemon/crates/wardnetd-api/src/tests/stubs.rs
@@ -826,7 +826,7 @@ pub struct StubNetworkZoneService;
 impl StubNetworkZoneService {
     /// A Trusted-like zone used to satisfy the return types of the create /
     /// update / get stubs.
-    fn stub_zone() -> NetworkZone {
+    pub(crate) fn stub_zone() -> NetworkZone {
         NetworkZone {
             id: Uuid::parse_str("00000000-0000-0000-0000-000000000201").unwrap(),
             name: "Trusted".to_owned(),

--- a/source/daemon/crates/wardnetd-data/migrations/20260810000000_managed_devices.sql
+++ b/source/daemon/crates/wardnetd-data/migrations/20260810000000_managed_devices.sql
@@ -48,3 +48,6 @@ UPDATE devices SET managed = 1 WHERE
     OR EXISTS (SELECT 1 FROM zone_exceptions t
                WHERE (t.from_kind = 'device' AND t.from_id = devices.id)
                   OR (t.to_kind   = 'device' AND t.to_id   = devices.id));
+
+-- The retention prune scans by `last_seen`.
+CREATE INDEX IF NOT EXISTS idx_devices_last_seen ON devices(last_seen);

--- a/source/daemon/crates/wardnetd-data/migrations/20260810000000_managed_devices.sql
+++ b/source/daemon/crates/wardnetd-data/migrations/20260810000000_managed_devices.sql
@@ -1,0 +1,50 @@
+-- Managed devices + retention (issue #1181).
+--
+-- "Managed" was previously *inferred* from `name IS NOT NULL`, which is wrong
+-- in both directions: a device granted Private DNS, a DHCP reservation, or a
+-- Remote peer credential rendered as "Discovered", while a bare name alone made
+-- a device "Managed". Retention (deleting long-absent devices) cannot be built
+-- on that inference — pruning on `name IS NULL` would silently revoke remote
+-- access and orphan admin-authored MAC-keyed rows that have no FK to clean them
+-- up.
+--
+-- So `managed` becomes an explicit, latching column, promoted by any admin
+-- configuration act and cleared only by an explicit release. That gives the
+-- invariant the prune depends on:
+--
+--     managed = 0  =>  no admin artefacts exist for this device
+--
+-- which is why deleting an unmanaged row can never orphan anything.
+ALTER TABLE devices ADD COLUMN managed INTEGER NOT NULL DEFAULT 0;
+
+-- Backfill: any ADMIN-created artefact means the admin decided to control this
+-- device. Self-service artefacts (user-created routing rules, device rule
+-- requests, push subscriptions) deliberately do NOT promote — those are the
+-- device asking, not the admin deciding, and promoting on them would make
+-- every guest phone permanently unprunable.
+--
+-- Deliberate gap: a past zone reassignment is NOT backfilled. Zone membership
+-- is sticky (CONTEXT.md), so `zone_id != <default-for-new>` is
+-- indistinguishable from "the default-for-new flag was later re-pointed at a
+-- different zone". Guessing inclusively would mark essentially every existing
+-- device managed, silently disabling retention on exactly the boxes that need
+-- it. Going forward `assign_device` promotes explicitly. See
+-- docs/adr/0032-managed-devices-and-retention.md.
+UPDATE devices SET managed = 1 WHERE
+       name IS NOT NULL
+    OR admin_locked = 1
+    OR dns_capture_enabled = 1
+    OR EXISTS (SELECT 1 FROM routing_rules r
+               WHERE r.device_id = devices.id AND r.created_by = 'admin')
+    OR EXISTS (SELECT 1 FROM routing_device_profile     t WHERE t.device_id = devices.id)
+    OR EXISTS (SELECT 1 FROM dns_filter_device_settings t WHERE t.device_id = devices.id)
+    OR EXISTS (SELECT 1 FROM dns_filter_device_profile  t WHERE t.device_id = devices.id)
+    -- No `dns_device_adblock` clause: that table was dropped by
+    -- 20260506000000_dns_filtering.sql and superseded by
+    -- `dns_filter_device_settings` above.
+    OR EXISTS (SELECT 1 FROM private_dns_grants         t WHERE t.device_id = devices.id)
+    OR EXISTS (SELECT 1 FROM inbound_wg_peers           t WHERE t.device_id = devices.id)
+    OR EXISTS (SELECT 1 FROM dhcp_reservations t WHERE t.mac_address = devices.mac)
+    OR EXISTS (SELECT 1 FROM zone_exceptions t
+               WHERE (t.from_kind = 'device' AND t.from_id = devices.id)
+                  OR (t.to_kind   = 'device' AND t.to_id   = devices.id));

--- a/source/daemon/crates/wardnetd-data/src/repository/device.rs
+++ b/source/daemon/crates/wardnetd-data/src/repository/device.rs
@@ -140,6 +140,18 @@ pub trait DeviceRepository: Send + Sync {
     /// device appears at most once; devices with no rule are simply absent.
     async fn find_all_rules(&self) -> anyhow::Result<Vec<RoutingRule>>;
 
+    /// Delete a device's routing rule, returning to "no rule" — which means
+    /// the device follows the gateway's global default policy.
+    ///
+    /// Distinct from writing a `Direct` rule: that is an explicit persisted
+    /// choice that *overrides* the default policy, and it is also subject to
+    /// the device's zone allow-list, so it can be rejected outright by a
+    /// tunnel-only zone. Deleting is the true revert-to-default and cannot
+    /// conflict with a zone. Used by the release flow (issue #1181).
+    ///
+    /// No-op if the device has no rule.
+    async fn delete_rule_for_device(&self, device_id: &str) -> anyhow::Result<()>;
+
     /// Insert or update a user-created routing rule for a device.
     async fn upsert_user_rule(
         &self,
@@ -188,4 +200,12 @@ pub trait DeviceRepository: Send + Sync {
 
     /// Return IDs of all devices that have DNS capture enabled.
     async fn find_all_capture_enabled_ids(&self) -> anyhow::Result<Vec<String>>;
+
+    /// Set the `managed` flag for a device.
+    ///
+    /// Idempotent, and a no-op if the device does not exist. Promotion
+    /// (`managed = true`) is called from every admin configuration act;
+    /// demotion is reached only through an explicit release, which first
+    /// reverts all managed configuration to default. See issue #1181.
+    async fn set_managed(&self, id: &str, managed: bool) -> anyhow::Result<()>;
 }

--- a/source/daemon/crates/wardnetd-data/src/repository/device.rs
+++ b/source/daemon/crates/wardnetd-data/src/repository/device.rs
@@ -25,6 +25,19 @@ pub struct DeviceRow {
     pub connection_mode: DeviceConnectionMode,
 }
 
+/// A device row removed by the retention prune.
+///
+/// Carries just enough to log the deletion and to evict the device from the
+/// discovery service's in-memory maps — which the caller *must* do, keyed by
+/// `mac`, or the next observation of that MAC resolves to a dangling
+/// `device_id` (issue #1181).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PrunedDevice {
+    pub id: String,
+    pub mac: String,
+    pub last_seen: String,
+}
+
 /// Data access for devices and their routing rules.
 ///
 /// Provides lookups by IP and ID, routing rule queries, and upserts.
@@ -208,4 +221,15 @@ pub trait DeviceRepository: Send + Sync {
     /// demotion is reached only through an explicit release, which first
     /// reverts all managed configuration to default. See issue #1181.
     async fn set_managed(&self, id: &str, managed: bool) -> anyhow::Result<()>;
+
+    /// Delete unmanaged devices last seen before the given ISO timestamp,
+    /// returning the rows that were removed.
+    ///
+    /// Only unmanaged devices are eligible: `managed = 0` implies no admin
+    /// artefact references the device, so the delete cannot orphan a row.
+    /// Managed devices are never auto-deleted at any age.
+    ///
+    /// The caller is responsible for evicting each returned `mac` from the
+    /// discovery service's in-memory state — see [`PrunedDevice`].
+    async fn delete_unmanaged_before(&self, cutoff: &str) -> anyhow::Result<Vec<PrunedDevice>>;
 }

--- a/source/daemon/crates/wardnetd-data/src/repository/mod.rs
+++ b/source/daemon/crates/wardnetd-data/src/repository/mod.rs
@@ -26,7 +26,7 @@ pub mod zone_exception;
 
 pub use admin::AdminRepository;
 pub use api_key::ApiKeyRepository;
-pub use device::{DeviceRepository, DeviceRow};
+pub use device::{DeviceRepository, DeviceRow, PrunedDevice};
 pub use device_identification::{DeviceIdentificationRepository, DeviceSignalRow};
 pub use dhcp::{DhcpLeaseLogRow, DhcpLeaseRow, DhcpRepository, DhcpReservationRow};
 pub use dns::{DnsRepository, QueryLogFilter, QueryLogRow};

--- a/source/daemon/crates/wardnetd-data/src/repository/sqlite/device.rs
+++ b/source/daemon/crates/wardnetd-data/src/repository/sqlite/device.rs
@@ -4,7 +4,7 @@ use wardnet_common::device::{Device, DeviceConnectionMode, DeviceType, Manufactu
 use wardnet_common::routing::{RoutingRule, RoutingTarget, RuleCreator};
 
 use super::super::DeviceRepository;
-use super::super::device::DeviceRow as InsertDeviceRow;
+use super::super::device::{DeviceRow as InsertDeviceRow, PrunedDevice};
 use crate::db::DbPools;
 
 /// SQLite-backed implementation of [`DeviceRepository`].
@@ -132,6 +132,8 @@ const FIND_BY_MAC_SQL: &str = "SELECT id, mac, name, hostname, manufacturer, man
      FROM devices WHERE mac = ?";
 const FIND_ALL_SQL: &str = "SELECT id, mac, name, hostname, manufacturer, manufacturer_source, is_randomized, device_type, first_seen, last_seen, last_ip, admin_locked, zone_id, dns_capture_enabled, dns_capture_cap_count, dns_capture_cap_days, connection_mode, managed \
      FROM devices ORDER BY last_seen DESC";
+const DELETE_UNMANAGED_BEFORE_SQL: &str =
+    "DELETE FROM devices WHERE managed = 0 AND last_seen < ? RETURNING id, mac, last_seen";
 const FIND_STALE_SQL: &str = "SELECT id, mac, name, hostname, manufacturer, manufacturer_source, is_randomized, device_type, first_seen, last_seen, last_ip, admin_locked, zone_id, dns_capture_enabled, dns_capture_cap_count, dns_capture_cap_days, connection_mode, managed \
      FROM devices WHERE last_seen < ?";
 
@@ -509,5 +511,26 @@ impl DeviceRepository for SqliteDeviceRepository {
             .execute(&self.pools.write)
             .await?;
         Ok(())
+    }
+
+    async fn delete_unmanaged_before(&self, cutoff: &str) -> anyhow::Result<Vec<PrunedDevice>> {
+        // `managed = 0` is the whole safety argument: an unmanaged device has
+        // no admin artefacts, so this DELETE cannot orphan anything. The
+        // per-device rows that do exist are either ON DELETE CASCADE
+        // (dns_events, device_signals, …), ON DELETE SET NULL (dhcp_leases),
+        // self-expiring (dns_query_log), or retained as historical truth
+        // (stats_*, notifications).
+        //
+        // RETURNING (precedent: sqlite/dns_local.rs) makes the delete and the
+        // "what was deleted" read one atomic statement — a separate SELECT
+        // could race a concurrent observation and report a row that survived.
+        let rows = sqlx::query_as::<_, (String, String, String)>(DELETE_UNMANAGED_BEFORE_SQL)
+            .bind(cutoff)
+            .fetch_all(&self.pools.write)
+            .await?;
+        Ok(rows
+            .into_iter()
+            .map(|(id, mac, last_seen)| PrunedDevice { id, mac, last_seen })
+            .collect())
     }
 }

--- a/source/daemon/crates/wardnetd-data/src/repository/sqlite/device.rs
+++ b/source/daemon/crates/wardnetd-data/src/repository/sqlite/device.rs
@@ -46,6 +46,7 @@ struct DeviceRow {
     dns_capture_cap_count: i64,
     dns_capture_cap_days: i64,
     connection_mode: String,
+    managed: i32,
 }
 
 impl DeviceRow {
@@ -80,6 +81,7 @@ impl DeviceRow {
             dns_capture_cap_count: self.dns_capture_cap_count,
             dns_capture_cap_days: self.dns_capture_cap_days,
             connection_mode,
+            managed: self.managed != 0,
         })
     }
 }
@@ -120,17 +122,17 @@ struct RuleRow {
 // Static SQL strings — every column list is inlined so no runtime format!()
 // allocation is needed for these fixed SELECTs. The genuinely dynamic queries
 // further down (JOIN/LIKE against routing_rules) keep their own literals.
-const FIND_BY_IP_SQL: &str = "SELECT id, mac, name, hostname, manufacturer, manufacturer_source, is_randomized, device_type, first_seen, last_seen, last_ip, admin_locked, zone_id, dns_capture_enabled, dns_capture_cap_count, dns_capture_cap_days, connection_mode \
+const FIND_BY_IP_SQL: &str = "SELECT id, mac, name, hostname, manufacturer, manufacturer_source, is_randomized, device_type, first_seen, last_seen, last_ip, admin_locked, zone_id, dns_capture_enabled, dns_capture_cap_count, dns_capture_cap_days, connection_mode, managed \
      FROM devices WHERE last_ip = ? ORDER BY last_seen DESC LIMIT 1";
-const FIND_ALL_BY_IP_SQL: &str = "SELECT id, mac, name, hostname, manufacturer, manufacturer_source, is_randomized, device_type, first_seen, last_seen, last_ip, admin_locked, zone_id, dns_capture_enabled, dns_capture_cap_count, dns_capture_cap_days, connection_mode \
+const FIND_ALL_BY_IP_SQL: &str = "SELECT id, mac, name, hostname, manufacturer, manufacturer_source, is_randomized, device_type, first_seen, last_seen, last_ip, admin_locked, zone_id, dns_capture_enabled, dns_capture_cap_count, dns_capture_cap_days, connection_mode, managed \
      FROM devices WHERE last_ip = ? ORDER BY last_seen DESC";
-const FIND_BY_ID_SQL: &str = "SELECT id, mac, name, hostname, manufacturer, manufacturer_source, is_randomized, device_type, first_seen, last_seen, last_ip, admin_locked, zone_id, dns_capture_enabled, dns_capture_cap_count, dns_capture_cap_days, connection_mode \
+const FIND_BY_ID_SQL: &str = "SELECT id, mac, name, hostname, manufacturer, manufacturer_source, is_randomized, device_type, first_seen, last_seen, last_ip, admin_locked, zone_id, dns_capture_enabled, dns_capture_cap_count, dns_capture_cap_days, connection_mode, managed \
      FROM devices WHERE id = ?";
-const FIND_BY_MAC_SQL: &str = "SELECT id, mac, name, hostname, manufacturer, manufacturer_source, is_randomized, device_type, first_seen, last_seen, last_ip, admin_locked, zone_id, dns_capture_enabled, dns_capture_cap_count, dns_capture_cap_days, connection_mode \
+const FIND_BY_MAC_SQL: &str = "SELECT id, mac, name, hostname, manufacturer, manufacturer_source, is_randomized, device_type, first_seen, last_seen, last_ip, admin_locked, zone_id, dns_capture_enabled, dns_capture_cap_count, dns_capture_cap_days, connection_mode, managed \
      FROM devices WHERE mac = ?";
-const FIND_ALL_SQL: &str = "SELECT id, mac, name, hostname, manufacturer, manufacturer_source, is_randomized, device_type, first_seen, last_seen, last_ip, admin_locked, zone_id, dns_capture_enabled, dns_capture_cap_count, dns_capture_cap_days, connection_mode \
+const FIND_ALL_SQL: &str = "SELECT id, mac, name, hostname, manufacturer, manufacturer_source, is_randomized, device_type, first_seen, last_seen, last_ip, admin_locked, zone_id, dns_capture_enabled, dns_capture_cap_count, dns_capture_cap_days, connection_mode, managed \
      FROM devices ORDER BY last_seen DESC";
-const FIND_STALE_SQL: &str = "SELECT id, mac, name, hostname, manufacturer, manufacturer_source, is_randomized, device_type, first_seen, last_seen, last_ip, admin_locked, zone_id, dns_capture_enabled, dns_capture_cap_count, dns_capture_cap_days, connection_mode \
+const FIND_STALE_SQL: &str = "SELECT id, mac, name, hostname, manufacturer, manufacturer_source, is_randomized, device_type, first_seen, last_seen, last_ip, admin_locked, zone_id, dns_capture_enabled, dns_capture_cap_count, dns_capture_cap_days, connection_mode, managed \
      FROM devices WHERE last_seen < ?";
 
 #[async_trait]
@@ -201,6 +203,10 @@ impl DeviceRepository for SqliteDeviceRepository {
     }
 
     async fn insert(&self, device: &InsertDeviceRow) -> anyhow::Result<()> {
+        // `managed` is deliberately absent from the column list: discovery is
+        // the only path that inserts, and a freshly discovered device is never
+        // managed. It takes the schema DEFAULT 0 and is promoted later, only by
+        // an explicit admin configuration act (`set_managed`).
         sqlx::query(
             "INSERT INTO devices (id, mac, hostname, manufacturer, manufacturer_source, is_randomized, device_type, first_seen, last_seen, last_ip, zone_id, connection_mode) \
              VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
@@ -358,6 +364,14 @@ impl DeviceRepository for SqliteDeviceRepository {
             .collect()
     }
 
+    async fn delete_rule_for_device(&self, device_id: &str) -> anyhow::Result<()> {
+        sqlx::query("DELETE FROM routing_rules WHERE device_id = ?")
+            .bind(device_id)
+            .execute(&self.pools.write)
+            .await?;
+        Ok(())
+    }
+
     async fn upsert_user_rule(
         &self,
         device_id: &str,
@@ -390,7 +404,7 @@ impl DeviceRepository for SqliteDeviceRepository {
              d.manufacturer_source, d.is_randomized, d.device_type, \
              d.first_seen, d.last_seen, d.last_ip, d.admin_locked, d.zone_id, \
              d.dns_capture_enabled, d.dns_capture_cap_count, d.dns_capture_cap_days, \
-             d.connection_mode \
+             d.connection_mode, d.managed \
              FROM devices d \
              JOIN routing_rules r ON r.device_id = d.id \
              WHERE r.target_json LIKE ? \
@@ -486,5 +500,14 @@ impl DeviceRepository for SqliteDeviceRepository {
                 .fetch_all(&self.pools.read)
                 .await?;
         Ok(ids)
+    }
+
+    async fn set_managed(&self, id: &str, managed: bool) -> anyhow::Result<()> {
+        sqlx::query("UPDATE devices SET managed = ? WHERE id = ?")
+            .bind(i32::from(managed))
+            .bind(id)
+            .execute(&self.pools.write)
+            .await?;
+        Ok(())
     }
 }

--- a/source/daemon/crates/wardnetd-data/src/repository/tests/device.rs
+++ b/source/daemon/crates/wardnetd-data/src/repository/tests/device.rs
@@ -981,3 +981,25 @@ async fn pruning_cascades_child_rows_and_nulls_the_lease_link() {
         "the lease survives with a null device_id"
     );
 }
+
+#[tokio::test]
+async fn delete_rule_for_device_removes_the_rule_and_tolerates_a_missing_one() {
+    // The release's revert-to-default. Deleting is used rather than writing a
+    // `Direct` rule because "no rule" is the state a never-configured device is
+    // in, and because a `Direct` write is zone-validated (issue #1181).
+    let pool = test_pool().await;
+    insert_device(&pool, DEV1, "aa:bb:cc:dd:ee:01", "192.168.1.10").await;
+    let repo = SqliteDeviceRepository::new(pool);
+
+    repo.upsert_user_rule(DEV1, r#"{"type":"direct"}"#, "2026-03-07T00:00:00Z")
+        .await
+        .unwrap();
+    assert!(repo.find_rule_for_device(DEV1).await.unwrap().is_some());
+
+    repo.delete_rule_for_device(DEV1).await.unwrap();
+    assert!(repo.find_rule_for_device(DEV1).await.unwrap().is_none());
+
+    // The release calls this unconditionally, so a second delete must be a
+    // no-op rather than an error.
+    repo.delete_rule_for_device(DEV1).await.unwrap();
+}

--- a/source/daemon/crates/wardnetd-data/src/repository/tests/device.rs
+++ b/source/daemon/crates/wardnetd-data/src/repository/tests/device.rs
@@ -770,7 +770,29 @@ async fn provenance_without_a_manufacturer_is_dropped_on_read() {
     assert_eq!(device.manufacturer_source, None);
 }
 
-// ── managed (issue #1181) ────────────────────────────────────────────────────
+// ── managed + retention (issue #1181) ────────────────────────────────────────
+
+/// Enable foreign-key enforcement, matching production (`db.rs` sets this
+/// PRAGMA on both pools).
+///
+/// It is off by default in `SQLite` and `test_pool` does not set it, so without
+/// this a cascade test would pass by never cascading — and the orphaned rows
+/// would only ever appear in production. The tests below assert the PRAGMA is
+/// actually on before relying on it.
+async fn enable_foreign_keys(pool: &sqlx::SqlitePool) {
+    sqlx::query("PRAGMA foreign_keys = ON")
+        .execute(pool)
+        .await
+        .unwrap();
+    let on: i64 = sqlx::query_scalar("PRAGMA foreign_keys")
+        .fetch_one(pool)
+        .await
+        .unwrap();
+    assert_eq!(
+        on, 1,
+        "foreign keys must be enforced for the cascade to bite"
+    );
+}
 
 async fn set_managed_flag(pool: &sqlx::SqlitePool, id: &str, managed: bool) {
     sqlx::query("UPDATE devices SET managed = ? WHERE id = ?")
@@ -780,6 +802,17 @@ async fn set_managed_flag(pool: &sqlx::SqlitePool, id: &str, managed: bool) {
         .await
         .unwrap();
 }
+
+async fn device_ids(pool: &sqlx::SqlitePool) -> Vec<String> {
+    sqlx::query_scalar::<_, String>("SELECT id FROM devices ORDER BY id")
+        .fetch_all(pool)
+        .await
+        .unwrap()
+}
+
+const STALE: &str = "2026-01-01T00:00:00Z";
+const RECENT: &str = "2026-06-01T00:00:00Z";
+const CUTOFF: &str = "2026-03-01T00:00:00Z";
 
 #[tokio::test]
 async fn insert_leaves_new_device_unmanaged() {
@@ -825,4 +858,126 @@ async fn set_managed_on_missing_device_is_a_no_op() {
     // A promotion must never be the thing that fails an otherwise-successful
     // configuration change (e.g. a DHCP reservation for a not-yet-seen MAC).
     repo.set_managed(DEV1, true).await.unwrap();
+}
+
+#[tokio::test]
+async fn delete_unmanaged_before_prunes_only_unmanaged_and_stale() {
+    let pool = test_pool().await;
+    // DEV1: unmanaged + stale  -> pruned
+    // DEV2: unmanaged + recent -> kept (still around, just quiet)
+    // DEV3: managed  + stale   -> kept (never auto-deleted at any age)
+    insert_device_seen_at(&pool, DEV1, "aa:bb:cc:dd:ee:01", "192.168.1.10", STALE).await;
+    insert_device_seen_at(&pool, DEV2, "aa:bb:cc:dd:ee:02", "192.168.1.11", RECENT).await;
+    insert_device_seen_at(&pool, DEV3, "aa:bb:cc:dd:ee:03", "192.168.1.12", STALE).await;
+    set_managed_flag(&pool, DEV3, true).await;
+
+    let repo = SqliteDeviceRepository::new(pool.clone());
+    let pruned = repo.delete_unmanaged_before(CUTOFF).await.unwrap();
+
+    assert_eq!(pruned.len(), 1);
+    assert_eq!(pruned[0].id, DEV1);
+    assert_eq!(pruned[0].mac, "aa:bb:cc:dd:ee:01");
+    assert_eq!(pruned[0].last_seen, STALE);
+    assert_eq!(
+        device_ids(&pool).await,
+        vec![DEV2.to_owned(), DEV3.to_owned()]
+    );
+}
+
+#[tokio::test]
+async fn delete_unmanaged_before_prunes_a_departed_device_with_a_cleared_ip() {
+    // A departed device has its `last_ip` emptied by `clear_last_ip`, not its
+    // row deleted. The prune predicate keys on `last_seen` only, so the empty
+    // sentinel must not exempt it — these are precisely the rows that
+    // accumulate.
+    let pool = test_pool().await;
+    insert_device_seen_at(&pool, DEV1, "aa:bb:cc:dd:ee:01", "", STALE).await;
+    insert_device_seen_at(&pool, DEV2, "aa:bb:cc:dd:ee:02", "192.168.1.11", STALE).await;
+
+    let repo = SqliteDeviceRepository::new(pool.clone());
+    let pruned = repo.delete_unmanaged_before(CUTOFF).await.unwrap();
+
+    assert_eq!(pruned.len(), 2, "a cleared last_ip must not exempt a row");
+    assert!(device_ids(&pool).await.is_empty());
+}
+
+#[tokio::test]
+async fn delete_unmanaged_before_returns_empty_when_nothing_matches() {
+    let pool = test_pool().await;
+    insert_device_seen_at(&pool, DEV1, "aa:bb:cc:dd:ee:01", "192.168.1.10", RECENT).await;
+
+    let repo = SqliteDeviceRepository::new(pool.clone());
+    assert!(
+        repo.delete_unmanaged_before(CUTOFF)
+            .await
+            .unwrap()
+            .is_empty()
+    );
+    assert_eq!(device_ids(&pool).await, vec![DEV1.to_owned()]);
+}
+
+#[tokio::test]
+async fn pruning_cascades_child_rows_and_nulls_the_lease_link() {
+    // The safety argument for deleting an unmanaged row is that nothing admin
+    // -authored references it, and that the machine-authored children clean
+    // themselves up. This pins that second half: CASCADE children go, the
+    // SET NULL lease link is nulled rather than deleting the lease.
+    let pool = test_pool().await;
+    enable_foreign_keys(&pool).await;
+    insert_device_seen_at(&pool, DEV1, "aa:bb:cc:dd:ee:01", "192.168.1.10", STALE).await;
+
+    sqlx::query(
+        "INSERT INTO dns_events (device_id, domain, status, captured_at) \
+         VALUES (?, 'example.com', 'allowed', ?)",
+    )
+    .bind(DEV1)
+    .bind(STALE)
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    sqlx::query(
+        "INSERT INTO device_signals (device_id, kind, value) \
+         VALUES (?, 'dhcp_hostname', 'my-host')",
+    )
+    .bind(DEV1)
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    sqlx::query(
+        "INSERT INTO dhcp_leases (id, mac_address, ip_address, lease_start, lease_end, device_id) \
+         VALUES ('lease-1', 'aa:bb:cc:dd:ee:01', '192.168.1.10', ?, ?, ?)",
+    )
+    .bind(STALE)
+    .bind(RECENT)
+    .bind(DEV1)
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    let repo = SqliteDeviceRepository::new(pool.clone());
+    assert_eq!(repo.delete_unmanaged_before(CUTOFF).await.unwrap().len(), 1);
+
+    let events: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM dns_events")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    assert_eq!(events, 0, "dns_events should cascade away");
+
+    let signals: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM device_signals")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    assert_eq!(signals, 0, "device_signals should cascade away");
+
+    let lease_device: Option<String> =
+        sqlx::query_scalar("SELECT device_id FROM dhcp_leases WHERE id = 'lease-1'")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+    assert_eq!(
+        lease_device, None,
+        "the lease survives with a null device_id"
+    );
 }

--- a/source/daemon/crates/wardnetd-data/src/repository/tests/device.rs
+++ b/source/daemon/crates/wardnetd-data/src/repository/tests/device.rs
@@ -769,3 +769,60 @@ async fn provenance_without_a_manufacturer_is_dropped_on_read() {
     assert_eq!(device.manufacturer, None);
     assert_eq!(device.manufacturer_source, None);
 }
+
+// ── managed (issue #1181) ────────────────────────────────────────────────────
+
+async fn set_managed_flag(pool: &sqlx::SqlitePool, id: &str, managed: bool) {
+    sqlx::query("UPDATE devices SET managed = ? WHERE id = ?")
+        .bind(i32::from(managed))
+        .bind(id)
+        .execute(pool)
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn insert_leaves_new_device_unmanaged() {
+    // A freshly discovered device is never managed — `insert` omits the column
+    // and takes the schema DEFAULT 0. This is what makes discovery-inserted
+    // devices eligible for retention at all.
+    let pool = test_pool().await;
+    let repo = SqliteDeviceRepository::new(pool);
+    repo.insert(&sample_device_row(
+        DEV1,
+        "aa:bb:cc:dd:ee:01",
+        "192.168.1.10",
+    ))
+    .await
+    .unwrap();
+
+    let device = repo.find_by_id(DEV1).await.unwrap().unwrap();
+    assert!(!device.managed);
+}
+
+#[tokio::test]
+async fn set_managed_round_trips_and_is_idempotent() {
+    let pool = test_pool().await;
+    insert_device(&pool, DEV1, "aa:bb:cc:dd:ee:01", "192.168.1.10").await;
+    let repo = SqliteDeviceRepository::new(pool);
+
+    repo.set_managed(DEV1, true).await.unwrap();
+    assert!(repo.find_by_id(DEV1).await.unwrap().unwrap().managed);
+
+    // Promotion is called from every admin config act, so re-promoting an
+    // already-managed device must be a no-op rather than an error.
+    repo.set_managed(DEV1, true).await.unwrap();
+    assert!(repo.find_by_id(DEV1).await.unwrap().unwrap().managed);
+
+    repo.set_managed(DEV1, false).await.unwrap();
+    assert!(!repo.find_by_id(DEV1).await.unwrap().unwrap().managed);
+}
+
+#[tokio::test]
+async fn set_managed_on_missing_device_is_a_no_op() {
+    let pool = test_pool().await;
+    let repo = SqliteDeviceRepository::new(pool);
+    // A promotion must never be the thing that fails an otherwise-successful
+    // configuration change (e.g. a DHCP reservation for a not-yet-seen MAC).
+    repo.set_managed(DEV1, true).await.unwrap();
+}

--- a/source/daemon/crates/wardnetd-data/src/repository/tests/managed_backfill.rs
+++ b/source/daemon/crates/wardnetd-data/src/repository/tests/managed_backfill.rs
@@ -1,0 +1,292 @@
+//! Tests for the one-shot `managed` backfill in
+//! `20260810000000_managed_devices.sql` (issue #1181).
+//!
+//! The backfill is a one-way door: it runs once per box, on real data, and
+//! getting it wrong is either a silently-revoked credential (too exclusive) or
+//! retention silently disabled forever (too inclusive). So these tests execute
+//! the **shipped statement**, read out of the migration file, rather than a
+//! copy pasted into the test — a copy would keep passing after the real
+//! predicate drifted.
+//!
+//! Mechanics: `test_pool` has already run every migration, so `managed` exists
+//! and is backfilled. Each test resets it to 0, seeds one artefact, and re-runs
+//! the statement — which is idempotent, being a pure `UPDATE ... WHERE`.
+
+use std::sync::LazyLock;
+
+use sqlx::SqlitePool;
+
+use super::test_pool;
+
+const MIGRATION: &str = include_str!("../../../migrations/20260810000000_managed_devices.sql");
+
+const DEV: &str = "00000000-0000-0000-0000-000000000001";
+const ZONE: &str = "00000000-0000-0000-0000-000000000201";
+const OTHER_ZONE: &str = "00000000-0000-0000-0000-0000000009f1";
+
+/// Extract the backfill `UPDATE` from the migration file.
+///
+/// Splitting on `;` is safe here only because the statement contains no string
+/// literal holding one — asserted below, so this stops working loudly rather
+/// than silently testing half a predicate.
+static BACKFILL: LazyLock<String> = LazyLock::new(|| {
+    let stmt = MIGRATION
+        .split(';')
+        .map(|s| {
+            // Drop comment lines so the `starts_with` test sees real SQL.
+            s.lines()
+                .filter(|l| !l.trim_start().starts_with("--"))
+                .collect::<Vec<_>>()
+                .join("\n")
+        })
+        .find(|s| s.trim_start().starts_with("UPDATE devices SET managed"))
+        .expect("migration must contain the backfill UPDATE");
+    assert!(
+        stmt.contains("EXISTS"),
+        "extracted statement looks truncated: {stmt}"
+    );
+    stmt
+});
+
+async fn seed_device(pool: &SqlitePool, name: Option<&str>) {
+    sqlx::query(
+        "INSERT INTO devices (id, mac, last_ip, name, device_type, first_seen, last_seen, zone_id) \
+         VALUES (?, 'aa:bb:cc:dd:ee:01', '192.168.1.10', ?, 'unknown', \
+                 '2026-03-07T00:00:00Z', '2026-03-07T00:00:00Z', ?)",
+    )
+    .bind(DEV)
+    .bind(name)
+    .bind(ZONE)
+    .execute(pool)
+    .await
+    .unwrap();
+
+    // Every migration has already run, so the device arrives pre-backfilled.
+    // Reset to the pre-migration state these tests are about.
+    sqlx::query("UPDATE devices SET managed = 0")
+        .execute(pool)
+        .await
+        .unwrap();
+}
+
+async fn run_backfill(pool: &SqlitePool) -> bool {
+    sqlx::query(&**BACKFILL).execute(pool).await.unwrap();
+    sqlx::query_scalar::<_, i64>("SELECT managed FROM devices WHERE id = ?")
+        .bind(DEV)
+        .fetch_one(pool)
+        .await
+        .unwrap()
+        == 1
+}
+
+/// Seed a device with no artefacts, apply `setup`, then report whether the
+/// shipped backfill promotes it.
+async fn promotes_after(setup: &'static str) -> bool {
+    let pool = test_pool().await;
+    seed_device(&pool, None).await;
+    for stmt in setup.split(";@").filter(|s| !s.trim().is_empty()) {
+        sqlx::query(stmt).execute(&pool).await.unwrap();
+    }
+    run_backfill(&pool).await
+}
+
+// ── Promotes: admin artefacts ────────────────────────────────────────────────
+
+#[tokio::test]
+async fn bare_device_is_not_promoted() {
+    // The control. A device with no name and no artefacts is exactly the
+    // population retention exists for; if this ever flips, the feature is off.
+    let pool = test_pool().await;
+    seed_device(&pool, None).await;
+    assert!(!run_backfill(&pool).await);
+}
+
+#[tokio::test]
+async fn a_name_promotes() {
+    let pool = test_pool().await;
+    seed_device(&pool, Some("Living room TV")).await;
+    assert!(run_backfill(&pool).await);
+}
+
+#[tokio::test]
+async fn admin_lock_promotes() {
+    assert!(promotes_after("UPDATE devices SET admin_locked = 1").await);
+}
+
+#[tokio::test]
+async fn dns_capture_promotes() {
+    assert!(promotes_after("UPDATE devices SET dns_capture_enabled = 1").await);
+}
+
+#[tokio::test]
+async fn an_admin_routing_rule_promotes() {
+    assert!(
+        promotes_after(
+            "INSERT INTO routing_rules (id, device_id, target_json, created_by) \
+             VALUES ('r1', '00000000-0000-0000-0000-000000000001', '{\"type\":\"direct\"}', 'admin')"
+        )
+        .await
+    );
+}
+
+#[tokio::test]
+async fn a_routing_profile_assignment_promotes() {
+    assert!(
+        promotes_after(
+            "INSERT INTO routing_profiles (id, name) VALUES ('p1', 'streaming');@\
+             INSERT INTO routing_device_profile (device_id, profile_id) \
+             VALUES ('00000000-0000-0000-0000-000000000001', 'p1')"
+        )
+        .await
+    );
+}
+
+#[tokio::test]
+async fn dns_filter_device_settings_promote() {
+    assert!(
+        promotes_after(
+            "INSERT INTO dns_filter_device_settings (device_id, enabled) \
+             VALUES ('00000000-0000-0000-0000-000000000001', 0)"
+        )
+        .await
+    );
+}
+
+#[tokio::test]
+async fn a_dns_filter_profile_assignment_promotes() {
+    assert!(
+        promotes_after(
+            "INSERT INTO dns_filter_profiles (id, name) VALUES ('fp1', 'kids');@\
+             INSERT INTO dns_filter_device_profile (device_id, profile_id) \
+             VALUES ('00000000-0000-0000-0000-000000000001', 'fp1')"
+        )
+        .await
+    );
+}
+
+#[tokio::test]
+async fn a_private_dns_grant_promotes() {
+    // The case that most needs it: a roaming phone's grant would otherwise be
+    // cascaded away 30 days after it last touched the LAN.
+    assert!(
+        promotes_after(
+            "INSERT INTO private_dns_grants (id, device_id, token, created_at) \
+             VALUES ('g1', '00000000-0000-0000-0000-000000000001', 'abc', '2026-03-07T00:00:00Z')"
+        )
+        .await
+    );
+}
+
+#[tokio::test]
+async fn an_inbound_wg_peer_promotes() {
+    assert!(
+        promotes_after(
+            "INSERT INTO inbound_wg_peers (id, public_key, allowed_ip, name, created_at, device_id) \
+             VALUES ('w1', 'pk', '10.100.64.2/32', 'phone', '2026-03-07T00:00:00Z', \
+                     '00000000-0000-0000-0000-000000000001')"
+        )
+        .await
+    );
+}
+
+#[tokio::test]
+async fn a_dhcp_reservation_promotes_by_mac() {
+    // Reservations are MAC-keyed, not device_id-keyed — the one artefact that
+    // would otherwise outlive the device row entirely.
+    assert!(
+        promotes_after(
+            "INSERT INTO dhcp_reservations (id, mac_address, ip_address) \
+             VALUES ('res1', 'aa:bb:cc:dd:ee:01', '192.168.1.10')"
+        )
+        .await
+    );
+}
+
+#[tokio::test]
+async fn a_zone_exception_promotes_from_either_side() {
+    let from = "INSERT INTO zone_exceptions (id, from_kind, from_id, to_kind, to_id) \
+         VALUES ('e1', 'device', '00000000-0000-0000-0000-000000000001', 'zone', 'z9')";
+    let to = "INSERT INTO zone_exceptions (id, from_kind, from_id, to_kind, to_id) \
+         VALUES ('e2', 'zone', 'z9', 'device', '00000000-0000-0000-0000-000000000001')";
+    assert!(promotes_after(from).await, "device on the `from` side");
+    assert!(promotes_after(to).await, "device on the `to` side");
+}
+
+// ── Does NOT promote: self-service and machine-derived ───────────────────────
+
+#[tokio::test]
+async fn a_user_routing_rule_does_not_promote() {
+    // The load-bearing exclusion. A guest tapping a toggle in the user PWA is
+    // the device asking, not the admin deciding — promoting here would make
+    // every guest phone permanently exempt from retention, which is the exact
+    // population issue #1181 is about.
+    assert!(
+        !promotes_after(
+            "INSERT INTO routing_rules (id, device_id, target_json, created_by) \
+             VALUES ('r1', '00000000-0000-0000-0000-000000000001', '{\"type\":\"direct\"}', 'user')"
+        )
+        .await
+    );
+}
+
+#[tokio::test]
+async fn a_device_rule_request_does_not_promote() {
+    assert!(
+        !promotes_after(
+            "INSERT INTO device_rule_requests (id, device_id, kind, domain, created_at) \
+             VALUES ('rr1', '00000000-0000-0000-0000-000000000001', 'block', 'ads.example', \
+                     '2026-03-07T00:00:00Z')"
+        )
+        .await
+    );
+}
+
+#[tokio::test]
+async fn a_push_subscription_does_not_promote() {
+    // Deliberately left dangling by design — see the push_subscriptions
+    // migration: a forgotten-then-rediscovered device keeps its MAC and its
+    // subscription stays valid; stale rows are pruned on 404/410 instead.
+    assert!(
+        !promotes_after(
+            "INSERT INTO push_subscriptions (id, owner_kind, owner_key, endpoint, p256dh, auth, created_at) \
+             VALUES ('s1', 'device', 'aa:bb:cc:dd:ee:01', 'https://push.example/1', 'k', 'a', \
+                     '2026-03-07T00:00:00Z')"
+        )
+        .await
+    );
+}
+
+#[tokio::test]
+async fn a_non_default_zone_does_not_promote() {
+    // The deliberate backfill gap (ADR 0032). Zone membership is sticky, so
+    // `zone_id != <default-for-new>` cannot distinguish "an admin moved this
+    // device" from "the default-for-new flag was later re-pointed". Promoting
+    // on it would mark essentially every device on such a box managed and
+    // silently disable retention entirely.
+    let pool = test_pool().await;
+    seed_device(&pool, None).await;
+    sqlx::query("INSERT INTO network_zones (id, name, is_default, is_default_for_new) VALUES (?, 'Guest-backfill-test', 0, 0)")
+        .bind(OTHER_ZONE)
+        .execute(&pool)
+        .await
+        .unwrap();
+    sqlx::query("UPDATE devices SET zone_id = ? WHERE id = ?")
+        .bind(OTHER_ZONE)
+        .bind(DEV)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+    assert!(!run_backfill(&pool).await);
+}
+
+#[tokio::test]
+async fn the_backfill_is_idempotent() {
+    // It is a pure `UPDATE ... WHERE`, so re-running it must never demote a
+    // device it already promoted — which is what lets these tests re-run it
+    // against an already-migrated pool at all.
+    let pool = test_pool().await;
+    seed_device(&pool, Some("Living room TV")).await;
+    assert!(run_backfill(&pool).await);
+    assert!(run_backfill(&pool).await);
+}

--- a/source/daemon/crates/wardnetd-data/src/repository/tests/mod.rs
+++ b/source/daemon/crates/wardnetd-data/src/repository/tests/mod.rs
@@ -8,6 +8,7 @@ mod dns_events;
 mod dns_filter;
 mod dns_local;
 mod inbound_wg;
+mod managed_backfill;
 mod network_zone;
 mod notification;
 mod private_dns;

--- a/source/daemon/crates/wardnetd-mock/src/main.rs
+++ b/source/daemon/crates/wardnetd-mock/src/main.rs
@@ -42,6 +42,7 @@ use wardnetd_mock::backends::noop_watchdog::NoopWatchdog;
 use wardnetd_mock::events::FakeEventEmitter;
 use wardnetd_mock::seed;
 use wardnetd_services::db_maintenance_runner::DbMaintenanceRunner;
+use wardnetd_services::device::DeviceRetentionRunner;
 use wardnetd_services::diagnostics::DiagnosticStore;
 use wardnetd_services::diagnostics::listener::DiagnosticsListener;
 use wardnetd_services::dns::DnsCaptureRunner;
@@ -443,6 +444,12 @@ async fn run(
     let db_maintenance_runner =
         DbMaintenanceRunner::start(services.maintenance.clone(), &tracing::Span::current());
 
+    // Device retention (#1181). Runs here too so the mock daemon exercises the
+    // same day-rollover path as production; with a fresh mock DB there is never
+    // anything 30 days stale to delete, so it is a no-op in practice.
+    let device_retention_runner =
+        DeviceRetentionRunner::start(services.discovery.clone(), &tracing::Span::current());
+
     // Drain the in-memory stats buffer into stats_intraday so the fake DNS
     // queries emitted by FakeEventEmitter show up in the live stats charts.
     // Use a 5-minute maintenance interval (vs 1 h in production) and no
@@ -515,6 +522,7 @@ async fn run(
     dns_query_log_runner.shutdown().await;
     dns_capture_runner.shutdown().await;
     db_maintenance_runner.shutdown().await;
+    device_retention_runner.shutdown().await;
     stats_flush_runner.shutdown().await;
 
     Ok(())

--- a/source/daemon/crates/wardnetd-services/src/device/discovery.rs
+++ b/source/daemon/crates/wardnetd-services/src/device/discovery.rs
@@ -1055,6 +1055,13 @@ impl DeviceDiscoveryService for DeviceDiscoveryServiceImpl {
             .to_owned();
 
         let name_to_write = match name {
+            // An explicitly blank name means "clear it", stored as NULL. An
+            // empty string would otherwise persist as a name that renders as no
+            // label at all while still counting as named — the ambiguity the
+            // `managed` column was introduced to remove (#1181), and the state
+            // the release handler needs in order to actually unname a device.
+            // Distinct from `None`, which means "leave the name alone".
+            Some(n) if n.trim().is_empty() => None,
             Some(n) => Some(n),
             None => current
                 .as_ref()
@@ -1067,6 +1074,18 @@ impl DeviceDiscoveryService for DeviceDiscoveryServiceImpl {
             .update_name_and_type(&id.to_string(), name_to_write, &type_str)
             .await
             .map_err(AppError::Internal)?;
+
+        // Promote to managed — but only for an ADMIN rename. This method is
+        // also the self-service path (`require_authenticated`, above, admits an
+        // `AuthContext::Device` renaming itself); a device naming itself is the
+        // device asking, not the admin deciding, and promoting on it would make
+        // every guest device permanently exempt from retention.
+        if matches!(ctx, AuthContext::Admin { .. }) {
+            self.devices
+                .set_managed(&id.to_string(), true)
+                .await
+                .map_err(AppError::Internal)?;
+        }
 
         self.devices
             .find_by_id(&id.to_string())

--- a/source/daemon/crates/wardnetd-services/src/device/discovery.rs
+++ b/source/daemon/crates/wardnetd-services/src/device/discovery.rs
@@ -33,6 +33,16 @@ struct DeviceMemoryState {
     gone: bool,
 }
 
+/// How long an unmanaged device may stay absent before its row is deleted.
+///
+/// Hard-coded rather than configurable, matching the existing retention
+/// precedent (`INTRADAY_RETENTION`, `NOTIFICATION_RETENTION_CAP`). Issue #1181
+/// asked for a configurable TTL; that deviation is deliberate and recorded in
+/// `docs/adr/0032-managed-devices-and-retention.md`.
+///
+/// Managed devices are exempt at any age.
+pub const DEVICE_RETENTION_DAYS: i64 = 30;
+
 /// How far back the IP-flap detector looks.
 const FLAP_WINDOW: std::time::Duration = std::time::Duration::from_mins(1);
 
@@ -193,6 +203,21 @@ pub trait DeviceDiscoveryService: Send + Sync {
         device_id: Uuid,
         timeout: std::time::Duration,
     ) -> Result<Option<Uuid>, AppError>;
+
+    /// Delete unmanaged devices absent for longer than
+    /// [`DEVICE_RETENTION_DAYS`], returning how many rows were removed.
+    ///
+    /// Only unmanaged devices are eligible, which is what makes the delete
+    /// safe: `managed = false` implies no admin artefact references the device
+    /// (see [`crate::device::service::DeviceService::mark_managed`]). Managed
+    /// devices are never auto-deleted at any age.
+    ///
+    /// Lives on the discovery service rather than [`DeviceService`] because
+    /// deleting the row is only half the job — the device must also be evicted
+    /// from this service's in-memory maps, which nothing else can reach.
+    ///
+    /// [`DeviceService`]: crate::device::service::DeviceService
+    async fn prune_unmanaged_devices(&self) -> Result<u64, AppError>;
 }
 
 /// Default implementation of [`DeviceDiscoveryService`].
@@ -1242,5 +1267,76 @@ impl DeviceDiscoveryService for DeviceDiscoveryServiceImpl {
             }
             None => Ok(None),
         }
+    }
+
+    async fn prune_unmanaged_devices(&self) -> Result<u64, AppError> {
+        auth_context::require_admin()?;
+
+        let cutoff =
+            (chrono::Utc::now() - chrono::Duration::days(DEVICE_RETENTION_DAYS)).to_rfc3339();
+
+        let pruned = self
+            .devices
+            .delete_unmanaged_before(&cutoff)
+            .await
+            .map_err(AppError::Internal)?;
+
+        for device in &pruned {
+            // Hold the per-mac lock across the eviction so an observation for
+            // this MAC cannot interleave and re-populate `state` from the row
+            // we just deleted.
+            //
+            // Ordering matters, and not merely for tidiness. The row is deleted
+            // FIRST, then the memory is evicted. Reversed, an observation
+            // landing in the window between the two reaches
+            // `handle_unknown_mac`, finds the row still present, and re-inserts
+            // it into `state` — leaving a live entry pointing at a row that is
+            // about to vanish.
+            //
+            // Skipping the eviction entirely is worse still: the pruned MAC
+            // would linger in `state` with `gone = true`, so the next
+            // observation takes the `Reappear` arm carrying a now-dangling
+            // `device_id`. `update_last_seen_and_ip` matches zero rows and
+            // returns `Ok(())` silently, `handle_unknown_mac` is never reached,
+            // and the device is never re-inserted — invisible in the UI while
+            // its traffic flows unattributed, until the daemon restarts.
+            let mac_lock = self.lock_for_mac(&device.mac).await;
+            {
+                let _guard = mac_lock.lock().await;
+                self.state.write().await.remove(&device.mac);
+                self.ip_history.write().await.remove(&device.mac);
+            }
+            // Drop the guard before removing the lock entry itself, so no other
+            // task is left holding an `Arc` to a mutex this map no longer owns.
+            // This also bounds `device_locks` and `ip_history`, which nothing
+            // pruned before now.
+            self.device_locks.lock().await.remove(&device.mac);
+
+            tracing::info!(
+                device_id = %device.id,
+                mac = %device.mac,
+                last_seen = %device.last_seen,
+                "pruned unmanaged device {} (mac {}, last seen {})",
+                device.id,
+                device.mac,
+                device.last_seen,
+            );
+        }
+
+        let deleted = pruned.len() as u64;
+        if deleted > 0 {
+            tracing::info!(
+                deleted,
+                retention_days = DEVICE_RETENTION_DAYS,
+                "device retention deleted {deleted} unmanaged device(s) absent over {DEVICE_RETENTION_DAYS} days",
+            );
+        } else {
+            tracing::debug!(
+                retention_days = DEVICE_RETENTION_DAYS,
+                "device retention found no unmanaged devices absent over {DEVICE_RETENTION_DAYS} days",
+            );
+        }
+
+        Ok(deleted)
     }
 }

--- a/source/daemon/crates/wardnetd-services/src/device/mod.rs
+++ b/source/daemon/crates/wardnetd-services/src/device/mod.rs
@@ -3,13 +3,17 @@ pub mod hostname_resolver;
 pub mod identification;
 pub mod ip_snapshot;
 pub mod packet_capture;
+pub mod retention_runner;
 pub mod service;
 
-pub use discovery::{DeviceDiscoveryService, DeviceDiscoveryServiceImpl, ObservationResult};
+pub use discovery::{
+    DEVICE_RETENTION_DAYS, DeviceDiscoveryService, DeviceDiscoveryServiceImpl, ObservationResult,
+};
 pub use hostname_resolver::HostnameResolver;
 pub use identification::{DeviceIdentificationService, DeviceIdentificationServiceImpl};
 pub use ip_snapshot::DeviceIpSnapshot;
 pub use packet_capture::{ObservedDevice, PacketCapture, PacketSource};
+pub use retention_runner::DeviceRetentionRunner;
 pub use service::{DeviceService, DeviceServiceImpl};
 
 #[cfg(test)]

--- a/source/daemon/crates/wardnetd-services/src/device/retention_runner.rs
+++ b/source/daemon/crates/wardnetd-services/src/device/retention_runner.rs
@@ -1,0 +1,147 @@
+//! Daily device-retention runner (issue #1181).
+//!
+//! Deletes unmanaged devices absent for longer than
+//! [`DEVICE_RETENTION_DAYS`](super::discovery::DEVICE_RETENTION_DAYS), once per
+//! calendar day.
+//!
+//! Without this the `devices` table only ever grows: a row is created on
+//! discovery and never removed. MAC randomization sharpens it — a phone that
+//! re-randomizes on every join mints a fresh row each time, so the rows that
+//! will *never* return under the same MAC are exactly the ones accumulating
+//! fastest.
+//!
+//! Only **unmanaged** devices are eligible, which is what makes the delete safe:
+//! `managed = false` implies no admin artefact references the device, so a
+//! prune cannot revoke a Private-DNS grant or a Remote peer credential out from
+//! under a working configuration. Managed devices are never auto-deleted at any
+//! age.
+//!
+//! Kept separate from [`DbMaintenanceRunner`](crate::db_maintenance_runner)
+//! rather than folded into it: that runner is database-level (vacuum,
+//! checkpoint, optimize) and takes only a `MaintenanceService`, whereas this is
+//! a domain-level policy over a specific table.
+//!
+//! Like every background component, it calls the auth-gated service under an
+//! admin [`crate::auth_context`] rather than holding a repository directly.
+//!
+//! The daily cadence is enforced by checking the calendar date on every hourly
+//! tick rather than sleeping for 24 hours, so the runner stays responsive to
+//! cancellation without a 24-hour drain delay.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use tokio_util::sync::CancellationToken;
+use tracing::Instrument;
+use uuid::Uuid;
+use wardnet_common::auth::AuthContext;
+
+use crate::auth_context;
+use crate::device::discovery::DeviceDiscoveryService;
+
+/// How often the runner wakes to check whether a day has rolled over.
+pub const TICK_INTERVAL: Duration = Duration::from_hours(1);
+
+/// Background task that prunes long-absent unmanaged devices once per calendar
+/// day.
+pub struct DeviceRetentionRunner {
+    cancel: CancellationToken,
+    handle: tokio::task::JoinHandle<()>,
+}
+
+impl DeviceRetentionRunner {
+    /// Start with the default hourly tick. Production entry point.
+    pub fn start(discovery: Arc<dyn DeviceDiscoveryService>, parent: &tracing::Span) -> Self {
+        Self::start_with_interval(discovery, TICK_INTERVAL, parent)
+    }
+
+    /// Start with a custom tick interval. Tests pass short intervals so they
+    /// can exercise the day-rollover logic without sleeping for an hour.
+    pub fn start_with_interval(
+        discovery: Arc<dyn DeviceDiscoveryService>,
+        tick_interval: Duration,
+        parent: &tracing::Span,
+    ) -> Self {
+        Self::start_with_interval_and_day(discovery, tick_interval, today(), parent)
+    }
+
+    /// Internal constructor that accepts an explicit initial day so tests can
+    /// set yesterday's date and have the first tick immediately fire a prune.
+    pub(crate) fn start_with_interval_and_day(
+        discovery: Arc<dyn DeviceDiscoveryService>,
+        tick_interval: Duration,
+        initial_day: chrono::NaiveDate,
+        parent: &tracing::Span,
+    ) -> Self {
+        let cancel = CancellationToken::new();
+        let span = tracing::info_span!(parent: parent, "device_retention_runner");
+
+        let handle = tokio::spawn(
+            runner_loop(discovery, tick_interval, cancel.clone(), initial_day).instrument(span),
+        );
+
+        Self { cancel, handle }
+    }
+
+    /// Cancel the runner and wait for it to stop.
+    pub async fn shutdown(self) {
+        self.cancel.cancel();
+        let _ = self.handle.await;
+        tracing::info!("Device retention runner shut down");
+    }
+}
+
+async fn runner_loop(
+    discovery: Arc<dyn DeviceDiscoveryService>,
+    tick_interval: Duration,
+    cancel: CancellationToken,
+    initial_day: chrono::NaiveDate,
+) {
+    let admin_ctx = AuthContext::Admin {
+        admin_id: Uuid::nil(),
+    };
+
+    let mut ticker = tokio::time::interval(tick_interval);
+    ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+    ticker.tick().await; // skip the immediate first tick
+
+    let mut last_prune_day = initial_day;
+
+    loop {
+        tokio::select! {
+            () = cancel.cancelled() => {
+                tracing::info!("Device retention runner cancellation received");
+                break;
+            }
+            _ = ticker.tick() => {
+                let today_now = today();
+                if today_now != last_prune_day {
+                    last_prune_day = today_now;
+                    prune(discovery.as_ref(), &admin_ctx).await;
+                }
+            }
+        }
+    }
+}
+
+/// Run one retention pass.
+///
+/// Failures are logged and swallowed: a prune that cannot run is a table that
+/// keeps growing for another day, not a reason to tear down the runner. The
+/// day-rollover gate has already advanced, so the retry lands on the next
+/// calendar day rather than on the next hourly tick.
+///
+/// `pub(crate)` so tests can drive a single pass without the ticker.
+pub(crate) async fn prune(discovery: &dyn DeviceDiscoveryService, admin_ctx: &AuthContext) {
+    // Per-device detail is logged inside the service, which is where the MACs
+    // and timestamps are in scope; this only reports the outcome of the pass.
+    if let Err(e) =
+        auth_context::with_context(admin_ctx.clone(), discovery.prune_unmanaged_devices()).await
+    {
+        tracing::warn!(error = %e, "device retention prune failed: {e}");
+    }
+}
+
+fn today() -> chrono::NaiveDate {
+    chrono::Utc::now().date_naive()
+}

--- a/source/daemon/crates/wardnetd-services/src/device/service.rs
+++ b/source/daemon/crates/wardnetd-services/src/device/service.rs
@@ -144,6 +144,49 @@ pub trait DeviceService: Send + Sync {
     /// revocation) — no auth check (matches this file's existing internal-method
     /// convention for `get_device` / `get_device_capture_settings`).
     async fn clear_remote_connection_mode(&self, device_id: &str) -> Result<(), AppError>;
+
+    /// Promote a device to **managed** — an admin has decided to control its
+    /// configuration.
+    ///
+    /// Called by every admin configuration act (naming, locking, an
+    /// admin-created routing rule or profile, DNS filter settings, DNS capture,
+    /// a Private-DNS grant, a Remote peer credential, a DHCP reservation, a
+    /// zone exception, an explicit zone reassignment). Idempotent, and a no-op
+    /// if the device does not exist — a promotion must never be the thing that
+    /// fails an otherwise-successful configuration change.
+    ///
+    /// Routed through this service rather than each caller writing
+    /// [`DeviceRepository`] directly, per the single-service-per-repository
+    /// rule. **Self-service acts must not call this**: a device configuring
+    /// itself is the device asking, not the admin deciding, and promoting on it
+    /// would make every guest device permanently exempt from retention.
+    async fn mark_managed(&self, device_id: &str) -> Result<(), AppError>;
+
+    /// Delete a device's routing rule, returning it to "no rule" — the state a
+    /// never-configured device is in, where it follows the gateway's global
+    /// default policy.
+    ///
+    /// Deliberately not `set_rule(Direct)`. That writes an explicit persisted
+    /// choice that *overrides* the default policy rather than deferring to it,
+    /// and it is validated against the device's zone allow-list — so on a
+    /// tunnel-only zone it is rejected outright, which would make releasing
+    /// such a device impossible. Deleting cannot conflict with a zone.
+    ///
+    /// Publishes `RoutingRuleChanged` carrying the *global default policy*, so
+    /// the routing listener tears down the device's per-device rules and leaves
+    /// it on the default path. Idempotent. Requires admin.
+    async fn clear_rule(&self, device_id: &str) -> Result<(), AppError>;
+
+    /// Demote a device back to unmanaged.
+    ///
+    /// **Only** the release handler (`POST /api/devices/{id}/release`) may call
+    /// this, and only as its final step, after every managed setting has been
+    /// reverted to default. Calling it with configuration still in place breaks
+    /// the invariant device retention relies on — `managed = false` implies no
+    /// admin artefacts exist — and the device's rows would be silently deleted
+    /// 30 days after it was last seen, taking a live Private-DNS grant or
+    /// Remote peer credential with them.
+    async fn clear_managed(&self, device_id: &str) -> Result<(), AppError>;
 }
 
 /// Default implementation of [`DeviceService`] backed by [`DeviceRepository`].
@@ -380,6 +423,26 @@ impl DeviceService for DeviceServiceImpl {
             AuthContext::Admin { .. } => RuleCreator::Admin,
             _ => RuleCreator::User,
         };
+
+        // An ADMIN-set routing rule promotes the device to managed (issue
+        // #1181); a self-service one deliberately does not — that is the device
+        // asking, not the admin deciding, and promoting on it would make every
+        // guest device permanently exempt from the retention prune. Gated on
+        // the same `ctx` that decides `changed_by`, so the two can't disagree.
+        //
+        // The stored `created_by` is not usable as this signal:
+        // `upsert_user_rule` hard-codes `'user'` regardless of caller, so an
+        // admin-set rule is indistinguishable in the row. That is also why the
+        // migration's `created_by = 'admin'` backfill clause matches nothing
+        // today — it is the correct predicate, kept for the day rules record
+        // their true author.
+        if changed_by == RuleCreator::Admin {
+            self.devices
+                .set_managed(device_id, true)
+                .await
+                .map_err(AppError::Internal)?;
+        }
+
         self.events.publish(WardnetEvent::RoutingRuleChanged {
             device_id: device.id,
             target,
@@ -425,6 +488,18 @@ impl DeviceService for DeviceServiceImpl {
             .update_admin_locked(device_id, locked)
             .await
             .map_err(AppError::Internal)?;
+
+        // Locking promotes to managed (issue #1181). Unlocking does not: it
+        // returns the flag to its default, so it is a revert rather than a
+        // configuration act — and `managed` is latching anyway, so a device
+        // locked then unlocked stays managed until explicitly released. Gating
+        // on `locked` also mirrors the migration's `admin_locked = 1` backfill.
+        if locked {
+            self.devices
+                .set_managed(device_id, true)
+                .await
+                .map_err(AppError::Internal)?;
+        }
 
         // Notify the affected device (push): its routing was locked/unlocked.
         if let Ok(id) = uuid::Uuid::parse_str(device_id) {
@@ -498,6 +573,22 @@ impl DeviceService for DeviceServiceImpl {
                 .map_err(AppError::Internal)?
                 .is_some_and(|d| d.dns_capture_enabled)
         };
+
+        // Enabling capture promotes to managed (issue #1181), mirroring the
+        // migration's `dns_capture_enabled = 1` backfill. Disabling is a revert
+        // to default and promotes nothing; `managed` is latching, so a device
+        // whose capture was enabled then disabled stays managed until released.
+        //
+        // Keyed on `now_enabled`, not `enabled`: a caller adjusting only the
+        // caps on an already-capturing device is still configuring capture on
+        // it. Note `set_my_capture_enabled` — the self-service path — is a
+        // separate method and deliberately promotes nothing.
+        if now_enabled {
+            self.devices
+                .set_managed(device_id, true)
+                .await
+                .map_err(AppError::Internal)?;
+        }
 
         let () = self
             .events
@@ -680,5 +771,68 @@ impl DeviceService for DeviceServiceImpl {
                 .map_err(AppError::Internal)?;
         }
         Ok(())
+    }
+
+    async fn clear_rule(&self, device_id: &str) -> Result<(), AppError> {
+        auth_context::require_admin()?;
+
+        let device_uuid: Uuid = device_id
+            .parse()
+            .map_err(|_| AppError::NotFound("device not found".to_owned()))?;
+
+        let previous = self
+            .devices
+            .find_rule_for_device(device_id)
+            .await
+            .map_err(AppError::Internal)?;
+
+        self.devices
+            .delete_rule_for_device(device_id)
+            .await
+            .map_err(AppError::Internal)?;
+
+        // Nothing to tear down if there was no rule; skipping the publish also
+        // keeps the release quiet for the common case.
+        if previous.is_none() {
+            return Ok(());
+        }
+
+        // Publish the target the device now follows — the global default policy
+        // — rather than the rule we removed, so the routing listener applies
+        // the right end state instead of re-installing what we just deleted.
+        let target = self
+            .system_config
+            .get_default_policy()
+            .await
+            .map_err(AppError::Internal)?
+            .and_then(|raw| serde_json::from_str::<RoutingTarget>(&raw).ok())
+            .unwrap_or(RoutingTarget::Direct);
+
+        self.events.publish(WardnetEvent::RoutingRuleChanged {
+            device_id: device_uuid,
+            target,
+            previous_target: previous.map(|r| r.target),
+            changed_by: RuleCreator::Admin,
+            timestamp: chrono::Utc::now(),
+        });
+        Ok(())
+    }
+
+    async fn mark_managed(&self, device_id: &str) -> Result<(), AppError> {
+        auth_context::require_admin()?;
+
+        self.devices
+            .set_managed(device_id, true)
+            .await
+            .map_err(AppError::Internal)
+    }
+
+    async fn clear_managed(&self, device_id: &str) -> Result<(), AppError> {
+        auth_context::require_admin()?;
+
+        self.devices
+            .set_managed(device_id, false)
+            .await
+            .map_err(AppError::Internal)
     }
 }

--- a/source/daemon/crates/wardnetd-services/src/device/tests/device.rs
+++ b/source/daemon/crates/wardnetd-services/src/device/tests/device.rs
@@ -36,6 +36,13 @@ impl DeviceRepository for MockDeviceRepo {
         Ok(())
     }
 
+    async fn delete_unmanaged_before(
+        &self,
+        _cutoff: &str,
+    ) -> anyhow::Result<Vec<wardnetd_data::repository::PrunedDevice>> {
+        Ok(Vec::new())
+    }
+
     async fn find_by_ip(&self, _ip: &str) -> anyhow::Result<Option<Device>> {
         Ok(self.device.clone())
     }
@@ -885,6 +892,13 @@ async fn update_dns_capture_settings_returns_404_for_unknown() {
 
         async fn set_managed(&self, _id: &str, _managed: bool) -> anyhow::Result<()> {
             Ok(())
+        }
+
+        async fn delete_unmanaged_before(
+            &self,
+            _cutoff: &str,
+        ) -> anyhow::Result<Vec<wardnetd_data::repository::PrunedDevice>> {
+            Ok(Vec::new())
         }
 
         async fn find_by_ip(&self, _ip: &str) -> anyhow::Result<Option<Device>> {

--- a/source/daemon/crates/wardnetd-services/src/device/tests/device.rs
+++ b/source/daemon/crates/wardnetd-services/src/device/tests/device.rs
@@ -10,6 +10,7 @@ use wardnet_common::network_zone::{AllowedTargetKind, NetworkZone, ZoneProvenanc
 use wardnet_common::routing::{RoutingRule, RoutingTarget, RuleCreator};
 
 use crate::auth_context;
+use crate::error::AppError;
 use crate::event::EventPublisher;
 use crate::{DeviceService, DeviceServiceImpl};
 use wardnetd_data::repository::device::DeviceRow;
@@ -27,6 +28,14 @@ struct MockDeviceRepo {
 
 #[async_trait]
 impl DeviceRepository for MockDeviceRepo {
+    async fn delete_rule_for_device(&self, _device_id: &str) -> anyhow::Result<()> {
+        Ok(())
+    }
+
+    async fn set_managed(&self, _id: &str, _managed: bool) -> anyhow::Result<()> {
+        Ok(())
+    }
+
     async fn find_by_ip(&self, _ip: &str) -> anyhow::Result<Option<Device>> {
         Ok(self.device.clone())
     }
@@ -171,11 +180,16 @@ impl DnsEventsRepository for MockDnsEventsRepo {
 
 // -- Mock event publisher -------------------------------------------------
 
-/// Stub event publisher that discards all events.
-struct MockEventPublisher;
+/// Stub event publisher that records what was published.
+#[derive(Default)]
+struct MockEventPublisher {
+    published: std::sync::Mutex<Vec<WardnetEvent>>,
+}
 
 impl EventPublisher for MockEventPublisher {
-    fn publish(&self, _event: WardnetEvent) {}
+    fn publish(&self, event: WardnetEvent) {
+        self.published.lock().unwrap().push(event);
+    }
     fn subscribe(&self) -> broadcast::Receiver<WardnetEvent> {
         let (tx, rx) = broadcast::channel(1);
         drop(tx);
@@ -299,6 +313,7 @@ fn sample_device(locked: bool) -> Device {
         dns_capture_cap_count: 1000,
         dns_capture_cap_days: 7,
         connection_mode: wardnet_common::device::DeviceConnectionMode::Lan,
+        managed: false,
     }
 }
 
@@ -332,7 +347,7 @@ fn make_svc(locked: bool, rule: Option<RoutingRule>) -> DeviceServiceImpl {
         Arc::new(MockDnsEventsRepo),
         Arc::new(MockNetworkZoneRepo),
         Arc::new(MockSystemConfigRepo),
-        Arc::new(MockEventPublisher),
+        Arc::new(MockEventPublisher::default()),
     )
 }
 
@@ -346,7 +361,7 @@ fn make_svc_no_device() -> DeviceServiceImpl {
         Arc::new(MockDnsEventsRepo),
         Arc::new(MockNetworkZoneRepo),
         Arc::new(MockSystemConfigRepo),
-        Arc::new(MockEventPublisher),
+        Arc::new(MockEventPublisher::default()),
     )
 }
 
@@ -360,7 +375,7 @@ fn make_svc_with_rules(all_rules: Vec<RoutingRule>) -> DeviceServiceImpl {
         Arc::new(MockDnsEventsRepo),
         Arc::new(MockNetworkZoneRepo),
         Arc::new(MockSystemConfigRepo),
-        Arc::new(MockEventPublisher),
+        Arc::new(MockEventPublisher::default()),
     )
 }
 
@@ -864,6 +879,14 @@ async fn update_dns_capture_settings_returns_404_for_unknown() {
 
     #[async_trait]
     impl DeviceRepository for NotFoundDeviceRepo {
+        async fn delete_rule_for_device(&self, _device_id: &str) -> anyhow::Result<()> {
+            Ok(())
+        }
+
+        async fn set_managed(&self, _id: &str, _managed: bool) -> anyhow::Result<()> {
+            Ok(())
+        }
+
         async fn find_by_ip(&self, _ip: &str) -> anyhow::Result<Option<Device>> {
             Ok(None)
         }
@@ -965,7 +988,7 @@ async fn update_dns_capture_settings_returns_404_for_unknown() {
         Arc::new(MockDnsEventsRepo),
         Arc::new(MockNetworkZoneRepo),
         Arc::new(MockSystemConfigRepo),
-        Arc::new(MockEventPublisher),
+        Arc::new(MockEventPublisher::default()),
     );
     let unknown_id = "00000000-0000-0000-0000-000000000099";
 
@@ -1094,7 +1117,7 @@ async fn fetch_pending_maps_rows_to_items() {
         Arc::new(RowsDnsEventsRepo { rows }),
         Arc::new(MockNetworkZoneRepo),
         Arc::new(MockSystemConfigRepo),
-        Arc::new(MockEventPublisher),
+        Arc::new(MockEventPublisher::default()),
     );
 
     crate::auth_context::with_context(
@@ -1127,7 +1150,7 @@ async fn ack_dns_events_delegates_to_repo() {
         Arc::new(RowsDnsEventsRepo { rows: vec![] }),
         Arc::new(MockNetworkZoneRepo),
         Arc::new(MockSystemConfigRepo),
-        Arc::new(MockEventPublisher),
+        Arc::new(MockEventPublisher::default()),
     );
 
     crate::auth_context::with_context(
@@ -1154,7 +1177,7 @@ async fn list_capture_enabled_device_ids_delegates_to_repo() {
         Arc::new(MockDnsEventsRepo),
         Arc::new(MockNetworkZoneRepo),
         Arc::new(MockSystemConfigRepo),
-        Arc::new(MockEventPublisher),
+        Arc::new(MockEventPublisher::default()),
     );
     let ids = auth_context::with_context(admin_ctx(), svc.list_capture_enabled_device_ids())
         .await
@@ -1176,7 +1199,7 @@ async fn get_device_capture_settings_returns_settings_when_device_found() {
         Arc::new(MockDnsEventsRepo),
         Arc::new(MockNetworkZoneRepo),
         Arc::new(MockSystemConfigRepo),
-        Arc::new(MockEventPublisher),
+        Arc::new(MockEventPublisher::default()),
     );
     let result = auth_context::with_context(admin_ctx(), svc.get_device_capture_settings("any-id"))
         .await
@@ -1198,7 +1221,7 @@ async fn get_device_capture_settings_returns_none_for_unknown_device() {
         Arc::new(MockDnsEventsRepo),
         Arc::new(MockNetworkZoneRepo),
         Arc::new(MockSystemConfigRepo),
-        Arc::new(MockEventPublisher),
+        Arc::new(MockEventPublisher::default()),
     );
     let result =
         auth_context::with_context(admin_ctx(), svc.get_device_capture_settings("unknown-id"))
@@ -1222,7 +1245,7 @@ fn svc_with_device() -> DeviceServiceImpl {
         Arc::new(RowsDnsEventsRepo { rows: vec![] }),
         Arc::new(MockNetworkZoneRepo),
         Arc::new(MockSystemConfigRepo),
-        Arc::new(MockEventPublisher),
+        Arc::new(MockEventPublisher::default()),
     )
 }
 
@@ -1237,7 +1260,7 @@ fn svc_without_device() -> DeviceServiceImpl {
         Arc::new(RowsDnsEventsRepo { rows: vec![] }),
         Arc::new(MockNetworkZoneRepo),
         Arc::new(MockSystemConfigRepo),
-        Arc::new(MockEventPublisher),
+        Arc::new(MockEventPublisher::default()),
     )
 }
 
@@ -1341,4 +1364,86 @@ async fn get_device_capture_settings_rejects_anonymous() {
     )
     .await;
     assert!(matches!(result, Err(crate::error::AppError::Forbidden(_))));
+}
+
+// ── clear_rule (issue #1181) ─────────────────────────────────────────────────
+
+/// Build a service whose device has the given rule, returning the event
+/// publisher so a test can inspect what was emitted.
+fn make_svc_recording(rule: Option<RoutingRule>) -> (DeviceServiceImpl, Arc<MockEventPublisher>) {
+    let events = Arc::new(MockEventPublisher::default());
+    let svc = DeviceServiceImpl::new(
+        Arc::new(MockDeviceRepo {
+            device: Some(sample_device(false)),
+            rule,
+            all_rules: vec![],
+        }),
+        Arc::new(MockDnsEventsRepo),
+        Arc::new(MockNetworkZoneRepo),
+        Arc::new(MockSystemConfigRepo),
+        events.clone(),
+    );
+    (svc, events)
+}
+
+const CLEAR_RULE_DEVICE: &str = "00000000-0000-0000-0000-000000000001";
+
+#[tokio::test]
+async fn clear_rule_requires_admin() {
+    let (svc, _events) = make_svc_recording(None);
+    assert!(matches!(
+        svc.clear_rule(CLEAR_RULE_DEVICE).await,
+        Err(AppError::Forbidden(_))
+    ));
+}
+
+#[tokio::test]
+async fn clear_rule_publishes_nothing_when_there_was_no_rule() {
+    // The release flow calls this unconditionally, so the no-rule case must be
+    // silent rather than asking the routing listener to re-apply something.
+    let (svc, events) = make_svc_recording(None);
+
+    auth_context::with_context(admin_ctx(), svc.clear_rule(CLEAR_RULE_DEVICE))
+        .await
+        .unwrap();
+
+    assert!(events.published.lock().unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn clear_rule_publishes_the_global_default_as_the_new_target() {
+    // The listener applies whatever target the event carries, so publishing the
+    // rule we just deleted would re-install it. What the device now follows is
+    // the gateway's global default policy.
+    let previous = RoutingRule {
+        device_id: CLEAR_RULE_DEVICE.parse().unwrap(),
+        target: RoutingTarget::Tunnel {
+            tunnel_id: Uuid::new_v4(),
+        },
+        created_by: RuleCreator::Admin,
+    };
+    let (svc, events) = make_svc_recording(Some(previous.clone()));
+
+    auth_context::with_context(admin_ctx(), svc.clear_rule(CLEAR_RULE_DEVICE))
+        .await
+        .unwrap();
+
+    let published = events.published.lock().unwrap();
+    assert_eq!(published.len(), 1);
+    match &published[0] {
+        WardnetEvent::RoutingRuleChanged {
+            device_id,
+            target,
+            previous_target,
+            ..
+        } => {
+            assert_eq!(device_id.to_string(), CLEAR_RULE_DEVICE);
+            assert!(
+                !matches!(target, RoutingTarget::Tunnel { .. }),
+                "must not re-publish the tunnel rule it just deleted"
+            );
+            assert_eq!(previous_target.as_ref(), Some(&previous.target));
+        }
+        other => panic!("expected RoutingRuleChanged, got {other:?}"),
+    }
 }

--- a/source/daemon/crates/wardnetd-services/src/device/tests/device.rs
+++ b/source/daemon/crates/wardnetd-services/src/device/tests/device.rs
@@ -1461,3 +1461,58 @@ async fn clear_rule_publishes_the_global_default_as_the_new_target() {
         other => panic!("expected RoutingRuleChanged, got {other:?}"),
     }
 }
+
+// ── mark_managed / clear_managed (issue #1181) ───────────────────────────────
+
+#[tokio::test]
+async fn mark_and_clear_managed_require_admin() {
+    let (svc, _events) = make_svc_recording(None);
+
+    assert!(matches!(
+        svc.mark_managed(CLEAR_RULE_DEVICE).await,
+        Err(AppError::Forbidden(_))
+    ));
+    assert!(matches!(
+        svc.clear_managed(CLEAR_RULE_DEVICE).await,
+        Err(AppError::Forbidden(_))
+    ));
+
+    // The device path is a caller, not an admin: a device must never be able to
+    // exempt itself from retention, nor release itself.
+    assert!(matches!(
+        auth_context::with_context(
+            device_ctx("aa:bb:cc:dd:ee:01"),
+            svc.mark_managed(CLEAR_RULE_DEVICE)
+        )
+        .await,
+        Err(AppError::Forbidden(_))
+    ));
+}
+
+#[tokio::test]
+async fn mark_managed_is_idempotent_and_tolerates_a_missing_device() {
+    let (svc, _events) = make_svc_recording(None);
+
+    // Promotion is called from every admin configuration act, so it must never
+    // be the thing that fails an otherwise-successful change — including for a
+    // device that no longer exists.
+    auth_context::with_context(admin_ctx(), svc.mark_managed(CLEAR_RULE_DEVICE))
+        .await
+        .unwrap();
+    auth_context::with_context(admin_ctx(), svc.mark_managed(CLEAR_RULE_DEVICE))
+        .await
+        .unwrap();
+    auth_context::with_context(admin_ctx(), svc.clear_managed(CLEAR_RULE_DEVICE))
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn clear_rule_rejects_a_malformed_device_id() {
+    let (svc, _events) = make_svc_recording(None);
+
+    assert!(matches!(
+        auth_context::with_context(admin_ctx(), svc.clear_rule("not-a-uuid")).await,
+        Err(AppError::NotFound(_))
+    ));
+}

--- a/source/daemon/crates/wardnetd-services/src/device/tests/discovery.rs
+++ b/source/daemon/crates/wardnetd-services/src/device/tests/discovery.rs
@@ -55,6 +55,9 @@ struct MockDeviceRepo {
     /// When set, `clear_last_ip` returns an error, exercising the departure
     /// sweep's failure-tolerant path.
     fail_clear_last_ip: std::sync::atomic::AtomicBool,
+    /// When set, `delete_unmanaged_before` returns an error, exercising the
+    /// retention prune's failure path (#1181).
+    fail_delete_unmanaged: std::sync::atomic::AtomicBool,
 }
 
 impl MockDeviceRepo {
@@ -76,6 +79,7 @@ impl MockDeviceRepo {
             hostname_updates: Mutex::new(Vec::new()),
             name_type_updates: Mutex::new(Vec::new()),
             fail_clear_last_ip: std::sync::atomic::AtomicBool::new(false),
+            fail_delete_unmanaged: std::sync::atomic::AtomicBool::new(false),
         }
     }
 }
@@ -92,6 +96,37 @@ impl DeviceRepository for MockDeviceRepo {
             d.managed = managed;
         }
         Ok(())
+    }
+
+    /// Mirrors the real DELETE ... RETURNING: removes the matching rows from
+    /// the backing store and returns what was removed, so the eviction tests
+    /// exercise the same "row is gone" postcondition production has.
+    async fn delete_unmanaged_before(
+        &self,
+        cutoff: &str,
+    ) -> anyhow::Result<Vec<wardnetd_data::repository::PrunedDevice>> {
+        if self
+            .fail_delete_unmanaged
+            .load(std::sync::atomic::Ordering::SeqCst)
+        {
+            anyhow::bail!("delete_unmanaged_before failed");
+        }
+        let cutoff: chrono::DateTime<chrono::Utc> = cutoff.parse()?;
+        let mut devices = self.devices.lock().unwrap();
+        let mut pruned = Vec::new();
+        devices.retain(|d| {
+            if !d.managed && d.last_seen < cutoff {
+                pruned.push(wardnetd_data::repository::PrunedDevice {
+                    id: d.id.to_string(),
+                    mac: d.mac.clone(),
+                    last_seen: d.last_seen.to_rfc3339(),
+                });
+                false
+            } else {
+                true
+            }
+        });
+        Ok(pruned)
     }
 
     async fn find_by_ip(&self, ip: &str) -> anyhow::Result<Option<Device>> {
@@ -701,6 +736,10 @@ impl TestHarness {
 
     async fn resolve_hostname(&self, mac: &str, ip: &str) -> Result<(), AppError> {
         auth_context::with_context(admin_ctx(), self.svc.resolve_hostname(mac, ip)).await
+    }
+
+    async fn prune_unmanaged_devices(&self) -> Result<u64, AppError> {
+        auth_context::with_context(admin_ctx(), self.svc.prune_unmanaged_devices()).await
     }
 }
 
@@ -2285,10 +2324,184 @@ async fn new_device_with_a_public_oui_is_named_from_the_ieee_table() {
     }
 }
 
-// ── Managed promotion (issue #1181) ──────────────────────────────────────────
+// ── Retention prune (issue #1181) ────────────────────────────────────────────
 
 const DEVICE_ID_1: &str = "00000000-0000-0000-0000-0000000f0001";
+const DEVICE_ID_2: &str = "00000000-0000-0000-0000-0000000f0002";
+const DEVICE_ID_3: &str = "00000000-0000-0000-0000-0000000f0003";
 const MAC_1: &str = "aa:bb:cc:dd:ef:01";
+const MAC_2: &str = "aa:bb:cc:dd:ef:02";
+const MAC_3: &str = "aa:bb:cc:dd:ef:03";
+
+/// A device last seen well outside the 30-day retention window.
+fn stale_device(id: &str, mac: &str, ip: &str) -> Device {
+    let mut device = sample_device(id, mac, ip);
+    device.last_seen = chrono::Utc::now() - chrono::Duration::days(90);
+    device
+}
+
+/// Push a device's `last_seen` back outside the retention window, undoing the
+/// refresh an observation performs.
+fn age_out(harness: &TestHarness, id: &str) {
+    let mut devices = harness.repo.devices.lock().unwrap();
+    let device = devices
+        .iter_mut()
+        .find(|d| d.id.to_string() == id)
+        .expect("device present");
+    device.last_seen = chrono::Utc::now() - chrono::Duration::days(90);
+}
+
+#[tokio::test]
+async fn prune_requires_admin() {
+    let harness =
+        build_harness_with_devices(vec![stale_device(DEVICE_ID_1, MAC_1, "192.168.1.10")]);
+
+    // Anonymous, and as the device itself: neither may trigger a prune.
+    let result = harness.svc.prune_unmanaged_devices().await;
+    assert!(matches!(result, Err(AppError::Forbidden(_))));
+
+    let result =
+        auth_context::with_context(device_ctx(MAC_1), harness.svc.prune_unmanaged_devices()).await;
+    assert!(matches!(result, Err(AppError::Forbidden(_))));
+
+    // And nothing was deleted while we were checking.
+    assert_eq!(harness.repo.find_all().await.unwrap().len(), 1);
+}
+
+#[tokio::test]
+async fn prune_deletes_stale_unmanaged_and_keeps_the_rest() {
+    let mut managed_stale = stale_device(DEVICE_ID_2, MAC_2, "192.168.1.11");
+    managed_stale.managed = true;
+
+    let harness = build_harness_with_devices(vec![
+        stale_device(DEVICE_ID_1, MAC_1, "192.168.1.10"),
+        managed_stale,
+        // Unmanaged but seen recently — `sample_device`'s own timestamp is
+        // inside the window relative to nothing, so stamp it explicitly.
+        {
+            let mut d = sample_device(DEVICE_ID_3, MAC_3, "192.168.1.12");
+            d.last_seen = chrono::Utc::now();
+            d
+        },
+    ]);
+
+    assert_eq!(harness.prune_unmanaged_devices().await.unwrap(), 1);
+
+    let remaining: Vec<String> = harness
+        .repo
+        .find_all()
+        .await
+        .unwrap()
+        .into_iter()
+        .map(|d| d.id.to_string())
+        .collect();
+    assert!(!remaining.contains(&DEVICE_ID_1.to_owned()));
+    assert!(
+        remaining.contains(&DEVICE_ID_2.to_owned()),
+        "managed is exempt at any age"
+    );
+    assert!(
+        remaining.contains(&DEVICE_ID_3.to_owned()),
+        "recent is exempt"
+    );
+}
+
+/// The load-bearing test.
+///
+/// Deleting the row without evicting the MAC from `state` leaves the entry
+/// behind with `gone = true`. The next observation then takes the `Reappear`
+/// arm carrying a dangling `device_id`, `update_last_seen_and_ip` matches zero
+/// rows and returns `Ok(())` **silently**, and `handle_unknown_mac` is never
+/// reached — so the device is never re-inserted. It becomes invisible in the UI
+/// while its traffic flows unattributed, until the daemon restarts.
+///
+/// Observing the MAC after a prune must therefore yield `NewDevice`, not
+/// `Reappeared`.
+#[tokio::test]
+async fn prune_evicts_pruned_mac_from_memory_so_it_is_rediscovered_not_resurrected() {
+    let harness =
+        build_harness_with_devices(vec![stale_device(DEVICE_ID_1, MAC_1, "192.168.1.10")]);
+
+    // Populate the in-memory maps the way a running daemon would: restore
+    // marks every device gone, and an observation registers live tracking.
+    harness.restore_devices().await.unwrap();
+    harness
+        .process_observation(&sample_observation(MAC_1, "192.168.1.10"))
+        .await
+        .unwrap();
+    // The observation legitimately refreshed `last_seen`, so age the row again
+    // — the point of this test is the eviction, not the predicate.
+    age_out(&harness, DEVICE_ID_1);
+
+    assert_eq!(harness.prune_unmanaged_devices().await.unwrap(), 1);
+
+    let result = harness
+        .process_observation(&sample_observation(MAC_1, "192.168.1.10"))
+        .await
+        .unwrap();
+
+    assert!(
+        matches!(result, ObservationResult::NewDevice { .. }),
+        "a pruned MAC must be rediscovered as new, not resurrected as a ghost \
+         pointing at a deleted row; got {result:?}"
+    );
+
+    // And the re-insert really happened, rather than the silent zero-row update.
+    assert!(harness.repo.find_by_mac(MAC_1).await.unwrap().is_some());
+}
+
+#[tokio::test]
+async fn prune_repo_error_propagates_as_internal_and_evicts_nothing() {
+    let harness =
+        build_harness_with_devices(vec![stale_device(DEVICE_ID_1, MAC_1, "192.168.1.10")]);
+    harness.restore_devices().await.unwrap();
+    harness
+        .process_observation(&sample_observation(MAC_1, "192.168.1.10"))
+        .await
+        .unwrap();
+    age_out(&harness, DEVICE_ID_1);
+
+    harness
+        .repo
+        .fail_delete_unmanaged
+        .store(true, std::sync::atomic::Ordering::SeqCst);
+
+    let result = harness.prune_unmanaged_devices().await;
+    assert!(matches!(result, Err(AppError::Internal(_))));
+
+    // The row survived, so the in-memory entry must survive with it — evicting
+    // on a failed delete would produce the mirror-image bug: a live device
+    // re-inserted as a duplicate row under a MAC that already has one.
+    harness
+        .repo
+        .fail_delete_unmanaged
+        .store(false, std::sync::atomic::Ordering::SeqCst);
+    let result = harness
+        .process_observation(&sample_observation(MAC_1, "192.168.1.10"))
+        .await
+        .unwrap();
+    assert!(
+        matches!(
+            result,
+            ObservationResult::Seen(_) | ObservationResult::Reappeared(_)
+        ),
+        "the device is still tracked; got {result:?}"
+    );
+}
+
+#[tokio::test]
+async fn prune_with_nothing_to_delete_is_a_no_op() {
+    let harness =
+        build_harness_with_devices(vec![sample_device(DEVICE_ID_1, MAC_1, "192.168.1.10")]);
+    // `sample_device`'s last_seen is a fixed past date, so pin it inside the
+    // window explicitly rather than depending on when the suite runs.
+    harness.repo.devices.lock().unwrap()[0].last_seen = chrono::Utc::now();
+
+    assert_eq!(harness.prune_unmanaged_devices().await.unwrap(), 0);
+    assert_eq!(harness.repo.find_all().await.unwrap().len(), 1);
+}
+
+// ── Managed promotion (issue #1181) ──────────────────────────────────────────
 
 #[tokio::test]
 async fn admin_rename_promotes_the_device_to_managed() {

--- a/source/daemon/crates/wardnetd-services/src/device/tests/discovery.rs
+++ b/source/daemon/crates/wardnetd-services/src/device/tests/discovery.rs
@@ -82,6 +82,18 @@ impl MockDeviceRepo {
 
 #[async_trait]
 impl DeviceRepository for MockDeviceRepo {
+    async fn delete_rule_for_device(&self, _device_id: &str) -> anyhow::Result<()> {
+        Ok(())
+    }
+
+    async fn set_managed(&self, id: &str, managed: bool) -> anyhow::Result<()> {
+        let mut devices = self.devices.lock().unwrap();
+        if let Some(d) = devices.iter_mut().find(|d| d.id.to_string() == id) {
+            d.managed = managed;
+        }
+        Ok(())
+    }
+
     async fn find_by_ip(&self, ip: &str) -> anyhow::Result<Option<Device>> {
         let devices = self.devices.lock().unwrap();
         Ok(devices.iter().find(|d| d.last_ip == ip).cloned())
@@ -143,6 +155,9 @@ impl DeviceRepository for MockDeviceRepo {
             dns_capture_cap_count: 1000,
             dns_capture_cap_days: 7,
             connection_mode: device.connection_mode,
+            // Mirrors the SQLite repo: `insert` omits `managed`, so a freshly
+            // discovered device always starts unmanaged (#1181).
+            managed: false,
         });
         Ok(())
     }
@@ -228,9 +243,12 @@ impl DeviceRepository for MockDeviceRepo {
         // Update the in-memory device so subsequent find_by_id returns updated data.
         let mut devices = self.devices.lock().unwrap();
         if let Some(d) = devices.iter_mut().find(|d| d.id.to_string() == id) {
-            if let Some(n) = name {
-                d.name = Some(n.to_owned());
-            }
+            // Assigned unconditionally, mirroring the real repo's
+            // `SET name = ?`: a `None` here means "write NULL" (the caller has
+            // already resolved partial-update semantics), not "leave it alone".
+            // The mock used to skip `None`, which made clearing a name silently
+            // untestable.
+            d.name = name.map(str::to_owned);
             if let Ok(dt) = serde_json::from_str(&format!("\"{device_type}\"")) {
                 d.device_type = dt;
             }
@@ -593,6 +611,7 @@ fn sample_device(id: &str, mac: &str, ip: &str) -> Device {
         dns_capture_cap_count: 1000,
         dns_capture_cap_days: 7,
         connection_mode: DeviceConnectionMode::Lan,
+        managed: false,
     }
 }
 
@@ -2264,4 +2283,105 @@ async fn new_device_with_a_public_oui_is_named_from_the_ieee_table() {
         }
         other => panic!("expected NewDevice, got {other:?}"),
     }
+}
+
+// ── Managed promotion (issue #1181) ──────────────────────────────────────────
+
+const DEVICE_ID_1: &str = "00000000-0000-0000-0000-0000000f0001";
+const MAC_1: &str = "aa:bb:cc:dd:ef:01";
+
+#[tokio::test]
+async fn admin_rename_promotes_the_device_to_managed() {
+    let device = sample_device(DEVICE_ID_1, MAC_1, "192.168.1.10");
+    let id = device.id;
+    let h = build_harness_with_devices(vec![device]);
+    assert!(
+        !h.repo
+            .find_by_id(&id.to_string())
+            .await
+            .unwrap()
+            .unwrap()
+            .managed
+    );
+
+    auth_context::with_context(
+        admin_ctx(),
+        h.svc.update_device(id, Some("Living Room TV"), None),
+    )
+    .await
+    .unwrap();
+
+    assert!(
+        h.repo
+            .find_by_id(&id.to_string())
+            .await
+            .unwrap()
+            .unwrap()
+            .managed
+    );
+}
+
+#[tokio::test]
+async fn a_device_renaming_itself_does_not_promote_it() {
+    // The exclusion the whole feature depends on. `update_device` is
+    // `require_authenticated`, so a device may rename itself — and a guest
+    // doing that is the device asking, not the admin deciding. Promoting here
+    // would make every guest phone permanently exempt from retention.
+    let device = sample_device(DEVICE_ID_1, MAC_1, "192.168.1.10");
+    let id = device.id;
+    let h = build_harness_with_devices(vec![device]);
+
+    auth_context::with_context(
+        device_ctx(MAC_1),
+        h.svc.update_device(id, Some("My Phone"), None),
+    )
+    .await
+    .unwrap();
+
+    let stored = h.repo.find_by_id(&id.to_string()).await.unwrap().unwrap();
+    assert_eq!(
+        stored.name,
+        Some("My Phone".to_owned()),
+        "the rename lands..."
+    );
+    assert!(!stored.managed, "...but it does not promote");
+}
+
+#[tokio::test]
+async fn a_blank_name_clears_the_name_to_null() {
+    // An empty string would persist as a name that renders as no label while
+    // still counting as named — the ambiguity `managed` exists to remove — and
+    // the release handler needs a way to genuinely unname a device.
+    let mut device = sample_device(DEVICE_ID_1, MAC_1, "192.168.1.10");
+    device.name = Some("Living Room TV".to_owned());
+    let id = device.id;
+    let h = build_harness_with_devices(vec![device]);
+
+    auth_context::with_context(admin_ctx(), h.svc.update_device(id, Some("   "), None))
+        .await
+        .unwrap();
+
+    let stored = h.repo.find_by_id(&id.to_string()).await.unwrap().unwrap();
+    assert_eq!(stored.name, None);
+}
+
+#[tokio::test]
+async fn omitting_the_name_still_preserves_it() {
+    // Guard against the blank-clears-it rule above swallowing the existing
+    // partial-update contract: `None` means "leave the name alone", and is
+    // distinct from `Some("")`.
+    let mut device = sample_device(DEVICE_ID_1, MAC_1, "192.168.1.10");
+    device.name = Some("Living Room TV".to_owned());
+    let id = device.id;
+    let h = build_harness_with_devices(vec![device]);
+
+    auth_context::with_context(
+        admin_ctx(),
+        h.svc.update_device(id, None, Some(DeviceType::Tv)),
+    )
+    .await
+    .unwrap();
+
+    let stored = h.repo.find_by_id(&id.to_string()).await.unwrap().unwrap();
+    assert_eq!(stored.name, Some("Living Room TV".to_owned()));
 }

--- a/source/daemon/crates/wardnetd-services/src/device/tests/ip_snapshot.rs
+++ b/source/daemon/crates/wardnetd-services/src/device/tests/ip_snapshot.rs
@@ -44,6 +44,13 @@ impl DeviceRepository for MockDeviceRepo {
         Ok(())
     }
 
+    async fn delete_unmanaged_before(
+        &self,
+        _cutoff: &str,
+    ) -> anyhow::Result<Vec<wardnetd_data::repository::PrunedDevice>> {
+        Ok(Vec::new())
+    }
+
     async fn find_by_ip(&self, _ip: &str) -> anyhow::Result<Option<Device>> {
         unimplemented!("not exercised by DeviceIpSnapshot")
     }

--- a/source/daemon/crates/wardnetd-services/src/device/tests/ip_snapshot.rs
+++ b/source/daemon/crates/wardnetd-services/src/device/tests/ip_snapshot.rs
@@ -36,6 +36,14 @@ impl MockDeviceRepo {
 
 #[async_trait]
 impl DeviceRepository for MockDeviceRepo {
+    async fn delete_rule_for_device(&self, _device_id: &str) -> anyhow::Result<()> {
+        Ok(())
+    }
+
+    async fn set_managed(&self, _id: &str, _managed: bool) -> anyhow::Result<()> {
+        Ok(())
+    }
+
     async fn find_by_ip(&self, _ip: &str) -> anyhow::Result<Option<Device>> {
         unimplemented!("not exercised by DeviceIpSnapshot")
     }
@@ -158,6 +166,7 @@ fn sample_device(id: &str, ip: &str, last_seen: &str) -> Device {
         dns_capture_cap_count: 1000,
         dns_capture_cap_days: 7,
         connection_mode: DeviceConnectionMode::Lan,
+        managed: false,
     }
 }
 

--- a/source/daemon/crates/wardnetd-services/src/dhcp/service.rs
+++ b/source/daemon/crates/wardnetd-services/src/dhcp/service.rs
@@ -934,6 +934,27 @@ impl DhcpService for DhcpServiceImpl {
             .await
             .map_err(AppError::Internal)?;
 
+        // Pinning an address is an admin configuration act, so the device it
+        // names is promoted to managed (issue #1181) and becomes exempt from
+        // the retention prune.
+        //
+        // Reservations are MAC-keyed and may legitimately pre-register a MAC no
+        // device row exists for yet; that lookup simply misses and nothing is
+        // promoted. Nothing is orphaned in that case either — the reservation
+        // row is keyed by MAC, not by `devices.id`, so it survives and keeps
+        // working regardless of the device row's fate.
+        if let Some(device) = self
+            .devices
+            .find_by_mac(mac)
+            .await
+            .map_err(AppError::Internal)?
+        {
+            self.devices
+                .set_managed(&device.id.to_string(), true)
+                .await
+                .map_err(AppError::Internal)?;
+        }
+
         let reservation = self
             .dhcp
             .find_reservation_by_mac(mac)

--- a/source/daemon/crates/wardnetd-services/src/dhcp/tests/dhcp.rs
+++ b/source/daemon/crates/wardnetd-services/src/dhcp/tests/dhcp.rs
@@ -375,6 +375,7 @@ impl MockDeviceRepository {
             dns_capture_cap_count: 0,
             dns_capture_cap_days: 0,
             connection_mode: wardnet_common::device::DeviceConnectionMode::Lan,
+            managed: false,
         };
         self.by_mac
             .lock()
@@ -385,6 +386,14 @@ impl MockDeviceRepository {
 
 #[async_trait]
 impl DeviceRepository for MockDeviceRepository {
+    async fn delete_rule_for_device(&self, _device_id: &str) -> anyhow::Result<()> {
+        Ok(())
+    }
+
+    async fn set_managed(&self, _id: &str, _managed: bool) -> anyhow::Result<()> {
+        Ok(())
+    }
+
     async fn find_by_mac(&self, mac: &str) -> anyhow::Result<Option<Device>> {
         Ok(self
             .by_mac

--- a/source/daemon/crates/wardnetd-services/src/dhcp/tests/dhcp.rs
+++ b/source/daemon/crates/wardnetd-services/src/dhcp/tests/dhcp.rs
@@ -394,6 +394,13 @@ impl DeviceRepository for MockDeviceRepository {
         Ok(())
     }
 
+    async fn delete_unmanaged_before(
+        &self,
+        _cutoff: &str,
+    ) -> anyhow::Result<Vec<wardnetd_data::repository::PrunedDevice>> {
+        Ok(Vec::new())
+    }
+
     async fn find_by_mac(&self, mac: &str) -> anyhow::Result<Option<Device>> {
         Ok(self
             .by_mac

--- a/source/daemon/crates/wardnetd-services/src/dns/tests/capture_runner.rs
+++ b/source/daemon/crates/wardnetd-services/src/dns/tests/capture_runner.rs
@@ -38,6 +38,18 @@ struct MockDeviceService {
 
 #[async_trait]
 impl DeviceService for MockDeviceService {
+    async fn clear_rule(&self, _device_id: &str) -> Result<(), crate::error::AppError> {
+        Ok(())
+    }
+
+    async fn mark_managed(&self, _device_id: &str) -> Result<(), crate::error::AppError> {
+        Ok(())
+    }
+
+    async fn clear_managed(&self, _device_id: &str) -> Result<(), crate::error::AppError> {
+        Ok(())
+    }
+
     async fn get_device(
         &self,
         _device_id: &str,
@@ -362,6 +374,7 @@ fn sample_device(capture_enabled: bool) -> Device {
         dns_capture_cap_count: 1000,
         dns_capture_cap_days: 7,
         connection_mode: wardnet_common::device::DeviceConnectionMode::Lan,
+        managed: false,
     }
 }
 

--- a/source/daemon/crates/wardnetd-services/src/dns_filter/service.rs
+++ b/source/daemon/crates/wardnetd-services/src/dns_filter/service.rs
@@ -1438,6 +1438,17 @@ impl DnsFilterService for DnsFilterServiceImpl {
             .await
             .map_err(AppError::Internal)?;
 
+        // Both writes above create `device_id`-keyed rows, so the device is now
+        // carrying admin artefacts and must be managed (issue #1181) — that is
+        // exactly the invariant the retention prune relies on. Promotion is
+        // unconditional, including for a settings row that merely *disables*
+        // filtering: it is the row's existence, not its value, that the prune
+        // would otherwise leave orphaned.
+        self.device_repo
+            .set_managed(&device_id.to_string(), true)
+            .await
+            .map_err(AppError::Internal)?;
+
         let settings = self
             .repo
             .find_device_settings(device_id)

--- a/source/daemon/crates/wardnetd-services/src/dns_filter/tests/service.rs
+++ b/source/daemon/crates/wardnetd-services/src/dns_filter/tests/service.rs
@@ -107,6 +107,7 @@ impl MemoryDeviceRepository {
                 dns_capture_cap_count: 1000,
                 dns_capture_cap_days: 7,
                 connection_mode: wardnet_common::device::DeviceConnectionMode::Lan,
+                managed: false,
             },
         );
     }
@@ -118,6 +119,14 @@ impl MemoryDeviceRepository {
 // returning empty data.
 #[async_trait]
 impl DeviceRepository for MemoryDeviceRepository {
+    async fn delete_rule_for_device(&self, _device_id: &str) -> anyhow::Result<()> {
+        Ok(())
+    }
+
+    async fn set_managed(&self, _id: &str, _managed: bool) -> anyhow::Result<()> {
+        Ok(())
+    }
+
     async fn find_by_ip(&self, _ip: &str) -> anyhow::Result<Option<Device>> {
         unimplemented!()
     }

--- a/source/daemon/crates/wardnetd-services/src/dns_filter/tests/service.rs
+++ b/source/daemon/crates/wardnetd-services/src/dns_filter/tests/service.rs
@@ -127,6 +127,13 @@ impl DeviceRepository for MemoryDeviceRepository {
         Ok(())
     }
 
+    async fn delete_unmanaged_before(
+        &self,
+        _cutoff: &str,
+    ) -> anyhow::Result<Vec<wardnetd_data::repository::PrunedDevice>> {
+        Ok(Vec::new())
+    }
+
     async fn find_by_ip(&self, _ip: &str) -> anyhow::Result<Option<Device>> {
         unimplemented!()
     }

--- a/source/daemon/crates/wardnetd-services/src/inbound_wg/service.rs
+++ b/source/daemon/crates/wardnetd-services/src/inbound_wg/service.rs
@@ -573,14 +573,19 @@ impl InboundWgService for InboundWgServiceImpl {
             )));
         }
 
-        // Only a *managed* device — one an admin has named — can be granted
-        // remote access; a bare discovered device must be adopted (named)
-        // first. The admin UI filters unmanaged devices out of the picker, so
-        // this is defense-in-depth. The peer's user-facing label is that
-        // admin-set name (never a free-text param).
+        // A peer's user-facing label is the device's admin-set name (never a
+        // free-text param), so a device must be named before it can be granted
+        // remote access.
+        //
+        // This is a *naming* requirement, not a managed-state one. Since #1181
+        // those are separate: `managed` is its own column, and granting remote
+        // access is itself one of the acts that promotes a device to managed
+        // (below) — so requiring `managed` here would be circular. The admin UI
+        // filters nameless devices out of the picker, making this
+        // defense-in-depth.
         let Some(name) = device.name.clone() else {
             return Err(AppError::Conflict(format!(
-                "device {device_id} is unmanaged - name (adopt) it before granting remote access"
+                "device {device_id} has no name - name it before granting remote access"
             )));
         };
 
@@ -633,6 +638,17 @@ impl InboundWgService for InboundWgServiceImpl {
             }
             return Err(AppError::Internal(error));
         }
+
+        // Issuing a Remote peer credential is an admin configuration act, so
+        // the device becomes managed and thereby exempt from the retention
+        // prune (issue #1181). Promotion comes after the interface accepted the
+        // peer, so the compensating rollback above doesn't leave a device
+        // marked managed for a credential that never existed.
+        //
+        // A roaming device is precisely the one that stays off the LAN longest,
+        // so without this the prune would cascade its `inbound_wg_peers` row
+        // away 30 days later and silently revoke its remote access.
+        self.devices.mark_managed(&device_id.to_string()).await?;
 
         // Assemble the full client config server-side (the private key never
         // leaves this method's memory otherwise). The server public key is the

--- a/source/daemon/crates/wardnetd-services/src/inbound_wg/tests/service.rs
+++ b/source/daemon/crates/wardnetd-services/src/inbound_wg/tests/service.rs
@@ -59,6 +59,7 @@ impl MockDeviceService {
             dns_capture_cap_count: 0,
             dns_capture_cap_days: 0,
             connection_mode: DeviceConnectionMode::Lan,
+            managed: false,
         };
         self.devices.lock().unwrap().insert(id.to_string(), device);
         id
@@ -67,6 +68,18 @@ impl MockDeviceService {
 
 #[async_trait]
 impl DeviceService for MockDeviceService {
+    async fn clear_rule(&self, _device_id: &str) -> Result<(), crate::error::AppError> {
+        Ok(())
+    }
+
+    async fn mark_managed(&self, _device_id: &str) -> Result<(), crate::error::AppError> {
+        Ok(())
+    }
+
+    async fn clear_managed(&self, _device_id: &str) -> Result<(), crate::error::AppError> {
+        Ok(())
+    }
+
     async fn get_device(&self, device_id: &str) -> Result<Option<Device>, AppError> {
         Ok(self.devices.lock().unwrap().get(device_id).cloned())
     }

--- a/source/daemon/crates/wardnetd-services/src/lib.rs
+++ b/source/daemon/crates/wardnetd-services/src/lib.rs
@@ -752,6 +752,7 @@ fn create_services(
         Arc::new(RoutingProfileServiceImpl::new(
             repo_factory.routing_profile(),
             tunnel_service.clone(),
+            device_service.clone(),
             domain_route_tx,
         ));
 

--- a/source/daemon/crates/wardnetd-services/src/network_zone/service.rs
+++ b/source/daemon/crates/wardnetd-services/src/network_zone/service.rs
@@ -486,6 +486,22 @@ impl NetworkZoneService for NetworkZoneServiceImpl {
             return Err(AppError::NotFound(format!("device {device_id} not found")));
         }
 
+        // An explicit zone reassignment is an admin configuration act, so it
+        // promotes to managed (issue #1181). Note this is the *only* way a zone
+        // promotes: zone membership is sticky and set at discovery from the
+        // default-for-new zone, so `zone_id` alone cannot distinguish "an admin
+        // moved this device" from "the default-for-new flag was later
+        // re-pointed" — which is why the migration deliberately does not
+        // backfill managed from zone membership.
+        //
+        // The no-op early return above means re-assigning a device to the zone
+        // it is already in promotes nothing, which is what the release handler
+        // relies on when it resets the zone before clearing `managed`.
+        self.devices
+            .set_managed(&device_id.to_string(), true)
+            .await
+            .map_err(AppError::Internal)?;
+
         self.events.publish(WardnetEvent::DeviceZoneChanged {
             device_id,
             old_zone_id,

--- a/source/daemon/crates/wardnetd-services/src/private_dns/mod.rs
+++ b/source/daemon/crates/wardnetd-services/src/private_dns/mod.rs
@@ -513,6 +513,16 @@ impl PrivateDnsService for PrivateDnsServiceImpl {
             return Err(AppError::Internal(e));
         }
 
+        // A grant is an admin configuration act, so the device becomes managed
+        // and thereby exempt from the retention prune (issue #1181). This is
+        // the case that most needs it: the grant's secret hostname is what a
+        // roaming phone resolves through, and that phone can easily be absent
+        // from the LAN for well over 30 days. Under the old
+        // `managed = name IS NOT NULL` inference, an unnamed device would have
+        // had its row — and, by cascade, its live grant — deleted underneath a
+        // working configuration.
+        self.devices.mark_managed(&row.device_id).await?;
+
         // Grant mutations re-emit the change event (enabled is true here —
         // granting requires it) so listeners holding token state refresh.
         self.publish_changed(true);

--- a/source/daemon/crates/wardnetd-services/src/private_dns/tests/service.rs
+++ b/source/daemon/crates/wardnetd-services/src/private_dns/tests/service.rs
@@ -188,6 +188,7 @@ impl MockDeviceService {
             dns_capture_cap_count: 0,
             dns_capture_cap_days: 0,
             connection_mode: DeviceConnectionMode::Lan,
+            managed: false,
         };
         self.devices.lock().unwrap().insert(id.to_string(), device);
         id
@@ -196,6 +197,18 @@ impl MockDeviceService {
 
 #[async_trait]
 impl DeviceService for MockDeviceService {
+    async fn clear_rule(&self, _device_id: &str) -> Result<(), crate::error::AppError> {
+        Ok(())
+    }
+
+    async fn mark_managed(&self, _device_id: &str) -> Result<(), crate::error::AppError> {
+        Ok(())
+    }
+
+    async fn clear_managed(&self, _device_id: &str) -> Result<(), crate::error::AppError> {
+        Ok(())
+    }
+
     async fn get_device(&self, device_id: &str) -> Result<Option<Device>, AppError> {
         Ok(self.devices.lock().unwrap().get(device_id).cloned())
     }

--- a/source/daemon/crates/wardnetd-services/src/routing/tests/routing.rs
+++ b/source/daemon/crates/wardnetd-services/src/routing/tests/routing.rs
@@ -60,6 +60,13 @@ impl DeviceRepository for MockDeviceRepo {
         Ok(())
     }
 
+    async fn delete_unmanaged_before(
+        &self,
+        _cutoff: &str,
+    ) -> anyhow::Result<Vec<wardnetd_data::repository::PrunedDevice>> {
+        Ok(Vec::new())
+    }
+
     async fn find_by_ip(&self, ip: &str) -> anyhow::Result<Option<Device>> {
         Ok(self.devices.iter().find(|d| d.last_ip == ip).cloned())
     }

--- a/source/daemon/crates/wardnetd-services/src/routing/tests/routing.rs
+++ b/source/daemon/crates/wardnetd-services/src/routing/tests/routing.rs
@@ -52,6 +52,14 @@ struct MockDeviceRepo {
 
 #[async_trait]
 impl DeviceRepository for MockDeviceRepo {
+    async fn delete_rule_for_device(&self, _device_id: &str) -> anyhow::Result<()> {
+        Ok(())
+    }
+
+    async fn set_managed(&self, _id: &str, _managed: bool) -> anyhow::Result<()> {
+        Ok(())
+    }
+
     async fn find_by_ip(&self, ip: &str) -> anyhow::Result<Option<Device>> {
         Ok(self.devices.iter().find(|d| d.last_ip == ip).cloned())
     }
@@ -958,6 +966,7 @@ fn sample_device(id: Uuid, ip: &str) -> Device {
         dns_capture_cap_count: 1000,
         dns_capture_cap_days: 7,
         connection_mode: wardnet_common::device::DeviceConnectionMode::Lan,
+        managed: false,
     }
 }
 

--- a/source/daemon/crates/wardnetd-services/src/routing_profile/service.rs
+++ b/source/daemon/crates/wardnetd-services/src/routing_profile/service.rs
@@ -26,6 +26,7 @@ use wardnetd_data::repository::{
 
 use crate::TunnelService;
 use crate::auth_context;
+use crate::device::service::DeviceService;
 use crate::error::AppError;
 
 use super::view::{CompiledRule, DeviceRoutingContext, RoutingView};
@@ -100,6 +101,12 @@ pub trait RoutingProfileService: Send + Sync {
 pub struct RoutingProfileServiceImpl {
     repo: Arc<dyn RoutingProfileRepository>,
     tunnels: Arc<dyn TunnelService>,
+    /// Used only to promote a device to managed when a profile is assigned to
+    /// it (issue #1181), per the single-service-per-repository rule. Safe to
+    /// hold: [`DeviceService`] does not depend on this service, so there is no
+    /// `Arc` cycle — unlike the release orchestration, which had to live in the
+    /// API handler for exactly that reason.
+    devices: Arc<dyn DeviceService>,
     /// Enforcement sink drained by the domain-route runner.
     sink: mpsc::Sender<DomainRouteRequest>,
     /// Lock-free compiled view consulted by [`Self::note_resolution`].
@@ -111,11 +118,13 @@ impl RoutingProfileServiceImpl {
     pub fn new(
         repo: Arc<dyn RoutingProfileRepository>,
         tunnels: Arc<dyn TunnelService>,
+        devices: Arc<dyn DeviceService>,
         sink: mpsc::Sender<DomainRouteRequest>,
     ) -> Self {
         Self {
             repo,
             tunnels,
+            devices,
             sink,
             view: Arc::new(ArcSwap::from_pointee(RoutingView::new())),
         }
@@ -351,6 +360,13 @@ impl RoutingProfileService for RoutingProfileServiceImpl {
             .set_device_profiles(device_id, profile_ids)
             .await
             .map_err(AppError::Internal)?;
+
+        // Assigning routing profiles is an admin configuration act, so the
+        // device is promoted to managed and thereby exempt from the retention
+        // prune (issue #1181) — `routing_device_profile` rows are `device_id`-
+        // keyed and would otherwise be cascaded away with the device.
+        self.devices.mark_managed(&device_id.to_string()).await?;
+
         self.refresh_view().await?;
         Ok(())
     }

--- a/source/daemon/crates/wardnetd-services/src/routing_profile/tests/service.rs
+++ b/source/daemon/crates/wardnetd-services/src/routing_profile/tests/service.rs
@@ -6,6 +6,7 @@
 //! unknown-tunnel rejection. CRUD happy paths and conflicts are covered by the
 //! API-layer tests, which drive the same service.
 
+use std::collections::HashMap;
 use std::net::{IpAddr, Ipv4Addr};
 use std::sync::Arc;
 
@@ -14,14 +15,20 @@ use sqlx::SqlitePool;
 use sqlx::sqlite::SqlitePoolOptions;
 use tokio::sync::mpsc;
 use uuid::Uuid;
-use wardnet_common::api::CreateTunnelRequest;
+use wardnet_common::api::{
+    CreateTunnelRequest, DeviceMeResponse, DnsCaptureSettingsResponse, DnsEventItem,
+    SetMyRuleResponse,
+};
 use wardnet_common::auth::AuthContext;
+use wardnet_common::device::Device;
+use wardnet_common::routing::RoutingTarget;
 use wardnet_common::routing_profile::DomainRoutingTarget;
 use wardnet_common::tunnel::Tunnel;
 use wardnetd_data::repository::SqliteRoutingProfileRepository;
 
 use crate::TunnelService;
 use crate::auth_context;
+use crate::device::service::DeviceService;
 use crate::error::AppError;
 use crate::routing_profile::service::{
     DomainRouteRequest, RoutingProfileService, RoutingProfileServiceImpl,
@@ -61,6 +68,108 @@ async fn insert_device(pool: &SqlitePool, id: Uuid, last_ip: &str) {
     .execute(pool)
     .await
     .unwrap();
+}
+
+/// A `DeviceService` that records the ids passed to `mark_managed` and panics
+/// on anything else.
+///
+/// `RoutingProfileServiceImpl` holds a `DeviceService` for exactly one reason —
+/// promoting a device to managed when a profile is assigned to it (#1181) — so
+/// every other method being `unimplemented!()` is the assertion that the
+/// dependency stays that narrow.
+#[derive(Default)]
+struct RecordingDeviceService {
+    marked: std::sync::Mutex<Vec<String>>,
+}
+
+#[async_trait]
+impl DeviceService for RecordingDeviceService {
+    async fn clear_rule(&self, _device_id: &str) -> Result<(), crate::error::AppError> {
+        Ok(())
+    }
+
+    async fn mark_managed(&self, device_id: &str) -> Result<(), AppError> {
+        self.marked.lock().unwrap().push(device_id.to_owned());
+        Ok(())
+    }
+
+    async fn clear_managed(&self, _device_id: &str) -> Result<(), AppError> {
+        unimplemented!("routing profiles never release a device")
+    }
+
+    async fn get_device_for_ip(&self, _ip: &str) -> Result<DeviceMeResponse, AppError> {
+        unimplemented!()
+    }
+    async fn set_rule_for_ip(
+        &self,
+        _ip: &str,
+        _target: RoutingTarget,
+    ) -> Result<SetMyRuleResponse, AppError> {
+        unimplemented!()
+    }
+    async fn set_rule(&self, _device_id: &str, _target: RoutingTarget) -> Result<(), AppError> {
+        unimplemented!()
+    }
+    async fn current_rules(&self) -> Result<HashMap<Uuid, RoutingTarget>, AppError> {
+        unimplemented!()
+    }
+    async fn get_rule_for_device(
+        &self,
+        _device_id: &str,
+    ) -> Result<Option<RoutingTarget>, AppError> {
+        unimplemented!()
+    }
+    async fn update_admin_locked(&self, _device_id: &str, _locked: bool) -> Result<(), AppError> {
+        unimplemented!()
+    }
+    async fn get_dns_capture_settings(
+        &self,
+        _device_id: &str,
+    ) -> Result<DnsCaptureSettingsResponse, AppError> {
+        unimplemented!()
+    }
+    async fn update_dns_capture_settings(
+        &self,
+        _device_id: &str,
+        _enabled: Option<bool>,
+        _cap_count: Option<i64>,
+        _cap_days: Option<i64>,
+    ) -> Result<(), AppError> {
+        unimplemented!()
+    }
+    async fn set_my_capture_enabled(
+        &self,
+        _ip: &str,
+        _enabled: bool,
+    ) -> Result<DnsCaptureSettingsResponse, AppError> {
+        unimplemented!()
+    }
+    async fn fetch_pending_dns_events(
+        &self,
+        _device_id: &str,
+        _after_id: i64,
+        _limit: i64,
+    ) -> Result<Vec<DnsEventItem>, AppError> {
+        unimplemented!()
+    }
+    async fn ack_dns_events(&self, _device_id: &str, _up_to_id: i64) -> Result<(), AppError> {
+        unimplemented!()
+    }
+    async fn list_capture_enabled_device_ids(&self) -> Result<Vec<String>, AppError> {
+        unimplemented!()
+    }
+    async fn get_device_capture_settings(
+        &self,
+        _device_id: &str,
+    ) -> Result<Option<(bool, i64, i64)>, AppError> {
+        unimplemented!()
+    }
+    async fn get_device(&self, _device_id: &str) -> Result<Option<Device>, AppError> {
+        unimplemented!()
+    }
+    async fn clear_remote_connection_mode(&self, _device_id: &str) -> Result<(), AppError> {
+        unimplemented!()
+    }
 }
 
 /// A `TunnelService` whose `get_tunnel` always reports "not found" (so
@@ -160,6 +269,7 @@ async fn setup() -> (
     let svc = Arc::new(RoutingProfileServiceImpl::new(
         repo,
         Arc::new(MissingTunnelService),
+        Arc::new(RecordingDeviceService::default()),
         tx,
     ));
 

--- a/source/daemon/crates/wardnetd-services/src/rule_request/tests/service.rs
+++ b/source/daemon/crates/wardnetd-services/src/rule_request/tests/service.rs
@@ -120,11 +120,24 @@ fn sample_device() -> Device {
         dns_capture_cap_count: 1000,
         dns_capture_cap_days: 7,
         connection_mode: wardnet_common::device::DeviceConnectionMode::Lan,
+        managed: false,
     }
 }
 
 #[async_trait]
 impl DeviceService for MockDeviceService {
+    async fn clear_rule(&self, _device_id: &str) -> Result<(), crate::error::AppError> {
+        Ok(())
+    }
+
+    async fn mark_managed(&self, _device_id: &str) -> Result<(), crate::error::AppError> {
+        Ok(())
+    }
+
+    async fn clear_managed(&self, _device_id: &str) -> Result<(), crate::error::AppError> {
+        Ok(())
+    }
+
     async fn get_device(
         &self,
         _device_id: &str,

--- a/source/daemon/crates/wardnetd-services/src/tests/device_retention_runner.rs
+++ b/source/daemon/crates/wardnetd-services/src/tests/device_retention_runner.rs
@@ -1,0 +1,236 @@
+//! Tests for [`DeviceRetentionRunner`] (issue #1181).
+//!
+//! Mirrors `db_maintenance_runner`'s shape: the runner's job is purely
+//! *cadence* — once per calendar day, responsive to cancellation — so these
+//! drive the day-rollover gate and the failure tolerance. What the prune
+//! actually deletes is covered in `device::tests::discovery`.
+
+use std::sync::Arc;
+use std::sync::Mutex;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use uuid::Uuid;
+use wardnet_common::auth::AuthContext;
+use wardnet_common::device::{Device, DeviceType};
+
+use crate::device::discovery::{DeviceDiscoveryService, ObservationResult};
+use crate::device::packet_capture::ObservedDevice;
+use crate::device::retention_runner::{DeviceRetentionRunner, prune};
+use crate::error::AppError;
+
+// ── Mock discovery service ───────────────────────────────────────────────────
+
+/// A `DeviceDiscoveryService` that counts prune calls, records the auth context
+/// each ran under, and can be made to fail. Every other method is
+/// `unimplemented!()` — the runner must touch nothing else.
+struct MockDiscovery {
+    fail: bool,
+    calls: Mutex<u32>,
+    /// Whether every prune so far saw an admin context. The runner is
+    /// responsible for supplying one; the service's own `require_admin` would
+    /// otherwise reject it.
+    always_admin: Mutex<bool>,
+}
+
+impl MockDiscovery {
+    fn ok() -> Arc<Self> {
+        Arc::new(Self {
+            fail: false,
+            calls: Mutex::new(0),
+            always_admin: Mutex::new(true),
+        })
+    }
+
+    fn err() -> Arc<Self> {
+        Arc::new(Self {
+            fail: true,
+            calls: Mutex::new(0),
+            always_admin: Mutex::new(true),
+        })
+    }
+
+    fn call_count(&self) -> u32 {
+        *self.calls.lock().unwrap()
+    }
+
+    fn always_admin(&self) -> bool {
+        *self.always_admin.lock().unwrap()
+    }
+}
+
+#[async_trait]
+impl DeviceDiscoveryService for MockDiscovery {
+    async fn prune_unmanaged_devices(&self) -> Result<u64, AppError> {
+        *self.calls.lock().unwrap() += 1;
+        let is_admin = crate::auth_context::try_current()
+            .unwrap_or(AuthContext::Anonymous)
+            .is_admin();
+        if !is_admin {
+            *self.always_admin.lock().unwrap() = false;
+        }
+        if self.fail {
+            return Err(AppError::Internal(anyhow::anyhow!("synthetic prune error")));
+        }
+        Ok(3)
+    }
+
+    async fn restore_devices(&self) -> Result<(), AppError> {
+        unimplemented!()
+    }
+    async fn rebuild_trusted_subnets(&self) -> Result<(), AppError> {
+        unimplemented!()
+    }
+    async fn process_observation(
+        &self,
+        _obs: &ObservedDevice,
+    ) -> Result<ObservationResult, AppError> {
+        unimplemented!()
+    }
+    async fn flush_last_seen(&self) -> Result<u64, AppError> {
+        unimplemented!()
+    }
+    async fn scan_departures(&self, _timeout_secs: u64) -> Result<Vec<Uuid>, AppError> {
+        unimplemented!()
+    }
+    async fn resolve_hostname(&self, _mac: &str, _ip: &str) -> Result<(), AppError> {
+        unimplemented!()
+    }
+    async fn get_all_devices(&self) -> Result<Vec<Device>, AppError> {
+        unimplemented!()
+    }
+    async fn get_device_by_id(&self, _id: Uuid) -> Result<Device, AppError> {
+        unimplemented!()
+    }
+    async fn update_device(
+        &self,
+        _id: Uuid,
+        _name: Option<&str>,
+        _device_type: Option<DeviceType>,
+    ) -> Result<Device, AppError> {
+        unimplemented!()
+    }
+    async fn process_peer_observation(
+        &self,
+        _device_id: Uuid,
+        _ip: &str,
+    ) -> Result<ObservationResult, AppError> {
+        unimplemented!()
+    }
+    async fn touch_peer_presence(&self, _device_id: Uuid) -> Result<(), AppError> {
+        unimplemented!()
+    }
+    async fn mark_peer_gone(
+        &self,
+        _device_id: Uuid,
+        _timeout: Duration,
+    ) -> Result<Option<Uuid>, AppError> {
+        unimplemented!()
+    }
+}
+
+fn admin_ctx() -> AuthContext {
+    AuthContext::Admin {
+        admin_id: Uuid::nil(),
+    }
+}
+
+// ── One pass ─────────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn prune_runs_under_an_admin_context() {
+    // The service method is `require_admin`-guarded like every other, so the
+    // runner has to supply the context — a background task has no session.
+    let discovery = MockDiscovery::ok();
+    prune(discovery.as_ref(), &admin_ctx()).await;
+
+    assert_eq!(discovery.call_count(), 1);
+    assert!(discovery.always_admin());
+}
+
+#[tokio::test]
+async fn prune_swallows_errors_rather_than_panicking() {
+    // A prune that cannot run is a table that keeps growing for another day,
+    // not a reason to tear down the runner.
+    let discovery = MockDiscovery::err();
+    prune(discovery.as_ref(), &admin_ctx()).await;
+
+    assert_eq!(discovery.call_count(), 1);
+}
+
+// ── Cadence ──────────────────────────────────────────────────────────────────
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn runner_shuts_down_cleanly() {
+    let discovery = MockDiscovery::ok();
+    let runner = DeviceRetentionRunner::start(discovery, &tracing::Span::none());
+    runner.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn runner_fires_on_day_rollover() {
+    let discovery = MockDiscovery::ok();
+    let yesterday = chrono::Utc::now().date_naive() - chrono::Days::new(1);
+
+    let runner = DeviceRetentionRunner::start_with_interval_and_day(
+        discovery.clone(),
+        Duration::from_millis(20),
+        yesterday,
+        &tracing::Span::none(),
+    );
+
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    runner.shutdown().await;
+
+    assert!(
+        discovery.call_count() >= 1,
+        "expected a prune on day rollover, call_count={}",
+        discovery.call_count()
+    );
+    assert!(discovery.always_admin());
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn runner_does_not_refire_within_the_same_day() {
+    // Several ticks inside one calendar day must produce zero prunes — the
+    // hourly tick exists to stay responsive to cancellation, not to prune
+    // hourly.
+    let discovery = MockDiscovery::ok();
+
+    let runner = DeviceRetentionRunner::start_with_interval(
+        discovery.clone(),
+        Duration::from_millis(20),
+        &tracing::Span::none(),
+    );
+
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    runner.shutdown().await;
+
+    assert_eq!(
+        discovery.call_count(),
+        0,
+        "prune must not fire when the day has not rolled over"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn runner_survives_a_failing_prune() {
+    // The day-rollover gate has already advanced when the prune runs, so a
+    // failure must neither panic the task nor stop later ticks — the retry
+    // lands on the next calendar day.
+    let discovery = MockDiscovery::err();
+    let yesterday = chrono::Utc::now().date_naive() - chrono::Days::new(1);
+
+    let runner = DeviceRetentionRunner::start_with_interval_and_day(
+        discovery.clone(),
+        Duration::from_millis(20),
+        yesterday,
+        &tracing::Span::none(),
+    );
+
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    // A panicked task would make this hang or the join fail.
+    runner.shutdown().await;
+
+    assert!(discovery.call_count() >= 1);
+}

--- a/source/daemon/crates/wardnetd-services/src/tests/mod.rs
+++ b/source/daemon/crates/wardnetd-services/src/tests/mod.rs
@@ -1,4 +1,5 @@
 mod db_maintenance_runner;
+mod device_retention_runner;
 mod entitlement;
 mod error;
 mod event;

--- a/source/daemon/crates/wardnetd-services/src/tunnel/tests/tunnel.rs
+++ b/source/daemon/crates/wardnetd-services/src/tunnel/tests/tunnel.rs
@@ -738,6 +738,14 @@ impl MockDeviceRepoWithSwitchedDevices {
 
 #[async_trait]
 impl DeviceRepository for MockDeviceRepoForTunnel {
+    async fn delete_rule_for_device(&self, _device_id: &str) -> anyhow::Result<()> {
+        Ok(())
+    }
+
+    async fn set_managed(&self, _id: &str, _managed: bool) -> anyhow::Result<()> {
+        Ok(())
+    }
+
     async fn find_by_ip(&self, _ip: &str) -> anyhow::Result<Option<Device>> {
         Ok(None)
     }
@@ -837,6 +845,14 @@ impl DeviceRepository for MockDeviceRepoForTunnel {
 
 #[async_trait]
 impl DeviceRepository for MockDeviceRepoWithSwitchedDevices {
+    async fn delete_rule_for_device(&self, _device_id: &str) -> anyhow::Result<()> {
+        Ok(())
+    }
+
+    async fn set_managed(&self, _id: &str, _managed: bool) -> anyhow::Result<()> {
+        Ok(())
+    }
+
     async fn find_by_ip(&self, _ip: &str) -> anyhow::Result<Option<Device>> {
         Ok(None)
     }

--- a/source/daemon/crates/wardnetd-services/src/tunnel/tests/tunnel.rs
+++ b/source/daemon/crates/wardnetd-services/src/tunnel/tests/tunnel.rs
@@ -746,6 +746,13 @@ impl DeviceRepository for MockDeviceRepoForTunnel {
         Ok(())
     }
 
+    async fn delete_unmanaged_before(
+        &self,
+        _cutoff: &str,
+    ) -> anyhow::Result<Vec<wardnetd_data::repository::PrunedDevice>> {
+        Ok(Vec::new())
+    }
+
     async fn find_by_ip(&self, _ip: &str) -> anyhow::Result<Option<Device>> {
         Ok(None)
     }
@@ -851,6 +858,13 @@ impl DeviceRepository for MockDeviceRepoWithSwitchedDevices {
 
     async fn set_managed(&self, _id: &str, _managed: bool) -> anyhow::Result<()> {
         Ok(())
+    }
+
+    async fn delete_unmanaged_before(
+        &self,
+        _cutoff: &str,
+    ) -> anyhow::Result<Vec<wardnetd_data::repository::PrunedDevice>> {
+        Ok(Vec::new())
     }
 
     async fn find_by_ip(&self, _ip: &str) -> anyhow::Result<Option<Device>> {

--- a/source/daemon/crates/wardnetd-services/src/zone_exception/service.rs
+++ b/source/daemon/crates/wardnetd-services/src/zone_exception/service.rs
@@ -204,6 +204,22 @@ impl ZoneExceptionService for ZoneExceptionServiceImpl {
             .insert(&exception)
             .await
             .map_err(AppError::Internal)?;
+
+        // An exception naming a device is an admin configuration act on that
+        // device, so it promotes to managed (issue #1181). Without this the
+        // retention prune could delete a device 30 days after it was last seen
+        // while this MAC-independent, FK-less exception row still referenced
+        // it — leaving a rule that grants cross-zone reach to whatever device
+        // next claims that id. Zone endpoints promote nothing.
+        for endpoint in [&exception.from, &exception.to] {
+            if endpoint.kind == ExceptionEndpointKind::Device {
+                self.devices
+                    .set_managed(&endpoint.id.to_string(), true)
+                    .await
+                    .map_err(AppError::Internal)?;
+            }
+        }
+
         self.emit_changed();
         Ok(exception)
     }

--- a/source/daemon/crates/wardnetd/src/main.rs
+++ b/source/daemon/crates/wardnetd/src/main.rs
@@ -67,6 +67,7 @@ use wardnetd_services::auth::SessionCleanupRunner;
 use wardnetd_services::cloud::TunnelerRunner;
 use wardnetd_services::db_maintenance_runner::DbMaintenanceRunner;
 use wardnetd_services::ddns::runner::DdnsUpdateRunner;
+use wardnetd_services::device::DeviceRetentionRunner;
 use wardnetd_services::dhcp::runner::DhcpRunner;
 use wardnetd_services::diagnostics::DiagnosticStore;
 use wardnetd_services::diagnostics::listener::DiagnosticsListener;
@@ -907,6 +908,13 @@ async fn run(
     let db_maintenance_runner =
         DbMaintenanceRunner::start(services.maintenance.clone(), &root_span);
 
+    // Delete unmanaged devices absent for over 30 days, once per day (#1181).
+    // Only unmanaged devices are eligible — `managed = false` implies no admin
+    // artefacts reference the device — so this can never revoke a working
+    // configuration.
+    let device_retention_runner =
+        DeviceRetentionRunner::start(services.discovery.clone(), &root_span);
+
     // Settle any `update_pending_version` marker left behind by an install
     // that restarted us. Must run before the update runner's first check so a
     // status poll never observes a version still "pending" that is in fact
@@ -1322,6 +1330,7 @@ async fn run(
     dns_query_log_runner.shutdown().await;
     dns_capture_runner.shutdown().await;
     db_maintenance_runner.shutdown().await;
+    device_retention_runner.shutdown().await;
     update_runner.shutdown().await;
     backup_cleanup_runner.shutdown().await;
     stats_flush_runner.shutdown().await;

--- a/source/daemon/crates/wardnetd/src/tests/device_detector.rs
+++ b/source/daemon/crates/wardnetd/src/tests/device_detector.rs
@@ -153,6 +153,10 @@ impl MockDiscovery {
 
 #[async_trait]
 impl DeviceDiscoveryService for MockDiscovery {
+    async fn prune_unmanaged_devices(&self) -> Result<u64, wardnetd_services::error::AppError> {
+        Ok(0)
+    }
+
     async fn process_peer_observation(
         &self,
         _device_id: Uuid,

--- a/source/daemon/crates/wardnetd/src/tests/device_snapshot_listener.rs
+++ b/source/daemon/crates/wardnetd/src/tests/device_snapshot_listener.rs
@@ -49,6 +49,14 @@ impl MockDeviceRepo {
 
 #[async_trait]
 impl DeviceRepository for MockDeviceRepo {
+    async fn delete_rule_for_device(&self, _device_id: &str) -> anyhow::Result<()> {
+        Ok(())
+    }
+
+    async fn set_managed(&self, _id: &str, _managed: bool) -> anyhow::Result<()> {
+        Ok(())
+    }
+
     async fn find_by_ip(&self, _ip: &str) -> anyhow::Result<Option<Device>> {
         unimplemented!("not exercised by DeviceSnapshotListener")
     }

--- a/source/daemon/crates/wardnetd/src/tests/device_snapshot_listener.rs
+++ b/source/daemon/crates/wardnetd/src/tests/device_snapshot_listener.rs
@@ -57,6 +57,13 @@ impl DeviceRepository for MockDeviceRepo {
         Ok(())
     }
 
+    async fn delete_unmanaged_before(
+        &self,
+        _cutoff: &str,
+    ) -> anyhow::Result<Vec<wardnetd_data::repository::PrunedDevice>> {
+        Ok(Vec::new())
+    }
+
     async fn find_by_ip(&self, _ip: &str) -> anyhow::Result<Option<Device>> {
         unimplemented!("not exercised by DeviceSnapshotListener")
     }

--- a/source/daemon/crates/wardnetd/src/tests/stubs.rs
+++ b/source/daemon/crates/wardnetd/src/tests/stubs.rs
@@ -141,6 +141,24 @@ pub struct StubDeviceService;
 
 #[async_trait]
 impl DeviceService for StubDeviceService {
+    async fn clear_rule(&self, _device_id: &str) -> Result<(), wardnetd_services::error::AppError> {
+        Ok(())
+    }
+
+    async fn mark_managed(
+        &self,
+        _device_id: &str,
+    ) -> Result<(), wardnetd_services::error::AppError> {
+        Ok(())
+    }
+
+    async fn clear_managed(
+        &self,
+        _device_id: &str,
+    ) -> Result<(), wardnetd_services::error::AppError> {
+        Ok(())
+    }
+
     async fn get_device(
         &self,
         _device_id: &str,

--- a/source/daemon/crates/wardnetd/src/tests/stubs.rs
+++ b/source/daemon/crates/wardnetd/src/tests/stubs.rs
@@ -248,6 +248,10 @@ pub struct StubDiscoveryService;
 
 #[async_trait]
 impl DeviceDiscoveryService for StubDiscoveryService {
+    async fn prune_unmanaged_devices(&self) -> Result<u64, wardnetd_services::error::AppError> {
+        Ok(0)
+    }
+
     async fn process_peer_observation(
         &self,
         _device_id: uuid::Uuid,

--- a/source/sdk/wardnet-go/client_test.go
+++ b/source/sdk/wardnet-go/client_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	wardnet "wardnet.network/go"
@@ -20,7 +21,7 @@ const deviceJSON = `{
   "last_ip":"192.168.1.42","admin_locked":false,
   "zone_id":"00000000-0000-0000-0000-000000000001",
   "dns_capture_enabled":false,"dns_capture_cap_count":0,"dns_capture_cap_days":0,
-  "connection_mode":"lan","dhcp_status":"lease",
+  "connection_mode":"lan","dhcp_status":"lease","managed":true,
   "current_rule":{"type":"tunnel","tunnel_id":"d4681478-8a90-4ce6-b220-0650a333d73c"}
 }`
 
@@ -89,6 +90,9 @@ func TestDevicesList(t *testing.T) {
 	}
 	if d.ConnectionMode != "lan" || d.DHCPStatus != "lease" {
 		t.Errorf("connection_mode=%q dhcp_status=%q", d.ConnectionMode, d.DHCPStatus)
+	}
+	if !d.Managed {
+		t.Error("managed = false, want true")
 	}
 	if d.Rule == nil || d.Rule.Kind != wardnet.RoutingTunnel {
 		t.Fatalf("rule = %+v, want tunnel", d.Rule)
@@ -222,5 +226,48 @@ func TestSystemRestartError(t *testing.T) {
 	var apiErr *wardnet.APIError
 	if !errors.As(err, &apiErr) || apiErr.StatusCode != http.StatusForbidden {
 		t.Fatalf("error = %v, want a 403 APIError", err)
+	}
+}
+
+// Release is destructive — it revokes the device's Private-DNS grant and
+// Remote peer credential — so this pins the method, verb and path rather than
+// leaving a mis-wired route to be discovered against a live daemon.
+func TestDevicesRelease(t *testing.T) {
+	const id = "6e05df45-1fa4-4327-8c1e-218c79b253ba"
+	c := newClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("method = %s, want POST", r.Method)
+		}
+		if want := "/api/devices/" + id + "/release"; r.URL.Path != want {
+			t.Errorf("path = %q, want %q", r.URL.Path, want)
+		}
+		// A released device comes back unmanaged and unnamed.
+		writeJSON(w, `{"device":`+strings.Replace(
+			strings.Replace(deviceJSON, `"managed":true`, `"managed":false`, 1),
+			`"name":"alice-phone"`, `"name":null`, 1)+`,"current_rule":null,"signals":[]}`)
+	}))
+
+	d, err := c.Devices.Release(context.Background(), id)
+	if err != nil {
+		t.Fatalf("Release: %v", err)
+	}
+	if d.Managed {
+		t.Error("managed = true, want false after release")
+	}
+	if d.Name != "" {
+		t.Errorf("name = %q, want empty after release", d.Name)
+	}
+	if d.Rule != nil {
+		t.Errorf("rule = %+v, want nil after release", d.Rule)
+	}
+}
+
+func TestDevicesReleaseRejectsBadID(t *testing.T) {
+	c := newClient(t, http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		t.Error("no request should be sent for a malformed id")
+	}))
+
+	if _, err := c.Devices.Release(context.Background(), "not-a-uuid"); err == nil {
+		t.Fatal("Release: expected an error for a malformed device id")
 	}
 }

--- a/source/sdk/wardnet-go/devices.go
+++ b/source/sdk/wardnet-go/devices.go
@@ -65,6 +65,19 @@ type Device struct {
 	// Rule is the device's own routing rule. Nil means it has no rule of its
 	// own and follows the gateway default policy.
 	Rule *RoutingTarget `json:"rule"`
+	// Managed reports whether an admin has decided to control this device's
+	// configuration (issue #1181).
+	//
+	// Set by any admin configuration act — naming, locking, a routing rule or
+	// profile, DNS filter settings, DNS capture, a Private-DNS grant, a Remote
+	// peer credential, a DHCP reservation, a zone exception, an explicit zone
+	// reassignment. Deliberately not derived from Name: a device can be
+	// configured without ever being named.
+	//
+	// Latching: it never clears on its own, only through Release. Only
+	// unmanaged devices are subject to device retention (deleted after 30 days
+	// away).
+	Managed bool `json:"managed"`
 }
 
 // List returns every discovered device.
@@ -131,6 +144,33 @@ func (s *DevicesService) SetRule(ctx context.Context, id string, target RoutingT
 	return deviceFromREST(&resp.JSON200.Device, resp.JSON200.CurrentRule)
 }
 
+// Release stops managing a device: it reverts every admin-set configuration to
+// default and returns the device to unmanaged (issue #1181).
+//
+// Destructive. It revokes the device's Private-DNS grant and its Remote peer
+// credential, disconnecting it, and clears the device's name, admin lock, DNS
+// capture, routing rule and profiles, DNS-filter settings, DHCP reservation,
+// and zone exceptions, returning it to the default-for-new zone.
+//
+// Once unmanaged the device becomes subject to device retention and is deleted
+// after 30 days away. Idempotent: a retry after a partial failure completes,
+// and a failure part-way leaves the device still managed rather than
+// half-released.
+func (s *DevicesService) Release(ctx context.Context, id string) (*Device, error) {
+	uid, err := parseUUID(id, "device")
+	if err != nil {
+		return nil, err
+	}
+	resp, err := s.c.rest.ReleaseDeviceWithResponse(ctx, uid)
+	if err != nil {
+		return nil, err
+	}
+	if resp.JSON200 == nil {
+		return nil, apiError(resp.HTTPResponse, resp.Body)
+	}
+	return deviceFromREST(&resp.JSON200.Device, resp.JSON200.CurrentRule)
+}
+
 // deviceFromREST maps the generated device onto the public type. rule is the
 // authoritative routing rule for the device — for the detail endpoints this is
 // the response's top-level current_rule, not the mirror nested on the device.
@@ -161,6 +201,7 @@ func deviceFromREST(d *rest.DeviceWithStatus, rule *rest.RoutingTarget) (*Device
 		ConnectionMode: ConnectionMode(d.ConnectionMode),
 		DHCPStatus:     DHCPStatus(d.DhcpStatus),
 		Rule:           r,
+		Managed:        d.Managed,
 	}, nil
 }
 

--- a/source/sdk/wardnet-go/internal/rest/rest.gen.go
+++ b/source/sdk/wardnet-go/internal/rest/rest.gen.go
@@ -2071,10 +2071,27 @@ type Device struct {
 	// IsRandomized Whether `mac` is locally administered (a privacy/randomized address).
 	// Deliberately separate from `manufacturer`: it says how the device
 	// presents itself, not who built it.
-	IsRandomized       bool                `json:"is_randomized"`
-	LastIp             string              `json:"last_ip"`
-	LastSeen           time.Time           `json:"last_seen"`
-	Mac                string              `json:"mac"`
+	IsRandomized bool      `json:"is_randomized"`
+	LastIp       string    `json:"last_ip"`
+	LastSeen     time.Time `json:"last_seen"`
+	Mac          string    `json:"mac"`
+
+	// Managed Whether an admin has decided to control this device's configuration.
+	//
+	// Set by *any* admin configuration act (naming, locking, a routing rule or
+	// profile, DNS filter settings, DNS capture, a Private-DNS grant, a Remote
+	// peer credential, a DHCP reservation, a zone exception, an explicit zone
+	// reassignment) and deliberately **not** inferred from `name` — a device
+	// can be configured without ever being named, and clearing a name must not
+	// silently revoke its remote access.
+	//
+	// Latching: never demotes automatically, only through an explicit release
+	// (`POST /api/devices/{id}/release`), which first reverts every managed
+	// setting to default. That upholds the invariant device retention depends
+	// on — `managed = false` implies no admin artefacts exist — so pruning a
+	// long-absent unmanaged device can never orphan a row. See issue #1181 and
+	// `docs/adr/0032-managed-devices-and-retention.md`.
+	Managed            bool                `json:"managed"`
 	Manufacturer       *string             `json:"manufacturer,omitempty"`
 	ManufacturerSource *ManufacturerSource `json:"manufacturer_source,omitempty"`
 	Name               *string             `json:"name,omitempty"`
@@ -2234,10 +2251,27 @@ type DeviceWithStatus struct {
 	// IsRandomized Whether `mac` is locally administered (a privacy/randomized address).
 	// Deliberately separate from `manufacturer`: it says how the device
 	// presents itself, not who built it.
-	IsRandomized       bool                `json:"is_randomized"`
-	LastIp             string              `json:"last_ip"`
-	LastSeen           time.Time           `json:"last_seen"`
-	Mac                string              `json:"mac"`
+	IsRandomized bool      `json:"is_randomized"`
+	LastIp       string    `json:"last_ip"`
+	LastSeen     time.Time `json:"last_seen"`
+	Mac          string    `json:"mac"`
+
+	// Managed Whether an admin has decided to control this device's configuration.
+	//
+	// Set by *any* admin configuration act (naming, locking, a routing rule or
+	// profile, DNS filter settings, DNS capture, a Private-DNS grant, a Remote
+	// peer credential, a DHCP reservation, a zone exception, an explicit zone
+	// reassignment) and deliberately **not** inferred from `name` — a device
+	// can be configured without ever being named, and clearing a name must not
+	// silently revoke its remote access.
+	//
+	// Latching: never demotes automatically, only through an explicit release
+	// (`POST /api/devices/{id}/release`), which first reverts every managed
+	// setting to default. That upholds the invariant device retention depends
+	// on — `managed = false` implies no admin artefacts exist — so pruning a
+	// long-absent unmanaged device can never orphan a row. See issue #1181 and
+	// `docs/adr/0032-managed-devices-and-retention.md`.
+	Managed            bool                `json:"managed"`
 	Manufacturer       *string             `json:"manufacturer,omitempty"`
 	ManufacturerSource *ManufacturerSource `json:"manufacturer_source,omitempty"`
 	Name               *string             `json:"name,omitempty"`
@@ -6061,6 +6095,11 @@ type ClientInterface interface {
 	// Update DNS capture settings for a device. Omitted fields are left unchanged.
 	UpdateDnsCaptureSettings(ctx context.Context, id string, body UpdateDnsCaptureSettingsJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
+	// ReleaseDevice performs a POST /api/devices/{id}/release (the `ReleaseDevice` operationId) request.
+	//
+	// Stop managing a device (issue #1181). Reverts every admin-set configuration to default and returns the device to unmanaged, after which it becomes subject to device retention and is deleted once it has been absent for 30 days. Destructive: this revokes the device's Private-DNS grant and its Remote peer credential, disconnecting it. Idempotent — each step is a no-op when there is nothing to revert, so a retry after a partial failure completes. Admin only.
+	ReleaseDevice(ctx context.Context, id openapi_types.UUID, reqEditors ...RequestEditorFn) (*http.Response, error)
+
 	// AssignDeviceZoneWithBody performs a PUT /api/devices/{id}/zone (the `AssignDeviceZone` operationId) request,
 	// with any type of body and a specified content type.
 	//
@@ -7763,6 +7802,21 @@ func (c *Client) UpdateDnsCaptureSettingsWithBody(ctx context.Context, id string
 // Update DNS capture settings for a device. Omitted fields are left unchanged.
 func (c *Client) UpdateDnsCaptureSettings(ctx context.Context, id string, body UpdateDnsCaptureSettingsJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewUpdateDnsCaptureSettingsRequest(c.Server, id, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+// ReleaseDevice performs a POST /api/devices/{id}/release (the `ReleaseDevice` operationId) request.
+//
+// Stop managing a device (issue #1181). Reverts every admin-set configuration to default and returns the device to unmanaged, after which it becomes subject to device retention and is deleted once it has been absent for 30 days. Destructive: this revokes the device's Private-DNS grant and its Remote peer credential, disconnecting it. Idempotent — each step is a no-op when there is nothing to revert, so a retry after a partial failure completes. Admin only.
+func (c *Client) ReleaseDevice(ctx context.Context, id openapi_types.UUID, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewReleaseDeviceRequest(c.Server, id)
 	if err != nil {
 		return nil, err
 	}
@@ -11736,6 +11790,40 @@ func NewUpdateDnsCaptureSettingsRequestWithBody(server string, id string, conten
 	}
 
 	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewReleaseDeviceRequest constructs an http.Request for the ReleaseDevice method
+func NewReleaseDeviceRequest(server string, id openapi_types.UUID) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "id", id, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: "uuid"})
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/devices/%s/release", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodPost, queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
 
 	return req, nil
 }
@@ -17422,6 +17510,13 @@ type ClientWithResponsesInterface interface {
 	// Update DNS capture settings for a device. Omitted fields are left unchanged.
 	UpdateDnsCaptureSettingsWithResponse(ctx context.Context, id string, body UpdateDnsCaptureSettingsJSONRequestBody, reqEditors ...RequestEditorFn) (*UpdateDnsCaptureSettingsResp, error)
 
+	// ReleaseDeviceWithResponse performs a POST /api/devices/{id}/release (the `ReleaseDevice` operationId) request.
+	//
+	// Stop managing a device (issue #1181). Reverts every admin-set configuration to default and returns the device to unmanaged, after which it becomes subject to device retention and is deleted once it has been absent for 30 days. Destructive: this revokes the device's Private-DNS grant and its Remote peer credential, disconnecting it. Idempotent — each step is a no-op when there is nothing to revert, so a retry after a partial failure completes. Admin only.
+	//
+	// Returns a wrapper object for the known response body format(s).
+	ReleaseDeviceWithResponse(ctx context.Context, id openapi_types.UUID, reqEditors ...RequestEditorFn) (*ReleaseDeviceResp, error)
+
 	// AssignDeviceZoneWithBodyWithResponse performs a PUT /api/devices/{id}/zone (the `AssignDeviceZone` operationId) request,
 	// with any type of body and a specified content type.
 	//
@@ -21214,6 +21309,142 @@ func (r UpdateDnsCaptureSettingsResp) StatusCode() int {
 
 // ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
 func (r UpdateDnsCaptureSettingsResp) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
+type ReleaseDeviceResp struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	// JSON200 the response for an HTTP 200 `application/json` response
+	JSON200 *DeviceDetailResponse
+	// JSON400 the response for an HTTP 400 `application/json` response
+	JSON400 *struct {
+		Detail *string `json:"detail,omitempty"`
+		Error  string  `json:"error"`
+
+		// RequestId Request ID for correlation with server logs.
+		RequestId *string `json:"request_id,omitempty"`
+	}
+	// JSON401 the response for an HTTP 401 `application/json` response
+	JSON401 *struct {
+		Detail *string `json:"detail,omitempty"`
+		Error  string  `json:"error"`
+
+		// RequestId Request ID for correlation with server logs.
+		RequestId *string `json:"request_id,omitempty"`
+	}
+	// JSON403 the response for an HTTP 403 `application/json` response
+	JSON403 *struct {
+		Detail *string `json:"detail,omitempty"`
+		Error  string  `json:"error"`
+
+		// RequestId Request ID for correlation with server logs.
+		RequestId *string `json:"request_id,omitempty"`
+	}
+	// JSON404 the response for an HTTP 404 `application/json` response
+	JSON404 *struct {
+		Detail *string `json:"detail,omitempty"`
+		Error  string  `json:"error"`
+
+		// RequestId Request ID for correlation with server logs.
+		RequestId *string `json:"request_id,omitempty"`
+	}
+	// JSON500 the response for an HTTP 500 `application/json` response
+	JSON500 *struct {
+		Detail *string `json:"detail,omitempty"`
+		Error  string  `json:"error"`
+
+		// RequestId Request ID for correlation with server logs.
+		RequestId *string `json:"request_id,omitempty"`
+	}
+}
+
+// GetJSON200 returns the response for an HTTP 200 `application/json` response
+func (r ReleaseDeviceResp) GetJSON200() *DeviceDetailResponse {
+	return r.JSON200
+}
+
+// GetJSON400 returns the response for an HTTP 400 `application/json` response
+func (r ReleaseDeviceResp) GetJSON400() *struct {
+	Detail *string `json:"detail,omitempty"`
+	Error  string  `json:"error"`
+
+	// RequestId Request ID for correlation with server logs.
+	RequestId *string `json:"request_id,omitempty"`
+} {
+	return r.JSON400
+}
+
+// GetJSON401 returns the response for an HTTP 401 `application/json` response
+func (r ReleaseDeviceResp) GetJSON401() *struct {
+	Detail *string `json:"detail,omitempty"`
+	Error  string  `json:"error"`
+
+	// RequestId Request ID for correlation with server logs.
+	RequestId *string `json:"request_id,omitempty"`
+} {
+	return r.JSON401
+}
+
+// GetJSON403 returns the response for an HTTP 403 `application/json` response
+func (r ReleaseDeviceResp) GetJSON403() *struct {
+	Detail *string `json:"detail,omitempty"`
+	Error  string  `json:"error"`
+
+	// RequestId Request ID for correlation with server logs.
+	RequestId *string `json:"request_id,omitempty"`
+} {
+	return r.JSON403
+}
+
+// GetJSON404 returns the response for an HTTP 404 `application/json` response
+func (r ReleaseDeviceResp) GetJSON404() *struct {
+	Detail *string `json:"detail,omitempty"`
+	Error  string  `json:"error"`
+
+	// RequestId Request ID for correlation with server logs.
+	RequestId *string `json:"request_id,omitempty"`
+} {
+	return r.JSON404
+}
+
+// GetJSON500 returns the response for an HTTP 500 `application/json` response
+func (r ReleaseDeviceResp) GetJSON500() *struct {
+	Detail *string `json:"detail,omitempty"`
+	Error  string  `json:"error"`
+
+	// RequestId Request ID for correlation with server logs.
+	RequestId *string `json:"request_id,omitempty"`
+} {
+	return r.JSON500
+}
+
+// GetBody returns the raw response body bytes
+func (r ReleaseDeviceResp) GetBody() []byte {
+	return r.Body
+}
+
+// Status returns HTTPResponse.Status
+func (r ReleaseDeviceResp) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r ReleaseDeviceResp) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r ReleaseDeviceResp) ContentType() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Header.Get("Content-Type")
 	}
@@ -37392,6 +37623,19 @@ func (c *ClientWithResponses) UpdateDnsCaptureSettingsWithResponse(ctx context.C
 	return ParseUpdateDnsCaptureSettingsResp(rsp)
 }
 
+// ReleaseDeviceWithResponse performs a POST /api/devices/{id}/release (the `ReleaseDevice` operationId) request.
+//
+// Stop managing a device (issue #1181). Reverts every admin-set configuration to default and returns the device to unmanaged, after which it becomes subject to device retention and is deleted once it has been absent for 30 days. Destructive: this revokes the device's Private-DNS grant and its Remote peer credential, disconnecting it. Idempotent — each step is a no-op when there is nothing to revert, so a retry after a partial failure completes. Admin only.
+//
+// Returns a wrapper object for the known response body format(s).
+func (c *ClientWithResponses) ReleaseDeviceWithResponse(ctx context.Context, id openapi_types.UUID, reqEditors ...RequestEditorFn) (*ReleaseDeviceResp, error) {
+	rsp, err := c.ReleaseDevice(ctx, id, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseReleaseDeviceResp(rsp)
+}
+
 // AssignDeviceZoneWithBodyWithResponse performs a PUT /api/devices/{id}/zone (the `AssignDeviceZone` operationId) request,
 // with any type of body and a specified content type.
 //
@@ -41578,6 +41822,97 @@ func ParseUpdateDnsCaptureSettingsResp(rsp *http.Response) (*UpdateDnsCaptureSet
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
 		var dest ApiError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON500 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseReleaseDeviceResp parses an HTTP response from a ReleaseDeviceWithResponse call
+func ParseReleaseDeviceResp(rsp *http.Response) (*ReleaseDeviceResp, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &ReleaseDeviceResp{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest DeviceDetailResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
+		var dest struct {
+			Detail *string `json:"detail,omitempty"`
+			Error  string  `json:"error"`
+
+			// RequestId Request ID for correlation with server logs.
+			RequestId *string `json:"request_id,omitempty"`
+		}
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON400 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest struct {
+			Detail *string `json:"detail,omitempty"`
+			Error  string  `json:"error"`
+
+			// RequestId Request ID for correlation with server logs.
+			RequestId *string `json:"request_id,omitempty"`
+		}
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 403:
+		var dest struct {
+			Detail *string `json:"detail,omitempty"`
+			Error  string  `json:"error"`
+
+			// RequestId Request ID for correlation with server logs.
+			RequestId *string `json:"request_id,omitempty"`
+		}
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON403 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
+		var dest struct {
+			Detail *string `json:"detail,omitempty"`
+			Error  string  `json:"error"`
+
+			// RequestId Request ID for correlation with server logs.
+			RequestId *string `json:"request_id,omitempty"`
+		}
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON404 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
+		var dest struct {
+			Detail *string `json:"detail,omitempty"`
+			Error  string  `json:"error"`
+
+			// RequestId Request ID for correlation with server logs.
+			RequestId *string `json:"request_id,omitempty"`
+		}
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}

--- a/source/sdk/wardnet-js/src/internal/openapi-schema.ts
+++ b/source/sdk/wardnet-js/src/internal/openapi-schema.ts
@@ -334,6 +334,23 @@ export interface paths {
         patch: operations["patch_api_devices_id_dns_capture"];
         trace?: never;
     };
+    "/api/devices/{id}/release": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** @description Stop managing a device (issue #1181). Reverts every admin-set configuration to default and returns the device to unmanaged, after which it becomes subject to device retention and is deleted once it has been absent for 30 days. Destructive: this revokes the device's Private-DNS grant and its Remote peer credential, disconnecting it. Idempotent — each step is a no-op when there is nothing to revert, so a retry after a partial failure completes. Admin only. */
+        post: operations["post_api_devices_id_release"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/devices/{id}/zone": {
         parameters: {
             query?: never;
@@ -2770,6 +2787,22 @@ export interface components {
             /** Format: date-time */
             last_seen: string;
             mac: string;
+            /** @description Whether an admin has decided to control this device's configuration.
+             *
+             *     Set by *any* admin configuration act (naming, locking, a routing rule or
+             *     profile, DNS filter settings, DNS capture, a Private-DNS grant, a Remote
+             *     peer credential, a DHCP reservation, a zone exception, an explicit zone
+             *     reassignment) and deliberately **not** inferred from `name` — a device
+             *     can be configured without ever being named, and clearing a name must not
+             *     silently revoke its remote access.
+             *
+             *     Latching: never demotes automatically, only through an explicit release
+             *     (`POST /api/devices/{id}/release`), which first reverts every managed
+             *     setting to default. That upholds the invariant device retention depends
+             *     on — `managed = false` implies no admin artefacts exist — so pruning a
+             *     long-absent unmanaged device can never orphan a row. See issue #1181 and
+             *     `docs/adr/0032-managed-devices-and-retention.md`. */
+            managed: boolean;
             manufacturer?: string | null;
             manufacturer_source?: null | components["schemas"]["ManufacturerSource"];
             name?: string | null;
@@ -6285,6 +6318,99 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["ApiError"];
+                };
+            };
+        };
+    };
+    post_api_devices_id_release: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Device ID */
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Updated device detail */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DeviceDetailResponse"];
+                };
+            };
+            /** @description Malformed or invalid request body */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        detail?: string | null;
+                        error: string;
+                        /** @description Request ID for correlation with server logs. */
+                        request_id?: string | null;
+                    };
+                };
+            };
+            /** @description Unauthenticated - session cookie or API key missing/invalid */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        detail?: string | null;
+                        error: string;
+                        /** @description Request ID for correlation with server logs. */
+                        request_id?: string | null;
+                    };
+                };
+            };
+            /** @description Forbidden - caller is not an admin */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        detail?: string | null;
+                        error: string;
+                        /** @description Request ID for correlation with server logs. */
+                        request_id?: string | null;
+                    };
+                };
+            };
+            /** @description Resource not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        detail?: string | null;
+                        error: string;
+                        /** @description Request ID for correlation with server logs. */
+                        request_id?: string | null;
+                    };
+                };
+            };
+            /** @description Internal server error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        detail?: string | null;
+                        error: string;
+                        /** @description Request ID for correlation with server logs. */
+                        request_id?: string | null;
+                    };
                 };
             };
         };

--- a/source/sdk/wardnet-js/src/services/devices.ts
+++ b/source/sdk/wardnet-js/src/services/devices.ts
@@ -49,6 +49,25 @@ export class DeviceService {
     return this.api.put("/devices/{id}", { path: { id }, body });
   }
 
+  /**
+   * Stop managing a device — revert every admin-set configuration to default
+   * and return it to unmanaged (admin only, issue #1181).
+   *
+   * **Destructive.** This revokes the device's Private-DNS grant and its
+   * Remote peer credential, disconnecting it. It also clears the device's
+   * name, admin lock, DNS capture, routing rule and profiles, DNS-filter
+   * settings, DHCP reservation, and zone exceptions, and returns it to the
+   * default-for-new zone.
+   *
+   * Once unmanaged the device becomes subject to device retention and is
+   * deleted after 30 days away. Idempotent: a retry after a partial failure
+   * completes, and a failure part-way leaves the device still managed rather
+   * than half-released.
+   */
+  async release(id: string): Promise<DeviceDetailResponse> {
+    return this.api.post("/devices/{id}/release", { path: { id } });
+  }
+
   /** Get DNS capture settings and storage stats for a device (admin only). */
   async getDnsCaptureSettings(id: string): Promise<DnsCaptureSettingsResponse> {
     return this.api.get("/devices/{id}/dns-capture", { path: { id } });

--- a/source/sdk/wardnet-js/src/types/device.ts
+++ b/source/sdk/wardnet-js/src/types/device.ts
@@ -71,6 +71,22 @@ export interface Device {
   current_rule: RoutingTarget | null;
   /** How the device is currently reachable (LAN vs. inbound WireGuard). */
   connection_mode: DeviceConnectionMode;
+  /**
+   * Whether an admin has decided to control this device's configuration
+   * (issue #1181).
+   *
+   * Set by *any* admin configuration act — naming, locking, a routing rule or
+   * profile, DNS filter settings, DNS capture, a Private-DNS grant, a Remote
+   * peer credential, a DHCP reservation, a zone exception, an explicit zone
+   * reassignment. Deliberately **not** derived from `name`: a device can be
+   * configured without ever being named, so rendering managed-ness from the
+   * name alone is wrong in both directions.
+   *
+   * Latching — it never clears on its own, only through
+   * {@link DeviceService.release}. Only unmanaged devices are subject to
+   * device retention (deleted after 30 days away).
+   */
+  managed: boolean;
 }
 
 /**

--- a/source/user-app/tests/test-utils.tsx
+++ b/source/user-app/tests/test-utils.tsx
@@ -58,6 +58,9 @@ export function makeDevice(overrides: Partial<Device> = {}): Device {
     dhcp_status: "lease",
     current_rule: null,
     connection_mode: "lan",
+    // Unmanaged by default: that is what a freshly discovered device is, and
+    // it keeps `managed: true` an explicit opt-in in the tests that need it.
+    managed: false,
     ...overrides,
   };
 }

--- a/source/web/src/hooks/useDevices.ts
+++ b/source/web/src/hooks/useDevices.ts
@@ -84,6 +84,36 @@ export function useUpdateDevice(options?: { successMessage?: string }) {
   });
 }
 
+/**
+ * Stop managing a device: revert every admin-set configuration to default and
+ * return it to unmanaged (issue #1181).
+ *
+ * Destructive — it revokes the device's Private-DNS grant and Remote peer
+ * credential — so callers must confirm before firing.
+ *
+ * Invalidates broadly rather than just the device: a release touches DHCP
+ * reservations, zone exceptions, DNS-filter settings, routing profiles and the
+ * device's zone, so any cached view of those is stale afterwards.
+ */
+export function useReleaseDevice() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (id: string) => deviceService.release(id),
+    onSuccess: (_data, id) => {
+      toast.success("Device released");
+      qc.invalidateQueries({ queryKey: ["devices"] });
+      qc.invalidateQueries({ queryKey: ["devices", id] });
+      qc.invalidateQueries({ queryKey: ["dhcp"] });
+      qc.invalidateQueries({ queryKey: ["zone-exceptions"] });
+      qc.invalidateQueries({ queryKey: ["dns-filter"] });
+      qc.invalidateQueries({ queryKey: ["routing-profiles"] });
+      qc.invalidateQueries({ queryKey: ["private-dns"] });
+      qc.invalidateQueries({ queryKey: ["inbound-wg"] });
+    },
+    onError: () => toast.error("Failed to release device"),
+  });
+}
+
 export function useDnsCaptureSettings(id: string) {
   return useQuery({
     queryKey: ["devices", id, "dns-capture"],

--- a/source/web/src/index.ts
+++ b/source/web/src/index.ts
@@ -131,6 +131,7 @@ export {
   useSetMyRule,
   useSetMyCaptureEnabled,
   useUpdateDevice,
+  useReleaseDevice,
   useDnsCaptureSettings,
   useUpdateDnsCaptureSettings,
 } from "./hooks/useDevices";

--- a/source/web/tests/hooks/useDevices.test.tsx
+++ b/source/web/tests/hooks/useDevices.test.tsx
@@ -13,6 +13,7 @@ const { deviceService } = vi.hoisted(() => ({
     setMyRule: vi.fn(),
     setMyCaptureEnabled: vi.fn(),
     update: vi.fn(),
+    release: vi.fn(),
     getDnsCaptureSettings: vi.fn(),
     updateDnsCaptureSettings: vi.fn(),
   },
@@ -36,6 +37,7 @@ import {
   useSetMyRule,
   useSetMyCaptureEnabled,
   useUpdateDevice,
+  useReleaseDevice,
   useDnsCaptureSettings,
   useUpdateDnsCaptureSettings,
 } from "../../src/hooks/useDevices";
@@ -141,5 +143,36 @@ describe("useDevices", () => {
       enabled: true,
     });
     expect(toast.success).toHaveBeenCalledWith("DNS capture settings saved");
+  });
+
+  it("releases a device and reports success", async () => {
+    deviceService.release.mockResolvedValue({});
+    const { result } = renderHook(() => useReleaseDevice(), {
+      wrapper: createQueryWrapper(),
+    });
+
+    await act(async () => {
+      await result.current.mutateAsync("d1");
+    });
+
+    expect(deviceService.release).toHaveBeenCalledWith("d1");
+    expect(toast.success).toHaveBeenCalledWith("Device released");
+  });
+
+  it("surfaces a failed release rather than reporting success", async () => {
+    // A release revokes credentials; silently swallowing the failure would
+    // leave the admin believing the device was released when it still holds
+    // its Private-DNS grant and Remote peer credential.
+    deviceService.release.mockRejectedValue(new Error("boom"));
+    const { result } = renderHook(() => useReleaseDevice(), {
+      wrapper: createQueryWrapper(),
+    });
+
+    await act(async () => {
+      await expect(result.current.mutateAsync("d1")).rejects.toThrow("boom");
+    });
+
+    expect(toast.error).toHaveBeenCalledWith("Failed to release device");
+    expect(toast.success).not.toHaveBeenCalled();
   });
 });

--- a/source/web/tests/test-utils.tsx
+++ b/source/web/tests/test-utils.tsx
@@ -72,6 +72,9 @@ export function makeDevice(overrides: Partial<Device> = {}): Device {
     dhcp_status: "lease",
     current_rule: null,
     connection_mode: "lan",
+    // Unmanaged by default: that is what a freshly discovered device is, and
+    // it keeps `managed: true` an explicit opt-in in the tests that need it.
+    managed: false,
     ...overrides,
   };
 }


### PR DESCRIPTION
Closes #1181.

## The problem, and the modelling bug under it

The `devices` table has no retention policy — a row is created on discovery and never removed. On a live box with 23 days uptime: 42 devices, 19 named, 23 unnamed, arriving ~1/day and never leaving. MAC randomization sharpens this from slow growth into a real leak: a phone that re-randomizes on each join mints a **new** row every time, so the rows that will never return under the same MAC accumulate fastest.

Retention couldn't be built until the modelling bug underneath it was fixed. "Managed" was inferred from `name != null` (`Devices.tsx`, `DeviceDetail.tsx`), which is wrong in **both** directions:

- Granting a device Private DNS, pinning a DHCP reservation, or issuing a Remote peer credential left it rendered "Discovered" — extensively configured, and the UI said otherwise.
- A bare name, never followed by any actual configuration, made a device "Managed".

Pruning on `name IS NULL` would therefore not merely mislabel things — it would **silently revoke remote access** (a roaming phone with a Private-DNS grant is exactly the device most likely to be off the LAN for 30 days) and orphan admin-authored MAC-keyed rows that have no FK to clean them up.

## What this does

`devices.managed` becomes an explicit, **latching** column, promoted by any *admin* configuration act and cleared only by an explicit release. That buys the invariant everything else rests on:

> `managed = 0` implies no admin artefacts exist for this device.

Which is why the prune can delete an unmanaged row without checking anything else, and can never orphan or revoke anything.

**Promotes:** naming, admin-locking, an admin-set routing rule, a routing profile assignment, DNS-filter settings/profiles, enabling DNS capture, a Private-DNS grant, a Remote peer credential, a DHCP reservation, a zone exception, an explicit zone reassignment.

**Does not promote:** a self-service routing rule, a device rule request, a push subscription, the zone assigned at discovery, quarantine, machine-derived signals. Two call sites are reachable by a non-admin — `update_device` (a device may rename itself) and `set_rule` (a device may set its own routing) — and gate promotion on the **auth context**, not on the write succeeding. A guest tapping a toggle in the user PWA is the device asking, not the admin deciding; promoting there would make every guest phone permanently exempt, and guest phones are the population this issue is about.

**Release** (`POST /api/devices/{id}/release`, "Stop managing") reverts every managed setting and sets `managed = 0` **last**, so a partial failure leaves the device still managed rather than half-released with a live credential it is no longer recorded as owning. Every step is idempotent, so a retry completes.

**Retention** — `DeviceRetentionRunner` deletes unmanaged devices absent over 30 days, once per calendar day.

## Three things worth a reviewer's attention

**1. The prune must delete *then* evict, and the ordering is load-bearing.** Deleting the row without evicting the MAC from discovery's in-memory `state` leaves the entry behind with `gone = true`. The next observation takes the `Reappear` arm carrying a now-dangling `device_id`; `update_last_seen_and_ip` matches zero rows and returns `Ok(())` **silently**; `handle_unknown_mac` is never reached, so the device is never re-inserted. Result: a device invisible in the UI while its traffic flows unattributed, until the daemon restarts. Evicting first is wrong the other way — an observation in the window finds the row still present and re-populates `state`. Both directions are covered by `prune_evicts_pruned_mac_from_memory_so_it_is_rediscovered_not_resurrected`. This also bounds `ip_history` and `device_locks`, which nothing pruned before.

**2. The backfill deliberately ignores zone membership.** Zones are sticky, so `zone_id != <default-for-new>` cannot distinguish "an admin moved this device" from "the default-for-new flag was later re-pointed at a different zone". Guessing inclusively would mark essentially every existing device managed on any box whose flag has ever moved — silently disabling retention on exactly the boxes that need it. Going forward `assign_device` promotes explicitly. Same reasoning rules out testing the zone in the prune predicate, where it would become a silent kill switch.

**3. Release orchestration lives in the API handler, and that's forced.** `InboundWgServiceImpl` and `PrivateDnsServiceImpl` both hold `Arc<dyn DeviceService>` (they call `mark_managed`), so a `DeviceService` reaching back into them to revoke a peer or grant would be an `Arc` cycle and a construction-order deadlock. `api/devices.rs` already orchestrates several services.

## Fixes found along the way

- **The plan's backfill SQL referenced a dropped table.** `dns_device_adblock` was dropped by `20260506000000_dns_filtering.sql` and superseded by `dns_filter_device_settings`. As written the migration failed outright, taking all 275 repository tests with it.
- **`set_rule(Direct)` was the wrong revert.** It's validated against the device's zone, so a device in a **tunnel-only zone could never be released**. And `Direct` is an explicit persisted choice that *overrides* the global default rather than deferring to it — "no rule" is the actual unconfigured state. Added `DeviceService::clear_rule`, which deletes the row and publishes `RoutingRuleChanged` carrying the **global default policy** (the listener applies whatever the event says, so publishing the deleted rule would re-install it).
- **An empty name persisted as `""`, not NULL**, so the release could not actually unname a device. `update_device` now treats a blank name as a clear — distinct from `None`, which still means "leave it alone".
- **Two places conflated "named" with "managed"** — the inbound-WireGuard `add_peer` gate and the Private-DNS grant picker. Both genuinely need a *name* as a credential label, so the gates stay, but gating on `managed` there would now be circular since granting is itself what promotes. Wording corrected.
- **Mock fidelity:** `MockDeviceRepo::update_name_and_type` skipped `None` while the real SQL writes `name = ?` unconditionally, which made name-clearing silently untestable.

## Deviation from the issue

The issue asks for a **configurable TTL**. This ships a hard-coded `DEVICE_RETENTION_DAYS: i64 = 30`, matching the existing `INTRADAY_RETENTION` / `NOTIFICATION_RETENTION_CAP` precedent. A setting needs a UI, validation, and a support answer for "why did my device vanish", and none of that is worth shipping before we know anyone wants a number other than 30. Revisitable without a data migration — neither the column nor the prune predicate changes. Recorded in ADR 0032 and noted on the issue.

## Commits

Two, split at the natural line so the model change can be read without the retention machinery mixed in. Each compiles and tests independently.

1. `feat(devices): make `managed` an explicit latching column and add release`
2. `feat(devices): delete unmanaged devices absent for over 30 days`

## Verification

- `make check-daemon` (podman/Linux): fmt + clippy `-D warnings` + **3,088 tests**, clean.
- `make check-web`: type-check, lint, format, and vitest across all four web workspaces, clean.
- New coverage: repository prune predicate + FK-cascade behaviour (asserting `PRAGMA foreign_keys` is actually on, since the test pool doesn't set it by default and a silent no-cascade would only orphan rows in production); migration backfill executed from the **shipped SQL read out of the migration file** rather than a copy, one case per artefact plus the three non-promoting ones; the ghost-device eviction test above; runner day-rollover/idempotence/failure-tolerance; release ordering (`clear_managed` asserted **last**) and the mid-sequence-failure path; admin-site tests for the badge, the save label, and the confirm dialog.

Not verified locally: the runner wiring in `wardnetd`/`wardnetd-mock` `main.rs` is compile-checked only — I did not boot a daemon. Manual end-to-end against the mock daemon (name a device → badge flips; grant Private DNS on an unnamed device → also flips; Stop managing → confirm dialog lists every revert) has not been run.

## Docs

- **ADR 0032** — records the sticky-zone rejection, the deliberate backfill gap, the `Arc`-cycle-forced handler orchestration, the `managed = 0` invariant, and the hard-coded-TTL deviation.
- **CONTEXT.md** — glossary entries for *Managed device*, *Release*, *Device retention*.
- **`.agents/architecture.md`** — new subsystem section; `DeviceRetentionRunner` added to the runner list. Flags that **a new per-device table must decide whether it promotes**, or the prune will cascade it away 30 days after the device was last seen.