### PR TITLE
fix(pwa): keep the install banner above page content

### DIFF
--- a/source/user-app/src/pages/Home.tsx
+++ b/source/user-app/src/pages/Home.tsx
@@ -192,7 +192,15 @@ function VerifyCard({ activeTunnel }: { activeTunnel: TunnelSummary | null }) {
           </div>
         ) : geo ? (
           <>
+            {/* Leaflet runs its own layers from z-index 400 (panes) to 1000
+                (controls) on a container it only ever gives
+                `position: relative` — no stacking context, so that ladder is
+                resolved against the app shell rather than against the map.
+                The scroll area's clipping keeps it in today; `isolate` makes
+                the containment the map's own property instead of an accident
+                of the layout above it. */}
             <MapContainer
+              className="isolate"
               center={[geo.latitude, geo.longitude]}
               zoom={8}
               dragging={false}

--- a/source/user-app/tests/pages/Home.test.tsx
+++ b/source/user-app/tests/pages/Home.test.tsx
@@ -22,8 +22,16 @@ vi.mock("@/hooks/useIpGeolocation", () => ({ useIpGeolocation }));
 // react-leaflet renders a real Leaflet map that jsdom can't drive; stub the
 // pieces Home uses as inert DOM so the rest of the card is exercised.
 vi.mock("react-leaflet", () => ({
-  MapContainer: ({ children }: { children?: React.ReactNode }) => (
-    <div data-testid="map">{children}</div>
+  MapContainer: ({
+    children,
+    className,
+  }: {
+    children?: React.ReactNode;
+    className?: string;
+  }) => (
+    <div data-testid="map" className={className}>
+      {children}
+    </div>
   ),
   TileLayer: () => <div data-testid="tile" />,
   Marker: () => <div data-testid="marker" />,
@@ -180,6 +188,15 @@ describe("Home page", () => {
     expect(screen.getByText("ISP AB")).toBeInTheDocument();
     // geo.country_code === tunnel.country_code ⇒ Match.
     expect(screen.getByText("Match")).toBeInTheDocument();
+  });
+
+  it("isolates the map so its layers stay inside the card", () => {
+    // Leaflet's panes/controls run from z-index 400 to 1000 and its container
+    // opens no stacking context of its own, so without this they are stacked
+    // against the app shell rather than against the map (#1175).
+    setMyDevice();
+    renderWithProviders(<Home />);
+    expect(screen.getByTestId("map")).toHaveClass("isolate");
   });
 
   it("shows a Mismatch pill when the geo country differs from the tunnel", () => {

--- a/source/web/src/components/InstallPrompt.tsx
+++ b/source/web/src/components/InstallPrompt.tsx
@@ -14,10 +14,19 @@ interface InstallPromptProps {
  * Home-screen install banner shared by the user and admin PWAs, so both apps
  * promote installation with identical placement and behaviour.
  *
- * Renders in flow at the top of the layout (place it between the connection
- * banner and `<main>`): a card overlaid on the bottom of a `100vh` container
- * gets clipped behind mobile browser chrome — which is exactly where the
- * banner matters, since an installed app never shows it.
+ * Placement is deliberate on two axes:
+ *
+ * - In flow at the top of the layout — place it between the connection banner
+ *   and `<main>`. Pinned to the bottom of a `100vh` shell instead, it lands
+ *   under the mobile browser's own chrome, which is exactly where it matters:
+ *   an installed app never shows the banner.
+ * - Its own stacking context (`relative z-10`). An in-flow element carrying no
+ *   z-index paints below anything positioned that reaches its box, so without
+ *   this the banner stays tappable only for as long as no page content
+ *   overlaps it — and page content stacks as it likes (Leaflet, for one, runs
+ *   its panes and controls from z-index 400 up without opening a stacking
+ *   context around them). #1175 is that failure on the bottom-pinned banner
+ *   this one replaced.
  *
  * Shows only on the app's home route, and only while the browser reports the
  * app as installable; dismissing it hides it for the session.
@@ -44,7 +53,7 @@ export function InstallPrompt({ icon }: InstallPromptProps) {
 
   return (
     <div
-      className="mx-3 mt-3 flex items-center gap-3 rounded-lg border border-line bg-card p-3.5 shadow-pop"
+      className="relative z-10 mx-3 mt-3 flex items-center gap-3 rounded-lg border border-line bg-card p-3.5 shadow-pop"
       style={{
         animation: "wn-install-slide-down 0.3s cubic-bezier(0.2, 0.8, 0.2, 1)",
       }}

--- a/source/web/tests/components/InstallPrompt.test.tsx
+++ b/source/web/tests/components/InstallPrompt.test.tsx
@@ -38,6 +38,14 @@ describe("InstallPrompt", () => {
     expect(container).toBeEmptyDOMElement();
   });
 
+  it("carries a stacking context so page content cannot cover it", () => {
+    const { container } = renderWithProviders(<InstallPrompt icon="i.svg" />);
+    // Positioned *and* given a z-index: without both, any positioned page
+    // element that reaches the banner's box paints over it and eats the tap,
+    // which is how the banner this one replaced ended up unclickable (#1175).
+    expect(container.firstElementChild).toHaveClass("relative", "z-10");
+  });
+
   it("shows a success toast and dismisses when install is accepted", async () => {
     promptInstall.mockResolvedValue({ outcome: "accepted" });
     renderWithProviders(<InstallPrompt icon="i.svg" />);


### PR DESCRIPTION
Closes #1175.

## What was wrong

`InstallPrompt` renders in flow between the connection banner and `<main>`, with no positioning of its own. An in-flow element carrying no z-index paints below *any* positioned content that reaches its box, so the banner is tappable only for as long as nothing on the page happens to overlap it.

The banner that #925 replaced (`absolute inset-x-3 bottom-3 z-30`) did overlap page content — it was pinned over `<main>`, directly across the Home map — and lost the stack to it. Leaflet is a bad neighbour by construction here (verified against `leaflet@1.9.4`):

- `.leaflet-pane` sits at `z-index: 400` (tile 200, shadow 500, marker 600, tooltip 650, popup 700), `.leaflet-control` at 800, and `.leaflet-top` / `.leaflet-bottom` at 1000.
- The map container only ever gets `position: relative` (`Map._initLayout` sets it inline when the element is unpositioned) and no `z-index`, so it opens **no stacking context** — that whole 400→1000 ladder is resolved against the app shell instead of against the map.

That matches the report precisely, and it points at a **stale bundle**: the banner has been in flow at the top of the layout since #925, and there it does not overlap the map at all. Reinstalling a PWA does not clear origin storage, so a client that never took the SW update keeps serving the old shell. **Worth confirming the app version in the reporter's screenshot before treating this as a live regression** — but the placement should not depend on luck either way, which is what this PR fixes.

## Changes

- **`web/InstallPrompt`** — `relative z-10` on the banner root, so it owns a stacking context and sits above page content instead of relying on nothing overlapping it.
- **`user-app/Home`** — `isolate` on the `MapContainer`, so Leaflet's ladder is stacked against the map. Note this is containment, not a live fix: `.leaflet-container` is `overflow: hidden` and `<main>` is `overflow-y: auto` (both axes clip), so in today's layout the panes are already clipped well before z-index matters. The point is that the map stops depending on the scroll area above it to stay contained.
- **Docblock** — it explained the placement (in flow at the top, not pinned to the bottom where mobile browser chrome covers it) but not the layering half of the contract. Both are written down now, since the placement is only correct with both.

## Tests

- `InstallPrompt` asserts the banner keeps its stacking context.
- `Home` asserts the map is isolated; its `react-leaflet` stub now forwards `className` so that assertion is real.
