### PR TITLE
fix(user-app): hold the Private DNS deep-link scroll while the page settles

### DIFF
--- a/source/user-app/src/hooks/useHashScrollTarget.ts
+++ b/source/user-app/src/hooks/useHashScrollTarget.ts
@@ -45,13 +45,20 @@ const TAKEOVER_EVENTS = [
  * the service worker calls `existing.navigate(…#fragment)`, a fragment-only
  * same-document navigation that fires `hashchange` but never `popstate` — and
  * `BrowserRouter` only listens to the latter, so the router's hash would stay
- * stale in exactly the case this exists for.
+ * stale in exactly the case this exists for. For the same reason the live
+ * `window.location.hash` is what the hook trusts, and a fragment that moves off
+ * the target releases the hold.
+ *
+ * The user always outranks the hold: the first scroll gesture ends it for the
+ * rest of this navigation, because scrolling away *is* an answer to the deep
+ * link. Only a new fragment revives it.
  *
  * @param targetHash Fragment that targets this element, including the `#`.
  * @param rearmOn Any value that changes when the element's *own* content
  *   changes (typically a query's `isLoading`). A change re-arms the window, so
  *   a query that resolves after `SETTLE_WINDOW_MS` still lands the user on the
- *   content instead of on the placeholder it replaced.
+ *   content instead of on the placeholder it replaced — unless they have
+ *   already scrolled away.
  * @returns Ref to attach to the element that should be scrolled to.
  */
 export function useHashScrollTarget<T extends HTMLElement>(
@@ -59,6 +66,11 @@ export function useHashScrollTarget<T extends HTMLElement>(
   rearmOn?: unknown,
 ): RefObject<T | null> {
   const ref = useRef<T>(null);
+  // Both survive effect re-runs, which is the point: `rearmOn` changing must
+  // not resurrect a hold the user already dismissed, and must not be mistaken
+  // for a fresh navigation.
+  const releasedRef = useRef(false);
+  const armedFragmentRef = useRef<string | null>(null);
   const { hash: routerHash } = useLocation();
 
   useEffect(() => {
@@ -66,6 +78,9 @@ export function useHashScrollTarget<T extends HTMLElement>(
     let stop = () => {};
 
     const arm = () => {
+      // Scrolling away is an answer to the deep link — a query resolving a
+      // moment later must not yank the reader back to where they left.
+      if (releasedRef.current) return;
       const el = ref.current;
       if (!el) return;
       // A second deep link restarts the window rather than stacking observers.
@@ -86,13 +101,19 @@ export function useHashScrollTarget<T extends HTMLElement>(
         observer.disconnect();
         window.clearTimeout(timer);
         for (const type of TAKEOVER_EVENTS) {
-          window.removeEventListener(type, disarm);
+          window.removeEventListener(type, release);
         }
         stop = () => {};
       };
+      // The window merely expiring leaves the deep link answerable — a late
+      // query may still re-arm. A user gesture ends it for good.
+      const release = () => {
+        releasedRef.current = true;
+        disarm();
+      };
       timer = window.setTimeout(disarm, SETTLE_WINDOW_MS);
       for (const type of TAKEOVER_EVENTS) {
-        window.addEventListener(type, disarm, { passive: true });
+        window.addEventListener(type, release, { passive: true });
       }
       stop = disarm;
     };
@@ -100,12 +121,29 @@ export function useHashScrollTarget<T extends HTMLElement>(
     // Named `fragment` rather than `hash`: the `security` ESLint plugin's
     // timing-attack heuristic keys off the identifier, and a URL fragment is
     // not a secret.
-    const armIfTargeted = (fragment: string) => {
-      if (fragment === targetHash) arm();
+    const retarget = (fragment: string) => {
+      if (fragment !== armedFragmentRef.current) {
+        // A fragment we haven't seen is a fresh navigation, so it outranks an
+        // earlier release: the reader asked to be taken somewhere again.
+        armedFragmentRef.current = fragment;
+        releasedRef.current = false;
+      }
+      if (fragment === targetHash) {
+        arm();
+      } else {
+        // The fragment moved off us — let go rather than keep dragging the
+        // page back to a target the URL no longer names. The effect does not
+        // re-run to clean this up on its own: a fragment-only navigation
+        // leaves the router's hash untouched.
+        stop();
+      }
     };
 
-    armIfTargeted(routerHash || window.location.hash);
-    const onHashChange = () => armIfTargeted(window.location.hash);
+    // The live fragment outranks the router's: on the fragment-only navigation
+    // above, `useLocation()` is stale by construction. It is empty under a
+    // MemoryRouter (tests, and any non-browser history), hence the fallback.
+    retarget(window.location.hash || routerHash);
+    const onHashChange = () => retarget(window.location.hash);
     window.addEventListener("hashchange", onHashChange);
     return () => {
       window.removeEventListener("hashchange", onHashChange);

--- a/source/user-app/src/hooks/useHashScrollTarget.ts
+++ b/source/user-app/src/hooks/useHashScrollTarget.ts
@@ -1,0 +1,117 @@
+import { useEffect, useRef, type RefObject } from "react";
+import { useLocation } from "react-router";
+
+/**
+ * How long we keep correcting the scroll position after a deep link arms it.
+ *
+ * The scroll itself is layout-driven, not timed — this only bounds how long a
+ * *late* sibling is still allowed to drag the target back into place, so the
+ * hook never fights a page that keeps growing (an infinite list, a slow image)
+ * long after the user has arrived.
+ */
+const SETTLE_WINDOW_MS = 2_000;
+
+/**
+ * Gestures that mean the user has taken over the scroll position.
+ *
+ * Deliberately not `scroll`: our own `scrollIntoView` emits scroll events, so
+ * listening for those would disarm the hook the moment it did its job. These
+ * four are all user-initiated.
+ */
+const TAKEOVER_EVENTS = [
+  "wheel",
+  "touchstart",
+  "keydown",
+  "pointerdown",
+] as const;
+
+/**
+ * Keep an element scrolled into view for as long as a URL fragment targets it,
+ * even while the page around it is still settling (issue #1176).
+ *
+ * A one-shot `scrollIntoView()` on mount is a race the deep link usually loses:
+ * the element scrolled to is a "Loading…" placeholder, and the data-driven
+ * cards *above* it then expand as their queries resolve and push the target
+ * back off-screen. The fix is to treat the scroll as a position to hold rather
+ * than an event to fire — a `ResizeObserver` on the element **and its
+ * container** re-issues the scroll whenever anything changes height, which is
+ * exactly when the target moves. Observing the container is what catches the
+ * siblings: they are the elements that actually displace the target, and a
+ * card that appears late (a list that renders `null` until it has rows) grows
+ * the container even though it was not around to be observed at arm time.
+ *
+ * Arms on mount and on `hashchange`. The `hashchange` listener is not
+ * redundant with `useLocation().hash`: when the app is already open on the page
+ * the service worker calls `existing.navigate(…#fragment)`, a fragment-only
+ * same-document navigation that fires `hashchange` but never `popstate` — and
+ * `BrowserRouter` only listens to the latter, so the router's hash would stay
+ * stale in exactly the case this exists for.
+ *
+ * @param targetHash Fragment that targets this element, including the `#`.
+ * @param rearmOn Any value that changes when the element's *own* content
+ *   changes (typically a query's `isLoading`). A change re-arms the window, so
+ *   a query that resolves after `SETTLE_WINDOW_MS` still lands the user on the
+ *   content instead of on the placeholder it replaced.
+ * @returns Ref to attach to the element that should be scrolled to.
+ */
+export function useHashScrollTarget<T extends HTMLElement>(
+  targetHash: string,
+  rearmOn?: unknown,
+): RefObject<T | null> {
+  const ref = useRef<T>(null);
+  const { hash: routerHash } = useLocation();
+
+  useEffect(() => {
+    // Reassigned by `arm()`; the cleanup below always calls the current one.
+    let stop = () => {};
+
+    const arm = () => {
+      const el = ref.current;
+      if (!el) return;
+      // A second deep link restarts the window rather than stacking observers.
+      stop();
+
+      const scroll = () =>
+        el.scrollIntoView({ behavior: "smooth", block: "start" });
+      scroll();
+
+      // Scrolling changes no box size, so re-scrolling from here cannot feed
+      // back into the observer.
+      const observer = new ResizeObserver(scroll);
+      observer.observe(el);
+      if (el.parentElement) observer.observe(el.parentElement);
+
+      let timer = 0;
+      const disarm = () => {
+        observer.disconnect();
+        window.clearTimeout(timer);
+        for (const type of TAKEOVER_EVENTS) {
+          window.removeEventListener(type, disarm);
+        }
+        stop = () => {};
+      };
+      timer = window.setTimeout(disarm, SETTLE_WINDOW_MS);
+      for (const type of TAKEOVER_EVENTS) {
+        window.addEventListener(type, disarm, { passive: true });
+      }
+      stop = disarm;
+    };
+
+    // Named `fragment` rather than `hash`: the `security` ESLint plugin's
+    // timing-attack heuristic keys off the identifier, and a URL fragment is
+    // not a secret.
+    const armIfTargeted = (fragment: string) => {
+      if (fragment === targetHash) arm();
+    };
+
+    armIfTargeted(routerHash || window.location.hash);
+    const onHashChange = () => armIfTargeted(window.location.hash);
+    window.addEventListener("hashchange", onHashChange);
+    return () => {
+      window.removeEventListener("hashchange", onHashChange);
+      stop();
+    };
+  }, [targetHash, routerHash, rearmOn]);
+
+  return ref;
+}

--- a/source/user-app/src/pages/Settings.tsx
+++ b/source/user-app/src/pages/Settings.tsx
@@ -1,5 +1,3 @@
-import { useEffect, useRef } from "react";
-import { useLocation } from "react-router";
 import { WifiOffIcon } from "lucide-react";
 import {
   ApiErrorAlert,
@@ -19,6 +17,7 @@ import {
   usePushNotifications,
   useSetMyCaptureEnabled,
 } from "@wardnet/web";
+import { useHashScrollTarget } from "@/hooks/useHashScrollTarget";
 
 /**
  * Notifications card (issue #594): enable/disable Web Push for this browser.
@@ -121,33 +120,21 @@ const PRIVATE_DNS_HASH = "#private-dns";
  */
 function PrivateDns() {
   const { data: me, isLoading } = usePrivateDnsMe();
-  const { hash: routerHash } = useLocation();
-  const cardRef = useRef<HTMLDivElement>(null);
 
   // The push deep-links to `/settings#private-dns`, but this card is the last
   // of four — without this the member taps "Private DNS is ready" and lands on
   // the DNS-capture toggle with the setup steps off-screen.
   //
-  // `useLocation().hash` alone is not enough. When the app is already open on
-  // /settings the service worker calls `existing.navigate(…#private-dns)`,
-  // which is a fragment-only, same-document navigation: it fires `hashchange`,
-  // never `popstate`, and `BrowserRouter` only listens to the latter — so the
-  // router's hash would stay stale in exactly the case this exists for. Listen
-  // for `hashchange` too and read `window.location` there. The card shell
-  // renders in every state, so the ref is always attached.
-  useEffect(() => {
-    // Named `fragment` rather than `hash`: the `security` ESLint plugin's
-    // timing-attack heuristic keys off the identifier, and a URL fragment is
-    // not a secret.
-    const scrollIfTargeted = (fragment: string) => {
-      if (fragment !== PRIVATE_DNS_HASH) return;
-      cardRef.current?.scrollIntoView({ behavior: "smooth", block: "start" });
-    };
-    scrollIfTargeted(routerHash || window.location.hash);
-    const onHashChange = () => scrollIfTargeted(window.location.hash);
-    window.addEventListener("hashchange", onHashChange);
-    return () => window.removeEventListener("hashchange", onHashChange);
-  }, [routerHash]);
+  // The three cards above are all data-driven and expand as their queries
+  // resolve, so a scroll fired once at mount lands on the card's "Loading…"
+  // line and is then pushed back below the fold by its own siblings (#1176).
+  // `useHashScrollTarget` holds the position while the page settles instead;
+  // `isLoading` re-arms it for a query that resolves after that window. The
+  // card shell renders in every state, so the ref is always attached.
+  const cardRef = useHashScrollTarget<HTMLDivElement>(
+    PRIVATE_DNS_HASH,
+    isLoading,
+  );
 
   // Each branch names a distinct server state. In particular a granted device
   // can still come back with no hostname: `/private-dns/me` resolves the domain

--- a/source/user-app/tests/helpers/resizeObserver.ts
+++ b/source/user-app/tests/helpers/resizeObserver.ts
@@ -34,7 +34,9 @@ export class FakeResizeObserver {
 
   /** The observer currently driving the page. */
   static get last(): FakeResizeObserver {
-    const observer = FakeResizeObserver.instances.at(-1);
+    // Not `.at(-1)`: the app compiles against the ES2020 lib.
+    const { instances } = FakeResizeObserver;
+    const observer = instances[instances.length - 1];
     if (!observer) throw new Error("no ResizeObserver was created");
     return observer;
   }

--- a/source/user-app/tests/helpers/resizeObserver.ts
+++ b/source/user-app/tests/helpers/resizeObserver.ts
@@ -1,0 +1,45 @@
+// jsdom ships no ResizeObserver, and the deep-link scroll (issue #1176) is
+// deliberately layout-driven — it re-scrolls when an observed box changes
+// size. This fake records what it was asked to observe and lets a test fire
+// the callback on demand, which is how "a sibling settled late and pushed the
+// target off-screen" is expressed without a real layout engine.
+
+/** Controllable stand-in for the platform `ResizeObserver`. */
+export class FakeResizeObserver {
+  /** Every observer constructed since the last `reset()`, in order. */
+  static instances: FakeResizeObserver[] = [];
+
+  readonly targets: Element[] = [];
+  disconnected = false;
+
+  constructor(private readonly callback: ResizeObserverCallback) {
+    FakeResizeObserver.instances.push(this);
+  }
+
+  observe(target: Element) {
+    this.targets.push(target);
+  }
+
+  unobserve() {}
+
+  disconnect() {
+    this.disconnected = true;
+  }
+
+  /** Pretend an observed box changed size; a disconnected observer is inert. */
+  fire() {
+    if (this.disconnected) return;
+    this.callback([], this as unknown as ResizeObserver);
+  }
+
+  /** The observer currently driving the page. */
+  static get last(): FakeResizeObserver {
+    const observer = FakeResizeObserver.instances.at(-1);
+    if (!observer) throw new Error("no ResizeObserver was created");
+    return observer;
+  }
+
+  static reset() {
+    FakeResizeObserver.instances = [];
+  }
+}

--- a/source/user-app/tests/hooks/useHashScrollTarget.test.tsx
+++ b/source/user-app/tests/hooks/useHashScrollTarget.test.tsx
@@ -1,0 +1,179 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { Mock } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router";
+import type { ReactElement } from "react";
+
+import { useHashScrollTarget } from "../../src/hooks/useHashScrollTarget";
+import { FakeResizeObserver } from "../helpers/resizeObserver";
+
+const TARGET_HASH = "#target";
+const SETTLE_WINDOW_MS = 2_000;
+
+/**
+ * Mirrors the shape the hook exists for: a target that is the last child of a
+ * container it shares with siblings that settle later.
+ */
+function Target({ rearmOn }: { rearmOn?: unknown }) {
+  const ref = useHashScrollTarget<HTMLDivElement>(TARGET_HASH, rearmOn);
+  return (
+    <div data-testid="container">
+      <div data-testid="sibling" />
+      <div data-testid="target" ref={ref} />
+    </div>
+  );
+}
+
+function renderAt(ui: ReactElement, route: string) {
+  return render(ui, {
+    wrapper: ({ children }) => (
+      <MemoryRouter initialEntries={[route]}>{children}</MemoryRouter>
+    ),
+  });
+}
+
+let scrollIntoView: Mock<(arg?: boolean | ScrollIntoViewOptions) => void>;
+let originalScrollIntoView: typeof Element.prototype.scrollIntoView;
+
+beforeEach(() => {
+  FakeResizeObserver.reset();
+  vi.stubGlobal("ResizeObserver", FakeResizeObserver);
+  originalScrollIntoView = Element.prototype.scrollIntoView;
+  // jsdom doesn't implement scrollIntoView, so assign rather than spyOn.
+  scrollIntoView = vi.fn();
+  Element.prototype.scrollIntoView = scrollIntoView;
+});
+
+afterEach(() => {
+  // A raw prototype assignment isn't undone by restoreAllMocks, and a pushed
+  // fragment would otherwise leak into every later test — the hook reads
+  // `window.location.hash` as well as the router's.
+  Element.prototype.scrollIntoView = originalScrollIntoView;
+  const url = new URL(window.location.href);
+  url.hash = "";
+  window.history.pushState(null, "", url);
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe("useHashScrollTarget", () => {
+  it("scrolls the target into view when the fragment targets it", () => {
+    renderAt(<Target />, `/settings${TARGET_HASH}`);
+    expect(scrollIntoView).toHaveBeenCalledWith({
+      behavior: "smooth",
+      block: "start",
+    });
+  });
+
+  it("does nothing when the fragment does not target it", () => {
+    renderAt(<Target />, "/settings");
+    expect(scrollIntoView).not.toHaveBeenCalled();
+    expect(FakeResizeObserver.instances).toHaveLength(0);
+  });
+
+  it("observes the container as well as the target", () => {
+    renderAt(<Target />, `/settings${TARGET_HASH}`);
+    // The siblings are what actually displace the target, and a sibling that
+    // mounts late (a list rendering `null` until it has rows) can't be
+    // observed directly — but it grows the container it joins.
+    expect(FakeResizeObserver.last.targets).toEqual([
+      screen.getByTestId("target"),
+      screen.getByTestId("container"),
+    ]);
+  });
+
+  it("re-scrolls when a late-settling sibling changes the layout", () => {
+    renderAt(<Target />, `/settings${TARGET_HASH}`);
+    expect(scrollIntoView).toHaveBeenCalledTimes(1);
+
+    // What the bug looked like: the cards above expand as their queries
+    // resolve and push the target back below the fold.
+    FakeResizeObserver.last.fire();
+    FakeResizeObserver.last.fire();
+
+    expect(scrollIntoView).toHaveBeenCalledTimes(3);
+  });
+
+  it("stops correcting once the settle window has elapsed", () => {
+    vi.useFakeTimers();
+    renderAt(<Target />, `/settings${TARGET_HASH}`);
+    const observer = FakeResizeObserver.last;
+
+    vi.advanceTimersByTime(SETTLE_WINDOW_MS);
+    observer.fire();
+
+    // Layout churn long after arrival is the page's business, not ours.
+    expect(scrollIntoView).toHaveBeenCalledTimes(1);
+    expect(observer.disconnected).toBe(true);
+  });
+
+  it("stops correcting as soon as the user takes over the scroll", () => {
+    renderAt(<Target />, `/settings${TARGET_HASH}`);
+    const observer = FakeResizeObserver.last;
+
+    window.dispatchEvent(new Event("wheel"));
+    observer.fire();
+
+    expect(scrollIntoView).toHaveBeenCalledTimes(1);
+    expect(observer.disconnected).toBe(true);
+  });
+
+  it("arms on a fragment-only navigation that only fires hashchange", () => {
+    // The SW's `existing.navigate(…#target)` on an already-open app is a
+    // same-document navigation: `hashchange` fires, `popstate` does not, so
+    // BrowserRouter's hash never updates.
+    renderAt(<Target />, "/settings");
+    expect(scrollIntoView).not.toHaveBeenCalled();
+
+    const url = new URL(window.location.href);
+    url.hash = TARGET_HASH;
+    window.history.pushState(null, "", url);
+    window.dispatchEvent(new HashChangeEvent("hashchange"));
+
+    expect(scrollIntoView).toHaveBeenCalledTimes(1);
+    FakeResizeObserver.last.fire();
+    expect(scrollIntoView).toHaveBeenCalledTimes(2);
+  });
+
+  it("re-arms when the target's own content settles after the window", () => {
+    vi.useFakeTimers();
+    const { rerender } = renderAt(
+      <Target rearmOn={true} />,
+      `/settings${TARGET_HASH}`,
+    );
+    vi.advanceTimersByTime(SETTLE_WINDOW_MS);
+    expect(scrollIntoView).toHaveBeenCalledTimes(1);
+
+    // A query that resolves this late replaces the placeholder the user was
+    // sent to, so the scroll is worth re-issuing.
+    rerender(<Target rearmOn={false} />);
+
+    expect(scrollIntoView).toHaveBeenCalledTimes(2);
+    expect(FakeResizeObserver.instances).toHaveLength(2);
+    expect(FakeResizeObserver.instances[0].disconnected).toBe(true);
+  });
+
+  it("restarts the window rather than stacking observers on a repeat link", () => {
+    renderAt(<Target />, `/settings${TARGET_HASH}`);
+    const first = FakeResizeObserver.last;
+
+    const url = new URL(window.location.href);
+    url.hash = TARGET_HASH;
+    window.history.pushState(null, "", url);
+    window.dispatchEvent(new HashChangeEvent("hashchange"));
+
+    expect(FakeResizeObserver.instances).toHaveLength(2);
+    expect(first.disconnected).toBe(true);
+    // Initial scroll + the re-arm; the retired observer moves nothing further.
+    first.fire();
+    expect(scrollIntoView).toHaveBeenCalledTimes(2);
+  });
+
+  it("stops observing when the target unmounts", () => {
+    const { unmount } = renderAt(<Target />, `/settings${TARGET_HASH}`);
+    const observer = FakeResizeObserver.last;
+    unmount();
+    expect(observer.disconnected).toBe(true);
+  });
+});

--- a/source/user-app/tests/hooks/useHashScrollTarget.test.tsx
+++ b/source/user-app/tests/hooks/useHashScrollTarget.test.tsx
@@ -119,6 +119,75 @@ describe("useHashScrollTarget", () => {
     expect(observer.disconnected).toBe(true);
   });
 
+  it("does not scroll back after a takeover, even when content settles", () => {
+    const { rerender } = renderAt(
+      <Target rearmOn={true} />,
+      `/settings${TARGET_HASH}`,
+    );
+    // Scrolling away *is* an answer to the deep link.
+    window.dispatchEvent(new Event("touchstart"));
+
+    rerender(<Target rearmOn={false} />);
+
+    // The re-arm path must not resurrect a hold the user dismissed, so the
+    // takeover has to outlive the effect that owned it.
+    expect(scrollIntoView).toHaveBeenCalledTimes(1);
+    expect(FakeResizeObserver.instances).toHaveLength(1);
+  });
+
+  it("revives the hold when a new deep link arrives after a takeover", () => {
+    const navigateTo = (fragment: string) => {
+      const url = new URL(window.location.href);
+      url.hash = fragment;
+      window.history.pushState(null, "", url);
+      window.dispatchEvent(new HashChangeEvent("hashchange"));
+    };
+
+    renderAt(<Target />, `/settings${TARGET_HASH}`);
+    window.dispatchEvent(new Event("wheel"));
+
+    // Navigating elsewhere and back is a fresh request to be taken somewhere,
+    // which outranks the earlier takeover. (A repeat tap on the *same*
+    // fragment fires no `hashchange` at all — the URL never changes.)
+    navigateTo("#elsewhere");
+    navigateTo(TARGET_HASH);
+
+    expect(scrollIntoView).toHaveBeenCalledTimes(2);
+  });
+
+  it("lets go when the fragment moves off the target", () => {
+    renderAt(<Target />, `/settings${TARGET_HASH}`);
+    const observer = FakeResizeObserver.last;
+
+    // The router's hash stays stale across a fragment-only navigation, so the
+    // effect never re-runs to clean this up — the listener has to.
+    const url = new URL(window.location.href);
+    url.hash = "#elsewhere";
+    window.history.pushState(null, "", url);
+    window.dispatchEvent(new HashChangeEvent("hashchange"));
+    observer.fire();
+
+    expect(scrollIntoView).toHaveBeenCalledTimes(1);
+    expect(observer.disconnected).toBe(true);
+  });
+
+  it("does not re-arm from a router hash the URL has moved off", () => {
+    vi.useFakeTimers();
+    const { rerender } = renderAt(
+      <Target rearmOn={true} />,
+      `/settings${TARGET_HASH}`,
+    );
+    const url = new URL(window.location.href);
+    url.hash = "#elsewhere";
+    window.history.pushState(null, "", url);
+    window.dispatchEvent(new HashChangeEvent("hashchange"));
+
+    rerender(<Target rearmOn={false} />);
+
+    // `useLocation()` still reports the old fragment here; the live one wins.
+    expect(scrollIntoView).toHaveBeenCalledTimes(1);
+  });
+
   it("arms on a fragment-only navigation that only fires hashchange", () => {
     // The SW's `existing.navigate(…#target)` on an already-open app is a
     // same-document navigation: `hashchange` fires, `popstate` does not, so

--- a/source/user-app/tests/pages/Settings.test.tsx
+++ b/source/user-app/tests/pages/Settings.test.tsx
@@ -6,6 +6,7 @@ import type { DeviceRuleRequest } from "@wardnet/js";
 
 import Settings from "../../src/pages/Settings";
 import { makeDevice, renderWithProviders } from "../test-utils";
+import { FakeResizeObserver } from "../helpers/resizeObserver";
 
 const {
   useMyDevice,
@@ -387,9 +388,12 @@ describe("Settings page", () => {
         // jsdom doesn't implement scrollIntoView, so assign rather than spyOn.
         scrollIntoView = vi.fn();
         Element.prototype.scrollIntoView = scrollIntoView;
+        FakeResizeObserver.reset();
+        vi.stubGlobal("ResizeObserver", FakeResizeObserver);
       });
 
       afterEach(() => {
+        vi.unstubAllGlobals();
         // A raw prototype assignment isn't undone by restoreAllMocks, and a
         // pushed fragment would otherwise leak into every later test — the
         // component reads `window.location.hash` as well as the router's.
@@ -431,6 +435,48 @@ describe("Settings page", () => {
           behavior: "smooth",
           block: "start",
         });
+      });
+
+      it("holds the card in view while the cards above it settle", () => {
+        // The bug (#1176): the scroll fired once at mount, landing on this
+        // card's one-line "Loading…" branch, and the three data-driven cards
+        // above then expanded and pushed it back below the fold. The observer
+        // watches the container the cards share, so their growth re-scrolls.
+        usePrivateDnsMe.mockReturnValue({ data: undefined, isLoading: true });
+        renderWithProviders(<Settings />, { route: "/settings#private-dns" });
+        expect(scrollIntoView).toHaveBeenCalledTimes(1);
+
+        const card = screen.getByTestId("private-dns-card");
+        expect(FakeResizeObserver.last.targets).toEqual([
+          card,
+          card.parentElement,
+        ]);
+
+        FakeResizeObserver.last.fire();
+        expect(scrollIntoView).toHaveBeenCalledTimes(2);
+      });
+
+      it("re-scrolls once this card's own grant query resolves", () => {
+        usePrivateDnsMe.mockReturnValue({ data: undefined, isLoading: true });
+        const { rerender } = renderWithProviders(<Settings />, {
+          route: "/settings#private-dns",
+        });
+        expect(scrollIntoView).toHaveBeenCalledTimes(1);
+
+        // Swapping "Loading…" for the setup steps changes what the user came
+        // for, so the landing position is re-taken even if the layout around
+        // the card happens not to move.
+        usePrivateDnsMe.mockReturnValue({
+          data: {
+            enabled: true,
+            granted: true,
+            hostname: "tok.abc.my.wardnet.services",
+          },
+          isLoading: false,
+        });
+        rerender(<Settings />);
+
+        expect(scrollIntoView).toHaveBeenCalledTimes(2);
       });
     });
 

--- a/source/user-app/tests/setup.ts
+++ b/source/user-app/tests/setup.ts
@@ -3,3 +3,14 @@ import "@testing-library/jest-dom";
 // real implementation. fake-indexeddb/auto installs a spec-compliant in-memory
 // one on globalThis (indexedDB, IDBKeyRange, …) for every test.
 import "fake-indexeddb/auto";
+
+// jsdom has no ResizeObserver, and layout-driven code (the deep-link scroll in
+// useHashScrollTarget) constructs one unconditionally. Install an inert
+// default so a component that merely renders doesn't die with a
+// ReferenceError; suites that assert on observation stub their own
+// controllable one over the top (tests/helpers/resizeObserver.ts).
+globalThis.ResizeObserver ??= class {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+};


### PR DESCRIPTION
Closes #1176.

## The bug

Tapping the `private_dns_granted` push landed on `/app/settings#private-dns` with the card off-screen. The scroll fired once from an effect keyed on `[routerHash]`, against the card's one-line `"Loading…"` branch — and the three data-driven cards above it (Notifications, `my-requests`, DNS capture) then expanded as their queries resolved and pushed the target back below the fold. It never ran again.

## The fix

New `useHashScrollTarget` hook (`source/user-app/src/hooks/useHashScrollTarget.ts`), used by the Private DNS card. It treats the fragment as a position to hold rather than an event to fire:

- **Layout-driven.** A `ResizeObserver` on the card **and on the container it shares with its siblings** re-issues the scroll whenever anything changes height. Observing the container is the part that matters: the siblings are what displace the target, and a card that mounts late (`MyRequests` renders `null` until it has rows) grows the container even though it wasn't around to be observed when the hold armed. Scrolling changes no observed box, so there's no feedback loop.
- **The reader outranks the hold.** The first `wheel`/`touchstart`/`keydown`/`pointerdown` releases it for the rest of the navigation — scrolling away *is* an answer to the deep link — and that release survives effect re-runs, so a query resolving a moment later can't yank the reader back. Only a new fragment revives it. `scroll` is deliberately not in that list: our own smooth scroll emits those.
- **Bounded.** The correction window is 2s, so the hook never fights a page that keeps growing. No `setTimeout` guess for the scroll itself — the timer only bounds how long corrections are allowed.
- **`isLoading` re-arms it**, covering a query that resolves *after* the window and replaces the placeholder the reader was sent to.
- **The URL outranks the router.** The live `window.location.hash` wins (with `useLocation()` as the fallback an empty one needs), and a fragment that moves off the target releases the hold — across a fragment-only navigation the router's hash is stale by construction, so no effect re-run cleans that up on its own. The existing `hashchange` listener stays for the SW's `existing.navigate(…#private-dns)` case.

## Tests

14 hook tests plus 2 page-level ones, with a shared controllable `FakeResizeObserver` (jsdom ships none), and an inert default `ResizeObserver` in `tests/setup.ts` so an unrelated suite rendering a hooked-up card can't die with a `ReferenceError`.

## Verification note

`yarn install` fails in the authoring container — `@wardnet/{ui,styles,brand}` come from GitHub Packages and the session token gets a 401 — so `make check-web` and the real user-app suite could not run there. Both suites were instead executed against real React 19 / react-router 8 / vitest with minimal stubs for the `@wardnet/web` primitives (39/39 passing), `tsc --strict` is clean on the hook and its ref assignability, and Prettier 3.9.6 reports every touched file formatted. CI is the first run against the real packages.

## Follow-up (not in this PR)

Issue #1176 raises deep-linking to a dedicated route instead of a fragment into a four-card settings page. That's the underlying UX problem; this is the correctness fix for the scroll.