### PR TITLE
feat(wctl): add logs, dns, dhcp, and system subcommands

### DIFF
--- a/.agents/technical-stack.md
+++ b/.agents/technical-stack.md
@@ -23,6 +23,13 @@
 - Linked via Yarn `portal:` protocol from all app surfaces (`"@wardnet/js": "portal:../sdk/wardnet-js"`)
 - Yarn 4 with `nodeLinker: node-modules`
 
+## SDK (`wardnet.network/go`) and `wctl`
+
+- Go 1.26; `internal/rest` is generated from `docs/openapi.json` with oapi-codegen and stays unexported, the public surface is hand-written
+- `github.com/coder/websocket` — WebSocket client for the daemon's log stream (`GET /api/system/logs/stream`), the one endpoint that cannot go through the generated REST client
+- `wctl` builds on the SDK: cobra for the command tree, BurntSushi/toml for `wctl.toml`, `golang.org/x/term` for no-echo passphrase prompts
+- `wctl` reaches the SDK through a `replace` directive, so the two move together
+
 ## Shared React library (`@wardnet/web`)
 - Lives at `source/web/`; linked via `"@wardnet/web": "portal:../web"`
 - Contains all shared TanStack Query hooks (useTunnels, useRebuildTunnel, useCombinedTunnelStats, useDevices, useStats, …), shared components (LoginForm, JobProgressDescription), Zustand stores, and utility functions

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -181,6 +181,19 @@ cd source/sdk/wardnet-go && go test ./...          # Go SDK the CLI is built on
 ../sdk/wardnet-go` directive, so local SDK edits are picked up without a
 publish step.
 
+Every command takes `--json`, so anything the admin UI shows is also
+scriptable: `status`, `devices`, `tunnels`, `dns`, `dhcp`, `logs`, `system`,
+`update`, and `backup`. Two of those have shapes worth knowing:
+
+- `wctl logs` writes the stored log file to stdout; `wctl logs --follow`
+  streams live entries to **stderr** until interrupted, leaving stdout free
+  for the surrounding pipeline. `--level` and `--target` filter the live
+  stream server-side.
+- The `dns` blocklist, allowlist, and rule subcommands are scoped to a DNS
+  filter profile. `--profile` takes a name or an ID and defaults to
+  `Ad Blocking`, so `wctl dns blocklists list` shows the same lists as the
+  admin UI's Ad Blocking page.
+
 Outside consumers `go get wardnet.network/go`, which resolves through a
 generated mirror. Go finds a module by subtracting the `go-import` meta tag's
 root-path from the module path, so a module named `wardnet.network/go` has to

--- a/source/sdk/wardnet-go/client.go
+++ b/source/sdk/wardnet-go/client.go
@@ -22,12 +22,26 @@ const defaultTimeout = 120 * time.Second
 type Client struct {
 	rest *rest.ClientWithResponses
 
+	// baseURL, httpClient, token, and userAgent are retained for the log
+	// stream, which upgrades to a WebSocket and so cannot go through the
+	// generated REST client.
+	baseURL    string
+	httpClient *http.Client
+	token      string
+	userAgent  string
+
 	// System reports daemon health and runtime status.
 	System *SystemService
 	// Devices lists discovered devices and manages their routing.
 	Devices *DevicesService
 	// Tunnels manages WireGuard tunnels.
 	Tunnels *TunnelsService
+	// DNS configures the resolver and its filtering rules.
+	DNS *DNSService
+	// DHCP configures the DHCP server, its leases, and its reservations.
+	DHCP *DHCPService
+	// Logs downloads and streams daemon logs.
+	Logs *LogsService
 	// Update drives the auto-update subsystem.
 	Update *UpdateService
 	// Backup exports and restores encrypted configuration bundles.
@@ -37,7 +51,7 @@ type Client struct {
 }
 
 type options struct {
-	httpClient rest.HttpRequestDoer
+	httpClient *http.Client
 	token      string
 	userAgent  string
 }
@@ -108,10 +122,19 @@ func New(baseURL string, opts ...Option) (*Client, error) {
 		return nil, err
 	}
 
-	c := &Client{rest: rc}
+	c := &Client{
+		rest:       rc,
+		baseURL:    baseURL,
+		httpClient: hc,
+		token:      o.token,
+		userAgent:  o.userAgent,
+	}
 	c.System = &SystemService{c: c}
 	c.Devices = &DevicesService{c: c}
 	c.Tunnels = &TunnelsService{c: c}
+	c.DNS = &DNSService{c: c}
+	c.DHCP = &DHCPService{c: c}
+	c.Logs = &LogsService{c: c}
 	c.Update = &UpdateService{c: c}
 	c.Backup = &BackupService{c: c}
 	c.Auth = &AuthService{c: c}

--- a/source/sdk/wardnet-go/client_test.go
+++ b/source/sdk/wardnet-go/client_test.go
@@ -170,3 +170,57 @@ func TestInvalidIDNoRequest(t *testing.T) {
 		t.Error("expected error for invalid device id")
 	}
 }
+
+func TestSystemRecentErrors(t *testing.T) {
+	c := newClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/system/errors" {
+			t.Errorf("path = %q", r.URL.Path)
+		}
+		writeJSON(w, `{"errors":[{"timestamp":"2026-08-01T00:00:00Z","code":"tunnel_start_failed",
+			"severity":"error","component":"tunnel","message":"handshake timed out",
+			"hint":"check the endpoint"}]}`)
+	}))
+
+	diags, err := c.System.RecentErrors(context.Background())
+	if err != nil {
+		t.Fatalf("RecentErrors: %v", err)
+	}
+	if len(diags) != 1 {
+		t.Fatalf("diagnostics = %d, want 1", len(diags))
+	}
+	if diags[0].Code != "tunnel_start_failed" || diags[0].Severity != "error" {
+		t.Errorf("unexpected diagnostic: %+v", diags[0])
+	}
+}
+
+func TestSystemRestart(t *testing.T) {
+	var called bool
+	c := newClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		if r.Method != http.MethodPost || r.URL.Path != "/api/system/restart" {
+			t.Errorf("%s %s", r.Method, r.URL.Path)
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+
+	if err := c.System.Restart(context.Background()); err != nil {
+		t.Fatalf("Restart: %v", err)
+	}
+	if !called {
+		t.Error("daemon never called")
+	}
+}
+
+func TestSystemRestartError(t *testing.T) {
+	c := newClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = io.WriteString(w, `{"error":"forbidden"}`)
+	}))
+
+	err := c.System.Restart(context.Background())
+	var apiErr *wardnet.APIError
+	if !errors.As(err, &apiErr) || apiErr.StatusCode != http.StatusForbidden {
+		t.Fatalf("error = %v, want a 403 APIError", err)
+	}
+}

--- a/source/sdk/wardnet-go/dhcp.go
+++ b/source/sdk/wardnet-go/dhcp.go
@@ -1,0 +1,260 @@
+package wardnet
+
+import (
+	"context"
+	"time"
+
+	"wardnet.network/go/internal/rest"
+)
+
+// DHCPService configures the DHCP server, its leases, and its reservations.
+type DHCPService struct{ c *Client }
+
+// DHCPConfig is the DHCP pool configuration. The gateway address is
+// auto-detected by the daemon rather than configured.
+type DHCPConfig struct {
+	// Enabled reports whether the server should be running.
+	Enabled bool `json:"enabled"`
+	// GatewayIP is wardnet's own LAN address, advertised as gateway and DNS.
+	GatewayIP string `json:"gateway_ip"`
+	// RouterIP is the upstream router, offered as the secondary gateway.
+	RouterIP string `json:"router_ip"`
+	// PoolStart / PoolEnd bound the dynamic address range.
+	PoolStart string `json:"pool_start"`
+	PoolEnd   string `json:"pool_end"`
+	// SubnetMask is the mask handed to clients.
+	SubnetMask string `json:"subnet_mask"`
+	// UpstreamDNS are the resolvers offered when wardnet's own is not used.
+	UpstreamDNS []string `json:"upstream_dns"`
+	// LeaseDurationSecs is how long an offered lease is valid.
+	LeaseDurationSecs int32 `json:"lease_duration_secs"`
+}
+
+// DHCPServerStatus is the DHCP server's live state. It is named apart from
+// [DHCPStatus], which describes how one device's address is managed.
+type DHCPServerStatus struct {
+	// Enabled is the configured intent; Running is the observed reality.
+	Enabled bool `json:"enabled"`
+	Running bool `json:"running"`
+	// ActiveLeaseCount is how many leases are currently held.
+	ActiveLeaseCount int64 `json:"active_lease_count"`
+	// PoolUsed / PoolTotal describe address exhaustion.
+	PoolUsed  int64 `json:"pool_used"`
+	PoolTotal int64 `json:"pool_total"`
+}
+
+// Lease is an active or historical DHCP lease.
+type Lease struct {
+	// ID is the lease's UUID.
+	ID string `json:"id"`
+	// MAC is the client's hardware address.
+	MAC string `json:"mac_address"`
+	// IP is the leased address.
+	IP string `json:"ip_address"`
+	// Hostname is the name the client claimed, when it sent one.
+	Hostname string `json:"hostname"`
+	// DeviceID is the matching known device, when one is tracked.
+	DeviceID string `json:"device_id"`
+	// Status is "active", "expired", or "released".
+	Status string `json:"status"`
+	// LeaseStart / LeaseEnd bound the lease's validity.
+	LeaseStart time.Time `json:"lease_start"`
+	LeaseEnd   time.Time `json:"lease_end"`
+}
+
+// Reservation is a static MAC-to-IP binding.
+type Reservation struct {
+	// ID is the reservation's UUID.
+	ID string `json:"id"`
+	// MAC is the hardware address the address is pinned to.
+	MAC string `json:"mac_address"`
+	// IP is the reserved address.
+	IP string `json:"ip_address"`
+	// Hostname is an optional name to hand back to the client.
+	Hostname string `json:"hostname"`
+	// Description is an optional operator note.
+	Description string `json:"description"`
+	// CreatedAt is when the reservation was made.
+	CreatedAt time.Time `json:"created_at"`
+}
+
+// CreateReservationParams describes a reservation to add.
+type CreateReservationParams struct {
+	// MAC is the hardware address to pin.
+	MAC string
+	// IP is the address to hand it.
+	IP string
+	// Hostname is an optional name for the client.
+	Hostname string
+	// Description is an optional operator note.
+	Description string
+}
+
+// Config fetches the DHCP configuration.
+func (s *DHCPService) Config(ctx context.Context) (*DHCPConfig, error) {
+	resp, err := s.c.rest.DhcpGetConfigWithResponse(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if resp.JSON200 == nil {
+		return nil, apiError(resp.HTTPResponse, resp.Body)
+	}
+	cfg := dhcpConfigFromREST(&resp.JSON200.Config)
+	return &cfg, nil
+}
+
+// SetEnabled starts or stops the DHCP server and returns the resulting config.
+func (s *DHCPService) SetEnabled(ctx context.Context, enabled bool) (*DHCPConfig, error) {
+	resp, err := s.c.rest.DhcpToggleWithResponse(ctx, rest.DhcpToggleJSONRequestBody{Enabled: enabled})
+	if err != nil {
+		return nil, err
+	}
+	if resp.JSON200 == nil {
+		return nil, apiError(resp.HTTPResponse, resp.Body)
+	}
+	cfg := dhcpConfigFromREST(&resp.JSON200.Config)
+	return &cfg, nil
+}
+
+// Status reports the DHCP server's live state.
+func (s *DHCPService) Status(ctx context.Context) (*DHCPServerStatus, error) {
+	resp, err := s.c.rest.DhcpStatusWithResponse(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if resp.JSON200 == nil {
+		return nil, apiError(resp.HTTPResponse, resp.Body)
+	}
+	m := resp.JSON200
+	return &DHCPServerStatus{
+		Enabled:          m.Enabled,
+		Running:          m.Running,
+		ActiveLeaseCount: m.ActiveLeaseCount,
+		PoolUsed:         m.PoolUsed,
+		PoolTotal:        m.PoolTotal,
+	}, nil
+}
+
+// Leases returns every known lease.
+func (s *DHCPService) Leases(ctx context.Context) ([]Lease, error) {
+	resp, err := s.c.rest.ListLeasesWithResponse(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if resp.JSON200 == nil {
+		return nil, apiError(resp.HTTPResponse, resp.Body)
+	}
+	out := make([]Lease, 0, len(resp.JSON200.Leases))
+	for i := range resp.JSON200.Leases {
+		l := &resp.JSON200.Leases[i]
+		lease := Lease{
+			ID:         l.Id.String(),
+			MAC:        l.MacAddress,
+			IP:         l.IpAddress,
+			Hostname:   deref(l.Hostname),
+			Status:     string(l.Status),
+			LeaseStart: l.LeaseStart,
+			LeaseEnd:   l.LeaseEnd,
+		}
+		if l.DeviceId != nil {
+			lease.DeviceID = l.DeviceId.String()
+		}
+		out = append(out, lease)
+	}
+	return out, nil
+}
+
+// RevokeLease releases a lease, freeing its address for reuse.
+func (s *DHCPService) RevokeLease(ctx context.Context, id string) error {
+	lid, err := parseUUID(id, "lease")
+	if err != nil {
+		return err
+	}
+	resp, err := s.c.rest.RevokeLeaseWithResponse(ctx, lid)
+	if err != nil {
+		return err
+	}
+	if resp.JSON200 == nil {
+		return apiError(resp.HTTPResponse, resp.Body)
+	}
+	return nil
+}
+
+// Reservations returns every static MAC-to-IP binding.
+func (s *DHCPService) Reservations(ctx context.Context) ([]Reservation, error) {
+	resp, err := s.c.rest.ListReservationsWithResponse(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if resp.JSON200 == nil {
+		return nil, apiError(resp.HTTPResponse, resp.Body)
+	}
+	out := make([]Reservation, 0, len(resp.JSON200.Reservations))
+	for i := range resp.JSON200.Reservations {
+		out = append(out, reservationFromREST(&resp.JSON200.Reservations[i]))
+	}
+	return out, nil
+}
+
+// AddReservation pins an address to a MAC.
+func (s *DHCPService) AddReservation(ctx context.Context, params CreateReservationParams) (*Reservation, error) {
+	body := rest.CreateReservationJSONRequestBody{
+		MacAddress: params.MAC,
+		IpAddress:  params.IP,
+	}
+	if params.Hostname != "" {
+		body.Hostname = ptr(params.Hostname)
+	}
+	if params.Description != "" {
+		body.Description = ptr(params.Description)
+	}
+	resp, err := s.c.rest.CreateReservationWithResponse(ctx, body)
+	if err != nil {
+		return nil, err
+	}
+	if resp.JSON201 == nil {
+		return nil, apiError(resp.HTTPResponse, resp.Body)
+	}
+	r := reservationFromREST(&resp.JSON201.Reservation)
+	return &r, nil
+}
+
+// RemoveReservation deletes a static MAC-to-IP binding.
+func (s *DHCPService) RemoveReservation(ctx context.Context, id string) error {
+	rid, err := parseUUID(id, "reservation")
+	if err != nil {
+		return err
+	}
+	resp, err := s.c.rest.DeleteReservationWithResponse(ctx, rid)
+	if err != nil {
+		return err
+	}
+	if resp.JSON200 == nil {
+		return apiError(resp.HTTPResponse, resp.Body)
+	}
+	return nil
+}
+
+func dhcpConfigFromREST(c *rest.DhcpConfig) DHCPConfig {
+	return DHCPConfig{
+		Enabled:           c.Enabled,
+		GatewayIP:         c.GatewayIp,
+		RouterIP:          deref(c.RouterIp),
+		PoolStart:         c.PoolStart,
+		PoolEnd:           c.PoolEnd,
+		SubnetMask:        c.SubnetMask,
+		UpstreamDNS:       c.UpstreamDns,
+		LeaseDurationSecs: c.LeaseDurationSecs,
+	}
+}
+
+func reservationFromREST(r *rest.DhcpReservation) Reservation {
+	return Reservation{
+		ID:          r.Id.String(),
+		MAC:         r.MacAddress,
+		IP:          r.IpAddress,
+		Hostname:    deref(r.Hostname),
+		Description: deref(r.Description),
+		CreatedAt:   r.CreatedAt,
+	}
+}

--- a/source/sdk/wardnet-go/dhcp_test.go
+++ b/source/sdk/wardnet-go/dhcp_test.go
@@ -1,0 +1,121 @@
+package wardnet_test
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"testing"
+
+	wardnet "wardnet.network/go"
+)
+
+func TestDHCPConfig(t *testing.T) {
+	c := newClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/dhcp/config" {
+			t.Errorf("path = %q", r.URL.Path)
+		}
+		writeJSON(w, `{"config":{"enabled":true,"gateway_ip":"192.168.1.1","router_ip":null,
+			"pool_start":"192.168.1.100","pool_end":"192.168.1.200","subnet_mask":"255.255.255.0",
+			"upstream_dns":["1.1.1.1"],"lease_duration_secs":86400}}`)
+	}))
+
+	cfg, err := c.DHCP.Config(context.Background())
+	if err != nil {
+		t.Fatalf("Config: %v", err)
+	}
+	if cfg.PoolStart != "192.168.1.100" || cfg.LeaseDurationSecs != 86400 {
+		t.Errorf("unexpected config: %+v", cfg)
+	}
+	if cfg.RouterIP != "" {
+		t.Errorf("router IP = %q, want empty for a null", cfg.RouterIP)
+	}
+}
+
+func TestDHCPLeases(t *testing.T) {
+	c := newClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/dhcp/leases" {
+			t.Errorf("path = %q", r.URL.Path)
+		}
+		writeJSON(w, `{"leases":[{"id":"3f8a5a6b-2c1d-4f5e-8a9b-0c1d2e3f4a5b",
+			"mac_address":"aa:bb:cc:11:22:02","ip_address":"192.168.1.42",
+			"hostname":"alice-phone","device_id":"6e05df45-1fa4-4327-8c1e-218c79b253ba",
+			"status":"active","lease_start":"2026-08-01T00:00:00Z",
+			"lease_end":"2026-08-02T00:00:00Z","created_at":"2026-08-01T00:00:00Z",
+			"updated_at":"2026-08-01T00:00:00Z"}]}`)
+	}))
+
+	leases, err := c.DHCP.Leases(context.Background())
+	if err != nil {
+		t.Fatalf("Leases: %v", err)
+	}
+	if len(leases) != 1 {
+		t.Fatalf("leases = %d, want 1", len(leases))
+	}
+	l := leases[0]
+	if l.IP != "192.168.1.42" || l.Status != "active" || l.Hostname != "alice-phone" {
+		t.Errorf("unexpected lease: %+v", l)
+	}
+	if l.DeviceID != "6e05df45-1fa4-4327-8c1e-218c79b253ba" {
+		t.Errorf("device ID = %q", l.DeviceID)
+	}
+}
+
+func TestDHCPLeaseWithoutDeviceOrHostname(t *testing.T) {
+	c := newClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		writeJSON(w, `{"leases":[{"id":"3f8a5a6b-2c1d-4f5e-8a9b-0c1d2e3f4a5b",
+			"mac_address":"aa:bb:cc:11:22:03","ip_address":"192.168.1.43",
+			"hostname":null,"device_id":null,"status":"expired",
+			"lease_start":"2026-08-01T00:00:00Z","lease_end":"2026-08-02T00:00:00Z",
+			"created_at":"2026-08-01T00:00:00Z","updated_at":"2026-08-01T00:00:00Z"}]}`)
+	}))
+
+	leases, err := c.DHCP.Leases(context.Background())
+	if err != nil {
+		t.Fatalf("Leases: %v", err)
+	}
+	if leases[0].DeviceID != "" || leases[0].Hostname != "" {
+		t.Errorf("nulls not flattened: %+v", leases[0])
+	}
+}
+
+func TestDHCPAddReservationOmitsEmptyOptionals(t *testing.T) {
+	var body map[string]any
+	c := newClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/api/dhcp/reservations" {
+			t.Errorf("%s %s", r.Method, r.URL.Path)
+		}
+		raw, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(raw, &body)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_, _ = io.WriteString(w, `{"reservation":{"id":"4f8a5a6b-2c1d-4f5e-8a9b-0c1d2e3f4a5b",
+			"mac_address":"aa:bb:cc:11:22:04","ip_address":"192.168.1.50","hostname":null,
+			"description":null,"created_at":"2026-08-01T00:00:00Z",
+			"updated_at":"2026-08-01T00:00:00Z"},"message":"created"}`)
+	}))
+
+	r, err := c.DHCP.AddReservation(context.Background(), wardnet.CreateReservationParams{
+		MAC: "aa:bb:cc:11:22:04",
+		IP:  "192.168.1.50",
+	})
+	if err != nil {
+		t.Fatalf("AddReservation: %v", err)
+	}
+	if _, ok := body["hostname"]; ok {
+		t.Errorf("body = %v, want no hostname field", body)
+	}
+	if r.IP != "192.168.1.50" {
+		t.Errorf("unexpected reservation: %+v", r)
+	}
+}
+
+func TestDHCPRevokeLeaseInvalidIDNoRequest(t *testing.T) {
+	c := newClient(t, http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		t.Error("daemon called with an unparseable lease ID")
+	}))
+
+	if err := c.DHCP.RevokeLease(context.Background(), "nope"); err == nil {
+		t.Fatal("RevokeLease: want error")
+	}
+}

--- a/source/sdk/wardnet-go/dns.go
+++ b/source/sdk/wardnet-go/dns.go
@@ -1,0 +1,633 @@
+package wardnet
+
+import (
+	"context"
+	"time"
+
+	"wardnet.network/go/internal/rest"
+)
+
+// DNSService configures the resolver and its filtering rules.
+//
+// Blocklists, allowlist entries, and custom rules are scoped to a filter
+// profile, so every method that touches them takes a profile ID. Use
+// [DNSService.Profiles] to discover the builtin ones ("Ad Blocking",
+// "Parental Controls", "Malware & Phishing").
+type DNSService struct{ c *Client }
+
+// DNSResolutionMode is the resolver strategy: "forwarding" or "recursive".
+type DNSResolutionMode string
+
+// ForwarderSelectionMode is how the configured upstreams are used while
+// forwarding: "failover", "fastest", or "single".
+type ForwarderSelectionMode string
+
+// UpstreamDNS is one configured upstream resolver.
+type UpstreamDNS struct {
+	// Name is the human-readable label (e.g. "Cloudflare").
+	Name string `json:"name"`
+	// Address is the IP or hostname to dial.
+	Address string `json:"address"`
+	// Protocol is the transport: "udp", "tcp", "tls", or "https".
+	Protocol string `json:"protocol"`
+	// Port is the upstream port, or 0 to use the protocol default.
+	Port int32 `json:"port"`
+	// TLSServerName is the SNI expected on the upstream's certificate. Set
+	// only for the TLS and HTTPS protocols.
+	TLSServerName string `json:"tls_server_name"`
+}
+
+// DNSConfig is the resolver's persisted configuration.
+type DNSConfig struct {
+	// Enabled reports whether the resolver should be running.
+	Enabled bool `json:"enabled"`
+	// ResolutionMode is the resolver strategy.
+	ResolutionMode DNSResolutionMode `json:"resolution_mode"`
+	// UpstreamServers are the configured forwarders.
+	UpstreamServers []UpstreamDNS `json:"upstream_servers"`
+	// ForwarderSelectionMode is how those forwarders are picked.
+	ForwarderSelectionMode ForwarderSelectionMode `json:"forwarder_selection_mode"`
+	// SingleUpstream is the chosen forwarder's address, set only when
+	// ForwarderSelectionMode is "single".
+	SingleUpstream string `json:"single_upstream"`
+	// CacheSize is the maximum number of cached answers.
+	CacheSize int32 `json:"cache_size"`
+	// CacheTTLMinSecs / CacheTTLMaxSecs clamp upstream TTLs.
+	CacheTTLMinSecs int32 `json:"cache_ttl_min_secs"`
+	CacheTTLMaxSecs int32 `json:"cache_ttl_max_secs"`
+	// DNSSECEnabled reports whether answers are validated.
+	DNSSECEnabled bool `json:"dnssec_enabled"`
+	// RebindingProtection drops private-range answers from public names.
+	RebindingProtection bool `json:"rebinding_protection"`
+	// RateLimitPerSecond bounds queries accepted from one client.
+	RateLimitPerSecond int32 `json:"rate_limit_per_second"`
+	// FilteringEnabled is the global filter kill switch: when false every
+	// query passes regardless of per-device or per-profile state.
+	FilteringEnabled bool `json:"dns_filtering_enabled"`
+	// QueryLogEnabled reports whether queries are recorded.
+	QueryLogEnabled bool `json:"query_log_enabled"`
+	// QueryLogRetentionDays is how long those records are kept.
+	QueryLogRetentionDays int32 `json:"query_log_retention_days"`
+}
+
+// UpstreamLatency is the background prober's view of one upstream.
+type UpstreamLatency struct {
+	// Address matches the configured [UpstreamDNS.Address].
+	Address string `json:"address"`
+	// Reachable reports whether the most recent probe got an answer.
+	Reachable bool `json:"reachable"`
+	// AvgLatencyMs is the rolling-average round trip, or nil before the
+	// first successful probe.
+	AvgLatencyMs *float64 `json:"avg_latency_ms"`
+}
+
+// DNSStatus is the resolver's live state.
+type DNSStatus struct {
+	// Enabled is the configured intent; Running is the observed reality.
+	Enabled bool `json:"enabled"`
+	Running bool `json:"running"`
+	// CacheSize / CacheCapacity describe cache occupancy.
+	CacheSize     int64 `json:"cache_size"`
+	CacheCapacity int32 `json:"cache_capacity"`
+	// CacheHitRate is the fraction of queries served from cache.
+	CacheHitRate float64 `json:"cache_hit_rate"`
+	// UpstreamLatencies is one entry per configured upstream, empty until
+	// the prober has run.
+	UpstreamLatencies []UpstreamLatency `json:"upstream_latencies"`
+}
+
+// FilterProfile is a named bundle of blocklists, allowlist entries, and
+// custom rules.
+type FilterProfile struct {
+	// ID is the profile's UUID.
+	ID string `json:"id"`
+	// Name is the display name (e.g. "Ad Blocking").
+	Name string `json:"name"`
+	// Description is an optional annotation.
+	Description string `json:"description"`
+	// Builtin profiles cannot be renamed or deleted.
+	Builtin bool `json:"builtin"`
+	// CreatedAt / UpdatedAt are the profile's timestamps.
+	CreatedAt time.Time `json:"created_at"`
+	UpdatedAt time.Time `json:"updated_at"`
+}
+
+// Blocklist is a URL-sourced domain list belonging to a filter profile.
+type Blocklist struct {
+	// ID is the blocklist's UUID.
+	ID string `json:"id"`
+	// ProfileID is the owning filter profile.
+	ProfileID string `json:"profile_id"`
+	// Name is the display name.
+	Name string `json:"name"`
+	// URL is where the list is downloaded from.
+	URL string `json:"url"`
+	// Enabled reports whether the list contributes to the filter.
+	Enabled bool `json:"enabled"`
+	// EntryCount is how many domains the last successful download yielded.
+	EntryCount int64 `json:"entry_count"`
+	// CronSchedule is the refresh schedule (e.g. "0 3 * * *").
+	CronSchedule string `json:"cron_schedule"`
+	// LastUpdated is the last successful refresh, if any.
+	LastUpdated *time.Time `json:"last_updated"`
+	// LastError and LastErrorAt describe the most recent failed refresh.
+	// Both are cleared by a success.
+	LastError   string     `json:"last_error"`
+	LastErrorAt *time.Time `json:"last_error_at"`
+	// ConsecutiveFailures drives the refresh runner's backoff.
+	ConsecutiveFailures int32 `json:"consecutive_failures"`
+	// CreatedAt / UpdatedAt are the blocklist's timestamps.
+	CreatedAt time.Time `json:"created_at"`
+	UpdatedAt time.Time `json:"updated_at"`
+}
+
+// AllowlistEntry is a domain that overrides any blocklist match within its
+// filter profile.
+type AllowlistEntry struct {
+	// ID is the entry's UUID.
+	ID string `json:"id"`
+	// ProfileID is the owning filter profile.
+	ProfileID string `json:"profile_id"`
+	// Domain is the allowed name.
+	Domain string `json:"domain"`
+	// Reason is an optional note explaining the exemption.
+	Reason string `json:"reason"`
+	// CreatedAt is when the entry was added.
+	CreatedAt time.Time `json:"created_at"`
+}
+
+// FilterRule is a user-written AdGuard-syntax rule within a filter profile.
+type FilterRule struct {
+	// ID is the rule's UUID.
+	ID string `json:"id"`
+	// ProfileID is the owning filter profile.
+	ProfileID string `json:"profile_id"`
+	// Text is the rule itself (e.g. "||ads.example.com^").
+	Text string `json:"rule_text"`
+	// Enabled reports whether the rule is applied.
+	Enabled bool `json:"enabled"`
+	// Comment is an optional note.
+	Comment string `json:"comment"`
+	// CreatedAt / UpdatedAt are the rule's timestamps.
+	CreatedAt time.Time `json:"created_at"`
+	UpdatedAt time.Time `json:"updated_at"`
+}
+
+// CreateBlocklistParams describes a blocklist to add.
+type CreateBlocklistParams struct {
+	// Name is the display name.
+	Name string
+	// URL is where the list is downloaded from.
+	URL string
+	// CronSchedule is the refresh schedule (e.g. "0 3 * * *").
+	CronSchedule string
+	// Enabled reports whether the list starts active.
+	Enabled bool
+}
+
+// UpdateBlocklistParams is a partial blocklist update: nil fields are left
+// unchanged.
+type UpdateBlocklistParams struct {
+	Name         *string
+	URL          *string
+	CronSchedule *string
+	Enabled      *bool
+}
+
+// CreateRuleParams describes a custom filter rule to add.
+type CreateRuleParams struct {
+	// Text is the AdGuard-syntax rule.
+	Text string
+	// Comment is an optional note.
+	Comment string
+	// Enabled reports whether the rule starts active.
+	Enabled bool
+}
+
+// UpdateRuleParams is a partial rule update: nil fields are left unchanged.
+type UpdateRuleParams struct {
+	Text    *string
+	Comment *string
+	Enabled *bool
+}
+
+// Config fetches the resolver configuration.
+func (s *DNSService) Config(ctx context.Context) (*DNSConfig, error) {
+	resp, err := s.c.rest.DnsGetConfigWithResponse(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if resp.JSON200 == nil {
+		return nil, apiError(resp.HTTPResponse, resp.Body)
+	}
+	cfg := dnsConfigFromREST(&resp.JSON200.Config)
+	return &cfg, nil
+}
+
+// SetEnabled starts or stops the resolver and returns the resulting config.
+func (s *DNSService) SetEnabled(ctx context.Context, enabled bool) (*DNSConfig, error) {
+	resp, err := s.c.rest.DnsToggleWithResponse(ctx, rest.DnsToggleJSONRequestBody{Enabled: enabled})
+	if err != nil {
+		return nil, err
+	}
+	if resp.JSON200 == nil {
+		return nil, apiError(resp.HTTPResponse, resp.Body)
+	}
+	cfg := dnsConfigFromREST(&resp.JSON200.Config)
+	return &cfg, nil
+}
+
+// Status reports the resolver's live state.
+func (s *DNSService) Status(ctx context.Context) (*DNSStatus, error) {
+	resp, err := s.c.rest.DnsStatusWithResponse(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if resp.JSON200 == nil {
+		return nil, apiError(resp.HTTPResponse, resp.Body)
+	}
+	m := resp.JSON200
+	out := &DNSStatus{
+		Enabled:           m.Enabled,
+		Running:           m.Running,
+		CacheSize:         m.CacheSize,
+		CacheCapacity:     m.CacheCapacity,
+		CacheHitRate:      m.CacheHitRate,
+		UpstreamLatencies: make([]UpstreamLatency, 0, len(m.UpstreamLatencies)),
+	}
+	for _, l := range m.UpstreamLatencies {
+		out.UpstreamLatencies = append(out.UpstreamLatencies, UpstreamLatency{
+			Address:      l.Address,
+			Reachable:    l.Reachable,
+			AvgLatencyMs: l.AvgLatencyMs,
+		})
+	}
+	return out, nil
+}
+
+// FlushCache empties the resolver cache and reports how many entries went.
+func (s *DNSService) FlushCache(ctx context.Context) (int64, error) {
+	resp, err := s.c.rest.FlushCacheWithResponse(ctx)
+	if err != nil {
+		return 0, err
+	}
+	if resp.JSON200 == nil {
+		return 0, apiError(resp.HTTPResponse, resp.Body)
+	}
+	return resp.JSON200.EntriesCleared, nil
+}
+
+// Profiles returns every DNS filter profile.
+func (s *DNSService) Profiles(ctx context.Context) ([]FilterProfile, error) {
+	resp, err := s.c.rest.DnsFilterListProfilesWithResponse(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if resp.JSON200 == nil {
+		return nil, apiError(resp.HTTPResponse, resp.Body)
+	}
+	out := make([]FilterProfile, 0, len(resp.JSON200.Profiles))
+	for _, p := range resp.JSON200.Profiles {
+		out = append(out, FilterProfile{
+			ID:          p.Id.String(),
+			Name:        p.Name,
+			Description: deref(p.Description),
+			Builtin:     p.Builtin,
+			CreatedAt:   p.CreatedAt,
+			UpdatedAt:   p.UpdatedAt,
+		})
+	}
+	return out, nil
+}
+
+// Blocklists returns every blocklist in a profile.
+func (s *DNSService) Blocklists(ctx context.Context, profileID string) ([]Blocklist, error) {
+	pid, err := parseUUID(profileID, "profile")
+	if err != nil {
+		return nil, err
+	}
+	resp, err := s.c.rest.ListBlocklistsWithResponse(ctx, pid)
+	if err != nil {
+		return nil, err
+	}
+	if resp.JSON200 == nil {
+		return nil, apiError(resp.HTTPResponse, resp.Body)
+	}
+	out := make([]Blocklist, 0, len(resp.JSON200.Blocklists))
+	for i := range resp.JSON200.Blocklists {
+		out = append(out, blocklistFromREST(&resp.JSON200.Blocklists[i]))
+	}
+	return out, nil
+}
+
+// AddBlocklist creates a blocklist in a profile.
+func (s *DNSService) AddBlocklist(ctx context.Context, profileID string, params CreateBlocklistParams) (*Blocklist, error) {
+	pid, err := parseUUID(profileID, "profile")
+	if err != nil {
+		return nil, err
+	}
+	resp, err := s.c.rest.CreateBlocklistWithResponse(ctx, pid, rest.CreateBlocklistJSONRequestBody{
+		Name:         params.Name,
+		Url:          params.URL,
+		CronSchedule: params.CronSchedule,
+		Enabled:      params.Enabled,
+	})
+	if err != nil {
+		return nil, err
+	}
+	if resp.JSON201 == nil {
+		return nil, apiError(resp.HTTPResponse, resp.Body)
+	}
+	b := blocklistFromREST(&resp.JSON201.Blocklist)
+	return &b, nil
+}
+
+// UpdateBlocklist applies a partial update to a blocklist.
+func (s *DNSService) UpdateBlocklist(ctx context.Context, profileID, id string, params UpdateBlocklistParams) (*Blocklist, error) {
+	pid, err := parseUUID(profileID, "profile")
+	if err != nil {
+		return nil, err
+	}
+	bid, err := parseUUID(id, "blocklist")
+	if err != nil {
+		return nil, err
+	}
+	resp, err := s.c.rest.UpdateBlocklistWithResponse(ctx, pid, bid, rest.UpdateBlocklistJSONRequestBody{
+		Name:         params.Name,
+		Url:          params.URL,
+		CronSchedule: params.CronSchedule,
+		Enabled:      params.Enabled,
+	})
+	if err != nil {
+		return nil, err
+	}
+	if resp.JSON200 == nil {
+		return nil, apiError(resp.HTTPResponse, resp.Body)
+	}
+	b := blocklistFromREST(&resp.JSON200.Blocklist)
+	return &b, nil
+}
+
+// RemoveBlocklist deletes a blocklist from a profile.
+func (s *DNSService) RemoveBlocklist(ctx context.Context, profileID, id string) error {
+	pid, err := parseUUID(profileID, "profile")
+	if err != nil {
+		return err
+	}
+	bid, err := parseUUID(id, "blocklist")
+	if err != nil {
+		return err
+	}
+	resp, err := s.c.rest.DeleteBlocklistWithResponse(ctx, pid, bid)
+	if err != nil {
+		return err
+	}
+	if resp.JSON200 == nil {
+		return apiError(resp.HTTPResponse, resp.Body)
+	}
+	return nil
+}
+
+// RefreshBlocklist queues a re-download of a blocklist and returns the ID of
+// the dispatched job. The download itself runs in the background.
+func (s *DNSService) RefreshBlocklist(ctx context.Context, profileID, id string) (string, error) {
+	pid, err := parseUUID(profileID, "profile")
+	if err != nil {
+		return "", err
+	}
+	bid, err := parseUUID(id, "blocklist")
+	if err != nil {
+		return "", err
+	}
+	resp, err := s.c.rest.RefreshBlocklistWithResponse(ctx, pid, bid)
+	if err != nil {
+		return "", err
+	}
+	if resp.JSON202 == nil {
+		return "", apiError(resp.HTTPResponse, resp.Body)
+	}
+	return resp.JSON202.JobId.String(), nil
+}
+
+// Allowlist returns every allowlist entry in a profile.
+func (s *DNSService) Allowlist(ctx context.Context, profileID string) ([]AllowlistEntry, error) {
+	pid, err := parseUUID(profileID, "profile")
+	if err != nil {
+		return nil, err
+	}
+	resp, err := s.c.rest.ListAllowlistWithResponse(ctx, pid)
+	if err != nil {
+		return nil, err
+	}
+	if resp.JSON200 == nil {
+		return nil, apiError(resp.HTTPResponse, resp.Body)
+	}
+	out := make([]AllowlistEntry, 0, len(resp.JSON200.Entries))
+	for i := range resp.JSON200.Entries {
+		out = append(out, allowlistEntryFromREST(&resp.JSON200.Entries[i]))
+	}
+	return out, nil
+}
+
+// AddAllowlistEntry exempts a domain from the profile's blocklists. An empty
+// reason is sent as no reason.
+func (s *DNSService) AddAllowlistEntry(ctx context.Context, profileID, domain, reason string) (*AllowlistEntry, error) {
+	pid, err := parseUUID(profileID, "profile")
+	if err != nil {
+		return nil, err
+	}
+	body := rest.CreateAllowlistEntryJSONRequestBody{Domain: domain}
+	if reason != "" {
+		body.Reason = ptr(reason)
+	}
+	resp, err := s.c.rest.CreateAllowlistEntryWithResponse(ctx, pid, body)
+	if err != nil {
+		return nil, err
+	}
+	if resp.JSON201 == nil {
+		return nil, apiError(resp.HTTPResponse, resp.Body)
+	}
+	e := allowlistEntryFromREST(&resp.JSON201.Entry)
+	return &e, nil
+}
+
+// RemoveAllowlistEntry deletes an allowlist entry from a profile.
+func (s *DNSService) RemoveAllowlistEntry(ctx context.Context, profileID, id string) error {
+	pid, err := parseUUID(profileID, "profile")
+	if err != nil {
+		return err
+	}
+	eid, err := parseUUID(id, "allowlist entry")
+	if err != nil {
+		return err
+	}
+	resp, err := s.c.rest.DeleteAllowlistEntryWithResponse(ctx, pid, eid)
+	if err != nil {
+		return err
+	}
+	if resp.JSON200 == nil {
+		return apiError(resp.HTTPResponse, resp.Body)
+	}
+	return nil
+}
+
+// Rules returns every custom filter rule in a profile.
+func (s *DNSService) Rules(ctx context.Context, profileID string) ([]FilterRule, error) {
+	pid, err := parseUUID(profileID, "profile")
+	if err != nil {
+		return nil, err
+	}
+	resp, err := s.c.rest.ListCustomRulesWithResponse(ctx, pid)
+	if err != nil {
+		return nil, err
+	}
+	if resp.JSON200 == nil {
+		return nil, apiError(resp.HTTPResponse, resp.Body)
+	}
+	out := make([]FilterRule, 0, len(resp.JSON200.Rules))
+	for i := range resp.JSON200.Rules {
+		out = append(out, filterRuleFromREST(&resp.JSON200.Rules[i]))
+	}
+	return out, nil
+}
+
+// AddRule creates a custom filter rule in a profile.
+func (s *DNSService) AddRule(ctx context.Context, profileID string, params CreateRuleParams) (*FilterRule, error) {
+	pid, err := parseUUID(profileID, "profile")
+	if err != nil {
+		return nil, err
+	}
+	body := rest.CreateCustomRuleJSONRequestBody{
+		RuleText: params.Text,
+		Enabled:  params.Enabled,
+	}
+	if params.Comment != "" {
+		body.Comment = ptr(params.Comment)
+	}
+	resp, err := s.c.rest.CreateCustomRuleWithResponse(ctx, pid, body)
+	if err != nil {
+		return nil, err
+	}
+	if resp.JSON201 == nil {
+		return nil, apiError(resp.HTTPResponse, resp.Body)
+	}
+	r := filterRuleFromREST(&resp.JSON201.Rule)
+	return &r, nil
+}
+
+// UpdateRule applies a partial update to a custom filter rule.
+func (s *DNSService) UpdateRule(ctx context.Context, profileID, id string, params UpdateRuleParams) (*FilterRule, error) {
+	pid, err := parseUUID(profileID, "profile")
+	if err != nil {
+		return nil, err
+	}
+	rid, err := parseUUID(id, "rule")
+	if err != nil {
+		return nil, err
+	}
+	resp, err := s.c.rest.UpdateCustomRuleWithResponse(ctx, pid, rid, rest.UpdateCustomRuleJSONRequestBody{
+		RuleText: params.Text,
+		Comment:  params.Comment,
+		Enabled:  params.Enabled,
+	})
+	if err != nil {
+		return nil, err
+	}
+	if resp.JSON200 == nil {
+		return nil, apiError(resp.HTTPResponse, resp.Body)
+	}
+	r := filterRuleFromREST(&resp.JSON200.Rule)
+	return &r, nil
+}
+
+// RemoveRule deletes a custom filter rule from a profile.
+func (s *DNSService) RemoveRule(ctx context.Context, profileID, id string) error {
+	pid, err := parseUUID(profileID, "profile")
+	if err != nil {
+		return err
+	}
+	rid, err := parseUUID(id, "rule")
+	if err != nil {
+		return err
+	}
+	resp, err := s.c.rest.DeleteCustomRuleWithResponse(ctx, pid, rid)
+	if err != nil {
+		return err
+	}
+	if resp.JSON200 == nil {
+		return apiError(resp.HTTPResponse, resp.Body)
+	}
+	return nil
+}
+
+func dnsConfigFromREST(c *rest.DnsConfig) DNSConfig {
+	out := DNSConfig{
+		Enabled:                c.Enabled,
+		ResolutionMode:         DNSResolutionMode(c.ResolutionMode),
+		ForwarderSelectionMode: ForwarderSelectionMode(c.ForwarderSelectionMode),
+		SingleUpstream:         deref(c.SingleUpstream),
+		CacheSize:              c.CacheSize,
+		CacheTTLMinSecs:        c.CacheTtlMinSecs,
+		CacheTTLMaxSecs:        c.CacheTtlMaxSecs,
+		DNSSECEnabled:          c.DnssecEnabled,
+		RebindingProtection:    c.RebindingProtection,
+		RateLimitPerSecond:     c.RateLimitPerSecond,
+		FilteringEnabled:       c.DnsFilteringEnabled,
+		QueryLogEnabled:        c.QueryLogEnabled,
+		QueryLogRetentionDays:  c.QueryLogRetentionDays,
+		UpstreamServers:        make([]UpstreamDNS, 0, len(c.UpstreamServers)),
+	}
+	for _, u := range c.UpstreamServers {
+		up := UpstreamDNS{
+			Name:          u.Name,
+			Address:       u.Address,
+			Protocol:      string(u.Protocol),
+			TLSServerName: deref(u.TlsServerName),
+		}
+		if u.Port != nil {
+			up.Port = *u.Port
+		}
+		out.UpstreamServers = append(out.UpstreamServers, up)
+	}
+	return out
+}
+
+func blocklistFromREST(b *rest.Blocklist) Blocklist {
+	return Blocklist{
+		ID:                  b.Id.String(),
+		ProfileID:           b.ProfileId.String(),
+		Name:                b.Name,
+		URL:                 b.Url,
+		Enabled:             b.Enabled,
+		EntryCount:          b.EntryCount,
+		CronSchedule:        b.CronSchedule,
+		LastUpdated:         b.LastUpdated,
+		LastError:           deref(b.LastError),
+		LastErrorAt:         b.LastErrorAt,
+		ConsecutiveFailures: b.ConsecutiveFailures,
+		CreatedAt:           b.CreatedAt,
+		UpdatedAt:           b.UpdatedAt,
+	}
+}
+
+func allowlistEntryFromREST(e *rest.AllowlistEntry) AllowlistEntry {
+	return AllowlistEntry{
+		ID:        e.Id.String(),
+		ProfileID: e.ProfileId.String(),
+		Domain:    e.Domain,
+		Reason:    deref(e.Reason),
+		CreatedAt: e.CreatedAt,
+	}
+}
+
+func filterRuleFromREST(r *rest.CustomFilterRule) FilterRule {
+	return FilterRule{
+		ID:        r.Id.String(),
+		ProfileID: r.ProfileId.String(),
+		Text:      r.RuleText,
+		Enabled:   r.Enabled,
+		Comment:   deref(r.Comment),
+		CreatedAt: r.CreatedAt,
+		UpdatedAt: r.UpdatedAt,
+	}
+}

--- a/source/sdk/wardnet-go/dns_test.go
+++ b/source/sdk/wardnet-go/dns_test.go
@@ -1,0 +1,188 @@
+package wardnet_test
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"testing"
+
+	wardnet "wardnet.network/go"
+)
+
+const adBlockingProfileID = "9d4b4d1c-3f4a-4a55-9f0c-6ac0d2a5b111"
+
+const blocklistJSON = `{
+  "id":"1f8a5a6b-2c1d-4f5e-8a9b-0c1d2e3f4a5b",
+  "profile_id":"` + adBlockingProfileID + `",
+  "name":"StevenBlack","url":"https://example.invalid/hosts",
+  "enabled":true,"entry_count":132000,"cron_schedule":"0 3 * * *",
+  "last_updated":"2026-08-01T03:00:00Z","last_error":null,"last_error_at":null,
+  "consecutive_failures":0,
+  "created_at":"2026-07-01T00:00:00Z","updated_at":"2026-08-01T03:00:00Z"
+}`
+
+func TestDNSConfig(t *testing.T) {
+	c := newClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/dns/config" {
+			t.Errorf("path = %q", r.URL.Path)
+		}
+		writeJSON(w, `{"config":{
+			"enabled":true,"resolution_mode":"forwarding",
+			"upstream_servers":[{"name":"Cloudflare","address":"1.1.1.1","protocol":"tls",
+				"port":853,"tls_server_name":"cloudflare-dns.com"}],
+			"forwarder_selection_mode":"fastest","single_upstream":null,
+			"cache_size":10000,"cache_ttl_min_secs":60,"cache_ttl_max_secs":86400,
+			"dnssec_enabled":true,"rebinding_protection":true,"rate_limit_per_second":100,
+			"dns_filtering_enabled":true,"query_log_enabled":true,"query_log_retention_days":7}}`)
+	}))
+
+	cfg, err := c.DNS.Config(context.Background())
+	if err != nil {
+		t.Fatalf("Config: %v", err)
+	}
+	if !cfg.Enabled || cfg.ResolutionMode != "forwarding" || cfg.CacheSize != 10000 {
+		t.Errorf("unexpected config: %+v", cfg)
+	}
+	if len(cfg.UpstreamServers) != 1 {
+		t.Fatalf("upstreams = %d, want 1", len(cfg.UpstreamServers))
+	}
+	up := cfg.UpstreamServers[0]
+	if up.Address != "1.1.1.1" || up.Port != 853 || up.TLSServerName != "cloudflare-dns.com" {
+		t.Errorf("unexpected upstream: %+v", up)
+	}
+	// A null single_upstream must land as the empty string, not a panic.
+	if cfg.SingleUpstream != "" {
+		t.Errorf("single upstream = %q, want empty", cfg.SingleUpstream)
+	}
+}
+
+func TestDNSSetEnabledSendsToggle(t *testing.T) {
+	var body map[string]any
+	c := newClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/api/dns/config/toggle" {
+			t.Errorf("%s %s", r.Method, r.URL.Path)
+		}
+		raw, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(raw, &body)
+		writeJSON(w, `{"config":{
+			"enabled":false,"resolution_mode":"forwarding","upstream_servers":[],
+			"forwarder_selection_mode":"failover","cache_size":0,
+			"cache_ttl_min_secs":0,"cache_ttl_max_secs":0,"dnssec_enabled":false,
+			"rebinding_protection":false,"rate_limit_per_second":0,
+			"dns_filtering_enabled":false,"query_log_enabled":false,
+			"query_log_retention_days":0}}`)
+	}))
+
+	cfg, err := c.DNS.SetEnabled(context.Background(), false)
+	if err != nil {
+		t.Fatalf("SetEnabled: %v", err)
+	}
+	if body["enabled"] != false {
+		t.Errorf("body = %v, want enabled:false", body)
+	}
+	if cfg.Enabled {
+		t.Error("returned config still enabled")
+	}
+}
+
+func TestDNSBlocklistsScopedToProfile(t *testing.T) {
+	c := newClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		want := "/api/dns/filter/profiles/" + adBlockingProfileID + "/blocklists"
+		if r.URL.Path != want {
+			t.Errorf("path = %q, want %q", r.URL.Path, want)
+		}
+		writeJSON(w, `{"blocklists":[`+blocklistJSON+`]}`)
+	}))
+
+	lists, err := c.DNS.Blocklists(context.Background(), adBlockingProfileID)
+	if err != nil {
+		t.Fatalf("Blocklists: %v", err)
+	}
+	if len(lists) != 1 {
+		t.Fatalf("blocklists = %d, want 1", len(lists))
+	}
+	b := lists[0]
+	if b.Name != "StevenBlack" || b.EntryCount != 132000 || !b.Enabled {
+		t.Errorf("unexpected blocklist: %+v", b)
+	}
+	if b.LastUpdated == nil {
+		t.Error("last_updated not decoded")
+	}
+	if b.LastError != "" {
+		t.Errorf("last error = %q, want empty", b.LastError)
+	}
+}
+
+func TestDNSUpdateBlocklistSendsOnlySetFields(t *testing.T) {
+	var body map[string]any
+	c := newClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		raw, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(raw, &body)
+		writeJSON(w, `{"blocklist":`+blocklistJSON+`,"message":"updated"}`)
+	}))
+
+	enabled := false
+	_, err := c.DNS.UpdateBlocklist(context.Background(), adBlockingProfileID,
+		"1f8a5a6b-2c1d-4f5e-8a9b-0c1d2e3f4a5b", wardnet.UpdateBlocklistParams{Enabled: &enabled})
+	if err != nil {
+		t.Fatalf("UpdateBlocklist: %v", err)
+	}
+	if len(body) != 1 {
+		t.Errorf("body = %v, want only the enabled field", body)
+	}
+	if body["enabled"] != false {
+		t.Errorf("enabled = %v, want false", body["enabled"])
+	}
+}
+
+func TestDNSAddAllowlistEntryOmitsEmptyReason(t *testing.T) {
+	var body map[string]any
+	c := newClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		raw, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(raw, &body)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_, _ = io.WriteString(w, `{"entry":{"id":"2a8a5a6b-2c1d-4f5e-8a9b-0c1d2e3f4a5b",
+			"profile_id":"`+adBlockingProfileID+`","domain":"example.com","reason":null,
+			"created_at":"2026-08-01T00:00:00Z"},"message":"created"}`)
+	}))
+
+	e, err := c.DNS.AddAllowlistEntry(context.Background(), adBlockingProfileID, "example.com", "")
+	if err != nil {
+		t.Fatalf("AddAllowlistEntry: %v", err)
+	}
+	if _, ok := body["reason"]; ok {
+		t.Errorf("body = %v, want no reason field", body)
+	}
+	if e.Domain != "example.com" || e.Reason != "" {
+		t.Errorf("unexpected entry: %+v", e)
+	}
+}
+
+func TestDNSFlushCache(t *testing.T) {
+	c := newClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/api/dns/cache/flush" {
+			t.Errorf("%s %s", r.Method, r.URL.Path)
+		}
+		writeJSON(w, `{"entries_cleared":42,"message":"flushed"}`)
+	}))
+
+	n, err := c.DNS.FlushCache(context.Background())
+	if err != nil {
+		t.Fatalf("FlushCache: %v", err)
+	}
+	if n != 42 {
+		t.Errorf("entries cleared = %d, want 42", n)
+	}
+}
+
+func TestDNSInvalidProfileIDNoRequest(t *testing.T) {
+	c := newClient(t, http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		t.Error("daemon called with an unparseable profile ID")
+	}))
+
+	if _, err := c.DNS.Blocklists(context.Background(), "not-a-uuid"); err == nil {
+		t.Fatal("Blocklists: want error")
+	}
+}

--- a/source/sdk/wardnet-go/doc.go
+++ b/source/sdk/wardnet-go/doc.go
@@ -3,10 +3,10 @@
 //
 // It offers a hand-crafted, domain-oriented API over the daemon's HTTP
 // interface: a [Client] exposes one service per area (System, Devices,
-// Tunnels, Update, Backup, Auth), each returning clean public types. The
-// low-level REST client generated from the daemon's OpenAPI document is an
-// unexported implementation detail (see internal/rest) and never appears in
-// this package's surface.
+// Tunnels, DNS, DHCP, Logs, Update, Backup, Auth), each returning clean
+// public types. The low-level REST client generated from the daemon's OpenAPI
+// document is an unexported implementation detail (see internal/rest) and
+// never appears in this package's surface.
 //
 // # Usage
 //
@@ -19,4 +19,8 @@
 // Every method takes a [context.Context] and returns a typed result or an
 // error. Errors from the daemon are returned as [*APIError]; transport
 // failures surface as the underlying error.
+//
+// [LogsService.Stream] is the one long-lived call: it upgrades to a WebSocket
+// and returns a [*LogStream] whose context governs the whole connection
+// rather than a single request.
 package wardnet

--- a/source/sdk/wardnet-go/go.mod
+++ b/source/sdk/wardnet-go/go.mod
@@ -3,6 +3,7 @@ module wardnet.network/go
 go 1.26.0
 
 require (
+	github.com/coder/websocket v1.8.15
 	github.com/google/uuid v1.6.0
 	github.com/oapi-codegen/runtime v1.6.0
 )

--- a/source/sdk/wardnet-go/go.sum
+++ b/source/sdk/wardnet-go/go.sum
@@ -2,6 +2,8 @@ github.com/RaveNoX/go-jsoncommentstrip v1.0.0/go.mod h1:78ihd09MekBnJnxpICcwzCMz
 github.com/apapsch/go-jsonmerge/v2 v2.0.0 h1:axGnT1gRIfimI7gJifB699GoE/oq+F2MU7Dml6nw9rQ=
 github.com/apapsch/go-jsonmerge/v2 v2.0.0/go.mod h1:lvDnEdqiQrp0O42VQGgmlKpxL1AP2+08jFMw88y4klk=
 github.com/bmatcuk/doublestar v1.1.1/go.mod h1:UD6OnuiIn0yFxxA2le/rnRU1G4RaI4UvFv1sNto9p6w=
+github.com/coder/websocket v1.8.15 h1:6B2JPeOGlpff2Uz6vOEH1Vzpi0iUz20A+lPVhPHtNUA=
+github.com/coder/websocket v1.8.15/go.mod h1:NX3SzP+inril6yawo5CQXx8+fk145lPDC6pumgx0mVg=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/source/sdk/wardnet-go/logs.go
+++ b/source/sdk/wardnet-go/logs.go
@@ -1,0 +1,178 @@
+package wardnet
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/coder/websocket"
+)
+
+// logStreamPath is the daemon's WebSocket log endpoint.
+const logStreamPath = "/api/system/logs/stream"
+
+// LogsService downloads and streams daemon logs.
+type LogsService struct{ c *Client }
+
+// LogEntry is one structured log line.
+type LogEntry struct {
+	// Timestamp is when the event was recorded, RFC 3339 with milliseconds.
+	Timestamp string `json:"timestamp"`
+	// Level is "TRACE", "DEBUG", "INFO", "WARN", or "ERROR".
+	Level string `json:"level"`
+	// Target is the emitting module path (e.g. "wardnetd_services::dns").
+	Target string `json:"target"`
+	// Message is the human-readable event text.
+	Message string `json:"message"`
+	// Fields are the event's structured fields, excluding the message.
+	Fields map[string]string `json:"fields,omitempty"`
+	// Span holds the fields of the enclosing tracing span, when there is one.
+	Span map[string]string `json:"span,omitempty"`
+}
+
+// LogFilter narrows what the daemon sends on a log stream. Filtering happens
+// server-side, so a narrow filter also saves bandwidth.
+type LogFilter struct {
+	// Level is the minimum severity to receive: "trace", "debug", "info",
+	// "warn", or "error". Empty leaves the daemon's default ("info").
+	Level string
+	// Target keeps only entries whose target starts with this prefix. Empty
+	// keeps every target.
+	Target string
+}
+
+// LogEvent is one message from a log stream: either an entry or a notice
+// that the daemon dropped entries because the client fell behind.
+type LogEvent struct {
+	// Entry is the log line, or nil for a drop notice.
+	Entry *LogEntry
+	// Skipped is how many entries were dropped, and is non-zero only on a
+	// drop notice.
+	Skipped int64
+}
+
+// LogStream is a live connection to the daemon's log stream. Call
+// [LogStream.Recv] in a loop and [LogStream.Close] when finished.
+type LogStream struct {
+	conn *websocket.Conn
+}
+
+// Download fetches the daemon's log file as plain text.
+func (s *LogsService) Download(ctx context.Context) ([]byte, error) {
+	resp, err := s.c.rest.DownloadLogsWithResponse(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if resp.HTTPResponse == nil || resp.HTTPResponse.StatusCode != http.StatusOK {
+		return nil, apiError(resp.HTTPResponse, resp.Body)
+	}
+	return resp.Body, nil
+}
+
+// Stream opens the log stream and applies filter to it. The stream stays open
+// until [LogStream.Close] is called or ctx is cancelled; ctx therefore governs
+// the whole connection, not just the handshake.
+func (s *LogsService) Stream(ctx context.Context, filter LogFilter) (*LogStream, error) {
+	header := http.Header{}
+	if s.c.token != "" {
+		header.Set("Authorization", "Bearer "+s.c.token)
+	}
+	if s.c.userAgent != "" {
+		header.Set("User-Agent", s.c.userAgent)
+	}
+
+	// The dial borrows the client's transport but never its timeout: a
+	// deadline that is right for a request would cut the stream off mid-run.
+	dialClient := &http.Client{}
+	if s.c.httpClient != nil {
+		dialClient.Transport = s.c.httpClient.Transport
+		dialClient.Jar = s.c.httpClient.Jar
+	}
+
+	conn, resp, err := websocket.Dial(ctx, wsURL(s.c.baseURL), &websocket.DialOptions{
+		HTTPClient: dialClient,
+		HTTPHeader: header,
+	})
+	if err != nil {
+		// A rejected upgrade is an ordinary HTTP failure (401 without a
+		// token, 403 without admin), so report it as one. Only the first
+		// kilobyte of a failed handshake's body is readable.
+		if resp != nil {
+			body, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
+			return nil, apiError(resp, body)
+		}
+		return nil, fmt.Errorf("wardnet: cannot open log stream: %w", err)
+	}
+
+	stream := &LogStream{conn: conn}
+	if filter.Level != "" || filter.Target != "" {
+		if err := stream.setFilter(ctx, filter); err != nil {
+			_ = stream.Close()
+			return nil, err
+		}
+	}
+	return stream, nil
+}
+
+// Recv blocks until the next stream message arrives. It returns an error once
+// the daemon hangs up or ctx is cancelled — check ctx.Err() to tell a
+// caller-requested stop from a lost connection.
+func (s *LogStream) Recv(ctx context.Context) (LogEvent, error) {
+	for {
+		_, data, err := s.conn.Read(ctx)
+		if err != nil {
+			return LogEvent{}, err
+		}
+		// The daemon multiplexes drop notices onto the same socket, tagged
+		// with a "type" the entries themselves never carry.
+		var probe struct {
+			Type    string `json:"type"`
+			Skipped int64  `json:"skipped"`
+		}
+		if err := json.Unmarshal(data, &probe); err == nil && probe.Type == "lagged" {
+			return LogEvent{Skipped: probe.Skipped}, nil
+		}
+		var entry LogEntry
+		if err := json.Unmarshal(data, &entry); err != nil {
+			// A message we cannot parse is not worth ending the stream over.
+			continue
+		}
+		return LogEvent{Entry: &entry}, nil
+	}
+}
+
+// Close ends the stream.
+func (s *LogStream) Close() error {
+	return s.conn.Close(websocket.StatusNormalClosure, "")
+}
+
+// setFilter tells the daemon which entries this client wants.
+func (s *LogStream) setFilter(ctx context.Context, filter LogFilter) error {
+	cmd := map[string]string{"type": "set_filter"}
+	if filter.Level != "" {
+		cmd["level"] = filter.Level
+	}
+	if filter.Target != "" {
+		cmd["target"] = filter.Target
+	}
+	payload, err := json.Marshal(cmd)
+	if err != nil {
+		return err
+	}
+	return s.conn.Write(ctx, websocket.MessageText, payload)
+}
+
+// wsURL rewrites an http(s) base URL into the ws(s) log stream endpoint.
+func wsURL(baseURL string) string {
+	switch {
+	case strings.HasPrefix(baseURL, "https://"):
+		return "wss://" + strings.TrimPrefix(baseURL, "https://") + logStreamPath
+	case strings.HasPrefix(baseURL, "http://"):
+		return "ws://" + strings.TrimPrefix(baseURL, "http://") + logStreamPath
+	default:
+		return baseURL + logStreamPath
+	}
+}

--- a/source/sdk/wardnet-go/logs_test.go
+++ b/source/sdk/wardnet-go/logs_test.go
@@ -1,0 +1,167 @@
+package wardnet_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"maps"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/coder/websocket"
+	wardnet "wardnet.network/go"
+)
+
+// logStreamServer accepts the upgrade, records the first client command, and
+// sends each message in turn before closing.
+func logStreamServer(t *testing.T, gotCommand chan<- string, messages ...string) http.Handler {
+	t.Helper()
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/system/logs/stream" {
+			t.Errorf("path = %q", r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer test-token" {
+			t.Errorf("Authorization = %q, want Bearer test-token", got)
+		}
+		conn, err := websocket.Accept(w, r, nil)
+		if err != nil {
+			t.Errorf("Accept: %v", err)
+			return
+		}
+		defer func() { _ = conn.CloseNow() }()
+
+		ctx, cancel := context.WithTimeout(r.Context(), 5*time.Second)
+		defer cancel()
+
+		if gotCommand != nil {
+			_, data, err := conn.Read(ctx)
+			if err != nil {
+				t.Errorf("Read: %v", err)
+				return
+			}
+			gotCommand <- string(data)
+		}
+		for _, m := range messages {
+			if err := conn.Write(ctx, websocket.MessageText, []byte(m)); err != nil {
+				return
+			}
+		}
+		_ = conn.Close(websocket.StatusNormalClosure, "")
+	})
+}
+
+func TestLogsStreamEntries(t *testing.T) {
+	c := newClient(t, logStreamServer(t, nil,
+		`{"timestamp":"2026-08-01T00:00:00.123Z","level":"INFO","target":"wardnetd::dns",
+		  "message":"resolver started","fields":{"port":"53"}}`,
+		`{"type":"lagged","skipped":7}`,
+	))
+
+	stream, err := c.Logs.Stream(context.Background(), wardnet.LogFilter{})
+	if err != nil {
+		t.Fatalf("Stream: %v", err)
+	}
+	defer func() { _ = stream.Close() }()
+
+	ev, err := stream.Recv(context.Background())
+	if err != nil {
+		t.Fatalf("Recv: %v", err)
+	}
+	if ev.Entry == nil {
+		t.Fatal("first event carried no entry")
+	}
+	if ev.Entry.Level != "INFO" || ev.Entry.Message != "resolver started" {
+		t.Errorf("unexpected entry: %+v", ev.Entry)
+	}
+	if ev.Entry.Fields["port"] != "53" {
+		t.Errorf("fields = %v", ev.Entry.Fields)
+	}
+
+	ev, err = stream.Recv(context.Background())
+	if err != nil {
+		t.Fatalf("Recv: %v", err)
+	}
+	if ev.Entry != nil || ev.Skipped != 7 {
+		t.Errorf("want a drop notice for 7 entries, got %+v", ev)
+	}
+}
+
+func TestLogsStreamSendsFilter(t *testing.T) {
+	gotCommand := make(chan string, 1)
+	c := newClient(t, logStreamServer(t, gotCommand))
+
+	stream, err := c.Logs.Stream(context.Background(), wardnet.LogFilter{
+		Level:  "warn",
+		Target: "wardnetd::dns",
+	})
+	if err != nil {
+		t.Fatalf("Stream: %v", err)
+	}
+	defer func() { _ = stream.Close() }()
+
+	select {
+	case cmd := <-gotCommand:
+		var got map[string]string
+		if err := json.Unmarshal([]byte(cmd), &got); err != nil {
+			t.Fatalf("command %s: %v", cmd, err)
+		}
+		want := map[string]string{"type": "set_filter", "level": "warn", "target": "wardnetd::dns"}
+		if !maps.Equal(got, want) {
+			t.Errorf("command = %v, want %v", got, want)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("no filter command arrived")
+	}
+}
+
+func TestLogsStreamRejectedUpgradeIsAPIError(t *testing.T) {
+	c := newClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = io.WriteString(w, `{"error":"unauthorized","detail":"admin session required"}`)
+	}))
+
+	_, err := c.Logs.Stream(context.Background(), wardnet.LogFilter{})
+	if err == nil {
+		t.Fatal("Stream: want error")
+	}
+	var apiErr *wardnet.APIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("error = %v, want *APIError", err)
+	}
+	if apiErr.StatusCode != http.StatusUnauthorized || apiErr.Message != "unauthorized" {
+		t.Errorf("unexpected API error: %+v", apiErr)
+	}
+}
+
+func TestLogsDownload(t *testing.T) {
+	c := newClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/system/logs/download" {
+			t.Errorf("path = %q", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+		_, _ = io.WriteString(w, "2026-08-01 INFO started\n")
+	}))
+
+	body, err := c.Logs.Download(context.Background())
+	if err != nil {
+		t.Fatalf("Download: %v", err)
+	}
+	if string(body) != "2026-08-01 INFO started\n" {
+		t.Errorf("body = %q", body)
+	}
+}
+
+func TestLogsDownloadError(t *testing.T) {
+	c := newClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = io.WriteString(w, `{"error":"forbidden"}`)
+	}))
+
+	if _, err := c.Logs.Download(context.Background()); err == nil {
+		t.Fatal("Download: want error")
+	}
+}

--- a/source/sdk/wardnet-go/system.go
+++ b/source/sdk/wardnet-go/system.go
@@ -2,6 +2,7 @@ package wardnet
 
 import (
 	"context"
+	"net/http"
 	"time"
 )
 
@@ -48,6 +49,23 @@ type LastShutdown struct {
 	AcknowledgedAt *time.Time `json:"acknowledged_at"`
 }
 
+// Diagnostic is one recent daemon-raised problem, as surfaced in the admin
+// UI's notification area.
+type Diagnostic struct {
+	// Timestamp is when the underlying condition occurred.
+	Timestamp time.Time `json:"timestamp"`
+	// Code is the stable class identifier (e.g. "tunnel_start_failed").
+	Code string `json:"code"`
+	// Severity is "error", "warning", or "info".
+	Severity string `json:"severity"`
+	// Component is the subsystem that raised it.
+	Component string `json:"component"`
+	// Message describes what happened.
+	Message string `json:"message"`
+	// Hint says what an admin can do about it.
+	Hint string `json:"hint"`
+}
+
 // Status fetches the current system status.
 func (s *SystemService) Status(ctx context.Context) (*SystemStatus, error) {
 	resp, err := s.c.rest.SystemStatusWithResponse(ctx)
@@ -77,4 +95,41 @@ func (s *SystemService) Status(ctx context.Context) (*SystemStatus, error) {
 			AcknowledgedAt: m.LastShutdown.AcknowledgedAt,
 		},
 	}, nil
+}
+
+// RecentErrors returns the daemon's recent diagnostics, newest first.
+func (s *SystemService) RecentErrors(ctx context.Context) ([]Diagnostic, error) {
+	resp, err := s.c.rest.RecentErrorsWithResponse(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if resp.JSON200 == nil {
+		return nil, apiError(resp.HTTPResponse, resp.Body)
+	}
+	out := make([]Diagnostic, 0, len(resp.JSON200.Errors))
+	for _, d := range resp.JSON200.Errors {
+		out = append(out, Diagnostic{
+			Timestamp: d.Timestamp,
+			Code:      d.Code,
+			Severity:  d.Severity,
+			Component: d.Component,
+			Message:   d.Message,
+			Hint:      d.Hint,
+		})
+	}
+	return out, nil
+}
+
+// Restart asks the daemon to exit so its supervisor starts it again. It
+// returns as soon as the restart is scheduled; the daemon is unreachable for
+// a few seconds afterwards.
+func (s *SystemService) Restart(ctx context.Context) error {
+	resp, err := s.c.rest.RestartWithResponse(ctx)
+	if err != nil {
+		return err
+	}
+	if resp.HTTPResponse == nil || resp.HTTPResponse.StatusCode != http.StatusNoContent {
+		return apiError(resp.HTTPResponse, resp.Body)
+	}
+	return nil
 }

--- a/source/wctl/cmd/wctl/cli_test.go
+++ b/source/wctl/cmd/wctl/cli_test.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"io"
+	"os"
+	"testing"
+)
+
+// runCLI executes wctl with args against daemonURL and returns whatever the
+// command wrote to stdout. The environment is pinned so a developer's real
+// ~/.config/wardnet/wctl.toml cannot influence the result.
+func runCLI(t *testing.T, daemonURL string, args ...string) (string, error) {
+	t.Helper()
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("WARDNET_DAEMON_URL", daemonURL)
+	t.Setenv("WARDNET_TOKEN", "test-token")
+
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	realStdout := os.Stdout
+	os.Stdout = w
+
+	done := make(chan string, 1)
+	go func() {
+		out, _ := io.ReadAll(r)
+		done <- string(out)
+	}()
+
+	cmd := rootCmd()
+	cmd.SetArgs(args)
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
+	runErr := cmd.Execute()
+
+	os.Stdout = realStdout
+	_ = w.Close()
+	out := <-done
+	_ = r.Close()
+	return out, runErr
+}

--- a/source/wctl/cmd/wctl/dhcp.go
+++ b/source/wctl/cmd/wctl/dhcp.go
@@ -1,0 +1,257 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+	wardnet "wardnet.network/go"
+)
+
+func newDHCPCmd(c *cli) *cobra.Command {
+	cmd := &cobra.Command{Use: "dhcp", Short: "Inspect and configure the DHCP server"}
+	cmd.AddCommand(
+		dhcpStatusCmd(c),
+		dhcpConfigCmd(c),
+		dhcpEnabledCmd(c, true),
+		dhcpEnabledCmd(c, false),
+		dhcpLeasesCmd(c),
+		dhcpReservationsCmd(c),
+	)
+	return cmd
+}
+
+func dhcpStatusCmd(c *cli) *cobra.Command {
+	return &cobra.Command{
+		Use:   "status",
+		Short: "Show DHCP server state and pool usage",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			client, err := c.client()
+			if err != nil {
+				return err
+			}
+			st, err := client.DHCP.Status(cmd.Context())
+			if err != nil {
+				return err
+			}
+			if c.jsonOut {
+				return printJSON(st)
+			}
+			fmt.Printf("enabled:       %t\n", st.Enabled)
+			fmt.Printf("running:       %t\n", st.Running)
+			fmt.Printf("active leases: %d\n", st.ActiveLeaseCount)
+			fmt.Printf("pool:          %d / %d addresses used\n", st.PoolUsed, st.PoolTotal)
+			return nil
+		},
+	}
+}
+
+func dhcpConfigCmd(c *cli) *cobra.Command {
+	return &cobra.Command{
+		Use:   "config",
+		Short: "Show the DHCP pool configuration",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			client, err := c.client()
+			if err != nil {
+				return err
+			}
+			cfg, err := client.DHCP.Config(cmd.Context())
+			if err != nil {
+				return err
+			}
+			if c.jsonOut {
+				return printJSON(cfg)
+			}
+			fmt.Printf("enabled:        %t\n", cfg.Enabled)
+			fmt.Printf("gateway:        %s\n", cfg.GatewayIP)
+			fmt.Printf("router:         %s\n", orDash(cfg.RouterIP))
+			fmt.Printf("pool:           %s - %s\n", cfg.PoolStart, cfg.PoolEnd)
+			fmt.Printf("subnet mask:    %s\n", cfg.SubnetMask)
+			fmt.Printf("upstream dns:   %s\n", orDash(strings.Join(cfg.UpstreamDNS, ", ")))
+			fmt.Printf("lease duration: %s\n", humanDuration(int64(cfg.LeaseDurationSecs)))
+			return nil
+		},
+	}
+}
+
+func dhcpEnabledCmd(c *cli, enabled bool) *cobra.Command {
+	use, short := "enable", "Start the DHCP server"
+	if !enabled {
+		use, short = "disable", "Stop the DHCP server"
+	}
+	return &cobra.Command{
+		Use:   use,
+		Short: short,
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			client, err := c.client()
+			if err != nil {
+				return err
+			}
+			cfg, err := client.DHCP.SetEnabled(cmd.Context(), enabled)
+			if err != nil {
+				return err
+			}
+			if c.jsonOut {
+				return printJSON(cfg)
+			}
+			fmt.Printf("dhcp enabled: %t\n", cfg.Enabled)
+			return nil
+		},
+	}
+}
+
+func dhcpLeasesCmd(c *cli) *cobra.Command {
+	cmd := &cobra.Command{Use: "leases", Short: "Inspect DHCP leases"}
+	cmd.AddCommand(leasesListCmd(c), leasesRevokeCmd(c))
+	return cmd
+}
+
+func leasesListCmd(c *cli) *cobra.Command {
+	return &cobra.Command{
+		Use:   "list",
+		Short: "List DHCP leases",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			client, err := c.client()
+			if err != nil {
+				return err
+			}
+			leases, err := client.DHCP.Leases(cmd.Context())
+			if err != nil {
+				return err
+			}
+			if c.jsonOut {
+				return printJSON(leases)
+			}
+			if len(leases) == 0 {
+				fmt.Println("no leases")
+				return nil
+			}
+			tw := newTabWriter()
+			fmt.Fprintln(tw, "ID\tMAC\tIP\tHOSTNAME\tSTATUS\tEXPIRES")
+			for _, l := range leases {
+				fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%s\n",
+					l.ID, l.MAC, l.IP, orDash(l.Hostname), l.Status,
+					l.LeaseEnd.Format("2006-01-02T15:04:05Z07:00"))
+			}
+			return tw.Flush()
+		},
+	}
+}
+
+func leasesRevokeCmd(c *cli) *cobra.Command {
+	return &cobra.Command{
+		Use:   "revoke <id>",
+		Short: "Release a lease so its address returns to the pool",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client, err := c.client()
+			if err != nil {
+				return err
+			}
+			if err := client.DHCP.RevokeLease(cmd.Context(), args[0]); err != nil {
+				return err
+			}
+			if c.jsonOut {
+				return printJSON(map[string]any{"revoked": args[0]})
+			}
+			fmt.Printf("revoked lease %s\n", args[0])
+			return nil
+		},
+	}
+}
+
+func dhcpReservationsCmd(c *cli) *cobra.Command {
+	cmd := &cobra.Command{Use: "reservations", Short: "Manage static MAC-to-IP reservations"}
+	cmd.AddCommand(reservationsListCmd(c), reservationsAddCmd(c), reservationsRemoveCmd(c))
+	return cmd
+}
+
+func reservationsListCmd(c *cli) *cobra.Command {
+	return &cobra.Command{
+		Use:   "list",
+		Short: "List static reservations",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			client, err := c.client()
+			if err != nil {
+				return err
+			}
+			reservations, err := client.DHCP.Reservations(cmd.Context())
+			if err != nil {
+				return err
+			}
+			if c.jsonOut {
+				return printJSON(reservations)
+			}
+			if len(reservations) == 0 {
+				fmt.Println("no reservations")
+				return nil
+			}
+			tw := newTabWriter()
+			fmt.Fprintln(tw, "ID\tMAC\tIP\tHOSTNAME\tDESCRIPTION")
+			for _, r := range reservations {
+				fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\n",
+					r.ID, r.MAC, r.IP, orDash(r.Hostname), orDash(r.Description))
+			}
+			return tw.Flush()
+		},
+	}
+}
+
+func reservationsAddCmd(c *cli) *cobra.Command {
+	var hostname, description string
+	cmd := &cobra.Command{
+		Use:   "add <mac> <ip>",
+		Short: "Pin an address to a MAC",
+		Args:  cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client, err := c.client()
+			if err != nil {
+				return err
+			}
+			r, err := client.DHCP.AddReservation(cmd.Context(), wardnet.CreateReservationParams{
+				MAC:         args[0],
+				IP:          args[1],
+				Hostname:    hostname,
+				Description: description,
+			})
+			if err != nil {
+				return err
+			}
+			if c.jsonOut {
+				return printJSON(r)
+			}
+			fmt.Printf("reserved %s for %s (%s)\n", r.IP, r.MAC, r.ID)
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&hostname, "hostname", "", "hostname to hand back to the client")
+	cmd.Flags().StringVar(&description, "description", "", "note describing the reservation")
+	return cmd
+}
+
+func reservationsRemoveCmd(c *cli) *cobra.Command {
+	return &cobra.Command{
+		Use:   "remove <id>",
+		Short: "Delete a static reservation",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client, err := c.client()
+			if err != nil {
+				return err
+			}
+			if err := client.DHCP.RemoveReservation(cmd.Context(), args[0]); err != nil {
+				return err
+			}
+			if c.jsonOut {
+				return printJSON(map[string]any{"removed": args[0]})
+			}
+			fmt.Printf("removed reservation %s\n", args[0])
+			return nil
+		},
+	}
+}

--- a/source/wctl/cmd/wctl/dns.go
+++ b/source/wctl/cmd/wctl/dns.go
@@ -1,0 +1,676 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+	wardnet "wardnet.network/go"
+)
+
+// defaultFilterProfile is the builtin profile the filtering subcommands act on
+// when --profile is not given. It is the one the admin UI's Ad Blocking page
+// shows, so `wctl dns blocklists list` matches that page by default.
+const defaultFilterProfile = "Ad Blocking"
+
+// dnsCLI carries the shared global flags plus the profile selector that every
+// filtering subcommand needs.
+type dnsCLI struct {
+	*cli
+	profile string
+}
+
+func newDNSCmd(c *cli) *cobra.Command {
+	d := &dnsCLI{cli: c}
+	cmd := &cobra.Command{Use: "dns", Short: "Inspect and configure the DNS resolver"}
+	cmd.PersistentFlags().StringVar(&d.profile, "profile", defaultFilterProfile,
+		"filter profile the blocklist, allowlist, and rule subcommands act on (name or ID)")
+	cmd.AddCommand(
+		dnsStatusCmd(d),
+		dnsConfigCmd(d),
+		dnsEnabledCmd(d, true),
+		dnsEnabledCmd(d, false),
+		dnsFlushCacheCmd(d),
+		dnsProfilesCmd(d),
+		dnsBlocklistsCmd(d),
+		dnsAllowlistCmd(d),
+		dnsRulesCmd(d),
+	)
+	return cmd
+}
+
+// profileID resolves --profile to a profile UUID. The flag takes either an ID
+// or a display name, so the common case reads as `--profile "Parental
+// Controls"` rather than a UUID nobody has memorised.
+func (d *dnsCLI) profileID(ctx context.Context, client *wardnet.Client) (string, error) {
+	profiles, err := client.DNS.Profiles(ctx)
+	if err != nil {
+		return "", err
+	}
+	for _, p := range profiles {
+		if p.ID == d.profile || strings.EqualFold(p.Name, d.profile) {
+			return p.ID, nil
+		}
+	}
+	names := make([]string, 0, len(profiles))
+	for _, p := range profiles {
+		names = append(names, p.Name)
+	}
+	return "", fmt.Errorf("no filter profile matches %q (have: %s)",
+		d.profile, strings.Join(names, ", "))
+}
+
+func dnsStatusCmd(d *dnsCLI) *cobra.Command {
+	return &cobra.Command{
+		Use:   "status",
+		Short: "Show resolver state, cache occupancy, and upstream latency",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			client, err := d.client()
+			if err != nil {
+				return err
+			}
+			st, err := client.DNS.Status(cmd.Context())
+			if err != nil {
+				return err
+			}
+			if d.jsonOut {
+				return printJSON(st)
+			}
+			fmt.Printf("enabled:  %t\n", st.Enabled)
+			fmt.Printf("running:  %t\n", st.Running)
+			fmt.Printf("cache:    %d / %d entries (%.1f%% hit rate)\n",
+				st.CacheSize, st.CacheCapacity, st.CacheHitRate*100)
+			if len(st.UpstreamLatencies) == 0 {
+				return nil
+			}
+			fmt.Println("upstreams:")
+			tw := newTabWriter()
+			fmt.Fprintln(tw, "  ADDRESS\tREACHABLE\tLATENCY")
+			for _, u := range st.UpstreamLatencies {
+				latency := "-"
+				if u.AvgLatencyMs != nil {
+					latency = fmt.Sprintf("%.1f ms", *u.AvgLatencyMs)
+				}
+				fmt.Fprintf(tw, "  %s\t%t\t%s\n", u.Address, u.Reachable, latency)
+			}
+			return tw.Flush()
+		},
+	}
+}
+
+func dnsConfigCmd(d *dnsCLI) *cobra.Command {
+	return &cobra.Command{
+		Use:   "config",
+		Short: "Show the resolver configuration",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			client, err := d.client()
+			if err != nil {
+				return err
+			}
+			cfg, err := client.DNS.Config(cmd.Context())
+			if err != nil {
+				return err
+			}
+			if d.jsonOut {
+				return printJSON(cfg)
+			}
+			printDNSConfig(cfg)
+			return nil
+		},
+	}
+}
+
+func printDNSConfig(cfg *wardnet.DNSConfig) {
+	fmt.Printf("enabled:             %t\n", cfg.Enabled)
+	fmt.Printf("resolution mode:     %s\n", cfg.ResolutionMode)
+	fmt.Printf("forwarder selection: %s\n", cfg.ForwarderSelectionMode)
+	if cfg.SingleUpstream != "" {
+		fmt.Printf("single upstream:     %s\n", cfg.SingleUpstream)
+	}
+	fmt.Printf("cache:               %d entries, TTL %d-%ds\n",
+		cfg.CacheSize, cfg.CacheTTLMinSecs, cfg.CacheTTLMaxSecs)
+	fmt.Printf("dnssec:              %t\n", cfg.DNSSECEnabled)
+	fmt.Printf("rebind protection:   %t\n", cfg.RebindingProtection)
+	fmt.Printf("rate limit:          %d/s\n", cfg.RateLimitPerSecond)
+	fmt.Printf("filtering:           %t\n", cfg.FilteringEnabled)
+	fmt.Printf("query log:           %t (%d day retention)\n",
+		cfg.QueryLogEnabled, cfg.QueryLogRetentionDays)
+	if len(cfg.UpstreamServers) == 0 {
+		return
+	}
+	fmt.Println("upstreams:")
+	for _, u := range cfg.UpstreamServers {
+		line := fmt.Sprintf("  %s (%s, %s", u.Name, u.Address, u.Protocol)
+		if u.Port != 0 {
+			line += fmt.Sprintf(":%d", u.Port)
+		}
+		if u.TLSServerName != "" {
+			line += ", sni " + u.TLSServerName
+		}
+		fmt.Println(line + ")")
+	}
+}
+
+func dnsEnabledCmd(d *dnsCLI, enabled bool) *cobra.Command {
+	use, short := "enable", "Start the resolver"
+	if !enabled {
+		use, short = "disable", "Stop the resolver"
+	}
+	return &cobra.Command{
+		Use:   use,
+		Short: short,
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			client, err := d.client()
+			if err != nil {
+				return err
+			}
+			cfg, err := client.DNS.SetEnabled(cmd.Context(), enabled)
+			if err != nil {
+				return err
+			}
+			if d.jsonOut {
+				return printJSON(cfg)
+			}
+			fmt.Printf("dns enabled: %t\n", cfg.Enabled)
+			return nil
+		},
+	}
+}
+
+func dnsFlushCacheCmd(d *dnsCLI) *cobra.Command {
+	return &cobra.Command{
+		Use:   "flush-cache",
+		Short: "Empty the resolver cache",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			client, err := d.client()
+			if err != nil {
+				return err
+			}
+			cleared, err := client.DNS.FlushCache(cmd.Context())
+			if err != nil {
+				return err
+			}
+			if d.jsonOut {
+				return printJSON(map[string]any{"entries_cleared": cleared})
+			}
+			fmt.Printf("flushed %d cache entries\n", cleared)
+			return nil
+		},
+	}
+}
+
+func dnsProfilesCmd(d *dnsCLI) *cobra.Command {
+	return &cobra.Command{
+		Use:   "profiles",
+		Short: "List DNS filter profiles",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			client, err := d.client()
+			if err != nil {
+				return err
+			}
+			profiles, err := client.DNS.Profiles(cmd.Context())
+			if err != nil {
+				return err
+			}
+			if d.jsonOut {
+				return printJSON(profiles)
+			}
+			if len(profiles) == 0 {
+				fmt.Println("no profiles")
+				return nil
+			}
+			tw := newTabWriter()
+			fmt.Fprintln(tw, "ID\tNAME\tBUILTIN\tDESCRIPTION")
+			for _, p := range profiles {
+				fmt.Fprintf(tw, "%s\t%s\t%t\t%s\n", p.ID, p.Name, p.Builtin, orDash(p.Description))
+			}
+			return tw.Flush()
+		},
+	}
+}
+
+func dnsBlocklistsCmd(d *dnsCLI) *cobra.Command {
+	cmd := &cobra.Command{Use: "blocklists", Short: "Manage a profile's blocklists"}
+	cmd.AddCommand(
+		blocklistsListCmd(d),
+		blocklistsAddCmd(d),
+		blocklistsUpdateCmd(d),
+		blocklistsRemoveCmd(d),
+		blocklistsRefreshCmd(d),
+	)
+	return cmd
+}
+
+func blocklistsListCmd(d *dnsCLI) *cobra.Command {
+	return &cobra.Command{
+		Use:   "list",
+		Short: "List the profile's blocklists",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			client, err := d.client()
+			if err != nil {
+				return err
+			}
+			profileID, err := d.profileID(cmd.Context(), client)
+			if err != nil {
+				return err
+			}
+			lists, err := client.DNS.Blocklists(cmd.Context(), profileID)
+			if err != nil {
+				return err
+			}
+			if d.jsonOut {
+				return printJSON(lists)
+			}
+			if len(lists) == 0 {
+				fmt.Println("no blocklists")
+				return nil
+			}
+			tw := newTabWriter()
+			fmt.Fprintln(tw, "ID\tNAME\tENABLED\tENTRIES\tSCHEDULE\tUPDATED\tERROR")
+			for i := range lists {
+				b := &lists[i]
+				fmt.Fprintf(tw, "%s\t%s\t%t\t%d\t%s\t%s\t%s\n",
+					b.ID, b.Name, b.Enabled, b.EntryCount, b.CronSchedule,
+					timeOrDash(b.LastUpdated), orDash(b.LastError))
+			}
+			return tw.Flush()
+		},
+	}
+}
+
+func blocklistsAddCmd(d *dnsCLI) *cobra.Command {
+	var schedule string
+	var disabled bool
+	cmd := &cobra.Command{
+		Use:   "add <name> <url>",
+		Short: "Add a blocklist to the profile",
+		Args:  cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client, err := d.client()
+			if err != nil {
+				return err
+			}
+			profileID, err := d.profileID(cmd.Context(), client)
+			if err != nil {
+				return err
+			}
+			b, err := client.DNS.AddBlocklist(cmd.Context(), profileID, wardnet.CreateBlocklistParams{
+				Name:         args[0],
+				URL:          args[1],
+				CronSchedule: schedule,
+				Enabled:      !disabled,
+			})
+			if err != nil {
+				return err
+			}
+			if d.jsonOut {
+				return printJSON(b)
+			}
+			fmt.Printf("added blocklist %s (%s)\n", b.Name, b.ID)
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&schedule, "schedule", "0 3 * * *", "cron schedule for automatic refreshes")
+	cmd.Flags().BoolVar(&disabled, "disabled", false, "add the blocklist without activating it")
+	return cmd
+}
+
+func blocklistsUpdateCmd(d *dnsCLI) *cobra.Command {
+	var name, url, schedule string
+	var enabled bool
+	cmd := &cobra.Command{
+		Use:   "update <id>",
+		Short: "Change a blocklist's name, URL, schedule, or enabled state",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			// Only flags the operator actually typed are sent, so an update
+			// of one field never resets the others to their zero values.
+			var params wardnet.UpdateBlocklistParams
+			if cmd.Flags().Changed("name") {
+				params.Name = &name
+			}
+			if cmd.Flags().Changed("url") {
+				params.URL = &url
+			}
+			if cmd.Flags().Changed("schedule") {
+				params.CronSchedule = &schedule
+			}
+			if cmd.Flags().Changed("enabled") {
+				params.Enabled = &enabled
+			}
+			if params == (wardnet.UpdateBlocklistParams{}) {
+				return fmt.Errorf("nothing to update: pass at least one of --name, --url, --schedule, --enabled")
+			}
+			client, err := d.client()
+			if err != nil {
+				return err
+			}
+			profileID, err := d.profileID(cmd.Context(), client)
+			if err != nil {
+				return err
+			}
+			b, err := client.DNS.UpdateBlocklist(cmd.Context(), profileID, args[0], params)
+			if err != nil {
+				return err
+			}
+			if d.jsonOut {
+				return printJSON(b)
+			}
+			fmt.Printf("updated blocklist %s\n", b.ID)
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&name, "name", "", "new display name")
+	cmd.Flags().StringVar(&url, "url", "", "new source URL")
+	cmd.Flags().StringVar(&schedule, "schedule", "", "new cron schedule")
+	cmd.Flags().BoolVar(&enabled, "enabled", true, "whether the blocklist is applied")
+	return cmd
+}
+
+func blocklistsRemoveCmd(d *dnsCLI) *cobra.Command {
+	return &cobra.Command{
+		Use:   "remove <id>",
+		Short: "Delete a blocklist from the profile",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client, err := d.client()
+			if err != nil {
+				return err
+			}
+			profileID, err := d.profileID(cmd.Context(), client)
+			if err != nil {
+				return err
+			}
+			if err := client.DNS.RemoveBlocklist(cmd.Context(), profileID, args[0]); err != nil {
+				return err
+			}
+			if d.jsonOut {
+				return printJSON(map[string]any{"removed": args[0]})
+			}
+			fmt.Printf("removed blocklist %s\n", args[0])
+			return nil
+		},
+	}
+}
+
+func blocklistsRefreshCmd(d *dnsCLI) *cobra.Command {
+	return &cobra.Command{
+		Use:   "refresh <id>",
+		Short: "Queue an immediate re-download of a blocklist",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client, err := d.client()
+			if err != nil {
+				return err
+			}
+			profileID, err := d.profileID(cmd.Context(), client)
+			if err != nil {
+				return err
+			}
+			jobID, err := client.DNS.RefreshBlocklist(cmd.Context(), profileID, args[0])
+			if err != nil {
+				return err
+			}
+			if d.jsonOut {
+				return printJSON(map[string]any{"job_id": jobID})
+			}
+			// The download runs in the background; `blocklists list` shows
+			// the outcome once it lands.
+			fmt.Printf("refresh queued as job %s\n", jobID)
+			return nil
+		},
+	}
+}
+
+func dnsAllowlistCmd(d *dnsCLI) *cobra.Command {
+	cmd := &cobra.Command{Use: "allowlist", Short: "Manage a profile's allowlist"}
+	cmd.AddCommand(allowlistListCmd(d), allowlistAddCmd(d), allowlistRemoveCmd(d))
+	return cmd
+}
+
+func allowlistListCmd(d *dnsCLI) *cobra.Command {
+	return &cobra.Command{
+		Use:   "list",
+		Short: "List the profile's allowlist entries",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			client, err := d.client()
+			if err != nil {
+				return err
+			}
+			profileID, err := d.profileID(cmd.Context(), client)
+			if err != nil {
+				return err
+			}
+			entries, err := client.DNS.Allowlist(cmd.Context(), profileID)
+			if err != nil {
+				return err
+			}
+			if d.jsonOut {
+				return printJSON(entries)
+			}
+			if len(entries) == 0 {
+				fmt.Println("no allowlist entries")
+				return nil
+			}
+			tw := newTabWriter()
+			fmt.Fprintln(tw, "ID\tDOMAIN\tREASON")
+			for _, e := range entries {
+				fmt.Fprintf(tw, "%s\t%s\t%s\n", e.ID, e.Domain, orDash(e.Reason))
+			}
+			return tw.Flush()
+		},
+	}
+}
+
+func allowlistAddCmd(d *dnsCLI) *cobra.Command {
+	var reason string
+	cmd := &cobra.Command{
+		Use:   "add <domain>",
+		Short: "Exempt a domain from the profile's blocklists",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client, err := d.client()
+			if err != nil {
+				return err
+			}
+			profileID, err := d.profileID(cmd.Context(), client)
+			if err != nil {
+				return err
+			}
+			e, err := client.DNS.AddAllowlistEntry(cmd.Context(), profileID, args[0], reason)
+			if err != nil {
+				return err
+			}
+			if d.jsonOut {
+				return printJSON(e)
+			}
+			fmt.Printf("allowed %s (%s)\n", e.Domain, e.ID)
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&reason, "reason", "", "note explaining the exemption")
+	return cmd
+}
+
+func allowlistRemoveCmd(d *dnsCLI) *cobra.Command {
+	return &cobra.Command{
+		Use:   "remove <id>",
+		Short: "Delete an allowlist entry",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client, err := d.client()
+			if err != nil {
+				return err
+			}
+			profileID, err := d.profileID(cmd.Context(), client)
+			if err != nil {
+				return err
+			}
+			if err := client.DNS.RemoveAllowlistEntry(cmd.Context(), profileID, args[0]); err != nil {
+				return err
+			}
+			if d.jsonOut {
+				return printJSON(map[string]any{"removed": args[0]})
+			}
+			fmt.Printf("removed allowlist entry %s\n", args[0])
+			return nil
+		},
+	}
+}
+
+func dnsRulesCmd(d *dnsCLI) *cobra.Command {
+	cmd := &cobra.Command{Use: "rules", Short: "Manage a profile's custom filter rules"}
+	cmd.AddCommand(rulesListCmd(d), rulesAddCmd(d), rulesUpdateCmd(d), rulesRemoveCmd(d))
+	return cmd
+}
+
+func rulesListCmd(d *dnsCLI) *cobra.Command {
+	return &cobra.Command{
+		Use:   "list",
+		Short: "List the profile's custom rules",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			client, err := d.client()
+			if err != nil {
+				return err
+			}
+			profileID, err := d.profileID(cmd.Context(), client)
+			if err != nil {
+				return err
+			}
+			rules, err := client.DNS.Rules(cmd.Context(), profileID)
+			if err != nil {
+				return err
+			}
+			if d.jsonOut {
+				return printJSON(rules)
+			}
+			if len(rules) == 0 {
+				fmt.Println("no custom rules")
+				return nil
+			}
+			tw := newTabWriter()
+			fmt.Fprintln(tw, "ID\tENABLED\tRULE\tCOMMENT")
+			for _, r := range rules {
+				fmt.Fprintf(tw, "%s\t%t\t%s\t%s\n", r.ID, r.Enabled, r.Text, orDash(r.Comment))
+			}
+			return tw.Flush()
+		},
+	}
+}
+
+func rulesAddCmd(d *dnsCLI) *cobra.Command {
+	var comment string
+	var disabled bool
+	cmd := &cobra.Command{
+		Use:   "add <rule>",
+		Short: "Add an AdGuard-syntax rule to the profile",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client, err := d.client()
+			if err != nil {
+				return err
+			}
+			profileID, err := d.profileID(cmd.Context(), client)
+			if err != nil {
+				return err
+			}
+			r, err := client.DNS.AddRule(cmd.Context(), profileID, wardnet.CreateRuleParams{
+				Text:    args[0],
+				Comment: comment,
+				Enabled: !disabled,
+			})
+			if err != nil {
+				return err
+			}
+			if d.jsonOut {
+				return printJSON(r)
+			}
+			fmt.Printf("added rule %s\n", r.ID)
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&comment, "comment", "", "note explaining the rule")
+	cmd.Flags().BoolVar(&disabled, "disabled", false, "add the rule without activating it")
+	return cmd
+}
+
+func rulesUpdateCmd(d *dnsCLI) *cobra.Command {
+	var text, comment string
+	var enabled bool
+	cmd := &cobra.Command{
+		Use:   "update <id>",
+		Short: "Change a custom rule's text, comment, or enabled state",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			var params wardnet.UpdateRuleParams
+			if cmd.Flags().Changed("rule") {
+				params.Text = &text
+			}
+			if cmd.Flags().Changed("comment") {
+				params.Comment = &comment
+			}
+			if cmd.Flags().Changed("enabled") {
+				params.Enabled = &enabled
+			}
+			if params == (wardnet.UpdateRuleParams{}) {
+				return fmt.Errorf("nothing to update: pass at least one of --rule, --comment, --enabled")
+			}
+			client, err := d.client()
+			if err != nil {
+				return err
+			}
+			profileID, err := d.profileID(cmd.Context(), client)
+			if err != nil {
+				return err
+			}
+			r, err := client.DNS.UpdateRule(cmd.Context(), profileID, args[0], params)
+			if err != nil {
+				return err
+			}
+			if d.jsonOut {
+				return printJSON(r)
+			}
+			fmt.Printf("updated rule %s\n", r.ID)
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&text, "rule", "", "new rule text")
+	cmd.Flags().StringVar(&comment, "comment", "", "new comment")
+	cmd.Flags().BoolVar(&enabled, "enabled", true, "whether the rule is applied")
+	return cmd
+}
+
+func rulesRemoveCmd(d *dnsCLI) *cobra.Command {
+	return &cobra.Command{
+		Use:   "remove <id>",
+		Short: "Delete a custom rule",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client, err := d.client()
+			if err != nil {
+				return err
+			}
+			profileID, err := d.profileID(cmd.Context(), client)
+			if err != nil {
+				return err
+			}
+			if err := client.DNS.RemoveRule(cmd.Context(), profileID, args[0]); err != nil {
+				return err
+			}
+			if d.jsonOut {
+				return printJSON(map[string]any{"removed": args[0]})
+			}
+			fmt.Printf("removed rule %s\n", args[0])
+			return nil
+		},
+	}
+}

--- a/source/wctl/cmd/wctl/dns_test.go
+++ b/source/wctl/cmd/wctl/dns_test.go
@@ -1,0 +1,116 @@
+package main
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+const (
+	adBlockingID = "9d4b4d1c-3f4a-4a55-9f0c-6ac0d2a5b111"
+	parentalID   = "7c2b4d1c-3f4a-4a55-9f0c-6ac0d2a5b222"
+)
+
+// filterProfilesServer serves the profile list plus a blocklist collection per
+// profile, recording which profile the CLI actually asked for.
+func filterProfilesServer(t *testing.T, requested *string) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/dns/filter/profiles", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"profiles":[
+			{"id":"`+adBlockingID+`","name":"Ad Blocking","description":"Seeded ad lists",
+			 "builtin":true,"created_at":"2026-07-01T00:00:00Z","updated_at":"2026-07-01T00:00:00Z"},
+			{"id":"`+parentalID+`","name":"Parental Controls","description":null,
+			 "builtin":true,"created_at":"2026-07-01T00:00:00Z","updated_at":"2026-07-01T00:00:00Z"}]}`)
+	})
+	mux.HandleFunc("/api/dns/filter/profiles/{profileID}/blocklists",
+		func(w http.ResponseWriter, r *http.Request) {
+			*requested = r.PathValue("profileID")
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, `{"blocklists":[{
+				"id":"1f8a5a6b-2c1d-4f5e-8a9b-0c1d2e3f4a5b","profile_id":"`+*requested+`",
+				"name":"StevenBlack","url":"https://example.invalid/hosts","enabled":true,
+				"entry_count":132000,"cron_schedule":"0 3 * * *",
+				"last_updated":"2026-08-01T03:00:00Z","last_error":null,"last_error_at":null,
+				"consecutive_failures":0,"created_at":"2026-07-01T00:00:00Z",
+				"updated_at":"2026-08-01T03:00:00Z"}]}`)
+		})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func TestDNSBlocklistsListDefaultsToAdBlocking(t *testing.T) {
+	var requested string
+	srv := filterProfilesServer(t, &requested)
+
+	out, err := runCLI(t, srv.URL, "dns", "blocklists", "list")
+	if err != nil {
+		t.Fatalf("dns blocklists list: %v", err)
+	}
+	if requested != adBlockingID {
+		t.Errorf("queried profile %q, want the Ad Blocking profile %q", requested, adBlockingID)
+	}
+	if !strings.Contains(out, "StevenBlack") || !strings.Contains(out, "132000") {
+		t.Errorf("output missing blocklist row:\n%s", out)
+	}
+}
+
+func TestDNSProfileFlagAcceptsName(t *testing.T) {
+	var requested string
+	srv := filterProfilesServer(t, &requested)
+
+	if _, err := runCLI(t, srv.URL, "dns", "blocklists", "list", "--profile", "parental controls"); err != nil {
+		t.Fatalf("dns blocklists list: %v", err)
+	}
+	if requested != parentalID {
+		t.Errorf("queried profile %q, want %q", requested, parentalID)
+	}
+}
+
+func TestDNSProfileFlagAcceptsID(t *testing.T) {
+	var requested string
+	srv := filterProfilesServer(t, &requested)
+
+	if _, err := runCLI(t, srv.URL, "dns", "blocklists", "list", "--profile", parentalID); err != nil {
+		t.Fatalf("dns blocklists list: %v", err)
+	}
+	if requested != parentalID {
+		t.Errorf("queried profile %q, want %q", requested, parentalID)
+	}
+}
+
+func TestDNSUnknownProfileNamesTheAlternatives(t *testing.T) {
+	var requested string
+	srv := filterProfilesServer(t, &requested)
+
+	_, err := runCLI(t, srv.URL, "dns", "blocklists", "list", "--profile", "Nonsense")
+	if err == nil {
+		t.Fatal("unknown profile: want error")
+	}
+	if !strings.Contains(err.Error(), "Ad Blocking") {
+		t.Errorf("error %q does not list the available profiles", err)
+	}
+	if requested != "" {
+		t.Errorf("blocklists fetched for %q despite the unknown profile", requested)
+	}
+}
+
+func TestDNSBlocklistUpdateRequiresAField(t *testing.T) {
+	var requested string
+	srv := filterProfilesServer(t, &requested)
+
+	// Without this guard, cobra's flag defaults would send an update that
+	// silently renamed the blocklist to the empty string.
+	_, err := runCLI(t, srv.URL, "dns", "blocklists", "update",
+		"1f8a5a6b-2c1d-4f5e-8a9b-0c1d2e3f4a5b")
+	if err == nil {
+		t.Fatal("update with no flags: want error")
+	}
+	if !strings.Contains(err.Error(), "nothing to update") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}

--- a/source/wctl/cmd/wctl/logs.go
+++ b/source/wctl/cmd/wctl/logs.go
@@ -1,0 +1,113 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+
+	"github.com/spf13/cobra"
+	wardnet "wardnet.network/go"
+)
+
+func newLogsCmd(c *cli) *cobra.Command {
+	var follow bool
+	var filter wardnet.LogFilter
+
+	cmd := &cobra.Command{
+		Use:   "logs",
+		Short: "Show daemon logs",
+		Long: "Without --follow, the daemon's stored log file is written to stdout.\n" +
+			"With --follow, live entries are written to stderr until interrupted,\n" +
+			"leaving stdout free for whatever the surrounding script is doing.",
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if !follow && (filter.Level != "" || filter.Target != "") {
+				return fmt.Errorf("--level and --target apply to --follow only")
+			}
+			client, err := c.client()
+			if err != nil {
+				return err
+			}
+			if follow {
+				return followLogs(cmd.Context(), c, client, filter)
+			}
+			body, err := client.Logs.Download(cmd.Context())
+			if err != nil {
+				return err
+			}
+			_, err = os.Stdout.Write(body)
+			return err
+		},
+	}
+	cmd.Flags().BoolVarP(&follow, "follow", "f", false, "stream live entries until interrupted")
+	cmd.Flags().StringVar(&filter.Level, "level", "",
+		"minimum level to stream: trace, debug, info, warn, error (default: the daemon's, info)")
+	cmd.Flags().StringVar(&filter.Target, "target", "",
+		"stream only entries whose target starts with this prefix")
+	return cmd
+}
+
+// followLogs streams entries to stderr until the daemon hangs up or the
+// context is cancelled. A cancelled context is how SIGINT arrives, so it ends
+// the stream without an error.
+func followLogs(ctx context.Context, c *cli, client *wardnet.Client, filter wardnet.LogFilter) error {
+	stream, err := client.Logs.Stream(ctx, filter)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = stream.Close() }()
+
+	for {
+		ev, err := stream.Recv(ctx)
+		if err != nil {
+			if ctx.Err() != nil {
+				return nil
+			}
+			return err
+		}
+		if ev.Entry == nil {
+			fmt.Fprintf(os.Stderr, "-- %d entries dropped: this client fell behind --\n", ev.Skipped)
+			continue
+		}
+		if c.jsonOut {
+			// One object per line, so a consumer can parse the stream
+			// incrementally instead of waiting for an array to close.
+			if err := printJSONLine(os.Stderr, ev.Entry); err != nil {
+				return err
+			}
+			continue
+		}
+		fmt.Fprintln(os.Stderr, formatLogEntry(ev.Entry))
+	}
+}
+
+// formatLogEntry renders one entry as a single human-readable line, with the
+// span context and structured fields trailing the message as key=value pairs.
+func formatLogEntry(e *wardnet.LogEntry) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "%s %-5s %s: %s", e.Timestamp, e.Level, e.Target, e.Message)
+	for _, kv := range append(sortedPairs(e.Span), sortedPairs(e.Fields)...) {
+		b.WriteString(" " + kv)
+	}
+	return b.String()
+}
+
+// sortedPairs renders a field map as "key=value" pairs in a stable order, so
+// successive lines line up rather than shuffling with Go's map iteration.
+func sortedPairs(m map[string]string) []string {
+	if len(m) == 0 {
+		return nil
+	}
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	pairs := make([]string, 0, len(keys))
+	for _, k := range keys {
+		pairs = append(pairs, k+"="+m[k])
+	}
+	return pairs
+}

--- a/source/wctl/cmd/wctl/logs_test.go
+++ b/source/wctl/cmd/wctl/logs_test.go
@@ -1,0 +1,123 @@
+package main
+
+import (
+	"bufio"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/coder/websocket"
+	wardnet "wardnet.network/go"
+)
+
+func TestFormatLogEntry(t *testing.T) {
+	entry := &wardnet.LogEntry{
+		Timestamp: "2026-08-01T00:00:00.123Z",
+		Level:     "WARN",
+		Target:    "wardnetd::dns",
+		Message:   "upstream timed out",
+		Fields:    map[string]string{"upstream": "1.1.1.1", "attempt": "2"},
+		Span:      map[string]string{"request_id": "abc"},
+	}
+
+	// Span context first, then event fields, each alphabetical, so repeated
+	// lines stay aligned instead of shuffling with map iteration order.
+	want := "2026-08-01T00:00:00.123Z WARN  wardnetd::dns: upstream timed out " +
+		"request_id=abc attempt=2 upstream=1.1.1.1"
+	if got := formatLogEntry(entry); got != want {
+		t.Errorf("formatLogEntry() =\n%q\nwant\n%q", got, want)
+	}
+}
+
+func TestFormatLogEntryWithoutFields(t *testing.T) {
+	entry := &wardnet.LogEntry{
+		Timestamp: "2026-08-01T00:00:00.123Z",
+		Level:     "INFO",
+		Target:    "wardnetd",
+		Message:   "started",
+	}
+	want := "2026-08-01T00:00:00.123Z INFO  wardnetd: started"
+	if got := formatLogEntry(entry); got != want {
+		t.Errorf("formatLogEntry() = %q, want %q", got, want)
+	}
+}
+
+func TestLogsFilterFlagsRequireFollow(t *testing.T) {
+	// The filters are applied server-side on the live stream, so accepting
+	// them for a file download would silently do nothing.
+	_, err := runCLI(t, "http://127.0.0.1:1", "logs", "--level", "warn")
+	if err == nil {
+		t.Fatal("logs --level without --follow: want error")
+	}
+}
+
+// logStreamServer accepts the upgrade and pushes one entry, then blocks until
+// the client goes away — standing in for a daemon with a quiet log.
+func logStreamServer(t *testing.T, entry string) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := websocket.Accept(w, r, nil)
+		if err != nil {
+			t.Errorf("Accept: %v", err)
+			return
+		}
+		defer func() { _ = conn.CloseNow() }()
+		if err := conn.Write(r.Context(), websocket.MessageText, []byte(entry)); err != nil {
+			return
+		}
+		<-r.Context().Done()
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func TestFollowLogsWritesToStderrUntilCancelled(t *testing.T) {
+	srv := logStreamServer(t, `{"timestamp":"2026-08-01T00:00:00.123Z","level":"INFO",
+		"target":"wardnetd::dns","message":"resolver started"}`)
+
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("WARDNET_DAEMON_URL", srv.URL)
+	t.Setenv("WARDNET_TOKEN", "test-token")
+
+	c := &cli{}
+	client, err := c.client()
+	if err != nil {
+		t.Fatalf("client: %v", err)
+	}
+
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	realStderr := os.Stderr
+	os.Stderr = w
+
+	// Stand in for SIGINT: the signal reaches the command as a cancelled
+	// root context, and a requested stop must not be reported as a failure.
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	lines := make(chan string, 1)
+	go func() {
+		buf := bufio.NewReader(r)
+		line, _ := buf.ReadString('\n')
+		lines <- line
+		cancel()
+	}()
+
+	runErr := followLogs(ctx, c, client, wardnet.LogFilter{})
+
+	os.Stderr = realStderr
+	_ = w.Close()
+	_ = r.Close()
+
+	if runErr != nil {
+		t.Errorf("followLogs after cancel = %v, want nil", runErr)
+	}
+	got := <-lines
+	if !strings.Contains(got, "resolver started") {
+		t.Errorf("stderr line = %q, want the log message", got)
+	}
+}

--- a/source/wctl/cmd/wctl/main.go
+++ b/source/wctl/cmd/wctl/main.go
@@ -5,9 +5,12 @@
 package main
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os"
+	"os/signal"
+	"syscall"
 
 	"github.com/spf13/cobra"
 	wardnet "wardnet.network/go"
@@ -18,7 +21,12 @@ import (
 var version = "dev"
 
 func main() {
-	if err := rootCmd().Execute(); err != nil {
+	// Cancelling the root context on a signal is what stops `logs --follow`
+	// cleanly; every other command inherits the same interruptibility.
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	if err := rootCmd().ExecuteContext(ctx); err != nil {
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)
 		os.Exit(exitCode(err))
 	}
@@ -47,6 +55,10 @@ func rootCmd() *cobra.Command {
 		newStatusCmd(c),
 		newDevicesCmd(c),
 		newTunnelsCmd(c),
+		newDNSCmd(c),
+		newDHCPCmd(c),
+		newLogsCmd(c),
+		newSystemCmd(c),
 		newUpdateCmd(c),
 		newBackupCmd(c),
 		newSelfUpdateCmd(c),

--- a/source/wctl/cmd/wctl/output.go
+++ b/source/wctl/cmd/wctl/output.go
@@ -3,6 +3,7 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"strings"
 	"time"
 
@@ -17,6 +18,17 @@ func printJSON(v any) error {
 	}
 	fmt.Println(string(b))
 	return nil
+}
+
+// printJSONLine writes v to w as a single line of JSON. Streaming output uses
+// it so each record is complete on its own line.
+func printJSONLine(w io.Writer, v any) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+	_, err = fmt.Fprintln(w, string(b))
+	return err
 }
 
 // orDash renders s, or "-" when empty.

--- a/source/wctl/cmd/wctl/status.go
+++ b/source/wctl/cmd/wctl/status.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
+	wardnet "wardnet.network/go"
 )
 
 func newStatusCmd(c *cli) *cobra.Command {
@@ -12,28 +13,38 @@ func newStatusCmd(c *cli) *cobra.Command {
 		Short: "Show system status",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			client, err := c.client()
-			if err != nil {
-				return err
-			}
-			st, err := client.System.Status(cmd.Context())
-			if err != nil {
-				return err
-			}
-			if c.jsonOut {
-				return printJSON(st)
-			}
-			fmt.Printf("version:       %s\n", st.ReleaseVersion)
-			fmt.Printf("build:         %s\n", st.Version)
-			fmt.Printf("uptime:        %s\n", humanDuration(st.UptimeSeconds))
-			fmt.Printf("devices:       %d\n", st.DeviceCount)
-			fmt.Printf("tunnels:       %d (%d active)\n", st.TunnelCount, st.TunnelActiveCount)
-			fmt.Printf("cpu:           %.1f%%\n", st.CPUUsagePercent)
-			fmt.Printf("memory:        %s / %s\n", humanBytes(st.MemoryUsedBytes), humanBytes(st.MemoryTotalBytes))
-			fmt.Printf("disk free:     %s / %s\n", humanBytes(st.DiskFreeBytes), humanBytes(st.DiskTotalBytes))
-			fmt.Printf("database:      %s\n", humanBytes(st.DBSizeBytes))
-			fmt.Printf("last shutdown: %s (%s)\n", st.LastShutdown.State, timeOrDash(st.LastShutdown.At))
-			return nil
+			return runStatus(cmd, c)
 		},
 	}
+}
+
+// runStatus backs both `wctl status` and `wctl system status`, so the two
+// cannot drift apart.
+func runStatus(cmd *cobra.Command, c *cli) error {
+	client, err := c.client()
+	if err != nil {
+		return err
+	}
+	st, err := client.System.Status(cmd.Context())
+	if err != nil {
+		return err
+	}
+	if c.jsonOut {
+		return printJSON(st)
+	}
+	printSystemStatus(st)
+	return nil
+}
+
+func printSystemStatus(st *wardnet.SystemStatus) {
+	fmt.Printf("version:       %s\n", st.ReleaseVersion)
+	fmt.Printf("build:         %s\n", st.Version)
+	fmt.Printf("uptime:        %s\n", humanDuration(st.UptimeSeconds))
+	fmt.Printf("devices:       %d\n", st.DeviceCount)
+	fmt.Printf("tunnels:       %d (%d active)\n", st.TunnelCount, st.TunnelActiveCount)
+	fmt.Printf("cpu:           %.1f%%\n", st.CPUUsagePercent)
+	fmt.Printf("memory:        %s / %s\n", humanBytes(st.MemoryUsedBytes), humanBytes(st.MemoryTotalBytes))
+	fmt.Printf("disk free:     %s / %s\n", humanBytes(st.DiskFreeBytes), humanBytes(st.DiskTotalBytes))
+	fmt.Printf("database:      %s\n", humanBytes(st.DBSizeBytes))
+	fmt.Printf("last shutdown: %s (%s)\n", st.LastShutdown.State, timeOrDash(st.LastShutdown.At))
 }

--- a/source/wctl/cmd/wctl/system.go
+++ b/source/wctl/cmd/wctl/system.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+func newSystemCmd(c *cli) *cobra.Command {
+	cmd := &cobra.Command{Use: "system", Short: "Inspect and control the daemon"}
+	cmd.AddCommand(systemStatusCmd(c), systemErrorsCmd(c), systemRestartCmd(c))
+	return cmd
+}
+
+func systemStatusCmd(c *cli) *cobra.Command {
+	return &cobra.Command{
+		Use:   "status",
+		Short: "Show system status",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runStatus(cmd, c)
+		},
+	}
+}
+
+func systemErrorsCmd(c *cli) *cobra.Command {
+	return &cobra.Command{
+		Use:   "errors",
+		Short: "List the daemon's recent diagnostics",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			client, err := c.client()
+			if err != nil {
+				return err
+			}
+			diags, err := client.System.RecentErrors(cmd.Context())
+			if err != nil {
+				return err
+			}
+			if c.jsonOut {
+				return printJSON(diags)
+			}
+			if len(diags) == 0 {
+				fmt.Println("no recent errors")
+				return nil
+			}
+			tw := newTabWriter()
+			fmt.Fprintln(tw, "TIME\tSEVERITY\tCOMPONENT\tCODE\tMESSAGE\tHINT")
+			for _, d := range diags {
+				fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%s\n",
+					d.Timestamp.Format("2006-01-02T15:04:05Z07:00"),
+					d.Severity, d.Component, d.Code, d.Message, orDash(d.Hint))
+			}
+			return tw.Flush()
+		},
+	}
+}
+
+func systemRestartCmd(c *cli) *cobra.Command {
+	return &cobra.Command{
+		Use:   "restart",
+		Short: "Ask the daemon to exit so its supervisor restarts it",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			client, err := c.client()
+			if err != nil {
+				return err
+			}
+			if err := client.System.Restart(cmd.Context()); err != nil {
+				return err
+			}
+			if c.jsonOut {
+				return printJSON(map[string]any{"restart": "scheduled"})
+			}
+			// The daemon answers before it exits, so it is briefly
+			// unreachable after this returns.
+			fmt.Println("restart scheduled")
+			return nil
+		},
+	}
+}

--- a/source/wctl/go.mod
+++ b/source/wctl/go.mod
@@ -6,6 +6,7 @@ toolchain go1.26.5
 
 require (
 	github.com/BurntSushi/toml v1.6.0
+	github.com/coder/websocket v1.8.15
 	github.com/spf13/cobra v1.10.2
 	golang.org/x/term v0.45.0
 	wardnet.network/go v0.0.0

--- a/source/wctl/go.sum
+++ b/source/wctl/go.sum
@@ -4,6 +4,8 @@ github.com/RaveNoX/go-jsoncommentstrip v1.0.0/go.mod h1:78ihd09MekBnJnxpICcwzCMz
 github.com/apapsch/go-jsonmerge/v2 v2.0.0 h1:axGnT1gRIfimI7gJifB699GoE/oq+F2MU7Dml6nw9rQ=
 github.com/apapsch/go-jsonmerge/v2 v2.0.0/go.mod h1:lvDnEdqiQrp0O42VQGgmlKpxL1AP2+08jFMw88y4klk=
 github.com/bmatcuk/doublestar v1.1.1/go.mod h1:UD6OnuiIn0yFxxA2le/rnRU1G4RaI4UvFv1sNto9p6w=
+github.com/coder/websocket v1.8.15 h1:6B2JPeOGlpff2Uz6vOEH1Vzpi0iUz20A+lPVhPHtNUA=
+github.com/coder/websocket v1.8.15/go.mod h1:NX3SzP+inril6yawo5CQXx8+fk145lPDC6pumgx0mVg=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=


### PR DESCRIPTION
Closes #230.

Fills out the CLI so anything reachable from the admin UI is also scriptable. Every new command honours `--json`.

## `wctl logs`

- Without `--follow`, the stored log file goes to **stdout**.
- With `--follow`, live entries go to **stderr** until interrupted, leaving stdout free for the surrounding pipeline.
- `--level` / `--target` filter the live stream server-side. They're rejected without `--follow`, where they would silently do nothing.

## `wctl dns`

`status`, `config`, `enable` / `disable`, `flush-cache`, `profiles`, and CRUD for `blocklists` (incl. `refresh`), `allowlist`, and `rules`.

Filter collections are profile-scoped (`/api/dns/filter/profiles/{id}/…`), so `--profile` takes a **name or an ID** and defaults to the builtin `Ad Blocking` profile — `wctl dns blocklists list` therefore returns the same data as the Ad Blocking page, which is the issue's acceptance criterion.

## `wctl dhcp`

`status`, `config`, `enable` / `disable`, `leases list|revoke`, `reservations list|add|remove`.

## `wctl system`

`status`, `errors`, `restart`. Safe Reboot/Shutdown stay out, per the issue. `system status` shares a printer with the top-level `wctl status` so the two can't drift.

## Notes

- **Partial updates only send the flags the operator actually typed.** `blocklists update --enabled=false` would otherwise also blank the name and URL from cobra's flag defaults.
- **The root context now cancels on SIGINT/SIGTERM.** That's what ends a `--follow` stream; a requested stop returns 0 rather than an error.
- **DNS/DHCP config editing is deliberately read-only** for now. Upstream lists and pool ranges are multi-field validated payloads that don't reduce cleanly to scalar flags; the toggle, cache flush, and the filter/lease/reservation CRUD cover the scriptable surface the issue asks for.

## Go SDK

New `DNS`, `DHCP`, and `Logs` services, plus `System.RecentErrors` and `System.Restart`.

The log stream is the one endpoint the generated REST client can't serve, since it upgrades to a WebSocket — this adds `github.com/coder/websocket` (pure Go, no transitive deps) to the SDK. It dials with the client's transport but never its timeout: a deadline that suits a request would cut the stream off mid-run. Drop notices arrive on the same socket and surface as a `LogEvent` with a `Skipped` count rather than as an error, so a lagging consumer sees the gap instead of a dead stream.

`DHCPServerStatus` is named apart from the pre-existing `DHCPStatus`, which describes how one device's address is managed.

## Testing

- `make check-go` passes: OpenAPI drift gate, `go build` / `go vet` / `go test -race`, and `golangci-lint` for both modules.
- `wctl` cross-compiles for all four released targets (linux and darwin × amd64/arm64).
- New SDK tests cover the DNS/DHCP mappings (including null-flattening and omitted optionals), the log stream (entries, drop notices, the filter command, and a rejected upgrade surfacing as an `APIError`), and the system additions.
- New CLI tests cover profile resolution by name and by ID, the unknown-profile error naming the alternatives, the empty-update guard, log line formatting, and a `--follow` run that writes to stderr and exits cleanly on cancellation.

No Rust or web changes, so `check-daemon` / `check-web` were not run locally; CI covers them.