### PR TITLE
fix(daemon): make daily DB maintenance observable and restart-safe; collapse blocked-domains onto its PK

### DIFF
--- a/.agents/logging.md
+++ b/.agents/logging.md
@@ -34,6 +34,38 @@ tracing::info!("device detected: mac={mac}, ip={ip}", mac = obs.mac, ip = obs.ip
 7. `debug` level — include counts and operational details: `"flushed {count} timestamps"`.
 8. `trace` level — rarely used, for packet-level details during development.
 
+## Where a line ends up
+
+Three sinks, three different filters — a line that is "logged" is not
+necessarily a line anyone will see:
+
+| Sink | Carries |
+|---|---|
+| Rotating log file + `OTel` | everything the subscriber's `EnvFilter` admits (INFO and above by default) |
+| Admin UI live stream | the same, minus `logging.ui_suppressed_targets` |
+| stderr → journald (`journalctl -u wardnetd`) | ERROR always; WARN minus `logging.journal_suppressed_targets`; INFO **only** from `logging.journal_info_targets` |
+
+The journal is the narrow one, and it is what an operator reads on a box
+they are debugging. If you are writing the line that answers *"is this
+background job still running?"*, an `info!` is not enough on its own —
+add the module's target prefix to `journal_info_targets`
+(`wardnet-common/src/config.rs`).
+
+Keep that list to targets emitting a **bounded, countable** number of
+INFO events per day. Per-request or per-query lines belong in the log
+file; a target added here at DEBUG-adjacent volume evicts other units'
+logs from the journal.
+
+## Report the boring outcome
+
+A periodic job that only logs when something goes wrong is
+indistinguishable from one that has stopped running. Log the successful
+case too, with the numbers that let a reader tell "nothing to do" from
+"could not do anything" — see `run_vacuum` in
+`wardnetd-services/src/db_maintenance_runner.rs`, which reports pages
+reclaimed, the freelist on both sides, and why the loop stopped, every
+run, including the runs that reclaim nothing.
+
 ## Performance
 
 Tracing macros are zero-cost when the level is filtered out. The level check happens first — if disabled, no arguments are evaluated, no strings are formatted.

--- a/source/daemon/crates/wardnet-common/src/config.rs
+++ b/source/daemon/crates/wardnet-common/src/config.rs
@@ -267,6 +267,25 @@ pub struct LoggingConfig {
     /// other units' logs and burying the ~30 genuinely actionable events
     /// (routing/route-monitor/sqlx) they are supposed to make visible.
     pub journal_suppressed_targets: Vec<String>,
+    /// Tracing targets whose INFO events are mirrored to stderr (and therefore
+    /// into journald) alongside the WARN-and-above slice.
+    ///
+    /// Matched as a prefix, exactly like [`Self::journal_suppressed_targets`],
+    /// which takes precedence when a target appears in both.
+    ///
+    /// The journal slice is otherwise WARN-and-above, on the reasoning that
+    /// anything an operator has to act on is at least a warning. Periodic
+    /// housekeeping breaks that assumption: a run that reclaims nothing and a
+    /// run that never happened both emit no warning, so a healthy-looking
+    /// journal is exactly what a stalled maintenance job produces. The only
+    /// evidence that separates the two is the successful-run record — an INFO
+    /// event by every other measure.
+    ///
+    /// Membership is therefore reserved for targets that emit a bounded,
+    /// countable number of INFO events per day. The two here run once per
+    /// calendar day and log a single summary line each; anything per-request or
+    /// per-query belongs in the log file, not the journal.
+    pub journal_info_targets: Vec<String>,
 }
 
 impl Default for LoggingConfig {
@@ -299,34 +318,66 @@ impl Default for LoggingConfig {
                 "hickory_resolver".to_owned(),
                 "wardnetd::dns::pipeline".to_owned(),
             ],
+            // The daily database maintenance sequence (incremental vacuum, WAL
+            // checkpoint, `PRAGMA optimize`) and the daily query-log retention
+            // pass. Four INFO lines per day between them, and they are the only
+            // record that the housekeeping which keeps the database from
+            // growing without bound actually ran.
+            journal_info_targets: vec![
+                "wardnetd_services::db_maintenance_runner".to_owned(),
+                "wardnetd_services::dns::query_log_runner".to_owned(),
+            ],
         }
     }
+}
+
+/// Whether `target` starts with any entry in `prefixes`.
+///
+/// Empty entries are skipped: an empty prefix matches every target, so a
+/// stray `""` in either list would turn a targeted rule into a blanket one —
+/// never what a config typo means to say.
+fn has_prefix(target: &str, prefixes: &[String]) -> bool {
+    prefixes
+        .iter()
+        .any(|p| !p.is_empty() && target.starts_with(p.as_str()))
 }
 
 impl LoggingConfig {
     /// Whether an event at `level` from `target` belongs in the slice mirrored
     /// to stderr, and so into journald.
     ///
-    /// `suppressed` holds target **prefixes** (normally
-    /// [`Self::journal_suppressed_targets`]), so `hickory_resolver` also covers
-    /// `hickory_resolver::recursor::handle`. Suppression applies at WARN only —
-    /// ERROR always passes, whatever the target.
+    /// Both lists hold target **prefixes**, so `hickory_resolver` also covers
+    /// `hickory_resolver::recursor::handle`:
     ///
-    /// Level alone is not the filter, because WARN is not a dependable "an
-    /// operator should look at this" signal here — see
+    /// * `suppressed` (normally [`Self::journal_suppressed_targets`]) drops
+    ///   WARN events that would otherwise pass. ERROR always passes, whatever
+    ///   the target.
+    /// * `info_targets` (normally [`Self::journal_info_targets`]) raises INFO
+    ///   events that would otherwise be dropped, for the handful of daily
+    ///   housekeeping summaries whose *absence* is the thing worth noticing.
+    ///
+    /// `suppressed` wins when a target appears in both — a deny-list entry is
+    /// the more specific statement of intent, and the alternative silently
+    /// re-admits exactly what an operator asked to be rid of.
+    ///
+    /// Level alone is not the filter in either direction, because WARN is not a
+    /// dependable "an operator should look at this" signal here — see
     /// [`Self::journal_suppressed_targets`] for the measured breakdown.
     ///
     /// Lives here rather than next to the subscriber setup in `wardnetd`: that
     /// crate is Linux-only (it links netlink), so a predicate defined there
     /// cannot be unit-tested on a developer machine.
     #[must_use]
-    pub fn journal_allows(level: tracing::Level, target: &str, suppressed: &[String]) -> bool {
+    pub fn journal_allows(
+        level: tracing::Level,
+        target: &str,
+        suppressed: &[String],
+        info_targets: &[String],
+    ) -> bool {
         // `tracing`'s `Level` ordering runs ERROR < WARN < INFO < DEBUG <
         // TRACE, so `<=` reads as "at least this severe".
-        if level > tracing::Level::WARN {
-            return false;
-        }
-        // Suppression applies to WARN only. The list targets crates that log
+        //
+        // ERROR is unconditional. The suppression list targets crates that log
         // one WARN per failed DNS lookup; an ERROR from those same crates is a
         // different animal and rare enough to be worth seeing — across seven
         // days of production logs the daemon emitted no ERROR events at all,
@@ -334,9 +385,13 @@ impl LoggingConfig {
         if level <= tracing::Level::ERROR {
             return true;
         }
-        !suppressed
-            .iter()
-            .any(|prefix| target.starts_with(prefix.as_str()))
+        if level > tracing::Level::INFO {
+            return false;
+        }
+        if has_prefix(target, suppressed) {
+            return false;
+        }
+        level <= tracing::Level::WARN || has_prefix(target, info_targets)
     }
 
     /// Build an `EnvFilter`-compatible directive string from this config.

--- a/source/daemon/crates/wardnet-common/src/tests/config.rs
+++ b/source/daemon/crates/wardnet-common/src/tests/config.rs
@@ -344,7 +344,12 @@ fn journal_defaults() -> Vec<String> {
     LoggingConfig::default().journal_suppressed_targets
 }
 
-/// INFO and below never reach the journal — that is what the log file is for.
+fn journal_info_defaults() -> Vec<String> {
+    LoggingConfig::default().journal_info_targets
+}
+
+/// INFO and below never reach the journal from an ordinary target — that is
+/// what the log file is for.
 #[test]
 fn journal_excludes_below_warn() {
     for level in [Level::INFO, Level::DEBUG, Level::TRACE] {
@@ -352,11 +357,73 @@ fn journal_excludes_below_warn() {
             !LoggingConfig::journal_allows(
                 level,
                 "wardnetd_services::routing::service",
-                &journal_defaults()
+                &journal_defaults(),
+                &journal_info_defaults(),
             ),
             "{level} should not reach the journal"
         );
     }
+}
+
+/// The daily housekeeping summaries are the exception: their absence is the
+/// signal, and a level-only filter cannot express that. Both runners report
+/// success at INFO, so without this the journal looks the same whether the
+/// database is being maintained or has quietly stopped shrinking.
+#[test]
+fn journal_includes_daily_maintenance_summaries_at_info() {
+    for target in [
+        "wardnetd_services::db_maintenance_runner",
+        "wardnetd_services::dns::query_log_runner",
+    ] {
+        assert!(
+            LoggingConfig::journal_allows(
+                Level::INFO,
+                target,
+                &journal_defaults(),
+                &journal_info_defaults(),
+            ),
+            "{target} INFO should reach the journal"
+        );
+    }
+}
+
+/// Raising INFO is target-scoped, not level-scoped: DEBUG from the very same
+/// module stays in the log file, or a `--log-level debug` run would flood the
+/// journal.
+#[test]
+fn journal_info_targets_do_not_admit_debug() {
+    for level in [Level::DEBUG, Level::TRACE] {
+        assert!(
+            !LoggingConfig::journal_allows(
+                level,
+                "wardnetd_services::db_maintenance_runner",
+                &journal_defaults(),
+                &journal_info_defaults(),
+            ),
+            "{level} from an INFO-raised target should not reach the journal"
+        );
+    }
+}
+
+/// Suppression wins over inclusion. An operator who silences a target has said
+/// the more specific thing, and the alternative quietly re-admits exactly what
+/// they asked to be rid of.
+#[test]
+fn journal_suppression_beats_info_inclusion() {
+    let both = vec!["wardnetd_services::db_maintenance_runner".to_owned()];
+    assert!(!LoggingConfig::journal_allows(
+        Level::INFO,
+        "wardnetd_services::db_maintenance_runner",
+        &both,
+        &both,
+    ));
+    // ERROR still passes: suppression is a noise filter, never a blind spot.
+    assert!(LoggingConfig::journal_allows(
+        Level::ERROR,
+        "wardnetd_services::db_maintenance_runner",
+        &both,
+        &both,
+    ));
 }
 
 /// The events an operator acts on do reach the journal.
@@ -376,7 +443,12 @@ fn journal_includes_actionable_warnings_and_errors() {
         (Level::ERROR, "hickory_resolver::recursor::handle"),
     ] {
         assert!(
-            LoggingConfig::journal_allows(level, target, &journal_defaults()),
+            LoggingConfig::journal_allows(
+                level,
+                target,
+                &journal_defaults(),
+                &journal_info_defaults(),
+            ),
             "{level} {target} should reach the journal"
         );
     }
@@ -397,7 +469,12 @@ fn journal_suppresses_per_query_dns_noise_at_warn() {
         "wardnetd::dns::pipeline",
     ] {
         assert!(
-            !LoggingConfig::journal_allows(Level::WARN, target, &journal_defaults()),
+            !LoggingConfig::journal_allows(
+                Level::WARN,
+                target,
+                &journal_defaults(),
+                &journal_info_defaults(),
+            ),
             "{target} WARN should be suppressed"
         );
     }
@@ -411,17 +488,20 @@ fn journal_suppression_matches_on_prefix_only() {
     assert!(!LoggingConfig::journal_allows(
         Level::WARN,
         "hickory_resolver::recursor::handle",
-        &suppressed
+        &suppressed,
+        &[],
     ));
     assert!(LoggingConfig::journal_allows(
         Level::WARN,
         "wardnetd::dns::pipeline",
-        &suppressed
+        &suppressed,
+        &[],
     ));
     assert!(LoggingConfig::journal_allows(
         Level::WARN,
         "hickory_proto::op",
-        &suppressed
+        &suppressed,
+        &[],
     ));
 }
 
@@ -432,11 +512,32 @@ fn journal_empty_suppression_list_admits_all_warnings() {
     assert!(LoggingConfig::journal_allows(
         Level::WARN,
         "hickory_resolver::recursor::handle",
-        &[]
+        &[],
+        &[],
     ));
     assert!(!LoggingConfig::journal_allows(
         Level::INFO,
         "wardnetd::route_monitor",
-        &[]
+        &[],
+        &[],
+    ));
+}
+
+/// An empty prefix would match every target. A stray `""` in either list is a
+/// config typo, not a request to journal the entire log stream.
+#[test]
+fn journal_ignores_empty_prefixes() {
+    let empty_entry = vec![String::new()];
+    assert!(LoggingConfig::journal_allows(
+        Level::WARN,
+        "wardnetd::route_monitor",
+        &empty_entry,
+        &[],
+    ));
+    assert!(!LoggingConfig::journal_allows(
+        Level::INFO,
+        "wardnetd::route_monitor",
+        &[],
+        &empty_entry,
     ));
 }

--- a/source/daemon/crates/wardnet-common/src/tests/config_restore.rs
+++ b/source/daemon/crates/wardnet-common/src/tests/config_restore.rs
@@ -35,6 +35,7 @@ const RESTORABLE_KEYS: &[&str] = &[
     "logging.broadcast_capacity",
     "logging.ui_suppressed_targets",
     "logging.journal_suppressed_targets",
+    "logging.journal_info_targets",
     "network.default_policy",
     "auth.session_expiry_hours",
     "auth.remember_me_expiry_hours",

--- a/source/daemon/crates/wardnetd-data/migrations/20260811000000_dns_filter_blocked_domains_without_rowid.sql
+++ b/source/daemon/crates/wardnetd-data/migrations/20260811000000_dns_filter_blocked_domains_without_rowid.sql
@@ -1,0 +1,58 @@
+-- Collapse `dns_filter_blocked_domains` onto its primary key.
+--
+-- The table is nothing but its primary key: three columns, all three in the
+-- key, no payload. With an implicit rowid it is stored twice — once as the
+-- table btree keyed by rowid, once as `sqlite_autoindex_..._1` keyed by
+-- (domain, blocklist_id, generation) and carrying the rowid back. Measured on
+-- a live box holding 2.4M domains:
+--
+--   sqlite_autoindex_dns_filter_blocked_domains_1        320.2 MB
+--   dns_filter_blocked_domains                           155.2 MB
+--   idx_dns_filter_blocked_domains_blocklist_gen_domain  173.4 MB
+--
+-- `WITHOUT ROWID` makes the primary key the table, so the first two become one
+-- structure instead of two. Reproduced on a synthetic 400k-row copy of this
+-- exact schema: 83.8 MB against 52.9 MB, a 37% reduction, which is ~186 MB at
+-- the row count above. No query plan changes — both indexes keep the same
+-- leading columns, so the resolution read (PK, leads on `domain`) and the
+-- delete-by-generation scan (secondary index, leads on `blocklist_id`) are
+-- served exactly as before.
+--
+-- SQLite cannot convert a table in place, so it is recreated — and, following
+-- the generation migration that established the pattern, recreated EMPTY.
+-- Copying 2.4M rows across costs ~49s of blocked startup on a Pi (measured
+-- then), and migrations run before READY=1: 49s of no DNS and no DHCP with
+-- systemd's start timeout ticking. `dns_filter_blocked_domains` is a cache of
+-- remote lists, not user data — every row is reconstructible from its source
+-- URL — so the rows are dropped and each blocklist marked never-imported
+-- (`last_updated = NULL`, `entry_count = 0`), which the DNS filter runner
+-- treats as due and re-imports in the background through the batched path.
+--
+-- The cost is the same one that migration accepted and must stay visible: for
+-- a few minutes after this upgrade the blocklists are empty and therefore not
+-- enforced. The daemon reports `filters_ready = false` while any enabled list
+-- is still unimported, and the admin UI shows a warning banner until it flips.
+--
+-- Note that dropping the rows hands ~650 MB to the freelist on a box the size
+-- of the one measured. That space comes back through the daily incremental
+-- vacuum rather than immediately.
+
+DROP TABLE dns_filter_blocked_domains;
+
+CREATE TABLE dns_filter_blocked_domains (
+    domain       TEXT NOT NULL,
+    blocklist_id TEXT NOT NULL REFERENCES dns_filter_blocklists(id) ON DELETE CASCADE,
+    generation   INTEGER NOT NULL DEFAULT 0,
+    PRIMARY KEY (domain, blocklist_id, generation)
+) WITHOUT ROWID;
+
+-- Unchanged from the generation migration: the one covering index the
+-- delete-by-generation path needs, leading on `blocklist_id` where the primary
+-- key leads on `domain`.
+CREATE INDEX IF NOT EXISTS idx_dns_filter_blocked_domains_blocklist_gen_domain
+    ON dns_filter_blocked_domains(blocklist_id, generation, domain);
+
+UPDATE dns_filter_blocklists
+   SET entry_count = 0,
+       last_updated = NULL,
+       active_generation = 0;

--- a/source/daemon/crates/wardnetd-data/src/repository/maintenance.rs
+++ b/source/daemon/crates/wardnetd-data/src/repository/maintenance.rs
@@ -28,6 +28,73 @@ pub struct WalCheckpointOutcome {
     pub checkpointed_frames: i64,
 }
 
+/// Why an incremental vacuum stopped reclaiming pages.
+///
+/// A run that reclaims nothing is the normal case on a healthy database and
+/// the symptom of a stuck one, and the page count alone cannot tell them
+/// apart. This says which happened, so the daily log line an operator reads is
+/// a diagnosis rather than a number to squint at.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum VacuumStop {
+    /// The freelist reached zero — everything that could come back, did.
+    Drained,
+    /// A chunk returned no pages while the freelist was still non-empty.
+    ///
+    /// Expected transiently: `auto_vacuum=NONE` (where the pragma is a no-op),
+    /// or free pages sitting below a pointer-map page that cannot be relocated
+    /// yet. Persisting across days with a large freelist is the signature of a
+    /// database that has stopped shrinking, which is the failure this whole
+    /// outcome exists to make visible.
+    Stalled,
+    /// The per-run chunk budget ran out with pages still on the freelist. Not a
+    /// fault — the next daily run continues from here.
+    BudgetExhausted,
+}
+
+impl VacuumStop {
+    /// Stable lowercase token for structured logs.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Drained => "drained",
+            Self::Stalled => "stalled",
+            Self::BudgetExhausted => "budget_exhausted",
+        }
+    }
+}
+
+impl std::fmt::Display for VacuumStop {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// Result of one bounded incremental-vacuum run.
+///
+/// Carries the freelist on both sides of the run rather than just the pages
+/// reclaimed. The two answer different questions: `reclaimed_pages` says how
+/// much came back, `freelist_after` says how much is still owed, and only the
+/// pair distinguishes "nothing to do" from "could not do anything".
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct IncrementalVacuumOutcome {
+    /// Pages returned to the filesystem, measured as the drop in
+    /// `PRAGMA page_count` across the run.
+    pub reclaimed_pages: u64,
+    /// `PRAGMA freelist_count` before the first chunk.
+    pub freelist_before: i64,
+    /// `PRAGMA freelist_count` after the last chunk. Can exceed
+    /// `freelist_before` on a busy database — retention deletes free pages
+    /// concurrently — which is why it is reported rather than differenced.
+    pub freelist_after: i64,
+    /// `PRAGMA page_count` after the last chunk: the current size of the
+    /// database file, in pages.
+    pub page_count_after: i64,
+    /// How many chunks ran. Zero means the freelist was empty on entry.
+    pub chunks: u32,
+    /// Why the loop ended.
+    pub stop: VacuumStop,
+}
+
 /// Cross-cutting database maintenance.
 #[async_trait]
 pub trait MaintenanceRepository: Send + Sync {
@@ -38,10 +105,11 @@ pub trait MaintenanceRepository: Send + Sync {
     /// it can't monopolise the writer lock — callers fire this from
     /// background cleanup ticks and expect it to return promptly.
     ///
-    /// Returns the number of pages reclaimed, best-effort. A zero
-    /// return doesn't imply failure (it can mean the freelist was
-    /// already empty, or the file is on `auto_vacuum=NONE`).
-    async fn incremental_vacuum(&self) -> anyhow::Result<u64>;
+    /// Returns an [`IncrementalVacuumOutcome`] describing the run,
+    /// best-effort. Zero reclaimed pages doesn't imply failure — see
+    /// [`VacuumStop`] for what separates the benign cases from the one worth
+    /// acting on.
+    async fn incremental_vacuum(&self) -> anyhow::Result<IncrementalVacuumOutcome>;
 
     /// Fold the WAL into the main database and truncate the `-wal`
     /// sidecar back to zero bytes via `PRAGMA wal_checkpoint(TRUNCATE)`.
@@ -69,6 +137,21 @@ pub trait MaintenanceRepository: Send + Sync {
     /// planner works from stale `sqlite_stat1` data and can pick bad
     /// indexes as tables like `dns_query_log` grow.
     async fn optimize(&self) -> anyhow::Result<()>;
+
+    /// The UTC calendar date of the last completed daily maintenance
+    /// sequence, or `None` if it has never run on this database.
+    ///
+    /// Persisted rather than held in memory because the schedule is
+    /// "once per calendar day", and an in-process marker restarts the clock on
+    /// every daemon restart: a box that restarts before its daily rollover
+    /// never reaches one. That is not hypothetical — the daemon restarts for
+    /// its own updates, and the field database this exists to shrink had
+    /// accumulated 411 MB of unreclaimed freelist.
+    async fn last_maintenance_day(&self) -> anyhow::Result<Option<chrono::NaiveDate>>;
+
+    /// Record `day` as the date of the last completed daily maintenance
+    /// sequence. See [`last_maintenance_day`](Self::last_maintenance_day).
+    async fn record_maintenance_day(&self, day: chrono::NaiveDate) -> anyhow::Result<()>;
 
     /// Cheap connectivity probe — runs `SELECT 1` against the read pool and
     /// returns `Ok(())` if the database answered. Used by the health

--- a/source/daemon/crates/wardnetd-data/src/repository/mod.rs
+++ b/source/daemon/crates/wardnetd-data/src/repository/mod.rs
@@ -40,7 +40,9 @@ pub use dns_local::{
     ZoneUpdate,
 };
 pub use inbound_wg::{InboundWgPeerRepository, InboundWgPeerRow};
-pub use maintenance::{MaintenanceRepository, WalCheckpointOutcome};
+pub use maintenance::{
+    IncrementalVacuumOutcome, MaintenanceRepository, VacuumStop, WalCheckpointOutcome,
+};
 pub use network_zone::NetworkZoneRepository;
 pub use notification::{NewNotification, NotificationRepository, StoredNotification};
 pub use private_dns::{PrivateDnsGrantRepository, PrivateDnsGrantRow};

--- a/source/daemon/crates/wardnetd-data/src/repository/sqlite/dns_filter.rs
+++ b/source/daemon/crates/wardnetd-data/src/repository/sqlite/dns_filter.rs
@@ -112,10 +112,16 @@ async fn delete_domains_in_batches(
     scope: DomainScope,
 ) -> anyhow::Result<u64> {
     let (predicate, generation) = scope.predicate();
+    // Identified by the primary key rather than by `rowid`: the table is
+    // `WITHOUT ROWID`, which is what collapsed its btree and PK autoindex into
+    // one structure, and such a table has no `rowid` to select. The row-value
+    // form is the direct equivalent — the subquery is served by the
+    // `(blocklist_id, generation, domain)` index as before, and the delete
+    // seeks the primary key.
     let sql = format!(
         "DELETE FROM dns_filter_blocked_domains \
-         WHERE rowid IN ( \
-             SELECT rowid FROM dns_filter_blocked_domains \
+         WHERE (domain, blocklist_id, generation) IN ( \
+             SELECT domain, blocklist_id, generation FROM dns_filter_blocked_domains \
              WHERE blocklist_id = ? {predicate} LIMIT ? \
          )"
     );

--- a/source/daemon/crates/wardnetd-data/src/repository/sqlite/maintenance.rs
+++ b/source/daemon/crates/wardnetd-data/src/repository/sqlite/maintenance.rs
@@ -4,7 +4,9 @@ use async_trait::async_trait;
 use sqlx::SqlitePool;
 
 use crate::db::DbPools;
-use crate::repository::maintenance::{MaintenanceRepository, WalCheckpointOutcome};
+use crate::repository::maintenance::{
+    IncrementalVacuumOutcome, MaintenanceRepository, VacuumStop, WalCheckpointOutcome,
+};
 
 /// How many pages a single `PRAGMA incremental_vacuum(N)` call is
 /// allowed to reclaim. Tuned for a Raspberry Pi: ~8 MiB at the `SQLite`
@@ -39,6 +41,14 @@ const ANALYSIS_LIMIT: u32 = 400;
 /// tick retry; `journal_size_limit` keeps the file capped meanwhile.
 const CHECKPOINT_BUSY_TIMEOUT_MS: u32 = 1_000;
 
+/// `system_config` key holding the date of the last completed daily
+/// maintenance sequence.
+const LAST_MAINTENANCE_DAY_KEY: &str = "db_maintenance_last_run_day";
+
+/// Storage format for [`LAST_MAINTENANCE_DAY_KEY`]. ISO 8601 so the value
+/// sorts and reads correctly when someone inspects the table by hand.
+const DAY_FMT: &str = "%Y-%m-%d";
+
 pub struct SqliteMaintenanceRepository {
     pools: DbPools,
 }
@@ -53,11 +63,30 @@ impl SqliteMaintenanceRepository {
     pub fn new_pools(pools: DbPools) -> Self {
         Self { pools }
     }
+
+    /// Pages currently on the freelist — space the database owns but the
+    /// filesystem has not got back.
+    ///
+    /// Read on the writer pool, like every other step of the vacuum: reading it
+    /// from a second connection would sample a different WAL snapshot than the
+    /// one the pragma is about to act on.
+    async fn freelist_count(&self) -> anyhow::Result<i64> {
+        Ok(sqlx::query_scalar("PRAGMA freelist_count")
+            .fetch_one(&self.pools.write)
+            .await?)
+    }
+
+    /// Size of the database file, in pages.
+    async fn page_count(&self) -> anyhow::Result<i64> {
+        Ok(sqlx::query_scalar("PRAGMA page_count")
+            .fetch_one(&self.pools.write)
+            .await?)
+    }
 }
 
 #[async_trait]
 impl MaintenanceRepository for SqliteMaintenanceRepository {
-    async fn incremental_vacuum(&self) -> anyhow::Result<u64> {
+    async fn incremental_vacuum(&self) -> anyhow::Result<IncrementalVacuumOutcome> {
         // `PRAGMA incremental_vacuum(N)` is a no-op on databases created with
         // `auto_vacuum=NONE`, so it is safe to call unconditionally.
         //
@@ -73,6 +102,14 @@ impl MaintenanceRepository for SqliteMaintenanceRepository {
         // returned to the filesystem, which is the thing being asked for.
         let stmt = format!("PRAGMA incremental_vacuum({INCREMENTAL_VACUUM_CHUNK_PAGES})");
         let mut reclaimed: i64 = 0;
+        let mut chunks: u32 = 0;
+
+        // Errors propagate rather than defaulting: a read that fails because
+        // the writer is busy must not be mistaken for "freelist is empty,
+        // nothing to do", which would silently skip the whole daily reclaim.
+        // The caller logs it and the next tick retries.
+        let mut free: i64 = self.freelist_count().await?;
+        let freelist_before = free;
 
         // Chunked rather than one big call: each `PRAGMA` takes and releases
         // the writer, so the DNS query log and stats flushes interleave instead
@@ -81,41 +118,42 @@ impl MaintenanceRepository for SqliteMaintenanceRepository {
         // whose freelist never reaches one chunk still has to get its pages
         // back, and `PRAGMA incremental_vacuum(N)` already reclaims only
         // `min(N, freelist)` so a partial final chunk costs nothing.
-        for _ in 0..INCREMENTAL_VACUUM_MAX_CHUNKS {
-            // Errors propagate rather than defaulting: a read that fails
-            // because the writer is busy must not be mistaken for "freelist is
-            // empty, nothing to do", which would silently skip the whole daily
-            // reclaim. The caller logs it and the next tick retries.
-            let free: i64 = sqlx::query_scalar("PRAGMA freelist_count")
-                .fetch_one(&self.pools.write)
-                .await?;
+        let stop = loop {
             if free <= 0 {
-                break;
+                break VacuumStop::Drained;
             }
-            let pages_before: i64 = sqlx::query_scalar("PRAGMA page_count")
-                .fetch_one(&self.pools.write)
-                .await?;
+            if chunks >= INCREMENTAL_VACUUM_MAX_CHUNKS {
+                break VacuumStop::BudgetExhausted;
+            }
+            let pages_before: i64 = self.page_count().await?;
 
             sqlx::query(sqlx::AssertSqlSafe(stmt.clone()))
                 .execute(&self.pools.write)
                 .await?;
+            chunks += 1;
 
-            let pages_after: i64 = sqlx::query_scalar("PRAGMA page_count")
-                .fetch_one(&self.pools.write)
-                .await?;
+            let pages_after: i64 = self.page_count().await?;
             let freed = pages_before - pages_after;
             if freed <= 0 {
                 // Nothing came back this pass: `auto_vacuum=NONE`, or every
                 // remaining free page sits below a pointer-map page that
                 // cannot be relocated yet. Stop rather than spinning the
                 // writer for the rest of the budget.
-                break;
+                break VacuumStop::Stalled;
             }
             reclaimed += freed;
             tokio::task::yield_now().await;
-        }
+            free = self.freelist_count().await?;
+        };
 
-        Ok(u64::try_from(reclaimed).unwrap_or(0))
+        Ok(IncrementalVacuumOutcome {
+            reclaimed_pages: u64::try_from(reclaimed).unwrap_or(0),
+            freelist_before,
+            freelist_after: self.freelist_count().await?,
+            page_count_after: self.page_count().await?,
+            chunks,
+            stop,
+        })
     }
 
     async fn wal_checkpoint_truncate(&self) -> anyhow::Result<WalCheckpointOutcome> {
@@ -176,6 +214,31 @@ impl MaintenanceRepository for SqliteMaintenanceRepository {
         .execute(&mut *conn)
         .await?;
         sqlx::query("PRAGMA optimize").execute(&mut *conn).await?;
+        Ok(())
+    }
+
+    async fn last_maintenance_day(&self) -> anyhow::Result<Option<chrono::NaiveDate>> {
+        let raw: Option<String> =
+            sqlx::query_scalar("SELECT value FROM system_config WHERE key = ?")
+                .bind(LAST_MAINTENANCE_DAY_KEY)
+                .fetch_optional(&self.pools.read)
+                .await?;
+        // An unparseable value reads as "never ran" rather than raising: the
+        // only consequence is one extra maintenance sequence, which then
+        // overwrites the bad value. Failing the read instead would strand the
+        // schedule on a single corrupt row forever.
+        Ok(raw.and_then(|s| chrono::NaiveDate::parse_from_str(&s, DAY_FMT).ok()))
+    }
+
+    async fn record_maintenance_day(&self, day: chrono::NaiveDate) -> anyhow::Result<()> {
+        sqlx::query(
+            "INSERT INTO system_config (key, value) VALUES (?, ?) \
+             ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+        )
+        .bind(LAST_MAINTENANCE_DAY_KEY)
+        .bind(day.format(DAY_FMT).to_string())
+        .execute(&self.pools.write)
+        .await?;
         Ok(())
     }
 

--- a/source/daemon/crates/wardnetd-data/src/repository/sqlite/tests/maintenance.rs
+++ b/source/daemon/crates/wardnetd-data/src/repository/sqlite/tests/maintenance.rs
@@ -2,8 +2,8 @@ use sqlx::SqlitePool;
 use sqlx::sqlite::{SqliteAutoVacuum, SqliteConnectOptions, SqliteJournalMode};
 use uuid::Uuid;
 
-use crate::repository::MaintenanceRepository;
 use crate::repository::sqlite::maintenance::SqliteMaintenanceRepository;
+use crate::repository::{MaintenanceRepository, VacuumStop};
 
 /// Open a temporary file-backed `SQLite` database with
 /// `auto_vacuum=INCREMENTAL`. Returns the pool and the path so the
@@ -68,10 +68,11 @@ async fn incremental_vacuum_reduces_freelist() {
     );
 
     let repo = SqliteMaintenanceRepository::new(pool.clone());
-    let reclaimed = repo.incremental_vacuum().await.unwrap();
+    let outcome = repo.incremental_vacuum().await.unwrap();
     assert!(
-        reclaimed > 0,
-        "incremental_vacuum should reclaim pages, got {reclaimed}"
+        outcome.reclaimed_pages > 0,
+        "incremental_vacuum should reclaim pages, got {}",
+        outcome.reclaimed_pages
     );
 
     let freelist_after: i64 = sqlx::query_scalar("PRAGMA freelist_count")
@@ -81,6 +82,15 @@ async fn incremental_vacuum_reduces_freelist() {
     assert!(
         freelist_after < freelist_before,
         "freelist should shrink after vacuum: before={freelist_before}, after={freelist_after}"
+    );
+    // The outcome is what the daily log line is built from, so it has to
+    // describe the run the caller just made, not a rounded version of it.
+    assert_eq!(outcome.freelist_before, freelist_before);
+    assert_eq!(outcome.freelist_after, freelist_after);
+    assert_eq!(outcome.stop, VacuumStop::Drained);
+    assert!(
+        outcome.chunks >= 1,
+        "a reclaiming run must report its chunks"
     );
 
     // Tidy up temp files.
@@ -140,12 +150,18 @@ async fn incremental_vacuum_drains_freelist_larger_than_one_chunk() {
     );
 
     let repo = SqliteMaintenanceRepository::new(pool.clone());
-    let reclaimed = repo.incremental_vacuum().await.unwrap();
+    let outcome = repo.incremental_vacuum().await.unwrap();
+    let reclaimed = outcome.reclaimed_pages;
 
     // The old fixed budget capped this at exactly 2,000.
     assert!(
         reclaimed > 2_000,
         "one call should drain past a single chunk, got {reclaimed}"
+    );
+    assert!(
+        outcome.chunks > 1,
+        "draining past one chunk must be reported as more than one chunk, got {}",
+        outcome.chunks
     );
 
     let freelist_after: i64 = sqlx::query_scalar("PRAGMA freelist_count")
@@ -229,7 +245,7 @@ async fn incremental_vacuum_makes_progress_while_the_freelist_grows() {
     });
 
     let repo = SqliteMaintenanceRepository::new(pool.clone());
-    let reclaimed = repo.incremental_vacuum().await.unwrap();
+    let reclaimed = repo.incremental_vacuum().await.unwrap().reclaimed_pages;
     let _ = churn.await;
 
     let pages_after: i64 = sqlx::query_scalar("PRAGMA page_count")
@@ -381,6 +397,86 @@ async fn ping_errors_when_pool_closed() {
         "ping must fail once the pool is closed"
     );
 
+    let _ = std::fs::remove_file(&path);
+    let _ = std::fs::remove_file(path.with_extension("db-wal"));
+    let _ = std::fs::remove_file(path.with_extension("db-shm"));
+}
+
+// ── last / record maintenance day ────────────────────────────────────────────
+
+/// Minimal `system_config` table — the migrations aren't run for these
+/// file-backed pools, and this is the only table the day marker touches.
+async fn make_config_table(pool: &SqlitePool) {
+    sqlx::query("CREATE TABLE system_config (key TEXT PRIMARY KEY, value TEXT NOT NULL)")
+        .execute(pool)
+        .await
+        .unwrap();
+}
+
+/// A database that has never run maintenance reports `None`, which the runner
+/// reads as "due now" rather than "already done today".
+#[tokio::test]
+async fn last_maintenance_day_is_none_before_any_run() {
+    let (pool, path) = make_incremental_pool().await;
+    make_config_table(&pool).await;
+    let repo = SqliteMaintenanceRepository::new(pool.clone());
+
+    assert_eq!(repo.last_maintenance_day().await.unwrap(), None);
+
+    pool.close().await;
+    let _ = std::fs::remove_file(&path);
+    let _ = std::fs::remove_file(path.with_extension("db-wal"));
+    let _ = std::fs::remove_file(path.with_extension("db-shm"));
+}
+
+/// The day survives the round trip, and re-recording overwrites rather than
+/// accumulating rows — the schedule is one marker, not a history.
+#[tokio::test]
+async fn record_maintenance_day_round_trips_and_overwrites() {
+    let (pool, path) = make_incremental_pool().await;
+    make_config_table(&pool).await;
+    let repo = SqliteMaintenanceRepository::new(pool.clone());
+
+    let first = chrono::NaiveDate::from_ymd_opt(2026, 8, 10).unwrap();
+    repo.record_maintenance_day(first).await.unwrap();
+    assert_eq!(repo.last_maintenance_day().await.unwrap(), Some(first));
+
+    let second = chrono::NaiveDate::from_ymd_opt(2026, 8, 11).unwrap();
+    repo.record_maintenance_day(second).await.unwrap();
+    assert_eq!(repo.last_maintenance_day().await.unwrap(), Some(second));
+
+    let rows: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM system_config WHERE key = 'db_maintenance_last_run_day'",
+    )
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(rows, 1, "the marker must be a single upserted row");
+
+    pool.close().await;
+    let _ = std::fs::remove_file(&path);
+    let _ = std::fs::remove_file(path.with_extension("db-wal"));
+    let _ = std::fs::remove_file(path.with_extension("db-shm"));
+}
+
+/// A value that isn't a date reads as "never ran". Raising instead would
+/// strand the schedule on one corrupt row forever; running an extra sequence
+/// costs nothing and rewrites the value.
+#[tokio::test]
+async fn last_maintenance_day_treats_an_unparseable_value_as_never_run() {
+    let (pool, path) = make_incremental_pool().await;
+    make_config_table(&pool).await;
+    sqlx::query("INSERT INTO system_config (key, value) VALUES (?, ?)")
+        .bind("db_maintenance_last_run_day")
+        .bind("not-a-date")
+        .execute(&pool)
+        .await
+        .unwrap();
+    let repo = SqliteMaintenanceRepository::new(pool.clone());
+
+    assert_eq!(repo.last_maintenance_day().await.unwrap(), None);
+
+    pool.close().await;
     let _ = std::fs::remove_file(&path);
     let _ = std::fs::remove_file(path.with_extension("db-wal"));
     let _ = std::fs::remove_file(path.with_extension("db-shm"));

--- a/source/daemon/crates/wardnetd-data/src/repository/sqlite/tests/maintenance.rs
+++ b/source/daemon/crates/wardnetd-data/src/repository/sqlite/tests/maintenance.rs
@@ -481,3 +481,24 @@ async fn last_maintenance_day_treats_an_unparseable_value_as_never_run() {
     let _ = std::fs::remove_file(path.with_extension("db-wal"));
     let _ = std::fs::remove_file(path.with_extension("db-shm"));
 }
+
+/// The `stop` tokens are a log contract, not a debug rendering: they are what
+/// an operator greps for and what a Loki query matches on, so they must stay
+/// stable and lowercase. `budget_exhausted` in particular has no cheap
+/// integration test — reaching it needs a freelist past 400,000 pages — so
+/// pinning the token here is what keeps it from drifting unnoticed.
+#[test]
+fn vacuum_stop_tokens_are_stable() {
+    assert_eq!(VacuumStop::Drained.as_str(), "drained");
+    assert_eq!(VacuumStop::Stalled.as_str(), "stalled");
+    assert_eq!(VacuumStop::BudgetExhausted.as_str(), "budget_exhausted");
+    // Display and `as_str` must agree — the log line uses one in the
+    // structured field and the other in the message text.
+    for stop in [
+        VacuumStop::Drained,
+        VacuumStop::Stalled,
+        VacuumStop::BudgetExhausted,
+    ] {
+        assert_eq!(stop.to_string(), stop.as_str());
+    }
+}

--- a/source/daemon/crates/wardnetd-data/src/repository/tests/dns_filter.rs
+++ b/source/daemon/crates/wardnetd-data/src/repository/tests/dns_filter.rs
@@ -983,3 +983,39 @@ async fn import_dedupes_and_counts_stored_rows() {
     );
     assert_eq!(repo.load_blocklist_domains(target).await.unwrap().len(), 2);
 }
+
+/// The domains table must stay `WITHOUT ROWID`.
+///
+/// It is the largest object in the database by a wide margin, and it is
+/// nothing but its primary key — so an implicit rowid stores every row twice,
+/// once in the table btree and once in the PK autoindex. Measured at 37% of
+/// the table's total footprint, ~186 MB at the 2.4M rows a threat-intel feed
+/// brings. A migration that recreates this table without the clause would
+/// hand that back silently, and it would also break
+/// `delete_domains_in_batches`, which identifies rows by the primary key
+/// precisely because there is no rowid to identify them by.
+#[tokio::test]
+async fn blocked_domains_table_is_without_rowid() {
+    let pool = test_pool().await;
+
+    let sql: String = sqlx::query_scalar(
+        "SELECT sql FROM sqlite_master WHERE type = 'table' \
+         AND name = 'dns_filter_blocked_domains'",
+    )
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert!(
+        sql.to_uppercase().contains("WITHOUT ROWID"),
+        "dns_filter_blocked_domains must be WITHOUT ROWID, got: {sql}"
+    );
+
+    // The property the batched delete depends on, stated directly.
+    let has_rowid = sqlx::query_scalar::<_, i64>("SELECT rowid FROM dns_filter_blocked_domains")
+        .fetch_optional(&pool)
+        .await;
+    assert!(
+        has_rowid.is_err(),
+        "a WITHOUT ROWID table must not expose a rowid"
+    );
+}

--- a/source/daemon/crates/wardnetd-data/src/tests/db.rs
+++ b/source/daemon/crates/wardnetd-data/src/tests/db.rs
@@ -321,8 +321,17 @@ async fn startup_vacuum_skip_line_names_the_freelist_and_threshold() {
         logs.contains("under threshold (25000); skipping VACUUM"),
         "skip line must name the freelist threshold, got: {logs}"
     );
+    // The observed count is named, not merely attached as a field. Parsed
+    // rather than compared against a literal: migrations that drop a table
+    // leave pages on the freelist of a fresh database, so the figure is an
+    // artefact of the current migration set — what matters is that the line
+    // reports it and that it is genuinely under the threshold.
+    let freelist = logs
+        .split_once("freelist (")
+        .and_then(|(_, rest)| rest.split_once(')'))
+        .and_then(|(n, _)| n.parse::<i64>().ok());
     assert!(
-        logs.contains("freelist (0)"),
+        matches!(freelist, Some(n) if n < 25_000),
         "skip line must name the observed freelist, got: {logs}"
     );
 

--- a/source/daemon/crates/wardnetd-services/src/db_maintenance_runner.rs
+++ b/source/daemon/crates/wardnetd-services/src/db_maintenance_runner.rs
@@ -190,7 +190,12 @@ pub(crate) async fn run_vacuum(maintenance: &dyn MaintenanceService, admin_ctx: 
                 freelist_after = outcome.freelist_after,
                 page_count = outcome.page_count_after,
                 chunks = outcome.chunks,
-                stop = outcome.stop.as_str(),
+                // Display rather than `as_str()`: the message text below
+                // renders the same value through `Display` anyway, and the two
+                // agree by construction (`Display` forwards to `as_str`), so
+                // going through it once keeps the field and the text from ever
+                // disagreeing about what `stop` was.
+                stop = %outcome.stop,
                 "incremental vacuum finished: reclaimed_pages={reclaimed_pages}, \
                  freelist_before={freelist_before}, freelist_after={freelist_after}, \
                  page_count={page_count}, chunks={chunks}, stop={stop}",

--- a/source/daemon/crates/wardnetd-services/src/db_maintenance_runner.rs
+++ b/source/daemon/crates/wardnetd-services/src/db_maintenance_runner.rs
@@ -23,7 +23,16 @@
 //!
 //! The daily cadence is enforced by checking the calendar date on every hourly
 //! tick rather than sleeping for 24 hours, so the runner stays responsive to
-//! cancellation without a 24-hour drain delay.
+//! cancellation without a 24-hour drain delay. The date of the last completed
+//! sequence lives in the database, so a restart resumes the schedule rather
+//! than restarting it.
+//!
+//! Every step reports at `info!`, including the ones with nothing to report.
+//! A daily job whose only output is "something went wrong" cannot be told apart
+//! from one that stopped running, and both look like a quiet journal — so the
+//! successful, boring case is exactly the one that has to leave a trace.
+//! `logging.journal_info_targets` carries this module so those lines reach
+//! `journalctl -u wardnetd` and not just the rotating log file.
 
 use std::sync::Arc;
 use std::time::Duration;
@@ -59,23 +68,11 @@ impl DbMaintenanceRunner {
         tick_interval: Duration,
         parent: &tracing::Span,
     ) -> Self {
-        Self::start_with_interval_and_day(maintenance, tick_interval, today(), parent)
-    }
-
-    /// Internal constructor that accepts an explicit initial day so tests can
-    /// set yesterday's date and have the first tick immediately fire a vacuum.
-    pub(crate) fn start_with_interval_and_day(
-        maintenance: Arc<dyn MaintenanceService>,
-        tick_interval: Duration,
-        initial_day: chrono::NaiveDate,
-        parent: &tracing::Span,
-    ) -> Self {
         let cancel = CancellationToken::new();
         let span = tracing::info_span!(parent: parent, "db_maintenance_runner");
 
-        let handle = tokio::spawn(
-            runner_loop(maintenance, tick_interval, cancel.clone(), initial_day).instrument(span),
-        );
+        let handle =
+            tokio::spawn(runner_loop(maintenance, tick_interval, cancel.clone()).instrument(span));
 
         Self { cancel, handle }
     }
@@ -92,7 +89,6 @@ async fn runner_loop(
     maintenance: Arc<dyn MaintenanceService>,
     tick_interval: Duration,
     cancel: CancellationToken,
-    initial_day: chrono::NaiveDate,
 ) {
     let admin_ctx = AuthContext::Admin {
         admin_id: Uuid::nil(),
@@ -102,7 +98,25 @@ async fn runner_loop(
     ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
     ticker.tick().await; // skip the immediate first tick
 
-    let mut last_vacuum_day = initial_day;
+    // Resume the schedule from the database rather than assuming this boot
+    // starts a fresh day. Seeding with "today" instead meant a daemon that
+    // restarted before its next UTC rollover — for an update, a reboot, a
+    // watchdog SIGABRT — pushed the run out another full day, indefinitely
+    // for a box that restarts daily. A read failure reads as "never ran",
+    // which costs one extra sequence and no correctness.
+    let mut last_run_day =
+        match auth_context::with_context(admin_ctx.clone(), maintenance.last_maintenance_day())
+            .await
+        {
+            Ok(day) => day,
+            Err(e) => {
+                tracing::warn!(
+                    error = %e,
+                    "could not read last maintenance day; treating as never run: {e}"
+                );
+                None
+            }
+        };
 
     loop {
         tokio::select! {
@@ -112,12 +126,31 @@ async fn runner_loop(
             }
             _ = ticker.tick() => {
                 let today_now = today();
-                if today_now != last_vacuum_day {
-                    last_vacuum_day = today_now;
+                if last_run_day != Some(today_now) {
+                    last_run_day = Some(today_now);
                     run_daily_maintenance(maintenance.as_ref(), &admin_ctx).await;
+                    record_day(maintenance.as_ref(), &admin_ctx, today_now).await;
                 }
             }
         }
+    }
+}
+
+/// Persist the day the sequence just ran on.
+///
+/// Written after the sequence, not before: a run that dies partway through
+/// leaves the date unwritten, so the next tick retries rather than counting a
+/// half-finished sequence as done. The in-memory marker is advanced either way,
+/// so a persistently failing write costs one retry per restart, not a loop.
+async fn record_day(
+    maintenance: &dyn MaintenanceService,
+    admin_ctx: &AuthContext,
+    day: chrono::NaiveDate,
+) {
+    if let Err(e) =
+        auth_context::with_context(admin_ctx.clone(), maintenance.record_maintenance_day(day)).await
+    {
+        tracing::warn!(error = %e, "failed to record maintenance day: {e}");
     }
 }
 
@@ -139,14 +172,36 @@ pub(crate) async fn run_daily_maintenance(
 pub(crate) async fn run_vacuum(maintenance: &dyn MaintenanceService, admin_ctx: &AuthContext) {
     match auth_context::with_context(admin_ctx.clone(), maintenance.run_incremental_vacuum()).await
     {
-        Ok(reclaimed) if reclaimed > 0 => {
+        Ok(outcome) => {
+            // Logged unconditionally, reclaimed pages or not. "Reclaimed 0"
+            // and "did not run" are the same silence otherwise, and they call
+            // for opposite responses: the first is a database with nothing to
+            // give back, the second is one that has quietly stopped shrinking.
+            // `stop` says which — `stalled` with a large `freelist_after` is
+            // the one to act on.
+            //
+            // Pages rather than bytes: the page size is a property of the file,
+            // not of this run, and multiplying here would bake a guess at it
+            // into every line. `freelist_after` × `page_size` is the reclaimable
+            // remainder when someone needs the figure in bytes.
             tracing::info!(
-                reclaimed_pages = reclaimed,
-                "incremental vacuum reclaimed pages: reclaimed_pages={reclaimed}",
-                reclaimed = reclaimed,
+                reclaimed_pages = outcome.reclaimed_pages,
+                freelist_before = outcome.freelist_before,
+                freelist_after = outcome.freelist_after,
+                page_count = outcome.page_count_after,
+                chunks = outcome.chunks,
+                stop = outcome.stop.as_str(),
+                "incremental vacuum finished: reclaimed_pages={reclaimed_pages}, \
+                 freelist_before={freelist_before}, freelist_after={freelist_after}, \
+                 page_count={page_count}, chunks={chunks}, stop={stop}",
+                reclaimed_pages = outcome.reclaimed_pages,
+                freelist_before = outcome.freelist_before,
+                freelist_after = outcome.freelist_after,
+                page_count = outcome.page_count_after,
+                chunks = outcome.chunks,
+                stop = outcome.stop,
             );
         }
-        Ok(_) => {}
         Err(e) => {
             tracing::warn!(error = %e, "incremental vacuum failed: {e}");
         }

--- a/source/daemon/crates/wardnetd-services/src/maintenance.rs
+++ b/source/daemon/crates/wardnetd-services/src/maintenance.rs
@@ -13,7 +13,9 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 
-use wardnetd_data::repository::{MaintenanceRepository, WalCheckpointOutcome};
+use wardnetd_data::repository::{
+    IncrementalVacuumOutcome, MaintenanceRepository, WalCheckpointOutcome,
+};
 
 use crate::auth_context;
 use crate::error::AppError;
@@ -24,8 +26,9 @@ use crate::error::AppError;
 #[async_trait]
 pub trait MaintenanceService: Send + Sync {
     /// Release free database pages back to the filesystem in a single
-    /// bounded step. Returns the number of pages reclaimed (best-effort).
-    async fn run_incremental_vacuum(&self) -> Result<u64, AppError>;
+    /// bounded step. Returns the run's outcome so the caller can log what
+    /// happened — including the case where nothing was reclaimed.
+    async fn run_incremental_vacuum(&self) -> Result<IncrementalVacuumOutcome, AppError>;
 
     /// Truncate the WAL sidecar back to ~0 via
     /// `PRAGMA wal_checkpoint(TRUNCATE)`. Returns the checkpoint outcome so
@@ -34,6 +37,14 @@ pub trait MaintenanceService: Send + Sync {
 
     /// Refresh the query planner's statistics via `PRAGMA optimize`.
     async fn run_optimize(&self) -> Result<(), AppError>;
+
+    /// The UTC calendar date the daily sequence last completed, or `None` if
+    /// it has never run. Read once at startup so a restart resumes the
+    /// schedule instead of restarting it.
+    async fn last_maintenance_day(&self) -> Result<Option<chrono::NaiveDate>, AppError>;
+
+    /// Record `day` as the date the daily sequence last completed.
+    async fn record_maintenance_day(&self, day: chrono::NaiveDate) -> Result<(), AppError>;
 }
 
 pub struct MaintenanceServiceImpl {
@@ -49,7 +60,7 @@ impl MaintenanceServiceImpl {
 
 #[async_trait]
 impl MaintenanceService for MaintenanceServiceImpl {
-    async fn run_incremental_vacuum(&self) -> Result<u64, AppError> {
+    async fn run_incremental_vacuum(&self) -> Result<IncrementalVacuumOutcome, AppError> {
         auth_context::require_admin()?;
         self.repo
             .incremental_vacuum()
@@ -68,5 +79,21 @@ impl MaintenanceService for MaintenanceServiceImpl {
     async fn run_optimize(&self) -> Result<(), AppError> {
         auth_context::require_admin()?;
         self.repo.optimize().await.map_err(AppError::Internal)
+    }
+
+    async fn last_maintenance_day(&self) -> Result<Option<chrono::NaiveDate>, AppError> {
+        auth_context::require_admin()?;
+        self.repo
+            .last_maintenance_day()
+            .await
+            .map_err(AppError::Internal)
+    }
+
+    async fn record_maintenance_day(&self, day: chrono::NaiveDate) -> Result<(), AppError> {
+        auth_context::require_admin()?;
+        self.repo
+            .record_maintenance_day(day)
+            .await
+            .map_err(AppError::Internal)
     }
 }

--- a/source/daemon/crates/wardnetd-services/src/tests/db_maintenance_runner.rs
+++ b/source/daemon/crates/wardnetd-services/src/tests/db_maintenance_runner.rs
@@ -11,12 +11,12 @@ use crate::db_maintenance_runner::{
 };
 use crate::error::AppError;
 use crate::maintenance::MaintenanceService;
-use wardnetd_data::repository::WalCheckpointOutcome;
+use wardnetd_data::repository::{IncrementalVacuumOutcome, VacuumStop, WalCheckpointOutcome};
 
 // ── Mock maintenance service ──────────────────────────────────────────────────
 
 struct MockMaintenance {
-    result: anyhow::Result<u64>,
+    result: anyhow::Result<IncrementalVacuumOutcome>,
     /// When the service is `ok`, whether the checkpoint reports `busy`
     /// (a reader blocked the truncation) rather than a clean truncate.
     checkpoint_busy: bool,
@@ -26,39 +26,56 @@ struct MockMaintenance {
     checkpoint_calls: Mutex<u32>,
     /// Calls to `run_optimize`.
     optimize_calls: Mutex<u32>,
+    /// The persisted last-run day the runner reads at startup.
+    last_day: Mutex<Option<chrono::NaiveDate>>,
+    /// Days handed to `record_maintenance_day`, in call order.
+    recorded_days: Mutex<Vec<chrono::NaiveDate>>,
+}
+
+/// An outcome that reclaimed `pages` and drained the freelist.
+fn drained(pages: u64) -> IncrementalVacuumOutcome {
+    IncrementalVacuumOutcome {
+        reclaimed_pages: pages,
+        freelist_before: i64::try_from(pages).unwrap(),
+        freelist_after: 0,
+        page_count_after: 1_000,
+        chunks: u32::from(pages > 0),
+        stop: VacuumStop::Drained,
+    }
 }
 
 impl MockMaintenance {
     fn ok(reclaimed: u64) -> Arc<Self> {
-        Arc::new(Self {
-            result: Ok(reclaimed),
-            checkpoint_busy: false,
-            calls: Mutex::new(0),
-            checkpoint_calls: Mutex::new(0),
-            optimize_calls: Mutex::new(0),
-        })
+        Self::with(Ok(drained(reclaimed)), false)
     }
 
     /// Like [`ok`](Self::ok) but the checkpoint reports `busy` so the
     /// runner's reader-active log branch is exercised.
     fn ok_busy_checkpoint() -> Arc<Self> {
-        Arc::new(Self {
-            result: Ok(0),
-            checkpoint_busy: true,
-            calls: Mutex::new(0),
-            checkpoint_calls: Mutex::new(0),
-            optimize_calls: Mutex::new(0),
-        })
+        Self::with(Ok(drained(0)), true)
     }
 
     fn err() -> Arc<Self> {
+        Self::with(Err(anyhow::anyhow!("synthetic vacuum error")), false)
+    }
+
+    fn with(result: anyhow::Result<IncrementalVacuumOutcome>, checkpoint_busy: bool) -> Arc<Self> {
         Arc::new(Self {
-            result: Err(anyhow::anyhow!("synthetic vacuum error")),
-            checkpoint_busy: false,
+            result,
+            checkpoint_busy,
             calls: Mutex::new(0),
             checkpoint_calls: Mutex::new(0),
             optimize_calls: Mutex::new(0),
+            // Never run: a fresh database, so the first tick fires.
+            last_day: Mutex::new(None),
+            recorded_days: Mutex::new(Vec::new()),
         })
+    }
+
+    /// Seed the persisted last-run day, standing in for a database that has
+    /// already seen a maintenance sequence on `day`.
+    fn ran_on(self: &Arc<Self>, day: chrono::NaiveDate) {
+        *self.last_day.lock().unwrap() = Some(day);
     }
 
     fn call_count(&self) -> u32 {
@@ -72,14 +89,18 @@ impl MockMaintenance {
     fn optimize_count(&self) -> u32 {
         *self.optimize_calls.lock().unwrap()
     }
+
+    fn recorded(&self) -> Vec<chrono::NaiveDate> {
+        self.recorded_days.lock().unwrap().clone()
+    }
 }
 
 #[async_trait]
 impl MaintenanceService for MockMaintenance {
-    async fn run_incremental_vacuum(&self) -> Result<u64, AppError> {
+    async fn run_incremental_vacuum(&self) -> Result<IncrementalVacuumOutcome, AppError> {
         *self.calls.lock().unwrap() += 1;
         match &self.result {
-            Ok(n) => Ok(*n),
+            Ok(o) => Ok(*o),
             Err(e) => Err(AppError::Internal(anyhow::anyhow!("{e}"))),
         }
     }
@@ -103,6 +124,15 @@ impl MaintenanceService for MockMaintenance {
             Err(e) => Err(AppError::Internal(anyhow::anyhow!("{e}"))),
         }
     }
+
+    async fn last_maintenance_day(&self) -> Result<Option<chrono::NaiveDate>, AppError> {
+        Ok(*self.last_day.lock().unwrap())
+    }
+
+    async fn record_maintenance_day(&self, day: chrono::NaiveDate) -> Result<(), AppError> {
+        self.recorded_days.lock().unwrap().push(day);
+        Ok(())
+    }
 }
 
 fn admin_ctx() -> AuthContext {
@@ -111,7 +141,11 @@ fn admin_ctx() -> AuthContext {
     }
 }
 
-// ── run_vacuum unit tests — cover all three match arms ───────────────────────
+fn today() -> chrono::NaiveDate {
+    chrono::Utc::now().date_naive()
+}
+
+// ── run_vacuum unit tests — cover both match arms ────────────────────────────
 
 #[tokio::test]
 async fn run_vacuum_logs_when_pages_reclaimed() {
@@ -120,9 +154,31 @@ async fn run_vacuum_logs_when_pages_reclaimed() {
     assert_eq!(repo.call_count(), 1);
 }
 
+/// A run that reclaims nothing still goes through the reporting path — it is
+/// the case an operator most needs to be able to see, since it is otherwise
+/// indistinguishable from the runner not having fired at all.
 #[tokio::test]
-async fn run_vacuum_silent_when_nothing_reclaimed() {
+async fn run_vacuum_reports_when_nothing_reclaimed() {
     let repo = MockMaintenance::ok(0);
+    run_vacuum(repo.as_ref(), &admin_ctx()).await;
+    assert_eq!(repo.call_count(), 1);
+}
+
+/// A stalled run (free pages left behind that could not be relocated) takes
+/// the same reporting path; `stop` is what tells the two apart in the log.
+#[tokio::test]
+async fn run_vacuum_reports_a_stalled_run() {
+    let repo = MockMaintenance::with(
+        Ok(IncrementalVacuumOutcome {
+            reclaimed_pages: 0,
+            freelist_before: 100_300,
+            freelist_after: 100_300,
+            page_count_after: 423_555,
+            chunks: 1,
+            stop: VacuumStop::Stalled,
+        }),
+        false,
+    );
     run_vacuum(repo.as_ref(), &admin_ctx()).await;
     assert_eq!(repo.call_count(), 1);
 }
@@ -178,27 +234,25 @@ async fn run_checkpoint_warns_and_does_not_panic_on_error() {
 
 /// Starting and immediately shutting down the runner must complete without
 /// panicking. Exercises `DbMaintenanceRunner::start` → `start_with_interval`
-/// → `start_with_interval_and_day` → `shutdown`, and the cancel branch of
-/// `runner_loop`.
+/// → `shutdown`, and the cancel branch of `runner_loop`.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn runner_shuts_down_cleanly() {
     let repo = MockMaintenance::ok(0);
+    repo.ran_on(today());
     let runner = DbMaintenanceRunner::start(repo.clone(), &tracing::Span::none());
     runner.shutdown().await;
 }
 
-/// When the runner is started with yesterday's date as the initial day,
-/// the very first tick (after a short interval) crosses the day boundary
-/// and fires a vacuum.
+/// With yesterday's date persisted, the very first tick crosses the day
+/// boundary and fires the whole sequence.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn runner_fires_vacuum_on_day_rollover() {
     let repo = MockMaintenance::ok(5);
-    let yesterday = chrono::Utc::now().date_naive() - chrono::Days::new(1);
+    repo.ran_on(today() - chrono::Days::new(1));
 
-    let runner = DbMaintenanceRunner::start_with_interval_and_day(
+    let runner = DbMaintenanceRunner::start_with_interval(
         repo.clone(),
         Duration::from_millis(20),
-        yesterday,
         &tracing::Span::none(),
     );
 
@@ -223,10 +277,13 @@ async fn runner_fires_vacuum_on_day_rollover() {
     );
 }
 
-/// When the initial day is today, ticks must not fire a vacuum.
+/// A database that already ran today must not run again — this is what a
+/// restart looks like from the runner's point of view, and it is the half of
+/// the schedule that must stay idempotent.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn runner_skips_vacuum_when_same_day() {
+async fn runner_skips_vacuum_when_already_run_today() {
     let repo = MockMaintenance::ok(0);
+    repo.ran_on(today());
 
     let runner = DbMaintenanceRunner::start_with_interval(
         repo.clone(),
@@ -240,6 +297,57 @@ async fn runner_skips_vacuum_when_same_day() {
     assert_eq!(
         repo.call_count(),
         0,
-        "vacuum must not fire when the day has not rolled over"
+        "vacuum must not fire when today's sequence already ran"
+    );
+}
+
+/// The other half: a database with no record of a run must not wait for the
+/// next UTC rollover. Seeding the marker with "today" at startup was what let
+/// a box that restarts daily go indefinitely without maintenance.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn runner_fires_when_no_previous_run_is_recorded() {
+    let repo = MockMaintenance::ok(7);
+
+    let runner = DbMaintenanceRunner::start_with_interval(
+        repo.clone(),
+        Duration::from_millis(20),
+        &tracing::Span::none(),
+    );
+
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    runner.shutdown().await;
+
+    assert!(
+        repo.call_count() >= 1,
+        "expected the sequence to run when no previous run is recorded, call_count={}",
+        repo.call_count()
+    );
+}
+
+/// Having run, the runner persists the day — otherwise the next restart would
+/// run it all again, and every restart after that.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn runner_records_the_day_after_running() {
+    let repo = MockMaintenance::ok(1);
+
+    let runner = DbMaintenanceRunner::start_with_interval(
+        repo.clone(),
+        Duration::from_millis(20),
+        &tracing::Span::none(),
+    );
+
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    runner.shutdown().await;
+
+    let recorded = repo.recorded();
+    assert_eq!(
+        recorded.first().copied(),
+        Some(today()),
+        "expected today's date to be persisted, got {recorded:?}"
+    );
+    assert_eq!(
+        recorded.len(),
+        1,
+        "the sequence must run once per day, got {recorded:?}"
     );
 }

--- a/source/daemon/crates/wardnetd-services/src/tests/db_maintenance_runner.rs
+++ b/source/daemon/crates/wardnetd-services/src/tests/db_maintenance_runner.rs
@@ -30,6 +30,10 @@ struct MockMaintenance {
     last_day: Mutex<Option<chrono::NaiveDate>>,
     /// Days handed to `record_maintenance_day`, in call order.
     recorded_days: Mutex<Vec<chrono::NaiveDate>>,
+    /// Make the startup read of the last-run day fail.
+    fail_last_day: bool,
+    /// Make the post-sequence write of the day fail.
+    fail_record: bool,
 }
 
 /// An outcome that reclaimed `pages` and drained the freelist.
@@ -60,7 +64,11 @@ impl MockMaintenance {
     }
 
     fn with(result: anyhow::Result<IncrementalVacuumOutcome>, checkpoint_busy: bool) -> Arc<Self> {
-        Arc::new(Self {
+        Arc::new(Self::build(result, checkpoint_busy))
+    }
+
+    fn build(result: anyhow::Result<IncrementalVacuumOutcome>, checkpoint_busy: bool) -> Self {
+        Self {
             result,
             checkpoint_busy,
             calls: Mutex::new(0),
@@ -69,7 +77,23 @@ impl MockMaintenance {
             // Never run: a fresh database, so the first tick fires.
             last_day: Mutex::new(None),
             recorded_days: Mutex::new(Vec::new()),
-        })
+            fail_last_day: false,
+            fail_record: false,
+        }
+    }
+
+    /// A mock whose day marker cannot be read at startup.
+    fn day_read_fails() -> Arc<Self> {
+        let mut m = Self::build(Ok(drained(3)), false);
+        m.fail_last_day = true;
+        Arc::new(m)
+    }
+
+    /// A mock whose day marker cannot be written after the sequence.
+    fn day_write_fails() -> Arc<Self> {
+        let mut m = Self::build(Ok(drained(3)), false);
+        m.fail_record = true;
+        Arc::new(m)
     }
 
     /// Seed the persisted last-run day, standing in for a database that has
@@ -126,10 +150,16 @@ impl MaintenanceService for MockMaintenance {
     }
 
     async fn last_maintenance_day(&self) -> Result<Option<chrono::NaiveDate>, AppError> {
+        if self.fail_last_day {
+            return Err(AppError::Internal(anyhow::anyhow!("synthetic read error")));
+        }
         Ok(*self.last_day.lock().unwrap())
     }
 
     async fn record_maintenance_day(&self, day: chrono::NaiveDate) -> Result<(), AppError> {
+        if self.fail_record {
+            return Err(AppError::Internal(anyhow::anyhow!("synthetic write error")));
+        }
         self.recorded_days.lock().unwrap().push(day);
         Ok(())
     }
@@ -166,8 +196,15 @@ async fn run_vacuum_reports_when_nothing_reclaimed() {
 
 /// A stalled run (free pages left behind that could not be relocated) takes
 /// the same reporting path; `stop` is what tells the two apart in the log.
+///
+/// Asserted on the *rendered message*, not just the call count. This line is
+/// the whole point of the change — it is what an operator greps for, and the
+/// numbers have to survive into the text per `.agents/logging.md`, not sit
+/// only in the structured fields. The figures are the ones from the field
+/// report: a freelist of 100,300 pages that would not come back.
 #[tokio::test]
 async fn run_vacuum_reports_a_stalled_run() {
+    let capture = wardnet_test_support::capture_logs(tracing::Level::INFO);
     let repo = MockMaintenance::with(
         Ok(IncrementalVacuumOutcome {
             reclaimed_pages: 0,
@@ -181,6 +218,36 @@ async fn run_vacuum_reports_a_stalled_run() {
     );
     run_vacuum(repo.as_ref(), &admin_ctx()).await;
     assert_eq!(repo.call_count(), 1);
+
+    let logs = capture.contents();
+    for fragment in [
+        "reclaimed_pages=0",
+        "freelist_before=100300",
+        "freelist_after=100300",
+        "page_count=423555",
+        "chunks=1",
+        "stop=stalled",
+    ] {
+        assert!(
+            logs.contains(fragment),
+            "vacuum line must name {fragment}, got: {logs}"
+        );
+    }
+}
+
+/// The healthy end state reads differently from the stuck one — same line,
+/// same fields, `stop=drained` and a freelist back at zero.
+#[tokio::test]
+async fn run_vacuum_reports_a_drained_run() {
+    let capture = wardnet_test_support::capture_logs(tracing::Level::INFO);
+    let repo = MockMaintenance::ok(2_500);
+    run_vacuum(repo.as_ref(), &admin_ctx()).await;
+
+    let logs = capture.contents();
+    assert!(
+        logs.contains("reclaimed_pages=2500") && logs.contains("stop=drained"),
+        "drained line must name the pages and the stop reason, got: {logs}"
+    );
 }
 
 #[tokio::test]
@@ -349,5 +416,59 @@ async fn runner_records_the_day_after_running() {
         recorded.len(),
         1,
         "the sequence must run once per day, got {recorded:?}"
+    );
+}
+
+/// A day marker that cannot be read must not silently disable the schedule.
+/// Treating the read failure as "already ran today" would reproduce exactly
+/// the bug the marker exists to fix, only harder to see.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn runner_runs_when_the_recorded_day_cannot_be_read() {
+    let repo = MockMaintenance::day_read_fails();
+
+    let runner = DbMaintenanceRunner::start_with_interval(
+        repo.clone(),
+        Duration::from_millis(20),
+        &tracing::Span::none(),
+    );
+
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    runner.shutdown().await;
+
+    assert!(
+        repo.call_count() >= 1,
+        "an unreadable day marker must fall back to running, call_count={}",
+        repo.call_count()
+    );
+}
+
+/// A day marker that cannot be written is logged and dropped — the sequence
+/// already ran, and the in-memory marker still holds it off for the rest of
+/// the day, so a failing write costs one retry per restart rather than a loop.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn runner_survives_a_failed_day_record() {
+    let repo = MockMaintenance::day_write_fails();
+
+    let runner = DbMaintenanceRunner::start_with_interval(
+        repo.clone(),
+        Duration::from_millis(20),
+        &tracing::Span::none(),
+    );
+
+    // Several ticks: a failed write must not make the runner re-run the
+    // sequence on every one of them.
+    tokio::time::sleep(Duration::from_millis(120)).await;
+    runner.shutdown().await;
+
+    assert_eq!(
+        repo.call_count(),
+        1,
+        "the sequence must still run once per day when the marker write fails, call_count={}",
+        repo.call_count()
+    );
+    assert!(
+        repo.recorded().is_empty(),
+        "a failed write records nothing, got {:?}",
+        repo.recorded()
     );
 }

--- a/source/daemon/crates/wardnetd-services/src/tests/health_checks.rs
+++ b/source/daemon/crates/wardnetd-services/src/tests/health_checks.rs
@@ -340,7 +340,9 @@ struct MockMaintenanceRepo {
 
 #[async_trait]
 impl wardnetd_data::repository::MaintenanceRepository for MockMaintenanceRepo {
-    async fn incremental_vacuum(&self) -> anyhow::Result<u64> {
+    async fn incremental_vacuum(
+        &self,
+    ) -> anyhow::Result<wardnetd_data::repository::IncrementalVacuumOutcome> {
         unimplemented!()
     }
     async fn wal_checkpoint_truncate(
@@ -349,6 +351,12 @@ impl wardnetd_data::repository::MaintenanceRepository for MockMaintenanceRepo {
         unimplemented!()
     }
     async fn optimize(&self) -> anyhow::Result<()> {
+        unimplemented!()
+    }
+    async fn last_maintenance_day(&self) -> anyhow::Result<Option<chrono::NaiveDate>> {
+        unimplemented!()
+    }
+    async fn record_maintenance_day(&self, _day: chrono::NaiveDate) -> anyhow::Result<()> {
         unimplemented!()
     }
     async fn ping(&self) -> anyhow::Result<()> {

--- a/source/daemon/crates/wardnetd-services/src/tests/maintenance.rs
+++ b/source/daemon/crates/wardnetd-services/src/tests/maintenance.rs
@@ -7,7 +7,9 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use uuid::Uuid;
 use wardnet_common::auth::AuthContext;
-use wardnetd_data::repository::{MaintenanceRepository, WalCheckpointOutcome};
+use wardnetd_data::repository::{
+    IncrementalVacuumOutcome, MaintenanceRepository, VacuumStop, WalCheckpointOutcome,
+};
 
 use crate::auth_context;
 use crate::error::AppError;
@@ -16,15 +18,24 @@ use crate::maintenance::{MaintenanceService, MaintenanceServiceImpl};
 /// Mock repository whose every operation succeeds or fails on demand.
 struct MockRepo {
     fail: bool,
+    /// Days handed to `record_maintenance_day`, in call order.
+    recorded_days: std::sync::Mutex<Vec<chrono::NaiveDate>>,
 }
 
 #[async_trait]
 impl MaintenanceRepository for MockRepo {
-    async fn incremental_vacuum(&self) -> anyhow::Result<u64> {
+    async fn incremental_vacuum(&self) -> anyhow::Result<IncrementalVacuumOutcome> {
         if self.fail {
             anyhow::bail!("synthetic vacuum error")
         }
-        Ok(7)
+        Ok(IncrementalVacuumOutcome {
+            reclaimed_pages: 7,
+            freelist_before: 7,
+            freelist_after: 0,
+            page_count_after: 100,
+            chunks: 1,
+            stop: VacuumStop::Drained,
+        })
     }
 
     async fn wal_checkpoint_truncate(&self) -> anyhow::Result<WalCheckpointOutcome> {
@@ -45,13 +56,31 @@ impl MaintenanceRepository for MockRepo {
         Ok(())
     }
 
+    async fn last_maintenance_day(&self) -> anyhow::Result<Option<chrono::NaiveDate>> {
+        if self.fail {
+            anyhow::bail!("synthetic read error")
+        }
+        Ok(Some(chrono::NaiveDate::from_ymd_opt(2026, 8, 10).unwrap()))
+    }
+
+    async fn record_maintenance_day(&self, day: chrono::NaiveDate) -> anyhow::Result<()> {
+        if self.fail {
+            anyhow::bail!("synthetic write error")
+        }
+        self.recorded_days.lock().unwrap().push(day);
+        Ok(())
+    }
+
     async fn ping(&self) -> anyhow::Result<()> {
         Ok(())
     }
 }
 
 fn service(fail: bool) -> MaintenanceServiceImpl {
-    MaintenanceServiceImpl::new(Arc::new(MockRepo { fail }))
+    MaintenanceServiceImpl::new(Arc::new(MockRepo {
+        fail,
+        recorded_days: std::sync::Mutex::new(Vec::new()),
+    }))
 }
 
 fn admin_ctx() -> AuthContext {
@@ -121,13 +150,65 @@ async fn run_optimize_forbidden_without_admin() {
     assert!(matches!(err, AppError::Forbidden(_)));
 }
 
-// ── run_incremental_vacuum (pre-existing method, exercised for completeness) ──
+// ── run_incremental_vacuum ────────────────────────────────────────────
 
 #[tokio::test]
-async fn run_incremental_vacuum_returns_reclaimed_for_admin() {
+async fn run_incremental_vacuum_returns_outcome_for_admin() {
     let svc = service(false);
-    let reclaimed = auth_context::with_context(admin_ctx(), svc.run_incremental_vacuum())
+    let outcome = auth_context::with_context(admin_ctx(), svc.run_incremental_vacuum())
         .await
         .expect("admin vacuum should succeed");
-    assert_eq!(reclaimed, 7);
+    assert_eq!(outcome.reclaimed_pages, 7);
+    assert_eq!(outcome.stop, VacuumStop::Drained);
+}
+
+// ── last / record maintenance day ──────────────────────────────────────
+
+#[tokio::test]
+async fn last_maintenance_day_returns_stored_day_for_admin() {
+    let svc = service(false);
+    let day = auth_context::with_context(admin_ctx(), svc.last_maintenance_day())
+        .await
+        .expect("admin read should succeed");
+    assert_eq!(day, chrono::NaiveDate::from_ymd_opt(2026, 8, 10));
+}
+
+#[tokio::test]
+async fn last_maintenance_day_forbidden_without_admin() {
+    let svc = service(false);
+    let err = svc
+        .last_maintenance_day()
+        .await
+        .expect_err("non-admin must be forbidden");
+    assert!(matches!(err, AppError::Forbidden(_)));
+}
+
+#[tokio::test]
+async fn record_maintenance_day_succeeds_for_admin() {
+    let svc = service(false);
+    let day = chrono::NaiveDate::from_ymd_opt(2026, 8, 11).unwrap();
+    auth_context::with_context(admin_ctx(), svc.record_maintenance_day(day))
+        .await
+        .expect("admin write should succeed");
+}
+
+#[tokio::test]
+async fn record_maintenance_day_maps_repo_error_to_internal() {
+    let svc = service(true);
+    let day = chrono::NaiveDate::from_ymd_opt(2026, 8, 11).unwrap();
+    let err = auth_context::with_context(admin_ctx(), svc.record_maintenance_day(day))
+        .await
+        .expect_err("repo failure should surface");
+    assert!(matches!(err, AppError::Internal(_)));
+}
+
+#[tokio::test]
+async fn record_maintenance_day_forbidden_without_admin() {
+    let svc = service(false);
+    let day = chrono::NaiveDate::from_ymd_opt(2026, 8, 11).unwrap();
+    let err = svc
+        .record_maintenance_day(day)
+        .await
+        .expect_err("non-admin must be forbidden");
+    assert!(matches!(err, AppError::Forbidden(_)));
 }

--- a/source/daemon/crates/wardnetd/src/main.rs
+++ b/source/daemon/crates/wardnetd/src/main.rs
@@ -1636,21 +1636,31 @@ fn init_tracing(
         // only systemd's own start/stop lines, and every daemon-side problem is
         // invisible unless someone knows to read the rotating file.
         //
-        // Level alone is not the filter. WARN is not a reliable "an operator
-        // should look at this" signal here: on a live gateway 97% of WARN+
-        // events are one-per-failed-lookup noise from the DNS recursor, so a
-        // plain `LevelFilter::WARN` would push ~30k lines/day into the journal
-        // and bury the ~30 that matter. `journal_suppressed_targets` carries
-        // the exclusions; see its doc comment for the measurements.
+        // Level alone is not the filter, in either direction. WARN is not a
+        // reliable "an operator should look at this" signal here: on a live
+        // gateway 97% of WARN+ events are one-per-failed-lookup noise from the
+        // DNS recursor, so a plain `LevelFilter::WARN` would push ~30k lines/day
+        // into the journal and bury the ~30 that matter. Nor is it a reliable
+        // "nothing to see here" signal: the daily maintenance sequence reports
+        // success at INFO, so a journal filtered on level alone looks identical
+        // whether that sequence ran or silently stopped running.
+        // `journal_suppressed_targets` carries the exclusions and
+        // `journal_info_targets` the inclusions; see their doc comments.
         //
         // ANSI off: journald stores the bytes verbatim, and escape codes make
         // `journalctl` output and log greps unreadable.
         let journal_suppressed = config.logging.journal_suppressed_targets.clone();
+        let journal_info = config.logging.journal_info_targets.clone();
         let stderr_layer = tracing_subscriber::fmt::layer()
             .with_writer(std::io::stderr)
             .with_ansi(false)
             .with_filter(FilterFn::new(move |meta| {
-                LoggingConfig::journal_allows(*meta.level(), meta.target(), &journal_suppressed)
+                LoggingConfig::journal_allows(
+                    *meta.level(),
+                    meta.target(),
+                    &journal_suppressed,
+                    &journal_info,
+                )
             }));
         registry.with(file_layer).with(stderr_layer).init();
     }


### PR DESCRIPTION
Closes #1182.

Problems 1 and 2 from the issue. Problem 3 turned out to be a "no change" answer — the audit is below. The blocklist URL is untouched, see the last section.

## Problem 1 — the maintenance job is unobservable

Three separate reasons the box could show nothing, all fixed.

**The journal never carried the lines.** The stderr slice mirrored into journald is WARN-and-above minus `journal_suppressed_targets`; the maintenance runner reports at `info!`. The lines existed, in the rotating log file, where nobody was looking. New `logging.journal_info_targets` raises INFO from named target prefixes into the journal slice, defaulting to the two daily runners — the maintenance sequence and query-log retention, four lines a day between them. Suppression still wins where the two lists overlap, so silencing a target stays a deny. ERROR is unconditional as before.

**A run that reclaimed nothing said nothing.** `run_vacuum` only logged on `reclaimed > 0`, so "ran, nothing to give back" and "did not run" were the same silence — and they call for opposite responses. `incremental_vacuum` now returns an outcome (pages reclaimed, freelist before and after, page count, chunks, and why the loop ended) and the runner logs it every run:

```
incremental vacuum finished: reclaimed_pages=0, freelist_before=100300,
  freelist_after=100300, page_count=423555, chunks=1, stop=stalled
```

`stop` is `drained` / `stalled` / `budget_exhausted`, which is exactly the "is it breaking early at the `freed <= 0` guard" question the issue could not answer from outside.

**It may well not have been running.** `last_vacuum_day` was seeded to `today()` in memory at startup, so the first run could only happen at a UTC rollover the process lived through. A daemon that restarts before its next rollover — an update, a reboot, a watchdog SIGABRT — pushed the run out another full day, every time. For a box that restarts daily that is never, which fits a freelist that grew to 411 MB while the budget was nowhere near the constraint. The date now lives in `system_config` and is read at startup, so a restart resumes the schedule instead of restarting it. It is written after the sequence, so a run that dies partway through is retried rather than counted as done.

## Problem 2 — two full copies of the key

`dns_filter_blocked_domains` is three columns, all three in the primary key, no payload. With an implicit rowid SQLite stores every row twice: the table btree keyed by rowid, plus `sqlite_autoindex_..._1` keyed by the PK and carrying the rowid back.

Measured on a synthetic 400k-row copy of this exact schema before committing to it:

| | size | |
|---|---|---|
| rowid | 83.8 MB | |
| `WITHOUT ROWID` | 52.9 MB | −36.9% |

That is ~186 MB at the 2.4M rows in the report, a bit better than the ~155 MB estimate. No query plan changes — both indexes keep the same leading columns, so the resolution read still seeks the PK on `domain` and the delete-by-generation scan still uses the secondary index on `blocklist_id`.

A `WITHOUT ROWID` table has no rowid, so `delete_domains_in_batches` now identifies rows by the primary key with the row-value `IN` form. Confirmed the same two access paths: the subquery on the covering index, the delete seeking the PK. A test pins the clause, since a future migration that recreated this table without it would hand the space back silently *and* break that delete.

**Migration cost, stated plainly.** The table is recreated empty rather than copied, following the generation migration that established the pattern: copying 2.4M rows costs ~49s of blocked startup on a Pi, and migrations run before `READY=1`. The rows are a cache of remote lists, so each blocklist is marked never-imported and refilled in the background. Same accepted cost as last time — a few minutes of unenforced blocklists after the upgrade, with `filters_ready = false` and the banner up meanwhile. Dropping the rows also hands ~650 MB to the freelist, which comes back through the daily vacuum rather than immediately.

## Problem 3 — the query-log index audit: no change, and why

I checked each of the five against the only four statements that touch `dns_query_log`, with `EXPLAIN QUERY PLAN` on a 200k-row copy:

| index | serves | verdict |
|---|---|---|
| `device_id` | `device_id = ?` → `SEARCH ... USING INDEX` | earns it |
| `result` | `result = ?` → `SEARCH ... USING INDEX` | earns it |
| `timestamp` | retention `DELETE ... WHERE timestamp < ?` → `SEARCH` | earns it |
| `client_ip` | `client_ip LIKE '%…%'` → `SCAN` | see below |
| `domain` | `domain LIKE '%…%'` → `SCAN` | see below |

The last two look like the obvious 116 MB to reclaim: both filters are leading-wildcard `LIKE` (the admin UI feeds them from free-text, so a partial IP has to narrow), which no index can help. But the plan for the *count* half of the pair is `SCAN ... USING COVERING INDEX`, and that is not nothing — the paginated `SELECT` stops early on `ORDER BY id DESC LIMIT 50`, so `query_log_count` is the expensive one, and dropping these turns its 42 MB / 74 MB covering scan into a 285 MB table scan. On an SD card that is seconds, on a page that currently answers in under one.

So: 116 MB of permanent disk on every box, against a multi-second stall whenever an admin types in the filter box. I do not think that trade is worth taking, and none of the five is dead weight. The query log's index-to-data ratio is intrinsic to what it is; the lever there is retention, not indexes. Happy to be overruled — it is a one-line migration either way.

## Not in scope

The dead HaGeZi URL. The backoff half already landed in `20260803000000_dns_filter_blocklist_failure_backoff.sql` and is wired into the runner, so the retry-forever behaviour is already gone. That leaves the URL itself, which I could not verify from here — worth filing separately with the corrected upstream path.

## Verification

- `make check-daemon` clean.
- Coverage holds at 88.9%, patch coverage 100% (80/80 new lines).
- New tests: the journal predicate's INFO/suppression/empty-prefix branches; the vacuum outcome fields, its rendered log line, and the stalled path; the `stop` tokens; the persisted day round-trip, overwrite, unparseable value, and never-run cases; the runner firing with no recorded run, skipping when today's already happened, recording after, and falling back when the marker cannot be read or written; the auth gates on both new service methods; the `WITHOUT ROWID` clause and the absence of a rowid.

## Re-measure after deploy

`journalctl -u wardnetd | grep -E "vacuum|checkpoint|optimize|cleanup"` should show the daily sequence within a day of the upgrade. `stop=drained` with `freelist_after` near zero is the healthy end state; `stop=stalled` with a large `freelist_after` means the pointer-map theory is right and there is a follow-up.
