### PR TITLE
fix(dns): evict the whole subtree when local DNS changes

### DIFF
--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -155,11 +155,11 @@ Authoritative answers fully short-circuit the pipeline (no cache store, no filte
 
 ### Event-driven rebuild
 
-`DnsLocalServiceImpl` publishes `WardnetEvent::DnsLocalChanged` after every mutation:
-- Zone mutations set `domain: None` — triggers a full view rebuild, no per-domain eviction.
-- Record and forwarding-rule mutations set `domain: Some(domain)` — triggers a view rebuild **and** evicts that domain from the DNS response cache.
+`DnsLocalServiceImpl` publishes `WardnetEvent::DnsLocalChanged` after every mutation. `domain` carries the **subtree the change governs** — the zone name for a zone mutation, the record or rule domain otherwise — and a mutation that moves a domain (a rename) emits twice, once for the vacated name and once for the claimed one.
 
-`DnsRunner` handles `DnsLocalChanged` by calling `DnsServer::update_authoritative_view` (atomic ArcSwap swap) and, if `domain` is `Some`, `DnsServer::invalidate_domain`.
+`DnsRunner` handles the event by calling `DnsServer::update_authoritative_view` (atomic ArcSwap swap) and `DnsServer::invalidate_subtree`.
+
+Eviction is **subtree-scoped**, not exact-name (issue #1184). Every form of local DNS applies to a whole subtree — a forwarding rule and an authoritative zone match by suffix, a wildcard record covers everything below its suffix — while the cache is consulted *before* any of them (step 1, ahead of the step-3 forward). Evicting only the exact name therefore left every already-cached subdomain resolving the old way until its TTL expired, so a new forwarding rule looked stored, enabled, and correct in the UI while doing nothing to the names that motivated it. A wildcard domain (`*.suffix`) evicts its suffix subtree; over-eviction costs one re-resolution, under-eviction costs correctness.
 
 ### Background runners call auth-gated services, never repositories
 

--- a/source/daemon/crates/wardnet-common/src/event.rs
+++ b/source/daemon/crates/wardnet-common/src/event.rs
@@ -165,11 +165,14 @@ pub enum WardnetEvent {
         timestamp: DateTime<Utc>,
     },
     /// A local DNS zone, custom record, or forwarding rule was created,
-    /// updated, or deleted. `domain` is set for record and rule mutations
-    /// (the specific domain that changed); `None` for zone mutations
-    /// (which require a view rebuild but no per-domain cache eviction).
+    /// updated, or deleted. `domain` is the subtree the change governs — the
+    /// record or rule domain, or the zone name for a zone mutation. Every
+    /// one of those is applied to the whole subtree below the name, so
+    /// subscribers evict their caches the same way (issue #1184). A mutation
+    /// that moves a domain emits twice, once for the old name and once for
+    /// the new.
     DnsLocalChanged {
-        domain: Option<String>,
+        domain: String,
         timestamp: DateTime<Utc>,
     },
     /// Private DNS state changed: the feature was enabled or disabled, or a

--- a/source/daemon/crates/wardnetd-api/src/tests/stubs.rs
+++ b/source/daemon/crates/wardnetd-api/src/tests/stubs.rs
@@ -1114,7 +1114,7 @@ impl DnsServer for StubDnsServer {
     }
     async fn update_config(&self, _config: wardnet_common::dns::DnsConfig) {}
     async fn update_authoritative_view(&self, _view: wardnetd_services::dns::AuthoritativeView) {}
-    async fn invalidate_domain(&self, _domain: &str) {}
+    async fn invalidate_subtree(&self, _domain: &str) {}
 }
 
 pub struct StubJobService;

--- a/source/daemon/crates/wardnetd-mock/src/backends/noop_dns.rs
+++ b/source/daemon/crates/wardnetd-mock/src/backends/noop_dns.rs
@@ -52,5 +52,5 @@ impl DnsServer for NoopDnsServer {
 
     async fn update_authoritative_view(&self, _view: wardnetd_services::dns::AuthoritativeView) {}
 
-    async fn invalidate_domain(&self, _domain: &str) {}
+    async fn invalidate_subtree(&self, _domain: &str) {}
 }

--- a/source/daemon/crates/wardnetd-services/src/dns/cache.rs
+++ b/source/daemon/crates/wardnetd-services/src/dns/cache.rs
@@ -199,13 +199,30 @@ impl DnsCache {
         self.compact_insertion_order();
     }
 
-    /// Remove all cache entries for `domain` across all upstream pools and
-    /// record types. Returns the number of entries removed.
-    pub fn invalidate_domain(&mut self, domain: &str) -> u64 {
-        let d = canonical_domain(domain);
+    /// Remove every cache entry at or below `domain` — the name itself plus
+    /// all of its subdomains — across all upstream pools and record types.
+    /// Returns the number of entries removed.
+    ///
+    /// The scope matches the way local DNS is *applied*: a conditional
+    /// forwarding rule, an authoritative zone, and a wildcard record each
+    /// govern a whole subtree, and the cache is consulted before any of them
+    /// is used. Evicting only the exact name would leave every already-cached
+    /// subdomain resolving the old way until its TTL expired, which for a
+    /// negative answer carrying a parent zone's SOA minimum can be hours.
+    ///
+    /// A wildcard domain (`*.example.com`) is evicted as its suffix subtree.
+    /// That also takes the apex, one name wider than the wildcard actually
+    /// covers; over-eviction costs a single re-resolution, under-eviction
+    /// costs correctness.
+    pub fn invalidate_subtree(&mut self, domain: &str) -> u64 {
+        let d = canonical_domain(domain.strip_prefix("*.").unwrap_or(domain));
         let before = self.entries.len() as u64;
-        self.entries
-            .retain(|(_, cached_domain, _), _| cached_domain != &d);
+        self.entries.retain(|(_, cached_domain, _), _| {
+            cached_domain != &d
+                && !cached_domain
+                    .strip_suffix(d.as_str())
+                    .is_some_and(|prefix| prefix.ends_with('.'))
+        });
         // A mass invalidation can orphan many queue slots at once; reclaim
         // them here rather than leaving the next insert to wade through
         // them under the hot-path write lock.

--- a/source/daemon/crates/wardnetd-services/src/dns/runner.rs
+++ b/source/daemon/crates/wardnetd-services/src/dns/runner.rs
@@ -147,15 +147,11 @@ async fn runner_loop(
                     Ok(WardnetEvent::DnsLocalChanged { domain, .. }) => {
                         let view = build_authoritative_view(&dns_local, &admin_ctx).await;
                         server.update_authoritative_view(view).await;
-                        if let Some(ref d) = domain {
-                            server.invalidate_domain(d).await;
-                            tracing::debug!(
-                                domain = %d,
-                                "rebuilt authoritative view and evicted domain cache"
-                            );
-                        } else {
-                            tracing::debug!("rebuilt authoritative view (zone-level change)");
-                        }
+                        server.invalidate_subtree(&domain).await;
+                        tracing::debug!(
+                            domain = %domain,
+                            "rebuilt authoritative view and evicted domain subtree from cache"
+                        );
                     }
                     Ok(_) => {}
                     Err(broadcast::error::RecvError::Lagged(n)) => {

--- a/source/daemon/crates/wardnetd-services/src/dns/runner/tests.rs
+++ b/source/daemon/crates/wardnetd-services/src/dns/runner/tests.rs
@@ -126,6 +126,7 @@ struct ServerState {
     running: AtomicBool,
     stopped: AtomicBool,
     view_updates: AtomicUsize,
+    invalidated: std::sync::Mutex<Vec<String>>,
 }
 
 struct MockDnsServer {
@@ -159,7 +160,13 @@ impl DnsServer for MockDnsServer {
     async fn update_authoritative_view(&self, _view: AuthoritativeView) {
         self.state.view_updates.fetch_add(1, Ordering::SeqCst);
     }
-    async fn invalidate_domain(&self, _domain: &str) {}
+    async fn invalidate_subtree(&self, domain: &str) {
+        self.state
+            .invalidated
+            .lock()
+            .unwrap()
+            .push(domain.to_owned());
+    }
 }
 
 async fn poll_until(f: impl Fn() -> bool) -> bool {
@@ -194,14 +201,21 @@ async fn runner_starts_server_loads_view_and_rebuilds_on_event() {
     );
     let after_start = state.view_updates.load(Ordering::SeqCst);
 
-    // A local-DNS change rebuilds the authoritative view.
+    // A local-DNS change rebuilds the authoritative view and evicts the
+    // changed domain's whole subtree — a rule or zone on `lab` governs
+    // everything under it, so leaving subdomains cached would keep them
+    // resolving the old way (issue #1184).
     events.publish(WardnetEvent::DnsLocalChanged {
-        domain: Some("nas.lab".to_owned()),
+        domain: "nas.lab".to_owned(),
         timestamp: chrono::Utc::now(),
     });
     assert!(
         poll_until(|| state.view_updates.load(Ordering::SeqCst) > after_start).await,
         "DnsLocalChanged should rebuild the authoritative view"
+    );
+    assert!(
+        poll_until(|| state.invalidated.lock().unwrap().as_slice() == ["nas.lab"]).await,
+        "DnsLocalChanged should evict the changed domain's subtree"
     );
 
     runner.shutdown().await;

--- a/source/daemon/crates/wardnetd-services/src/dns/server.rs
+++ b/source/daemon/crates/wardnetd-services/src/dns/server.rs
@@ -49,9 +49,11 @@ pub trait DnsServer: Send + Sync {
     /// `DnsLocalChanged` event arrives.
     async fn update_authoritative_view(&self, view: AuthoritativeView);
 
-    /// Evict all cache entries for `domain` so the next query for that
-    /// domain is re-resolved rather than served from a stale cached answer.
-    async fn invalidate_domain(&self, domain: &str);
+    /// Evict every cache entry at or below `domain` — the name and all of
+    /// its subdomains — so the next query for any of them is re-resolved
+    /// rather than served from a stale cached answer. Local DNS is applied
+    /// per subtree, so eviction has to be too.
+    async fn invalidate_subtree(&self, domain: &str);
 
     /// Latest rolling-average latency per configured upstream, produced by the
     /// background prober. One entry per current upstream address (empty until

--- a/source/daemon/crates/wardnetd-services/src/dns/tests/cache.rs
+++ b/source/daemon/crates/wardnetd-services/src/dns/tests/cache.rs
@@ -99,10 +99,83 @@ fn trailing_dot_normalized_across_insert_get_and_invalidate() {
         "bare-name lookup must hit the FQDN-inserted entry"
     );
     assert_eq!(
-        cache.invalidate_domain("example.com"),
+        cache.invalidate_subtree("example.com"),
         1,
         "bare-name invalidation must evict the FQDN-inserted entry"
     );
+    assert!(cache.is_empty());
+}
+
+#[test]
+fn invalidate_subtree_evicts_the_name_and_its_subdomains() {
+    let mut cache = DnsCache::new(100);
+    for domain in [
+        "example.com",
+        "mqtt.example.com",
+        "a.b.example.com",
+        // Neither of these is below `example.com`: a sibling that merely
+        // ends with the same characters, and an unrelated name.
+        "notexample.com",
+        "example.com.evil.net",
+    ] {
+        cache.insert(
+            DEFAULT,
+            domain,
+            RecordType::A,
+            wire(&make_response()),
+            300,
+            0,
+            86400,
+        );
+    }
+
+    assert_eq!(cache.invalidate_subtree("example.com"), 3);
+    assert!(get_msg(&cache, DEFAULT, "notexample.com", RecordType::A).is_some());
+    assert!(get_msg(&cache, DEFAULT, "example.com.evil.net", RecordType::A).is_some());
+    assert!(get_msg(&cache, DEFAULT, "mqtt.example.com", RecordType::A).is_none());
+}
+
+#[test]
+fn invalidate_subtree_of_a_wildcard_evicts_its_suffix() {
+    // A wildcard record is stored as `*.<suffix>` but serves the subtree
+    // below the suffix, so that subtree is what has to be evicted.
+    let mut cache = DnsCache::new(100);
+    for domain in ["host.lab.internal", "other.net"] {
+        cache.insert(
+            DEFAULT,
+            domain,
+            RecordType::A,
+            wire(&make_response()),
+            300,
+            0,
+            86400,
+        );
+    }
+
+    assert_eq!(cache.invalidate_subtree("*.lab.internal"), 1);
+    assert!(get_msg(&cache, DEFAULT, "other.net", RecordType::A).is_some());
+}
+
+#[test]
+fn invalidate_subtree_spans_upstreams_and_record_types() {
+    let mut cache = DnsCache::new(100);
+    for (upstream, rtype) in [
+        (DEFAULT, RecordType::A),
+        (DEFAULT, RecordType::AAAA),
+        (UpstreamId::Tunnel(Uuid::nil()), RecordType::A),
+    ] {
+        cache.insert(
+            upstream,
+            "mqtt.example.com",
+            rtype,
+            wire(&make_response()),
+            300,
+            0,
+            86400,
+        );
+    }
+
+    assert_eq!(cache.invalidate_subtree("example.com"), 3);
     assert!(cache.is_empty());
 }
 
@@ -584,7 +657,7 @@ fn eviction_skips_slots_of_invalidated_entries() {
         0,
         86400,
     );
-    assert_eq!(cache.invalidate_domain("a.com"), 1);
+    assert_eq!(cache.invalidate_subtree("a.com"), 1);
     cache.insert(
         DEFAULT,
         "c.com",

--- a/source/daemon/crates/wardnetd-services/src/dns_local/service.rs
+++ b/source/daemon/crates/wardnetd-services/src/dns_local/service.rs
@@ -92,18 +92,15 @@ impl DnsLocalServiceImpl {
         Self { repo, events }
     }
 
-    fn emit_zone_changed(&self) {
-        use wardnet_common::event::WardnetEvent;
-        self.events.publish(WardnetEvent::DnsLocalChanged {
-            domain: None,
-            timestamp: chrono::Utc::now(),
-        });
-    }
-
+    /// Announce that everything at or below `domain` may resolve differently
+    /// now. Zone names go through here as well as record and rule domains: an
+    /// enabled zone claims its whole namespace, so a zone mutation has the
+    /// same subtree reach as a rule and leaving it unannounced left
+    /// already-cached names under the zone resolving the old way.
     fn emit_domain_changed(&self, domain: String) {
         use wardnet_common::event::WardnetEvent;
         self.events.publish(WardnetEvent::DnsLocalChanged {
-            domain: Some(domain),
+            domain,
             timestamp: chrono::Utc::now(),
         });
     }
@@ -251,7 +248,7 @@ impl DnsLocalService for DnsLocalServiceImpl {
             .create_zone(&row)
             .await
             .map_err(|e| Self::map_repo_err(e, "a zone with this name already exists"))?;
-        self.emit_zone_changed();
+        self.emit_domain_changed(zone.name.clone());
         Ok(CreateZoneResponse {
             zone,
             message: "zone created".to_owned(),
@@ -264,6 +261,8 @@ impl DnsLocalService for DnsLocalServiceImpl {
         req: UpdateZoneRequest,
     ) -> Result<UpdateZoneResponse, AppError> {
         auth_context::require_admin()?;
+        // Capture the pre-update zone to detect renames for cache eviction.
+        let old_zone = self.ensure_zone(id).await?;
         if let Some(name) = req.name.as_deref() {
             Self::validate_zone_name(name)?;
         }
@@ -277,7 +276,12 @@ impl DnsLocalService for DnsLocalServiceImpl {
             .await
             .map_err(|e| Self::map_repo_err(e, "a zone with this name already exists"))?
             .ok_or_else(|| AppError::NotFound(format!("zone {id} not found")))?;
-        self.emit_zone_changed();
+        // A rename moves the namespace: the old suffix stops being ours and
+        // the new one starts, so both subtrees need evicting.
+        if old_zone.name != zone.name {
+            self.emit_domain_changed(old_zone.name);
+        }
+        self.emit_domain_changed(zone.name.clone());
         Ok(UpdateZoneResponse {
             zone,
             message: "zone updated".to_owned(),
@@ -302,7 +306,7 @@ impl DnsLocalService for DnsLocalServiceImpl {
         if !deleted {
             return Err(AppError::NotFound(format!("zone {id} not found")));
         }
-        self.emit_zone_changed();
+        self.emit_domain_changed(zone.name);
         Ok(DeleteZoneResponse {
             message: format!("zone {id} deleted"),
         })

--- a/source/daemon/crates/wardnetd-services/src/dns_local/tests.rs
+++ b/source/daemon/crates/wardnetd-services/src/dns_local/tests.rs
@@ -22,6 +22,7 @@ use wardnetd_data::repository::SqliteDnsLocalRepository;
 use crate::auth_context;
 use crate::dns_local::service::{DnsLocalService, DnsLocalServiceImpl};
 use crate::error::AppError;
+use crate::event::EventPublisher;
 
 async fn test_pool() -> SqlitePool {
     let pool = SqlitePoolOptions::new()
@@ -36,11 +37,35 @@ async fn test_pool() -> SqlitePool {
 }
 
 async fn build() -> DnsLocalServiceImpl {
+    build_with_events().await.0
+}
+
+/// Same service, plus a subscriber on its bus. Used by the tests that assert
+/// which domain a mutation announces, since that domain is what the DNS
+/// runner evicts from the cache.
+async fn build_with_events() -> (
+    DnsLocalServiceImpl,
+    tokio::sync::broadcast::Receiver<wardnet_common::event::WardnetEvent>,
+) {
     let pool = test_pool().await;
     let repo = Arc::new(SqliteDnsLocalRepository::new(pool));
-    let events: Arc<dyn crate::event::EventPublisher> =
-        Arc::new(crate::event::BroadcastEventBus::new(16));
-    DnsLocalServiceImpl::new(repo, events)
+    let bus = Arc::new(crate::event::BroadcastEventBus::new(16));
+    let rx = bus.subscribe();
+    let events: Arc<dyn crate::event::EventPublisher> = bus;
+    (DnsLocalServiceImpl::new(repo, events), rx)
+}
+
+/// Drain the `DnsLocalChanged` domains published so far, in order.
+fn changed_domains(
+    rx: &mut tokio::sync::broadcast::Receiver<wardnet_common::event::WardnetEvent>,
+) -> Vec<String> {
+    let mut domains = Vec::new();
+    while let Ok(event) = rx.try_recv() {
+        if let wardnet_common::event::WardnetEvent::DnsLocalChanged { domain, .. } = event {
+            domains.push(domain);
+        }
+    }
+    domains
 }
 
 /// Run a future inside an `Admin` task-local context. Every service method
@@ -400,6 +425,96 @@ async fn delete_forwarding_rule_missing_is_not_found() {
             .await
             .unwrap_err();
         assert!(matches!(err, AppError::NotFound(_)));
+    })
+    .await;
+}
+
+// ── Change announcements (issue #1184) ─────────────────────────────────
+
+/// The runner evicts the announced domain's subtree, so a zone mutation that
+/// announced nothing left every cached name under the zone untouched.
+#[tokio::test]
+async fn zone_mutations_announce_the_zone_name() {
+    let (svc, mut rx) = build_with_events().await;
+    as_admin(async {
+        let created = svc.create_zone(create_zone_req("lab")).await.unwrap();
+        assert_eq!(
+            changed_domains(&mut rx),
+            ["lab"],
+            "create announces the zone"
+        );
+
+        svc.update_zone(
+            created.zone.id,
+            UpdateZoneRequest {
+                enabled: Some(false),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+        assert_eq!(
+            changed_domains(&mut rx),
+            ["lab"],
+            "update announces the zone"
+        );
+
+        svc.delete_zone(created.zone.id).await.unwrap();
+        assert_eq!(
+            changed_domains(&mut rx),
+            ["lab"],
+            "delete announces the zone"
+        );
+    })
+    .await;
+}
+
+/// A rename moves the namespace, so both the vacated and the claimed suffix
+/// have to be announced.
+#[tokio::test]
+async fn renaming_a_zone_announces_both_names() {
+    let (svc, mut rx) = build_with_events().await;
+    as_admin(async {
+        let created = svc.create_zone(create_zone_req("lab")).await.unwrap();
+        let _ = changed_domains(&mut rx);
+
+        svc.update_zone(
+            created.zone.id,
+            UpdateZoneRequest {
+                name: Some("lab2".to_owned()),
+                enabled: None,
+            },
+        )
+        .await
+        .unwrap();
+        assert_eq!(changed_domains(&mut rx), ["lab", "lab2"]);
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn forwarding_rule_mutations_announce_the_rule_domain() {
+    let (svc, mut rx) = build_with_events().await;
+    as_admin(async {
+        let created = svc
+            .create_forwarding_rule(create_rule_req("ecoflow.com"))
+            .await
+            .unwrap();
+        assert_eq!(changed_domains(&mut rx), ["ecoflow.com"]);
+
+        svc.update_forwarding_rule(
+            created.rule.id,
+            UpdateForwardingRuleRequest {
+                upstream: Some("1.1.1.1".to_owned()),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+        assert_eq!(changed_domains(&mut rx), ["ecoflow.com"]);
+
+        svc.delete_forwarding_rule(created.rule.id).await.unwrap();
+        assert_eq!(changed_domains(&mut rx), ["ecoflow.com"]);
     })
     .await;
 }

--- a/source/daemon/crates/wardnetd-services/src/tests/health_checks.rs
+++ b/source/daemon/crates/wardnetd-services/src/tests/health_checks.rs
@@ -118,7 +118,7 @@ impl DnsServer for MockDnsServer {
     async fn update_config(&self, _config: DnsConfig) {}
     async fn update_authoritative_view(&self, _view: crate::dns::authoritative::AuthoritativeView) {
     }
-    async fn invalidate_domain(&self, _domain: &str) {}
+    async fn invalidate_subtree(&self, _domain: &str) {}
 }
 
 fn dns_check(enabled: bool, running: bool, fail: bool) -> DnsServerHealthCheck {

--- a/source/daemon/crates/wardnetd/src/dns/server.rs
+++ b/source/daemon/crates/wardnetd/src/dns/server.rs
@@ -438,10 +438,10 @@ impl DnsServer for UdpDnsServer {
         self.pipeline.authoritative_view.swap(Arc::new(view));
     }
 
-    async fn invalidate_domain(&self, domain: &str) {
-        let removed = self.pipeline.cache.write().await.invalidate_domain(domain);
+    async fn invalidate_subtree(&self, domain: &str) {
+        let removed = self.pipeline.cache.write().await.invalidate_subtree(domain);
         if removed > 0 {
-            tracing::debug!(domain, removed, "evicted DNS cache entries for domain");
+            tracing::debug!(domain, removed, "evicted DNS cache entries for subtree");
         }
     }
 

--- a/source/daemon/crates/wardnetd/src/dns/tests/pipeline.rs
+++ b/source/daemon/crates/wardnetd/src/dns/tests/pipeline.rs
@@ -491,6 +491,71 @@ async fn conditional_forwarding_relays_and_caches_the_upstream_answer() {
     assert_eq!(next_row(&mut rx).await.result, "cache_hit");
 }
 
+/// Issue #1184. A rule governs everything below its domain, but the cache is
+/// consulted before the rule is applied, so a rule that lands while a
+/// subdomain is already cached only takes effect if the eviction reaches the
+/// whole subtree. The sticky case is exactly the one that sends an operator
+/// to conditional forwarding in the first place: a negative answer whose TTL
+/// comes from a parent zone's SOA.
+#[tokio::test]
+async fn a_new_rule_governs_already_cached_subdomains() {
+    let default_upstream = spawn_stub_upstream(StubAnswer::NxDomain).await;
+    let cond_upstream = spawn_stub_upstream(StubAnswer::A(Ipv4Addr::new(203, 0, 113, 42))).await;
+    let (sink, mut rx) = DnsLogSink::new();
+    let pipeline = build_pipeline(config_with_upstream(default_upstream), Some(sink));
+
+    // The subdomain resolves NXDOMAIN, and the negative answer is cached.
+    let first = ask(
+        &pipeline,
+        &query_bytes(0x7101, "mqtt.example.com.", RecordType::A),
+        ip_client(),
+    )
+    .await
+    .expect("negative answer");
+    assert_eq!(first.metadata.response_code, ResponseCode::NXDomain);
+    assert_eq!(next_row(&mut rx).await.result, "negative");
+    ask(
+        &pipeline,
+        &query_bytes(0x7102, "mqtt.example.com.", RecordType::A),
+        ip_client(),
+    )
+    .await
+    .expect("cached negative");
+    assert_eq!(next_row(&mut rx).await.result, "cache_hit");
+
+    // The operator adds a rule on the parent domain: the runner swaps in the
+    // new view and evicts the rule's subtree.
+    pipeline
+        .authoritative_view
+        .store(Arc::new(AuthoritativeView::build(
+            &[],
+            vec![],
+            vec![forwarding_rule("example.com", cond_upstream.to_string())],
+        )));
+    pipeline
+        .cache
+        .write()
+        .await
+        .invalidate_subtree("example.com");
+
+    // The rule is live immediately — no manual cache flush, no TTL wait.
+    let after = ask(
+        &pipeline,
+        &query_bytes(0x7103, "mqtt.example.com.", RecordType::A),
+        ip_client(),
+    )
+    .await
+    .expect("conditionally forwarded answer");
+    assert_eq!(after.metadata.response_code, ResponseCode::NoError);
+    assert_eq!(after.answers.len(), 1, "the rule's upstream answered");
+    let row = next_row(&mut rx).await;
+    assert_eq!(row.result, "forwarded");
+    assert_eq!(
+        row.upstream.as_deref(),
+        Some(cond_upstream.ip().to_string()).as_deref()
+    );
+}
+
 #[tokio::test]
 async fn conditional_forwarding_failure_returns_servfail() {
     // 127.0.0.1:1 is unbound — the connected socket's send/recv errors

--- a/source/daemon/crates/wardnetd/src/tests/stubs.rs
+++ b/source/daemon/crates/wardnetd/src/tests/stubs.rs
@@ -1242,7 +1242,7 @@ impl wardnetd_services::dns::server::DnsServer for StubDnsServer {
     }
     async fn update_config(&self, _config: wardnet_common::dns::DnsConfig) {}
     async fn update_authoritative_view(&self, _view: wardnetd_services::dns::AuthoritativeView) {}
-    async fn invalidate_domain(&self, _domain: &str) {}
+    async fn invalidate_subtree(&self, _domain: &str) {}
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #1184.

## The bug

A conditional-forwarding rule matches an entire subtree — the exact name *or* any subdomain of it — but creating, updating, or deleting one evicted only the cache entry keyed **exactly** on the rule domain:

```rust
self.entries.retain(|(_, cached_domain, _), _| cached_domain != &d);
```

The cache is consulted at step 1 of the pipeline and the conditional forward happens at step 3, so every already-cached subdomain kept short-circuiting to its old answer. The rule was stored, enabled, and visibly correct in the UI while changing nothing about resolution until the TTL expired or someone ran `POST /api/dns/cache/flush`.

The negative case is the sticky one, and it is exactly the case that sends an operator to conditional forwarding in the first place (the #1002 mitigation): `relay_negative` caches with the RFC 2308 TTL `min(SOA TTL, SOA MINIMUM)` taken from the **parent zone's** SOA, which for a delegation-shaped NXDOMAIN can be far longer than any record TTL on screen.

Zone mutations had the same gap in a wider form: `emit_zone_changed` announced no domain at all, so nothing was ever evicted for a zone change.

## The fix

`DnsCache::invalidate_domain` becomes `invalidate_subtree` — it drops the name and everything below it — and the `DnsLocalChanged` arm calls it for every change. `DnsLocalChanged.domain` is now a plain `String` carrying the subtree the change governs (the zone name for a zone mutation, the record or rule domain otherwise), so a change that announces nothing is no longer representable.

Details worth flagging:

- **Wildcards.** A wildcard record is stored as `*.<suffix>` but serves the subtree below the suffix, so that suffix is what gets evicted. This also takes the apex — one name wider than the wildcard covers. Over-eviction costs a single re-resolution; under-eviction costs correctness.
- **Renames** announce twice, once for the vacated name and once for the claimed one, matching what `update_record` already did.
- **Cost is unchanged.** The eviction already did a full `retain` scan; suffix matching adds no asymptotic cost and allocates nothing beyond the canonical form it already built.

## Tests

- `a_new_rule_governs_already_cached_subdomains` — the issue's reproduction end-to-end through the pipeline: NXDOMAIN cached for `mqtt.example.com`, confirmed serving from cache, rule added on `example.com`, next query is forwarded to the rule's upstream. Fails on the exact-name eviction.
- Cache unit tests for subtree scope (siblings like `notexample.com` and `example.com.evil.net` survive), the wildcard form, and eviction across upstream pools and record types.
- Service tests asserting which domain each zone and forwarding-rule mutation announces, including the rename pair.
- Runner test asserting the event's domain reaches `invalidate_subtree`.

`make check-daemon` green.