### PR TITLE
fix(routing): stop treating kernel-reserved tables as wardnet-managed

### DIFF
--- a/source/daemon/crates/wardnetd/src/route_monitor.rs
+++ b/source/daemon/crates/wardnetd/src/route_monitor.rs
@@ -10,16 +10,31 @@ use wardnet_common::event::WardnetEvent;
 
 use wardnetd_services::event::EventPublisher;
 
-/// Minimum routing table number managed by Wardnet.
+/// Lowest routing table number managed by Wardnet.
 ///
-/// Tables below 100 are kernel defaults (local, main, default) and must not
-/// be treated as Wardnet-managed.
+/// `RoutingServiceImpl::table_for_index` maps tunnel interface index *n* to
+/// table `100 + n`, so 100 is the first table we ever file a route in.
 const WARDNET_MIN_TABLE: u32 = 100;
+
+/// Highest routing table number managed by Wardnet.
+///
+/// The kernel reserves the top four tables — 252 (`compat`), 253 (`default`),
+/// 254 (`main`) and 255 (`local`) — so Wardnet's range stops just below them.
+/// Treating those as ours republishes ordinary kernel routing churn as a
+/// Wardnet fault: a live Pi logged `detected route deletion in wardnet-managed
+/// table table=254` for a routine change to `main`, raising a spurious
+/// `RouteTableLost` diagnostic.
+///
+/// 252 earns its place twice. Besides being reserved, it is the value the
+/// kernel stamps into the u8 `header.table` for any table id too wide to fit
+/// there, so a deletion in someone else's table 1000 arriving without an
+/// `RTA_TABLE` attribute resolves to 252 through `route_table`'s fallback.
+const WARDNET_MAX_TABLE: u32 = 251;
 
 /// Background task that subscribes to kernel route change events via netlink.
 ///
 /// Watches for `RTM_DELROUTE` messages on Wardnet-managed routing tables
-/// (tables >= 100). When such a deletion is detected — typically because the
+/// (100..=251). When such a deletion is detected — typically because the
 /// interface was removed or recreated externally — it publishes a
 /// [`WardnetEvent::RouteTableLost`] so the routing service can re-add the
 /// route.
@@ -46,7 +61,7 @@ impl RouteMonitor {
         let cancel_clone = cancel.clone();
         let handle = tokio::spawn(
             async move {
-                tracing::info!("route monitor started, watching for route deletions on tables >= {WARDNET_MIN_TABLE}");
+                tracing::info!("route monitor started, watching for route deletions on tables {WARDNET_MIN_TABLE}..={WARDNET_MAX_TABLE}");
                 loop {
                     tokio::select! {
                         () = cancel_clone.cancelled() => break,
@@ -79,14 +94,14 @@ impl RouteMonitor {
 
 /// Inspect a netlink route message and publish `RouteTableLost` if it's a
 /// deletion from a Wardnet-managed table.
-fn handle_message(payload: RouteNetlinkMessage, events: &dyn EventPublisher) {
+pub(crate) fn handle_message(payload: RouteNetlinkMessage, events: &dyn EventPublisher) {
     let RouteNetlinkMessage::DelRoute(route) = payload else {
         return;
     };
 
     let table = crate::policy_router_netlink::route_table(&route);
 
-    if table < WARDNET_MIN_TABLE {
+    if !(WARDNET_MIN_TABLE..=WARDNET_MAX_TABLE).contains(&table) {
         return;
     }
 

--- a/source/daemon/crates/wardnetd/src/tests/mod.rs
+++ b/source/daemon/crates/wardnetd/src/tests/mod.rs
@@ -16,6 +16,7 @@ mod packet_capture;
 mod pidfile;
 mod policy_router_netlink;
 mod profiling;
+mod route_monitor;
 mod routing_listener;
 pub mod stubs;
 mod systemctl_power_ops;

--- a/source/daemon/crates/wardnetd/src/tests/route_monitor.rs
+++ b/source/daemon/crates/wardnetd/src/tests/route_monitor.rs
@@ -1,0 +1,154 @@
+//! Host-independent tests for the route monitor's table predicate.
+//!
+//! The netlink multicast socket has no mockable boundary (it needs a real
+//! kernel), but the decision that matters is pure: which `RTM_DELROUTE`
+//! messages count as a lost *Wardnet* table. Getting that wrong in the
+//! permissive direction republishes the kernel's own routing churn as a
+//! Wardnet fault — a live Pi logged `detected route deletion in
+//! wardnet-managed table table=254` for an ordinary change to `main`.
+
+use std::sync::Mutex;
+
+use rtnetlink::packet_route::route::{RouteAttribute, RouteHeader, RouteMessage};
+use rtnetlink::packet_route::{AddressFamily, RouteNetlinkMessage};
+use tokio::sync::broadcast;
+use wardnet_common::event::WardnetEvent;
+use wardnetd_services::event::EventPublisher;
+
+use crate::route_monitor::handle_message;
+
+/// The kernel's reserved tables. netlink-packet-route exports only `MAIN`, so
+/// libc is the canonical source for the other three.
+const RT_TABLE_COMPAT: u32 = libc::RT_TABLE_COMPAT as u32;
+const RT_TABLE_DEFAULT: u32 = libc::RT_TABLE_DEFAULT as u32;
+const RT_TABLE_MAIN: u32 = RouteHeader::RT_TABLE_MAIN as u32;
+const RT_TABLE_LOCAL: u32 = libc::RT_TABLE_LOCAL as u32;
+
+/// Records every published event so a test can assert on what the monitor
+/// decided. The shipped `StubEventPublisher` drops them on the floor.
+#[derive(Default)]
+struct RecordingEventPublisher {
+    events: Mutex<Vec<WardnetEvent>>,
+}
+
+impl RecordingEventPublisher {
+    /// The tables this publisher was told were lost, in publish order.
+    fn lost_tables(&self) -> Vec<u32> {
+        self.events
+            .lock()
+            .expect("events mutex poisoned")
+            .iter()
+            .filter_map(|e| match e {
+                WardnetEvent::RouteTableLost { table, .. } => Some(*table),
+                _ => None,
+            })
+            .collect()
+    }
+}
+
+impl EventPublisher for RecordingEventPublisher {
+    fn publish(&self, event: WardnetEvent) {
+        self.events
+            .lock()
+            .expect("events mutex poisoned")
+            .push(event);
+    }
+
+    fn subscribe(&self) -> broadcast::Receiver<WardnetEvent> {
+        let (tx, rx) = broadcast::channel(1);
+        drop(tx);
+        rx
+    }
+}
+
+/// An `RTM_DELROUTE` for `table`. The number rides both `header.table` and the
+/// `Table` attribute, mirroring what the kernel sends for a table that fits in
+/// a `u8` — `route_table` prefers the attribute either way.
+fn del_route(table: u32) -> RouteNetlinkMessage {
+    let mut msg = RouteMessage::default();
+    msg.header = RouteHeader {
+        address_family: AddressFamily::Inet,
+        table: u8::try_from(table).expect("test tables all fit in a u8"),
+        ..RouteHeader::default()
+    };
+    msg.attributes = vec![RouteAttribute::Table(table)];
+    RouteNetlinkMessage::DelRoute(msg)
+}
+
+/// Feed one deletion to the monitor and report the tables it declared lost.
+fn lost_tables_for(table: u32) -> Vec<u32> {
+    let events = RecordingEventPublisher::default();
+    handle_message(del_route(table), &events);
+    events.lost_tables()
+}
+
+#[test]
+fn kernel_main_table_deletion_is_ignored() {
+    // Wardnet *does* file routes in `main` — `add_host_route` sets no table id,
+    // so its /32 device host routes land there. They are still not what this
+    // event describes: `handle_route_table_lost` only re-applies rules whose
+    // `table == Some(254)`, which no device rule ever has, so a `RouteTableLost`
+    // for `main` can recover nothing and only raises a spurious diagnostic.
+    assert!(
+        lost_tables_for(RT_TABLE_MAIN).is_empty(),
+        "a deletion in the kernel's main table (254) must not be reported as a lost \
+         Wardnet table — the event is per-table and carries no route, so it cannot \
+         describe the loss of a host route filed there"
+    );
+}
+
+#[test]
+fn kernel_reserved_table_deletions_are_ignored() {
+    // The kernel reserves four tables, not three: `compat` (252) as well as
+    // `default`, `main` and `local`. 252 matters twice over — it is also the
+    // value the kernel stamps into the u8 `header.table` for any table id too
+    // wide to fit, so a deletion in someone else's table 1000 that arrives
+    // without an RTA_TABLE attribute resolves to 252.
+    for table in [RT_TABLE_COMPAT, RT_TABLE_DEFAULT, RT_TABLE_LOCAL] {
+        assert!(
+            lost_tables_for(table).is_empty(),
+            "table {table} is kernel-reserved and must not be reported as a lost Wardnet table"
+        );
+    }
+}
+
+#[test]
+fn wardnet_table_deletion_is_reported() {
+    // `table_for_index` maps tunnel index 0 -> 100 and index 2 -> 102; a live
+    // Pi carries `lookup 102`. These are the deletions the monitor exists for.
+    for table in [100, 102] {
+        assert_eq!(
+            lost_tables_for(table),
+            vec![table],
+            "table {table} is Wardnet-managed and its loss must be published"
+        );
+    }
+}
+
+#[test]
+fn wardnet_table_range_boundaries_are_respected() {
+    assert_eq!(
+        lost_tables_for(251),
+        vec![251],
+        "251 is the last table below the kernel-reserved block and is still ours"
+    );
+    assert!(
+        lost_tables_for(99).is_empty(),
+        "99 is below the Wardnet range and belongs to whoever else is using it"
+    );
+}
+
+#[test]
+fn non_deletion_messages_are_ignored() {
+    let events = RecordingEventPublisher::default();
+    let RouteNetlinkMessage::DelRoute(route) = del_route(102) else {
+        unreachable!("del_route always builds a DelRoute")
+    };
+
+    handle_message(RouteNetlinkMessage::NewRoute(route), &events);
+
+    assert!(
+        events.lost_tables().is_empty(),
+        "a route being added is not a route being lost"
+    );
+}


### PR DESCRIPTION
## Problem

The route monitor decided "is this table ours?" with `table < WARDNET_MIN_TABLE (100) -> return`, under a doc comment claiming *"Tables below 100 are kernel defaults (local, main, default)"*.

That is inverted. The kernel's reserved tables are **252** (`compat`), **253** (`default`), **254** (`main`) and **255** (`local`) — every one of them passes a `>= 100` check. So ordinary kernel routing churn was being republished as a Wardnet fault.

Found while diagnosing an unrelated connectivity complaint on a live box, which logged:

```
WARN wardnetd::route_monitor: detected route deletion in wardnet-managed table table=254
WARN wardnetd_services::routing::service: handling lost route table table=254
```

`Diagnostic::from_event` converts `RouteTableLost` unconditionally into an **Error-severity** admin diagnostic, so this surfaces in the UI as a red "managed routing table was lost" with a hint to go looking for some other tool flushing routes.

The recovery path itself is harmless here — no applied rule ever carries `table == Some(254)`, so `handle_route_table_lost` finds nothing and returns early — but the diagnostic is user-visible and actively misleading.

## Fix

Bound the predicate to the range Wardnet actually allocates. `table_for_index` maps tunnel interface index *n* to `100 + n`, so the managed range is `100..=251`, stopping below the reserved block.

**252 is excluded for two independent reasons.** Besides being `RT_TABLE_COMPAT` (verified in `libc-0.2.189`, `linux/mod.rs:2330`), it is the value the kernel stamps into the u8 `header.table` for any table id too wide to fit there — so a deletion in an unrelated wide table (a co-resident VPN, `systemd-networkd RouteTable=1000`) arriving without an `RTA_TABLE` attribute resolves to 252 via `route_table`'s fallback. An inclusive bound of 252 would have shipped a subtler version of the same bug.

## Scope note

The exclusion of `main` is about **this event**, not about ownership. `add_host_route` sets no table id, so Wardnet's `/32` device host routes genuinely do live in `main` — visible on a live Pi as `192.168.250.10 dev eth0 proto static scope link`. `RouteTableLost` is per-table and carries no route, so it could never have described the loss of one. The test comments say this explicitly so the next reader doesn't conclude `main` is untouched by Wardnet.

## Testing

Test-first: the two kernel-table tests failed against the old bound with the predicted assertions while the other three passed, then all five passed after the fix. The corrected `252` boundary went through the same cycle independently.

New `crates/wardnetd/src/tests/route_monitor.rs` — there was no coverage here before. It uses a recording `EventPublisher` because the shipped `StubEventPublisher` discards what it is given.

- `kernel_main_table_deletion_is_ignored`
- `kernel_reserved_table_deletions_are_ignored` (252 / 253 / 255)
- `wardnet_table_deletion_is_reported` (100, 102 — a live Pi carries `lookup 102`)
- `wardnet_table_range_boundaries_are_respected` (251 ours, 99 not)
- `non_deletion_messages_are_ignored`

`handle_message` becomes `pub(crate)` so the tests can reach it — visibility only, no logic change.

Verified in the Linux container (`rust:1.96`), since the crate is Linux-only:

- `cargo test -p wardnetd --lib` — **518 passed, 0 failed**, 4 ignored
- `cargo clippy -p wardnetd --all-targets -- -D warnings` — clean
- `cargo fmt --check` — clean

## Follow-up not included here

A high-effort review surfaced three **pre-existing** bugs in adjacent code, deliberately left out so this stays a single-purpose fix. Filing separately:

1. **`list_wardnet_rules` (`policy_router_netlink.rs:300`) carries the same unbounded `table < 100` predicate**, so it treats switchback carve-outs targeting `main` as device rules. A device with two cross-zone casting targets yields `(src_ip, 254)` with count=2, the reconcile prune deletes one, and `reconcile_switchback_for_device` won't re-add it because `applied_switchback` still records it as installed — cross-zone casting breaks after every reconcile. The real fix is one shared `is_wardnet_table` helper rather than two copies of the rule.
2. **Wardnet's own deliberate teardowns still raise `RouteTableLost`.** `handle_tunnel_down` calls `remove_route_table(table)`, so stopping a tunnel on purpose produces the same Error diagnostic. This is the remaining half of the false-positive class.
3. **`table_for_index` is unbounded and unvalidated.** `next_interface_index` is `MAX(index)+1` and never reclaims, so enough config rotations push a tunnel's table into — and eventually past — the reserved block, where index 154 would put it in `main` itself.