### PR TITLE
ci: stop the Rust cache thrashing itself, and take cubit off the PR path

### DIFF
--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -29,6 +29,25 @@ inputs:
       Passed directly to Swatinem/rust-cache. Defaults to the daemon workspace.
     required: false
     default: "source/daemon"
+  shared-key:
+    description: >
+      Cache lineage shared across jobs, replacing rust-cache's default of one
+      cache per job. Jobs compiling the same workspace at the same profile
+      should share one: separate lineages multiply a ~900MB cache by the number
+      of jobs, and the repository-wide 10GB ceiling then evicts them faster than
+      they are reused.
+    required: false
+    default: ""
+  save-if:
+    description: >
+      Whether this run may write a cache. Defaults to the default branch only.
+
+      Caches saved on a PR ref are readable by that PR and nothing else, so
+      they buy one branch a warm build while consuming shared quota — and the
+      eviction they cause lands on the default-branch caches every PR restores
+      from. Restoring everywhere and saving on main is what keeps those alive.
+    required: false
+    default: ""
 
 runs:
   using: composite
@@ -52,3 +71,5 @@ runs:
       with:
         workspaces: ${{ inputs.workspaces }}
         key: ${{ inputs.cache-key }}
+        shared-key: ${{ inputs.shared-key }}
+        save-if: ${{ inputs.save-if || (github.ref == format('refs/heads/{0}', github.event.repository.default_branch)) }}

--- a/.github/workflows/build-daemon.yml
+++ b/.github/workflows/build-daemon.yml
@@ -86,6 +86,9 @@ jobs:
       - uses: ./.github/actions/setup-rust
         with:
           components: clippy, rustfmt
+          # Shared with check-openapi: same workspace, same debug profile, so
+          # two lineages held two ~900MB copies of the same dependency build.
+          shared-key: daemon-debug
 
       - name: Install clippy SARIF tooling
         uses: taiki-e/install-action@6c6fd71fe4fb72c3697d269963d0e15df8adedad # v2
@@ -133,6 +136,10 @@ jobs:
           ref: ${{ inputs.ref }}
 
       - uses: ./.github/actions/setup-rust
+        with:
+          # Same workspace and profile as check-daemon, so they share one
+          # lineage rather than each holding its own ~900MB copy.
+          shared-key: daemon-debug
 
       - name: Regenerate docs/openapi.json and verify no drift
         # `make check-openapi` runs `dump_openapi` against the current

--- a/.github/workflows/cubit.yml
+++ b/.github/workflows/cubit.yml
@@ -20,6 +20,10 @@ name: Cubit
 # benched.
 
 on:
+  # Dispatchable directly: cubit no longer runs on every pull request, so an
+  # on-demand run is how a perf question gets answered without pushing a commit
+  # to provoke one.
+  workflow_dispatch:
   workflow_call:
     secrets:
       PERF_REPORTS_TOKEN:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -194,41 +194,6 @@ jobs:
     uses: ./.github/workflows/tests-e2e.yml
     secrets: inherit
 
-  cubit:
-    name: Cubit
-    needs: preflight
-    # Advisory performance-regression tracking (compare + PR comment). Gated on
-    # the same `daemon || ci` filter as build-daemon. Skip bot-authored PRs:
-    # same-repo bot branches (Dependabot etc.) get a read-only token, so the PR
-    # comment can't be posted — matching the coverage leaf's bot skip. Gate on
-    # the PR author, not github.actor, so a re-run doesn't flip it.
-    #
-    # Deliberately NOT listed in `all-checks-passed` below: cubit is a light
-    # gate and must never block a merge.
-    if: >
-      github.event.pull_request.user.type != 'Bot' && (
-        needs.preflight.outputs.daemon == 'true' ||
-        needs.preflight.outputs.ci == 'true'
-      )
-    permissions:
-      contents: write # cubit pushes/reads the cubit-state baseline branch
-      pull-requests: write # cubit posts the sticky performance comment
-    uses: ./.github/workflows/cubit.yml
-    # PERF_REPORTS_TOKEN (org secret) — lets cubit publish the PR's dashboard
-    # to the wardnet/perf-reports Pages hub. ci.yml's record path never
-    # publishes, so only this caller passes secrets.
-    secrets: inherit
-
-  # Aggregator for branch protection. Lists every other job as a
-  # dependency, runs unconditionally (if: always()), and passes iff
-  # each dependency either succeeded or was legitimately skipped via
-  # the changes filter. Failing or cancelled leaves short-circuit to
-  # exit 1.
-  #
-  # Required-check on main branch protection: require ONLY
-  # "All checks passed". Single source of truth, immune to the
-  # gated-leaf trap where a skipped job never reports and blocks the
-  # PR forever.
   all-checks-passed:
     name: All checks passed
     needs: [preflight, build-daemon, build-go, build-site, build-admin-web, build-admin-app, build-user-app, coverage, tests-e2e]


### PR DESCRIPTION
A PR takes **~23 minutes wall clock and ~95 minutes of runner time**, almost all of it the daemon being compiled from cold five times over.

## The cause is not a missing cache

`setup-rust` has had `Swatinem/rust-cache` all along — I initially concluded otherwise by grepping the workflows and not the composite action. The caches exist; they evict each other before they can be reused.

```
9.45 GiB of caches   ·   GitHub's per-repo ceiling is 10 GiB
27 entries on main   +   1.83 GiB on PR refs
```

`rust-cache` keys per job by default, so `check-daemon`, `check-openapi`, `build`, `cubit` and `daemon-coverage` each hold a separate 0.5–0.9 GB copy of largely the same dependency build, several generations deep. The repo holds more cache than it is allowed, the oldest is dropped, and the next run rebuilds what it just evicted.

**This repository contains its own control experiment:**

| Job | Duration | Cache state |
|---|---|---|
| `Coverage / Daemon coverage` | **4m25s** | survived |
| `Check Daemon` | 9m39s | evicted |
| `Build Daemon (x86_64)` | 9m57s | evicted |
| `Cubit` | 20m21s | evicted |

## Two changes, both in `setup-rust`

**`save-if` now defaults to the default branch only.** A cache saved on a PR ref is readable by that PR and nothing else — it buys one branch a warm build while the eviction it causes lands on the main-branch caches that *every* PR restores from. Restore everywhere, save on main.

**`shared-key`** lets jobs compiling the same workspace at the same profile share one lineage. `check-daemon` and `check-openapi` now do. The release build keeps its own, since a debug target directory would not serve it.

## cubit comes off the PR path

Its own comment says it is "deliberately NOT listed in `all-checks-passed`" and "must never block a merge" — so it was spending 20 minutes of runner time per PR producing advisory output that cannot fail the build.

`ci.yml` already records the baseline on every push to main, which is what the next PR compares against, so no data is lost. It gains `workflow_dispatch`, so a perf question can be answered on demand rather than by pushing a commit to provoke one.

## Deliberately not addressed here

The **E2E daemon job spends 21m34s in a single step** doing a cold `cargo build` inside Docker with no layer cache, and it is the critical path — the largest remaining win. Fixing it means plumbing buildx cache flags through the `Makefile` that local devs run with podman, which is a larger and riskier change. It does not belong in a PR whose effect should be measurable on its own.

## How to tell whether this worked

Watch `Check Daemon` and `Build Daemon (x86_64)` on the second and third PRs after this merges — the first still pays for a cold main-branch cache. If they trend toward `Daemon coverage`'s 4m25s, it worked. Cache count should also settle well under 27 entries.