### PR TITLE
fix(deps): build Go on 1.26.6 to clear eight stdlib advisories

### DIFF
--- a/source/sdk/wardnet-go/go.mod
+++ b/source/sdk/wardnet-go/go.mod
@@ -2,6 +2,8 @@ module wardnet.network/go
 
 go 1.26.0
 
+toolchain go1.26.6
+
 require (
 	github.com/coder/websocket v1.8.15
 	github.com/google/uuid v1.6.0

--- a/source/wctl/go.mod
+++ b/source/wctl/go.mod
@@ -2,7 +2,7 @@ module github.com/wardnet/wardnet/source/wctl
 
 go 1.26.0
 
-toolchain go1.26.5
+toolchain go1.26.6
 
 require (
 	github.com/BurntSushi/toml v1.6.0


### PR DESCRIPTION
`Coverage / bulwark` is failing on every pull request with **8 govulncheck findings**. This clears them.

## What they are

Four standard-library advisories, reported once per Go module:

| Advisory | Package |
|---|---|
| `GO-2026-6218` | `net/url` |
| `GO-2026-6090` | `crypto/tls` |
| `GO-2026-5972` | `encoding/asn1` |
| `GO-2026-5026` | `net/http` |

Every one reads `Found in: …@go1.26.5` / `Fixed in: …@go1.26.6`. No dependency is implicated, and no code changes.

## The fix

- `source/wctl/go.mod` — `toolchain go1.26.5` → `go1.26.6`
- `source/sdk/wardnet-go/go.mod` — **no** toolchain directive, so `setup-go`'s `go-version-file` resolved the bare `go 1.26.0` and built the SDK on a toolchain older still. Now pinned explicitly.

Every workflow resolves Go through `go-version-file: <module>/go.mod`, so the toolchain directive is the single source of truth — nothing else needs touching.

Pinning the SDK is worth doing on its own merits: leaving a published module's build toolchain to whatever the runner resolves is how it silently drifts backwards.

## Verified locally on 1.26.6

```
wctl:  No vulnerabilities found.   build ✓ vet ✓ test ✓
sdk:   No vulnerabilities found.   build ✓ vet ✓ test ✓
```

## Please merge this first

This is **pre-existing on `main`**, not introduced by any open branch, and it blocks *every* PR because `Coverage / bulwark` is required. #1232 is waiting on it.