### PR TITLE
perf(ci): cache the e2e image's dependency layer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -184,7 +184,7 @@ jobs:
     # from GitHub Packages.
     permissions:
       contents: read
-      packages: read
+      packages: write # the image build exports its layer cache to GHCR
     uses: ./.github/workflows/tests-e2e.yml
     secrets: inherit
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -187,10 +187,12 @@ jobs:
     # warrants the full e2e validation.
     if: needs.preflight.outputs.daemon == 'true' || needs.preflight.outputs.ci == 'true'
     # build-web (run on the host before the Docker build) reads @wardnet/*
-    # from GitHub Packages.
+    # from GitHub Packages, and the image build exports its layer cache to a
+    # GHCR image. A called workflow can only narrow what the caller grants, so
+    # the write has to be given here.
     permissions:
       contents: read
-      packages: read
+      packages: write
     uses: ./.github/workflows/tests-e2e.yml
     secrets: inherit
 

--- a/.github/workflows/tests-e2e.yml
+++ b/.github/workflows/tests-e2e.yml
@@ -145,16 +145,20 @@ jobs:
           args="--builder wardnetd-cache --load"
           args="${args} --cache-from type=registry,ref=${CACHE_REF}"
           args="${args} --cache-from type=registry,ref=${UI_CACHE_REF}"
+          read_args="${args}"
           if [[ "${CAN_WRITE_CACHE}" == "true" ]]; then
             args="${args} --cache-to type=registry,ref=${CACHE_REF},mode=max"
           else
             echo "read-only token — restoring the build cache without updating it"
           fi
 
+          # The release-server image reads the cache but never writes it, so
+          # its shorter layer set cannot replace the daemon image's in the ref.
           make end2end-daemon \
             CONTAINER_RT="$(command -v docker)" \
             IMAGE_BUILDER="docker buildx" \
-            IMAGE_TEST_BUILD_ARGS="${args}"
+            IMAGE_TEST_BUILD_ARGS="${args}" \
+            IMAGE_TEST_RELEASE_BUILD_ARGS="${read_args}"
         env:
           CACHE_REF: ghcr.io/${{ github.repository }}/wardnetd-test-cache:buildcache
           UI_CACHE_REF: ghcr.io/${{ github.repository }}/wardnetd-ui-test-cache:buildcache

--- a/.github/workflows/tests-e2e.yml
+++ b/.github/workflows/tests-e2e.yml
@@ -37,7 +37,7 @@ permissions:
   # that installs the web apps, which pull @wardnet/{ui,styles,brand} from
   # GitHub Packages. Granted by the caller job (pr.yml/ci.yml/release.yml) and
   # surfaced here so the leaf doesn't restrict it back to none.
-  packages: read
+  packages: write
 
 env:
   CARGO_TERM_COLOR: always
@@ -75,6 +75,18 @@ jobs:
 
       - uses: ./.github/actions/setup-rust
 
+      - name: Set up buildx
+        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
+
+      - name: Log in to GHCR for the build cache
+        # Read access to the cache image comes from the job's packages scope;
+        # this login is what allows the export when the token permits one.
+        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Run daemon e2e suite
         # `make end2end-daemon` chains: build-web → image-test (cargo
         # build inside Docker) → compose up --wait wardnetd → vitest in
@@ -85,10 +97,40 @@ jobs:
         # Makefile's default podman-first auto-detection. ubuntu-latest
         # ships both binaries; podman's classic image builder rejects
         # the BuildKit heredoc syntax used in source/daemon/Dockerfile.test
-        # ("Unknown instruction: SET"). Docker BuildKit honours the
-        # `# syntax=docker/dockerfile:1` directive and parses heredocs
-        # cleanly. Local devs on macOS keep the podman default.
-        run: make end2end-daemon CONTAINER_RT=$(command -v docker)
+        # ("Unknown instruction: SET"). Local devs on macOS keep the podman
+        # default.
+        #
+        # IMAGE_BUILDER is separate because this target also runs `compose`,
+        # which buildx has no subcommand for. Only the image build goes through
+        # buildx, whose docker-container driver is the one that can export a
+        # cache. The cache lives on GHCR rather than in
+        # the Actions cache: a Rust dependency layer is GB-scale, and the
+        # Actions cache is a 10 GiB per-repo budget the Rust caches already
+        # compete over. Registry cache is also shared across branches, where an
+        # Actions cache saved on a PR ref is readable only by that PR.
+        #
+        # mode=max exports intermediate layers, which is the point — the
+        # dependency layer is the one worth restoring.
+        run: |
+          set -euo pipefail
+
+          # Restoring only needs a readable registry; exporting needs a
+          # writable token, which a fork PR and any Dependabot event do not
+          # have. Push the cache where we can, read it everywhere.
+          args="--load --cache-from type=registry,ref=${CACHE_REF}"
+          if [[ "${CAN_WRITE_CACHE}" == "true" ]]; then
+            args="${args} --cache-to type=registry,ref=${CACHE_REF},mode=max"
+          else
+            echo "read-only token — restoring the build cache without updating it"
+          fi
+
+          make end2end-daemon \
+            CONTAINER_RT="$(command -v docker)" \
+            IMAGE_BUILDER="docker buildx" \
+            IMAGE_TEST_BUILD_ARGS="${args}"
+        env:
+          CACHE_REF: ghcr.io/${{ github.repository }}/wardnetd-test-cache:buildcache
+          CAN_WRITE_CACHE: ${{ github.event_name != 'pull_request' || (github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]') }}
 
       - name: Surface captured logs
         # Print the trap-captured compose logs + JUnit/JSON reports

--- a/.github/workflows/tests-e2e.yml
+++ b/.github/workflows/tests-e2e.yml
@@ -140,7 +140,11 @@ jobs:
           # --builder targets the named builder set up above without making it
           # the default; --load exports the result into the host's docker image
           # store, which is where compose then finds wardnetd:dev-test.
-          args="--builder wardnetd-cache --load --cache-from type=registry,ref=${CACHE_REF}"
+          # Reads both suites' refs — the dependency layer is shared, so a warm
+          # UI cache serves this job too. Writes only this suite's own ref.
+          args="--builder wardnetd-cache --load"
+          args="${args} --cache-from type=registry,ref=${CACHE_REF}"
+          args="${args} --cache-from type=registry,ref=${UI_CACHE_REF}"
           if [[ "${CAN_WRITE_CACHE}" == "true" ]]; then
             args="${args} --cache-to type=registry,ref=${CACHE_REF},mode=max"
           else
@@ -153,6 +157,7 @@ jobs:
             IMAGE_TEST_BUILD_ARGS="${args}"
         env:
           CACHE_REF: ghcr.io/${{ github.repository }}/wardnetd-test-cache:buildcache
+          UI_CACHE_REF: ghcr.io/${{ github.repository }}/wardnetd-ui-test-cache:buildcache
           CAN_WRITE_CACHE: ${{ github.event_name != 'pull_request' || (github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]') }}
 
       - name: Surface captured logs
@@ -226,13 +231,54 @@ jobs:
 
       - uses: ./.github/actions/setup-rust
 
+      - name: Set up buildx
+        # `use: false` for the same reason as the daemon job: this compose stack
+        # also has a `FROM ${WARDNETD_TEST_IMAGE}` (test_debian), which a
+        # docker-container builder cannot resolve from the local image store.
+        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
+        with:
+          name: wardnetd-cache
+          use: false
+
+      - name: Log in to GHCR for the build cache
+        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Run web-ui e2e suite
-        # `make e2e-ui` chains: build-web → compose up --build --wait
-        # wardnetd-ui (cargo build + WEB_DIST=real embed inside Docker) →
-        # Playwright in ui_runner → trap dumps compose logs into reports/
-        # and tears the stack down. Reports are written even on failure.
+        # `make e2e-ui` chains: build-web → image-test-ui (cargo build +
+        # WEB_DIST=real embed inside Docker) → compose up → Playwright in
+        # ui_runner → trap dumps compose logs into reports/ and tears the stack
+        # down. Reports are written even on failure.
         # CONTAINER_RT=docker forces BuildKit (see the daemon job note).
-        run: make e2e-ui CONTAINER_RT=$(command -v docker)
+        run: |
+          set -euo pipefail
+
+          # Read BOTH cache refs. Everything up to `cargo chef cook` is
+          # byte-identical across the two suites — WEB_DIST only selects the
+          # `web` stage, and the builder's `COPY --from=web` comes after cook —
+          # so a warm daemon cache serves this job's dependency layer even the
+          # first time the UI ref is empty. Writes stay on this suite's own ref,
+          # so the two jobs never race to publish the same tag.
+          args="--builder wardnetd-cache --load"
+          args="${args} --cache-from type=registry,ref=${UI_CACHE_REF}"
+          args="${args} --cache-from type=registry,ref=${DAEMON_CACHE_REF}"
+          if [[ "${CAN_WRITE_CACHE}" == "true" ]]; then
+            args="${args} --cache-to type=registry,ref=${UI_CACHE_REF},mode=max"
+          else
+            echo "read-only token — restoring the build cache without updating it"
+          fi
+
+          make e2e-ui \
+            CONTAINER_RT="$(command -v docker)" \
+            IMAGE_BUILDER="docker buildx" \
+            IMAGE_TEST_UI_BUILD_ARGS="${args}"
+        env:
+          UI_CACHE_REF: ghcr.io/${{ github.repository }}/wardnetd-ui-test-cache:buildcache
+          DAEMON_CACHE_REF: ghcr.io/${{ github.repository }}/wardnetd-test-cache:buildcache
+          CAN_WRITE_CACHE: ${{ github.event_name != 'pull_request' || (github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]') }}
 
       - name: Surface captured logs
         if: always()

--- a/.github/workflows/tests-e2e.yml
+++ b/.github/workflows/tests-e2e.yml
@@ -76,7 +76,25 @@ jobs:
       - uses: ./.github/actions/setup-rust
 
       - name: Set up buildx
+        # `use: false` is load-bearing. The action defaults to `use: true`,
+        # which makes this docker-container builder the DEFAULT for everything
+        # docker builds afterwards — including `docker compose build`, which we
+        # do not want touched. That driver runs in its own container with its
+        # own image store and cannot see the host's local images, so
+        # deploy/docker/Dockerfile.client's `FROM ${WARDNETD_TEST_IMAGE}` (i.e.
+        # the just-built wardnetd:dev-test) stopped resolving locally and was
+        # looked up as docker.io/library/wardnetd:dev-test instead:
+        #
+        #   target test_debian: failed to solve: pull access denied,
+        #   repository does not exist or may require authorization
+        #
+        # A named builder referenced explicitly by --builder keeps the cache
+        # export scoped to the one image that wants it and leaves compose on
+        # the default docker driver, exactly as before.
         uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
+        with:
+          name: wardnetd-cache
+          use: false
 
       - name: Log in to GHCR for the build cache
         # Read access to the cache image comes from the job's packages scope;
@@ -101,9 +119,11 @@ jobs:
         # default.
         #
         # IMAGE_BUILDER is separate because this target also runs `compose`,
-        # which buildx has no subcommand for. Only the image build goes through
-        # buildx, whose docker-container driver is the one that can export a
-        # cache. The cache lives on GHCR rather than in
+        # which buildx has no subcommand for — and which must keep using the
+        # default docker driver so `FROM wardnetd:dev-test` still resolves from
+        # the local image store. Only the image build goes through the named
+        # buildx builder, whose docker-container driver is the one that can
+        # export a cache. The cache lives on GHCR rather than in
         # the Actions cache: a Rust dependency layer is GB-scale, and the
         # Actions cache is a 10 GiB per-repo budget the Rust caches already
         # compete over. Registry cache is also shared across branches, where an
@@ -117,7 +137,10 @@ jobs:
           # Restoring only needs a readable registry; exporting needs a
           # writable token, which a fork PR and any Dependabot event do not
           # have. Push the cache where we can, read it everywhere.
-          args="--load --cache-from type=registry,ref=${CACHE_REF}"
+          # --builder targets the named builder set up above without making it
+          # the default; --load exports the result into the host's docker image
+          # store, which is where compose then finds wardnetd:dev-test.
+          args="--builder wardnetd-cache --load --cache-from type=registry,ref=${CACHE_REF}"
           if [[ "${CAN_WRITE_CACHE}" == "true" ]]; then
             args="${args} --cache-to type=registry,ref=${CACHE_REF},mode=max"
           else

--- a/Makefile
+++ b/Makefile
@@ -595,6 +595,16 @@ E2E_DAEMON_COMPOSE := $(E2E_DAEMON_DIR)/compose.yaml
 E2E_UI_DIR := source/end2end-tests/web-ui
 E2E_UI_COMPOSE := $(E2E_UI_DIR)/compose.ui.yaml
 
+# The wardnetd service is brought up WITHOUT --build: the image-test
+# prerequisite above has already built and tagged that exact image from that
+# exact Dockerfile, so `--build` only rebuilt it a second time. That was free
+# while both builds shared one builder and hit cache, but it stops being free
+# as soon as they don't — and it was always a duplicate. compose still builds
+# the service on its own if the image is genuinely absent.
+#
+# test_debian/test_ubuntu keep --build: they have no other producer, and their
+# Dockerfile.client does `FROM ${WARDNETD_TEST_IMAGE}`, which resolves from the
+# local image store that image-test just loaded into.
 end2end-daemon: image-test
 	@test -n "$(CONTAINER_RT)" || { echo "Error: podman or docker is required"; exit 1; }
 	@mkdir -p $(E2E_DAEMON_DIR)/reports
@@ -607,7 +617,7 @@ end2end-daemon: image-test
 	        $(CONTAINER_RT) inspect "$$cid" >> '"$$REPORTS"'/inspect.json 2>&1 || true; \
 	      done; \
 	      $(CONTAINER_RT) compose -f $(E2E_DAEMON_COMPOSE) down -v --remove-orphans' EXIT; \
-	$(CONTAINER_RT) compose -f $(E2E_DAEMON_COMPOSE) up -d --build --wait wardnetd; \
+	$(CONTAINER_RT) compose -f $(E2E_DAEMON_COMPOSE) up -d --wait wardnetd; \
 	$(CONTAINER_RT) compose -f $(E2E_DAEMON_COMPOSE) up -d --build --wait test_debian test_ubuntu || \
 	    echo "warning: client services not healthy; running vitest anyway so failures surface as assertions"; \
 	echo "::group::compose ps before vitest"; \

--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,9 @@ IMAGE_TEST_TAG ?= wardnetd:dev-test
 # Must match compose.ui.yaml's ${WARDNETD_UI_TEST_IMAGE} default, since the UI
 # suite's services resolve the image by that name.
 IMAGE_TEST_UI_TAG ?= wardnetd:dev-test-ui
+# Must match compose.yaml's update_release_server `image:`, which is a fixed
+# literal rather than a variable.
+IMAGE_TEST_RELEASE_SERVER_TAG ?= wardnet-e2e-release-server:dev
 IMAGE_BASE_TAG ?= wardnet-base:dev
 IMAGE_VERSION  ?= latest
 # Linux build artefacts live here (gitignored, persists on host for
@@ -562,6 +565,12 @@ image-multiarch:
 # podman.
 IMAGE_BUILDER ?= $(CONTAINER_RT)
 IMAGE_TEST_BUILD_ARGS ?=
+# Defaults to the same flags, but CI overrides it with a cache-READ-only
+# variant: both builds below would otherwise export to the same cache ref, and
+# the release-server build — which stops at the builder stage and never touches
+# stage-7 — would publish last and drop the daemon image's final layers from
+# the cache.
+IMAGE_TEST_RELEASE_BUILD_ARGS ?= $(IMAGE_TEST_BUILD_ARGS)
 
 image-test:
 	@test -n "$(CONTAINER_RT)" || { echo "Error: podman or docker is required"; exit 1; }
@@ -569,6 +578,20 @@ image-test:
 		$(IMAGE_TEST_BUILD_ARGS) \
 		-f source/daemon/Dockerfile.test \
 		-t $(IMAGE_TEST_TAG) \
+		.
+	@# The release-server image MUST come from the same builder, back to back
+	@# with the daemon image above. Both are `COPY --from=builder`, and that
+	@# builder stage generates an EPHEMERAL minisign keypair at build time: the
+	@# daemon embeds the public half, and the release bundle this image serves
+	@# is signed with the private half. Build them on two builders (or two cold
+	@# caches) and you get two different keypairs, so the daemon rejects the
+	@# bundle with "signature verification failed" — at runtime, long after the
+	@# build looked fine. Same invocation, same cache, same key.
+	$(IMAGE_BUILDER) build \
+		$(IMAGE_TEST_RELEASE_BUILD_ARGS) \
+		--target release-server \
+		-f source/daemon/Dockerfile.test \
+		-t $(IMAGE_TEST_RELEASE_SERVER_TAG) \
 		.
 
 # The web-UI variant of image-test: same Dockerfile, same builder plumbing, but
@@ -630,9 +653,17 @@ E2E_UI_COMPOSE := $(E2E_UI_DIR)/compose.ui.yaml
 # as soon as they don't — and it was always a duplicate. compose still builds
 # the service on its own if the image is genuinely absent.
 #
-# test_debian/test_ubuntu keep --build: they have no other producer, and their
-# Dockerfile.client does `FROM ${WARDNETD_TEST_IMAGE}`, which resolves from the
-# local image store that image-test just loaded into.
+# test_debian/test_ubuntu still need building — they have no other producer —
+# but via `compose build`, never `up --build`. `up --build` builds every
+# service it brings up INCLUDING dependencies, and both depend_on wardnetd, so
+# it silently rebuilt and re-tagged the daemon image behind image-test's back.
+# That is not merely wasteful, it corrupts the run: the rebuild produces a
+# fresh ephemeral minisign keypair, compose recreates the container on the new
+# image, and the wardnet_state volume keeps the OLD image's signed
+# wardnet-postupgrade.bin — Docker seeds a named volume only when it is first
+# created, never on recreate. The daemon then boots trusting a key that did not
+# sign the payload and fails with "signature verification failed".
+# `compose build` takes only the services named, which is what we want.
 end2end-daemon: image-test
 	@test -n "$(CONTAINER_RT)" || { echo "Error: podman or docker is required"; exit 1; }
 	@mkdir -p $(E2E_DAEMON_DIR)/reports
@@ -646,7 +677,8 @@ end2end-daemon: image-test
 	      done; \
 	      $(CONTAINER_RT) compose -f $(E2E_DAEMON_COMPOSE) down -v --remove-orphans' EXIT; \
 	$(CONTAINER_RT) compose -f $(E2E_DAEMON_COMPOSE) up -d --wait wardnetd; \
-	$(CONTAINER_RT) compose -f $(E2E_DAEMON_COMPOSE) up -d --build --wait test_debian test_ubuntu || \
+	{ $(CONTAINER_RT) compose -f $(E2E_DAEMON_COMPOSE) build test_debian test_ubuntu && \
+	  $(CONTAINER_RT) compose -f $(E2E_DAEMON_COMPOSE) up -d --wait test_debian test_ubuntu; } || \
 	    echo "warning: client services not healthy; running vitest anyway so failures surface as assertions"; \
 	echo "::group::compose ps before vitest"; \
 	$(CONTAINER_RT) compose -f $(E2E_DAEMON_COMPOSE) ps -a; \
@@ -691,7 +723,8 @@ e2e-ui: build-web image-test-ui
 	      $(CONTAINER_RT) compose -f $(E2E_UI_COMPOSE) down -v --remove-orphans' EXIT; \
 	$(CONTAINER_RT) compose -f $(E2E_UI_COMPOSE) build nordvpn_mock; \
 	$(CONTAINER_RT) compose -f $(E2E_UI_COMPOSE) up -d --wait wardnetd-ui wardnetd-ui-fresh tls_proxy tls_proxy_lan blocklist_server nordvpn_mock; \
-	$(CONTAINER_RT) compose -f $(E2E_UI_COMPOSE) up -d --build --wait test_debian || \
+	{ $(CONTAINER_RT) compose -f $(E2E_UI_COMPOSE) build test_debian && \
+	  $(CONTAINER_RT) compose -f $(E2E_UI_COMPOSE) up -d --wait test_debian; } || \
 	    echo "warning: test_debian (LAN client) not healthy; running playwright anyway so failures surface as assertions"; \
 	echo "::group::compose ps before playwright"; \
 	$(CONTAINER_RT) compose -f $(E2E_UI_COMPOSE) ps -a; \

--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,9 @@ BINDGEN_APT := apt-get update -qq && apt-get install -y -qq clang libclang-dev >
 #   make image IMAGE_VERSION=0.2.0
 IMAGE_TAG      ?= wardnetd:dev
 IMAGE_TEST_TAG ?= wardnetd:dev-test
+# Must match compose.ui.yaml's ${WARDNETD_UI_TEST_IMAGE} default, since the UI
+# suite's services resolve the image by that name.
+IMAGE_TEST_UI_TAG ?= wardnetd:dev-test-ui
 IMAGE_BASE_TAG ?= wardnet-base:dev
 IMAGE_VERSION  ?= latest
 # Linux build artefacts live here (gitignored, persists on host for
@@ -60,7 +63,7 @@ COV_RUNNER ?=
         coverage-daemon-report-json \
         openapi check-openapi \
         fmt clippy test \
-        image image-multiarch image-test image-base \
+        image image-multiarch image-test image-test-ui image-base \
         end2end-daemon e2e-ui e2e-ui-update-snapshots e2e-all \
         run-dev run-dev-daemon run-dev-web run-dev-user-app run-dev-admin-app \
         run-dev-push \
@@ -568,6 +571,31 @@ image-test:
 		-t $(IMAGE_TEST_TAG) \
 		.
 
+# The web-UI variant of image-test: same Dockerfile, same builder plumbing, but
+# WEB_DIST=real so the image embeds the actual dist/ trees the Playwright suite
+# drives, instead of the placeholder the API-only daemon suite is happy with.
+#
+# It exists as its own target for the same reason image-test does: it gives the
+# UI suite one producer for the image, which can then be pointed at a build
+# cache. Everything up to and including `cargo chef cook` is byte-identical to
+# the daemon image — WEB_DIST only selects the `web` stage, and the builder
+# stage's `COPY --from=web` happens after cook — so the two suites share a
+# dependency layer even though the final images differ.
+IMAGE_TEST_UI_BUILD_ARGS ?=
+
+# build-web is a prerequisite, not just an ordering convention: the web-real
+# stage COPYs source/*/dist out of the build context, so those trees must exist
+# on the host before this image is built. Naming it here keeps that true even
+# under `make -j`, where prerequisite order alone would not.
+image-test-ui: build-web
+	@test -n "$(CONTAINER_RT)" || { echo "Error: podman or docker is required"; exit 1; }
+	$(IMAGE_BUILDER) build \
+		$(IMAGE_TEST_UI_BUILD_ARGS) \
+		--build-arg WEB_DIST=real \
+		-f source/daemon/Dockerfile.test \
+		-t $(IMAGE_TEST_UI_TAG) \
+		.
+
 # Build the wardnet-base image locally. Published copies of this image
 # live on GHCR (see .github/workflows/release-base-image.yml); use this
 # target to validate Dockerfile.base changes before tagging a base-vN
@@ -637,10 +665,23 @@ end2end-daemon: image-test
 # land on the host ready to `git add`.
 PW_RUN_FLAGS ?=
 
-e2e-ui: build-web
+# image-test-ui is a prerequisite for the same reason image-test is one of
+# end2end-daemon: it makes a single target the producer of wardnetd:dev-test-ui,
+# so the build can be pointed at a cache. compose then consumes that image
+# rather than rebuilding it.
+#
+# Hence the first `up` below dropped its `--build`. Of the services it starts,
+# only wardnetd-ui and nordvpn_mock have a build section, and wardnetd-ui now
+# has a producer — so nordvpn_mock gets an explicit `compose build` to keep its
+# rebuild-every-run behaviour, which a bare `up` would only do when its image
+# is missing entirely. test_debian keeps `--build` further down: it has no
+# other producer, and its `FROM ${WARDNETD_TEST_IMAGE}` resolves the UI image
+# out of the local store.
+e2e-ui: build-web image-test-ui
 	@test -n "$(CONTAINER_RT)" || { echo "Error: podman or docker is required"; exit 1; }
 	@mkdir -p $(E2E_UI_DIR)/reports $(E2E_UI_DIR)/snapshots
 	@set -euo pipefail; \
+	export WARDNETD_UI_TEST_IMAGE=$(IMAGE_TEST_UI_TAG); \
 	REPORTS=$(E2E_UI_DIR)/reports; \
 	trap '$(CONTAINER_RT) compose -f $(E2E_UI_COMPOSE) ps -a > '"$$REPORTS"'/compose-ps.txt 2>&1 || true; \
 	      $(CONTAINER_RT) compose -f $(E2E_UI_COMPOSE) logs --no-color > '"$$REPORTS"'/compose-logs.txt 2>&1 || true; \
@@ -648,7 +689,8 @@ e2e-ui: build-web
 	        $(CONTAINER_RT) inspect "$$cid" >> '"$$REPORTS"'/inspect.json 2>&1 || true; \
 	      done; \
 	      $(CONTAINER_RT) compose -f $(E2E_UI_COMPOSE) down -v --remove-orphans' EXIT; \
-	$(CONTAINER_RT) compose -f $(E2E_UI_COMPOSE) up -d --build --wait wardnetd-ui wardnetd-ui-fresh tls_proxy tls_proxy_lan blocklist_server nordvpn_mock; \
+	$(CONTAINER_RT) compose -f $(E2E_UI_COMPOSE) build nordvpn_mock; \
+	$(CONTAINER_RT) compose -f $(E2E_UI_COMPOSE) up -d --wait wardnetd-ui wardnetd-ui-fresh tls_proxy tls_proxy_lan blocklist_server nordvpn_mock; \
 	$(CONTAINER_RT) compose -f $(E2E_UI_COMPOSE) up -d --build --wait test_debian || \
 	    echo "warning: test_debian (LAN client) not healthy; running playwright anyway so failures surface as assertions"; \
 	echo "::group::compose ps before playwright"; \

--- a/Makefile
+++ b/Makefile
@@ -549,9 +549,21 @@ image-multiarch:
 # after git checkout. Building placeholder content inside the image
 # sidesteps that cache entirely. The e2e suite targets API endpoints,
 # not the web UI, so placeholder content is sufficient.
+# IMAGE_BUILDER is the command that builds images, separate from CONTAINER_RT
+# because the rest of this target also runs `compose`, which buildx has no
+# subcommand for. CI overrides it with "docker buildx": the default docker
+# driver cannot export a build cache, and only buildx can.
+#
+# IMAGE_TEST_BUILD_ARGS carries extra builder flags. Both default to today's
+# behaviour, so a local `make image-test` is unchanged and still works under
+# podman.
+IMAGE_BUILDER ?= $(CONTAINER_RT)
+IMAGE_TEST_BUILD_ARGS ?=
+
 image-test:
 	@test -n "$(CONTAINER_RT)" || { echo "Error: podman or docker is required"; exit 1; }
-	$(CONTAINER_RT) build \
+	$(IMAGE_BUILDER) build \
+		$(IMAGE_TEST_BUILD_ARGS) \
 		-f source/daemon/Dockerfile.test \
 		-t $(IMAGE_TEST_TAG) \
 		.

--- a/source/daemon/Dockerfile.test
+++ b/source/daemon/Dockerfile.test
@@ -82,7 +82,11 @@ RUN apt-get update \
 # it a single layer carries both, so any change under source/daemon/ rebuilds
 # ~500 dependencies from scratch — most of the 21 minutes this image took, on
 # exactly the changes that trigger it.
-RUN cargo install cargo-chef --locked --version 0.1.68
+# Version-pinned, and not below 0.1.77: the workspace Cargo.toml sets
+# `resolver = "3"`, which every cargo-chef before 0.1.69 rejects outright
+# ("unknown variant `3`, expected `1` or `2`") because it bundles a
+# pre-Rust-2024 TOML parser.
+RUN cargo install cargo-chef --locked --version 0.1.77
 
 WORKDIR /build
 

--- a/source/daemon/Dockerfile.test
+++ b/source/daemon/Dockerfile.test
@@ -58,7 +58,9 @@ FROM web-${WEB_DIST} AS web
 # ---- Builder stage: compile wardnetd + wardnet-test-agent ----
 # Pinned by digest for supply-chain integrity. Matches the workspace
 # rust-version in source/daemon/rust-toolchain.toml.
-FROM rust:1.97-slim-bookworm@sha256:96c0af8cf054fd006435089f0076729716784ec9be485bd655de59c55df105ce AS builder
+# The toolchain layer every Rust stage below shares, so the apt install and the
+# cargo-chef install are paid once and cached rather than repeated per stage.
+FROM rust:1.97-slim-bookworm@sha256:96c0af8cf054fd006435089f0076729716784ec9be485bd655de59c55df105ce AS chef
 
 # minisign is needed at build time to generate the ephemeral signing
 # key + sign the synthetic release tarball that install.sh consumes.
@@ -76,14 +78,37 @@ RUN apt-get update \
         linux-libc-dev \
     && rm -rf /var/lib/apt/lists/*
 
+# cargo-chef splits dependency compilation from workspace compilation. Without
+# it a single layer carries both, so any change under source/daemon/ rebuilds
+# ~500 dependencies from scratch — most of the 21 minutes this image took, on
+# exactly the changes that trigger it.
+RUN cargo install cargo-chef --locked --version 0.1.68
+
 WORKDIR /build
-# Rust workspace lives at /build; rust-embed paths in wardnetd-api are
-# three ../ steps from /build/crates/wardnetd-api/, resolving at the
-# filesystem root — so asset trees land at /admin-site/dist,
-# /user-app/dist, and /admin-app/dist. /deploy/keys/wardnet-release.pub is
-# baked into wardnetd-services via include_str! against a six-level
-# relative path that walks back to the repo root, so the deploy tree
-# must mirror its repo location too.
+
+# Reduces the workspace to its manifests. recipe.json changes only when a
+# Cargo.toml or Cargo.lock does, which is what lets the cook layer below
+# survive an ordinary source change.
+FROM chef AS planner
+COPY source/daemon/ /build/
+RUN cargo chef prepare --recipe-path /recipe.json
+
+FROM chef AS builder
+
+# cook compiles the workspace skeleton, so each crate's build.rs still runs:
+# build-support/version.rs reads ../../../../CALVER and wardnetd-services
+# include_str!s deploy/keys/wardnet-release.pub. Both must exist before
+# dependency compilation, and both are near-static, so putting them ahead of
+# the cook layer costs no cache hits.
+COPY CALVER /CALVER
+COPY deploy/ /deploy/
+
+COPY --from=planner /recipe.json /recipe.json
+RUN cargo chef cook --release --recipe-path /recipe.json
+
+# The real sources, replacing the skeleton cook left behind. This is the first
+# layer an ordinary daemon change invalidates, so everything above it — the
+# toolchain, the apt packages and the ~500 compiled dependencies — survives.
 COPY source/daemon/ /build/
 # web.rs embeds three asset trees via rust-embed; paths resolve from the
 # crate manifest dir (/build/crates/wardnetd-api/) three ../ steps up,
@@ -95,12 +120,6 @@ COPY --from=web /web/admin-site/dist /admin-site/dist
 COPY --from=web /web/user-app/dist /user-app/dist
 COPY --from=web /web/admin-app/dist /admin-app/dist
 COPY --from=web /web/admin-site/src/assets /admin-site/src/assets
-COPY deploy/ /deploy/
-# CALVER is read by the daemon build scripts (build-support/version.rs)
-# and resolved as `../../../../CALVER` from each crate's build.rs cwd
-# inside /build/crates/<crate>/, which lands at /CALVER. Copy it here
-# so the build doesn't panic with "No such file or directory".
-COPY CALVER /CALVER
 
 # Default to a synthetic dev version when no release tag exists.
 # install.sh extracts the version from the tarball filename, so any


### PR DESCRIPTION
The daemon e2e image takes ~21 minutes, and nearly all of it is recompiling the same ~500 Rust dependencies on every run. `Dockerfile.test` carried workspace sources and dependency compilation in one layer, so any change under `source/daemon/` — the exact change that makes the suite run at all — invalidated the whole thing.

## What changed

**cargo-chef split.** A `planner` stage reduces the workspace to its manifests; the `builder` cooks dependencies from that recipe *before* the real sources arrive. `recipe.json` changes only when a `Cargo.toml` or `Cargo.lock` does, so an ordinary source change now starts from warm dependencies.

`CALVER` and `deploy/` moved above the cook step. `cargo chef cook` compiles the workspace skeleton, so each crate's `build.rs` still runs — `build-support/version.rs` reads `CALVER`, and `wardnetd-services` `include_str!`s `deploy/keys/wardnet-release.pub`. Both are near-static, so sitting above the cook layer costs no cache hits. Profiles match (`cook --release` against two `cargo build --release` invocations, no feature flags), which is what makes the cooked artifacts reusable.

**GHCR registry cache.** Layer caching only helps across runs if the layers persist, so CI exports them via buildx. Registry rather than the Actions cache for two reasons:

- a Rust dependency layer is GB-scale, against a 10 GiB per-repo budget the Rust caches in #1232 already compete over;
- a registry cache is readable from every branch, where an Actions cache saved on a PR ref is not.

Exporting needs a writable token, which fork PRs and Dependabot events do not have — those restore the cache without updating it.

**`IMAGE_BUILDER`** is a new Makefile variable, separate from `CONTAINER_RT`, because `end2end-daemon` also runs `compose` and buildx has no `compose` subcommand. Both default to today's values, so a local `make image-test` is unchanged and still works under podman.

`packages: read` → `packages: write` on the tests-e2e leaf and both callers: a called workflow can only narrow what the caller grants, so the write has to be given at each level.

## Verification

**This cannot be validated locally.** Podman's classic builder rejects this Dockerfile's BuildKit heredocs (`Unknown instruction: SET`), and there is no docker on my machine — so the restructure only gets exercised by a CI run on this PR. What I did check statically: both cargo invocations use `--release` with no feature flags, the Makefile expands correctly under the podman default, all three workflows parse, and actionlint reports nothing new.

The first run pays full cost and populates the cache; the second run is the one that shows the win. Worth comparing the `Run daemon e2e suite` step duration between them before merging.

The failure mode if the `build.rs` inputs are wrong is loud — the cook step fails the build — not a silent cache miss.

Stacks on #1232 (Rust cache thrashing) conceptually but touches no shared files, so either can land first.