### PR TITLE
fix(ci): declare coverage.source for bulwark v1.7.0

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -407,35 +407,37 @@ jobs:
           path: coverage/
 
       - name: Restore per-package coverage reports for bulwark
-        # bulwark's TS coverage auto-discovery reads
-        # <pkgDir>/coverage/{coverage-summary.json,lcov.info} in-place (no
-        # flag), so the downloaded pkg-summaries have to land back at their
-        # original per-package paths. Rust coverage is a pair of explicit
-        # flags instead: --rust-report (the llvm-cov JSON, aggregate) and
-        # --rust-lcov-report (the lcov export, patch coverage — without it
-        # bulwark's patch gate has no per-line data and reports the language
-        # as unmeasured, while Codecov happily grades the same diff from the
-        # lcov it auto-discovered; that's how #957 got a green bulwark
-        # comment next to a red codecov/patch). All of these are skipped
-        # gracefully (empty flag outputs, package simply absent) when their
-        # producer job didn't run — bulwark just measures whatever's present.
+        # Every language is staged at the path bulwark's auto-discovery already
+        # searches, so nothing here is named again at the call site. bulwark
+        # v1.7.0 removed the --rust-report/--rust-lcov-report/--tests-mode
+        # inputs; coverage production is declared once in source/.bulwark.yml
+        # as `coverage.source: report`, and the reports are found by convention.
+        #
+        # Rust needs BOTH exports. The llvm-cov JSON carries the aggregate
+        # percentage and no per-line data at all, so without the lcov export
+        # bulwark's patch gate reports the language as unmeasured while Codecov
+        # happily grades the same diff from the lcov it auto-discovered — that
+        # is how #957 got a green bulwark comment next to a red codecov/patch.
+        #
+        # All of it is skipped gracefully (file simply absent) when the
+        # producing job didn't run — bulwark measures whatever is present.
         id: restore
         run: |
           set -euo pipefail
-          rust_report=""
+          # Rust: source/daemon is the only crate dir bulwark discovers, since
+          # its Cargo.toml declares [workspace] and members under a workspace
+          # ancestor are dropped. Its candidate lists are
+          # coverage/llvm-cov.json and coverage/lcov.info relative to that dir,
+          # which is why the JSON is renamed on the way in — the artifact's
+          # own name is not one bulwark looks for.
           if [[ -f coverage/daemon-llvm-cov.json ]]; then
             mkdir -p source/daemon/coverage
-            cp coverage/daemon-llvm-cov.json source/daemon/coverage/daemon-llvm-cov.json
-            rust_report="daemon/coverage/daemon-llvm-cov.json"
+            cp coverage/daemon-llvm-cov.json source/daemon/coverage/llvm-cov.json
           fi
-          echo "rust-report=${rust_report}" >> "$GITHUB_OUTPUT"
-          rust_lcov_report=""
           if [[ -f coverage/daemon.coverage.info ]]; then
             mkdir -p source/daemon/coverage
             cp coverage/daemon.coverage.info source/daemon/coverage/lcov.info
-            rust_lcov_report="daemon/coverage/lcov.info"
           fi
-          echo "rust-lcov-report=${rust_lcov_report}" >> "$GITHUB_OUTPUT"
           # Go: each module's profile goes back inside that module, where
           # bulwark's per-module candidate search (coverage.out / cover.out /
           # c.out, relative to the module dir) finds it with no flag. Passing
@@ -460,10 +462,10 @@ jobs:
 
       - uses: wardnet/bulwark@v1
         with:
+          # `dir` is the only input left that concerns coverage: it is the scan
+          # root, and bulwark must know the root before it can read the
+          # .bulwark.yml that declares everything else.
           dir: source
-          tests-mode: skip
-          rust-report: ${{ steps.restore.outputs.rust-report }}
-          rust-lcov-report: ${{ steps.restore.outputs.rust-lcov-report }}
           codecov-token: ${{ secrets.CODECOV_TOKEN }}
           semgrep-app-token: ${{ secrets.SEMGREP_APP_TOKEN }}
 

--- a/source/.bulwark.yml
+++ b/source/.bulwark.yml
@@ -1,15 +1,35 @@
 # bulwark configuration for the wardnet monorepo.
 #
-# This file can only NARROW what bulwark does — it cannot tune rule severity or
-# suppress individual findings, and that is deliberate. Genuine findings get
-# fixed; a reviewed false positive gets an `eslint-disable-next-line <rule> --
-# <why>` on the exact line, with a reason naming where the value actually comes
-# from. No rule is switched off globally — that would hide the next genuine
-# finding, which is the whole point of running this.
-#
-# There is nothing to narrow today, so this file sets nothing. It is kept as the
-# place such decisions would be recorded, and to explain why two tempting ones
-# were rejected:
+# Beyond declaring how coverage is produced, this file can only NARROW what
+# bulwark does — it cannot tune rule severity or suppress individual findings,
+# and that is deliberate. Genuine findings get fixed; a reviewed false positive
+# gets an `eslint-disable-next-line <rule> -- <why>` on the exact line, with a
+# reason naming where the value actually comes from. No rule is switched off
+# globally — that would hide the next genuine finding, which is the whole point
+# of running this.
+
+coverage:
+  # This repo's CI already runs every suite instrumented and uploads the
+  # reports, so bulwark must never execute anything itself — it runs last in
+  # coverage.yml purely as a report consumer. The default is `run`, which would
+  # execute the Rust and TypeScript suites a third time (they already run once
+  # plain for pass/fail and once instrumented for coverage).
+  #
+  # This lives here rather than at the call site because it describes how the
+  # repo's pipeline is built — one answer, true for every workflow — which is
+  # why bulwark v1.7.0 removed the `tests-mode` action input that used to carry
+  # it. See wardnet/bulwark ADR 0003.
+  #
+  # No report paths are set: coverage.yml stages every report at the path
+  # bulwark's own candidate search already checks — Rust at
+  # daemon/coverage/{llvm-cov.json,lcov.info}, Go at each module's
+  # coverage.out, TypeScript at each package's coverage/ directory. An override
+  # here would have to be keyed per unit and would go stale the moment a module
+  # is added.
+  source: report
+
+# Nothing is narrowed today. The file is also the place such decisions would be
+# recorded, and explains why two tempting ones were rejected:
 #
 #   * `typescript: {enabled: false}` — used briefly while bulwark's ESLint check
 #     was broken: it declared no `files:` glob, so it silently linted no


### PR DESCRIPTION
bulwark v1.7.0 ([#29](https://github.com/wardnet/bulwark/pull/29)) is a breaking change, and we track `wardnet/bulwark@v1` — a moving tag. So this already landed: **`main` is broken right now**, not just the open PRs.

From the v1.7.0 tag message:

> BREAKING: the composite action's `tests-mode`, `go-report`, `rust-report` and `rust-lcov-report` inputs are removed. Coverage production is now declared in .bulwark.yml at the scan root.

`coverage.yml` passed three of those four. The important one is `tests-mode: skip` — with no replacement the setting defaults to `run`, which has bulwark **execute the Rust and TypeScript suites itself**. `coverage.yml` already runs them twice (once plain for pass/fail, once instrumented for coverage); this would have made it three times.

## The fix

`source/.bulwark.yml` declares `coverage.source: report`, and the dead inputs come off the call site. `dir` stays, since bulwark has to know the scan root before it can read the config that lives there.

**No report paths are configured, deliberately.** bulwark's per-unit candidate search already checks each unit's conventional location, and `coverage.yml` stages Go (`<module>/coverage.out`) and TypeScript (`<pkg>/coverage/`) exactly there. Rust was the lone exception — it staged the llvm-cov JSON under the artifact's own name, `daemon-llvm-cov.json`, which was only ever found because of the explicit flag. Renaming it to `llvm-cov.json` means every language is discovered the same way and nothing is named twice. An override would have to be keyed per unit and would go stale the first time a module is added.

`source/daemon` is the only Rust unit bulwark discovers — its `Cargo.toml` declares `[workspace]`, and `RustCrateDirs` drops members under a workspace ancestor — so the bare candidate paths resolve unambiguously.

## Verification

Checked against the real v1.7.0 parser, not the docs:

- `bulwark update` to v1.7.0 locally, then `bulwark coverage --dir source` with a deliberately invalid value → `Error: source/.bulwark.yml: coverage.source must be "run" or "report", got "bogus"`. That proves the file is read **at this path** and the key is honoured — a config in the wrong place would have failed silently by defaulting to `run`.
- `bulwark coverage --help` at v1.7.0 documents the candidate lists this change depends on: Rust `coverage/llvm-cov.json` and `coverage/lcov.info`, Go `coverage.out`, each relative to its unit dir.
- `actionlint` clean on `coverage.yml`.

What I could not verify locally is the end result — that bulwark finds a real report and produces the same coverage numbers. That needs a CI run with the artifacts actually present. The failure mode is visible rather than silent: a report bulwark cannot find shows up as the language reported unmeasured in the PR comment, so it's worth a look at this PR's bulwark output before merging.

## Merge order

This should go in first, then #1232 and #1234 rebase onto it — same flow as #1233. It is deliberately a separate PR rather than the same edit copied into both: duplicating it guarantees a conflict on the second merge, and it keeps a bulwark config change out of a PR about Docker layer caching.