### PR TITLE
chore(ci): adopt gt repo governance

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,56 +1,234 @@
+# Managed by gt — edit .gt-repo.yaml, then run `gt repo sync`.
+#
+# Shared policy (cooldown, commit-message prefix, schedule) lives in gt's
+# template, not here, so changing it for every repo is a one-line edit in gt.
+#
+# The 7-day cooldown is the supply-chain guard: by the time a PR exists,
+# the upstream release has been in the wild long enough to surface yanks and
+# compromised publishers before an auto-merge-eligible PR lands on the default
+# branch.
 version: 2
 updates:
+  # The daemon workspace. Covers every member crate through the single
+  # Cargo.lock at this directory.
   - package-ecosystem: "cargo"
     directory: "/source/daemon"
     schedule:
       interval: "weekly"
+    # Dependabot's commit message is also its PR title, and PRs are
+    # squash-merged, so the prefix is what keeps dependency updates inside
+    # Conventional Commits. `include: scope` appends the dependency scope,
+    # producing e.g. `build(deps): bump …`.
     commit-message:
-      prefix: "chore(deps):"
-    # 3-day cooldown before Dependabot opens a PR for a new version.
-    # Gives the wider ecosystem time to surface supply-chain issues
-    # (yanked releases, compromised publishers) before an auto-merge
-    # eligible PR lands on main.
+      prefix: "build"
+      include: scope
     cooldown:
-      default-days: 3
+      default-days: 7
+    open-pull-requests-limit: 25
 
-  # Two independent Go modules, each with its own go.mod, so each needs its
-  # own entry — gomod has no workspace-root equivalent to the npm setup below.
-  # Both ship: the SDK is published to outside consumers as wardnet.network/go,
-  # and wctl is distributed as a signed release binary, so an unpatched
-  # advisory in either reaches users directly.
+  # Its own workspace, not a member of the daemon's — source/daemon/Cargo.toml
+  # excludes it so libfuzzer-sys and the nightly sanitizer rustflags cannot
+  # leak into normal builds. That separation also means its Cargo.lock is
+  # invisible to the entry above, so it needs its own.
+  - package-ecosystem: "cargo"
+    directory: "/source/daemon/fuzz"
+    schedule:
+      interval: "weekly"
+    # Dependabot's commit message is also its PR title, and PRs are
+    # squash-merged, so the prefix is what keeps dependency updates inside
+    # Conventional Commits. `include: scope` appends the dependency scope,
+    # producing e.g. `build(deps): bump …`.
+    commit-message:
+      prefix: "build"
+      include: scope
+    cooldown:
+      default-days: 7
+    open-pull-requests-limit: 25
+
+  # ClusterFuzzLite build image. Every FROM is digest-pinned for Scorecard and
+  # supply-chain integrity, so Dependabot is the only channel that surfaces
+  # upstream image updates.
+  - package-ecosystem: "docker"
+    directory: "/.clusterfuzzlite"
+    schedule:
+      interval: "weekly"
+    # Dependabot's commit message is also its PR title, and PRs are
+    # squash-merged, so the prefix is what keeps dependency updates inside
+    # Conventional Commits. `include: scope` appends the dependency scope,
+    # producing e.g. `build(deps): bump …`.
+    commit-message:
+      prefix: "build"
+      include: scope
+    cooldown:
+      default-days: 7
+    open-pull-requests-limit: 25
+
+  # Digest-pinned like the above:
+  #
+  #   Dockerfile        production image (FROM wardnet-base)
+  #   Dockerfile.base   shared OS layer (FROM debian:bookworm-slim)
+  #   Dockerfile.test   end-to-end test image (FROM rust + wardnet-base)
+  - package-ecosystem: "docker"
+    directory: "/source/daemon"
+    schedule:
+      interval: "weekly"
+    # Dependabot's commit message is also its PR title, and PRs are
+    # squash-merged, so the prefix is what keeps dependency updates inside
+    # Conventional Commits. `include: scope` appends the dependency scope,
+    # producing e.g. `build(deps): bump …`.
+    commit-message:
+      prefix: "build"
+      include: scope
+    cooldown:
+      default-days: 7
+    open-pull-requests-limit: 25
+
+  - package-ecosystem: "docker"
+    directory: "/source/end2end-tests/daemon/mocks/nordvpn"
+    schedule:
+      interval: "weekly"
+    # Dependabot's commit message is also its PR title, and PRs are
+    # squash-merged, so the prefix is what keeps dependency updates inside
+    # Conventional Commits. `include: scope` appends the dependency scope,
+    # producing e.g. `build(deps): bump …`.
+    commit-message:
+      prefix: "build"
+      include: scope
+    cooldown:
+      default-days: 7
+    open-pull-requests-limit: 25
+
+  - package-ecosystem: "docker"
+    directory: "/source/end2end-tests/daemon/mocks/wg-gateway"
+    schedule:
+      interval: "weekly"
+    # Dependabot's commit message is also its PR title, and PRs are
+    # squash-merged, so the prefix is what keeps dependency updates inside
+    # Conventional Commits. `include: scope` appends the dependency scope,
+    # producing e.g. `build(deps): bump …`.
+    commit-message:
+      prefix: "build"
+      include: scope
+    cooldown:
+      default-days: 7
+    open-pull-requests-limit: 25
+
+  - package-ecosystem: "docker"
+    directory: "/source/end2end-tests/daemon/mocks/wg-tunnel-gateway"
+    schedule:
+      interval: "weekly"
+    # Dependabot's commit message is also its PR title, and PRs are
+    # squash-merged, so the prefix is what keeps dependency updates inside
+    # Conventional Commits. `include: scope` appends the dependency scope,
+    # producing e.g. `build(deps): bump …`.
+    commit-message:
+      prefix: "build"
+      include: scope
+    cooldown:
+      default-days: 7
+    open-pull-requests-limit: 25
+
+  - package-ecosystem: "docker"
+    directory: "/source/end2end-tests/web-ui/mocks/wardnet-cloud"
+    schedule:
+      interval: "weekly"
+    # Dependabot's commit message is also its PR title, and PRs are
+    # squash-merged, so the prefix is what keeps dependency updates inside
+    # Conventional Commits. `include: scope` appends the dependency scope,
+    # producing e.g. `build(deps): bump …`.
+    commit-message:
+      prefix: "build"
+      include: scope
+    cooldown:
+      default-days: 7
+    open-pull-requests-limit: 25
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    # Dependabot's commit message is also its PR title, and PRs are
+    # squash-merged, so the prefix is what keeps dependency updates inside
+    # Conventional Commits. `include: scope` appends the dependency scope,
+    # producing e.g. `ci(deps): bump …`.
+    commit-message:
+      prefix: "ci"
+      include: scope
+    cooldown:
+      default-days: 7
+    open-pull-requests-limit: 25
+    # Grouped dependencies share a single PR. A group exists when its members
+    # must move together: landing one alone breaks the default branch, and the
+    # sibling PR then fails that same broken check — so auto-merge cannot
+    # recover on its own.
+    groups:
+      # codeql-action/init and codeql-action/analyze MUST move in lockstep:
+      # init writes a config file stamped with its own version and analyze
+      # refuses to read one written by a different version, failing with
+      # "Loaded a configuration file for version X, but running version Y".
+      #
+      # Dependabot treats each action path as its own dependency, so without
+      # this group it opens a separate PR per path. The daily auto-merge batch
+      # then lands one of them alone and main goes red — and because the
+      # sibling PR now fails that same broken CodeQL job, auto-merge won't
+      # merge it either, so main stays red until a human intervenes. That
+      # deadlock cost us #991, #1059 and #1069.
+      codeql-action:
+        patterns:
+          - "github/codeql-action*"
+
   - package-ecosystem: "gomod"
     directory: "/source/sdk/wardnet-go"
     schedule:
       interval: "weekly"
+    # Dependabot's commit message is also its PR title, and PRs are
+    # squash-merged, so the prefix is what keeps dependency updates inside
+    # Conventional Commits. `include: scope` appends the dependency scope,
+    # producing e.g. `build(deps): bump …`.
     commit-message:
-      prefix: "chore(deps):"
+      prefix: "build"
+      include: scope
     cooldown:
-      default-days: 3
+      default-days: 7
+    open-pull-requests-limit: 25
 
   - package-ecosystem: "gomod"
     directory: "/source/wctl"
     schedule:
       interval: "weekly"
+    # Dependabot's commit message is also its PR title, and PRs are
+    # squash-merged, so the prefix is what keeps dependency updates inside
+    # Conventional Commits. `include: scope` appends the dependency scope,
+    # producing e.g. `build(deps): bump …`.
     commit-message:
-      prefix: "chore(deps):"
+      prefix: "build"
+      include: scope
     cooldown:
-      default-days: 3
+      default-days: 7
+    open-pull-requests-limit: 25
 
-  # The web codebase is a Yarn-workspaces monorepo with a SINGLE lockfile
-  # at /source/yarn.lock. Dependabot must point at the workspace ROOT so
-  # every version bump also regenerates the lockfile — per-workspace
-  # entries (e.g. /source/admin-site) edit only that package.json, leave
-  # yarn.lock stale, and every PR fails CI's `yarn install --immutable`.
+  # The web codebase is a Yarn-workspaces monorepo with a SINGLE lockfile at
+  # /source/yarn.lock. Dependabot must point at the workspace ROOT so every
+  # version bump also regenerates the lockfile — per-workspace entries (e.g.
+  # /source/admin-site) edit only that package.json, leave yarn.lock stale,
+  # and every PR then fails CI's `yarn install --immutable`.
+  #
   # This one entry covers the root manifest plus all workspaces
   # (sdk/wardnet-js, web, admin-site, admin-app, user-app, marketing-site).
   - package-ecosystem: "npm"
     directory: "/source"
     schedule:
       interval: "weekly"
+    # Dependabot's commit message is also its PR title, and PRs are
+    # squash-merged, so the prefix is what keeps dependency updates inside
+    # Conventional Commits. `include: scope` appends the dependency scope,
+    # producing e.g. `build(deps): bump …`.
     commit-message:
-      prefix: "chore(deps):"
+      prefix: "build"
+      include: scope
     cooldown:
-      default-days: 3
+      default-days: 7
+    open-pull-requests-limit: 25
 
   # Standalone package with its own yarn.lock — not part of the /source
   # workspace, so it keeps its own entry.
@@ -58,61 +236,29 @@ updates:
     directory: "/source/end2end-tests/daemon"
     schedule:
       interval: "weekly"
+    # Dependabot's commit message is also its PR title, and PRs are
+    # squash-merged, so the prefix is what keeps dependency updates inside
+    # Conventional Commits. `include: scope` appends the dependency scope,
+    # producing e.g. `build(deps): bump …`.
     commit-message:
-      prefix: "chore(deps):"
+      prefix: "build"
+      include: scope
     cooldown:
-      default-days: 3
+      default-days: 7
+    open-pull-requests-limit: 25
 
-  - package-ecosystem: "github-actions"
-    directory: "/"
+  # Standalone package with its own yarn.lock, same as the daemon suite above.
+  - package-ecosystem: "npm"
+    directory: "/source/end2end-tests/web-ui"
     schedule:
       interval: "weekly"
+    # Dependabot's commit message is also its PR title, and PRs are
+    # squash-merged, so the prefix is what keeps dependency updates inside
+    # Conventional Commits. `include: scope` appends the dependency scope,
+    # producing e.g. `build(deps): bump …`.
     commit-message:
-      prefix: "chore(ci):"
+      prefix: "build"
+      include: scope
     cooldown:
-      default-days: 3
-    # codeql-action/init and codeql-action/analyze MUST move in lockstep:
-    # init writes a config file stamped with its own version and analyze
-    # refuses to read one written by a different version, failing with
-    # "Loaded a configuration file for version X, but running version Y".
-    #
-    # Dependabot treats each action path as its own dependency, so without
-    # this group it opens a separate PR per path. The daily auto-merge batch
-    # then lands one of them alone and main goes red — and because the
-    # sibling PR now fails that same broken CodeQL job, auto-merge won't
-    # merge it either, so main stays red until a human intervenes. That
-    # deadlock cost us #991, #1059 and #1069.
-    #
-    # Grouping makes every codeql-action bump a single atomic PR.
-    groups:
-      codeql-action:
-        patterns:
-          - "github/codeql-action*"
-
-  # source/daemon/ Dockerfiles — all FROM lines are pinned by digest
-  # for Scorecard / supply-chain integrity, so Dependabot is the
-  # channel that surfaces upstream image updates.
-  #
-  #   Dockerfile        — production image (FROM wardnet-base)
-  #   Dockerfile.base   — shared OS layer (FROM debian:bookworm-slim)
-  #   Dockerfile.test   — end-to-end test image (FROM rust + wardnet-base)
-  - package-ecosystem: "docker"
-    directory: "/source/daemon"
-    schedule:
-      interval: "weekly"
-    commit-message:
-      prefix: "chore(deps):"
-    cooldown:
-      default-days: 3
-
-  # ClusterFuzzLite build image (.clusterfuzzlite/Dockerfile) — same
-  # pin-then-bump story.
-  - package-ecosystem: "docker"
-    directory: "/.clusterfuzzlite"
-    schedule:
-      interval: "weekly"
-    commit-message:
-      prefix: "chore(deps):"
-    cooldown:
-      default-days: 3
-
+      default-days: 7
+    open-pull-requests-limit: 25

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -1,0 +1,23 @@
+# ci-build — this file is yours.
+#
+# gt created it once and will never modify or delete it again. Put this
+# repository's build steps here; the orchestration around it stays gt's.
+#
+# It is called by ci-orchestration.yml and must keep `workflow_call`, or the
+# orchestrator loses the stage.
+name: ci-build
+
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: build
+    runs-on: ubuntu-latest
+    steps:
+      # A no-op so the stage is green from the first run. Replace it.
+      - name: Nothing to do yet
+        run: echo "No build steps defined. Add them in .github/workflows/ci-build.yml"

--- a/.github/workflows/ci-end2end.yml
+++ b/.github/workflows/ci-end2end.yml
@@ -1,0 +1,23 @@
+# ci-end2end — this file is yours.
+#
+# gt created it once and will never modify or delete it again. Put this
+# repository's end-to-end tests here; the orchestration around it stays gt's.
+#
+# It is called by ci-orchestration.yml and must keep `workflow_call`, or the
+# orchestrator loses the stage.
+name: ci-end2end
+
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+
+jobs:
+  end2end:
+    name: end2end
+    runs-on: ubuntu-latest
+    steps:
+      # A no-op so the stage is green from the first run. Replace it.
+      - name: Nothing to do yet
+        run: echo "No end2end steps defined. Add them in .github/workflows/ci-end2end.yml"

--- a/.github/workflows/ci-orchestration.yml
+++ b/.github/workflows/ci-orchestration.yml
@@ -55,6 +55,13 @@ jobs:
     needs: [attest]
     if: needs.attest.outputs.validated != 'true'
     uses: ./.github/workflows/ci-preflight.yml
+    # `inherit` rather than an enumerated `secrets:` block, and semgrep's
+    # secrets-inherit rule is answered rather than silenced: gt renders this
+    # orchestrator for every repository and cannot know their secret names, so
+    # there is no list to write. The callee is this same repository's own
+    # workflow, so no secret crosses a trust boundary that `inherit` did not
+    # already sit inside.
+    # nosemgrep: yaml.github-actions.security.secrets-inherit.secrets-inherit
     secrets: inherit
     # packages: read because several repositories resolve private @scope
     # dependencies from GitHub Packages during install, and a called workflow
@@ -69,6 +76,13 @@ jobs:
     needs: [attest, preflight]
     if: needs.attest.outputs.validated != 'true' && needs.preflight.outputs.run-build != 'false'
     uses: ./.github/workflows/ci-build.yml
+    # `inherit` rather than an enumerated `secrets:` block, and semgrep's
+    # secrets-inherit rule is answered rather than silenced: gt renders this
+    # orchestrator for every repository and cannot know their secret names, so
+    # there is no list to write. The callee is this same repository's own
+    # workflow, so no secret crosses a trust boundary that `inherit` did not
+    # already sit inside.
+    # nosemgrep: yaml.github-actions.security.secrets-inherit.secrets-inherit
     secrets: inherit
     # packages: read because several repositories resolve private @scope
     # dependencies from GitHub Packages during install, and a called workflow
@@ -83,6 +97,13 @@ jobs:
     needs: [attest, build, preflight]
     if: needs.attest.outputs.validated != 'true' && needs.preflight.outputs.run-test != 'false'
     uses: ./.github/workflows/ci-test.yml
+    # `inherit` rather than an enumerated `secrets:` block, and semgrep's
+    # secrets-inherit rule is answered rather than silenced: gt renders this
+    # orchestrator for every repository and cannot know their secret names, so
+    # there is no list to write. The callee is this same repository's own
+    # workflow, so no secret crosses a trust boundary that `inherit` did not
+    # already sit inside.
+    # nosemgrep: yaml.github-actions.security.secrets-inherit.secrets-inherit
     secrets: inherit
     # packages: read because several repositories resolve private @scope
     # dependencies from GitHub Packages during install, and a called workflow
@@ -97,6 +118,13 @@ jobs:
     needs: [attest, build, preflight]
     if: needs.attest.outputs.validated != 'true' && needs.preflight.outputs.run-end2end != 'false'
     uses: ./.github/workflows/ci-end2end.yml
+    # `inherit` rather than an enumerated `secrets:` block, and semgrep's
+    # secrets-inherit rule is answered rather than silenced: gt renders this
+    # orchestrator for every repository and cannot know their secret names, so
+    # there is no list to write. The callee is this same repository's own
+    # workflow, so no secret crosses a trust boundary that `inherit` did not
+    # already sit inside.
+    # nosemgrep: yaml.github-actions.security.secrets-inherit.secrets-inherit
     secrets: inherit
     # packages: read because several repositories resolve private @scope
     # dependencies from GitHub Packages during install, and a called workflow

--- a/.github/workflows/ci-orchestration.yml
+++ b/.github/workflows/ci-orchestration.yml
@@ -6,7 +6,14 @@
 # confuse "absent" with "not started yet".
 #
 # Branch protection requires exactly one check: "ci-gate".
-name: CI
+#
+# Named "gt CI" rather than "CI" for the same reason the file is not ci.yml:
+# every repository already has a workflow called CI, and the stages move into
+# this one a few at a time, so the two coexist for a long while. Two workflows
+# sharing a display name make the Actions list ambiguous and every check read
+# as "CI / …" from one of two places. The `gt ` prefix matches the reusable
+# workflows this calls — gt attest, gt bulwark, gt sync.
+name: gt CI
 
 on:
   # No `branches:` filter: a PR stacked onto a feature branch must run CI too.

--- a/.github/workflows/ci-orchestration.yml
+++ b/.github/workflows/ci-orchestration.yml
@@ -1,0 +1,166 @@
+# Managed by gt — edit .gt-repo.yaml, then run `gt repo sync`.
+#
+# gt owns the orchestration; the ci-* stages it calls are yours. Because every
+# stage is a job in this one workflow, `ci-gate` aggregates them with
+# `needs:` rather than polling the checks API — no timeout, and no way to
+# confuse "absent" with "not started yet".
+#
+# Branch protection requires exactly one check: "ci-gate".
+name: CI
+
+on:
+  # No `branches:` filter: a PR stacked onto a feature branch must run CI too.
+  pull_request:
+    # `edited` is load-bearing: without it, correcting a rejected title leaves
+    # the check red until an unrelated push.
+    types: [opened, synchronize, reopened, edited, ready_for_review]
+  # On the default branch an already-validated tree skips every stage.
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+# Superseded pushes to the same PR are cancelled; runs on the default branch and
+# in a merge queue are not. Cancelling a PR run costs nothing — a newer commit
+# is about to be validated anyway — whereas cancelling a default-branch run
+# discards the attestation it was about to record, and cancelling a queued
+# merge would drop it from the queue.
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions:
+  contents: read
+
+jobs:
+  # Reports whether this exact tree already passed the gate, so a push that
+  # merely squashed an already-validated PR does not run everything again.
+  attest:
+    uses: pedromvgomes/gt/.github/workflows/reusable-attest.yml@v1
+    # A called workflow may only narrow these. Granting less than
+    # reusable-attest declares fails the run at parse time, before any job
+    # starts — so ci-gate never reports and every PR blocks.
+    permissions:
+      contents: read
+      statuses: read
+      pull-requests: read
+
+  preflight:
+    needs: [attest]
+    if: needs.attest.outputs.validated != 'true'
+    uses: ./.github/workflows/ci-preflight.yml
+    secrets: inherit
+    # packages: read because several repositories resolve private @scope
+    # dependencies from GitHub Packages during install, and a called workflow
+    # can only narrow what the caller grants — a stage cannot ask for it back.
+    # Read-only, so granting it where it is unused costs nothing. A stage
+    # needing more than this is a gt change.
+    permissions:
+      contents: read
+      packages: read
+
+  build:
+    needs: [attest, preflight]
+    if: needs.attest.outputs.validated != 'true' && needs.preflight.outputs.run-build != 'false'
+    uses: ./.github/workflows/ci-build.yml
+    secrets: inherit
+    # packages: read because several repositories resolve private @scope
+    # dependencies from GitHub Packages during install, and a called workflow
+    # can only narrow what the caller grants — a stage cannot ask for it back.
+    # Read-only, so granting it where it is unused costs nothing. A stage
+    # needing more than this is a gt change.
+    permissions:
+      contents: read
+      packages: read
+
+  test:
+    needs: [attest, build, preflight]
+    if: needs.attest.outputs.validated != 'true' && needs.preflight.outputs.run-test != 'false'
+    uses: ./.github/workflows/ci-test.yml
+    secrets: inherit
+    # packages: read because several repositories resolve private @scope
+    # dependencies from GitHub Packages during install, and a called workflow
+    # can only narrow what the caller grants — a stage cannot ask for it back.
+    # Read-only, so granting it where it is unused costs nothing. A stage
+    # needing more than this is a gt change.
+    permissions:
+      contents: read
+      packages: read
+
+  end2end:
+    needs: [attest, build, preflight]
+    if: needs.attest.outputs.validated != 'true' && needs.preflight.outputs.run-end2end != 'false'
+    uses: ./.github/workflows/ci-end2end.yml
+    secrets: inherit
+    # packages: read because several repositories resolve private @scope
+    # dependencies from GitHub Packages during install, and a called workflow
+    # can only narrow what the caller grants — a stage cannot ask for it back.
+    # Read-only, so granting it where it is unused costs nothing. A stage
+    # needing more than this is a gt change.
+    permissions:
+      contents: read
+      packages: read
+
+  conventional-commits:
+    needs: [attest]
+    if: needs.attest.outputs.validated != 'true'
+    uses: pedromvgomes/gt/.github/workflows/reusable-conventional-commits.yml@v1
+    permissions:
+      contents: read
+      pull-requests: read
+
+  governance:
+    needs: [attest]
+    if: needs.attest.outputs.validated != 'true'
+    uses: pedromvgomes/gt/.github/workflows/reusable-governance.yml@v1
+
+  # The single required check. `if: always()` so it still reports when a stage
+  # was skipped, and a skipped stage passes — that is the point of preflight.
+  ci-gate:
+    name: ci-gate
+    needs: [attest, preflight, build, test, end2end, conventional-commits, governance]
+    if: always()
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      statuses: write
+    steps:
+      - name: Verify every stage succeeded or was legitimately skipped
+        env:
+          RESULTS: ${{ toJSON(needs.*.result) }}
+        run: |
+          set -euo pipefail
+          echo "stage results: ${RESULTS}"
+          if [[ "${{ contains(needs.*.result, 'failure') }}" == "true" ]]; then
+            echo "::error::a required stage failed"
+            exit 1
+          fi
+          if [[ "${{ contains(needs.*.result, 'cancelled') }}" == "true" ]]; then
+            echo "::error::a required stage was cancelled"
+            exit 1
+          fi
+
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      # Records the tree this run validated, so a later push or tag can prove
+      # the same content already passed rather than re-running to find out.
+      - name: Attest the validated tree
+        # Read-only GITHUB_TOKEN (fork PRs, and every Dependabot event) cannot
+        # POST a status. Losing the attestation only costs a re-run on the
+        # default branch; failing the gate would block the PR entirely.
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+        run: |
+          set -euo pipefail
+          # For a pull_request event HEAD is refs/pull/N/merge, so this is the
+          # tree of the merged result — which is exactly what a squash merge
+          # puts on the default branch.
+          tree=$(git rev-parse "HEAD^{tree}")
+          gh api "repos/${REPO}/statuses/${SHA}" \
+            -f state=success \
+            -f context=gt/validated-tree \
+            -f description="$tree" >/dev/null
+          echo "attested tree ${tree} on ${SHA}"

--- a/.github/workflows/ci-preflight.yml
+++ b/.github/workflows/ci-preflight.yml
@@ -1,0 +1,42 @@
+# ci-preflight — this file is yours.
+#
+# gt created it once and will never modify or delete it again.
+#
+# This stage decides which later stages run. Emit `false` for a stage to skip
+# it; anything else — including nothing at all, as below — runs it. That is why
+# the stub is a no-op: out of the box every stage runs, and change detection is
+# something you opt into rather than out of.
+#
+# A typical implementation sets these from a paths filter, so an untouched area
+# is not rebuilt. A skipped stage still passes the gate.
+name: ci-preflight
+
+on:
+  workflow_call:
+    outputs:
+      run-build:
+        description: Set to "false" to skip the build stage.
+        value: ${{ jobs.preflight.outputs.run-build }}
+      run-test:
+        description: Set to "false" to skip the test stage.
+        value: ${{ jobs.preflight.outputs.run-test }}
+      run-end2end:
+        description: Set to "false" to skip the end2end stage.
+        value: ${{ jobs.preflight.outputs.run-end2end }}
+
+permissions:
+  contents: read
+
+jobs:
+  preflight:
+    name: preflight
+    runs-on: ubuntu-latest
+    outputs:
+      run-build: ${{ steps.decide.outputs.run-build }}
+      run-test: ${{ steps.decide.outputs.run-test }}
+      run-end2end: ${{ steps.decide.outputs.run-end2end }}
+    steps:
+      - name: Decide which stages to run
+        id: decide
+        # Emitting nothing runs everything. Replace with change detection.
+        run: echo "every stage runs by default"

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -1,0 +1,29 @@
+# ci-test — this file is yours.
+#
+# gt created it once and will never modify or delete it again. Put this
+# repository's test suite here; the orchestration around it stays gt's.
+#
+# Upload coverage as an artifact named `gt-coverage` and the bulwark
+# stage will consume it instead of running the suite a second time. Without it
+# bulwark falls back to running the tests itself, which is correct but slower.
+#
+#   - uses: actions/upload-artifact@<sha>
+#     with:
+#       name: gt-coverage
+#       path: coverage.out
+name: ci-test
+
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: test
+    runs-on: ubuntu-latest
+    steps:
+      # A no-op so the stage is green from the first run. Replace it.
+      - name: Nothing to do yet
+        run: echo "No test steps defined. Add them in .github/workflows/ci-test.yml"

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,159 +1,28 @@
+# Managed by gt — edit .gt-repo.yaml, then run `gt repo sync`.
+#
+# Daily batch window for merging Dependabot's eligible bumps. The Dependabot
+# cooldown (set in .github/dependabot.yml) is the supply-chain guard; this is
+# the merge executor on top of it.
+#
+# Bumps above `minor` are left for human review.
+#
+# Known gap, not a bug: Dependabot PRs touching .github/workflows/** can never
+# be merged here. There is no permissions: key granting GITHUB_TOKEN the
+# `workflow` scope, so the github-actions ecosystem always needs a human or
+# `gt repo fleet merge-pending`, which runs with your own credentials.
 name: Dependabot auto-merge
-
-# Daily batch window for merging Dependabot's patch and minor bumps.
-#
-# The Dependabot cooldown (3 days, set in .github/dependabot.yml) is
-# the supply-chain guard — by the time a PR exists, the upstream
-# release has been in the wild long enough to surface yanks /
-# compromises. This workflow is the merge executor on top of that:
-#
-#   1. List open Dependabot PRs
-#   2. For each: parse the bump type from the title, check the PR is
-#      actually mergeable (all required checks green, no review blocks)
-#   3. Squash-merge the eligible ones
-#
-# Major bumps are skipped — those get a human review. Non-Dependabot
-# PRs are untouched.
-#
-# Production exposure is further bounded by the release cycle:
-# dependency updates ride the next tagged release, not every merge to
-# main, so a bad merge has more chances to be caught before users see
-# it.
 
 on:
   schedule:
-    - cron: "0 1 * * *"  # 01:00 UTC daily
-  workflow_dispatch:     # allow manual triggering for debugging
+    - cron: "0 1 * * *"
+  workflow_dispatch:
 
-# Minimal top-level default; the write scopes are granted only to the
-# job that actually needs them (see below).
+# A called reusable workflow can only narrow the caller's token, never widen
+# it, so the writes the merge job needs have to be granted here.
 permissions:
-  contents: read
+  contents: write
+  pull-requests: write
 
 jobs:
   auto-merge:
-    name: Auto-merge Dependabot patch/minor PRs
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    permissions:
-      contents: write        # required to squash-merge PRs and delete their branches
-      pull-requests: write
-    steps:
-      - name: Harden the runner (Audit all outbound calls)
-        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
-        with:
-          egress-policy: audit
-
-      - name: Merge eligible Dependabot PRs
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          REPO: ${{ github.repository }}
-        run: |
-          set -euo pipefail
-
-          # Pull every open Dependabot PR's merge-relevant fields.
-          # mergeStateStatus ∈ {BEHIND, BLOCKED, CLEAN, DIRTY, DRAFT,
-          # HAS_HOOKS, UNKNOWN, UNSTABLE}; CLEAN / HAS_HOOKS mean the
-          # PR is ready per branch protection.
-          gh pr list --repo "$REPO" \
-            --author app/dependabot \
-            --state open \
-            --json number,title,mergeable,mergeStateStatus,isDraft \
-            > prs.json
-
-          count=$(jq 'length' prs.json)
-          echo "Found ${count} open Dependabot PR(s)."
-
-          # Track per-PR merge failures so one bad PR doesn't abort the
-          # whole batch (the loop runs under `set -e`). We surface a red
-          # X at the end if any eligible merge failed.
-          failed=0
-
-          # Extract "from X.Y.Z to A.B.C" out of the title, classify
-          # the bump via semver comparison, merge if patch/minor and
-          # the PR is ready.
-          # Fed via process substitution (not a pipe) so the loop runs
-          # in this shell and `failed` survives past `done`.
-          while read -r pr; do
-            number=$(echo "$pr" | jq -r '.number')
-            title=$(echo "$pr" | jq -r '.title')
-            mergeable=$(echo "$pr" | jq -r '.mergeable')
-            state=$(echo "$pr" | jq -r '.mergeStateStatus')
-            draft=$(echo "$pr" | jq -r '.isDraft')
-
-            echo ""
-            echo "── PR #${number}: ${title}"
-            echo "   mergeable=${mergeable} state=${state} draft=${draft}"
-
-            if [[ "$draft" == "true" ]]; then
-              echo "   → skip: draft"
-              continue
-            fi
-            if [[ "$mergeable" != "MERGEABLE" ]]; then
-              echo "   → skip: not mergeable (conflicts?)"
-              continue
-            fi
-            if [[ "$state" != "CLEAN" && "$state" != "HAS_HOOKS" && "$state" != "UNSTABLE" ]]; then
-              # UNSTABLE = required checks passed but optional checks failed.
-              # Treat as eligible; branch protection already enforces the required set.
-              echo "   → skip: mergeStateStatus=${state} (checks not green)"
-              continue
-            fi
-
-            # Parse versions from the title. Dependabot's format is
-            # stable: "bump <pkg> from <old> to <new>" (possibly with
-            # " in /path" suffix). Extract old/new.
-            if [[ ! "$title" =~ from\ ([0-9]+\.[0-9]+\.[0-9]+)(-[A-Za-z0-9\.\-]+)?\ to\ ([0-9]+\.[0-9]+\.[0-9]+)(-[A-Za-z0-9\.\-]+)? ]]; then
-              echo "   → skip: couldn't parse versions from title"
-              continue
-            fi
-            old="${BASH_REMATCH[1]}"
-            new="${BASH_REMATCH[3]}"
-            old_major="${old%%.*}"
-            new_major="${new%%.*}"
-            old_rest="${old#*.}"; old_minor="${old_rest%%.*}"
-            new_rest="${new#*.}"; new_minor="${new_rest%%.*}"
-
-            if [[ "$old_major" != "$new_major" ]]; then
-              bump="major"
-            elif [[ "$old_minor" != "$new_minor" ]]; then
-              bump="minor"
-            else
-              bump="patch"
-            fi
-            echo "   bump: ${old} → ${new} (${bump})"
-
-            if [[ "$bump" == "major" ]]; then
-              echo "   → skip: major bumps require human review"
-              continue
-            fi
-
-            echo "   → merging (squash)"
-            if out=$(gh pr merge "$number" --repo "$REPO" --squash --delete-branch 2>&1); then
-              echo "   → merged"
-              continue
-            fi
-            # The merge was rejected. Classify: some reasons are
-            # expected and benign for a daily batch and must NOT fail
-            # the job; anything else is a genuine problem.
-            echo "$out" | sed 's/^/     /'
-            if echo "$out" | grep -qiE 'merge conflict|not mergeable'; then
-              # MERGEABLE at list time can go stale by merge time.
-              # Dependabot rebases conflicted PRs; a later run merges it.
-              echo "   → skip: merge conflict — Dependabot will rebase; picked up next run"
-            elif echo "$out" | grep -qi "without .workflows. permission"; then
-              # The default GITHUB_TOKEN cannot merge PRs that touch
-              # .github/workflows/** — there is no permissions: key that
-              # grants the `workflow` scope. These need a human/PAT merge.
-              echo "   → skip: touches a workflow file; GITHUB_TOKEN can't merge these — merge manually"
-            else
-              echo "   → FAILED to merge #${number}; continuing with the rest"
-              failed=1
-            fi
-          done < <(jq -c '.[]' prs.json)
-
-          if [[ "$failed" -ne 0 ]]; then
-            echo ""
-            echo "One or more eligible PRs failed to merge — see log above."
-            exit 1
-          fi
+    uses: pedromvgomes/gt/.github/workflows/reusable-dependabot-auto-merge.yml@v1

--- a/.github/workflows/gt-sync.yml
+++ b/.github/workflows/gt-sync.yml
@@ -1,0 +1,25 @@
+# Managed by gt — edit .gt-repo.yaml, then run `gt repo sync`.
+#
+# Weekly drift check and repair. Runs `gt repo sync`, and opens a PR only if
+# something changed — it never pushes to main, so gt's own updates are
+# reviewed by the gate like any other change.
+#
+# Workflow files are deliberately excluded: GITHUB_TOKEN cannot create or
+# update anything under .github/workflows/**. When one of them has drifted the
+# job reports it and asks for a local `gt repo fleet sync`, which runs with
+# your own credentials. Because the callers pin the moving v1 tag, this is
+# rare — gate logic changes need no file change at all.
+name: gt sync
+
+on:
+  schedule:
+    - cron: "0 6 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  sync:
+    uses: pedromvgomes/gt/.github/workflows/reusable-sync.yml@v1

--- a/.github/workflows/gt-sync.yml
+++ b/.github/workflows/gt-sync.yml
@@ -7,7 +7,7 @@
 # Workflow files are deliberately excluded: GITHUB_TOKEN cannot create or
 # update anything under .github/workflows/**. When one of them has drifted the
 # job reports it and asks for a local `gt repo fleet sync`, which runs with
-# your own credentials. Because the callers pin the moving v1 tag, this is
+# your own credentials. Because the callers pin a moving major tag, this is
 # rare — gate logic changes need no file change at all.
 name: gt sync
 

--- a/.gt-repo.yaml
+++ b/.gt-repo.yaml
@@ -1,0 +1,193 @@
+# Repository governance for gt. This file is the source of truth; run
+# 'gt repo sync' to render it, and 'gt repo check' to verify.
+#
+# Shared policy (Dependabot cooldown, commit-message prefixes, the weekly sync
+# schedule) lives in gt's templates, not here, so it stays consistent across
+# every governed repo.
+#
+# The pipeline stages below become jobs in ci-orchestration.yml, each calling a
+# ci-*/cd-* workflow that belongs to this repository: gt creates those once and
+# never touches them again. Branch protection needs exactly one check, ci-gate,
+# which waits on all of them.
+#
+# ONBOARDING STATE. This repository's 26 existing workflows still run and are
+# still what branch protection requires. The ci-*/cd-* stages gt scaffolds here
+# are empty no-ops on purpose: landing them changes nothing, and the existing
+# jobs move into them one stage at a time in follow-up PRs. Do not make ci-gate
+# the required check until that migration is done, or the gate will pass on an
+# empty pipeline.
+
+gt_version: v1.0.0
+dependabot:
+  - ecosystem: cargo
+    directory: /source/daemon
+    note: |
+      The daemon workspace. Covers every member crate through the single
+      Cargo.lock at this directory.
+
+  - ecosystem: cargo
+    directory: /source/daemon/fuzz
+    note: |
+      Its own workspace, not a member of the daemon's — source/daemon/Cargo.toml
+      excludes it so libfuzzer-sys and the nightly sanitizer rustflags cannot
+      leak into normal builds. That separation also means its Cargo.lock is
+      invisible to the entry above, so it needs its own.
+
+  - ecosystem: docker
+    directory: /.clusterfuzzlite
+    note: |
+      ClusterFuzzLite build image. Every FROM is digest-pinned for Scorecard and
+      supply-chain integrity, so Dependabot is the only channel that surfaces
+      upstream image updates.
+
+  - ecosystem: docker
+    directory: /source/daemon
+    note: |
+      Digest-pinned like the above:
+
+        Dockerfile        production image (FROM wardnet-base)
+        Dockerfile.base   shared OS layer (FROM debian:bookworm-slim)
+        Dockerfile.test   end-to-end test image (FROM rust + wardnet-base)
+
+  - ecosystem: docker
+    directory: /source/end2end-tests/daemon/mocks/nordvpn
+  - ecosystem: docker
+    directory: /source/end2end-tests/daemon/mocks/wg-gateway
+  - ecosystem: docker
+    directory: /source/end2end-tests/daemon/mocks/wg-tunnel-gateway
+  - ecosystem: docker
+    directory: /source/end2end-tests/web-ui/mocks/wardnet-cloud
+
+  - ecosystem: github-actions
+    directory: /
+    groups:
+      - name: codeql-action
+        patterns:
+          - github/codeql-action*
+        note: |
+          codeql-action/init and codeql-action/analyze MUST move in lockstep:
+          init writes a config file stamped with its own version and analyze
+          refuses to read one written by a different version, failing with
+          "Loaded a configuration file for version X, but running version Y".
+
+          Dependabot treats each action path as its own dependency, so without
+          this group it opens a separate PR per path. The daily auto-merge batch
+          then lands one of them alone and main goes red — and because the
+          sibling PR now fails that same broken CodeQL job, auto-merge won't
+          merge it either, so main stays red until a human intervenes. That
+          deadlock cost us #991, #1059 and #1069.
+
+  - ecosystem: gomod
+    directory: /source/sdk/wardnet-go
+  - ecosystem: gomod
+    directory: /source/wctl
+
+  - ecosystem: npm
+    directory: /source
+    note: |
+      The web codebase is a Yarn-workspaces monorepo with a SINGLE lockfile at
+      /source/yarn.lock. Dependabot must point at the workspace ROOT so every
+      version bump also regenerates the lockfile — per-workspace entries (e.g.
+      /source/admin-site) edit only that package.json, leave yarn.lock stale,
+      and every PR then fails CI's `yarn install --immutable`.
+
+      This one entry covers the root manifest plus all workspaces
+      (sdk/wardnet-js, web, admin-site, admin-app, user-app, marketing-site).
+
+  - ecosystem: npm
+    directory: /source/end2end-tests/daemon
+    note: |
+      Standalone package with its own yarn.lock — not part of the /source
+      workspace, so it keeps its own entry.
+
+  - ecosystem: npm
+    directory: /source/end2end-tests/web-ui
+    note: |
+      Standalone package with its own yarn.lock, same as the daemon suite above.
+
+dependabot_auto_merge:
+  enabled: true
+  schedule: 0 1 * * *
+  max_bump: minor
+  delete_branch: true
+
+bulwark:
+  # Off until the test stage migration lands, then flipped on with `dir: source`.
+  #
+  # gt's reusable-bulwark consumes a single `gt-coverage` artifact and drops
+  # coverage.out / lcov.info at the scan root. This repo's coverage.yml does
+  # considerably more: it stages a Rust llvm-cov.json and lcov.info, a
+  # coverage.out per Go module, and a coverage/ directory per TypeScript
+  # package, each at the path bulwark's own candidate search already checks.
+  #
+  # Enabling gt's copy now would run bulwark twice per PR, and the gt run would
+  # find no reports — which is not merely wasted time, because bulwark caches
+  # coverage baselines on the bulwark-state branch and a report-less run would
+  # write an empty baseline over a real one.
+  enabled: false
+
+pipeline:
+  ci:
+    enabled: true
+    stages:
+      - preflight
+      - build
+      - test
+      - end2end
+    # Merge queues need an organization-owned repository.
+    merge_queue: false
+  # Off until the release workflows migrate, and this one is not merely
+  # cosmetic. CI can land inert — its stages are no-ops and nothing requires
+  # ci-gate yet — but CD cannot, because it claims a live trigger.
+  #
+  # cd-orchestration fires on push of `v*.*.*`, which is exactly the tag
+  # release.yml already ships on, and its verify-attestation runs with
+  # require: true. No tree on main carries a gt attestation yet, so the very
+  # next release would go red on a pipeline that ships nothing.
+  #
+  # Turn this on in the same PR that moves release.yml into the cd-* stages.
+  cd:
+    enabled: false
+    stages:
+      - preflight
+      - publish
+      - deploy
+      - verify
+    # wardnet ships on more than one pattern — @wardnet/js@*.*.* for the SDK and
+    # base-v* for the base image — so migrating CD means deciding whether those
+    # become separate stages or stay their own workflows.
+    tags:
+      - v*.*.*
+
+conventional_commits:
+  enabled: true
+  scope: pr_title
+  types:
+    - feat
+    - fix
+    - docs
+    - style
+    - refactor
+    - perf
+    - test
+    - build
+    - ci
+    - chore
+    - revert
+
+settings:
+  merge:
+    squash: true
+    merge_commit: false
+    rebase: false
+    delete_branch_on_merge: true
+  branch_protection:
+    branch: main
+    required_approvals: 0
+    # The attestation records the tree a run validated, so an up-to-date
+    # requirement would force re-runs that prove nothing new.
+    require_up_to_date: false
+
+files:
+  - sync
+  - dependabot-auto-merge


### PR DESCRIPTION
Onboards this repository onto gt's governance subsystem
(pedromvgomes/gt#31). A committed `.gt-repo.yaml` becomes the source of
truth, and `gt repo sync` renders the files from it.

> [!IMPORTANT]
> **Do not merge before gt `v1` is cut.** Every rendered caller pins
> `pedromvgomes/gt@v1`, which does not exist yet. The auto-merge workflow
> works today, and an unresolvable `uses:` would stop it.

## What actually changes behaviour

**`.github/dependabot.yml` gains six uncovered ecosystems** — the fuzz
workspace (its own `Cargo.lock`, since `source/daemon/Cargo.toml` excludes
it so libfuzzer-sys and the nightly sanitizer rustflags cannot leak into
normal builds), the four end2end mock images, and the web-UI e2e package.
Expect a burst of PRs on the first weekly run.

Nothing was dropped — verified by parsing both files and diffing on
`(ecosystem, directory)`.

**Policy moves to gt's:** cooldown 3 days → 7, and the commit prefix from
`chore(deps):` to `build(deps):` / `ci(deps):` with `include: scope`.
Nothing in this repository greps for the old prefix, and `build` and `ci`
are both in `conventional_commits.types`, so dependency PRs still pass the
title check.

**The codeql-action grouping is preserved**, rationale and incident
references included. gt could not express groups at all until
pedromvgomes/gt#31 added them — this repository is why.

**`dependabot-auto-merge.yml` becomes a thin caller.** The logic upstream is
gt's copy of this repository's own script, so behaviour is unchanged;
`max_bump` and `delete_branch` are read from `.gt-repo.yaml` at run time.

## What is deliberately inert

The `ci-*` stages are empty no-ops. All 26 existing workflows still run, and
branch protection still requires exactly what it required before. The real
jobs move into the stages one at a time in follow-up PRs, and `ci-gate`
becomes the required check only once that is done — making it required now
would gate on an empty pipeline.

New checks that will appear and are meant to: `conventional-commits`
(this repository has no PR-title enforcement today) and `governance`.

## What is deliberately off

**CD.** This is the one part that cannot land inert. `cd-orchestration`
fires on push of `v*.*.*` — exactly the tag `release.yml` already ships on —
and its `verify-attestation` runs with `require: true`. No tree on main
carries a gt attestation yet, so the next release would go red on a pipeline
that ships nothing. It also needs a decision this PR should not make: this
repository ships on three patterns (`v*.*.*`, `@wardnet/js@*.*.*`,
`base-v*`), so migrating CD means deciding whether those become stages or
stay separate workflows.

**bulwark.** gt's reusable stage consumes one `gt-coverage` artifact and
drops `coverage.out`/`lcov.info` at the scan root. `coverage.yml` here does
considerably more: a Rust `llvm-cov.json` and `lcov.info`, a `coverage.out`
per Go module, and a `coverage/` per TypeScript package, each at a path
bulwark's own candidate search already checks. Running both would not merely
waste time — bulwark caches coverage baselines on the `bulwark-state`
branch, and a report-less run would write an empty baseline over a real one.
It gets enabled in the same PR that moves the test stage.

## Verification

- `gt repo check` reports the repository compliant.
- Every rendered file parses as YAML.
- Semantic diff of old vs new `dependabot.yml`: nothing dropped, six added,
  and the only field changes are the intended policy moves.
- `.github/CODEOWNERS` is untouched — it was the case that surfaced the
  orphan-removal fix in pedromvgomes/gt#31.

https://claude.ai/code/session_01PvwKxJ5vnqa9h9XXyTEj43