### PR TITLE
test: verify gt bulwark Rust toolchain path (DO NOT MERGE)

### DIFF
--- a/.github/workflows/zz-test-bulwark-toolchain.yml
+++ b/.github/workflows/zz-test-bulwark-toolchain.yml
@@ -1,0 +1,26 @@
+# THROWAWAY. Verifies the Rust half of pedromvgomes/gt@fix/bulwark-toolchain-cache
+# before that change is released. Delete with the branch.
+#
+# Minimal on purpose: the governance branch is 17 commits behind main and
+# conflicting, so GitHub never computes a merge commit for it and dispatches no
+# pull_request workflow at all. This calls the same reusable workflow with the
+# same `dir: source` the repo will use, off current main, so it actually runs.
+name: zz test bulwark toolchain
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  bulwark:
+    uses: pedromvgomes/gt/.github/workflows/reusable-bulwark.yml@fix/bulwark-toolchain-cache
+    with:
+      dir: source
+    secrets:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+      SEMGREP_APP_TOKEN: ${{ secrets.SEMGREP_APP_TOKEN }}
+    permissions:
+      contents: write
+      pull-requests: write


### PR DESCRIPTION
Throwaway, closing once observed. Adds one workflow file and nothing else.

Verifies the Rust half of `pedromvgomes/gt@fix/bulwark-toolchain-cache` — gt's `reusable-bulwark` provisions no language toolchain and no cache, which killed inforge's scan three times running. The Go half is already proven fixed; this is the Rust half you asked to see before a release.

Off current `main` deliberately. wardnet-cloud is private and the org has hit an Actions spending limit, so nothing runs there; and `chore/gt-repo-governance` here is 17 commits behind and CONFLICTING, so GitHub computes no merge commit and dispatches no `pull_request` workflow at all.

Calls the reusable workflow with `dir: source`, which is what `.gt-repo.yaml` already says this repo will use. Rust lives at `source/daemon/` with its own `rust-toolchain.toml`, so this exercises nested-crate detection and the `dir` input together.

Checking that the toolchain/cache steps resolve and the scan completes — not that bulwark passes. First-ever findings on this tree are expected and are not the point.