### PR TITLE
perf(e2e): reuse the agent's DHCP lease instead of re-acquiring it per spec

### DIFF
--- a/source/end2end-tests/daemon/tests/helpers.ts
+++ b/source/end2end-tests/daemon/tests/helpers.ts
@@ -496,12 +496,17 @@ export async function ensureDnsEnabled(
 
 /**
  * Idempotent DHCP setup for specs that need a leased `test_debian`.
- * Toggles DHCP on, narrows the pool to `[start, end]`, drives the agent
- * through `dhclient renew` until a lease lands, then issues a DNS query
- * via the agent so the daemon's packet-capture-driven device discovery
- * has at least one observation to act on (otherwise `/api/devices`
- * sometimes hasn't seen the agent yet by the time the spec polls).
- * Safe to call across specs that vitest reorders.
+ * Toggles DHCP on, narrows the pool to `[start, end]` if it isn't
+ * already, reuses the agent's existing in-pool address or drives
+ * `dhclient renew` until one lands, then issues a DNS query via the
+ * agent so the daemon's packet-capture-driven device discovery has at
+ * least one observation to act on (otherwise `/api/devices` sometimes
+ * hasn't seen the agent yet by the time the spec polls).
+ *
+ * Every step is conditional because eleven specs call this and vitest
+ * reorders them: the first one through does the real work, the rest
+ * find the daemon and the agent already in the desired state and skip
+ * straight to the DNS poke.
  */
 export async function ensureLeasedAgent(
   client: WardnetClient,
@@ -515,20 +520,35 @@ export async function ensureLeasedAgent(
   if (!cfg.enabled) {
     await dhcp.toggle({ enabled: true });
   }
-  // updateConfig is idempotent; calling it across specs only re-sets to
-  // the same values. Safer than checking each field for drift.
-  await dhcp.updateConfig({
-    pool_start: poolStart,
-    pool_end: poolEnd,
-    subnet_mask: cfg.subnet_mask,
-    upstream_dns: cfg.upstream_dns,
-    lease_duration_secs: cfg.lease_duration_secs,
-    ...(cfg.router_ip ? { router_ip: cfg.router_ip } : {}),
-  });
-  // If the agent already has an in-pool lease, /dhcp/renew is a fast
-  // no-op; if not, it triggers DISCOVER → REQUEST → ACK against the
-  // daemon. Up to 5 attempts spread over ~7.5 s.
-  const ip = await acquireLeaseInRange(agent, iface, poolStart, poolEnd, 5);
+  // Only write the pool when it actually differs. updateConfig respawns
+  // the daemon's DHCP runner, and a renew issued into that restart window
+  // is what made dhclient miss its first exchange and sit out its
+  // retransmit backoff.
+  if (cfg.pool_start !== poolStart || cfg.pool_end !== poolEnd) {
+    await dhcp.updateConfig({
+      pool_start: poolStart,
+      pool_end: poolEnd,
+      subnet_mask: cfg.subnet_mask,
+      upstream_dns: cfg.upstream_dns,
+      lease_duration_secs: cfg.lease_duration_secs,
+      ...(cfg.router_ip ? { router_ip: cfg.router_ip } : {}),
+    });
+  }
+  // Reuse an address the agent already holds. The agent's /dhcp/renew is
+  // NOT a no-op for an already-leased interface: it shells out to
+  // `dhclient -r` and then `dhclient <iface>` unconditionally (see
+  // wardnet-test-agent/src/client/dhcp.rs), dropping a good lease to
+  // re-acquire it. The daemon answers DISCOVER in a few ms, but
+  // dhclient's own release/acquire cycle cost 45-60 s per call — paid
+  // once per spec by each of the eleven specs using this helper.
+  // Checking the interface first turns all but the first into one GET.
+  const ifaces = await agentGet<AgentInterfacesResponse>(
+    agent,
+    `/interfaces?name=${iface}`,
+  );
+  const ip =
+    ipv4InRange(ifaces, iface, poolStart, poolEnd) ??
+    (await acquireLeaseInRange(agent, iface, poolStart, poolEnd, 5));
   // Poke the agent into doing one DNS lookup against the daemon. The
   // daemon registers the device when it observes traffic on the LAN
   // (DeviceDiscoveryService consumes packet_capture events); a single

--- a/source/end2end-tests/web-ui/fixtures/dhcp.ts
+++ b/source/end2end-tests/web-ui/fixtures/dhcp.ts
@@ -29,6 +29,8 @@ export const DHCP_POOL_END = "10.91.0.150";
 /** Subset of the daemon's DhcpConfig we read back before re-saving. */
 interface DhcpConfig {
   enabled: boolean;
+  pool_start: string;
+  pool_end: string;
   subnet_mask: string;
   upstream_dns: string[];
   lease_duration_secs: number;
@@ -174,19 +176,27 @@ export async function seedDhcpLease(): Promise<string> {
       body: JSON.stringify({ enabled: true }),
     });
   }
-  // updateConfig is idempotent — re-setting to the same values is safe.
-  await api("/dhcp/config", {
-    method: "PUT",
-    token,
-    body: JSON.stringify({
-      pool_start: DHCP_POOL_START,
-      pool_end: DHCP_POOL_END,
-      subnet_mask: config.subnet_mask,
-      upstream_dns: config.upstream_dns,
-      lease_duration_secs: config.lease_duration_secs,
-      ...(config.router_ip ? { router_ip: config.router_ip } : {}),
-    }),
-  });
+  // Only write the pool when it actually differs. The PUT respawns the
+  // daemon's DHCP runner, and the renew below lands in that restart
+  // window — which is what makes dhclient miss its first exchange and
+  // sit out its retransmit backoff for the better part of a minute.
+  if (
+    config.pool_start !== DHCP_POOL_START ||
+    config.pool_end !== DHCP_POOL_END
+  ) {
+    await api("/dhcp/config", {
+      method: "PUT",
+      token,
+      body: JSON.stringify({
+        pool_start: DHCP_POOL_START,
+        pool_end: DHCP_POOL_END,
+        subnet_mask: config.subnet_mask,
+        upstream_dns: config.upstream_dns,
+        lease_duration_secs: config.lease_duration_secs,
+        ...(config.router_ip ? { router_ip: config.router_ip } : {}),
+      }),
+    });
+  }
 
   return acquireLeaseInRange(
     TEST_DEBIAN_AGENT,


### PR DESCRIPTION
## What

`ensureLeasedAgent` documented `/dhcp/renew` as "a fast no-op" when the agent already holds an in-pool lease. It isn't — the test agent's handler (`wardnet-test-agent/src/client/dhcp.rs:84`) runs `dhclient -r` then `dhclient <iface>` unconditionally, so all eleven callers dropped a good lease and re-acquired it.

## Measurement

Baseline is `E2E Daemon Tests` on run [32688637246](https://github.com/wardnet/wardnet/actions/runs/32688637246) — 23m04s total:

| segment | time |
|---|---|
| image build | ~9m40s |
| compose bring-up | ~2m |
| **vitest** | **639.8s** |

**382s of that 639s is dead time between spec files**, in `beforeAll`, as seven discrete stalls:

```
44.8s  dns-filter-default-profile     57.3s  devices-rules
46.7s  dns-filter-device-toggle       49.3s  devices-list
59.7s  dns-filter-profile-swap        60.2s  admin-lock
                                      60.4s  devices-me
```

Every one of those specs calls `ensureLeasedAgent`. The daemon isn't the bottleneck: the compose logs show `DHCPOFFER`→`DHCPACK` served in ~4ms, with exactly one successful exchange at the *end* of each stall. The time is spent inside dhclient's own release/acquire cycle — made worse by the unconditional `updateConfig` immediately above it, which respawns the daemon's DHCP runner so the renew lands in the restart window.

## Change

Make both steps conditional:

- write the pool only when it actually differs
- reuse an in-pool address the interface already carries, falling back to `acquireLeaseInRange` when there isn't one

The first spec through does the real work; the rest collapse to a single agent GET.

`web-ui`'s `seedDhcpLease` has one caller so it never paid the elevenfold cost, but it hit the same restart-window race — same guard applied.

## Why this is safe under vitest's reordering

Worth stating explicitly, since `--shard`/reordering was the original plan here:

- all eleven callers use the same `10.91.0.100-150` pool
- no spec ever toggles DHCP **off** (every `dhcp.toggle` call in the suite is `enabled: true`)
- the two specs calling `dhcp.updateConfig` directly both preserve the pool — `arp-failover` echoes `cfg.pool_start`/`pool_end`, `dhcp-reservations` re-sets the same constants and only when DHCP was disabled

So the daemon stays DHCP-enabled on a stable pool for the whole run, and a held address remains a valid lease.

## Verification

- `yarn type-check` clean in both `end2end-tests/daemon` and `end2end-tests/web-ui`
- Biome clean under bulwark's pinned toolchain (2.5.10, `security`+`correctness` at error)
- expected ~6min off the daemon job; **the real before/after comes from this PR's own run** — I'll confirm against the Actions API rather than assert it

## Note on the original plan

This started as the 3-shard e2e refactor. Measuring first showed the suite is not test-bound in the way that plan assumed — sharding would have paid the ~9m40s image build three times and still left 2-3 of these 60s stalls in each shard. This gets most of the win on one runner. Sharding is still available on top afterwards if the numbers justify it.