### PR TITLE
fix(daemon): repair cross-zone routing and DHCP renewal reliability

### DIFF
--- a/source/daemon/crates/wardnetd-mock/src/backends/noop_routing.rs
+++ b/source/daemon/crates/wardnetd-mock/src/backends/noop_routing.rs
@@ -152,7 +152,7 @@ impl PolicyRouter for NoopPolicyRouter {
         Ok(true)
     }
 
-    async fn add_ip_rule(&self, src_ip: &str, table: u32) -> anyhow::Result<()> {
+    async fn add_ip_rule(&self, src_ip: &str, table: u32, _priority: u32) -> anyhow::Result<()> {
         tracing::debug!(
             src_ip,
             table,
@@ -161,7 +161,7 @@ impl PolicyRouter for NoopPolicyRouter {
         Ok(())
     }
 
-    async fn remove_ip_rule(&self, src_ip: &str, table: u32) -> anyhow::Result<()> {
+    async fn remove_ip_rule(&self, src_ip: &str, table: u32, _priority: u32) -> anyhow::Result<()> {
         tracing::debug!(
             src_ip,
             table,
@@ -170,7 +170,7 @@ impl PolicyRouter for NoopPolicyRouter {
         Ok(())
     }
 
-    async fn list_wardnet_rules(&self) -> anyhow::Result<Vec<(String, u32)>> {
+    async fn list_wardnet_rules(&self) -> anyhow::Result<Vec<(String, u32, u32)>> {
         Ok(Vec::new())
     }
 

--- a/source/daemon/crates/wardnetd-mock/src/tests/backends.rs
+++ b/source/daemon/crates/wardnetd-mock/src/tests/backends.rs
@@ -64,9 +64,9 @@ async fn noop_policy_router_all_methods_ok() {
     p.enable_ip_forwarding().await.unwrap();
     p.add_route_table("wg_mock0", 100).await.unwrap();
     assert!(p.has_route_table(100).await.unwrap());
-    p.add_ip_rule("10.0.0.2", 100).await.unwrap();
+    p.add_ip_rule("10.0.0.2", 100, 3000).await.unwrap();
     assert!(p.list_wardnet_rules().await.unwrap().is_empty());
-    p.remove_ip_rule("10.0.0.2", 100).await.unwrap();
+    p.remove_ip_rule("10.0.0.2", 100, 3000).await.unwrap();
     p.remove_route_table(100).await.unwrap();
     p.flush_conntrack("10.0.0.2").await.unwrap();
     p.flush_route_cache().await.unwrap();

--- a/source/daemon/crates/wardnetd-services/src/dhcp/service.rs
+++ b/source/daemon/crates/wardnetd-services/src/dhcp/service.rs
@@ -153,6 +153,16 @@ pub struct DhcpServiceImpl {
     zones: Arc<dyn NetworkZoneRepository>,
     /// Wardnet's own LAN IP, auto-detected at startup.
     gateway_ip: Ipv4Addr,
+    /// Serializes pool allocation.
+    ///
+    /// Picking a free address and inserting the lease that claims it are
+    /// separate awaits over a table with no uniqueness constraint on
+    /// `ip_address`, so two allocations that overlap can both see the same
+    /// address free and both take it. Packets from different MACs are handled
+    /// concurrently, and a power-up or access-point reboot delivers exactly
+    /// that burst, so the window is reached in normal use rather than under
+    /// contrived load.
+    alloc_lock: tokio::sync::Mutex<()>,
 }
 
 impl DhcpServiceImpl {
@@ -172,6 +182,7 @@ impl DhcpServiceImpl {
             devices,
             zones,
             gateway_ip,
+            alloc_lock: tokio::sync::Mutex::new(()),
         }
     }
 
@@ -1134,6 +1145,10 @@ impl DhcpService for DhcpServiceImpl {
                 compatible
             });
 
+        // Held until the lease row exists, so no other allocation can observe
+        // this address as free in between.
+        let _alloc = self.alloc_lock.lock().await;
+
         let ip = if let Some(reservation) = reservation {
             tracing::info!(mac, ip = %reservation.ip_address, "using static reservation");
             reservation.ip_address
@@ -1162,6 +1177,8 @@ impl DhcpService for DhcpServiceImpl {
             .insert_lease(&row)
             .await
             .map_err(AppError::Internal)?;
+
+        drop(_alloc);
 
         self.dhcp
             .insert_lease_log(&DhcpLeaseLogRow {

--- a/source/daemon/crates/wardnetd-services/src/routing/policy_router.rs
+++ b/source/daemon/crates/wardnetd-services/src/routing/policy_router.rs
@@ -21,16 +21,27 @@ pub trait PolicyRouter: Send + Sync {
     /// Check whether a default route exists in the specified routing table.
     async fn has_route_table(&self, table: u32) -> anyhow::Result<bool>;
 
-    /// Add a source-based routing rule that directs traffic from `src_ip` through the given table.
-    async fn add_ip_rule(&self, src_ip: &str, table: u32) -> anyhow::Result<()>;
+    /// Add a source-based routing rule that directs traffic from `src_ip`
+    /// through the given table, at `priority`.
+    ///
+    /// The priority must be passed explicitly rather than left to the kernel:
+    /// `fib_default_rule_pref` derives it from whatever is already installed,
+    /// which lets a narrower carve-out added earlier push this rule ahead of
+    /// itself and defeat its own purpose.
+    async fn add_ip_rule(&self, src_ip: &str, table: u32, priority: u32) -> anyhow::Result<()>;
 
-    /// Remove a source-based routing rule for `src_ip` and the given table.
-    async fn remove_ip_rule(&self, src_ip: &str, table: u32) -> anyhow::Result<()>;
+    /// Remove the source-based routing rule for `src_ip`, `table` and
+    /// `priority`. The priority is part of the match so this can never delete a
+    /// carve-out that happens to share the same source and table.
+    async fn remove_ip_rule(&self, src_ip: &str, table: u32, priority: u32) -> anyhow::Result<()>;
 
     /// List all Wardnet-managed routing rules (tables >= 100).
     ///
-    /// Returns tuples of (`source_ip`, `table_number`).
-    async fn list_wardnet_rules(&self) -> anyhow::Result<Vec<(String, u32)>>;
+    /// Returns tuples of (`source_ip`, `table_number`, `priority`). The priority
+    /// is reported so reconcile can recognise a rule left at a priority this
+    /// version no longer writes and rebuild it, rather than seeing a rule at the
+    /// right source and table and assuming it is correct.
+    async fn list_wardnet_rules(&self) -> anyhow::Result<Vec<(String, u32, u32)>>;
 
     // --- Cross-zone switchback carve-outs (pass-switchback) ---
     //

--- a/source/daemon/crates/wardnetd-services/src/routing/service.rs
+++ b/source/daemon/crates/wardnetd-services/src/routing/service.rs
@@ -325,7 +325,14 @@ struct RoutingState {
     /// Carve-out CIDRs currently installed in the kernel per device, so the diff
     /// on the next reconcile knows what to add/remove. Present only for
     /// tunnel-bound devices with a non-empty desired set.
-    applied_switchback: HashMap<Uuid, Vec<String>>,
+    /// Carve-outs believed to be in the kernel, as `(device_ip, dst_cidrs)`.
+    ///
+    /// Only CIDRs whose `add_switchback_rule` returned `Ok` are recorded, and
+    /// the IP they were installed under travels with them. Both matter for the
+    /// diff to be a truthful picture of the kernel: an add that failed must
+    /// stay absent so the next reconcile retries it, and an entry installed
+    /// under a stale IP must be rebuilt rather than counted as present.
+    applied_switchback: HashMap<Uuid, (String, Vec<String>)>,
     /// Per-destination domain-route leases, keyed by `(device_ip, dst_ip)`.
     /// Installed by [`RoutingService::route_resolved_domain`] as the DNS server
     /// resolves matched domains, and expired by
@@ -802,11 +809,20 @@ impl RoutingServiceImpl {
             Vec::new()
         };
 
-        let applied = state
-            .applied_switchback
-            .get(&device_id)
-            .cloned()
-            .unwrap_or_default();
+        // A carve-out is only "already present" if it was installed under the
+        // IP in play. When the device's IP has moved, tear the old rules down
+        // at their own IP first — `remove_switchback_rule` matches on source,
+        // so removing them at the new IP would miss, leaking a rule that
+        // outlives the address it was written for.
+        let applied = match state.applied_switchback.get(&device_id) {
+            Some((ip, cidrs)) if *ip == device_ip => cidrs.clone(),
+            Some(_) => {
+                self.remove_switchback_for_device(state, device_id, "")
+                    .await;
+                Vec::new()
+            }
+            None => Vec::new(),
+        };
 
         // Remove stale carve-outs.
         for cidr in &applied {
@@ -826,49 +842,69 @@ impl RoutingServiceImpl {
             }
         }
 
-        // Add newly-desired carve-outs.
+        // Add newly-desired carve-outs, tracking which ones the kernel actually
+        // accepted. A device whose DHCP lease has not landed yet reaches here
+        // with an empty `device_ip` that netlink rejects; recording that CIDR
+        // anyway would make every later reconcile diff it away as already
+        // present, and the carve-out would never be installed.
+        let mut installed: Vec<String> = Vec::new();
         for cidr in &desired_set {
-            if !applied.contains(cidr)
-                && let Err(e) = self
-                    .netlink
-                    .add_switchback_rule(&device_ip, cidr, SWITCHBACK_RULE_PRIORITY)
-                    .await
+            if applied.contains(cidr) {
+                installed.push(cidr.clone());
+                continue;
+            }
+            match self
+                .netlink
+                .add_switchback_rule(&device_ip, cidr, SWITCHBACK_RULE_PRIORITY)
+                .await
             {
-                tracing::warn!(
+                Ok(()) => installed.push(cidr.clone()),
+                Err(e) => tracing::warn!(
                     error = %e,
                     device_id = %device_id,
                     device_ip = %device_ip,
                     dst_cidr = %cidr,
                     "failed to add switchback carve-out"
-                );
+                ),
             }
         }
 
-        if desired_set.is_empty() {
+        if installed.is_empty() {
             state.applied_switchback.remove(&device_id);
         } else {
             tracing::debug!(
                 device_id = %device_id,
                 device_ip = %device_ip,
-                carve_outs = desired_set.len(),
+                carve_outs = installed.len(),
                 "materialized switchback carve-outs for tunnel-bound device"
             );
-            state.applied_switchback.insert(device_id, desired_set);
+            state
+                .applied_switchback
+                .insert(device_id, (device_ip, installed));
         }
     }
 
-    /// Remove ALL installed switchback carve-outs for a device (using the given
-    /// `device_ip`) and drop the applied-tracking entry. Leaves the stored
-    /// desired target set untouched. Caller holds the state lock.
+    /// Remove ALL installed switchback carve-outs for a device and drop the
+    /// applied-tracking entry. Leaves the stored desired target set untouched.
+    /// Caller holds the state lock.
+    ///
+    /// Each rule is removed at the IP it was installed under, which is the only
+    /// IP that can match it. `fallback_ip` is used when nothing was recorded —
+    /// pass `""` when the caller has no better IP than the record itself.
     #[allow(clippy::similar_names)]
     async fn remove_switchback_for_device(
         &self,
         state: &mut RoutingState,
         device_id: Uuid,
-        device_ip: &str,
+        fallback_ip: &str,
     ) {
-        let Some(applied) = state.applied_switchback.remove(&device_id) else {
+        let Some((installed_ip, applied)) = state.applied_switchback.remove(&device_id) else {
             return;
+        };
+        let device_ip = if installed_ip.is_empty() {
+            fallback_ip
+        } else {
+            installed_ip.as_str()
         };
         for cidr in &applied {
             if let Err(e) = self

--- a/source/daemon/crates/wardnetd-services/src/routing/service.rs
+++ b/source/daemon/crates/wardnetd-services/src/routing/service.rs
@@ -260,21 +260,36 @@ pub trait RoutingService: Send + Sync {
 
 /// Priority of the cross-zone switchback carve-out `ip rule`s.
 ///
-/// Must be numerically LOWER (evaluated earlier) than the kernel's per-tunnel
-/// source rules — which the `rule().add()` builder lets the kernel auto-assign
-/// around 32764/32765 — so a carve-out to a cross-zone LAN destination wins over
-/// the `from <device_ip> lookup <tunnelTable>` rule. It is higher than the
-/// `local` table rule (priority 0), so on-box delivery is unaffected.
+/// Must be numerically LOWER (evaluated earlier) than
+/// [`DEVICE_RULE_PRIORITY`], so a carve-out to a cross-zone LAN destination
+/// wins over the device's own `from <device_ip> lookup <tunnelTable>` rule. It
+/// is higher than the `local` table rule (priority 0), so on-box delivery is
+/// unaffected.
 pub const SWITCHBACK_RULE_PRIORITY: u32 = 1000;
 
 /// Priority of the per-domain routing carve-out `ip rule`s.
 ///
 /// Sits in its own band, numerically higher than [`SWITCHBACK_RULE_PRIORITY`]
-/// (so a switchback carve-out still wins for its narrow cross-zone pair) yet far
-/// below the kernel's per-tunnel source rules (~32764), so a `from <device_ip>
-/// to <resolved_ip> lookup <table>` decision wins over the device's own
-/// `from <device_ip> lookup <deviceTable>` rule for that one destination.
+/// (so a switchback carve-out still wins for its narrow cross-zone pair) yet
+/// lower than [`DEVICE_RULE_PRIORITY`], so a `from <device_ip> to <resolved_ip>
+/// lookup <table>` decision wins over the device's own `from <device_ip> lookup
+/// <deviceTable>` rule for that one destination.
 pub const DOMAIN_ROUTE_RULE_PRIORITY: u32 = 2000;
+
+/// Priority of the per-device source `ip rule`s that bind a device to its
+/// tunnel table.
+///
+/// Every narrower carve-out — switchback at [`SWITCHBACK_RULE_PRIORITY`],
+/// per-domain at [`DOMAIN_ROUTE_RULE_PRIORITY`] — exists to beat this rule for
+/// one destination, so it must be evaluated last of the three.
+///
+/// Setting it explicitly is what makes that ordering hold. Left unset, the
+/// kernel's `fib_default_rule_pref` assigns one less than the lowest-priority
+/// rule already installed, so the first switchback carve-out at 1000 drags
+/// every device rule added after it to 999 — ahead of every carve-out, and
+/// ahead of the domain-route band too. Cross-zone traffic then stays captured
+/// by the tunnel, which is the failure the carve-outs exist to prevent.
+pub const DEVICE_RULE_PRIORITY: u32 = 3000;
 
 /// The kernel `main` routing table id (254), used as the target table for a
 /// `direct` domain rule — carving a domain out of the device's tunnel back to
@@ -730,7 +745,11 @@ impl RoutingServiceImpl {
                 // duplicates that accumulated from restarts or races (issue #78).
                 let mut removed = 0u32;
                 loop {
-                    match self.netlink.remove_ip_rule(&rule.device_ip, table).await {
+                    match self
+                        .netlink
+                        .remove_ip_rule(&rule.device_ip, table, DEVICE_RULE_PRIORITY)
+                        .await
+                    {
                         Ok(()) => removed += 1,
                         Err(e) => {
                             if removed == 0 {
@@ -1344,7 +1363,11 @@ impl RoutingService for RoutingServiceImpl {
 
             // Add source-based ip rule.
             tracing::debug!(device_ip, table, "adding ip rule");
-            if let Err(e) = self.netlink.add_ip_rule(device_ip, table).await {
+            if let Err(e) = self
+                .netlink
+                .add_ip_rule(device_ip, table, DEVICE_RULE_PRIORITY)
+                .await
+            {
                 tracing::warn!(
                     error = %e,
                     device_ip,
@@ -1796,16 +1819,74 @@ impl RoutingService for RoutingServiceImpl {
                     .filter_map(|r| r.table.map(|_| r.device_ip.as_str()))
                     .collect();
 
-                // Group by (ip, table) to detect both orphans and duplicates.
-                let mut ip_rule_counts: HashMap<(String, u32), u32> = HashMap::new();
-                for (src_ip, table) in &kernel_rules {
-                    *ip_rule_counts.entry((src_ip.clone(), *table)).or_insert(0) += 1;
+                // Group by (ip, table, priority) to detect orphans, duplicates
+                // and rules stranded at a priority this version no longer
+                // writes. The carve-out bands are listed too — they share a
+                // source with the device rule and `main` is itself a table
+                // >= 100 — but they have their own reconcilers below, so skip
+                // them here rather than let this loop prune them.
+                let mut ip_rule_counts: HashMap<(String, u32, u32), u32> = HashMap::new();
+                for (src_ip, table, priority) in &kernel_rules {
+                    if *priority == SWITCHBACK_RULE_PRIORITY
+                        || *priority == DOMAIN_ROUTE_RULE_PRIORITY
+                    {
+                        continue;
+                    }
+                    *ip_rule_counts
+                        .entry((src_ip.clone(), *table, *priority))
+                        .or_insert(0) += 1;
                 }
 
                 let mut orphan_count = 0u32;
                 let mut duplicate_count = 0u32;
-                for ((src_ip, table), count) in &ip_rule_counts {
-                    if !known_ips.contains(src_ip.as_str()) {
+                let mut repriority_count = 0u32;
+                for ((src_ip, table, priority), count) in &ip_rule_counts {
+                    if known_ips.contains(src_ip.as_str()) && *priority != DEVICE_RULE_PRIORITY {
+                        // A live device bound at the wrong priority: the rule
+                        // works, but every carve-out meant to override it is
+                        // dead while it sits ahead of them. Rewrite it in place
+                        // — remove at the priority it actually has, re-add at
+                        // the band it belongs in.
+                        tracing::warn!(
+                            src_ip = %src_ip,
+                            table,
+                            priority,
+                            "rewriting ip rule stranded at the wrong priority: src_ip={src_ip}, table={table}, priority={priority}"
+                        );
+                        for _ in 0..*count {
+                            if let Err(e) =
+                                self.netlink.remove_ip_rule(src_ip, *table, *priority).await
+                            {
+                                tracing::warn!(
+                                    error = %e,
+                                    src_ip = %src_ip,
+                                    table,
+                                    priority,
+                                    "failed to remove ip rule at wrong priority for {src_ip}, table={table}, priority={priority}: {e}",
+                                    src_ip = src_ip,
+                                    table = table,
+                                    priority = priority
+                                );
+                                break;
+                            }
+                        }
+                        if let Err(e) = self
+                            .netlink
+                            .add_ip_rule(src_ip, *table, DEVICE_RULE_PRIORITY)
+                            .await
+                        {
+                            tracing::warn!(
+                                error = %e,
+                                src_ip = %src_ip,
+                                table,
+                                "failed to re-add ip rule at {DEVICE_RULE_PRIORITY} for {src_ip}, table={table}: {e}",
+                                src_ip = src_ip,
+                                table = table
+                            );
+                        } else {
+                            repriority_count += 1;
+                        }
+                    } else if !known_ips.contains(src_ip.as_str()) {
                         // Orphan: remove all occurrences of this rule.
                         for _ in 0..*count {
                             tracing::warn!(
@@ -1815,7 +1896,9 @@ impl RoutingService for RoutingServiceImpl {
                                 src_ip = src_ip,
                                 table = table
                             );
-                            if let Err(e) = self.netlink.remove_ip_rule(src_ip, *table).await {
+                            if let Err(e) =
+                                self.netlink.remove_ip_rule(src_ip, *table, *priority).await
+                            {
                                 tracing::warn!(
                                     error = %e,
                                     src_ip = %src_ip,
@@ -1843,7 +1926,9 @@ impl RoutingService for RoutingServiceImpl {
                             extras = extras
                         );
                         for _ in 0..extras {
-                            if let Err(e) = self.netlink.remove_ip_rule(src_ip, *table).await {
+                            if let Err(e) =
+                                self.netlink.remove_ip_rule(src_ip, *table, *priority).await
+                            {
                                 tracing::warn!(
                                     error = %e,
                                     src_ip = %src_ip,
@@ -1872,6 +1957,13 @@ impl RoutingService for RoutingServiceImpl {
                         duplicate_count,
                         "pruned duplicate ip rules: duplicate_count={duplicate_count}",
                         duplicate_count = duplicate_count
+                    );
+                }
+                if repriority_count > 0 {
+                    tracing::info!(
+                        repriority_count,
+                        "rewrote ip rules into the device priority band: repriority_count={repriority_count}",
+                        repriority_count = repriority_count
                     );
                 }
             }

--- a/source/daemon/crates/wardnetd-services/src/routing/service.rs
+++ b/source/daemon/crates/wardnetd-services/src/routing/service.rs
@@ -745,6 +745,15 @@ impl RoutingServiceImpl {
                 // duplicates that accumulated from restarts or races (issue #78).
                 let mut removed = 0u32;
                 loop {
+                    // Only the device band is matched here, which is safe
+                    // because startup reconcile rewrites any rule left at a
+                    // kernel-chosen priority by an older build *before* the
+                    // event listeners or the API can serve a teardown. Widening
+                    // the match to "any priority" would be worse than the gap
+                    // it closes: the kernel treats an omitted attribute as
+                    // don't-care, so a delete carrying neither priority nor
+                    // destination can match a domain-route rule that shares
+                    // this source and tunnel table.
                     match self
                         .netlink
                         .remove_ip_rule(&rule.device_ip, table, DEVICE_RULE_PRIORITY)
@@ -1813,10 +1822,20 @@ impl RoutingService for RoutingServiceImpl {
                     "found kernel ip rules"
                 );
                 let state = self.state.lock().await;
-                let known_ips: HashSet<&str> = state
+                // Every binding that is actually applied, as `(ip, table)`.
+                //
+                // Keyed on the pair rather than the IP for two reasons: a rule
+                // whose table is not one this device is bound to is stale
+                // however current its source looks, and two applied entries
+                // can legitimately share an IP (a device row replaced, or a
+                // stale entry for an offline device whose address was
+                // re-leased). Keying `ip -> table` would keep only whichever
+                // the iteration happened to reach last and delete the other
+                // device's live rule every reconcile.
+                let wanted: HashSet<(&str, u32)> = state
                     .applied
                     .values()
-                    .filter_map(|r| r.table.map(|_| r.device_ip.as_str()))
+                    .filter_map(|r| r.table.map(|t| (r.device_ip.as_str(), t)))
                     .collect();
 
                 // Group by (ip, table, priority) to detect orphans, duplicates
@@ -1841,18 +1860,27 @@ impl RoutingService for RoutingServiceImpl {
                 let mut duplicate_count = 0u32;
                 let mut repriority_count = 0u32;
                 for ((src_ip, table, priority), count) in &ip_rule_counts {
-                    if known_ips.contains(src_ip.as_str()) && *priority != DEVICE_RULE_PRIORITY {
-                        // A live device bound at the wrong priority: the rule
-                        // works, but every carve-out meant to override it is
-                        // dead while it sits ahead of them. Rewrite it in place
-                        // — remove at the priority it actually has, re-add at
-                        // the band it belongs in.
+                    let is_current_binding = wanted.contains(&(src_ip.as_str(), *table));
+                    if is_current_binding && *priority != DEVICE_RULE_PRIORITY {
+                        // This device's current binding, stranded at a priority
+                        // this version no longer writes. The rule works, but
+                        // every carve-out meant to override it is dead while it
+                        // sits ahead of them. Rewrite it — remove at the
+                        // priority it actually has, and add it back in the
+                        // device band unless it is already there, which it is
+                        // whenever `apply_rule` ran earlier in this reconcile.
+                        let already_correct = ip_rule_counts.contains_key(&(
+                            src_ip.clone(),
+                            *table,
+                            DEVICE_RULE_PRIORITY,
+                        ));
                         tracing::warn!(
                             src_ip = %src_ip,
                             table,
                             priority,
                             "rewriting ip rule stranded at the wrong priority: src_ip={src_ip}, table={table}, priority={priority}"
                         );
+                        let mut removed_all = true;
                         for _ in 0..*count {
                             if let Err(e) =
                                 self.netlink.remove_ip_rule(src_ip, *table, *priority).await
@@ -1867,10 +1895,20 @@ impl RoutingService for RoutingServiceImpl {
                                     table = table,
                                     priority = priority
                                 );
+                                removed_all = false;
                                 break;
                             }
                         }
-                        if let Err(e) = self
+                        if !removed_all {
+                            // The old rule is still there and still wins. Adding
+                            // the replacement now would leave the device bound
+                            // twice with the carve-outs still dead, and count it
+                            // as repaired. Leave it for the next reconcile.
+                            continue;
+                        }
+                        if already_correct {
+                            repriority_count += 1;
+                        } else if let Err(e) = self
                             .netlink
                             .add_ip_rule(src_ip, *table, DEVICE_RULE_PRIORITY)
                             .await
@@ -1886,7 +1924,7 @@ impl RoutingService for RoutingServiceImpl {
                         } else {
                             repriority_count += 1;
                         }
-                    } else if !known_ips.contains(src_ip.as_str()) {
+                    } else if !is_current_binding {
                         // Orphan: remove all occurrences of this rule.
                         for _ in 0..*count {
                             tracing::warn!(

--- a/source/daemon/crates/wardnetd-services/src/routing/service.rs
+++ b/source/daemon/crates/wardnetd-services/src/routing/service.rs
@@ -730,9 +730,7 @@ impl RoutingServiceImpl {
             // down, IP change, or removal), so the tunnel-capture problem the
             // carve-outs work around no longer applies. The desired target set
             // is left intact so a later re-bind re-materializes them.
-            let device_ip = rule.device_ip.clone();
-            self.remove_switchback_for_device(state, device_id, &device_ip)
-                .await;
+            self.remove_switchback_for_device(state, device_id).await;
             if let Some(table) = rule.table {
                 tracing::debug!(
                     device_ip = %rule.device_ip,
@@ -813,13 +811,7 @@ impl RoutingServiceImpl {
     async fn reconcile_switchback_for_device(&self, state: &mut RoutingState, device_id: Uuid) {
         let Some((device_ip, desired)) = state.switchback_targets.get(&device_id).cloned() else {
             // No desired targets — ensure nothing is installed.
-            let ip = state
-                .applied
-                .get(&device_id)
-                .map(|r| r.device_ip.clone())
-                .unwrap_or_default();
-            self.remove_switchback_for_device(state, device_id, &ip)
-                .await;
+            self.remove_switchback_for_device(state, device_id).await;
             return;
         };
 
@@ -845,8 +837,7 @@ impl RoutingServiceImpl {
         let applied = match state.applied_switchback.get(&device_id) {
             Some((ip, cidrs)) if *ip == device_ip => cidrs.clone(),
             Some(_) => {
-                self.remove_switchback_for_device(state, device_id, "")
-                    .await;
+                self.remove_switchback_for_device(state, device_id).await;
                 Vec::new()
             }
             None => Vec::new(),
@@ -917,23 +908,14 @@ impl RoutingServiceImpl {
     /// Caller holds the state lock.
     ///
     /// Each rule is removed at the IP it was installed under, which is the only
-    /// IP that can match it. `fallback_ip` is used when nothing was recorded —
-    /// pass `""` when the caller has no better IP than the record itself.
+    /// IP that can match it — and the only IP ever recorded, since a carve-out
+    /// is tracked exactly when the kernel accepted it under that source.
     #[allow(clippy::similar_names)]
-    async fn remove_switchback_for_device(
-        &self,
-        state: &mut RoutingState,
-        device_id: Uuid,
-        fallback_ip: &str,
-    ) {
-        let Some((installed_ip, applied)) = state.applied_switchback.remove(&device_id) else {
+    async fn remove_switchback_for_device(&self, state: &mut RoutingState, device_id: Uuid) {
+        let Some((device_ip, applied)) = state.applied_switchback.remove(&device_id) else {
             return;
         };
-        let device_ip = if installed_ip.is_empty() {
-            fallback_ip
-        } else {
-            installed_ip.as_str()
-        };
+        let device_ip = device_ip.as_str();
         for cidr in &applied {
             if let Err(e) = self
                 .netlink
@@ -2265,7 +2247,7 @@ impl RoutingService for RoutingServiceImpl {
             // No desired targets — forget the device and tear down any carve-outs
             // currently installed under this IP.
             state.switchback_targets.remove(&device_id);
-            self.remove_switchback_for_device(&mut state, device_id, &device_ip)
+            self.remove_switchback_for_device(&mut state, device_id)
                 .await;
         } else {
             state

--- a/source/daemon/crates/wardnetd-services/src/routing/tests/routing.rs
+++ b/source/daemon/crates/wardnetd-services/src/routing/tests/routing.rs
@@ -601,6 +601,12 @@ impl PolicyRouter for MockNetlink {
         self.calls.lock().await.push(format!(
             "add_switchback_rule:{src_ip}:{dst_cidr}:{priority}"
         ));
+        // Mirror the netlink implementation, which parses before it builds the
+        // message: an unset `last_ip` reaches here as an empty string and must
+        // fail rather than silently install nothing.
+        src_ip
+            .parse::<std::net::Ipv4Addr>()
+            .map_err(|e| anyhow::anyhow!("invalid switchback src IP {src_ip}: {e}"))?;
         let mut sw = self.switchback.lock().await;
         let entry = (src_ip.to_owned(), dst_cidr.to_owned(), priority);
         if !sw.contains(&entry) {
@@ -3608,5 +3614,55 @@ async fn domain_route_unavailable_tunnel_is_skipped() {
             .iter()
             .any(|c| c.starts_with("add_domain_route_rule")),
         "no rule may be installed for an unresolvable tunnel"
+    );
+}
+
+/// A device whose `last_ip` is not yet known reaches the carve-out installer as
+/// an empty string, which netlink rejects. The failed CIDRs must not be recorded
+/// as installed: the device gets its address moments later, and the re-push that
+/// follows is the only chance to install them. Recording a failed add makes the
+/// diff in `reconcile_switchback_for_device` a no-op forever after.
+#[tokio::test]
+async fn carveouts_that_failed_to_install_are_retried_once_the_device_has_an_ip() {
+    let ts = setup();
+    let target = RoutingTarget::Tunnel {
+        tunnel_id: tunnel_id_1(),
+    };
+    as_admin(
+        ts.routing
+            .apply_rule(device_id_1(), "192.168.200.10", &target),
+    )
+    .await
+    .unwrap();
+
+    // The zone enforcer pushes the snapshot it has, which carries no IP yet.
+    as_admin(
+        ts.routing
+            .set_switchback_targets(device_id_1(), String::new(), vec![ent_subnet()]),
+    )
+    .await
+    .unwrap();
+    assert!(
+        ts.netlink_switchback.lock().await.is_empty(),
+        "an empty src IP cannot install a carve-out"
+    );
+
+    // DHCP completes, the device row gains an IP, and the enforcer re-pushes.
+    as_admin(ts.routing.set_switchback_targets(
+        device_id_1(),
+        "192.168.200.10".to_owned(),
+        vec![ent_subnet()],
+    ))
+    .await
+    .unwrap();
+
+    assert_eq!(
+        *ts.netlink_switchback.lock().await,
+        vec![(
+            "192.168.200.10".to_owned(),
+            ent_subnet(),
+            SWITCHBACK_RULE_PRIORITY
+        )],
+        "the carve-out must be installed once a real IP is known"
     );
 }

--- a/source/daemon/crates/wardnetd-services/src/routing/tests/routing.rs
+++ b/source/daemon/crates/wardnetd-services/src/routing/tests/routing.rs
@@ -15,7 +15,7 @@ use crate::error::AppError;
 use crate::routing::firewall::FirewallManager;
 use crate::routing::policy_router::PolicyRouter;
 use crate::routing::service::{
-    DOMAIN_ROUTE_RULE_PRIORITY, RoutingServiceImpl, SWITCHBACK_RULE_PRIORITY,
+    DEVICE_RULE_PRIORITY, DOMAIN_ROUTE_RULE_PRIORITY, RoutingServiceImpl, SWITCHBACK_RULE_PRIORITY,
 };
 use crate::{RoutingService, TunnelService};
 use wardnet_common::auth::AuthContext;
@@ -489,7 +489,7 @@ impl TunnelService for MockTunnelService {
 /// Records all netlink calls for assertion.
 struct MockNetlink {
     calls: Arc<Mutex<Vec<String>>>,
-    wardnet_rules: Vec<(String, u32)>,
+    wardnet_rules: Vec<(String, u32, u32)>,
     /// Number of times `add_route_table` should fail with "not up" before
     /// succeeding. Used to test the retry logic in `ensure_tunnel_table`.
     route_add_failures_remaining: Arc<Mutex<u32>>,
@@ -512,6 +512,41 @@ struct MockNetlink {
     /// removes, `list_domain_route_rules` returns the current set. Pre-seeded to
     /// simulate stale kernel rules for reconcile-prune tests.
     domain_routes: Arc<Mutex<Vec<(String, String, u32)>>>,
+    /// Installed per-device source rules as `(src_ip, table, priority)`.
+    ///
+    /// The priority is what the kernel actually ends up with, so a test can
+    /// assert the evaluation order between a device rule and the carve-outs
+    /// that must win over it. When `add_ip_rule` supplies no priority the mock
+    /// reproduces the kernel's `fib_default_rule_pref`: one less than the
+    /// lowest non-zero priority already present.
+    device_rules: Arc<Mutex<Vec<(String, u32, u32)>>>,
+}
+
+impl MockNetlink {
+    /// The priority the kernel assigns a rule added without an explicit one:
+    /// `fib_default_rule_pref` returns the first existing rule's priority minus
+    /// one, scanning past the priority-0 `local` rule.
+    async fn kernel_default_rule_pref(&self) -> u32 {
+        let lowest = self
+            .device_rules
+            .lock()
+            .await
+            .iter()
+            .map(|(_, _, p)| *p)
+            .chain(self.switchback.lock().await.iter().map(|(_, _, p)| *p))
+            .chain(
+                self.domain_routes
+                    .lock()
+                    .await
+                    .iter()
+                    .map(|_| DOMAIN_ROUTE_RULE_PRIORITY),
+            )
+            .filter(|p| *p > 0)
+            .min();
+        // With no other rule present the kernel counts down from the `main`
+        // rule at 32766.
+        lowest.unwrap_or(32766) - 1
+    }
 }
 
 #[async_trait]
@@ -556,11 +591,22 @@ impl PolicyRouter for MockNetlink {
         Ok(*self.has_route_table_result.lock().await)
     }
 
-    async fn add_ip_rule(&self, src_ip: &str, table: u32) -> anyhow::Result<()> {
+    async fn add_ip_rule(&self, src_ip: &str, table: u32, priority: u32) -> anyhow::Result<()> {
         self.calls
             .lock()
             .await
-            .push(format!("add_ip_rule:{src_ip}:{table}"));
+            .push(format!("add_ip_rule:{src_ip}:{table}:{priority}"));
+        // A priority of 0 is never written deliberately; treat it the way the
+        // kernel treats an unset one so a caller that forgets is caught.
+        let priority = if priority == 0 {
+            self.kernel_default_rule_pref().await
+        } else {
+            priority
+        };
+        self.device_rules
+            .lock()
+            .await
+            .push((src_ip.to_owned(), table, priority));
         *self
             .rule_counts
             .lock()
@@ -570,21 +616,28 @@ impl PolicyRouter for MockNetlink {
         Ok(())
     }
 
-    async fn remove_ip_rule(&self, src_ip: &str, table: u32) -> anyhow::Result<()> {
+    async fn remove_ip_rule(&self, src_ip: &str, table: u32, priority: u32) -> anyhow::Result<()> {
         self.calls
             .lock()
             .await
-            .push(format!("remove_ip_rule:{src_ip}:{table}"));
+            .push(format!("remove_ip_rule:{src_ip}:{table}:{priority}"));
         let mut counts = self.rule_counts.lock().await;
         let count = counts.entry((src_ip.to_owned(), table)).or_insert(0);
         if *count == 0 {
             anyhow::bail!("RTNETLINK answers: No such process");
         }
         *count -= 1;
+        let mut installed = self.device_rules.lock().await;
+        if let Some(pos) = installed
+            .iter()
+            .position(|(s, t, _)| s == src_ip && *t == table)
+        {
+            installed.remove(pos);
+        }
         Ok(())
     }
 
-    async fn list_wardnet_rules(&self) -> anyhow::Result<Vec<(String, u32)>> {
+    async fn list_wardnet_rules(&self) -> anyhow::Result<Vec<(String, u32, u32)>> {
         self.calls
             .lock()
             .await
@@ -949,6 +1002,9 @@ struct TestSetup {
     netlink_rule_counts: Arc<Mutex<HashMap<(String, u32), u32>>>,
     /// Exposed so tests can assert / pre-seed installed switchback carve-outs.
     netlink_switchback: Arc<Mutex<Vec<(String, String, u32)>>>,
+    /// Exposed so tests can assert the priority the per-device source rules
+    /// landed at, relative to the carve-outs that must be evaluated first.
+    netlink_device_rules: Arc<Mutex<Vec<(String, u32, u32)>>>,
     /// Flip to make the tunnel repo's `find_by_id` / `find_config_by_id`
     /// fail, for the device-snapshot degradation tests.
     tunnel_find_error: Arc<Mutex<bool>>,
@@ -1137,6 +1193,7 @@ fn setup_with_zones(
         Arc::new(MockZoneRepo { zones });
     let rule_counts: Arc<Mutex<HashMap<(String, u32), u32>>> = Arc::new(Mutex::new(HashMap::new()));
     let switchback: Arc<Mutex<Vec<(String, String, u32)>>> = Arc::new(Mutex::new(Vec::new()));
+    let device_rules: Arc<Mutex<Vec<(String, u32, u32)>>> = Arc::new(Mutex::new(Vec::new()));
     let netlink: Arc<dyn PolicyRouter> = Arc::new(MockNetlink {
         calls: netlink_calls.clone(),
         wardnet_rules: vec![],
@@ -1146,6 +1203,7 @@ fn setup_with_zones(
         rule_counts: rule_counts.clone(),
         switchback: switchback.clone(),
         domain_routes: Arc::new(Mutex::new(Vec::new())),
+        device_rules: device_rules.clone(),
     });
     let nftables: Arc<dyn FirewallManager> = Arc::new(MockNftables {
         calls: nftables_calls.clone(),
@@ -1182,6 +1240,7 @@ fn setup_with_zones(
         add_tcp_reset_reject_fail,
         netlink_rule_counts: rule_counts,
         netlink_switchback: switchback,
+        netlink_device_rules: device_rules,
         tunnel_find_error,
     }
 }
@@ -1192,7 +1251,7 @@ fn setup_with_orphaned_rules(
     rules: HashMap<String, RoutingRule>,
     tunnel: Option<Tunnel>,
     tunnel_config: Option<TunnelConfig>,
-    kernel_rules: Vec<(String, u32)>,
+    kernel_rules: Vec<(String, u32, u32)>,
 ) -> TestSetup {
     let netlink_calls = Arc::new(Mutex::new(Vec::new()));
     let nftables_calls = Arc::new(Mutex::new(Vec::new()));
@@ -1217,12 +1276,13 @@ fn setup_with_orphaned_rules(
     let initial_counts: HashMap<(String, u32), u32> =
         kernel_rules
             .iter()
-            .fold(HashMap::new(), |mut m, (ip, table)| {
+            .fold(HashMap::new(), |mut m, (ip, table, _priority)| {
                 *m.entry((ip.clone(), *table)).or_insert(0) += 1;
                 m
             });
     let rule_counts: Arc<Mutex<HashMap<(String, u32), u32>>> = Arc::new(Mutex::new(initial_counts));
     let switchback: Arc<Mutex<Vec<(String, String, u32)>>> = Arc::new(Mutex::new(Vec::new()));
+    let device_rules: Arc<Mutex<Vec<(String, u32, u32)>>> = Arc::new(Mutex::new(Vec::new()));
     let netlink: Arc<dyn PolicyRouter> = Arc::new(MockNetlink {
         calls: netlink_calls.clone(),
         wardnet_rules: kernel_rules,
@@ -1232,6 +1292,7 @@ fn setup_with_orphaned_rules(
         rule_counts: rule_counts.clone(),
         switchback: switchback.clone(),
         domain_routes: Arc::new(Mutex::new(Vec::new())),
+        device_rules: device_rules.clone(),
     });
     let nftables: Arc<dyn FirewallManager> = Arc::new(MockNftables {
         calls: nftables_calls.clone(),
@@ -1273,6 +1334,7 @@ fn setup_with_orphaned_rules(
         add_tcp_reset_reject_fail,
         netlink_rule_counts: rule_counts,
         netlink_switchback: switchback,
+        netlink_device_rules: device_rules,
         tunnel_find_error,
     }
 }
@@ -1305,6 +1367,7 @@ fn setup_with_route_add_failures(failures: u32) -> TestSetup {
     });
     let rule_counts: Arc<Mutex<HashMap<(String, u32), u32>>> = Arc::new(Mutex::new(HashMap::new()));
     let switchback: Arc<Mutex<Vec<(String, String, u32)>>> = Arc::new(Mutex::new(Vec::new()));
+    let device_rules: Arc<Mutex<Vec<(String, u32, u32)>>> = Arc::new(Mutex::new(Vec::new()));
     let netlink: Arc<dyn PolicyRouter> = Arc::new(MockNetlink {
         calls: netlink_calls.clone(),
         wardnet_rules: vec![],
@@ -1314,6 +1377,7 @@ fn setup_with_route_add_failures(failures: u32) -> TestSetup {
         rule_counts: rule_counts.clone(),
         switchback: switchback.clone(),
         domain_routes: Arc::new(Mutex::new(Vec::new())),
+        device_rules: device_rules.clone(),
     });
     let nftables: Arc<dyn FirewallManager> = Arc::new(MockNftables {
         calls: nftables_calls.clone(),
@@ -1355,6 +1419,7 @@ fn setup_with_route_add_failures(failures: u32) -> TestSetup {
         add_tcp_reset_reject_fail,
         netlink_rule_counts: rule_counts,
         netlink_switchback: switchback,
+        netlink_device_rules: device_rules,
         tunnel_find_error,
     }
 }
@@ -1563,7 +1628,9 @@ async fn apply_rule_tunnel_adds_ip_rule_and_masquerade() {
         "expected add_route_table call: {nl:?}"
     );
     assert!(
-        nl.contains(&"add_ip_rule:192.168.1.10:100".to_owned()),
+        nl.contains(&format!(
+            "add_ip_rule:192.168.1.10:100:{DEVICE_RULE_PRIORITY}"
+        )),
         "expected add_ip_rule call: {nl:?}"
     );
     assert!(
@@ -2103,7 +2170,9 @@ async fn remove_device_routes_cleans_up_kernel_state() {
     let nf = ts.nftables_calls.lock().await;
 
     assert!(
-        nl.contains(&"remove_ip_rule:192.168.1.10:100".to_owned()),
+        nl.contains(&format!(
+            "remove_ip_rule:192.168.1.10:100:{DEVICE_RULE_PRIORITY}"
+        )),
         "expected remove_ip_rule call: {nl:?}"
     );
     assert!(
@@ -2145,12 +2214,16 @@ async fn handle_ip_change_re_applies_rule() {
 
     // Old rule should be removed.
     assert!(
-        nl.contains(&"remove_ip_rule:192.168.1.10:100".to_owned()),
+        nl.contains(&format!(
+            "remove_ip_rule:192.168.1.10:100:{DEVICE_RULE_PRIORITY}"
+        )),
         "expected old ip rule removal: {nl:?}"
     );
     // New rule should be added.
     assert!(
-        nl.contains(&"add_ip_rule:192.168.1.20:100".to_owned()),
+        nl.contains(&format!(
+            "add_ip_rule:192.168.1.20:100:{DEVICE_RULE_PRIORITY}"
+        )),
         "expected new ip rule addition: {nl:?}"
     );
 }
@@ -2192,11 +2265,15 @@ async fn handle_tunnel_down_removes_affected_device_rules() {
 
     // Both devices' ip rules should be removed.
     assert!(
-        nl.contains(&"remove_ip_rule:192.168.1.10:100".to_owned()),
+        nl.contains(&format!(
+            "remove_ip_rule:192.168.1.10:100:{DEVICE_RULE_PRIORITY}"
+        )),
         "expected device 1 ip rule removal: {nl:?}"
     );
     assert!(
-        nl.contains(&"remove_ip_rule:192.168.1.11:100".to_owned()),
+        nl.contains(&format!(
+            "remove_ip_rule:192.168.1.11:100:{DEVICE_RULE_PRIORITY}"
+        )),
         "expected device 2 ip rule removal: {nl:?}"
     );
 
@@ -2249,11 +2326,15 @@ async fn handle_tunnel_up_re_applies_rules() {
 
     // Both devices should get ip rules.
     assert!(
-        nl.contains(&"add_ip_rule:192.168.1.10:100".to_owned()),
+        nl.contains(&format!(
+            "add_ip_rule:192.168.1.10:100:{DEVICE_RULE_PRIORITY}"
+        )),
         "expected device 1 ip rule: {nl:?}"
     );
     assert!(
-        nl.contains(&"add_ip_rule:192.168.1.11:100".to_owned()),
+        nl.contains(&format!(
+            "add_ip_rule:192.168.1.11:100:{DEVICE_RULE_PRIORITY}"
+        )),
         "expected device 2 ip rule: {nl:?}"
     );
 }
@@ -2331,7 +2412,9 @@ async fn reconcile_applies_stored_rules() {
 
     // The device's tunnel rule should be applied during reconcile.
     assert!(
-        nl.contains(&"add_ip_rule:192.168.1.10:100".to_owned()),
+        nl.contains(&format!(
+            "add_ip_rule:192.168.1.10:100:{DEVICE_RULE_PRIORITY}"
+        )),
         "expected reconciled ip rule: {nl:?}"
     );
 }
@@ -2339,7 +2422,7 @@ async fn reconcile_applies_stored_rules() {
 #[tokio::test]
 async fn reconcile_cleans_up_orphaned_rules() {
     // Kernel has a rule for 192.168.1.99:100 but no device in the DB has that.
-    let orphaned_rules = vec![("192.168.1.99".to_owned(), 100)];
+    let orphaned_rules = vec![("192.168.1.99".to_owned(), 100, DEVICE_RULE_PRIORITY)];
 
     let ts = setup_with_orphaned_rules(
         vec![],
@@ -2355,7 +2438,9 @@ async fn reconcile_cleans_up_orphaned_rules() {
 
     // Orphaned rule should be removed.
     assert!(
-        nl.contains(&"remove_ip_rule:192.168.1.99:100".to_owned()),
+        nl.contains(&format!(
+            "remove_ip_rule:192.168.1.99:100:{DEVICE_RULE_PRIORITY}"
+        )),
         "expected orphaned rule removal: {nl:?}"
     );
 }
@@ -2428,7 +2513,9 @@ async fn ensure_tunnel_table_retries_on_interface_not_up() {
 
     // The ip rule should still be added after the retry succeeds.
     assert!(
-        nl.contains(&"add_ip_rule:192.168.1.10:100".to_owned()),
+        nl.contains(&format!(
+            "add_ip_rule:192.168.1.10:100:{DEVICE_RULE_PRIORITY}"
+        )),
         "expected add_ip_rule after successful retry: {nl:?}"
     );
 }
@@ -2635,7 +2722,9 @@ async fn handle_route_table_lost_re_applies_rules() {
     );
     // The device's ip rule should be re-applied.
     assert!(
-        nl.contains(&"add_ip_rule:192.168.1.10:100".to_owned()),
+        nl.contains(&format!(
+            "add_ip_rule:192.168.1.10:100:{DEVICE_RULE_PRIORITY}"
+        )),
         "expected ip rule to be re-applied: {nl:?}"
     );
 }
@@ -2676,7 +2765,7 @@ async fn remove_device_kernel_state_drains_duplicate_ip_rules() {
     // Count=2 → 2 successes + 1 failing attempt = 3 calls total.
     let remove_count = nl
         .iter()
-        .filter(|c| c.as_str() == "remove_ip_rule:192.168.1.10:100")
+        .filter(|c| **c == format!("remove_ip_rule:192.168.1.10:100:{DEVICE_RULE_PRIORITY}"))
         .count();
     assert_eq!(
         remove_count, 3,
@@ -2700,9 +2789,9 @@ async fn reconcile_prunes_duplicate_rules_for_active_device() {
 
     // Kernel has 3 entries for the same (ip, table) — 2 are duplicates.
     let kernel_rules = vec![
-        ("192.168.1.10".to_owned(), 100u32),
-        ("192.168.1.10".to_owned(), 100u32),
-        ("192.168.1.10".to_owned(), 100u32),
+        ("192.168.1.10".to_owned(), 100u32, DEVICE_RULE_PRIORITY),
+        ("192.168.1.10".to_owned(), 100u32, DEVICE_RULE_PRIORITY),
+        ("192.168.1.10".to_owned(), 100u32, DEVICE_RULE_PRIORITY),
     ];
     let ts = setup_with_orphaned_rules(
         vec![d1],
@@ -2719,7 +2808,7 @@ async fn reconcile_prunes_duplicate_rules_for_active_device() {
     // extras=2 → exactly 2 remove_ip_rule calls for the duplicate pruning.
     let remove_count = nl
         .iter()
-        .filter(|c| c.as_str() == "remove_ip_rule:192.168.1.10:100")
+        .filter(|c| **c == format!("remove_ip_rule:192.168.1.10:100:{DEVICE_RULE_PRIORITY}"))
         .count();
     assert_eq!(
         remove_count, 2,
@@ -3664,5 +3753,106 @@ async fn carveouts_that_failed_to_install_are_retried_once_the_device_has_an_ip(
             SWITCHBACK_RULE_PRIORITY
         )],
         "the carve-out must be installed once a real IP is known"
+    );
+}
+
+/// A carve-out only wins over the device's own tunnel rule if the kernel
+/// evaluates it first. Leaving the device rule's priority for the kernel to pick
+/// inverts that: `fib_default_rule_pref` counts down from the lowest rule already
+/// present, so the first carve-out at 1000 makes every later device rule 999 and
+/// the carve-out is dead on arrival.
+#[tokio::test]
+async fn device_source_rule_is_evaluated_after_its_switchback_carveouts() {
+    let ts = setup();
+    let target = RoutingTarget::Tunnel {
+        tunnel_id: tunnel_id_1(),
+    };
+    as_admin(
+        ts.routing
+            .apply_rule(device_id_1(), "192.168.200.10", &target),
+    )
+    .await
+    .unwrap();
+    as_admin(ts.routing.set_switchback_targets(
+        device_id_1(),
+        "192.168.200.10".to_owned(),
+        vec![ent_subnet()],
+    ))
+    .await
+    .unwrap();
+
+    // A second device binding after the carve-out exists is the case that breaks.
+    as_admin(
+        ts.routing
+            .apply_rule(device_id_2(), "192.168.200.11", &target),
+    )
+    .await
+    .unwrap();
+
+    let installed = ts.netlink_device_rules.lock().await.clone();
+    assert!(!installed.is_empty(), "expected per-device source rules");
+    for (src_ip, table, priority) in installed {
+        assert!(
+            priority > SWITCHBACK_RULE_PRIORITY,
+            "device rule from {src_ip} lookup {table} landed at priority {priority}, \
+             which preempts switchback carve-outs at {SWITCHBACK_RULE_PRIORITY}"
+        );
+        assert!(
+            priority > DOMAIN_ROUTE_RULE_PRIORITY,
+            "device rule from {src_ip} lookup {table} landed at priority {priority}, \
+             which preempts domain-route rules at {DOMAIN_ROUTE_RULE_PRIORITY}"
+        );
+    }
+}
+
+/// A device rule written by an older daemon sits at whatever priority the kernel
+/// chose for it, which is ahead of the carve-out bands. Reconcile must rewrite it
+/// into the device band rather than accept it as correct — matching on source and
+/// table alone cannot tell a working rule from one that silently disables every
+/// carve-out aimed at it.
+#[tokio::test]
+async fn reconcile_rewrites_device_rules_stranded_at_a_kernel_chosen_priority() {
+    let d1 = sample_device(device_id_1(), "192.168.1.10");
+    let mut rules = HashMap::new();
+    rules.insert(
+        DEVICE_1_ID.to_owned(),
+        RoutingRule {
+            device_id: device_id_1(),
+            target: RoutingTarget::Tunnel {
+                tunnel_id: tunnel_id_1(),
+            },
+            created_by: RuleCreator::User,
+        },
+    );
+    // `fib_default_rule_pref` put this one just ahead of the switchback band.
+    let kernel_rules = vec![(
+        "192.168.1.10".to_owned(),
+        100u32,
+        SWITCHBACK_RULE_PRIORITY - 1,
+    )];
+
+    let ts = setup_with_orphaned_rules(
+        vec![d1],
+        rules,
+        Some(sample_tunnel(tunnel_id_1(), "wg_ward0", TunnelStatus::Up)),
+        Some(sample_tunnel_config(vec!["1.1.1.1".to_owned()])),
+        kernel_rules,
+    );
+
+    as_admin(ts.routing.reconcile()).await.unwrap();
+
+    let nl = ts.netlink_calls.lock().await;
+    assert!(
+        nl.contains(&format!(
+            "remove_ip_rule:192.168.1.10:100:{}",
+            SWITCHBACK_RULE_PRIORITY - 1
+        )),
+        "the stranded rule must be removed at the priority it actually has: {nl:?}"
+    );
+    assert!(
+        nl.contains(&format!(
+            "add_ip_rule:192.168.1.10:100:{DEVICE_RULE_PRIORITY}"
+        )),
+        "it must be re-added in the device band: {nl:?}"
     );
 }

--- a/source/daemon/crates/wardnetd-services/src/routing/tests/routing.rs
+++ b/source/daemon/crates/wardnetd-services/src/routing/tests/routing.rs
@@ -3856,3 +3856,137 @@ async fn reconcile_rewrites_device_rules_stranded_at_a_kernel_chosen_priority() 
         "it must be re-added in the device band: {nl:?}"
     );
 }
+
+/// Carve-outs are matched on their source address, so ones installed under a
+/// previous IP can only ever be removed at that IP. A push carrying a new
+/// address must tear the old rules down where they actually are and rebuild at
+/// the new one — treating them as already present would strand rules under an
+/// address the device no longer has.
+#[tokio::test]
+async fn carveouts_are_rebuilt_at_the_new_ip_when_the_device_moves() {
+    let ts = setup();
+    let target = RoutingTarget::Tunnel {
+        tunnel_id: tunnel_id_1(),
+    };
+    as_admin(
+        ts.routing
+            .apply_rule(device_id_1(), "192.168.200.10", &target),
+    )
+    .await
+    .unwrap();
+    as_admin(ts.routing.set_switchback_targets(
+        device_id_1(),
+        "192.168.200.10".to_owned(),
+        vec![ent_subnet()],
+    ))
+    .await
+    .unwrap();
+
+    as_admin(ts.routing.set_switchback_targets(
+        device_id_1(),
+        "192.168.200.99".to_owned(),
+        vec![ent_subnet()],
+    ))
+    .await
+    .unwrap();
+
+    let nl = ts.netlink_calls.lock().await;
+    assert!(
+        nl.contains(&format!(
+            "remove_switchback_rule:192.168.200.10:{}:{SWITCHBACK_RULE_PRIORITY}",
+            ent_subnet()
+        )),
+        "the old carve-out must be removed at the IP it was installed under: {nl:?}"
+    );
+    assert_eq!(
+        *ts.netlink_switchback.lock().await,
+        vec![(
+            "192.168.200.99".to_owned(),
+            ent_subnet(),
+            SWITCHBACK_RULE_PRIORITY
+        )],
+        "only the carve-out at the current IP may remain"
+    );
+}
+
+/// Re-pushing an unchanged target set must not touch the kernel. The reconcile
+/// runs on every zone or device event, so churning rules it already installed
+/// would tear down and reinstate working carve-outs continuously.
+#[tokio::test]
+async fn re_pushing_unchanged_targets_installs_nothing_further() {
+    let ts = setup();
+    let target = RoutingTarget::Tunnel {
+        tunnel_id: tunnel_id_1(),
+    };
+    as_admin(
+        ts.routing
+            .apply_rule(device_id_1(), "192.168.200.10", &target),
+    )
+    .await
+    .unwrap();
+    for _ in 0..3 {
+        as_admin(ts.routing.set_switchback_targets(
+            device_id_1(),
+            "192.168.200.10".to_owned(),
+            vec![ent_subnet()],
+        ))
+        .await
+        .unwrap();
+    }
+
+    let nl = ts.netlink_calls.lock().await;
+    let adds = nl
+        .iter()
+        .filter(|c| c.starts_with("add_switchback_rule:"))
+        .count();
+    let removes = nl
+        .iter()
+        .filter(|c| c.starts_with("remove_switchback_rule:"))
+        .count();
+    assert_eq!(adds, 1, "the carve-out must be installed once: {nl:?}");
+    assert_eq!(removes, 0, "an unchanged set must remove nothing: {nl:?}");
+}
+
+/// Dropping a target removes the carve-out it installed. Withdrawing a casting
+/// exception has to close the hole it opened, or the device keeps reaching a
+/// zone it is no longer allowed into.
+#[tokio::test]
+async fn dropping_a_target_removes_only_that_carveout() {
+    let ts = setup();
+    let target = RoutingTarget::Tunnel {
+        tunnel_id: tunnel_id_1(),
+    };
+    let other_subnet = "192.168.202.0/24".to_owned();
+    as_admin(
+        ts.routing
+            .apply_rule(device_id_1(), "192.168.200.10", &target),
+    )
+    .await
+    .unwrap();
+    as_admin(ts.routing.set_switchback_targets(
+        device_id_1(),
+        "192.168.200.10".to_owned(),
+        vec![ent_subnet(), other_subnet.clone()],
+    ))
+    .await
+    .unwrap();
+    assert_eq!(ts.netlink_switchback.lock().await.len(), 2);
+
+    as_admin(ts.routing.set_switchback_targets(
+        device_id_1(),
+        "192.168.200.10".to_owned(),
+        vec![ent_subnet()],
+    ))
+    .await
+    .unwrap();
+
+    assert_eq!(
+        *ts.netlink_switchback.lock().await,
+        vec![(
+            "192.168.200.10".to_owned(),
+            ent_subnet(),
+            SWITCHBACK_RULE_PRIORITY
+        )],
+        "only the dropped target's carve-out may be removed"
+    );
+}

--- a/source/daemon/crates/wardnetd-services/src/tests/init.rs
+++ b/source/daemon/crates/wardnetd-services/src/tests/init.rs
@@ -139,13 +139,18 @@ impl PolicyRouter for StubPolicyRouter {
     async fn has_route_table(&self, _table: u32) -> anyhow::Result<bool> {
         unimplemented!()
     }
-    async fn add_ip_rule(&self, _src_ip: &str, _table: u32) -> anyhow::Result<()> {
+    async fn add_ip_rule(&self, _src_ip: &str, _table: u32, _priority: u32) -> anyhow::Result<()> {
         unimplemented!()
     }
-    async fn remove_ip_rule(&self, _src_ip: &str, _table: u32) -> anyhow::Result<()> {
+    async fn remove_ip_rule(
+        &self,
+        _src_ip: &str,
+        _table: u32,
+        _priority: u32,
+    ) -> anyhow::Result<()> {
         unimplemented!()
     }
-    async fn list_wardnet_rules(&self) -> anyhow::Result<Vec<(String, u32)>> {
+    async fn list_wardnet_rules(&self) -> anyhow::Result<Vec<(String, u32, u32)>> {
         unimplemented!()
     }
     async fn add_switchback_rule(

--- a/source/daemon/crates/wardnetd-services/src/zone_enforcement/tests/service.rs
+++ b/source/daemon/crates/wardnetd-services/src/zone_enforcement/tests/service.rs
@@ -169,13 +169,18 @@ impl PolicyRouter for RecordingPolicy {
     async fn has_route_table(&self, _table: u32) -> anyhow::Result<bool> {
         Ok(true)
     }
-    async fn add_ip_rule(&self, _src_ip: &str, _table: u32) -> anyhow::Result<()> {
+    async fn add_ip_rule(&self, _src_ip: &str, _table: u32, _priority: u32) -> anyhow::Result<()> {
         Ok(())
     }
-    async fn remove_ip_rule(&self, _src_ip: &str, _table: u32) -> anyhow::Result<()> {
+    async fn remove_ip_rule(
+        &self,
+        _src_ip: &str,
+        _table: u32,
+        _priority: u32,
+    ) -> anyhow::Result<()> {
         Ok(())
     }
-    async fn list_wardnet_rules(&self) -> anyhow::Result<Vec<(String, u32)>> {
+    async fn list_wardnet_rules(&self) -> anyhow::Result<Vec<(String, u32, u32)>> {
         Ok(Vec::new())
     }
     async fn add_switchback_rule(

--- a/source/daemon/crates/wardnetd/src/dhcp/server.rs
+++ b/source/daemon/crates/wardnetd/src/dhcp/server.rs
@@ -1,13 +1,14 @@
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::sync::Arc;
+use std::sync::Mutex as StdMutex;
 use std::sync::atomic::{AtomicBool, Ordering};
 
 use async_trait::async_trait;
 use dhcproto::v4::{DhcpOption, Flags, HType, Message, MessageType, Opcode, OptionCode};
 use dhcproto::{Decodable, Decoder, Encodable, Encoder};
 use tokio::net::UdpSocket;
-use tokio::sync::Mutex;
+use tokio::sync::{Mutex, Semaphore};
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 use wardnet_common::auth::AuthContext;
@@ -242,6 +243,152 @@ impl DhcpServer for UdpDhcpServer {
 }
 
 // ---------------------------------------------------------------------------
+// Dispatcher
+// ---------------------------------------------------------------------------
+
+/// Upper bound on DHCP handlers running at once.
+///
+/// Sized for a home LAN's client count with room to spare, not for the traffic
+/// an attacker can generate: port 67 takes unauthenticated broadcast, so a
+/// spawn per packet with no ceiling is a memory-exhaustion path. Packets that
+/// arrive with every permit taken are dropped, and DHCP clients retransmit.
+const MAX_CONCURRENT_HANDLERS: usize = 64;
+
+/// A packet parked behind the handler currently serving its MAC.
+type PendingPacket = (MessageType, Message, SocketAddr);
+
+/// Runs packet handlers concurrently across MACs while keeping each MAC's own
+/// packets strictly in order.
+///
+/// The receive loop must never wait on lease work: it owns the only socket, so
+/// a slow database call made inline stalls every client at once, and the
+/// clients respond by retransmitting into a server that is already behind.
+///
+/// Serializing per MAC is not just tidiness. `assign_lease` and `renew_lease`
+/// read a MAC's current lease and write it back, so two packets from one client
+/// in flight together are two writers racing over one row — and a retransmitting
+/// client produces exactly that. Each MAC therefore gets at most one running
+/// handler plus one pending packet; a further packet replaces the pending one,
+/// which collapses a retransmit burst into a single answer built from the
+/// client's newest message.
+struct Dispatcher {
+    socket: Arc<dyn DhcpSocket>,
+    service: Arc<dyn DhcpService>,
+    identification: Option<Arc<dyn DeviceIdentificationService>>,
+    /// MACs with a handler running. The value is that MAC's pending packet, if
+    /// one arrived while the handler was busy. Held under a `std::sync::Mutex`
+    /// because every critical section is a map lookup with no `.await` in it,
+    /// and because [`InflightGuard`] has to release the slot from `Drop`.
+    inflight: Arc<StdMutex<HashMap<String, Option<PendingPacket>>>>,
+    permits: Arc<Semaphore>,
+}
+
+/// Releases a MAC's handler slot even if the handler panics.
+///
+/// Without this a panicking handler would leave the MAC marked as busy forever,
+/// and that client would never be served again for the lifetime of the process.
+struct InflightGuard {
+    inflight: Arc<StdMutex<HashMap<String, Option<PendingPacket>>>>,
+    mac: String,
+}
+
+impl Drop for InflightGuard {
+    fn drop(&mut self) {
+        if let Ok(mut map) = self.inflight.lock() {
+            map.remove(&self.mac);
+        }
+    }
+}
+
+impl Dispatcher {
+    fn new(
+        socket: Arc<dyn DhcpSocket>,
+        service: Arc<dyn DhcpService>,
+        identification: Option<Arc<dyn DeviceIdentificationService>>,
+    ) -> Self {
+        Self {
+            socket,
+            service,
+            identification,
+            inflight: Arc::new(StdMutex::new(HashMap::new())),
+            permits: Arc::new(Semaphore::new(MAX_CONCURRENT_HANDLERS)),
+        }
+    }
+
+    /// Hand one packet off for handling. Returns immediately — never awaits the
+    /// handler, so the caller can get straight back to `recv_from`.
+    fn dispatch(&self, msg_type: MessageType, msg: Message, mac: String, src_addr: SocketAddr) {
+        {
+            let Ok(mut map) = self.inflight.lock() else {
+                tracing::error!(%mac, "DHCP dispatch state poisoned, dropping packet");
+                return;
+            };
+            if let Some(slot) = map.get_mut(&mac) {
+                // A handler for this MAC is mid-flight. Keep only the newest
+                // packet: an older queued one is a retransmit of a question this
+                // client has already restated.
+                if slot.is_some() {
+                    tracing::debug!(%mac, "superseding queued DHCP packet with a newer one");
+                }
+                *slot = Some((msg_type, msg, src_addr));
+                return;
+            }
+
+            let Ok(permit) = Arc::clone(&self.permits).try_acquire_owned() else {
+                tracing::warn!(
+                    %mac,
+                    ?msg_type,
+                    max = MAX_CONCURRENT_HANDLERS,
+                    "DHCP handler limit reached, dropping packet"
+                );
+                return;
+            };
+
+            map.insert(mac.clone(), None);
+
+            let socket = Arc::clone(&self.socket);
+            let service = Arc::clone(&self.service);
+            let identification = self.identification.clone();
+            let inflight = Arc::clone(&self.inflight);
+            tokio::spawn(async move {
+                let _permit = permit;
+                let _guard = InflightGuard {
+                    inflight: Arc::clone(&inflight),
+                    mac: mac.clone(),
+                };
+                let mut current = (msg_type, msg, src_addr);
+                loop {
+                    let (msg_type, msg, src_addr) = current;
+                    handle_packet(
+                        &socket,
+                        &service,
+                        identification.as_ref(),
+                        msg_type,
+                        &msg,
+                        &mac,
+                        src_addr,
+                    )
+                    .await;
+
+                    // Take whatever arrived for this MAC while we worked. The
+                    // slot is cleared and the MAC released in the same locked
+                    // section, so a packet can never land between the two and
+                    // be stranded with no handler to pick it up.
+                    let Ok(mut map) = inflight.lock() else {
+                        return;
+                    };
+                    let Some(next) = map.get_mut(&mac).and_then(Option::take) else {
+                        map.remove(&mac);
+                        return;
+                    };
+                    current = next;
+                }
+            });
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Server loop and helpers
 // ---------------------------------------------------------------------------
 
@@ -254,12 +401,13 @@ pub(crate) async fn server_loop(
     cancel: CancellationToken,
     own_macs: Arc<HashSet<String>>,
 ) {
+    let dispatcher = Dispatcher::new(socket, service, identification);
     let mut buf = vec![0u8; 1500];
 
     loop {
         let (len, src_addr) = tokio::select! {
             () = cancel.cancelled() => break,
-            result = socket.recv_from(&mut buf) => {
+            result = dispatcher.socket.recv_from(&mut buf) => {
                 match result {
                     Ok(r) => r,
                     Err(e) => {
@@ -318,50 +466,63 @@ pub(crate) async fn server_loop(
             continue;
         }
 
-        match msg_type {
-            MessageType::Discover => {
-                let _ = record_dhcp_signals(identification.as_ref(), &msg, &mac);
-                match handle_discover(&service, &msg, &mac).await {
-                    Ok(response) => {
-                        // DHCP OFFERs must be broadcast — the client has no IP yet
-                        // and can only receive broadcast packets.
-                        let broadcast = SocketAddr::from(([255, 255, 255, 255], 68));
-                        send_response(socket.as_ref(), &response, broadcast).await;
-                    }
-                    Err(e) => {
-                        tracing::error!(%mac, error = %e, "failed to handle DHCPDISCOVER for {mac}: {e}");
-                    }
-                }
-            }
-            MessageType::Request => {
-                let _ = record_dhcp_signals(identification.as_ref(), &msg, &mac);
-                match handle_request(&service, &msg, &mac).await {
-                    Ok(response) => {
-                        // If the client is requesting from 0.0.0.0 (new lease), send
-                        // via broadcast. Renewals come from the client's existing IP
-                        // and can be unicast.
-                        let dest = if src_addr.ip().is_unspecified() {
-                            SocketAddr::from(([255, 255, 255, 255], 68))
-                        } else {
-                            src_addr
-                        };
-                        send_response(socket.as_ref(), &response, dest).await;
-                    }
-                    Err(e) => {
-                        tracing::error!(%mac, error = %e, "failed to handle DHCPREQUEST for {mac}: {e}");
-                    }
-                }
-            }
-            MessageType::Release => {
-                handle_release(&service, &msg, &mac, src_addr).await;
-            }
-            other => {
-                tracing::debug!(%mac, ?other, "ignoring unsupported DHCP message type: mac={mac}, type={other:?}");
-            }
-        }
+        dispatcher.dispatch(msg_type, msg, mac, src_addr);
     }
 
     running.store(false, Ordering::SeqCst);
+}
+
+/// Serve one DHCP message and send whatever it produces.
+async fn handle_packet(
+    socket: &Arc<dyn DhcpSocket>,
+    service: &Arc<dyn DhcpService>,
+    identification: Option<&Arc<dyn DeviceIdentificationService>>,
+    msg_type: MessageType,
+    msg: &Message,
+    mac: &str,
+    src_addr: SocketAddr,
+) {
+    match msg_type {
+        MessageType::Discover => {
+            let _ = record_dhcp_signals(identification, msg, mac);
+            match handle_discover(service, msg, mac).await {
+                Ok(response) => {
+                    // DHCP OFFERs must be broadcast — the client has no IP yet
+                    // and can only receive broadcast packets.
+                    let broadcast = SocketAddr::from(([255, 255, 255, 255], 68));
+                    send_response(socket.as_ref(), &response, broadcast).await;
+                }
+                Err(e) => {
+                    tracing::error!(%mac, error = %e, "failed to handle DHCPDISCOVER for {mac}: {e}");
+                }
+            }
+        }
+        MessageType::Request => {
+            let _ = record_dhcp_signals(identification, msg, mac);
+            match handle_request(service, msg, mac).await {
+                Ok(response) => {
+                    // If the client is requesting from 0.0.0.0 (new lease), send
+                    // via broadcast. Renewals come from the client's existing IP
+                    // and can be unicast.
+                    let dest = if src_addr.ip().is_unspecified() {
+                        SocketAddr::from(([255, 255, 255, 255], 68))
+                    } else {
+                        src_addr
+                    };
+                    send_response(socket.as_ref(), &response, dest).await;
+                }
+                Err(e) => {
+                    tracing::error!(%mac, error = %e, "failed to handle DHCPREQUEST for {mac}: {e}");
+                }
+            }
+        }
+        MessageType::Release => {
+            handle_release(service, msg, mac, src_addr).await;
+        }
+        other => {
+            tracing::debug!(%mac, ?other, "ignoring unsupported DHCP message type: mac={mac}, type={other:?}");
+        }
+    }
 }
 
 /// Handle a DHCPDISCOVER message: assign a lease and build an OFFER response.

--- a/source/daemon/crates/wardnetd/src/dhcp/server.rs
+++ b/source/daemon/crates/wardnetd/src/dhcp/server.rs
@@ -290,10 +290,22 @@ struct Dispatcher {
 struct InflightGuard {
     inflight: Arc<StdMutex<HashMap<String, Option<PendingPacket>>>>,
     mac: String,
+    /// Cleared once the handler has released the slot itself.
+    ///
+    /// The handler's own exit removes the entry under the lock and then
+    /// returns, dropping that lock before this guard runs. Removing a second
+    /// time would delete an entry belonging to a handler dispatch had already
+    /// started for the same MAC in between — and with no entry left, the next
+    /// packet starts a third. Two handlers for one MAC is precisely what the
+    /// dispatcher exists to prevent.
+    armed: bool,
 }
 
 impl Drop for InflightGuard {
     fn drop(&mut self) {
+        if !self.armed {
+            return;
+        }
         if let Ok(mut map) = self.inflight.lock() {
             map.remove(&self.mac);
         }
@@ -315,6 +327,17 @@ impl Dispatcher {
         }
     }
 
+    /// Wait until every in-flight handler has finished.
+    ///
+    /// Acquiring every permit is only possible once none are held, and
+    /// `forget` keeps them out of circulation so nothing starts afterwards.
+    async fn drain(&self) {
+        let all = u32::try_from(MAX_CONCURRENT_HANDLERS).unwrap_or(u32::MAX);
+        if let Ok(permits) = self.permits.acquire_many(all).await {
+            permits.forget();
+        }
+    }
+
     /// Hand one packet off for handling. Returns immediately — never awaits the
     /// handler, so the caller can get straight back to `recv_from`.
     fn dispatch(&self, msg_type: MessageType, msg: Message, mac: String, src_addr: SocketAddr) {
@@ -327,7 +350,20 @@ impl Dispatcher {
                 // A handler for this MAC is mid-flight. Keep only the newest
                 // packet: an older queued one is a retransmit of a question this
                 // client has already restated.
-                if slot.is_some() {
+                //
+                // A queued DHCPRELEASE is the exception — it is not a restated
+                // question but a distinct instruction, and the DISCOVER a
+                // rebooting client sends straight after would otherwise drop
+                // it and leave the lease held.
+                if let Some((queued_type, _, _)) = slot.as_ref() {
+                    if *queued_type == MessageType::Release {
+                        tracing::debug!(
+                            %mac,
+                            ?msg_type,
+                            "keeping queued DHCPRELEASE, dropping the packet behind it"
+                        );
+                        return;
+                    }
                     tracing::debug!(%mac, "superseding queued DHCP packet with a newer one");
                 }
                 *slot = Some((msg_type, msg, src_addr));
@@ -352,9 +388,10 @@ impl Dispatcher {
             let inflight = Arc::clone(&self.inflight);
             tokio::spawn(async move {
                 let _permit = permit;
-                let _guard = InflightGuard {
+                let mut guard = InflightGuard {
                     inflight: Arc::clone(&inflight),
                     mac: mac.clone(),
+                    armed: true,
                 };
                 let mut current = (msg_type, msg, src_addr);
                 loop {
@@ -379,6 +416,7 @@ impl Dispatcher {
                     };
                     let Some(next) = map.get_mut(&mac).and_then(Option::take) else {
                         map.remove(&mac);
+                        guard.armed = false;
                         return;
                     };
                     current = next;
@@ -469,6 +507,11 @@ pub(crate) async fn server_loop(
         dispatcher.dispatch(msg_type, msg, mac, src_addr);
     }
 
+    // Handlers run on their own tasks and keep using the socket and the lease
+    // service after the loop breaks. Clearing `running` first would tell a
+    // shutdown it is safe to tear those down mid-write, so wait until every
+    // permit is back before saying the server has stopped.
+    dispatcher.drain().await;
     running.store(false, Ordering::SeqCst);
 }
 
@@ -532,6 +575,13 @@ async fn handle_packet(
 /// every time round.
 fn reply_destination(request: &Message, reply: &Message, src_addr: SocketAddr) -> SocketAddr {
     let broadcast = SocketAddr::from(([255, 255, 255, 255], 68));
+    // §4.1: a non-zero `giaddr` is the first test, ahead of everything else.
+    // The reply goes back to the relay that forwarded it and the relay decides
+    // how to deliver it — broadcasting instead would put the reply on this
+    // server's own segment, which is not the one the client is on.
+    if !request.giaddr().is_unspecified() {
+        return SocketAddr::from((request.giaddr(), 67));
+    }
     // §4.3.2: a DHCPNAK for a request that arrived without a relay is
     // broadcast. It says the address the client is holding is wrong, so that
     // address is the one place it cannot usefully be sent.

--- a/source/daemon/crates/wardnetd/src/dhcp/server.rs
+++ b/source/daemon/crates/wardnetd/src/dhcp/server.rs
@@ -501,14 +501,7 @@ async fn handle_packet(
             let _ = record_dhcp_signals(identification, msg, mac);
             match handle_request(service, msg, mac).await {
                 Ok(response) => {
-                    // If the client is requesting from 0.0.0.0 (new lease), send
-                    // via broadcast. Renewals come from the client's existing IP
-                    // and can be unicast.
-                    let dest = if src_addr.ip().is_unspecified() {
-                        SocketAddr::from(([255, 255, 255, 255], 68))
-                    } else {
-                        src_addr
-                    };
+                    let dest = reply_destination(msg, &response, src_addr);
                     send_response(socket.as_ref(), &response, dest).await;
                 }
                 Err(e) => {
@@ -523,6 +516,36 @@ async fn handle_packet(
             tracing::debug!(%mac, ?other, "ignoring unsupported DHCP message type: mac={mac}, type={other:?}");
         }
     }
+}
+
+/// Where a reply to `request` should be sent.
+///
+/// RFC 2131 §4.1: a client that cannot take delivery of a unicast IP datagram
+/// sets the BROADCAST flag, and a server replying directly to a client SHOULD
+/// honour it. Deciding purely on whether the request arrived from 0.0.0.0
+/// misses that entirely, and the client it strands is one that renews
+/// perfectly well: it holds an address, so it asks from that address, and the
+/// unicast ACK it cannot accept never registers. It retransmits at the
+/// RENEWING floor of 60 seconds until the lease is nearly gone, then releases
+/// and starts again from DHCPDISCOVER — which is broadcast, so it succeeds,
+/// and the whole cycle repeats. An access point doing that drops its clients
+/// every time round.
+fn reply_destination(request: &Message, reply: &Message, src_addr: SocketAddr) -> SocketAddr {
+    let broadcast = SocketAddr::from(([255, 255, 255, 255], 68));
+    // §4.3.2: a DHCPNAK for a request that arrived without a relay is
+    // broadcast. It says the address the client is holding is wrong, so that
+    // address is the one place it cannot usefully be sent.
+    if reply.opts().msg_type() == Some(MessageType::Nak) {
+        return broadcast;
+    }
+    if request.flags().broadcast() {
+        return broadcast;
+    }
+    // A client still in SELECTING/INIT-REBOOT has no address to be reached at.
+    if src_addr.ip().is_unspecified() {
+        return broadcast;
+    }
+    src_addr
 }
 
 /// Handle a DHCPDISCOVER message: assign a lease and build an OFFER response.

--- a/source/daemon/crates/wardnetd/src/dhcp/tests/server.rs
+++ b/source/daemon/crates/wardnetd/src/dhcp/tests/server.rs
@@ -2221,6 +2221,8 @@ struct GatedDhcpService {
     peak_per_mac: Arc<Mutex<u32>>,
     /// MACs seen, in the order their calls completed.
     completed: Arc<Mutex<Vec<String>>>,
+    /// When set, the next gated call panics instead of returning.
+    panic_once: Arc<AtomicBool>,
 }
 
 impl GatedDhcpService {
@@ -2234,11 +2236,21 @@ impl GatedDhcpService {
             active: Arc::new(Mutex::new(std::collections::HashMap::new())),
             peak_per_mac: Arc::new(Mutex::new(0)),
             completed: Arc::new(Mutex::new(Vec::new())),
+            panic_once: Arc::new(AtomicBool::new(false)),
         }
+    }
+
+    /// Whether this MAC is the gated one. `"*"` gates every MAC.
+    fn is_gated(&self, mac: &str) -> bool {
+        self.gate_mac == "*" || self.gate_mac == mac
     }
 
     /// Enter the call, blocking if this MAC is the gated one.
     async fn enter(&self, mac: &str) {
+        assert!(
+            !(self.is_gated(mac) && self.panic_once.swap(false, Ordering::SeqCst)),
+            "simulated handler failure for {mac}"
+        );
         {
             let mut active = self.active.lock().await;
             let n = active.entry(mac.to_owned()).or_insert(0);
@@ -2247,7 +2259,7 @@ impl GatedDhcpService {
             let mut peak = self.peak_per_mac.lock().await;
             *peak = (*peak).max(observed);
         }
-        if mac == self.gate_mac && !self.gate_open.load(Ordering::SeqCst) {
+        if self.is_gated(mac) && !self.gate_open.load(Ordering::SeqCst) {
             self.gate_reached.store(true, Ordering::SeqCst);
             self.gate.notified().await;
         }
@@ -2640,4 +2652,197 @@ async fn relayed_request_is_answered_to_the_relay() {
         "10.9.9.1:67".parse::<SocketAddr>().unwrap(),
         "a relayed request must be answered to the relay's server port"
     );
+}
+
+/// A client in SELECTING has no address yet, so a reply aimed at the address
+/// being offered cannot reach it.
+#[tokio::test]
+async fn request_from_an_unconfigured_client_is_broadcast() {
+    let lease = test_lease();
+    let service: Arc<dyn DhcpService> = Arc::new(MockDhcpService::new(lease));
+    let socket = Arc::new(MockDhcpSocket::new());
+
+    let request = build_request([0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff]);
+    socket
+        .push_message(&request, "0.0.0.0:68".parse().unwrap())
+        .await;
+
+    let socket = run_server_loop_until_idle(socket, service).await;
+
+    let messages = socket.sent_messages().await;
+    assert_eq!(messages.len(), 1, "expected exactly one response");
+    assert_eq!(
+        messages[0].1,
+        "255.255.255.255:68".parse::<SocketAddr>().unwrap(),
+        "a client with no address must be answered by broadcast"
+    );
+}
+
+/// A DHCPRELEASE queued behind a busy handler survives the packets that arrive
+/// after it. The slot keeps the newest packet because a retransmit restates a
+/// question already asked, but a RELEASE is a separate instruction — losing it
+/// to the DISCOVER a rebooting client sends next would leave the lease held.
+#[tokio::test]
+async fn a_queued_release_is_not_displaced_by_later_packets() {
+    let mac = [0xAA, 0xBB, 0xCC, 0x00, 0x00, 0x01];
+    let mac_str = "aa:bb:cc:00:00:01";
+    let service = Arc::new(GatedDhcpService::new(test_lease(), mac_str));
+    let gate = Arc::clone(&service.gate);
+    let gate_open = Arc::clone(&service.gate_open);
+    let gate_reached = Arc::clone(&service.gate_reached);
+    let completed = Arc::clone(&service.completed);
+
+    let socket = Arc::new(MockDhcpSocket::new());
+    let running = Arc::new(AtomicBool::new(true));
+    let cancel = tokio_util::sync::CancellationToken::new();
+    let socket_dyn: Arc<dyn DhcpSocket> = Arc::clone(&socket) as Arc<dyn DhcpSocket>;
+    let svc: Arc<dyn DhcpService> = Arc::clone(&service) as Arc<dyn DhcpService>;
+    let cancel_clone = cancel.clone();
+    let running_clone = Arc::clone(&running);
+    let handle = tokio::spawn(async move {
+        server::server_loop(
+            socket_dyn,
+            svc,
+            None,
+            running_clone,
+            cancel_clone,
+            Arc::new(HashSet::new()),
+        )
+        .await;
+    });
+
+    // Park a handler, then queue a RELEASE and let a DISCOVER land behind it.
+    socket
+        .push_message(&build_request(mac), client_addr())
+        .await;
+    wait_for_gate(&gate_reached).await;
+    socket
+        .push_message(&build_release(mac), "192.168.1.100:68".parse().unwrap())
+        .await;
+    socket
+        .push_message(&build_discover(mac), client_addr())
+        .await;
+    tokio::time::sleep(std::time::Duration::from_millis(30)).await;
+
+    gate_open.store(true, Ordering::SeqCst);
+    gate.notify_waiters();
+    tokio::time::sleep(std::time::Duration::from_millis(80)).await;
+
+    let seen = completed.lock().await.clone();
+    assert!(
+        seen.len() >= 2,
+        "the queued RELEASE must still have been served: {seen:?}"
+    );
+
+    cancel.cancel();
+    let _ = handle.await;
+}
+
+/// A handler that panics must not take its client's DHCP with it. The MAC's
+/// slot is held for the duration of a handler, so a panic that left it behind
+/// would mark that client permanently busy and it would never be served again
+/// for the life of the process.
+#[tokio::test]
+async fn a_panicking_handler_does_not_wedge_its_mac() {
+    let mac = [0xAA, 0xBB, 0xCC, 0x00, 0x00, 0x01];
+    let mac_str = "aa:bb:cc:00:00:01";
+    let service = Arc::new(GatedDhcpService::new(test_lease(), mac_str));
+    // Never park; just fail the first call.
+    service.gate_open.store(true, Ordering::SeqCst);
+    service.panic_once.store(true, Ordering::SeqCst);
+    let completed = Arc::clone(&service.completed);
+
+    let socket = Arc::new(MockDhcpSocket::new());
+    let running = Arc::new(AtomicBool::new(true));
+    let cancel = tokio_util::sync::CancellationToken::new();
+    let socket_dyn: Arc<dyn DhcpSocket> = Arc::clone(&socket) as Arc<dyn DhcpSocket>;
+    let svc: Arc<dyn DhcpService> = Arc::clone(&service) as Arc<dyn DhcpService>;
+    let cancel_clone = cancel.clone();
+    let running_clone = Arc::clone(&running);
+    let handle = tokio::spawn(async move {
+        server::server_loop(
+            socket_dyn,
+            svc,
+            None,
+            running_clone,
+            cancel_clone,
+            Arc::new(HashSet::new()),
+        )
+        .await;
+    });
+
+    socket
+        .push_message(&build_request(mac), client_addr())
+        .await;
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    socket
+        .push_message(&build_request(mac), client_addr())
+        .await;
+    tokio::time::sleep(std::time::Duration::from_millis(80)).await;
+
+    assert!(
+        completed.lock().await.iter().any(|m| m == mac_str),
+        "the client must still be served after a handler panicked"
+    );
+
+    cancel.cancel();
+    let _ = handle.await;
+}
+
+/// Port 67 accepts unauthenticated broadcast, so handlers are capped. Once the
+/// cap is reached further packets are dropped rather than queued — DHCP clients
+/// retransmit, and an unbounded task per packet is a memory-exhaustion path.
+#[tokio::test]
+async fn packets_beyond_the_handler_cap_are_dropped() {
+    // "*" parks every MAC, so the cap fills and stays full.
+    let service = Arc::new(GatedDhcpService::new(test_lease(), "*"));
+    let gate = Arc::clone(&service.gate);
+    let gate_open = Arc::clone(&service.gate_open);
+    let active = Arc::clone(&service.active);
+
+    let socket = Arc::new(MockDhcpSocket::new());
+    let running = Arc::new(AtomicBool::new(true));
+    let cancel = tokio_util::sync::CancellationToken::new();
+    let socket_dyn: Arc<dyn DhcpSocket> = Arc::clone(&socket) as Arc<dyn DhcpSocket>;
+    let svc: Arc<dyn DhcpService> = Arc::clone(&service) as Arc<dyn DhcpService>;
+    let cancel_clone = cancel.clone();
+    let running_clone = Arc::clone(&running);
+    let handle = tokio::spawn(async move {
+        server::server_loop(
+            socket_dyn,
+            svc,
+            None,
+            running_clone,
+            cancel_clone,
+            Arc::new(HashSet::new()),
+        )
+        .await;
+    });
+
+    // One distinct MAC per packet, well past the cap.
+    for i in 0u16..200 {
+        let mac = [
+            0xAA,
+            0xBB,
+            0xCC,
+            0x01,
+            u8::try_from(i >> 8).expect("high byte"),
+            u8::try_from(i & 0xFF).expect("low byte"),
+        ];
+        socket
+            .push_message(&build_discover(mac), client_addr())
+            .await;
+    }
+    tokio::time::sleep(std::time::Duration::from_millis(150)).await;
+
+    let parked = active.lock().await.values().filter(|n| **n > 0).count();
+    assert!(
+        parked <= 64,
+        "handlers must be capped, found {parked} parked at once"
+    );
+
+    gate_open.store(true, Ordering::SeqCst);
+    gate.notify_waiters();
+    cancel.cancel();
+    let _ = handle.await;
 }

--- a/source/daemon/crates/wardnetd/src/dhcp/tests/server.rs
+++ b/source/daemon/crates/wardnetd/src/dhcp/tests/server.rs
@@ -2559,3 +2559,85 @@ async fn nak_is_broadcast_even_when_the_client_could_take_unicast() {
         "a NAK must not be unicast to the address it is rejecting"
     );
 }
+
+/// Sustained traffic from one MAC must never overlap in the lease service.
+///
+/// The handler releases its own slot under the lock and returns; a guard that
+/// then removed the key a second time would delete an entry belonging to a
+/// handler dispatched for the same MAC in between, and the packet after that
+/// would start a third alongside it. Only a stream of packets that keeps
+/// re-entering dispatch as handlers finish exposes it.
+#[tokio::test]
+async fn sustained_traffic_from_one_mac_never_overlaps() {
+    let mac = [0xAA, 0xBB, 0xCC, 0x00, 0x00, 0x01];
+    // No gating: handlers complete immediately, so slots are released and
+    // re-taken constantly, which is what opens the window.
+    let service = Arc::new(GatedDhcpService::new(test_lease(), "no:such:mac"));
+    let peak = Arc::clone(&service.peak_per_mac);
+
+    let socket = Arc::new(MockDhcpSocket::new());
+    let running = Arc::new(AtomicBool::new(true));
+    let cancel = tokio_util::sync::CancellationToken::new();
+    let socket_dyn: Arc<dyn DhcpSocket> = Arc::clone(&socket) as Arc<dyn DhcpSocket>;
+    let svc: Arc<dyn DhcpService> = Arc::clone(&service) as Arc<dyn DhcpService>;
+    let cancel_clone = cancel.clone();
+    let running_clone = Arc::clone(&running);
+    let handle = tokio::spawn(async move {
+        server::server_loop(
+            socket_dyn,
+            svc,
+            None,
+            running_clone,
+            cancel_clone,
+            Arc::new(HashSet::new()),
+        )
+        .await;
+    });
+
+    for _ in 0..200 {
+        socket
+            .push_message(&build_request(mac), client_addr())
+            .await;
+        tokio::task::yield_now().await;
+    }
+    wait_for_sent(&socket, 1).await;
+    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
+    assert_eq!(
+        *peak.lock().await,
+        1,
+        "two handlers for one MAC ran at the same time"
+    );
+
+    cancel.cancel();
+    let _ = handle.await;
+}
+
+/// A request that came via a relay is answered to the relay, whatever else
+/// would otherwise apply. RFC 2131 §4.1 makes a non-zero `giaddr` the first
+/// test: broadcasting would put the reply on this server's segment rather than
+/// the client's, and the relay is what knows how to reach the client.
+#[tokio::test]
+async fn relayed_request_is_answered_to_the_relay() {
+    let lease = test_lease();
+    let service: Arc<dyn DhcpService> = Arc::new(MockDhcpService::new(lease));
+    let socket = Arc::new(MockDhcpSocket::new());
+
+    let mut request = build_request([0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff]);
+    // Both of the rules that would otherwise force a broadcast.
+    request.set_flags(Flags::default().set_broadcast());
+    request.set_giaddr(Ipv4Addr::new(10, 9, 9, 1));
+    socket
+        .push_message(&request, "10.9.9.1:67".parse().unwrap())
+        .await;
+
+    let socket = run_server_loop_until_idle(socket, service).await;
+
+    let messages = socket.sent_messages().await;
+    assert_eq!(messages.len(), 1, "expected exactly one response");
+    assert_eq!(
+        messages[0].1,
+        "10.9.9.1:67".parse::<SocketAddr>().unwrap(),
+        "a relayed request must be answered to the relay's server port"
+    );
+}

--- a/source/daemon/crates/wardnetd/src/dhcp/tests/server.rs
+++ b/source/daemon/crates/wardnetd/src/dhcp/tests/server.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 
 use async_trait::async_trait;
-use dhcproto::v4::{DhcpOption, Message, MessageType, Opcode, OptionCode};
+use dhcproto::v4::{DhcpOption, Flags, Message, MessageType, Opcode, OptionCode};
 use dhcproto::{Decodable, Decoder, Encodable, Encoder};
 use tokio::sync::Mutex;
 use uuid::Uuid;
@@ -2466,4 +2466,96 @@ async fn packets_from_one_mac_are_never_handled_concurrently() {
     gate.notify_waiters();
     cancel.cancel();
     let _ = handle.await;
+}
+
+/// A client that sets the BROADCAST flag is stating it cannot take delivery of
+/// a unicast reply, and RFC 2131 §4.1 says a server sending directly to a
+/// client SHOULD honour it. Answering such a renewal by unicast strands the
+/// client: it never sees the ACK, retransmits at the RENEWING floor of 60
+/// seconds for the whole lease, and only recovers by releasing and starting
+/// over from DHCPDISCOVER — which is broadcast, and therefore works.
+#[tokio::test]
+async fn request_with_the_broadcast_flag_is_answered_by_broadcast() {
+    let lease = test_lease();
+    let service: Arc<dyn DhcpService> = Arc::new(MockDhcpService::new(lease));
+    let socket = Arc::new(MockDhcpSocket::new());
+
+    let mut request = build_request([0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff]);
+    request.set_flags(Flags::default().set_broadcast());
+    // A RENEWING client holds its address, so it asks from that address.
+    request.set_ciaddr(Ipv4Addr::new(192, 168, 1, 100));
+    socket
+        .push_message(&request, "192.168.1.100:68".parse().unwrap())
+        .await;
+
+    let socket = run_server_loop_until_idle(socket, service).await;
+
+    let messages = socket.sent_messages().await;
+    assert_eq!(messages.len(), 1, "expected exactly one response");
+    assert_eq!(messages[0].0.opts().msg_type(), Some(MessageType::Ack));
+    assert_eq!(
+        messages[0].1,
+        "255.255.255.255:68".parse::<SocketAddr>().unwrap(),
+        "a client asking for a broadcast reply must not be answered by unicast"
+    );
+}
+
+/// Without the flag, a renewal is answered at the address the client holds.
+/// Broadcasting every ACK would put every renewal on the wire for every host.
+#[tokio::test]
+async fn request_without_the_broadcast_flag_is_answered_by_unicast() {
+    let lease = test_lease();
+    let service: Arc<dyn DhcpService> = Arc::new(MockDhcpService::new(lease));
+    let socket = Arc::new(MockDhcpSocket::new());
+
+    let mut request = build_request([0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff]);
+    request.set_ciaddr(Ipv4Addr::new(192, 168, 1, 100));
+    socket
+        .push_message(&request, "192.168.1.100:68".parse().unwrap())
+        .await;
+
+    let socket = run_server_loop_until_idle(socket, service).await;
+
+    let messages = socket.sent_messages().await;
+    assert_eq!(messages.len(), 1, "expected exactly one response");
+    assert_eq!(
+        messages[0].1,
+        "192.168.1.100:68".parse::<SocketAddr>().unwrap(),
+        "a renewal with no broadcast flag is answered at the client's address"
+    );
+}
+
+/// A DHCPNAK exists to tell a client the address it is holding is wrong, so
+/// sending it to that address is self-defeating. RFC 2131 §4.3.2 has the server
+/// broadcast a NAK whenever the request came without a relay, regardless of what
+/// the client can otherwise receive.
+#[tokio::test]
+async fn nak_is_broadcast_even_when_the_client_could_take_unicast() {
+    let lease = test_lease();
+    let service: Arc<dyn DhcpService> = Arc::new(MockDhcpService::new(lease));
+    let socket = Arc::new(MockDhcpSocket::new());
+
+    // Ask to keep an address the service does not hand back, which is what
+    // drives the NAK.
+    let mut request = build_request([0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff]);
+    request.set_ciaddr(Ipv4Addr::new(192, 168, 1, 55));
+    request
+        .opts_mut()
+        .insert(DhcpOption::RequestedIpAddress(Ipv4Addr::new(
+            192, 168, 1, 55,
+        )));
+    socket
+        .push_message(&request, "192.168.1.55:68".parse().unwrap())
+        .await;
+
+    let socket = run_server_loop_until_idle(socket, service).await;
+
+    let messages = socket.sent_messages().await;
+    assert_eq!(messages.len(), 1, "expected exactly one response");
+    assert_eq!(messages[0].0.opts().msg_type(), Some(MessageType::Nak));
+    assert_eq!(
+        messages[0].1,
+        "255.255.255.255:68".parse::<SocketAddr>().unwrap(),
+        "a NAK must not be unicast to the address it is rejecting"
+    );
 }

--- a/source/daemon/crates/wardnetd/src/dhcp/tests/server.rs
+++ b/source/daemon/crates/wardnetd/src/dhcp/tests/server.rs
@@ -2192,3 +2192,278 @@ async fn a_failing_signal_write_is_swallowed() {
     let handle = server::record_dhcp_signals(Some(&svc), &msg, "aa:bb:cc:dd:ee:ff").unwrap();
     handle.await.expect("the recorder must not panic on error");
 }
+
+// ---------------------------------------------------------------------------
+// Dispatch concurrency
+// ---------------------------------------------------------------------------
+
+/// A `DhcpService` that can be held mid-call, so a test can observe what the
+/// server does with other packets while one client's lease work is stuck.
+///
+/// `gate_mac` names the MAC whose calls block until released. Every call also
+/// updates a per-MAC concurrency tally so a test can prove that two packets
+/// from one MAC were never in the service at the same time.
+struct GatedDhcpService {
+    lease: DhcpLease,
+    gate_mac: String,
+    gate: Arc<tokio::sync::Notify>,
+    /// Once set, gated calls stop parking. A one-shot wake is not enough: the
+    /// retransmits a test queues behind the first packet would each park again
+    /// and the test could never drain.
+    gate_open: Arc<AtomicBool>,
+    /// Set once a gated call has parked. Polled rather than signalled: a
+    /// `Notify` only wakes waiters already registered, so a test that has not
+    /// reached its await yet would miss the wakeup and hang.
+    gate_reached: Arc<AtomicBool>,
+    /// Number of calls currently executing, per MAC.
+    active: Arc<Mutex<std::collections::HashMap<String, u32>>>,
+    /// Highest concurrent call count ever observed for a single MAC.
+    peak_per_mac: Arc<Mutex<u32>>,
+    /// MACs seen, in the order their calls completed.
+    completed: Arc<Mutex<Vec<String>>>,
+}
+
+impl GatedDhcpService {
+    fn new(lease: DhcpLease, gate_mac: &str) -> Self {
+        Self {
+            lease,
+            gate_mac: gate_mac.to_owned(),
+            gate: Arc::new(tokio::sync::Notify::new()),
+            gate_open: Arc::new(AtomicBool::new(false)),
+            gate_reached: Arc::new(AtomicBool::new(false)),
+            active: Arc::new(Mutex::new(std::collections::HashMap::new())),
+            peak_per_mac: Arc::new(Mutex::new(0)),
+            completed: Arc::new(Mutex::new(Vec::new())),
+        }
+    }
+
+    /// Enter the call, blocking if this MAC is the gated one.
+    async fn enter(&self, mac: &str) {
+        {
+            let mut active = self.active.lock().await;
+            let n = active.entry(mac.to_owned()).or_insert(0);
+            *n += 1;
+            let observed = *n;
+            let mut peak = self.peak_per_mac.lock().await;
+            *peak = (*peak).max(observed);
+        }
+        if mac == self.gate_mac && !self.gate_open.load(Ordering::SeqCst) {
+            self.gate_reached.store(true, Ordering::SeqCst);
+            self.gate.notified().await;
+        }
+        let mut active = self.active.lock().await;
+        if let Some(n) = active.get_mut(mac) {
+            *n -= 1;
+        }
+        self.completed.lock().await.push(mac.to_owned());
+    }
+}
+
+#[async_trait]
+impl DhcpService for GatedDhcpService {
+    async fn assign_lease(
+        &self,
+        mac: &str,
+        _hostname: Option<&str>,
+    ) -> Result<DhcpLease, AppError> {
+        self.enter(mac).await;
+        Ok(self.lease.clone())
+    }
+
+    async fn renew_lease(&self, mac: &str, _hostname: Option<&str>) -> Result<DhcpLease, AppError> {
+        self.enter(mac).await;
+        Ok(self.lease.clone())
+    }
+
+    async fn scope_for_mac(&self, _mac: &str) -> Result<DhcpScope, AppError> {
+        Ok(test_scope())
+    }
+
+    async fn active_lease(&self, _mac: &str) -> Result<Option<DhcpLease>, AppError> {
+        Ok(Some(self.lease.clone()))
+    }
+
+    async fn release_lease(&self, mac: &str) -> Result<(), AppError> {
+        self.enter(mac).await;
+        Ok(())
+    }
+
+    async fn get_config(&self) -> Result<DhcpConfigResponse, AppError> {
+        unimplemented!("not used in dispatch tests")
+    }
+    async fn update_config(
+        &self,
+        _r: UpdateDhcpConfigRequest,
+    ) -> Result<DhcpConfigResponse, AppError> {
+        unimplemented!("not used in dispatch tests")
+    }
+    async fn preview_config(
+        &self,
+        _r: PreviewDhcpConfigRequest,
+    ) -> Result<PreviewDhcpConfigResponse, AppError> {
+        unimplemented!("not used in dispatch tests")
+    }
+    async fn toggle(&self, _r: ToggleDhcpRequest) -> Result<DhcpConfigResponse, AppError> {
+        unimplemented!("not used in dispatch tests")
+    }
+    async fn list_leases(&self) -> Result<ListDhcpLeasesResponse, AppError> {
+        unimplemented!("not used in dispatch tests")
+    }
+    async fn revoke_lease(&self, _id: Uuid) -> Result<RevokeDhcpLeaseResponse, AppError> {
+        unimplemented!("not used in dispatch tests")
+    }
+    async fn list_reservations(&self) -> Result<ListDhcpReservationsResponse, AppError> {
+        unimplemented!("not used in dispatch tests")
+    }
+    async fn create_reservation(
+        &self,
+        _r: CreateDhcpReservationRequest,
+    ) -> Result<CreateDhcpReservationResponse, AppError> {
+        unimplemented!("not used in dispatch tests")
+    }
+    async fn delete_reservation(
+        &self,
+        _id: Uuid,
+    ) -> Result<DeleteDhcpReservationResponse, AppError> {
+        unimplemented!("not used in dispatch tests")
+    }
+    async fn status(&self) -> Result<DhcpStatusResponse, AppError> {
+        unimplemented!("not used in dispatch tests")
+    }
+    async fn cleanup_expired(&self) -> Result<u64, AppError> {
+        unimplemented!("not used in dispatch tests")
+    }
+    async fn get_dhcp_config(&self) -> Result<DhcpConfig, AppError> {
+        unimplemented!("not used in dispatch tests")
+    }
+}
+
+/// Poll until a gated handler has parked inside the service.
+async fn wait_for_gate(flag: &AtomicBool) {
+    tokio::time::timeout(std::time::Duration::from_secs(2), async {
+        while !flag.load(Ordering::SeqCst) {
+            tokio::time::sleep(std::time::Duration::from_millis(2)).await;
+        }
+    })
+    .await
+    .expect("the gated client's handler never reached the service");
+}
+
+/// One client's slow lease write must not hold up every other client. The
+/// server reads from a single socket, so handling each packet to completion
+/// before the next `recv_from` makes one stalled database call a network-wide
+/// DHCP outage.
+#[tokio::test]
+async fn a_stalled_client_does_not_block_responses_to_other_clients() {
+    let stuck_mac = [0xAA, 0xBB, 0xCC, 0x00, 0x00, 0x01];
+    let other_mac = [0xAA, 0xBB, 0xCC, 0x00, 0x00, 0x02];
+    let service = Arc::new(GatedDhcpService::new(test_lease(), "aa:bb:cc:00:00:01"));
+    let gate = Arc::clone(&service.gate);
+    let gate_open = Arc::clone(&service.gate_open);
+    let gate_reached = Arc::clone(&service.gate_reached);
+
+    let socket = Arc::new(MockDhcpSocket::new());
+    let running = Arc::new(AtomicBool::new(true));
+    let cancel = tokio_util::sync::CancellationToken::new();
+    let socket_dyn: Arc<dyn DhcpSocket> = Arc::clone(&socket) as Arc<dyn DhcpSocket>;
+    let svc: Arc<dyn DhcpService> = Arc::clone(&service) as Arc<dyn DhcpService>;
+    let cancel_clone = cancel.clone();
+    let running_clone = Arc::clone(&running);
+    let handle = tokio::spawn(async move {
+        server::server_loop(
+            socket_dyn,
+            svc,
+            None,
+            running_clone,
+            cancel_clone,
+            Arc::new(HashSet::new()),
+        )
+        .await;
+    });
+
+    socket
+        .push_message(&build_discover(stuck_mac), client_addr())
+        .await;
+    wait_for_gate(&gate_reached).await;
+
+    // The first client is now parked inside the service. The second must still
+    // get an answer.
+    socket
+        .push_message(&build_discover(other_mac), client_addr())
+        .await;
+    wait_for_sent(&socket, 1).await;
+
+    let sent = socket.sent_messages().await;
+    assert_eq!(
+        sent.len(),
+        1,
+        "expected exactly the unblocked client's OFFER: {sent:?}"
+    );
+    assert_eq!(
+        sent[0].0.chaddr(),
+        other_mac,
+        "the OFFER must belong to the client that was not stalled"
+    );
+
+    gate_open.store(true, Ordering::SeqCst);
+    gate.notify_waiters();
+    cancel.cancel();
+    let _ = handle.await;
+}
+
+/// Two packets from one MAC must never be inside the lease service at once.
+/// `assign_lease` and `renew_lease` read the current lease and write a new one;
+/// overlapping them for a single client races two writers over one row, which
+/// is exactly what a retransmitting client produces.
+#[tokio::test]
+async fn packets_from_one_mac_are_never_handled_concurrently() {
+    let mac = [0xAA, 0xBB, 0xCC, 0x00, 0x00, 0x01];
+    let service = Arc::new(GatedDhcpService::new(test_lease(), "aa:bb:cc:00:00:01"));
+    let gate = Arc::clone(&service.gate);
+    let gate_open = Arc::clone(&service.gate_open);
+    let gate_reached = Arc::clone(&service.gate_reached);
+    let peak = Arc::clone(&service.peak_per_mac);
+
+    let socket = Arc::new(MockDhcpSocket::new());
+    let running = Arc::new(AtomicBool::new(true));
+    let cancel = tokio_util::sync::CancellationToken::new();
+    let socket_dyn: Arc<dyn DhcpSocket> = Arc::clone(&socket) as Arc<dyn DhcpSocket>;
+    let svc: Arc<dyn DhcpService> = Arc::clone(&service) as Arc<dyn DhcpService>;
+    let cancel_clone = cancel.clone();
+    let running_clone = Arc::clone(&running);
+    let handle = tokio::spawn(async move {
+        server::server_loop(
+            socket_dyn,
+            svc,
+            None,
+            running_clone,
+            cancel_clone,
+            Arc::new(HashSet::new()),
+        )
+        .await;
+    });
+
+    socket
+        .push_message(&build_discover(mac), client_addr())
+        .await;
+    wait_for_gate(&gate_reached).await;
+
+    // The client retransmits while the first packet is still being served.
+    for _ in 0..3 {
+        socket
+            .push_message(&build_request(mac), client_addr())
+            .await;
+    }
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+    assert_eq!(
+        *peak.lock().await,
+        1,
+        "two packets from one MAC were in the lease service at the same time"
+    );
+
+    gate_open.store(true, Ordering::SeqCst);
+    gate.notify_waiters();
+    cancel.cancel();
+    let _ = handle.await;
+}

--- a/source/daemon/crates/wardnetd/src/policy_router_netlink.rs
+++ b/source/daemon/crates/wardnetd/src/policy_router_netlink.rs
@@ -230,7 +230,7 @@ impl PolicyRouter for NetlinkPolicyRouter {
         Ok(false)
     }
 
-    async fn add_ip_rule(&self, src_ip: &str, table: u32) -> anyhow::Result<()> {
+    async fn add_ip_rule(&self, src_ip: &str, table: u32, priority: u32) -> anyhow::Result<()> {
         let ip: Ipv4Addr = src_ip
             .parse()
             .map_err(|e| anyhow::anyhow!("invalid IP {src_ip}: {e}"))?;
@@ -241,26 +241,33 @@ impl PolicyRouter for NetlinkPolicyRouter {
             .v4()
             .source_prefix(ip, 32)
             .table_id(table)
+            .priority(priority)
             .action(RuleAction::ToTable)
             .execute()
             .await
             .map_err(|e| {
-                anyhow::anyhow!("failed to add ip rule from {src_ip} lookup {table}: {e}")
+                anyhow::anyhow!(
+                    "failed to add ip rule from {src_ip} lookup {table} priority {priority}: {e}"
+                )
             })?;
 
         Ok(())
     }
 
-    async fn remove_ip_rule(&self, src_ip: &str, table: u32) -> anyhow::Result<()> {
+    async fn remove_ip_rule(&self, src_ip: &str, table: u32, priority: u32) -> anyhow::Result<()> {
         let ip: Ipv4Addr = src_ip
             .parse()
             .map_err(|e| anyhow::anyhow!("invalid IP {src_ip}: {e}"))?;
 
-        // Build a RuleMessage matching the rule to delete.
+        // Build a RuleMessage matching the rule to delete. The priority is part
+        // of the match: a switchback or domain-route carve-out shares this
+        // source and can share the table, and only the priority tells them
+        // apart.
         let mut rule_msg = RuleMessage::default();
         rule_msg.header.family = AddressFamily::Inet;
         rule_msg.header.src_len = 32;
         rule_msg.attributes.push(RuleAttribute::Source(ip.into()));
+        rule_msg.attributes.push(RuleAttribute::Priority(priority));
         if table > 255 {
             rule_msg.attributes.push(RuleAttribute::Table(table));
         } else {
@@ -279,7 +286,7 @@ impl PolicyRouter for NetlinkPolicyRouter {
         Ok(())
     }
 
-    async fn list_wardnet_rules(&self) -> anyhow::Result<Vec<(String, u32)>> {
+    async fn list_wardnet_rules(&self) -> anyhow::Result<Vec<(String, u32, u32)>> {
         let mut rules_stream = self.handle.rule().get(rtnetlink::IpVersion::V4).execute();
         let mut result = Vec::new();
 
@@ -310,8 +317,20 @@ impl PolicyRouter for NetlinkPolicyRouter {
                 }
             });
 
+            let priority = rule
+                .attributes
+                .iter()
+                .find_map(|a| {
+                    if let RuleAttribute::Priority(p) = a {
+                        Some(*p)
+                    } else {
+                        None
+                    }
+                })
+                .unwrap_or(0);
+
             if let Some(ip) = src_ip {
-                result.push((ip, table));
+                result.push((ip, table, priority));
             }
         }
 

--- a/source/daemon/crates/wardnetd/src/policy_router_netlink.rs
+++ b/source/daemon/crates/wardnetd/src/policy_router_netlink.rs
@@ -22,6 +22,19 @@ use wardnetd_services::routing::policy_router::PolicyRouter;
 /// LAN traffic locally instead of over its per-tunnel table.
 const RT_TABLE_MAIN: u8 = 254;
 
+/// Whether a netlink error is the kernel refusing something that already exists.
+///
+/// Every `rule().add()` carries `NLM_F_EXCL`, so re-asserting a rule the kernel
+/// already holds comes back as `EEXIST` rather than succeeding quietly. Rule
+/// adders must treat that as success: reconcile re-asserts the whole desired
+/// set on a restart that deliberately leaves kernel state in place (ADR 0028),
+/// and treating "already correct" as a failure is worse than the failure it
+/// reports — a device whose source rule cannot be added is demoted to direct
+/// and then loses the surviving kernel rule to the orphan sweep.
+pub(crate) fn is_already_exists(e: &rtnetlink::Error) -> bool {
+    matches!(e, rtnetlink::Error::NetlinkError(msg) if msg.to_string().contains("File exists"))
+}
+
 /// Parse an IPv4 `a.b.c.d/p` CIDR into `(address, prefix_length)`. A bare
 /// address (no `/p`) is treated as a `/32` host route.
 fn parse_ipv4_cidr(cidr: &str) -> anyhow::Result<(Ipv4Addr, u8)> {
@@ -181,7 +194,7 @@ impl PolicyRouter for NetlinkPolicyRouter {
 
         match result {
             Ok(()) => Ok(()),
-            Err(rtnetlink::Error::NetlinkError(msg)) if msg.to_string().contains("File exists") => {
+            Err(ref e) if is_already_exists(e) => {
                 tracing::debug!(interface, table, "route already exists, skipping");
                 Ok(())
             }
@@ -235,7 +248,8 @@ impl PolicyRouter for NetlinkPolicyRouter {
             .parse()
             .map_err(|e| anyhow::anyhow!("invalid IP {src_ip}: {e}"))?;
 
-        self.handle
+        let result = self
+            .handle
             .rule()
             .add()
             .v4()
@@ -244,14 +258,24 @@ impl PolicyRouter for NetlinkPolicyRouter {
             .priority(priority)
             .action(RuleAction::ToTable)
             .execute()
-            .await
-            .map_err(|e| {
-                anyhow::anyhow!(
+            .await;
+
+        match result {
+            Ok(()) => Ok(()),
+            // Idempotent, like every other rule adder here. Now that the
+            // priority is fixed rather than kernel-assigned, re-asserting a
+            // rule reproduces it exactly and the kernel answers EEXIST — which
+            // means the rule is already right, not that routing failed.
+            Err(ref e) if is_already_exists(e) => {
+                tracing::debug!(src_ip, table, priority, "ip rule already exists, skipping");
+                Ok(())
+            }
+            Err(e) => {
+                anyhow::bail!(
                     "failed to add ip rule from {src_ip} lookup {table} priority {priority}: {e}"
                 )
-            })?;
-
-        Ok(())
+            }
+        }
     }
 
     async fn remove_ip_rule(&self, src_ip: &str, table: u32, priority: u32) -> anyhow::Result<()> {
@@ -366,7 +390,7 @@ impl PolicyRouter for NetlinkPolicyRouter {
 
         match result {
             Ok(()) => Ok(()),
-            Err(rtnetlink::Error::NetlinkError(msg)) if msg.to_string().contains("File exists") => {
+            Err(ref e) if is_already_exists(e) => {
                 tracing::debug!(
                     src_ip,
                     dst_cidr,
@@ -506,7 +530,7 @@ impl PolicyRouter for NetlinkPolicyRouter {
 
         match result {
             Ok(()) => Ok(()),
-            Err(rtnetlink::Error::NetlinkError(msg)) if msg.to_string().contains("File exists") => {
+            Err(ref e) if is_already_exists(e) => {
                 tracing::debug!(
                     src_ip,
                     dst_ip,
@@ -729,7 +753,7 @@ impl PolicyRouter for NetlinkPolicyRouter {
             .await
         {
             Ok(()) => Ok(()),
-            Err(rtnetlink::Error::NetlinkError(msg)) if msg.to_string().contains("File exists") => {
+            Err(ref e) if is_already_exists(e) => {
                 tracing::debug!(
                     interface,
                     ip,

--- a/source/daemon/crates/wardnetd/src/tests/policy_router_netlink.rs
+++ b/source/daemon/crates/wardnetd/src/tests/policy_router_netlink.rs
@@ -7,13 +7,16 @@
 
 use std::net::Ipv4Addr;
 
+use rtnetlink::packet_core::ErrorMessage;
 use rtnetlink::packet_route::AddressFamily;
 use rtnetlink::packet_route::route::{
     RouteAddress, RouteAttribute, RouteHeader, RouteMessage, RouteScope, RouteType,
 };
 use rtnetlink::packet_route::rule::{RuleAttribute, RuleMessage};
 
-use crate::policy_router_netlink::{build_host_route, is_removable_host_route, rule_table};
+use crate::policy_router_netlink::{
+    build_host_route, is_already_exists, is_removable_host_route, rule_table,
+};
 
 /// `main` (254) is where `add_host_route` files our routes; `local` (255) is
 /// the kernel-owned table holding the `scope host` route that delivers each of
@@ -204,4 +207,32 @@ fn rule_table_prefers_wide_table_attribute_over_header() {
     rule.attributes.push(RuleAttribute::Table(300));
     assert_eq!(rule_table(&rule), 300);
     assert_ne!(rule_table(&rule), u32::from(RT_TABLE_MAIN));
+}
+
+/// `rule().add()` carries `NLM_F_EXCL`, so re-asserting a rule the kernel
+/// already holds is answered with EEXIST. Every adder treats that as success —
+/// reconcile re-asserts the full desired set on a restart that leaves kernel
+/// state in place, and reading "already correct" as a routing failure demotes
+/// the device to direct and then strips its surviving rule as an orphan.
+#[test]
+fn eexist_is_recognised_as_already_present() {
+    // `ErrorMessage` is `#[non_exhaustive]`, so it is built by field rather
+    // than by literal.
+    let mut msg = ErrorMessage::default();
+    msg.code = std::num::NonZeroI32::new(-libc::EEXIST);
+    assert!(
+        is_already_exists(&rtnetlink::Error::NetlinkError(msg)),
+        "EEXIST must be read as the rule already being installed"
+    );
+}
+
+/// Any other kernel refusal is a real failure and must surface.
+#[test]
+fn other_netlink_errors_are_not_treated_as_already_present() {
+    let mut msg = ErrorMessage::default();
+    msg.code = std::num::NonZeroI32::new(-libc::EPERM);
+    assert!(
+        !is_already_exists(&rtnetlink::Error::NetlinkError(msg)),
+        "EPERM is a genuine failure, not an already-installed rule"
+    );
 }


### PR DESCRIPTION
## Why

Recurring, minutes-long internet outages on a live box. The trigger looked like flapping mesh APs; it turned out to be a DHCP interop bug, sitting on top of two cross-zone routing defects that left a device's traffic captured by its tunnel.

Diagnosed on a running Pi with a raw-socket DHCP capture and the kernel's own `ip rule` state, then reproduced in tests before any fix.

## What was wrong

**1. Switchback carve-outs latched out permanently.** `reconcile_switchback_for_device` recorded every desired CIDR as applied whether or not netlink accepted it. The zone enforcer builds its snapshot from `devices.last_ip`, which is empty for a device whose DHCP lease has not landed. Netlink rejected the empty source, the CIDRs were recorded anyway, and the re-push moments later diffed them as already present. The device stayed tunnel-bound with no cross-zone carve-outs — permanently.

**2. Device source rules preempted their own carve-outs.** `add_ip_rule` left the priority unset, so `fib_default_rule_pref` assigned one *below* the lowest rule already installed. The first switchback carve-out at 1000 therefore dragged every subsequent device rule to 999, ahead of every carve-out meant to override it. Live confirmation: `999: from 192.168.100.23 lookup 102` sitting above the 1000-priority carve-outs.

Device rules now occupy an explicit band (3000), below switchback (1000) and domain-route (2000), so ordering holds by construction rather than by install order. `list_wardnet_rules` reports priority so reconcile can rewrite rules stranded by an older build.

**3. DHCP replies ignored the client's BROADCAST flag.** The destination was chosen from the source address alone. A client that renews correctly — holding an address, asking from it, with the flag set — never registered the unicast ACK, retransmitted at the RENEWING floor of 60s until the lease was nearly spent, then released and started over from DISCOVER, which *is* broadcast and therefore worked. A capture shows a TP-Link AP doing this around the clock: same xid, `flags=0x8000`, one REQUEST every 67 seconds. Each cycle restarts the AP and drops its clients. That is the flap.

## Also here

The DHCP server handled each packet to completion before the next `recv_from`, so any slow lease write was a network-wide outage — and clients answered by retransmitting into a server already behind. Handlers now run concurrently across MACs and strictly in order per MAC: `assign_lease`/`renew_lease` are read-modify-write on one row, so overlapping a client's own packets races two writers, which is exactly what a retransmitting client produces. A retransmit burst collapses to one answer.

Two rounds of review then found real defects in the above, fixed in the last two commits — most seriously that pinning the rule priority made `NLM_F_EXCL` reachable for the first time, so re-asserting a rule returned `EEXIST`; the caller read that as failure and demoted the device to direct, after which the orphan sweep deleted its surviving rule. That would have broken tunnel binding on every six-hourly auto-update.

## Verification

`make check-daemon` green on top of `main` (fmt, clippy `-D warnings`, 3529 tests), including the rtnetlink 0.21 → 0.23 bump this rebases onto. `NLM_F_EXCL` re-verified against 0.23.

Every fix was driven from a failing test first. Two worth calling out:
- The routing mock, once it emulated `fib_default_rule_pref`, independently produced priority **999** — the exact value observed on the box.
- The per-MAC serialization test was checked against a naive spawn-per-packet dispatcher and fails there with "two packets from one MAC were in the lease service at the same time".

**Honest gap:** `sustained_traffic_from_one_mac_never_overlaps` does *not* catch the `InflightGuard` double-remove race — verified by reverting the fix, where it passed 3/3. The window is too tight to hit reliably. That fix is correct by construction, not by that test.

**Not addressed:** the 1.6 GB database on the live box. Concurrent dispatch means a stall there no longer takes DHCP down network-wide, but it does not make the stalls go away.