### PR TITLE
chore(rust): move the daemon to 1.98

### DIFF
--- a/.agents/commands.md
+++ b/.agents/commands.md
@@ -11,7 +11,7 @@ All builds are driven by the root **Makefile**. Use `make help` to see all targe
 - **`make check`** — run all checks (SDK + web + site + daemon: format, lint, tests)
 - **`make check-sdk`** — SDK typecheck + format check
 - **`make check-web`** — web UI typecheck + lint + format check (depends on SDK)
-- **`make check-daemon`** — Rust format + clippy + tests. **Linux-only**: the daemon depends on Linux kernel interfaces (netlink, rtnetlink) and cannot compile on macOS. On non-Linux hosts this target auto-detects `podman` or `docker` and runs inside a `rust:1.96` container. Build artefacts are cached in `.target-linux/` (gitignored) and crate downloads in a named volume (`wardnet-cargo-cache`).
+- **`make check-daemon`** — Rust format + clippy + tests. **Linux-only**: the daemon depends on Linux kernel interfaces (netlink, rtnetlink) and cannot compile on macOS. On non-Linux hosts this target auto-detects `podman` or `docker` and runs inside a `rust:1.98` container. Build artefacts are cached in `.target-linux/` (gitignored) and crate downloads in a named volume (`wardnet-cargo-cache`).
 - **`make coverage-daemon`** — line-coverage summary via `cargo-llvm-cov`. Same platform auto-detection as `check-daemon` (container on macOS). Uses the same ignore regex as CI.
 - **`make run-dev`** — mock daemon + all three Vite dev servers (admin-site :7412/admin/, user-app :7413, admin-app :7414/admin-app/). `RESUME=true` persists the DB at `.wardnet-local/wardnet.db`.
 - **`make run-dev-daemon`** — run just `wardnetd-mock` on :7411.

--- a/.agents/technical-stack.md
+++ b/.agents/technical-stack.md
@@ -1,7 +1,7 @@
 # Technical Stack
 
 ## Daemon
-- Rust 1.96 (pinned in `rust-toolchain.toml`)
+- Rust 1.98 (pinned in `rust-toolchain.toml`)
 - **Multi-crate workspace**: `wardnet-common` (shared types/config) → `wardnetd-data` (repositories + database dumper + secret store) → `wardnetd-services` (business logic) → `wardnetd-api` (HTTP layer) → `wardnetd` (Linux binary)
 - axum 0.8 (with `macros`, `multipart`, `ws` features), tokio, tower-http
 - utoipa + utoipa-axum for OpenAPI generation, utoipa-scalar for the `/api/docs` UI

--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -8,7 +8,7 @@ inputs:
   toolchain:
     description: Rust toolchain version (must match `rust-toolchain.toml`).
     required: false
-    default: "1.96"
+    default: "1.98"
   targets:
     description: Comma- or space-separated list of additional Rust targets to install.
     required: false

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -84,7 +84,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # master
         with:
-          toolchain: "1.96"
+          toolchain: "1.98"
 
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
         with:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # master
         with:
-          toolchain: "1.96"
+          toolchain: "1.98"
 
       - name: Install cargo-audit
         run: cargo install cargo-audit

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ SITE_DIR     := source/marketing-site
 # Container runtime: prefer podman, fall back to docker.
 CONTAINER_RT := $(shell command -v podman 2>/dev/null || command -v docker 2>/dev/null)
 CONTAINER_RT_NAME := $(notdir $(CONTAINER_RT))
-RUST_IMAGE   := docker.io/library/rust:1.96
+RUST_IMAGE   := docker.io/library/rust:1.98
 
 # rustables' build.rs runs bindgen against <linux/netfilter/nf_tables.h>, so the
 # in-container daemon build needs clang/libclang (issue #307). The kernel uapi

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [![CI](https://github.com/wardnet/wardnet/actions/workflows/ci-orchestration.yml/badge.svg)](https://github.com/wardnet/wardnet/actions/workflows/ci-orchestration.yml)
 [![codecov](https://codecov.io/gh/wardnet/wardnet/branch/main/graph/badge.svg)](https://codecov.io/gh/wardnet/wardnet)
-[![Rust](https://img.shields.io/badge/rust-1.96-orange.svg)](https://www.rust-lang.org)
+[![Rust](https://img.shields.io/badge/rust-1.98-orange.svg)](https://www.rust-lang.org)
 [![Rust Report Card](https://rust-reportcard.xuri.me/badge/github.com/wardnet/wardnet)](https://rust-reportcard.xuri.me/report/github.com/wardnet/wardnet)
 [![Security Audit](https://github.com/wardnet/wardnet/actions/workflows/security.yml/badge.svg)](https://github.com/wardnet/wardnet/actions/workflows/security.yml)
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/wardnet/wardnet/badge)](https://securityscorecards.dev/viewer/?uri=github.com/wardnet/wardnet)

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -98,7 +98,7 @@ All business logic lives in `@wardnet/js`. Components are pure presentation. Hoo
 
 | Component       | Technology                                                    |
 |-----------------|---------------------------------------------------------------|
-| Daemon          | Rust 1.96, axum 0.8, SQLite (sqlx 0.8)                        |
+| Daemon          | Rust 1.98, axum 0.8, SQLite (sqlx 0.8)                        |
 | Web UI          | React 19, TypeScript 5.9, Vite 8, Tailwind CSS 4              |
 | SDK             | TypeScript 5.9, zero runtime dependencies, native `fetch`     |
 | Package manager | Yarn 4 (via Corepack)                                         |
@@ -113,7 +113,7 @@ All business logic lives in `@wardnet/js`. Components are pure presentation. Hoo
 
 ### Prerequisites
 
-- Rust 1.96+ (pinned via `rust-toolchain.toml`)
+- Rust 1.98+ (pinned via `rust-toolchain.toml`)
 - Node.js 25+
 - Yarn 4 (enabled via `corepack enable`)
 - **Daemon checks on macOS**: Podman or Docker. The daemon uses Linux-only kernel interfaces (netlink, rtnetlink) and cannot compile natively on macOS — `make check-daemon` runs checks inside a Linux container automatically.

--- a/source/daemon/Cargo.toml
+++ b/source/daemon/Cargo.toml
@@ -19,7 +19,7 @@ resolver = "3"
 [workspace.package]
 version = "0.7.0"
 edition = "2024"
-rust-version = "1.96"
+rust-version = "1.98"
 # GPL-3.0-or-later, not MIT: the daemon links `rustables` (GPL-3.0-or-later,
 # never published under any other license), and Rust links statically — so the
 # compiled binary is a combined work GPL-3.0's terms extend to. The SDK and web

--- a/source/daemon/Dockerfile.test
+++ b/source/daemon/Dockerfile.test
@@ -67,7 +67,7 @@ FROM rust:1.98-slim-bookworm@sha256:94e9efa4033213dbb70d4f665527e7ece3944ddb7ba1
 #
 # clang + libclang-dev: rustables' build.rs runs bindgen against
 # <linux/netfilter/nf_tables.h> (issue #307). linux-libc-dev supplies
-# those kernel uapi headers — unlike the full rust:1.96 image the
+# those kernel uapi headers — unlike the full rust:1.98 image the
 # Makefile container path uses, the slim image here ships neither the
 # headers nor libclang, so both must be added explicitly.
 RUN apt-get update \

--- a/source/daemon/crates/wardnet-common/src/trackers.rs
+++ b/source/daemon/crates/wardnet-common/src/trackers.rs
@@ -140,10 +140,8 @@ pub fn company_for_domain(domain: &str) -> Option<&'static str> {
         if let Some(&company) = TRACKER_MAP.get(candidate) {
             return Some(company);
         }
-        match candidate.find('.') {
-            Some(idx) => candidate = &candidate[idx + 1..],
-            None => return None,
-        }
+        let idx = candidate.find('.')?;
+        candidate = &candidate[idx + 1..];
     }
 }
 

--- a/source/daemon/crates/wardnetd-api/src/api/middleware.rs
+++ b/source/daemon/crates/wardnetd-api/src/api/middleware.rs
@@ -21,16 +21,20 @@ pub struct ClientIp(pub IpAddr);
 impl FromRequestParts<AppState> for ClientIp {
     type Rejection = AppError;
 
-    async fn from_request_parts(
+    fn from_request_parts(
         parts: &mut Parts,
         _state: &AppState,
-    ) -> Result<Self, Self::Rejection> {
-        let connect_info = parts
-            .extensions
-            .get::<ConnectInfo<SocketAddr>>()
-            .ok_or_else(|| AppError::Internal(anyhow::anyhow!("missing ConnectInfo extension")))?;
-
-        Ok(Self(connect_info.0.ip()))
+    ) -> impl std::future::Future<Output = Result<Self, Self::Rejection>> + Send {
+        // Reading an extension awaits nothing, so resolve it here and hand back
+        // an already-complete future rather than building a state machine that
+        // finishes on its first poll.
+        std::future::ready(
+            parts
+                .extensions
+                .get::<ConnectInfo<SocketAddr>>()
+                .ok_or_else(|| AppError::Internal(anyhow::anyhow!("missing ConnectInfo extension")))
+                .map(|connect_info| Self(connect_info.0.ip())),
+        )
     }
 }
 
@@ -46,14 +50,14 @@ impl FromRequestParts<AppState> for ClientIp {
 impl axum::extract::OptionalFromRequestParts<AppState> for ClientIp {
     type Rejection = std::convert::Infallible;
 
-    async fn from_request_parts(
+    fn from_request_parts(
         parts: &mut Parts,
         _state: &AppState,
-    ) -> Result<Option<Self>, Self::Rejection> {
-        Ok(parts
+    ) -> impl std::future::Future<Output = Result<Option<Self>, Self::Rejection>> + Send {
+        std::future::ready(Ok(parts
             .extensions
             .get::<ConnectInfo<SocketAddr>>()
-            .map(|ci| Self(ci.0.ip())))
+            .map(|ci| Self(ci.0.ip()))))
     }
 }
 

--- a/source/daemon/crates/wardnetd-services/src/private_dns/tests/service.rs
+++ b/source/daemon/crates/wardnetd-services/src/private_dns/tests/service.rs
@@ -693,7 +693,10 @@ async fn enable_persists_seeds_wildcard_and_publishes() {
 
     assert!(status.enabled);
     assert_eq!(status.domain.as_deref(), Some(DOMAIN));
-    assert!(h.system_config.get("private_dns_enabled").await.unwrap() == Some("true".to_owned()));
+    assert_eq!(
+        h.system_config.get("private_dns_enabled").await.unwrap(),
+        Some("true".to_owned())
+    );
     assert_eq!(h.dns_local.record_domains(), vec![format!("*.{DOMAIN}")]);
     assert!(matches!(
         rx.try_recv(),

--- a/source/daemon/fuzz/rust-toolchain.toml
+++ b/source/daemon/fuzz/rust-toolchain.toml
@@ -11,12 +11,23 @@
 # (typical OSS-Fuzz projects bump quarterly). Bumping procedure:
 #
 #   1. Pick a nightly from the same minor version as the daemon's
-#      stable pin (currently 1.96 — see ../rust-toolchain.toml and
+#      stable pin (currently 1.98 — see ../rust-toolchain.toml and
 #      the workspace `rust-version`). Tracking the stable minor avoids
 #      running the fuzzer on unreleased compiler features that would
-#      never be exercised by production builds. The 1.96 nightly
-#      window was roughly 2026-03-06 → 2026-04-14; resolve a specific
-#      date at https://rust-lang.github.io/rustup-components-history/
+#      never be exercised by production builds.
+#
+#      Rust's cadence is a strict 6 weeks, so given stable <N> shipped
+#      on date S, the <N>-nightly window ran S-12w → S-6w. 1.98 shipped
+#      2026-08-18, putting its window at 2026-05-26 → 2026-07-06;
+#      2026-07-07 already resolves to 1.99.0-nightly. Pick a date late
+#      in the window but clear of the branch cut.
+#
+#      Resolve a date without needing the OSS-Fuzz image — the dist
+#      manifest is authoritative and needs no emulation (`rustc
+#      --version` segfaults under qemu on Apple Silicon):
+#
+#        curl -s https://static.rust-lang.org/dist/<DATE>/channel-rust-nightly.toml \
+#          | grep -m1 -A3 '^\[pkg.rust\]' | grep -m1 version
 #   2. Update the channel below + `cargo +nightly-<date> fuzz build`
 #      locally once to confirm.
 #   3. Commit. The next fuzzing-scheduled run will pick it up.
@@ -24,5 +35,5 @@
 # Dependabot doesn't auto-bump this — no ecosystem support for
 # nightly-date pins.
 [toolchain]
-channel = "nightly-2026-04-01"
+channel = "nightly-2026-07-01"
 components = ["rust-src"]

--- a/source/daemon/rust-toolchain.toml
+++ b/source/daemon/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.96"
+channel = "1.98"
 components = ["clippy", "rustfmt"]
 targets = ["aarch64-unknown-linux-gnu"]


### PR DESCRIPTION
Moves the daemon to **Rust 1.98** (latest stable, shipped 2026-08-18), ahead of the `v2026.08.01` release so the release ships on it.

## Why every pin, not just the image

Dependabot already bumped `source/daemon/Dockerfile.test` to `rust:1.98-slim-bookworm` in #1260. That changed nothing on its own — `rust-toolchain.toml` overrides whatever toolchain a base image ships, so that container was downloading 1.96 on every run. The project was still 1.96 everywhere that decides anything.

All twelve pins move together here:

| File | Pin |
|---|---|
| `source/daemon/rust-toolchain.toml` | `channel` |
| `source/daemon/Cargo.toml` | `rust-version` (MSRV) |
| `Makefile` | `RUST_IMAGE` |
| `.github/actions/setup-rust/action.yml` | `default` |
| `.github/workflows/coverage.yml`, `security.yml` | `toolchain` |
| `README.md` | badge |
| `.agents/technical-stack.md`, `.agents/commands.md` | docs |
| `docs/DEVELOPMENT.md` | tech-stack row + prerequisites |
| `source/daemon/Dockerfile.test` | stale comment |
| `source/daemon/fuzz/rust-toolchain.toml` | nightly + worked example |

`grep -rn "1\.96"` over md/yml/toml/Dockerfile/Makefile comes back empty.

## Fuzzing nightly

`nightly-2026-04-01` → **`nightly-2026-07-01`** = `rustc 1.98.0-nightly (f46ec5218 2026-06-30)`, keeping the fuzzer on the stable minor rather than two minors ahead.

Rust's 6-week cadence puts the 1.98 nightly window at 2026-05-26 → 2026-07-06, which I checked against the dist manifests rather than trusting the arithmetic:

| Date | Resolves to |
|---|---|
| 2026-05-26 | `1.98.0-nightly` ← opens |
| 2026-07-01 | `1.98.0-nightly (f46ec5218)` ← **chosen** |
| 2026-07-05 | `1.98.0-nightly` ← last 1.98 |
| 2026-07-07 | `1.99.0-nightly` ← branch cut |

Late in the window but six days clear of the cut.

The skill's documented way to resolve a date runs `rustc --version` inside the OSS-Fuzz base image, which **segfaults under qemu on Apple Silicon** (`uncaught target signal 11`). The `channel-rust-nightly.toml` dist manifest gives the same answer with no emulation, so the header comment now documents that instead, along with the cadence arithmetic.

## Lints new or widened in 1.98

Fixed rather than `#[allow]`-ed, per the skill:

- **`question_mark`** — a `match` arm returning `None` in `company_for_domain` is just `?`.
- **`unused_async`**, now covering async trait impls — both `FromRequestParts` extractors only read a request extension and await nothing, so they return `std::future::ready(..)` instead of an async state machine that completes on its first poll. This is a genuine (small) win, not lint appeasement.
- **`manual_assert_eq`** — `assert!(a == b)` → `assert_eq!(a, b)`, which prints both sides when it fails.

## Test plan

`make check-daemon` on `rust:1.98` — exit 0, fmt + clippy `-D warnings` + **3536 tests**.

Not run: `cargo fuzz build` on the new nightly. The OSS-Fuzz image is amd64-only and rustc segfaults under emulation on this machine, so the nightly is verified by dist-manifest resolution rather than a local build. Worth a CI fuzz run before relying on it.

## After merge

Rebase `chore/release-prep-2026-08-01` (#1275) onto main so `v2026.08.01` ships built on 1.98.

## Merge Commit Message

chore(rust): move the daemon to 1.98

Moves every toolchain pin — channel, MSRV, container image, CI actions, README badge and docs — from 1.96 to latest stable 1.98, plus the fuzzing nightly to nightly-2026-07-01 (rustc 1.98.0-nightly). Fixes three lints new or widened in 1.98: question_mark, unused_async on async trait impls, and manual_assert_eq.
