### PR TITLE
chore(ci): drop the unproven e2e registry cache and audit every token write

### DIFF
--- a/.github/workflows/ci-end2end.yml
+++ b/.github/workflows/ci-end2end.yml
@@ -30,13 +30,12 @@ jobs:
     # gated only on build, so nothing serialises that did not before.
     #
     # build-web (run on the host before the Docker build) reads @wardnet/*
-    # from GitHub Packages, and the image build exports its layer cache to a
-    # GHCR image. A called workflow can only narrow what the caller grants, so
-    # `packages: write` has to reach here from
-    # pipeline.ci.stage_permissions.end2end in .gt-repo.yaml. Without it the
-    # cache export is refused and the build silently stops warming it.
+    # from GitHub Packages — read only. This job used to hold `packages: write`
+    # for a GHCR layer-cache export; that cache never demonstrated a win and
+    # was removed, which took the write with it. `read` is the stage baseline,
+    # so no stage_permissions grant is needed either.
     permissions:
       contents: read
-      packages: write
+      packages: read
     uses: ./.github/workflows/tests-e2e.yml
     secrets: inherit

--- a/.github/workflows/ci-orchestration.yml
+++ b/.github/workflows/ci-orchestration.yml
@@ -142,18 +142,14 @@ jobs:
     # already sit inside.
     # nosemgrep: yaml.github-actions.security.secrets-inherit.secrets-inherit
     secrets: inherit
-    # Widened beyond the stage baseline (contents: read, packages: read) by
-    # pipeline.ci.stage_permissions in .gt-repo.yaml.
-    #
-    # A called workflow can only narrow what its caller grants, so a leaf that
-    # genuinely needs more — uploading SARIF to code scanning, pushing a build
-    # cache to a registry — cannot ask for it back. The calling job grants it
-    # here and the leaf narrows from it. Every scope below was named
-    # explicitly in the spec, so the grant is reviewable in this diff rather
-    # than implied by a template.
+    # packages: read because several repositories resolve private @scope
+    # dependencies from GitHub Packages during install, and a called workflow
+    # can only narrow what the caller grants — a stage cannot ask for it back.
+    # Read-only, so granting it where it is unused costs nothing. A stage
+    # needing more says so in pipeline.ci.stage_permissions.
     permissions:
       contents: read
-      packages: write
+      packages: read
 
   conventional-commits:
     needs: [attest]

--- a/.github/workflows/tests-e2e.yml
+++ b/.github/workflows/tests-e2e.yml
@@ -35,9 +35,10 @@ permissions:
   contents: read
   # Both e2e jobs run `make build-web` on the host before the Docker build;
   # that installs the web apps, which pull @wardnet/{ui,styles,brand} from
-  # GitHub Packages. Granted by the caller job (ci-end2end.yml/release.yml) and
-  # surfaced here so the leaf doesn't restrict it back to none.
-  packages: write
+  # GitHub Packages. Read, not write: nothing here publishes a package any
+  # more. Granted by the caller job (ci-end2end.yml/release.yml) and surfaced
+  # here so the leaf doesn't restrict it back to none.
+  packages: read
 
 env:
   CARGO_TERM_COLOR: always
@@ -75,95 +76,20 @@ jobs:
 
       - uses: ./.github/actions/setup-rust
 
-      - name: Set up buildx
-        # `use: false` is load-bearing. The action defaults to `use: true`,
-        # which makes this docker-container builder the DEFAULT for everything
-        # docker builds afterwards — including `docker compose build`, which we
-        # do not want touched. That driver runs in its own container with its
-        # own image store and cannot see the host's local images, so
-        # deploy/docker/Dockerfile.client's `FROM ${WARDNETD_TEST_IMAGE}` (i.e.
-        # the just-built wardnetd:dev-test) stopped resolving locally and was
-        # looked up as docker.io/library/wardnetd:dev-test instead:
-        #
-        #   target test_debian: failed to solve: pull access denied,
-        #   repository does not exist or may require authorization
-        #
-        # A named builder referenced explicitly by --builder keeps the cache
-        # export scoped to the one image that wants it and leaves compose on
-        # the default docker driver, exactly as before.
-        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
-        with:
-          name: wardnetd-cache
-          use: false
 
-      - name: Log in to GHCR for the build cache
-        # Read access to the cache image comes from the job's packages scope;
-        # this login is what allows the export when the token permits one.
-        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run daemon e2e suite
-        # `make end2end-daemon` chains: build-web → image-test (cargo
-        # build inside Docker) → compose up --wait wardnetd → vitest in
-        # test_runner → trap dumps compose logs into reports/ and
-        # tears the stack down. Reports are written even on failure.
+        # `make end2end-daemon` chains: build-web → image-test (cargo build
+        # inside Docker) → compose up --wait wardnetd → vitest in test_runner →
+        # trap dumps compose logs into reports/ and tears the stack down.
+        # Reports are written even on failure.
         #
         # CONTAINER_RT=docker forces Docker's BuildKit instead of the
-        # Makefile's default podman-first auto-detection. ubuntu-latest
-        # ships both binaries; podman's classic image builder rejects
-        # the BuildKit heredoc syntax used in source/daemon/Dockerfile.test
-        # ("Unknown instruction: SET"). Local devs on macOS keep the podman
-        # default.
-        #
-        # IMAGE_BUILDER is separate because this target also runs `compose`,
-        # which buildx has no subcommand for — and which must keep using the
-        # default docker driver so `FROM wardnetd:dev-test` still resolves from
-        # the local image store. Only the image build goes through the named
-        # buildx builder, whose docker-container driver is the one that can
-        # export a cache. The cache lives on GHCR rather than in
-        # the Actions cache: a Rust dependency layer is GB-scale, and the
-        # Actions cache is a 10 GiB per-repo budget the Rust caches already
-        # compete over. Registry cache is also shared across branches, where an
-        # Actions cache saved on a PR ref is readable only by that PR.
-        #
-        # mode=max exports intermediate layers, which is the point — the
-        # dependency layer is the one worth restoring.
-        run: |
-          set -euo pipefail
-
-          # Restoring only needs a readable registry; exporting needs a
-          # writable token, which a fork PR and any Dependabot event do not
-          # have. Push the cache where we can, read it everywhere.
-          # --builder targets the named builder set up above without making it
-          # the default; --load exports the result into the host's docker image
-          # store, which is where compose then finds wardnetd:dev-test.
-          # Reads both suites' refs — the dependency layer is shared, so a warm
-          # UI cache serves this job too. Writes only this suite's own ref.
-          args="--builder wardnetd-cache --load"
-          args="${args} --cache-from type=registry,ref=${CACHE_REF}"
-          args="${args} --cache-from type=registry,ref=${UI_CACHE_REF}"
-          read_args="${args}"
-          if [[ "${CAN_WRITE_CACHE}" == "true" ]]; then
-            args="${args} --cache-to type=registry,ref=${CACHE_REF},mode=max"
-          else
-            echo "read-only token — restoring the build cache without updating it"
-          fi
-
-          # The release-server image reads the cache but never writes it, so
-          # its shorter layer set cannot replace the daemon image's in the ref.
-          make end2end-daemon \
-            CONTAINER_RT="$(command -v docker)" \
-            IMAGE_BUILDER="docker buildx" \
-            IMAGE_TEST_BUILD_ARGS="${args}" \
-            IMAGE_TEST_RELEASE_BUILD_ARGS="${read_args}"
-        env:
-          CACHE_REF: ghcr.io/${{ github.repository }}/wardnetd-test-cache:buildcache
-          UI_CACHE_REF: ghcr.io/${{ github.repository }}/wardnetd-ui-test-cache:buildcache
-          CAN_WRITE_CACHE: ${{ github.event_name != 'pull_request' || (github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]') }}
-
+        # Makefile's default podman-first auto-detection. ubuntu-latest ships
+        # both binaries; podman's classic image builder rejects the BuildKit
+        # heredoc syntax used in source/daemon/Dockerfile.test ("Unknown
+        # instruction: SET"). Local devs on macOS keep the podman default.
+        run: make end2end-daemon CONTAINER_RT="$(command -v docker)"
       - name: Surface captured logs
         # Print the trap-captured compose logs + JUnit/JSON reports
         # inline so a reviewer can diagnose a failure straight from the
@@ -235,21 +161,7 @@ jobs:
 
       - uses: ./.github/actions/setup-rust
 
-      - name: Set up buildx
-        # `use: false` for the same reason as the daemon job: this compose stack
-        # also has a `FROM ${WARDNETD_TEST_IMAGE}` (test_debian), which a
-        # docker-container builder cannot resolve from the local image store.
-        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
-        with:
-          name: wardnetd-cache
-          use: false
 
-      - name: Log in to GHCR for the build cache
-        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run web-ui e2e suite
         # `make e2e-ui` chains: build-web → image-test-ui (cargo build +
@@ -257,33 +169,7 @@ jobs:
         # ui_runner → trap dumps compose logs into reports/ and tears the stack
         # down. Reports are written even on failure.
         # CONTAINER_RT=docker forces BuildKit (see the daemon job note).
-        run: |
-          set -euo pipefail
-
-          # Read BOTH cache refs. Everything up to `cargo chef cook` is
-          # byte-identical across the two suites — WEB_DIST only selects the
-          # `web` stage, and the builder's `COPY --from=web` comes after cook —
-          # so a warm daemon cache serves this job's dependency layer even the
-          # first time the UI ref is empty. Writes stay on this suite's own ref,
-          # so the two jobs never race to publish the same tag.
-          args="--builder wardnetd-cache --load"
-          args="${args} --cache-from type=registry,ref=${UI_CACHE_REF}"
-          args="${args} --cache-from type=registry,ref=${DAEMON_CACHE_REF}"
-          if [[ "${CAN_WRITE_CACHE}" == "true" ]]; then
-            args="${args} --cache-to type=registry,ref=${UI_CACHE_REF},mode=max"
-          else
-            echo "read-only token — restoring the build cache without updating it"
-          fi
-
-          make e2e-ui \
-            CONTAINER_RT="$(command -v docker)" \
-            IMAGE_BUILDER="docker buildx" \
-            IMAGE_TEST_UI_BUILD_ARGS="${args}"
-        env:
-          UI_CACHE_REF: ghcr.io/${{ github.repository }}/wardnetd-ui-test-cache:buildcache
-          DAEMON_CACHE_REF: ghcr.io/${{ github.repository }}/wardnetd-test-cache:buildcache
-          CAN_WRITE_CACHE: ${{ github.event_name != 'pull_request' || (github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]') }}
-
+        run: make e2e-ui CONTAINER_RT="$(command -v docker)"
       - name: Surface captured logs
         if: always()
         run: |

--- a/.gt-repo.yaml
+++ b/.gt-repo.yaml
@@ -101,8 +101,6 @@ pipeline:
       build:
         actions: read
         security-events: write
-      end2end:
-        packages: write
       test:
         contents: write
         pull-requests: write

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -305,7 +305,9 @@ reusable `workflow_call` leaves described below:
 | test | [`ci-test.yml`](../.github/workflows/ci-test.yml) | coverage (which hosts bulwark) |
 | end2end | [`ci-end2end.yml`](../.github/workflows/ci-end2end.yml) | tests-e2e |
 
-`ci-gate` aggregates every stage and is the single required check. Note that
+`ci-gate` aggregates every stage and is the single required check. Every
+`write` scope the pipeline grants is indexed and justified in
+[ci-token-permissions.md](ci-token-permissions.md). Note that
 `end2end` is declared `independent_stages` in the spec: its suite rebuilds the
 daemon from source inside Docker and consumes nothing the build stage
 produces, so it runs alongside `build` rather than after it.

--- a/docs/ci-token-permissions.md
+++ b/docs/ci-token-permissions.md
@@ -1,0 +1,85 @@
+# CI token permissions
+
+Every `write` scope granted to a workflow in this repository, why it exists,
+and whether it can go away.
+
+Scorecard's `Token-Permissions` check scores **0 for any write**, so a green
+score is not the goal and is not reachable while the pipeline signs releases,
+caches coverage baselines and uploads SARIF. The goal is that every write is
+**job-scoped, necessary, and explained at the point it is granted** — so a
+reviewer can tell a required grant from an accidental one without running the
+pipeline. This file is the index; the reasoning lives next to each grant.
+
+Last audited: 2026-08-31, against `main` at `310c12b9`.
+
+## Granted and required
+
+| workflow | scope | why |
+|---|---|---|
+| `ci-build.yml` | `security-events: write` | `codeql-action/upload-sarif` publishes clippy findings to Code Scanning. Silently stops publishing without it — it does not fail. |
+| `ci-test.yml` | `contents: write`, `pull-requests: write` | Ceiling for `coverage.yml`'s bulwark job below. |
+| `coverage.yml` | `contents: write`, `pull-requests: write` | bulwark caches coverage baselines on the `bulwark-state` branch and posts a sticky PR summary. |
+| `cubit.yml` | `contents: write` | Pushes the `cubit-state` baseline branch on a push to `main`. |
+| `release-edge.yml` | `contents: write` (×3) | Pushes the `edge-v*` tag, publishes the release, prunes superseded ones. |
+| `release-edge.yml` | `id-token: write` | SLSA provenance attestation. |
+| `prune-edge.yml` | `contents: write` | Deletes superseded edge releases and their tags. |
+| `update-visual-snapshots.yml` | `contents: write` | Commits regenerated Playwright baselines back to the branch. |
+
+All of the above are **job-scoped**, not workflow-level, and each carries an
+inline comment. None is reducible without losing the function it exists for.
+
+## Granted by gt, not editable here
+
+`ci-orchestration.yml`, `gt-sync.yml` and `dependabot-auto-merge.yml` are
+rendered by [gt](https://github.com/pedromvgomes/gt) from `.gt-repo.yaml`;
+editing them is drift that the next `gt repo sync` reverts.
+
+| grant | why |
+|---|---|
+| `statuses: write` | `reusable-attest` records the validated-tree commit status. |
+| `contents: write` + `pull-requests: write` on the bulwark stage | Same baseline-caching and PR-comment needs as above. |
+| `security-events: write` on the build stage | This repo's own `stage_permissions.build`, for the SARIF upload. |
+| `contents: write` (gt-sync, dependabot-auto-merge) | Committing a re-render, and merging a Dependabot PR. |
+
+Narrowing any of these is a gt change, not a wardnet one.
+
+## Removed
+
+- **`packages: write` on `tests-e2e.yml`** — was workflow-level, so both e2e
+  jobs held it, and it existed only to export a GHCR layer cache. The cache was
+  never shown to pay for itself (baseline e2e runs ranged 14–30 min with it,
+  which is wider than any effect it could have had), so it was removed and the
+  write went with it. That also cleared the grant from `ci-end2end.yml` and the
+  `stage_permissions.end2end` entry in `.gt-repo.yaml` — three findings from
+  one deletion.
+
+## Open questions, deliberately not changed
+
+Both need a live run to settle, and neither is exercised by pull-request CI.
+
+- **`release-edge.yml`'s `security-events: write`.** `run-checks: false` means
+  `check-daemon` never runs, so nothing uploads SARIF — but the comment says
+  the grant is required anyway because a called workflow may not exceed its
+  caller and the leaf declares the scope. If GitHub validates that lazily, the
+  grant is dead and can go. Removing it blind would break the edge release
+  path, which no PR run would catch.
+- **`cubit.yml`'s `pull-requests: write`.** cubit runs on push-to-`main` and
+  `workflow_dispatch` only; neither carries pull-request context, so the sticky
+  comment path looks unreachable. Retained until a dispatch run confirms it,
+  because cubit is advisory and never fails the build — a silently missing
+  comment is exactly the kind of thing nobody would notice.
+
+## Not token findings
+
+Scorecard also reports, on the same page:
+
+- `PinnedDependenciesID` — first-party actions on moving majors
+  (`wardnet/bulwark@v2`, `wardnet/cubit@v0`, `pedromvgomes/gt@v1`). Deliberate:
+  fixes reach every repo without a bump. Third-party actions **are** SHA-pinned.
+- `CodeReviewID` — `required_approvals: 0`, a solo-maintainer decision recorded
+  in `.gt-repo.yaml`.
+- `BranchProtectionID` — partly `require_up_to_date: false`, which
+  `.gt-repo.yaml` explains: the attestation records the tree a run validated,
+  so an up-to-date requirement forces re-runs that prove nothing new.
+- `VulnerabilitiesID` — 5 advisories including `RUSTSEC-2026-0221`. Real
+  dependency work, unrelated to workflow permissions, tracked separately.


### PR DESCRIPTION
Addresses the Token-Permissions findings on the [code scanning page](https://github.com/wardnet/wardnet/security/code-scanning).

## What those findings actually are

They're **Scorecard**, not CodeQL, and Scorecard scores **0 for any write scope**. Of the 18 high findings, most are irreducible — the pipeline signs releases, caches coverage baselines on state branches, and uploads SARIF. A green score isn't reachable and isn't the goal.

The reachable goal: every write is **job-scoped, necessary, and explained where it's granted**, so a reviewer can tell a required grant from an accidental one without running the pipeline.

Three of the eighteen were neither.

## Removed: the GHCR registry cache

`tests-e2e.yml` held `packages: write` at **workflow level** — both e2e jobs carried it — and it existed for exactly one thing: exporting a layer cache to GHCR.

That cache was never shown to pay for itself. E2E daemon runs on `main` range **14–30 minutes** with it in place, a spread far wider than any effect it could have had. So it's removed and the write goes with it, which cascades:

| finding | cleared by |
|---|---|
| `tests-e2e.yml:40` workflow-level `packages: write` | cache removal |
| `ci-end2end.yml:40` `packages: write` | no longer needed |
| `ci-orchestration.yml:156` `packages: write` | `stage_permissions.end2end` dropped from `.gt-repo.yaml` |

Three findings from one deletion, plus **121 lines** of buildx setup, GHCR login and cache-argument plumbing out of the leaf. The `end2end` stage is back on the plain baseline.

**I'm not claiming this makes e2e faster.** The baseline is far too noisy to support that from one run. The claim is narrower: a cache with no demonstrated benefit shouldn't also cost a write scope.

## The audit

The remaining fifteen are documented in [`docs/ci-token-permissions.md`](docs/ci-token-permissions.md) — what each write is for, which are gt-rendered and so not editable here, and what's deliberate policy rather than a defect.

Every remaining write is already job-scoped with an inline justification. None is reducible without losing the function it exists for.

## Two candidates I deliberately did NOT change

Both need a live run to settle, and **neither is exercised by pull-request CI** — so changing them here would mean shipping an untested change to a release path:

- **`release-edge.yml`'s `security-events: write`.** `run-checks: false` skips `check-daemon`, so nothing uploads SARIF — but the existing comment says the grant is required anyway, since a called workflow may not exceed its caller and the leaf declares the scope. If GitHub validates that lazily, it's dead and can go. If not, removing it breaks edge releases.
- **`cubit.yml`'s `pull-requests: write`.** cubit runs on push-to-`main` and dispatch only; neither carries PR context, so the sticky-comment path looks unreachable. cubit is advisory and never fails the build, so a silently missing comment is exactly what nobody would notice.

Both are written up in the doc rather than guessed at.

## Not token findings (deliberate, on the same page)

- `PinnedDependenciesID` — first-party moving majors (`wardnet/bulwark@v2`, `wardnet/cubit@v0`, `pedromvgomes/gt@v1`). Third-party actions *are* SHA-pinned.
- `CodeReviewID` — `required_approvals: 0`.
- `BranchProtectionID` — partly `require_up_to_date: false`, which `.gt-repo.yaml` explains.
- `VulnerabilitiesID` — 5 real advisories incl. `RUSTSEC-2026-0221`. Genuine work, unrelated to permissions, not in this PR.

## Verification

- `actionlint` clean across all workflows this touches (and it fixes the unquoted `$(command -v docker)` that shellcheck flags in the restored form)
- `gt repo check` compliant; `gt repo config` unchanged apart from the dropped grant
- rendered `end2end` stage permissions now `contents: read` / `packages: read`