### PR TITLE
perf(dns): normalise the query log onto lookup ids

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -179,10 +179,13 @@ you're about to make, rather than the whole set.
   the log must outlive — plus `VACUUM` may renumber a non-`INTEGER` table's
   rowid), **no integer enums** for the closed columns (`DnsQueryResult::slot` is
   a compile-time exhaustiveness device, not a wire format), and **no FTS5**
-  (+232 MB and slower than `LIKE`). Invariants: only **`lk_domain`** is pruned —
-  the others are bounded by physical reality and the `SELECT DISTINCT` scan is
-  paid per table; the prune uses **`NOT IN (SELECT DISTINCT …)`**, never a
-  correlated `NOT EXISTS` (367 ms vs 135 s); and **nothing above `wardnetd-data`
+  (+232 MB and slower than `LIKE`). Invariants: only **`lk_dns_domain`** is pruned —
+  the others grow far more slowly and the `SELECT DISTINCT` scan is paid per
+  table; the prune uses **`NOT IN (SELECT DISTINCT …)`**, never a correlated
+  `NOT EXISTS` (135 s), and **`dns_query_log(domain_id)` must stay indexed** or
+  `PRAGMA foreign_keys=ON` makes each orphan scan the whole log (33.5 s vs
+  0.016 s on 500k rows — any timing taken in the `sqlite3` CLI has foreign keys
+  *off* and does not apply); and **nothing above `wardnetd-data`
   knows lookup tables exist**, which is what keeps the API contract unchanged.
 - **[Auth model](.agents/auth.md)** — setup wizard,
   unauthenticated vs admin endpoints, and the HARD REQUIREMENT

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -171,8 +171,9 @@ you're about to make, rather than the whole set.
 - **[Query-log normalisation](docs/adr/0034-query-log-normalisation.md)** —
   why `dns_query_log` moved its seven repeated text columns onto
   `(id INTEGER PRIMARY KEY, v TEXT UNIQUE)` lookup tables and an epoch
-  `timestamp` (591 MB → 109 MB, measured), and why it is **a space change, not a
-  speed change**. Covers the rejections that a reader would otherwise re-propose:
+  `timestamp` (591 MB → **146 MB**, measured — 109 MB for the normalisation plus
+  ~37 MB of integer indexes it cannot run correctly without), and why it is
+  **a space change, not a speed change**. Covers the rejections that a reader would otherwise re-propose:
   **no id cache** (per-batch resolution already removed the cost, and the cache
   was the only thing forcing the prune's placement), **no FK into `devices`**
   (`devices.id` is `TEXT`, so it saves nothing, and device retention deletes rows

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -168,6 +168,22 @@ you're about to make, rather than the whole set.
   profiles combine by **rank, not order**, and assigning any explicit
   `profile_ids` **drops the household defaults**. Invariant: **asking never
   promotes a device to managed** — only the approval's `grant_device` does.
+- **[Query-log normalisation](docs/adr/0034-query-log-normalisation.md)** —
+  why `dns_query_log` moved its seven repeated text columns onto
+  `(id INTEGER PRIMARY KEY, v TEXT UNIQUE)` lookup tables and an epoch
+  `timestamp` (591 MB → 109 MB, measured), and why it is **a space change, not a
+  speed change**. Covers the rejections that a reader would otherwise re-propose:
+  **no id cache** (per-batch resolution already removed the cost, and the cache
+  was the only thing forcing the prune's placement), **no FK into `devices`**
+  (`devices.id` is `TEXT`, so it saves nothing, and device retention deletes rows
+  the log must outlive — plus `VACUUM` may renumber a non-`INTEGER` table's
+  rowid), **no integer enums** for the closed columns (`DnsQueryResult::slot` is
+  a compile-time exhaustiveness device, not a wire format), and **no FTS5**
+  (+232 MB and slower than `LIKE`). Invariants: only **`lk_domain`** is pruned —
+  the others are bounded by physical reality and the `SELECT DISTINCT` scan is
+  paid per table; the prune uses **`NOT IN (SELECT DISTINCT …)`**, never a
+  correlated `NOT EXISTS` (367 ms vs 135 s); and **nothing above `wardnetd-data`
+  knows lookup tables exist**, which is what keeps the API contract unchanged.
 - **[Auth model](.agents/auth.md)** — setup wizard,
   unauthenticated vs admin endpoints, and the HARD REQUIREMENT
   that every service method opens with

--- a/docs/adr/0034-query-log-normalisation.md
+++ b/docs/adr/0034-query-log-normalisation.md
@@ -64,10 +64,16 @@ release notes for whichever version ships it.
 - **Only `lk_dns_domain` is pruned.** It is the only lookup that grows fast enough
   to matter (~543 orphans/day, ~198k/year) and the only one whose size is
   load-bearing: the substring scan is fast precisely because it reads thousands
-  of rows. The other
-  six are pinned by physical or configured reality and total kilobytes forever.
-  Pruning them is not free — the expensive half is the `SELECT DISTINCT` scan of
-  1.79M rows, paid *per table*, on a single-connection write pool.
+  of rows. The other six are **not** pruned, and two of them do grow without an
+  upper bound: `lk_dns_device` gains an entry per device UUID, and MAC
+  randomisation plus the 30-day device retention means a returning phone can
+  mint a new one, while `lk_dns_client_ip` keeps every address ever seen and
+  IPv6 privacy extensions rotate those roughly daily. That is a slow leak of
+  kilobytes a year against a table measured in hundreds of megabytes, and it is
+  left unreclaimed deliberately: pruning is not free — the expensive half is the
+  `SELECT DISTINCT` scan of 1.79M rows, paid *per table*, on a
+  single-connection write pool. Revisit it if either lookup ever grows large
+  enough to slow the filter that scans it.
 - **The prune lives inside `cleanup_query_log`, not behind its own trait method.**
   It is only meaningful immediately after the retention delete, has no independent
   cadence and no other caller. A separate method would put the word `lookup` in the

--- a/docs/adr/0034-query-log-normalisation.md
+++ b/docs/adr/0034-query-log-normalisation.md
@@ -61,10 +61,12 @@ release notes for whichever version ships it.
 
 ## Consequences
 
-- **Only `lk_dns_domain` is pruned.** It is the only lookup that grows fast enough
-  to matter (~543 orphans/day, ~198k/year) and the only one whose size is
-  load-bearing: the substring scan is fast precisely because it reads thousands
-  of rows. The other six are **not** pruned, and two of them do grow without an
+- **Only `lk_dns_domain` is pruned.** It is the lookup that grows fast enough to
+  matter — ~543 orphans/day, ~198k/year, against tens or hundreds a year for the
+  rest — and its size is load-bearing: the substring scan is fast precisely
+  because it reads thousands of rows. It is not the *only* load-bearing one:
+  `lk_dns_client_ip` is scanned by a `LIKE` in the same way, it simply stays
+  small enough that scanning it is free. The other six are **not** pruned, and two of them do grow without an
   upper bound: `lk_dns_device` gains an entry per device UUID, and MAC
   randomisation plus the 30-day device retention means a returning phone can
   mint a new one, while `lk_dns_client_ip` keeps every address ever seen and

--- a/docs/adr/0034-query-log-normalisation.md
+++ b/docs/adr/0034-query-log-normalisation.md
@@ -1,4 +1,10 @@
-# Normalising the DNS query log onto lookup ids
+---
+status: accepted
+date: 2026-09-02
+issue: "#1323 (dns_query_log: normalise repeated text onto lookup ids)"
+---
+
+# ADR: Normalising the DNS query log onto lookup ids
 
 `dns_query_log` stored every column as repeated text. Across 1.79M rows there are
 3,792 distinct domains, 29 device ids held as 36-byte UUID strings, 24 client IPs

--- a/docs/adr/0034-query-log-normalisation.md
+++ b/docs/adr/0034-query-log-normalisation.md
@@ -4,8 +4,14 @@
 3,792 distinct domains, 29 device ids held as 36-byte UUID strings, 24 client IPs
 and 8 results — 591 MB for the table and its indexes. Moving the seven repeated
 columns onto `(id INTEGER PRIMARY KEY, v TEXT UNIQUE)` lookup tables and storing
-`timestamp` as an epoch integer takes the subsystem to 109 MB (−82%) and the whole
-database from 1.07 GB to ~585 MB, measured on a snapshot of the live box.
+`timestamp` as an epoch integer takes the subsystem to **146 MB (−75%)** and the
+whole database from 1.07 GB to **~620 MB**, measured on a snapshot of the live box.
+
+The normalisation alone reaches 109 MB. The remaining 37 MB is two integer
+indexes — `domain_id` and `result_id` — that the measurement did not include and
+that the daemon cannot run correctly without; see the consequences below. Quoting
+the 109 MB figure describes a database that would stall its writer for minutes a
+day and scan the whole log for a result filter.
 
 **It is a space change, not a speed change.** The joins cost a fraction of a
 millisecond on already-trivial queries and win on the expensive ones. Removing the
@@ -67,6 +73,13 @@ release notes for whichever version ships it.
   cadence and no other caller. A separate method would put the word `lookup` in the
   service trait and the mock, and would move a mandatory ordering into a runner
   convention that no test protects.
+- **`dns_query_log(domain_id)` and `(result_id)` are indexed, and that is not
+  optional.** Together they cost ~37 MB, which is the whole difference between
+  the 109 MB the normalisation reaches on its own and the 146 MB that ships.
+  `result_id` restores what the old `result` index did — a reverse-ordered seek
+  with early exit for the admin log's result dropdown, measured 79.6 ms versus
+  0.3 ms for a rare result on a warm cache — and `domain_id` is what keeps the
+  prune from stalling the writer, below.
 - **The prune is fast only if two separate things hold.** Use
   `DELETE FROM lk_dns_domain WHERE id NOT IN (SELECT DISTINCT domain_id FROM dns_query_log)`.
   The `NOT EXISTS` form reads more naturally, is a correlated subquery that
@@ -78,7 +91,7 @@ release notes for whichever version ships it.
   with them on and no index**, 0.016 s with the index. Any prune timing measured
   in the `sqlite3` CLI is measured with foreign keys *off*, because that is the
   CLI's default and not the daemon's — the two are not comparable. The index
-  costs ~20 MB and is why this lands at roughly 128 MB rather than 109 MB.
+  costs ~20 MB, and with `result_id` accounts for the 146 MB this lands at.
 - **Timestamps are whole seconds, deliberately.** `QueryLogRow.timestamp` is a
   `DateTime<Utc>` and the producer truncates sub-second precision explicitly. That
   rule previously lived by accident inside a format string. Without the truncation

--- a/docs/adr/0034-query-log-normalisation.md
+++ b/docs/adr/0034-query-log-normalisation.md
@@ -50,13 +50,15 @@ indexed integer `IN`, scanning thousands of rows instead of millions.
 no DNS and no DHCP while systemd's start timeout runs. The new table is therefore
 created empty and the old one dropped: **existing query-log history is discarded.**
 Accepted deliberately — the log is capped at 7 days, refills immediately, and the
-box has a single operator who agreed to the loss. Called out in the release notes.
+box has a single operator who agreed to the loss. This must be called out in the
+release notes for whichever version ships it.
 
 ## Consequences
 
-- **Only `lk_domain` is pruned.** It is the only lookup that grows without bound
-  (~543 orphans/day, ~198k/year) and the only one whose size is load-bearing: the
-  substring scan is fast precisely because it reads thousands of rows. The other
+- **Only `lk_dns_domain` is pruned.** It is the only lookup that grows fast enough
+  to matter (~543 orphans/day, ~198k/year) and the only one whose size is
+  load-bearing: the substring scan is fast precisely because it reads thousands
+  of rows. The other
   six are pinned by physical or configured reality and total kilobytes forever.
   Pruning them is not free — the expensive half is the `SELECT DISTINCT` scan of
   1.79M rows, paid *per table*, on a single-connection write pool.
@@ -65,11 +67,18 @@ box has a single operator who agreed to the loss. Called out in the release note
   cadence and no other caller. A separate method would put the word `lookup` in the
   service trait and the mock, and would move a mandatory ordering into a runner
   convention that no test protects.
-- **The prune query form matters by 370×.** Use
-  `DELETE FROM lk_domain WHERE id NOT IN (SELECT DISTINCT domain_id FROM dns_query_log)`
-  (367 ms). The `NOT EXISTS` form reads more naturally, is a correlated subquery
-  that rescans the log per lookup row, and measured 135 s — a two-minute writer
-  stall. The plan is asserted in a test.
+- **The prune is fast only if two separate things hold.** Use
+  `DELETE FROM lk_dns_domain WHERE id NOT IN (SELECT DISTINCT domain_id FROM dns_query_log)`.
+  The `NOT EXISTS` form reads more naturally, is a correlated subquery that
+  rescans the log per lookup row, and measured 135 s — a two-minute writer stall.
+  Separately, **`dns_query_log(domain_id)` must stay indexed**: the daemon runs
+  with `PRAGMA foreign_keys=ON`, and SQLite proves a parent DELETE safe by
+  scanning the child table once per deleted row unless the child key is indexed.
+  Measured on 500k rows and 2,000 orphans: 0.061 s with foreign keys off, **33.5 s
+  with them on and no index**, 0.016 s with the index. Any prune timing measured
+  in the `sqlite3` CLI is measured with foreign keys *off*, because that is the
+  CLI's default and not the daemon's — the two are not comparable. The index
+  costs ~20 MB and is why this lands at roughly 128 MB rather than 109 MB.
 - **Timestamps are whole seconds, deliberately.** `QueryLogRow.timestamp` is a
   `DateTime<Utc>` and the producer truncates sub-second precision explicitly. That
   rule previously lived by accident inside a format string. Without the truncation

--- a/docs/adr/0034-query-log-normalisation.md
+++ b/docs/adr/0034-query-log-normalisation.md
@@ -86,6 +86,16 @@ release notes for whichever version ships it.
   with early exit for the admin log's result dropdown, measured 79.6 ms versus
   0.3 ms for a rare result on a warm cache — and `domain_id` is what keeps the
   prune from stalling the writer, below.
+
+  `domain_id` also makes the substring search **faster for narrow patterns and
+  slower for broad ones**, which is worth stating plainly because it is easy to
+  read the headline as a uniform win. Measured over 1.79M rows: a pattern
+  matching one domain goes 141 ms → 0.3 ms; a pattern matching ~3,700 domains
+  goes 1.8 ms → 17.9 ms, because the planner seeks per id and sorts into a temp
+  b-tree for `ORDER BY id DESC` instead of scanning in rowid order and exiting
+  early at `LIMIT`. Suppressing the index for that predicate (`+q.domain_id`)
+  would buy back the 16 ms and give up the 140 ms; it is not worth it, and the
+  losing case reads index pages where the winning case would read the table.
 - **The prune is fast only if two separate things hold.** Use
   `DELETE FROM lk_dns_domain WHERE id NOT IN (SELECT DISTINCT domain_id FROM dns_query_log)`.
   The `NOT EXISTS` form reads more naturally, is a correlated subquery that

--- a/docs/adr/0034-query-log-normalisation.md
+++ b/docs/adr/0034-query-log-normalisation.md
@@ -1,0 +1,87 @@
+# Normalising the DNS query log onto lookup ids
+
+`dns_query_log` stored every column as repeated text. Across 1.79M rows there are
+3,792 distinct domains, 29 device ids held as 36-byte UUID strings, 24 client IPs
+and 8 results — 591 MB for the table and its indexes. Moving the seven repeated
+columns onto `(id INTEGER PRIMARY KEY, v TEXT UNIQUE)` lookup tables and storing
+`timestamp` as an epoch integer takes the subsystem to 109 MB (−82%) and the whole
+database from 1.07 GB to ~585 MB, measured on a snapshot of the live box.
+
+**It is a space change, not a speed change.** The joins cost a fraction of a
+millisecond on already-trivial queries and win on the expensive ones. Removing the
+pagination `COUNT` is what fixed the 300 ms page load; this is orthogonal.
+
+## What was rejected, and why
+
+**A cache of lookup ids.** Ids are resolved per batch — one `SELECT … WHERE v IN
+(…)` for misses, `INSERT … ON CONFLICT(v) DO NOTHING` for new values — with no LRU
+in front. Batching already collapses 1.79M lookups a week into two statements per
+one-second flush against a `UNIQUE` index, on a write pool that is idle in between.
+A cache would protect a cost the batching already removed, and it is the sole
+reason the orphan prune would need to be co-located with the writer: a prune that
+deletes a domain whose id is still cached writes rows pointing at a row that no
+longer exists. No cache, no hazard, no constraint on where the prune runs.
+
+**An FK from `device_id` into `devices`.** It saves nothing — `devices.id` is
+`TEXT PRIMARY KEY`, so referencing it stores the same 36 bytes. Worse, the device
+retention runner deletes unmanaged devices after 30 days, so an FK forces a choice
+between cascading (shredding log history as devices age out) and blocking (a
+retention delete that fails against a 7-day log). Today log rows outlive their
+device by design; a lookup table preserves that exactly. Note also that FKing
+against the implicit `rowid` to get an integer for free is unsafe: `VACUUM` may
+renumber rowids for any table whose primary key is not `INTEGER PRIMARY KEY`, and
+this daemon runs incremental vacuum on a schedule.
+
+**Integer enums for the closed columns.** `result` and `protocol` are closed sets,
+so they could store a discriminant with no lookup table and no join. They don't.
+The saving is identical either way — the row holds an integer regardless — so the
+only thing at stake is a sub-millisecond join. Against that: `DnsQueryResult::slot`
+exists as a compile-time exhaustiveness device over a freely-editable `ALL` array,
+and persisting it would silently couple every historical row to that array's
+*order*, with no test able to catch a reorder. Seven uniform lookup tables also
+keep the database self-describing for a box with no `sqlite3` installed.
+
+**FTS5 for the substring search.** A trigram index over the real domains costs
++231.8 MB and `MATCH` measured *slower* than `LIKE` (0.67 ms vs 0.10 ms). With only
+~3,800 distinct domains, search resolves against the lookup table and feeds an
+indexed integer `IN`, scanning thousands of rows instead of millions.
+
+**Rewriting the rows in place.** A 2.4M-row copy was measured at ~49 s, taken with
+no DNS and no DHCP while systemd's start timeout runs. The new table is therefore
+created empty and the old one dropped: **existing query-log history is discarded.**
+Accepted deliberately — the log is capped at 7 days, refills immediately, and the
+box has a single operator who agreed to the loss. Called out in the release notes.
+
+## Consequences
+
+- **Only `lk_domain` is pruned.** It is the only lookup that grows without bound
+  (~543 orphans/day, ~198k/year) and the only one whose size is load-bearing: the
+  substring scan is fast precisely because it reads thousands of rows. The other
+  six are pinned by physical or configured reality and total kilobytes forever.
+  Pruning them is not free — the expensive half is the `SELECT DISTINCT` scan of
+  1.79M rows, paid *per table*, on a single-connection write pool.
+- **The prune lives inside `cleanup_query_log`, not behind its own trait method.**
+  It is only meaningful immediately after the retention delete, has no independent
+  cadence and no other caller. A separate method would put the word `lookup` in the
+  service trait and the mock, and would move a mandatory ordering into a runner
+  convention that no test protects.
+- **The prune query form matters by 370×.** Use
+  `DELETE FROM lk_domain WHERE id NOT IN (SELECT DISTINCT domain_id FROM dns_query_log)`
+  (367 ms). The `NOT EXISTS` form reads more naturally, is a correlated subquery
+  that rescans the log per lookup row, and measured 135 s — a two-minute writer
+  stall. The plan is asserted in a test.
+- **Timestamps are whole seconds, deliberately.** `QueryLogRow.timestamp` is a
+  `DateTime<Utc>` and the producer truncates sub-second precision explicitly. That
+  rule previously lived by accident inside a format string. Without the truncation
+  the streamed event would carry nanoseconds the epoch-second column cannot return,
+  so the same query would render differently live and on reload.
+- **The wire is unchanged.** `QueryLogEvent.timestamp` becomes `DateTime<Utc>` for
+  consistency with `DnsQueryLogEntry`, which was already typed that way. It is a
+  WebSocket message and not part of the OpenAPI surface, and chrono renders a
+  whole-second UTC value as `…:56Z` — the bytes it already emitted. No schema diff,
+  no SDK bump.
+- **Nothing above `wardnetd-data` learns that lookup tables exist.** The repository
+  joins them on read and resolves them on write, which is what keeps the API
+  contract untouched.
+- **`created_at` is dropped.** It recorded the batch-flush time, always within 11 s
+  of `timestamp`, and nothing ever read it.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -48,3 +48,4 @@ edge-release-channel one.
 | [0031](0031-household-identity.md) | Household identity is box-local; the cloud never vouches, and device affinity never authenticates | 2026-08-10 | Accepted |
 | [0032](0032-managed-devices-and-retention.md) | `managed` is an explicit latching column; only unmanaged devices are pruned | 2026-08-10 | Accepted |
 | [0033](0033-household-access-requests.md) | One access-request inbox, with per-kind approvers | 2026-08-14 | Accepted — supersedes §5 of [ADR-0029](0029-private-dns-dot.md) in part |
+| [0034](0034-query-log-normalisation.md) | The DNS query log is normalised onto integer lookup ids | 2026-09-02 | Accepted |

--- a/source/daemon/Cargo.lock
+++ b/source/daemon/Cargo.lock
@@ -78,7 +78,7 @@ dependencies = [
  "lazy_static",
  "ml-kem",
  "nom 8.0.0",
- "p256",
+ "p256 0.13.2",
  "pin-project",
  "rand 0.8.5",
  "rust-embed",
@@ -494,6 +494,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
 
 [[package]]
+name = "base16ct"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd307490d624467aa6f74b0eabb77633d1f758a7b25f12bceb0b22e08d9726f6"
+
+[[package]]
 name = "base64"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -600,7 +606,7 @@ version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
 dependencies = [
- "hybrid-array 0.4.8",
+ "hybrid-array 0.4.14",
 ]
 
 [[package]]
@@ -826,8 +832,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b77c319abfd5219629c45c34c89ba945ed3c5e49fcde9d16b6c3885f118a730"
 dependencies = [
  "const-oid 0.9.6",
- "der",
- "spki",
+ "der 0.7.10",
+ "spki 0.7.3",
  "x509-cert",
 ]
 
@@ -924,6 +930,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "cpubits"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15b85f9c39137c3a891689859392b1bd49812121d0d61c9caf00d46ed5ce06ae"
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1006,9 +1018,9 @@ checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
 
 [[package]]
 name = "cron"
-version = "0.16.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "089df96cf6a25253b4b6b6744d86f91150a3d4df546f31a95def47976b8cba97"
+checksum = "a5dcd6f69605c2956916ce24e8af637b754964c9a83f4662d3a2361654cdba09"
 dependencies = [
  "chrono",
  "once_cell",
@@ -1068,6 +1080,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-bigint"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a52aa3fcda4e6302a9f48734f234d35d4721b96f8fe07d073f07ce9df4f0271"
+dependencies = [
+ "cpubits",
+ "ctutils",
+ "getrandom 0.4.2",
+ "hybrid-array 0.4.14",
+ "num-traits",
+ "rand_core 0.10.0",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1084,7 +1112,9 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
 dependencies = [
- "hybrid-array 0.4.8",
+ "getrandom 0.4.2",
+ "hybrid-array 0.4.14",
+ "rand_core 0.10.0",
 ]
 
 [[package]]
@@ -1109,6 +1139,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
 dependencies = [
  "cmov",
+ "subtle",
 ]
 
 [[package]]
@@ -1200,7 +1231,18 @@ dependencies = [
  "const-oid 0.9.6",
  "der_derive",
  "flagset",
- "pem-rfc7468",
+ "pem-rfc7468 0.7.0",
+ "zeroize",
+]
+
+[[package]]
+name = "der"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a69dedd701da44b0536442edf09c81a64b0ab97a7a4a5e3d1971f00027cbc63d"
+dependencies = [
+ "const-oid 0.10.2",
+ "pem-rfc7468 1.0.0",
  "zeroize",
 ]
 
@@ -1334,12 +1376,27 @@ version = "0.16.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
 dependencies = [
- "der",
+ "der 0.7.10",
  "digest 0.10.7",
- "elliptic-curve",
- "rfc6979",
- "signature",
- "spki",
+ "elliptic-curve 0.13.8",
+ "rfc6979 0.4.0",
+ "signature 2.2.0",
+ "spki 0.7.3",
+]
+
+[[package]]
+name = "ecdsa"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0681a4fc24c767085329728d8dfba959af91228aa4610cca4f8ce317ba46ae0"
+dependencies = [
+ "der 0.8.1",
+ "digest 0.11.2",
+ "elliptic-curve 0.14.1",
+ "rfc6979 0.6.0",
+ "signature 3.0.0",
+ "spki 0.8.0",
+ "zeroize",
 ]
 
 [[package]]
@@ -1359,8 +1416,8 @@ version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
 dependencies = [
- "pkcs8",
- "signature",
+ "pkcs8 0.10.2",
+ "signature 2.2.0",
 ]
 
 [[package]]
@@ -1392,17 +1449,38 @@ version = "0.13.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
 dependencies = [
- "base16ct",
- "crypto-bigint",
+ "base16ct 0.2.0",
+ "crypto-bigint 0.5.5",
  "digest 0.10.7",
- "ff",
+ "ff 0.13.1",
  "generic-array",
- "group",
+ "group 0.13.0",
  "hkdf 0.12.4",
- "pem-rfc7468",
- "pkcs8",
+ "pem-rfc7468 0.7.0",
+ "pkcs8 0.10.2",
  "rand_core 0.6.4",
- "sec1",
+ "sec1 0.7.3",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "elliptic-curve"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d65aa39b3a5c1c9c1b745c9a019234bb7a21b77abcb4f4d266d706e2d577d65"
+dependencies = [
+ "base16ct 1.0.0",
+ "crypto-bigint 0.7.5",
+ "crypto-common 0.2.1",
+ "digest 0.11.2",
+ "ff 0.14.0",
+ "group 0.14.0",
+ "hybrid-array 0.4.14",
+ "pem-rfc7468 1.0.0",
+ "pkcs8 0.11.0",
+ "rand_core 0.10.0",
+ "sec1 0.8.1",
  "subtle",
  "zeroize",
 ]
@@ -1491,6 +1569,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
 dependencies = [
  "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
+name = "ff"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1f686ab92a9fb0eaf188f6c6c87b89490baa6fdb0db4544ba4dc47f7942489f"
+dependencies = [
+ "rand_core 0.10.0",
  "subtle",
 ]
 
@@ -1863,8 +1951,19 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
 dependencies = [
- "ff",
+ "ff 0.13.1",
  "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
+name = "group"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fd1a1c7a5206c5b7a3f5a0d7ccd3ff85d0c8f5133d62a02680255b0004af5f4"
+dependencies = [
+ "ff 0.14.0",
+ "rand_core 0.10.0",
  "subtle",
 ]
 
@@ -2108,7 +2207,7 @@ dependencies = [
  "generic-array",
  "hkdf 0.12.4",
  "hmac 0.12.1",
- "p256",
+ "p256 0.13.2",
  "rand_core 0.6.4",
  "sha2 0.10.9",
  "subtle",
@@ -2171,11 +2270,13 @@ dependencies = [
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.8"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8655f91cd07f2b9d0c24137bd650fe69617773435ee5ec83022377777ce65ef1"
+checksum = "707114b52a152fa7bdb290cd7cd5912d9467273b6d74e21b8d81aca1f8533f6b"
 dependencies = [
+ "subtle",
  "typenum",
+ "zeroize",
 ]
 
 [[package]]
@@ -3519,10 +3620,23 @@ version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
 dependencies = [
- "ecdsa",
- "elliptic-curve",
- "primeorder",
+ "ecdsa 0.16.9",
+ "elliptic-curve 0.13.8",
+ "primeorder 0.13.6",
  "sha2 0.10.9",
+]
+
+[[package]]
+name = "p256"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2c9239b2dbc807adbbe147e8cf72ea7450c3a0aabe62cb8e75ff4ec22e1f72a"
+dependencies = [
+ "ecdsa 0.17.0",
+ "elliptic-curve 0.14.1",
+ "primefield",
+ "primeorder 0.14.0",
+ "sha2 0.11.0",
 ]
 
 [[package]]
@@ -3624,6 +3738,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "pem-rfc7468"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6305423e0e7738146434843d1694d621cce767262b2a86910beab705e4493d9"
+dependencies = [
+ "base64ct",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3709,8 +3832,18 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
 dependencies = [
- "der",
- "spki",
+ "der 0.7.10",
+ "spki 0.7.3",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "451913da69c775a56034ea8d9003d27ee8948e12443eae7c038ba100a4f21cb7"
+dependencies = [
+ "der 0.8.1",
+ "spki 0.8.0",
 ]
 
 [[package]]
@@ -3891,12 +4024,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "primefield"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c555a6e4eb7d4e158fcb028c835c3b8642206ddc279b5c6b202ef9a8bdb592f4"
+dependencies = [
+ "crypto-bigint 0.7.5",
+ "crypto-common 0.2.1",
+ "ff 0.14.0",
+ "rand_core 0.10.0",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "primeorder"
 version = "0.13.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
 dependencies = [
- "elliptic-curve",
+ "elliptic-curve 0.13.8",
+]
+
+[[package]]
+name = "primeorder"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c9f42978c78a00e3d68f69fc03e57a234debae69da4020a4fb588fcdcd07b06"
+dependencies = [
+ "elliptic-curve 0.14.1",
+ "once_cell",
+ "primefield",
+ "serdect",
+ "wnaf",
 ]
 
 [[package]]
@@ -4334,6 +4494,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rfc6979"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4a459cddafb3fe76b31fd8f1108007566c40301feb64dc7b54656eb7388172b"
+dependencies = [
+ "crypto-bigint 0.7.5",
+ "hmac 0.13.0",
+]
+
+[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4658,10 +4828,24 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
 dependencies = [
- "base16ct",
- "der",
+ "base16ct 0.2.0",
+ "der 0.7.10",
  "generic-array",
- "pkcs8",
+ "pkcs8 0.10.2",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "sec1"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d56d437c2f19203ce5f7122e507831de96f3d2d4d3be5af44a0b0a09d8a80e4d"
+dependencies = [
+ "base16ct 1.0.0",
+ "ctutils",
+ "der 0.8.1",
+ "hybrid-array 0.4.14",
  "subtle",
  "zeroize",
 ]
@@ -4803,6 +4987,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "serdect"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66cf8fedced2fcf12406bcb34223dffb92eaf34908ede12fed414c82b7f00b3e"
+dependencies = [
+ "base16ct 1.0.0",
+ "serde",
+]
+
+[[package]]
 name = "sha1"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4898,6 +5092,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "signature"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28d567dcbaf0049cb8ac2608a76cd95ff9e4412e1899d389ee400918ca7537f5"
+dependencies = [
+ "digest 0.11.2",
+ "rand_core 0.10.0",
+]
+
+[[package]]
 name = "simd-adler32"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4986,7 +5190,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
 dependencies = [
  "base64ct",
- "der",
+ "der 0.7.10",
+]
+
+[[package]]
+name = "spki"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d9efca8738c78ee9484207732f728b1ef517bbb1833d6fc0879ca898a522f6f"
+dependencies = [
+ "base64ct",
+ "der 0.8.1",
 ]
 
 [[package]]
@@ -5887,9 +6101,9 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.19.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "unic-langid"
@@ -6313,7 +6527,7 @@ dependencies = [
  "const-oid 0.9.6",
  "criterion",
  "cron",
- "der",
+ "der 0.7.10",
  "ed25519-dalek",
  "flate2",
  "futures",
@@ -6324,7 +6538,7 @@ dependencies = [
  "ipnetwork 0.21.1",
  "minisign",
  "minisign-verify",
- "p256",
+ "p256 0.14.0",
  "rand 0.10.2",
  "rcgen",
  "regex",
@@ -6333,7 +6547,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.11.0",
- "spki",
+ "spki 0.7.3",
  "sqlx",
  "sysinfo",
  "tar",
@@ -6497,7 +6711,7 @@ dependencies = [
  "ece-native",
  "hkdf 0.13.0",
  "http",
- "p256",
+ "p256 0.13.2",
  "sha2 0.11.0",
 ]
 
@@ -7018,6 +7232,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "wnaf"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab12e7090f27e2ffd9322651492942d50c2926094af30601e1964337db39daf1"
+dependencies = [
+ "ff 0.14.0",
+ "group 0.14.0",
+ "hybrid-array 0.4.14",
+]
+
+[[package]]
 name = "writeable"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7052,8 +7277,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1301e935010a701ae5f8655edc0ad17c44bad3ac5ce8c39185f75453b720ae94"
 dependencies = [
  "const-oid 0.9.6",
- "der",
- "spki",
+ "der 0.7.10",
+ "spki 0.7.3",
  "tls_codec",
 ]
 

--- a/source/daemon/crates/wardnet-common/src/api.rs
+++ b/source/daemon/crates/wardnet-common/src/api.rs
@@ -1884,8 +1884,8 @@ pub struct ListQueryLogResponse {
 /// `dns_query_log` so clients can render entries before they're persisted.
 #[derive(Debug, Clone, Serialize, Deserialize, utoipa::ToSchema)]
 pub struct QueryLogEvent {
-    /// RFC 3339 timestamp.
-    pub timestamp: String,
+    /// Whole-second UTC instant, serialised as RFC 3339 (`...:56Z`).
+    pub timestamp: DateTime<Utc>,
     pub client_ip: String,
     pub domain: String,
     pub query_type: String,

--- a/source/daemon/crates/wardnet-common/src/tests/api.rs
+++ b/source/daemon/crates/wardnet-common/src/tests/api.rs
@@ -89,3 +89,26 @@ fn update_network_zone_request_subnet_is_three_state() {
         serde_json::from_str(r#"{"subnet":{"cidr":"10.44.0.0/24"}}"#).unwrap();
     assert_eq!(set.subnet.unwrap().unwrap().cidr, "10.44.0.0/24");
 }
+
+/// The DNS query-stream WebSocket is not described by `OpenAPI`, so nothing else
+/// pins its shape. A whole-second UTC instant must serialise as `...:56Z` —
+/// the admin UI parses these, and chrono would happily emit `+00:00` or a
+/// fractional part if the value carried one.
+#[test]
+fn query_log_event_timestamp_serialises_as_whole_second_zulu() {
+    let event = crate::api::QueryLogEvent {
+        timestamp: chrono::DateTime::parse_from_rfc3339("2026-05-05T12:34:56Z")
+            .expect("literal is valid RFC 3339")
+            .with_timezone(&chrono::Utc),
+        client_ip: "10.0.0.1".to_owned(),
+        domain: "example.com".to_owned(),
+        query_type: "A".to_owned(),
+        result: crate::dns::DnsQueryResult::Forwarded,
+        upstream: None,
+        latency_ms: 1.0,
+        device_id: None,
+    };
+
+    let json = serde_json::to_value(&event).expect("event serialises");
+    assert_eq!(json["timestamp"], "2026-05-05T12:34:56Z");
+}

--- a/source/daemon/crates/wardnetd-api/src/api/tests/dns_log_ws.rs
+++ b/source/daemon/crates/wardnetd-api/src/api/tests/dns_log_ws.rs
@@ -8,7 +8,9 @@ use crate::api::dns_log_ws::ClientFilter;
 
 fn event(domain: &str, ip: &str, result: &str) -> QueryLogEvent {
     QueryLogEvent {
-        timestamp: "2026-05-05T00:00:00Z".to_owned(),
+        timestamp: chrono::DateTime::parse_from_rfc3339("2026-05-05T00:00:00Z")
+            .expect("test timestamp literal is valid RFC 3339")
+            .with_timezone(&chrono::Utc),
         client_ip: ip.to_owned(),
         domain: domain.to_owned(),
         query_type: "A".to_owned(),

--- a/source/daemon/crates/wardnetd-data/migrations/20260901000000_dns_query_log_normalisation.sql
+++ b/source/daemon/crates/wardnetd-data/migrations/20260901000000_dns_query_log_normalisation.sql
@@ -40,9 +40,24 @@ CREATE TABLE IF NOT EXISTS dns_query_log (
     protocol_id   INTEGER NOT NULL REFERENCES lk_dns_protocol(id)
 );
 
--- Only two indexes survive. `timestamp` serves the retention DELETE, and
--- `device_id` serves the per-device seek (measured 0.4 ms -> 145.6 ms without
--- it). The old covering indexes on domain / client_ip / result existed solely
--- for a pagination COUNT that no longer runs, and cost 152 MB.
+-- `timestamp` serves the retention DELETE; `device_id` serves the per-device
+-- seek (measured 0.4 ms -> 145.6 ms without it).
+--
+-- `domain_id` is indexed because the daemon runs with `PRAGMA foreign_keys=ON`
+-- (see `db.rs`). SQLite proves a parent DELETE safe by scanning the child table
+-- once per deleted parent row, so pruning `lk_dns_domain` without this index
+-- costs a full scan of this table per orphan: measured 33.5 s against 500k rows
+-- and 2,000 orphans, versus 0.016 s with it. It also turns the domain substring
+-- filter into a covering-index seek.
+--
+-- The old text indexes on `domain` and `client_ip` are gone for good: both
+-- filters are leading-wildcard LIKE, which can never seek, so they only ever
+-- covered a pagination COUNT that no longer runs.
+--
+-- `result` is a deliberate regression, not dead weight: its old index was a
+-- real reverse-ordered seek for `WHERE result = ? ORDER BY id DESC LIMIT n`,
+-- and filtering the admin log by an uncommon result now scans the table.
+-- Indexing `result_id` would restore it for ~18 MB.
 CREATE INDEX IF NOT EXISTS idx_dns_query_log_timestamp ON dns_query_log(timestamp);
 CREATE INDEX IF NOT EXISTS idx_dns_query_log_device_id ON dns_query_log(device_id);
+CREATE INDEX IF NOT EXISTS idx_dns_query_log_domain_id ON dns_query_log(domain_id);

--- a/source/daemon/crates/wardnetd-data/migrations/20260901000000_dns_query_log_normalisation.sql
+++ b/source/daemon/crates/wardnetd-data/migrations/20260901000000_dns_query_log_normalisation.sql
@@ -54,10 +54,12 @@ CREATE TABLE IF NOT EXISTS dns_query_log (
 -- filters are leading-wildcard LIKE, which can never seek, so they only ever
 -- covered a pagination COUNT that no longer runs.
 --
--- `result` is a deliberate regression, not dead weight: its old index was a
--- real reverse-ordered seek for `WHERE result = ? ORDER BY id DESC LIMIT n`,
--- and filtering the admin log by an uncommon result now scans the table.
--- Indexing `result_id` would restore it for ~18 MB.
+-- `result_id` is indexed because the old `result` index was never dead weight:
+-- it served `WHERE result = ? ORDER BY id DESC LIMIT n` as a reverse-ordered
+-- seek with early exit, which is what the admin log's result dropdown does.
+-- Without it that filter scans the table — measured 79.6 ms versus 0.3 ms for
+-- a rare result, and that is a warm page cache, not an SD card.
 CREATE INDEX IF NOT EXISTS idx_dns_query_log_timestamp ON dns_query_log(timestamp);
 CREATE INDEX IF NOT EXISTS idx_dns_query_log_device_id ON dns_query_log(device_id);
 CREATE INDEX IF NOT EXISTS idx_dns_query_log_domain_id ON dns_query_log(domain_id);
+CREATE INDEX IF NOT EXISTS idx_dns_query_log_result_id ON dns_query_log(result_id);

--- a/source/daemon/crates/wardnetd-data/migrations/20260901000000_dns_query_log_normalisation.sql
+++ b/source/daemon/crates/wardnetd-data/migrations/20260901000000_dns_query_log_normalisation.sql
@@ -47,8 +47,16 @@ CREATE TABLE IF NOT EXISTS dns_query_log (
 -- (see `db.rs`). SQLite proves a parent DELETE safe by scanning the child table
 -- once per deleted parent row, so pruning `lk_dns_domain` without this index
 -- costs a full scan of this table per orphan: measured 33.5 s against 500k rows
--- and 2,000 orphans, versus 0.016 s with it. It also turns the domain substring
--- filter into a covering-index seek.
+-- and 2,000 orphans, versus 0.016 s with it.
+--
+-- It also changes the domain substring filter, and not uniformly. A pattern
+-- matching few domains becomes a covering-index seek — 141 ms to 0.3 ms for a
+-- rare domain over 1.79M rows. A pattern matching thousands of domains instead
+-- makes the planner seek per id and sort into a temp b-tree for `ORDER BY id
+-- DESC`, where a plain scan would have early-exited at `LIMIT`: worst measured
+-- 17.9 ms against 1.8 ms. The trade is taken deliberately — a ~16 ms worst case
+-- against a ~140 ms best case, and on the Pi's SD card the losing side reads a
+-- few index pages while the winning side would read the whole table.
 --
 -- The old text indexes on `domain` and `client_ip` are gone for good: both
 -- filters are leading-wildcard LIKE, which can never seek, so they only ever

--- a/source/daemon/crates/wardnetd-data/migrations/20260901000000_dns_query_log_normalisation.sql
+++ b/source/daemon/crates/wardnetd-data/migrations/20260901000000_dns_query_log_normalisation.sql
@@ -1,0 +1,48 @@
+-- Normalise `dns_query_log` onto integer lookup ids and an epoch timestamp.
+-- See docs/adr/0034-query-log-normalisation.md.
+--
+-- The table is recreated EMPTY and the old one dropped: existing query-log
+-- history is discarded. Rewriting 1.79M rows in place measured ~49 s, taken
+-- with no DNS and no DHCP while systemd's start timeout runs. The log is
+-- capped at 7 days by `dns_query_log_retention_days` and refills immediately.
+
+DROP TABLE IF EXISTS dns_query_log;
+
+-- One lookup per repeated column. `v` carries the text exactly as the old
+-- column did, so the repository joins them back into the same wire shape.
+CREATE TABLE IF NOT EXISTS lk_dns_domain     (id INTEGER PRIMARY KEY, v TEXT NOT NULL UNIQUE);
+CREATE TABLE IF NOT EXISTS lk_dns_client_ip  (id INTEGER PRIMARY KEY, v TEXT NOT NULL UNIQUE);
+CREATE TABLE IF NOT EXISTS lk_dns_device     (id INTEGER PRIMARY KEY, v TEXT NOT NULL UNIQUE);
+CREATE TABLE IF NOT EXISTS lk_dns_query_type (id INTEGER PRIMARY KEY, v TEXT NOT NULL UNIQUE);
+CREATE TABLE IF NOT EXISTS lk_dns_result     (id INTEGER PRIMARY KEY, v TEXT NOT NULL UNIQUE);
+CREATE TABLE IF NOT EXISTS lk_dns_upstream   (id INTEGER PRIMARY KEY, v TEXT NOT NULL UNIQUE);
+CREATE TABLE IF NOT EXISTS lk_dns_protocol   (id INTEGER PRIMARY KEY, v TEXT NOT NULL UNIQUE);
+
+-- `timestamp` is whole-second Unix epoch. `latency_ms` stays REAL: integer
+-- milliseconds would round every sub-millisecond cache hit to zero, which is
+-- the range that distinguishes a cache hit from a forward.
+--
+-- No FK on `device_id`: `devices.id` is TEXT (so a reference saves nothing)
+-- and the retention runner deletes unmanaged devices that log rows outlive.
+--
+-- No `created_at`: it recorded the batch-flush time, always within 11 s of
+-- `timestamp`, and nothing read it.
+CREATE TABLE IF NOT EXISTS dns_query_log (
+    id            INTEGER PRIMARY KEY,
+    timestamp     INTEGER NOT NULL,
+    client_ip_id  INTEGER NOT NULL REFERENCES lk_dns_client_ip(id),
+    domain_id     INTEGER NOT NULL REFERENCES lk_dns_domain(id),
+    query_type_id INTEGER NOT NULL REFERENCES lk_dns_query_type(id),
+    result_id     INTEGER NOT NULL REFERENCES lk_dns_result(id),
+    upstream_id   INTEGER          REFERENCES lk_dns_upstream(id),
+    latency_ms    REAL    NOT NULL DEFAULT 0,
+    device_id     INTEGER          REFERENCES lk_dns_device(id),
+    protocol_id   INTEGER NOT NULL REFERENCES lk_dns_protocol(id)
+);
+
+-- Only two indexes survive. `timestamp` serves the retention DELETE, and
+-- `device_id` serves the per-device seek (measured 0.4 ms -> 145.6 ms without
+-- it). The old covering indexes on domain / client_ip / result existed solely
+-- for a pagination COUNT that no longer runs, and cost 152 MB.
+CREATE INDEX IF NOT EXISTS idx_dns_query_log_timestamp ON dns_query_log(timestamp);
+CREATE INDEX IF NOT EXISTS idx_dns_query_log_device_id ON dns_query_log(device_id);

--- a/source/daemon/crates/wardnetd-data/src/repository/dns.rs
+++ b/source/daemon/crates/wardnetd-data/src/repository/dns.rs
@@ -27,8 +27,13 @@ pub trait DnsRepository: Send + Sync {
         filter: &QueryLogFilter,
     ) -> anyhow::Result<Vec<QueryLogRow>>;
 
-    /// Delete query log entries older than `retention_days`, then prune the
-    /// domain lookups the delete orphaned. Returns the query-log rows deleted.
+    /// Delete query log entries older than `retention_days`, then make a
+    /// best-effort attempt to prune the domain lookups the delete orphaned.
+    ///
+    /// Returns the query-log rows deleted. The retention delete commits before
+    /// the prune runs, so a prune failure is logged and the count still
+    /// returned rather than reported as a failed cleanup — the consequence is
+    /// orphans surviving a tick, not lost retention.
     async fn cleanup_query_log(&self, retention_days: u32) -> anyhow::Result<u64>;
 }
 

--- a/source/daemon/crates/wardnetd-data/src/repository/dns.rs
+++ b/source/daemon/crates/wardnetd-data/src/repository/dns.rs
@@ -11,6 +11,7 @@
 //! query log table.
 
 use async_trait::async_trait;
+use chrono::{DateTime, Utc};
 use wardnet_common::dns::DnsQueryResult;
 
 #[async_trait]
@@ -26,7 +27,8 @@ pub trait DnsRepository: Send + Sync {
         filter: &QueryLogFilter,
     ) -> anyhow::Result<Vec<QueryLogRow>>;
 
-    /// Delete query log entries older than `retention_days`.
+    /// Delete query log entries older than `retention_days`, then prune the
+    /// domain lookups the delete orphaned. Returns the query-log rows deleted.
     async fn cleanup_query_log(&self, retention_days: u32) -> anyhow::Result<u64>;
 }
 
@@ -35,7 +37,10 @@ pub trait DnsRepository: Send + Sync {
 /// Row struct for DNS query log inserts.
 #[derive(Debug, Clone)]
 pub struct QueryLogRow {
-    pub timestamp: String,
+    /// Whole seconds. The producer truncates sub-second precision explicitly so
+    /// the streamed event never carries a resolution the epoch-second column
+    /// cannot return.
+    pub timestamp: DateTime<Utc>,
     pub client_ip: String,
     pub domain: String,
     pub query_type: String,

--- a/source/daemon/crates/wardnetd-data/src/repository/sqlite/dns.rs
+++ b/source/daemon/crates/wardnetd-data/src/repository/sqlite/dns.rs
@@ -296,12 +296,16 @@ impl DnsRepository for SqliteDnsRepository {
         // Prune orphaned domains in the same call, immediately after the
         // retention delete — before it, almost nothing is orphaned yet.
         //
-        // `NOT IN (SELECT DISTINCT ...)` measured 367 ms; the equivalent
-        // correlated `NOT EXISTS` rescans the log once per lookup row and
-        // measured 135 s, which would stall the single-connection write pool
-        // for two minutes. `lk_dns_domain` is the only lookup pruned: it is the
-        // only one that grows without bound, and the only one whose size is
-        // load-bearing (substring search scans it).
+        // Use `NOT IN (SELECT DISTINCT ...)`: the equivalent correlated
+        // `NOT EXISTS` rescans the log once per lookup row and measured 135 s,
+        // which would stall the single-connection write pool for two minutes.
+        //
+        // `lk_dns_domain` is the only lookup pruned because it is the only one
+        // that grows fast enough to matter — ~543 orphans/day against tens or
+        // hundreds a year. It is *not* the only one that grows, nor the only
+        // one whose size is load-bearing: `lk_dns_client_ip` also accumulates
+        // and is also scanned by a `LIKE` in `build_where`. Pruning a second
+        // lookup is a live question, not a settled one; see ADR 0034.
         // The retention DELETE has already committed — it and the prune are
         // separate autocommit statements. A prune failure is therefore reported
         // rather than propagated: returning `Err` here would tell the runner the

--- a/source/daemon/crates/wardnetd-data/src/repository/sqlite/dns.rs
+++ b/source/daemon/crates/wardnetd-data/src/repository/sqlite/dns.rs
@@ -285,15 +285,29 @@ impl DnsRepository for SqliteDnsRepository {
         // for two minutes. `lk_dns_domain` is the only lookup pruned: it is the
         // only one that grows without bound, and the only one whose size is
         // load-bearing (substring search scans it).
-        let pruned = sqlx::query(sqlx::AssertSqlSafe(format!(
+        // The retention DELETE has already committed — it and the prune are
+        // separate autocommit statements. A prune failure is therefore reported
+        // rather than propagated: returning `Err` here would tell the runner the
+        // whole cleanup failed and hide the rows retention did delete, when the
+        // only real consequence is that some orphaned domains outlive one tick.
+        match sqlx::query(sqlx::AssertSqlSafe(format!(
             "DELETE FROM {LK_DOMAIN} WHERE id NOT IN (SELECT DISTINCT domain_id FROM dns_query_log)"
         )))
         .execute(&self.pools.write)
-        .await?
-        .rows_affected();
-
-        if pruned > 0 {
-            tracing::debug!(pruned, "pruned orphaned query-log domains: pruned={pruned}");
+        .await
+        {
+            Ok(result) => {
+                let pruned = result.rows_affected();
+                if pruned > 0 {
+                    tracing::debug!(pruned, "pruned orphaned query-log domains: pruned={pruned}");
+                }
+            }
+            Err(e) => {
+                tracing::warn!(
+                    error = %e,
+                    "failed to prune orphaned query-log domains; retention delete stands: {e}"
+                );
+            }
         }
         Ok(deleted)
     }

--- a/source/daemon/crates/wardnetd-data/src/repository/sqlite/dns.rs
+++ b/source/daemon/crates/wardnetd-data/src/repository/sqlite/dns.rs
@@ -89,14 +89,19 @@ impl DbQueryLogRow {
     }
 }
 
+/// Largest number of distinct values bound in one statement.
+///
+/// `insert_query_log_batch` is a public trait method, so the batch size is the
+/// caller's choice; chunking here means a caller that hands over more distinct
+/// values than SQLite will bind gets a few more statements rather than
+/// `too many SQL variables` at runtime.
+const RESOLVE_CHUNK: usize = 256;
+
 /// Resolve every `values` entry in `table` to its lookup id, inserting the ones
 /// that are new.
 ///
-/// Two statements per table per batch, never one per row — that is what keeps
-/// roughly 1.79M lookups a week off the writer without needing a cache in front
-/// of it. A batch carries at most as many distinct values as it has rows, and
-/// both callers flush in chunks of `BATCH_MAX`, so the bind count stays well
-/// inside SQLite's parameter limit.
+/// Two statements per chunk, never one per row — that is what keeps roughly
+/// 1.79M lookups a week off the writer without needing a cache in front of it.
 async fn resolve_ids(
     tx: &mut Transaction<'_, Sqlite>,
     table: &str,
@@ -106,7 +111,19 @@ async fn resolve_ids(
     if values.is_empty() {
         return Ok(ids);
     }
-    let values: Vec<&str> = values.iter().copied().collect();
+    let all: Vec<&str> = values.iter().copied().collect();
+    for chunk in all.chunks(RESOLVE_CHUNK) {
+        resolve_chunk(tx, table, chunk, &mut ids).await?;
+    }
+    Ok(ids)
+}
+
+async fn resolve_chunk(
+    tx: &mut Transaction<'_, Sqlite>,
+    table: &str,
+    values: &[&str],
+    ids: &mut HashMap<String, i64>,
+) -> anyhow::Result<()> {
     let placeholders = vec!["?"; values.len()].join(", ");
 
     // `ON CONFLICT DO NOTHING` rather than `INSERT OR IGNORE`: the latter also
@@ -115,7 +132,7 @@ async fn resolve_ids(
         "INSERT INTO {table} (v) VALUES {} ON CONFLICT(v) DO NOTHING",
         vec!["(?)"; values.len()].join(", ")
     )));
-    for v in &values {
+    for v in values {
         q = q.bind(*v);
     }
     q.execute(&mut **tx).await?;
@@ -123,13 +140,13 @@ async fn resolve_ids(
     let mut q = sqlx::query_as::<_, (i64, String)>(sqlx::AssertSqlSafe(format!(
         "SELECT id, v FROM {table} WHERE v IN ({placeholders})"
     )));
-    for v in &values {
+    for v in values {
         q = q.bind(*v);
     }
     for (id, v) in q.fetch_all(&mut **tx).await? {
         ids.insert(v, id);
     }
-    Ok(ids)
+    Ok(())
 }
 
 /// Look up an id the batch is known to have resolved. A miss means the resolve

--- a/source/daemon/crates/wardnetd-data/src/repository/sqlite/dns.rs
+++ b/source/daemon/crates/wardnetd-data/src/repository/sqlite/dns.rs
@@ -1,16 +1,34 @@
 //! SQLite-backed [`DnsRepository`] implementation — query log only.
 //!
-//! After the Stage 7 split, filter-source CRUD lives in
+//! Filter-source CRUD lives in
 //! [`SqliteDnsFilterRepository`](super::dns_filter::SqliteDnsFilterRepository).
-//! DNS observability stats moved to the generic `StatsRepository`.
+//! DNS observability stats are served by the generic `StatsRepository`.
+//!
+//! The query log is normalised: every repeated column is an integer id into a
+//! `lk_dns_*` lookup table and `timestamp` is a whole-second Unix epoch. That
+//! layout is confined to this module — the repository resolves ids on write and
+//! joins them back on read, so nothing above `wardnetd-data` knows the lookup
+//! tables exist. See `docs/adr/0034-query-log-normalisation.md`.
+
+use std::collections::{HashMap, HashSet};
 
 use async_trait::async_trait;
-use sqlx::SqlitePool;
+use chrono::DateTime;
+use sqlx::{Sqlite, SqlitePool, Transaction};
 
 use crate::db::DbPools;
 use crate::repository::dns::{DnsRepository, QueryLogFilter, QueryLogRow};
 
-const TS_FMT: &str = "%Y-%m-%dT%H:%M:%SZ";
+/// Lookup table for each repeated column, paired with the `dns_query_log`
+/// column holding its id. Table names reach the SQL builders from this array
+/// only — never from a caller — which is what makes the dynamic SQL below safe.
+const LK_DOMAIN: &str = "lk_dns_domain";
+const LK_CLIENT_IP: &str = "lk_dns_client_ip";
+const LK_DEVICE: &str = "lk_dns_device";
+const LK_QUERY_TYPE: &str = "lk_dns_query_type";
+const LK_RESULT: &str = "lk_dns_result";
+const LK_UPSTREAM: &str = "lk_dns_upstream";
+const LK_PROTOCOL: &str = "lk_dns_protocol";
 
 pub struct SqliteDnsRepository {
     pools: DbPools,
@@ -30,7 +48,7 @@ impl SqliteDnsRepository {
 
 #[derive(sqlx::FromRow)]
 struct DbQueryLogRow {
-    timestamp: String,
+    timestamp: i64,
     client_ip: String,
     domain: String,
     query_type: String,
@@ -42,9 +60,11 @@ struct DbQueryLogRow {
 }
 
 impl DbQueryLogRow {
-    fn into_row(self) -> QueryLogRow {
-        QueryLogRow {
-            timestamp: self.timestamp,
+    /// A row whose epoch seconds are outside `DateTime`'s range is dropped
+    /// rather than clamped — a clamped timestamp reads as a real observation.
+    fn into_row(self) -> Option<QueryLogRow> {
+        Some(QueryLogRow {
+            timestamp: DateTime::from_timestamp(self.timestamp, 0)?,
             client_ip: self.client_ip,
             domain: self.domain,
             query_type: self.query_type,
@@ -53,30 +73,146 @@ impl DbQueryLogRow {
             latency_ms: self.latency_ms,
             device_id: self.device_id,
             protocol: self.protocol,
-        }
+        })
     }
+}
+
+/// Resolve every `values` entry in `table` to its lookup id, inserting the ones
+/// that are new.
+///
+/// Two statements per table per batch, never one per row — that is what keeps
+/// roughly 1.79M lookups a week off the writer without needing a cache in front
+/// of it. A batch carries at most as many distinct values as it has rows, and
+/// both callers flush in chunks of `BATCH_MAX`, so the bind count stays well
+/// inside SQLite's parameter limit.
+async fn resolve_ids(
+    tx: &mut Transaction<'_, Sqlite>,
+    table: &str,
+    values: &HashSet<&str>,
+) -> anyhow::Result<HashMap<String, i64>> {
+    let mut ids = HashMap::with_capacity(values.len());
+    if values.is_empty() {
+        return Ok(ids);
+    }
+    let values: Vec<&str> = values.iter().copied().collect();
+    let placeholders = vec!["?"; values.len()].join(", ");
+
+    // `ON CONFLICT DO NOTHING` rather than `INSERT OR IGNORE`: the latter also
+    // swallows unrelated constraint failures on this table.
+    let mut q = sqlx::query(sqlx::AssertSqlSafe(format!(
+        "INSERT INTO {table} (v) VALUES {} ON CONFLICT(v) DO NOTHING",
+        vec!["(?)"; values.len()].join(", ")
+    )));
+    for v in &values {
+        q = q.bind(*v);
+    }
+    q.execute(&mut **tx).await?;
+
+    let mut q = sqlx::query_as::<_, (i64, String)>(sqlx::AssertSqlSafe(format!(
+        "SELECT id, v FROM {table} WHERE v IN ({placeholders})"
+    )));
+    for v in &values {
+        q = q.bind(*v);
+    }
+    for (id, v) in q.fetch_all(&mut **tx).await? {
+        ids.insert(v, id);
+    }
+    Ok(ids)
+}
+
+/// Look up an id the batch is known to have resolved. A miss means the resolve
+/// step and the bind step disagree about which values the batch contains, which
+/// would silently write a wrong id; fail the batch instead.
+fn id_for(ids: &HashMap<String, i64>, table: &str, value: &str) -> anyhow::Result<i64> {
+    ids.get(value)
+        .copied()
+        .ok_or_else(|| anyhow::anyhow!("unresolved {table} lookup value: {value}"))
 }
 
 #[async_trait]
 impl DnsRepository for SqliteDnsRepository {
     async fn insert_query_log_batch(&self, entries: &[QueryLogRow]) -> anyhow::Result<()> {
+        if entries.is_empty() {
+            return Ok(());
+        }
         let mut tx = self.pools.write.begin().await?;
+
+        let domains = resolve_ids(
+            &mut tx,
+            LK_DOMAIN,
+            &entries.iter().map(|e| e.domain.as_str()).collect(),
+        )
+        .await?;
+        let client_ips = resolve_ids(
+            &mut tx,
+            LK_CLIENT_IP,
+            &entries.iter().map(|e| e.client_ip.as_str()).collect(),
+        )
+        .await?;
+        let query_types = resolve_ids(
+            &mut tx,
+            LK_QUERY_TYPE,
+            &entries.iter().map(|e| e.query_type.as_str()).collect(),
+        )
+        .await?;
+        let results = resolve_ids(
+            &mut tx,
+            LK_RESULT,
+            &entries.iter().map(|e| e.result.as_str()).collect(),
+        )
+        .await?;
+        let protocols = resolve_ids(
+            &mut tx,
+            LK_PROTOCOL,
+            &entries.iter().map(|e| e.protocol.as_str()).collect(),
+        )
+        .await?;
+        let upstreams = resolve_ids(
+            &mut tx,
+            LK_UPSTREAM,
+            &entries
+                .iter()
+                .filter_map(|e| e.upstream.as_deref())
+                .collect(),
+        )
+        .await?;
+        let devices = resolve_ids(
+            &mut tx,
+            LK_DEVICE,
+            &entries
+                .iter()
+                .filter_map(|e| e.device_id.as_deref())
+                .collect(),
+        )
+        .await?;
+
         for entry in entries {
+            let upstream_id = entry
+                .upstream
+                .as_deref()
+                .map(|v| id_for(&upstreams, LK_UPSTREAM, v))
+                .transpose()?;
+            let device_id = entry
+                .device_id
+                .as_deref()
+                .map(|v| id_for(&devices, LK_DEVICE, v))
+                .transpose()?;
+
             sqlx::query(
                 "INSERT INTO dns_query_log \
-                 (timestamp, client_ip, domain, query_type, result, upstream, latency_ms, \
-                 device_id, protocol) \
+                 (timestamp, client_ip_id, domain_id, query_type_id, result_id, upstream_id, \
+                 latency_ms, device_id, protocol_id) \
                  VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
             )
-            .bind(&entry.timestamp)
-            .bind(&entry.client_ip)
-            .bind(&entry.domain)
-            .bind(&entry.query_type)
-            .bind(&entry.result)
-            .bind(&entry.upstream)
+            .bind(entry.timestamp.timestamp())
+            .bind(id_for(&client_ips, LK_CLIENT_IP, &entry.client_ip)?)
+            .bind(id_for(&domains, LK_DOMAIN, &entry.domain)?)
+            .bind(id_for(&query_types, LK_QUERY_TYPE, &entry.query_type)?)
+            .bind(id_for(&results, LK_RESULT, &entry.result)?)
+            .bind(upstream_id)
             .bind(entry.latency_ms)
-            .bind(&entry.device_id)
-            .bind(&entry.protocol)
+            .bind(device_id)
+            .bind(id_for(&protocols, LK_PROTOCOL, &entry.protocol)?)
             .execute(&mut *tx)
             .await?;
         }
@@ -92,10 +228,18 @@ impl DnsRepository for SqliteDnsRepository {
     ) -> anyhow::Result<Vec<QueryLogRow>> {
         let (where_clause, binds) = build_where(filter);
         let sql = format!(
-            "SELECT timestamp, client_ip, domain, query_type, result, upstream, latency_ms, \
-             device_id, protocol \
-             FROM dns_query_log {where_clause} \
-             ORDER BY id DESC LIMIT ? OFFSET ?"
+            "SELECT q.timestamp, ip.v AS client_ip, d.v AS domain, qt.v AS query_type, \
+             r.v AS result, up.v AS upstream, q.latency_ms, dev.v AS device_id, p.v AS protocol \
+             FROM dns_query_log q \
+             JOIN {LK_CLIENT_IP} ip ON ip.id = q.client_ip_id \
+             JOIN {LK_DOMAIN} d ON d.id = q.domain_id \
+             JOIN {LK_QUERY_TYPE} qt ON qt.id = q.query_type_id \
+             JOIN {LK_RESULT} r ON r.id = q.result_id \
+             JOIN {LK_PROTOCOL} p ON p.id = q.protocol_id \
+             LEFT JOIN {LK_UPSTREAM} up ON up.id = q.upstream_id \
+             LEFT JOIN {LK_DEVICE} dev ON dev.id = q.device_id \
+             {where_clause} \
+             ORDER BY q.id DESC LIMIT ? OFFSET ?"
         );
 
         let mut q = sqlx::query_as::<_, DbQueryLogRow>(sqlx::AssertSqlSafe(sql));
@@ -105,44 +249,79 @@ impl DnsRepository for SqliteDnsRepository {
         q = q.bind(limit).bind(offset);
 
         let rows = q.fetch_all(&self.pools.read).await?;
-        Ok(rows.into_iter().map(DbQueryLogRow::into_row).collect())
+        Ok(rows
+            .into_iter()
+            .filter_map(DbQueryLogRow::into_row)
+            .collect())
     }
 
     async fn cleanup_query_log(&self, retention_days: u32) -> anyhow::Result<u64> {
         let cutoff = chrono::Utc::now()
             .checked_sub_signed(chrono::Duration::days(i64::from(retention_days)))
             .unwrap_or_else(chrono::Utc::now)
-            .format(TS_FMT)
-            .to_string();
+            .timestamp();
 
         let result = sqlx::query("DELETE FROM dns_query_log WHERE timestamp < ?")
-            .bind(&cutoff)
+            .bind(cutoff)
             .execute(&self.pools.write)
             .await?;
-        Ok(result.rows_affected())
+        let deleted = result.rows_affected();
+
+        // Prune orphaned domains in the same call, immediately after the
+        // retention delete — before it, almost nothing is orphaned yet.
+        //
+        // `NOT IN (SELECT DISTINCT ...)` measured 367 ms; the equivalent
+        // correlated `NOT EXISTS` rescans the log once per lookup row and
+        // measured 135 s, which would stall the single-connection write pool
+        // for two minutes. `lk_dns_domain` is the only lookup pruned: it is the
+        // only one that grows without bound, and the only one whose size is
+        // load-bearing (substring search scans it).
+        let pruned = sqlx::query(sqlx::AssertSqlSafe(format!(
+            "DELETE FROM {LK_DOMAIN} WHERE id NOT IN (SELECT DISTINCT domain_id FROM dns_query_log)"
+        )))
+        .execute(&self.pools.write)
+        .await?
+        .rows_affected();
+
+        if pruned > 0 {
+            tracing::debug!(pruned, "pruned orphaned query-log domains: pruned={pruned}");
+        }
+        Ok(deleted)
     }
 }
 
 fn build_where(filter: &QueryLogFilter) -> (String, Vec<String>) {
-    let mut conditions: Vec<&str> = Vec::new();
+    let mut conditions: Vec<String> = Vec::new();
     let mut binds: Vec<String> = Vec::new();
     // Substring match, mirroring the domain filter: the admin UI feeds this
     // from a free-text input, so a partial IP ("192.168.1") must narrow
     // rather than silently matching nothing.
+    //
+    // Every filter resolves against its lookup table and feeds an indexed
+    // integer `IN`. That is what makes substring search cheap: the scan reads
+    // the few thousand distinct values, not the millions of log rows.
     if let Some(ref ip) = filter.client_ip {
-        conditions.push("client_ip LIKE ?");
+        conditions.push(format!(
+            "q.client_ip_id IN (SELECT id FROM {LK_CLIENT_IP} WHERE v LIKE ?)"
+        ));
         binds.push(format!("%{ip}%"));
     }
     if let Some(ref device_id) = filter.device_id {
-        conditions.push("device_id = ?");
+        conditions.push(format!(
+            "q.device_id IN (SELECT id FROM {LK_DEVICE} WHERE v = ?)"
+        ));
         binds.push(device_id.clone());
     }
     if let Some(ref domain) = filter.domain {
-        conditions.push("domain LIKE ?");
+        conditions.push(format!(
+            "q.domain_id IN (SELECT id FROM {LK_DOMAIN} WHERE v LIKE ?)"
+        ));
         binds.push(format!("%{domain}%"));
     }
     if let Some(result) = filter.result {
-        conditions.push("result = ?");
+        conditions.push(format!(
+            "q.result_id IN (SELECT id FROM {LK_RESULT} WHERE v = ?)"
+        ));
         binds.push(result.as_str().to_owned());
     }
     let where_clause = if conditions.is_empty() {

--- a/source/daemon/crates/wardnetd-data/src/repository/sqlite/dns.rs
+++ b/source/daemon/crates/wardnetd-data/src/repository/sqlite/dns.rs
@@ -306,6 +306,15 @@ impl DnsRepository for SqliteDnsRepository {
         // one whose size is load-bearing: `lk_dns_client_ip` also accumulates
         // and is also scanned by a `LIKE` in `build_where`. Pruning a second
         // lookup is a live question, not a settled one; see ADR 0034.
+        // Nothing but the retention DELETE can orphan a domain, so a tick that
+        // removed no rows has nothing to prune and skips the scan — which is
+        // every tick on a box younger than its retention window. A prune that
+        // failed on an earlier tick is picked up by the next one that deletes,
+        // so orphans are deferred rather than stranded.
+        if deleted == 0 {
+            return Ok(0);
+        }
+
         // The retention DELETE has already committed — it and the prune are
         // separate autocommit statements. A prune failure is therefore reported
         // rather than propagated: returning `Err` here would tell the runner the

--- a/source/daemon/crates/wardnetd-data/src/repository/sqlite/dns.rs
+++ b/source/daemon/crates/wardnetd-data/src/repository/sqlite/dns.rs
@@ -60,11 +60,23 @@ struct DbQueryLogRow {
 }
 
 impl DbQueryLogRow {
-    /// A row whose epoch seconds are outside `DateTime`'s range is dropped
-    /// rather than clamped — a clamped timestamp reads as a real observation.
-    fn into_row(self) -> Option<QueryLogRow> {
-        Some(QueryLogRow {
-            timestamp: DateTime::from_timestamp(self.timestamp, 0)?,
+    /// An epoch outside `DateTime`'s range falls back to the Unix epoch rather
+    /// than dropping the row. Every value this repository writes is in range,
+    /// so reaching the fallback means the column was written by something else
+    /// — and a visibly wrong 1970 timestamp in a seven-day log is diagnosable,
+    /// whereas a silently shorter page makes the caller's `has_more` report
+    /// that no further page exists.
+    fn into_row(self) -> QueryLogRow {
+        let timestamp = DateTime::from_timestamp(self.timestamp, 0).unwrap_or_else(|| {
+            tracing::warn!(
+                epoch = self.timestamp,
+                "query log row has an out-of-range timestamp: epoch={epoch}",
+                epoch = self.timestamp,
+            );
+            DateTime::UNIX_EPOCH
+        });
+        QueryLogRow {
+            timestamp,
             client_ip: self.client_ip,
             domain: self.domain,
             query_type: self.query_type,
@@ -73,7 +85,7 @@ impl DbQueryLogRow {
             latency_ms: self.latency_ms,
             device_id: self.device_id,
             protocol: self.protocol,
-        })
+        }
     }
 }
 
@@ -249,10 +261,7 @@ impl DnsRepository for SqliteDnsRepository {
         q = q.bind(limit).bind(offset);
 
         let rows = q.fetch_all(&self.pools.read).await?;
-        Ok(rows
-            .into_iter()
-            .filter_map(DbQueryLogRow::into_row)
-            .collect())
+        Ok(rows.into_iter().map(DbQueryLogRow::into_row).collect())
     }
 
     async fn cleanup_query_log(&self, retention_days: u32) -> anyhow::Result<u64> {
@@ -307,8 +316,12 @@ fn build_where(filter: &QueryLogFilter) -> (String, Vec<String>) {
         binds.push(format!("%{ip}%"));
     }
     if let Some(ref device_id) = filter.device_id {
+        // Scalar `=`, not `IN`: an IN-list SQLite cannot prove is a single
+        // value forces `USE TEMP B-TREE FOR ORDER BY`, which sorts every row
+        // for that device before `LIMIT` applies. The scalar form keeps
+        // `idx_dns_query_log_device_id` serving the ordering with an early exit.
         conditions.push(format!(
-            "q.device_id IN (SELECT id FROM {LK_DEVICE} WHERE v = ?)"
+            "q.device_id = (SELECT id FROM {LK_DEVICE} WHERE v = ?)"
         ));
         binds.push(device_id.clone());
     }
@@ -319,8 +332,9 @@ fn build_where(filter: &QueryLogFilter) -> (String, Vec<String>) {
         binds.push(format!("%{domain}%"));
     }
     if let Some(result) = filter.result {
+        // Scalar, for the same reason as the device filter above.
         conditions.push(format!(
-            "q.result_id IN (SELECT id FROM {LK_RESULT} WHERE v = ?)"
+            "q.result_id = (SELECT id FROM {LK_RESULT} WHERE v = ?)"
         ));
         binds.push(result.as_str().to_owned());
     }

--- a/source/daemon/crates/wardnetd-data/src/repository/tests/dns.rs
+++ b/source/daemon/crates/wardnetd-data/src/repository/tests/dns.rs
@@ -491,3 +491,46 @@ async fn prune_never_orphans_a_live_log_row() {
     assert_eq!(rows.len(), 1);
     assert_eq!(rows[0].domain, "kept.com");
 }
+
+/// A batch spanning several `RESOLVE_CHUNK` chunks must resolve every value to
+/// its own id — the failure this guards is a later chunk's ids overwriting or
+/// shadowing an earlier one's, which would silently file rows under the wrong
+/// domain.
+///
+/// It does not reach SQLite's bind limit (700 binds is far under it) and is not
+/// meant to: the limit is why the chunking exists, this pins that the chunking
+/// is correct. `insert_query_log_batch` is a public trait method, so the batch
+/// size is the caller's choice, not a convention this repository can assume.
+#[tokio::test]
+async fn resolves_more_distinct_values_than_one_statement_can_bind() {
+    let pool = test_pool().await;
+    let repo = SqliteDnsRepository::new(pool.clone());
+
+    let entries: Vec<QueryLogRow> = (0..700)
+        .map(|i| {
+            sample_row(
+                &format!("10.0.{}.{}", i / 256, i % 256),
+                &format!("d{i}.example"),
+                "allowed",
+            )
+        })
+        .collect();
+    repo.insert_query_log_batch(&entries).await.unwrap();
+
+    let (domains,): (i64,) = sqlx::query_as("SELECT COUNT(*) FROM lk_dns_domain")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    assert_eq!(domains, 700);
+
+    let rows = repo
+        .query_log_paginated(1000, 0, &QueryLogFilter::default())
+        .await
+        .unwrap();
+    assert_eq!(rows.len(), 700);
+    // Every row must carry its own domain, not a neighbour's id.
+    let mut seen: Vec<String> = rows.into_iter().map(|r| r.domain).collect();
+    seen.sort();
+    seen.dedup();
+    assert_eq!(seen.len(), 700, "some rows resolved to the wrong lookup id");
+}

--- a/source/daemon/crates/wardnetd-data/src/repository/tests/dns.rs
+++ b/source/daemon/crates/wardnetd-data/src/repository/tests/dns.rs
@@ -541,3 +541,31 @@ async fn resolves_values_spanning_several_chunks() {
     seen.dedup();
     assert_eq!(seen.len(), 700, "some rows resolved to the wrong lookup id");
 }
+
+/// A tick that deletes nothing skips the prune scan entirely. Only the
+/// retention delete can orphan a domain, so there is nothing to collect — and
+/// on a box younger than its retention window that is every tick.
+#[tokio::test]
+async fn cleanup_skips_the_prune_when_nothing_expired() {
+    let pool = test_pool().await;
+    let repo = SqliteDnsRepository::new(pool.clone());
+    repo.insert_query_log_batch(&[sample_row("10.0.0.1", "kept.com", "allowed")])
+        .await
+        .unwrap();
+
+    // An orphan that no retention delete produced. The prune would collect it;
+    // the guard means this tick does not look.
+    sqlx::query("INSERT INTO lk_dns_domain (v) VALUES ('never-referenced.example')")
+        .execute(&pool)
+        .await
+        .unwrap();
+
+    let deleted = repo.cleanup_query_log(30).await.unwrap();
+    assert_eq!(deleted, 0);
+
+    let domains: Vec<String> = sqlx::query_scalar("SELECT v FROM lk_dns_domain ORDER BY v")
+        .fetch_all(&pool)
+        .await
+        .unwrap();
+    assert_eq!(domains, vec!["kept.com", "never-referenced.example"]);
+}

--- a/source/daemon/crates/wardnetd-data/src/repository/tests/dns.rs
+++ b/source/daemon/crates/wardnetd-data/src/repository/tests/dns.rs
@@ -465,9 +465,14 @@ async fn prune_never_orphans_a_live_log_row() {
     )
     .execute(&pool)
     .await;
+    let error = rejected
+        .expect_err("a dangling lookup id must be refused")
+        .to_string();
     assert!(
-        rejected.is_err(),
-        "foreign keys are not enforced on this pool, so the assertions below prove nothing"
+        error.to_uppercase().contains("FOREIGN KEY"),
+        "the insert must fail on the foreign key, not on something else — a \
+         later NOT NULL column would otherwise keep this green while foreign \
+         key enforcement silently regressed. Got: {error}"
     );
 
     repo.cleanup_query_log(30).await.unwrap();
@@ -492,17 +497,19 @@ async fn prune_never_orphans_a_live_log_row() {
     assert_eq!(rows[0].domain, "kept.com");
 }
 
-/// A batch spanning several `RESOLVE_CHUNK` chunks must resolve every value to
-/// its own id — the failure this guards is a later chunk's ids overwriting or
-/// shadowing an earlier one's, which would silently file rows under the wrong
-/// domain.
+/// A batch spanning several `RESOLVE_CHUNK` chunks resolves every value to its
+/// own id — the failure guarded here is a later chunk's ids overwriting or
+/// shadowing an earlier one's, which would file rows under the wrong domain
+/// with nothing failing.
 ///
-/// It does not reach SQLite's bind limit (700 binds is far under it) and is not
-/// meant to: the limit is why the chunking exists, this pins that the chunking
-/// is correct. `insert_query_log_batch` is a public trait method, so the batch
-/// size is the caller's choice, not a convention this repository can assume.
+/// This does **not** prove the chunking is necessary: 700 binds is far under
+/// SQLite's limit, so it passes with `RESOLVE_CHUNK` removed. The limit is why
+/// chunking exists; this pins that chunking is *correct*. Reaching the real
+/// limit needs >32,766 distinct values in one batch, which no caller produces
+/// and which would trade a slow test for a case the type system already makes
+/// unreachable in practice.
 #[tokio::test]
-async fn resolves_more_distinct_values_than_one_statement_can_bind() {
+async fn resolves_values_spanning_several_chunks() {
     let pool = test_pool().await;
     let repo = SqliteDnsRepository::new(pool.clone());
 

--- a/source/daemon/crates/wardnetd-data/src/repository/tests/dns.rs
+++ b/source/daemon/crates/wardnetd-data/src/repository/tests/dns.rs
@@ -4,6 +4,16 @@ use crate::repository::dns::{DnsRepository, QueryLogFilter, QueryLogRow};
 use chrono::{DateTime, SubsecRound, Utc};
 use wardnet_common::dns::DnsQueryResult;
 
+/// sqlx leaves `foreign_keys` off by default, but the daemon's pools set it on
+/// (`db.rs`). Without this the seven lookup constraints are never exercised —
+/// neither a violation nor the cost they impose on the prune.
+async fn enable_foreign_keys(pool: &sqlx::SqlitePool) {
+    sqlx::query("PRAGMA foreign_keys = ON")
+        .execute(pool)
+        .await
+        .unwrap();
+}
+
 fn ts_now() -> DateTime<Utc> {
     Utc::now().trunc_subsecs(0)
 }
@@ -368,16 +378,47 @@ async fn cleanup_prunes_orphaned_domains_and_keeps_live_ones() {
     assert_eq!(domains, vec!["kept.com"]);
 }
 
-/// The prune must stay a single scan of the log. The correlated `NOT EXISTS`
-/// form rescans `dns_query_log` once per lookup row and measured 135 s against
-/// a real database — a two-minute stall on the single-connection write pool.
+/// The prune must stay a single scan of the log, in two independent respects.
+///
+/// The query plan covers one: a correlated `NOT EXISTS` rescans
+/// `dns_query_log` per lookup row and measured 135 s against a real database.
+///
+/// The plan cannot cover the other. With `foreign_keys=ON` — which is how the
+/// daemon runs — SQLite proves each parent DELETE safe by scanning the child
+/// table, once per deleted row, unless the child key is indexed. Those scans
+/// never appear in `EXPLAIN QUERY PLAN`, so the index is asserted directly:
+/// measured 33.5 s without it versus 0.016 s with, on 500k rows.
 #[tokio::test]
-async fn prune_plan_scans_the_log_once() {
+async fn prune_scans_the_log_once() {
     let pool = test_pool().await;
+    enable_foreign_keys(&pool).await;
     let repo = SqliteDnsRepository::new(pool.clone());
     repo.insert_query_log_batch(&[sample_row("10.0.0.1", "example.com", "allowed")])
         .await
         .unwrap();
+
+    let indexed: Vec<String> =
+        sqlx::query_scalar("SELECT name FROM pragma_index_list('dns_query_log')")
+            .fetch_all(&pool)
+            .await
+            .unwrap();
+    let mut covers_domain_id = false;
+    for index in indexed {
+        let cols: Vec<String> = sqlx::query_scalar(sqlx::AssertSqlSafe(format!(
+            "SELECT name FROM pragma_index_info('{index}')"
+        )))
+        .fetch_all(&pool)
+        .await
+        .unwrap();
+        if cols.first().map(String::as_str) == Some("domain_id") {
+            covers_domain_id = true;
+        }
+    }
+    assert!(
+        covers_domain_id,
+        "dns_query_log.domain_id must be indexed or the FK check makes the \
+         prune scan the whole log once per orphaned domain"
+    );
 
     let rows = sqlx::query_as::<_, (i64, i64, i64, String)>(
         "EXPLAIN QUERY PLAN \
@@ -401,4 +442,43 @@ async fn prune_plan_scans_the_log_once() {
         !plan.contains("CORRELATED"),
         "prune must not become a correlated subquery, got: {plan}"
     );
+}
+
+/// The lookup ids are real foreign keys, so a row pointing at a domain the
+/// prune removed must be impossible rather than merely unlikely.
+#[tokio::test]
+async fn prune_never_orphans_a_live_log_row() {
+    let pool = test_pool().await;
+    enable_foreign_keys(&pool).await;
+    let repo = SqliteDnsRepository::new(pool.clone());
+
+    let old = DateTime::parse_from_rfc3339("2020-01-01T00:00:00Z")
+        .unwrap()
+        .with_timezone(&Utc);
+    let mut stale = sample_row("10.0.0.1", "expired.com", "allowed");
+    stale.timestamp = old;
+    repo.insert_query_log_batch(&[stale, sample_row("10.0.0.2", "kept.com", "allowed")])
+        .await
+        .unwrap();
+
+    repo.cleanup_query_log(30).await.unwrap();
+
+    let (violations,): (i64,) = sqlx::query_as(
+        "SELECT COUNT(*) FROM dns_query_log q \
+         LEFT JOIN lk_dns_domain d ON d.id = q.domain_id WHERE d.id IS NULL",
+    )
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(
+        violations, 0,
+        "prune left a log row pointing at a deleted domain"
+    );
+
+    let rows = repo
+        .query_log_paginated(10, 0, &QueryLogFilter::default())
+        .await
+        .unwrap();
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].domain, "kept.com");
 }

--- a/source/daemon/crates/wardnetd-data/src/repository/tests/dns.rs
+++ b/source/daemon/crates/wardnetd-data/src/repository/tests/dns.rs
@@ -1,11 +1,11 @@
 use super::test_pool;
 use crate::repository::SqliteDnsRepository;
 use crate::repository::dns::{DnsRepository, QueryLogFilter, QueryLogRow};
-use chrono::Utc;
+use chrono::{DateTime, SubsecRound, Utc};
 use wardnet_common::dns::DnsQueryResult;
 
-fn ts_now() -> String {
-    Utc::now().format("%Y-%m-%dT%H:%M:%SZ").to_string()
+fn ts_now() -> DateTime<Utc> {
+    Utc::now().trunc_subsecs(0)
 }
 
 fn sample_row(client_ip: &str, domain: &str, result: &str) -> QueryLogRow {
@@ -189,12 +189,14 @@ async fn cleanup_query_log() {
     let pool = test_pool().await;
     let repo = SqliteDnsRepository::new(pool);
 
-    let old_ts = "2020-01-01T00:00:00Z".to_owned();
+    let old_ts = DateTime::parse_from_rfc3339("2020-01-01T00:00:00Z")
+        .unwrap()
+        .with_timezone(&Utc);
     let recent_ts = ts_now();
 
     let entries = vec![
         QueryLogRow {
-            timestamp: old_ts.clone(),
+            timestamp: old_ts,
             client_ip: "10.0.0.1".to_owned(),
             domain: "old.com".to_owned(),
             query_type: "A".to_owned(),
@@ -275,4 +277,128 @@ async fn insert_empty_batch() {
         .await
         .unwrap();
     assert!(rows.is_empty());
+}
+
+#[tokio::test]
+async fn repeated_values_share_one_lookup_row() {
+    let pool = test_pool().await;
+    let repo = SqliteDnsRepository::new(pool.clone());
+
+    let entries = vec![
+        sample_row("192.168.1.10", "example.com", "allowed"),
+        sample_row("192.168.1.10", "example.com", "allowed"),
+        sample_row("192.168.1.10", "example.com", "blocked"),
+    ];
+    repo.insert_query_log_batch(&entries).await.unwrap();
+    // A second batch re-resolves values the first batch already inserted.
+    repo.insert_query_log_batch(&entries).await.unwrap();
+
+    for (table, expected) in [
+        ("lk_dns_domain", 1),
+        ("lk_dns_client_ip", 1),
+        ("lk_dns_result", 2),
+        ("lk_dns_protocol", 1),
+    ] {
+        let (count,): (i64,) =
+            sqlx::query_as(sqlx::AssertSqlSafe(format!("SELECT COUNT(*) FROM {table}")))
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(
+            count, expected,
+            "{table} should hold {expected} distinct values"
+        );
+    }
+
+    let rows = repo
+        .query_log_paginated(10, 0, &QueryLogFilter::default())
+        .await
+        .unwrap();
+    assert_eq!(rows.len(), 6);
+    assert!(rows.iter().all(|r| r.domain == "example.com"));
+}
+
+#[tokio::test]
+async fn timestamp_survives_the_epoch_round_trip() {
+    let pool = test_pool().await;
+    let repo = SqliteDnsRepository::new(pool);
+
+    let when = DateTime::parse_from_rfc3339("2026-05-05T12:34:56Z")
+        .unwrap()
+        .with_timezone(&Utc);
+    let mut entry = sample_row("10.0.0.1", "example.com", "allowed");
+    entry.timestamp = when;
+    repo.insert_query_log_batch(&[entry]).await.unwrap();
+
+    let rows = repo
+        .query_log_paginated(10, 0, &QueryLogFilter::default())
+        .await
+        .unwrap();
+    assert_eq!(rows[0].timestamp, when);
+}
+
+#[tokio::test]
+async fn cleanup_prunes_orphaned_domains_and_keeps_live_ones() {
+    let pool = test_pool().await;
+    let repo = SqliteDnsRepository::new(pool.clone());
+
+    let old = DateTime::parse_from_rfc3339("2020-01-01T00:00:00Z")
+        .unwrap()
+        .with_timezone(&Utc);
+
+    let mut stale = sample_row("10.0.0.1", "expired.com", "allowed");
+    stale.timestamp = old;
+    let fresh = sample_row("10.0.0.2", "kept.com", "allowed");
+    repo.insert_query_log_batch(&[stale, fresh]).await.unwrap();
+
+    let domains: Vec<String> = sqlx::query_scalar("SELECT v FROM lk_dns_domain ORDER BY v")
+        .fetch_all(&pool)
+        .await
+        .unwrap();
+    assert_eq!(domains, vec!["expired.com", "kept.com"]);
+
+    repo.cleanup_query_log(30).await.unwrap();
+
+    // The retention delete orphaned `expired.com`; the prune in the same call
+    // removes it. `kept.com` is still referenced and must survive.
+    let domains: Vec<String> = sqlx::query_scalar("SELECT v FROM lk_dns_domain ORDER BY v")
+        .fetch_all(&pool)
+        .await
+        .unwrap();
+    assert_eq!(domains, vec!["kept.com"]);
+}
+
+/// The prune must stay a single scan of the log. The correlated `NOT EXISTS`
+/// form rescans `dns_query_log` once per lookup row and measured 135 s against
+/// a real database — a two-minute stall on the single-connection write pool.
+#[tokio::test]
+async fn prune_plan_scans_the_log_once() {
+    let pool = test_pool().await;
+    let repo = SqliteDnsRepository::new(pool.clone());
+    repo.insert_query_log_batch(&[sample_row("10.0.0.1", "example.com", "allowed")])
+        .await
+        .unwrap();
+
+    let rows = sqlx::query_as::<_, (i64, i64, i64, String)>(
+        "EXPLAIN QUERY PLAN \
+         DELETE FROM lk_dns_domain \
+         WHERE id NOT IN (SELECT DISTINCT domain_id FROM dns_query_log)",
+    )
+    .fetch_all(&pool)
+    .await
+    .unwrap();
+
+    let plan = rows
+        .into_iter()
+        .map(|(_, _, _, detail)| detail)
+        .collect::<Vec<_>>()
+        .join(" | ");
+    assert!(
+        plan.contains("LIST SUBQUERY"),
+        "prune should resolve the log once into a list, got: {plan}"
+    );
+    assert!(
+        !plan.contains("CORRELATED"),
+        "prune must not become a correlated subquery, got: {plan}"
+    );
 }

--- a/source/daemon/crates/wardnetd-data/src/repository/tests/dns.rs
+++ b/source/daemon/crates/wardnetd-data/src/repository/tests/dns.rs
@@ -4,16 +4,6 @@ use crate::repository::dns::{DnsRepository, QueryLogFilter, QueryLogRow};
 use chrono::{DateTime, SubsecRound, Utc};
 use wardnet_common::dns::DnsQueryResult;
 
-/// sqlx leaves `foreign_keys` off by default, but the daemon's pools set it on
-/// (`db.rs`). Without this the seven lookup constraints are never exercised —
-/// neither a violation nor the cost they impose on the prune.
-async fn enable_foreign_keys(pool: &sqlx::SqlitePool) {
-    sqlx::query("PRAGMA foreign_keys = ON")
-        .execute(pool)
-        .await
-        .unwrap();
-}
-
 fn ts_now() -> DateTime<Utc> {
     Utc::now().trunc_subsecs(0)
 }
@@ -391,7 +381,6 @@ async fn cleanup_prunes_orphaned_domains_and_keeps_live_ones() {
 #[tokio::test]
 async fn prune_scans_the_log_once() {
     let pool = test_pool().await;
-    enable_foreign_keys(&pool).await;
     let repo = SqliteDnsRepository::new(pool.clone());
     repo.insert_query_log_batch(&[sample_row("10.0.0.1", "example.com", "allowed")])
         .await
@@ -444,12 +433,16 @@ async fn prune_scans_the_log_once() {
     );
 }
 
-/// The lookup ids are real foreign keys, so a row pointing at a domain the
-/// prune removed must be impossible rather than merely unlikely.
+/// The prune must not leave a log row pointing at a domain it deleted.
+///
+/// The first assertion is what stops the rest being vacuous: the prune deletes
+/// only unreferenced rows by construction, so it could never orphan one on its
+/// own — the check that a dangling id is *refused* is what ties this to the
+/// declared constraints. It also pins the enforcement the prune's cost depends
+/// on: see `prune_scans_the_log_once`.
 #[tokio::test]
 async fn prune_never_orphans_a_live_log_row() {
     let pool = test_pool().await;
-    enable_foreign_keys(&pool).await;
     let repo = SqliteDnsRepository::new(pool.clone());
 
     let old = DateTime::parse_from_rfc3339("2020-01-01T00:00:00Z")
@@ -460,6 +453,22 @@ async fn prune_never_orphans_a_live_log_row() {
     repo.insert_query_log_batch(&[stale, sample_row("10.0.0.2", "kept.com", "allowed")])
         .await
         .unwrap();
+
+    // A dangling id must be refused outright, not merely never produced.
+    // sqlx enables `foreign_keys` by default and the daemon's pools set it
+    // explicitly, so this asserts a property both rely on rather than one this
+    // test arranges.
+    let rejected = sqlx::query(
+        "INSERT INTO dns_query_log \
+         (timestamp, client_ip_id, domain_id, query_type_id, result_id, latency_ms, protocol_id) \
+         VALUES (0, 1, 999999, 1, 1, 0, 1)",
+    )
+    .execute(&pool)
+    .await;
+    assert!(
+        rejected.is_err(),
+        "foreign keys are not enforced on this pool, so the assertions below prove nothing"
+    );
 
     repo.cleanup_query_log(30).await.unwrap();
 

--- a/source/daemon/crates/wardnetd-mock/src/events.rs
+++ b/source/daemon/crates/wardnetd-mock/src/events.rs
@@ -18,7 +18,7 @@
 use std::sync::Arc;
 use std::time::Duration;
 
-use chrono::Utc;
+use chrono::{SubsecRound, Utc};
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 use uuid::Uuid;
@@ -325,7 +325,7 @@ fn emit_fake_dns_queries(
         };
 
         sink.record(QueryLogRow {
-            timestamp: Utc::now().format("%Y-%m-%dT%H:%M:%SZ").to_string(),
+            timestamp: Utc::now().trunc_subsecs(0),
             client_ip: client.1.clone(),
             domain,
             query_type: "A".to_owned(),

--- a/source/daemon/crates/wardnetd-mock/src/seed.rs
+++ b/source/daemon/crates/wardnetd-mock/src/seed.rs
@@ -11,7 +11,7 @@
 //! Admin credentials are **not** seeded — the setup wizard runs on every
 //! mock launch so developers can exercise that flow repeatedly.
 
-use chrono::{Datelike, Duration, Utc};
+use chrono::{Datelike, Duration, SubsecRound, Utc};
 use uuid::Uuid;
 use wardnet_common::device::{DeviceSignalKind, ManufacturerSource};
 use wardnet_common::routing_profile::DomainRoutingTarget;
@@ -1034,7 +1034,7 @@ fn generate_dns_query_log(
             };
 
             rows.push(QueryLogRow {
-                timestamp: ts.format("%Y-%m-%dT%H:%M:%SZ").to_string(),
+                timestamp: ts.trunc_subsecs(0),
                 client_ip: client.clone(),
                 domain,
                 query_type: "A".to_owned(),

--- a/source/daemon/crates/wardnetd-services/benches/dns_components.rs
+++ b/source/daemon/crates/wardnetd-services/benches/dns_components.rs
@@ -389,7 +389,9 @@ fn bench_log_sink(c: &mut Criterion) {
     let mut group = c.benchmark_group("dns_log_sink");
 
     let row = QueryLogRow {
-        timestamp: "2026-05-05T00:00:00Z".to_owned(),
+        timestamp: chrono::DateTime::parse_from_rfc3339("2026-05-05T00:00:00Z")
+            .expect("bench timestamp literal is valid RFC 3339")
+            .with_timezone(&chrono::Utc),
         client_ip: "10.0.0.1".to_owned(),
         domain: "metrics.analytics-node.example".to_owned(),
         query_type: "A".to_owned(),

--- a/source/daemon/crates/wardnetd-services/src/dns/capture_runner.rs
+++ b/source/daemon/crates/wardnetd-services/src/dns/capture_runner.rs
@@ -27,10 +27,10 @@ use crate::auth_context;
 use crate::device::DeviceService;
 use crate::event::EventPublisher;
 
-/// Prune loop tick interval.
 /// Rendering for `dns_events.captured_at`, which is a TEXT column.
 const CAPTURED_AT_FMT: &str = "%Y-%m-%dT%H:%M:%SZ";
 
+/// Prune loop tick interval.
 pub const PRUNE_INTERVAL: Duration = Duration::from_hours(1);
 
 /// Background runner capturing per-device DNS events.

--- a/source/daemon/crates/wardnetd-services/src/dns/capture_runner.rs
+++ b/source/daemon/crates/wardnetd-services/src/dns/capture_runner.rs
@@ -28,6 +28,9 @@ use crate::device::DeviceService;
 use crate::event::EventPublisher;
 
 /// Prune loop tick interval.
+/// Rendering for `dns_events.captured_at`, which is a TEXT column.
+const CAPTURED_AT_FMT: &str = "%Y-%m-%dT%H:%M:%SZ";
+
 pub const PRUNE_INTERVAL: Duration = Duration::from_hours(1);
 
 /// Background runner capturing per-device DNS events.
@@ -154,8 +157,12 @@ async fn runner_loop(
                 if let Some(ref device_id) = row.device_id
                     && enabled.contains(device_id.as_str())
                 {
+                    // `dns_events.captured_at` is TEXT and stays that way, so
+                    // the instant is rendered here in the one shape that column
+                    // has always held.
+                    let captured_at = row.timestamp.format(CAPTURED_AT_FMT).to_string();
                     match dns_events_repo
-                        .insert(device_id, &row.domain, &row.result, &row.timestamp)
+                        .insert(device_id, &row.domain, &row.result, &captured_at)
                         .await
                     {
                         Ok(row_id) => {
@@ -165,7 +172,7 @@ async fn runner_loop(
                                 row_id,
                                 domain: row.domain,
                                 status: row.result,
-                                captured_at: row.timestamp,
+                                captured_at,
                                 timestamp: Utc::now(),
                             });
                         }

--- a/source/daemon/crates/wardnetd-services/src/dns/log_sink.rs
+++ b/source/daemon/crates/wardnetd-services/src/dns/log_sink.rs
@@ -210,7 +210,7 @@ impl DnsLogSink {
 #[must_use]
 pub fn row_to_event(row: &QueryLogRow) -> QueryLogEvent {
     QueryLogEvent {
-        timestamp: row.timestamp.clone(),
+        timestamp: row.timestamp,
         client_ip: row.client_ip.clone(),
         domain: row.domain.clone(),
         query_type: row.query_type.clone(),

--- a/source/daemon/crates/wardnetd-services/src/dns/service.rs
+++ b/source/daemon/crates/wardnetd-services/src/dns/service.rs
@@ -569,8 +569,10 @@ impl DnsService for DnsServiceImpl {
 
         // Over-fetch a single row past the page to learn whether another page
         // exists. This runs after the clamp above, so the cap still governs
-        // what is returned, and `has_more` is read before the extra row is
-        // truncated away.
+        // what is returned. `has_more` is read before the extra row is truncated
+        // away, and is exact because the repository's row mapping is total — a
+        // mapping that can drop a row would let a full page report that no
+        // further page exists.
         let mut rows = self
             .dns_repo
             .query_log_paginated(limit + 1, offset, &filter)

--- a/source/daemon/crates/wardnetd-services/src/dns/service.rs
+++ b/source/daemon/crates/wardnetd-services/src/dns/service.rs
@@ -570,9 +570,11 @@ impl DnsService for DnsServiceImpl {
         // Over-fetch a single row past the page to learn whether another page
         // exists. This runs after the clamp above, so the cap still governs
         // what is returned. `has_more` is read before the extra row is truncated
-        // away, and is exact because the repository's row mapping is total — a
-        // mapping that can drop a row would let a full page report that no
-        // further page exists.
+        // away, and is exact as long as the repository returns a row per stored
+        // row: its Rust mapping is total, and its lookup joins are inner joins
+        // held up by the foreign keys on those columns. Break either — a
+        // fallible mapping, or a lookup row deleted behind the constraint — and
+        // a full page reports that no further page exists.
         let mut rows = self
             .dns_repo
             .query_log_paginated(limit + 1, offset, &filter)

--- a/source/daemon/crates/wardnetd-services/src/dns/service.rs
+++ b/source/daemon/crates/wardnetd-services/src/dns/service.rs
@@ -569,9 +569,8 @@ impl DnsService for DnsServiceImpl {
 
         // Over-fetch a single row past the page to learn whether another page
         // exists. This runs after the clamp above, so the cap still governs
-        // what is returned. `has_more` is taken from the raw row count rather
-        // than from `entries`, because the mapping below drops rows whose
-        // timestamp will not parse.
+        // what is returned, and `has_more` is read before the extra row is
+        // truncated away.
         let mut rows = self
             .dns_repo
             .query_log_paginated(limit + 1, offset, &filter)
@@ -582,23 +581,19 @@ impl DnsService for DnsServiceImpl {
 
         let entries: Vec<DnsQueryLogEntry> = rows
             .into_iter()
-            .filter_map(|row| {
-                let timestamp = parse_iso_timestamp(&row.timestamp).ok()?;
-                let device_id = row
+            .map(|row| DnsQueryLogEntry {
+                id: 0,
+                timestamp: row.timestamp,
+                client_ip: row.client_ip,
+                domain: row.domain,
+                query_type: row.query_type,
+                result: DnsQueryResult::parse(&row.result),
+                upstream: row.upstream,
+                latency_ms: row.latency_ms,
+                device_id: row
                     .device_id
                     .as_deref()
-                    .and_then(|s| Uuid::parse_str(s).ok());
-                Some(DnsQueryLogEntry {
-                    id: 0,
-                    timestamp,
-                    client_ip: row.client_ip,
-                    domain: row.domain,
-                    query_type: row.query_type,
-                    result: DnsQueryResult::parse(&row.result),
-                    upstream: row.upstream,
-                    latency_ms: row.latency_ms,
-                    device_id,
-                })
+                    .and_then(|s| Uuid::parse_str(s).ok()),
             })
             .collect();
 
@@ -619,10 +614,4 @@ impl DnsService for DnsServiceImpl {
         auth_context::require_admin()?;
         Ok(0)
     }
-}
-
-fn parse_iso_timestamp(s: &str) -> anyhow::Result<chrono::DateTime<chrono::Utc>> {
-    use chrono::NaiveDateTime;
-    let naive = NaiveDateTime::parse_from_str(s, "%Y-%m-%dT%H:%M:%SZ")?;
-    Ok(chrono::TimeZone::from_utc_datetime(&chrono::Utc, &naive))
 }

--- a/source/daemon/crates/wardnetd-services/src/dns/tests/capture_runner.rs
+++ b/source/daemon/crates/wardnetd-services/src/dns/tests/capture_runner.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use async_trait::async_trait;
-use chrono::Utc;
+use chrono::{SubsecRound, Utc};
 use std::collections::HashMap;
 use tokio::sync::{Mutex, broadcast, mpsc};
 use uuid::Uuid;
@@ -351,7 +351,7 @@ where
 
 fn sample_row(device_id: Option<&str>, domain: &str) -> QueryLogRow {
     QueryLogRow {
-        timestamp: Utc::now().to_rfc3339(),
+        timestamp: Utc::now().trunc_subsecs(0),
         client_ip: "192.168.1.10".to_owned(),
         domain: domain.to_owned(),
         query_type: "A".to_owned(),

--- a/source/daemon/crates/wardnetd-services/src/dns/tests/log_sink.rs
+++ b/source/daemon/crates/wardnetd-services/src/dns/tests/log_sink.rs
@@ -1,6 +1,7 @@
 //! Unit tests for `DnsLogSink` — the hot-path channel between the DNS
 //! server and the persistence runner / WS subscribers.
 
+use super::ts;
 use crate::dns::log_sink::DnsLogSink;
 use crate::stats::buffer::StatsBuffer;
 use crate::stats::meter::Meter;
@@ -8,7 +9,7 @@ use wardnetd_data::repository::QueryLogRow;
 
 fn sample_row(domain: &str) -> QueryLogRow {
     QueryLogRow {
-        timestamp: "2026-05-05T00:00:00Z".to_owned(),
+        timestamp: ts("2026-05-05T00:00:00Z"),
         client_ip: "10.0.0.1".to_owned(),
         domain: domain.to_owned(),
         query_type: "A".to_owned(),

--- a/source/daemon/crates/wardnetd-services/src/dns/tests/mod.rs
+++ b/source/daemon/crates/wardnetd-services/src/dns/tests/mod.rs
@@ -14,3 +14,10 @@ use wardnet_common::auth::AuthContext;
 pub(crate) fn admin() -> AuthContext {
     AuthContext::system()
 }
+
+/// Parse a whole-second RFC 3339 literal into the `QueryLogRow` timestamp type.
+pub(crate) fn ts(literal: &str) -> chrono::DateTime<chrono::Utc> {
+    chrono::DateTime::parse_from_rfc3339(literal)
+        .expect("test timestamp literal is valid RFC 3339")
+        .with_timezone(&chrono::Utc)
+}

--- a/source/daemon/crates/wardnetd-services/src/dns/tests/query_log_runner.rs
+++ b/source/daemon/crates/wardnetd-services/src/dns/tests/query_log_runner.rs
@@ -19,6 +19,7 @@ use wardnet_common::auth::AuthContext;
 use wardnet_common::dns::{DnsConfig, DnsResolutionMode};
 use wardnetd_data::repository::QueryLogRow;
 
+use super::ts;
 use crate::DnsService;
 use crate::dns::log_sink::DnsLogSink;
 use crate::dns::query_log_runner::DnsQueryLogRunner;
@@ -141,7 +142,7 @@ impl DnsService for MockService {
 
 fn sample_row() -> QueryLogRow {
     QueryLogRow {
-        timestamp: "2026-05-05T00:00:00Z".to_owned(),
+        timestamp: ts("2026-05-05T00:00:00Z"),
         client_ip: "10.0.0.1".to_owned(),
         domain: "example.com".to_owned(),
         query_type: "A".to_owned(),

--- a/source/daemon/crates/wardnetd-services/src/dns/tests/service.rs
+++ b/source/daemon/crates/wardnetd-services/src/dns/tests/service.rs
@@ -9,7 +9,7 @@ use wardnet_common::api::{ListQueryLogParams, UpdateDnsConfigRequest, UpstreamDn
 use wardnet_common::dns::DnsProtocol;
 use wardnet_common::dns::ForwarderSelectionMode::{self, Failover, Fastest, Single};
 
-use super::admin;
+use super::{admin, ts};
 use crate::dns::service::{
     DnsService, DnsServiceImpl, FORWARD_DEADLINE_MAX_MS, FORWARD_DEADLINE_MIN_MS,
     QUERY_LOG_MAX_LIMIT, UPSTREAM_TIMEOUT_MAX_MS, UPSTREAM_TIMEOUT_MIN_MS,
@@ -384,7 +384,7 @@ impl DnsRepository for PagingDnsRepo {
         let n = self.available.min(limit as usize);
         Ok((0..n)
             .map(|i| QueryLogRow {
-                timestamp: "2026-09-01T00:00:00Z".to_owned(),
+                timestamp: ts("2026-09-01T00:00:00Z"),
                 client_ip: "10.0.0.1".to_owned(),
                 domain: format!("d{i}.com"),
                 query_type: "A".to_owned(),

--- a/source/daemon/crates/wardnetd/src/dns/pipeline.rs
+++ b/source/daemon/crates/wardnetd/src/dns/pipeline.rs
@@ -19,7 +19,7 @@ use std::net::{IpAddr, SocketAddr};
 use std::sync::Arc;
 
 use arc_swap::ArcSwap;
-use chrono::Utc;
+use chrono::{SubsecRound, Utc};
 use hickory_proto::op::{Message, OpCode, ResponseCode};
 use hickory_proto::serialize::binary::{BinDecodable, BinEncodable};
 use hickory_resolver::Resolver;
@@ -1841,7 +1841,9 @@ pub(crate) fn record_query(
     let Some(sink) = sink else { return };
 
     let row = QueryLogRow {
-        timestamp: Utc::now().format("%Y-%m-%dT%H:%M:%SZ").to_string(),
+        // Whole seconds: the log's resolution is one second, and anything
+        // finer would stream a precision the stored row cannot return.
+        timestamp: Utc::now().trunc_subsecs(0),
         client_ip: src.ip().to_string(),
         domain: domain.trim_end_matches('.').to_owned(),
         query_type: format!("{rtype:?}"),


### PR DESCRIPTION
Closes #1323. Rebased onto #1324, which removed the pagination `COUNT` this depends on.

`dns_query_log` stored every column as repeated text — 3,792 distinct domains, 29 device ids held as 36-byte UUID strings, 24 client IPs and 8 results across 1.79M rows. The seven repeated columns move onto `(id INTEGER PRIMARY KEY, v TEXT UNIQUE)` lookup tables, `timestamp` becomes an epoch integer, and `created_at` is dropped.

**591 MB → 146 MB (−75%)**, database 1.07 GB → ~620 MB, measured on a snapshot of the live box.

> [!IMPORTANT]
> **This discards all existing DNS query-log history.** The table is recreated empty and the old one dropped. Rewriting 1.79M rows in place measured ~49 s of blocked startup with no DNS and no DHCP while systemd's start timeout runs, so the copy is not viable. The log is capped at 7 days by `dns_query_log_retention_days` and refills immediately, but it is not reconstructible — unlike a blocklist. **This needs a `> [!IMPORTANT]` callout in the release notes for whichever version ships it**, matching the `dns_filter_blocked_domains` precedent in `v2026.08.01`. No release-notes file exists yet for the next version, which is why it is not in this PR.

> [!WARNING]
> **Once merged, `20260901000000_dns_query_log_normalisation.sql` must never be edited again — not even a comment.** sqlx checksums migration files and refuses to start with `VersionMismatch` if an applied migration's contents change. The file was revised several times in-branch; that is safe only because it has never existed on `main`.

## Why 146 MB and not the 109 MB in the issue

The issue's variant E was measured with two indexes. The daemon needs four, and the missing two cost ~37 MB. Both are load-bearing, and the issue body has been corrected with a variant F row:

- **`dns_query_log(domain_id)`** — the daemon runs with `PRAGMA foreign_keys=ON`. SQLite proves a parent `DELETE` safe by scanning the child table *once per deleted row* unless the child key is indexed, so without this the daily orphan prune holds the single-connection write pool for minutes and drops query-log entries throughout. Measured on 500k rows / 2,000 orphans: **0.061 s** foreign keys off, **33.5 s** on and unindexed, **0.016 s** with the index. Every prune timing in the issue was taken in the `sqlite3` CLI, which defaults foreign keys *off* — those numbers never described the daemon.
- **`dns_query_log(result_id)`** — the old `result` index was not, as the issue assumed, only covering the `COUNT`. It served `WHERE result = ? ORDER BY id DESC LIMIT n` as a reverse-ordered seek with early exit, which is the admin log's result dropdown. Without it that filter scans the table: **79.6 ms vs 0.3 ms** for a rare result, on a warm cache rather than an SD card.

## Design

Ids resolve **per batch**, chunked, with **no cache**. Batching already keeps the lookups off the writer, and no cache means no way for a prune to leave a stale id pointing at a deleted row — which is what frees the prune to live inside `cleanup_query_log`, immediately after the retention delete, where the ordering it depends on is guaranteed rather than conventional. The prune is best-effort: the retention delete has already committed, so a prune failure is logged and the count still returned. It is skipped entirely when nothing expired, since only the retention delete can orphan a domain.

Only `lk_dns_domain` is pruned — it is the one that grows fast enough to matter (~543 orphans/day). `lk_dns_client_ip` and `lk_dns_device` also grow, slowly and unreclaimed; that is deliberate and written down rather than claimed away.

`device_id` gets a lookup table, **not** a foreign key into `devices`: `devices.id` is `TEXT`, so a reference saves nothing, and the retention runner deletes unmanaged devices that log rows are meant to outlive.

Full rationale, including the rejected alternatives (an id cache, integer enums for the closed columns, FTS5, an in-place rewrite): [ADR 0034](docs/adr/0034-query-log-normalisation.md).

## API impact: none

`QueryLogRow::timestamp` and `QueryLogEvent::timestamp` become `DateTime<Utc>`, matching `DnsQueryLogEntry`, which was already typed that way. The producer truncates sub-second precision explicitly so the streamed event never carries a resolution the stored row cannot return. `QueryLogEvent` is a WebSocket type absent from the OpenAPI surface, and chrono renders a whole-second UTC value as the `…:56Z` already on the wire — pinned by a test. `make check-openapi` reports no diff; no SDK bump.

## Trade-off taken knowingly

`domain_id` makes substring search faster for narrow patterns and slower for broad ones. Over 1.79M rows: one matching domain goes 141 ms → 0.3 ms; ~3,700 matching domains go 1.8 ms → 17.9 ms, because the planner seeks per id and sorts into a temp b-tree instead of scanning in rowid order and exiting early. A ~16 ms worst case against a ~140 ms best case, where the losing side reads index pages and the winning side would read the whole table off an SD card.

## Included: a lockfile refresh

Dependabot PRs titled *"in /source/daemon/fuzz"* (#1302, #1294) edited the workspace root manifest but regenerated only the fuzz lockfile, so `cargo metadata --locked` failed on `main` and `cargo audit` was scanning a graph nobody builds. No CI job passes `--locked`, which is why it stayed invisible. Kept as its own commit — it is a semver-major `p256` bump reaching the iOS profile CMS signer.

## Verification

- `make check-daemon` equivalent, full, in a Linux container: `check-inline-tests`, `check-auth-constructors`, `cargo fmt --check`, `clippy --all-targets -D warnings`, `cargo test --workspace` — **3,289 tests, zero failures**
- `make check-openapi` — in sync, no diff
- New tests: lookup dedup, epoch round-trip, orphan prune, prune-skips-when-nothing-expired, cross-chunk id resolution, dangling-id rejection, WS wire format
- The prune test asserts the `domain_id` index directly, because foreign-key enforcement scans never appear in `EXPLAIN QUERY PLAN` — verified it fails when the index is removed
- Not run locally: e2e (the systemd stack does not boot under macOS podman); CI covers it
