### PR TITLE
fix(ci): restore the admin-site dist placeholder

### DIFF
--- a/source/admin-site/dist/.info
+++ b/source/admin-site/dist/.info
@@ -1,0 +1,10 @@
+This directory is intentionally kept in git via this .info file.
+
+The daemon embeds this folder at compile time with rust-embed
+(source/daemon/crates/wardnetd-api/src/web.rs: #[folder = "../../../admin-site/dist"]),
+so the directory must exist for the daemon crate to compile — even before
+`make build-web` has produced the real Vite output. Git cannot track an empty
+directory, so this file holds the place.
+
+Everything else here is build output and is gitignored. Run `make build-web` to
+regenerate it; never commit the generated files.


### PR DESCRIPTION
`Check Daemon` and `Check OpenAPI drift` are failing on `main`:

```
error: #[derive(RustEmbed)] folder '.../source/admin-site/dist' does not exist
error: no associated function or constant named `get` found for struct `web::AdminSiteAssets`
```

`wardnetd-api` embeds `source/admin-site/dist` at compile time, so the directory must exist before any Vite output is produced. Git cannot track an empty directory, so `source/admin-site/dist/.info` holds the place — and `.gitignore` whitelists exactly that one path.

A Vite build empties `dist/` before writing, which deletes the placeholder along with the stale output. It was lost that way in #1253 and `main` has been red since. This restores it.
